### PR TITLE
ci: configure Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot keeps our dependencies current with automated PRs.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Rust dependencies across the Cargo workspace.
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: build
+      include: scope
+    groups:
+      # Batch low-risk bumps into one PR to keep the queue quiet.
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by our workflows.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Weekly automated dependency PRs for the two ecosystems in the repo:

- **cargo** — the Cargo workspace
- **github-actions** — workflow actions

Minor/patch bumps are grouped per ecosystem to keep the PR queue quiet; majors still come through individually so they get a proper look.

---
**Stack (base):** `main` ← **this** ← `thet/core-domain-model`