### PR TITLE
feat(core): tool contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +197,7 @@ version = "0.0.0"
 name = "openwave-core"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ all = { level = "warn", priority = -1 }
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+async-trait = "0.1"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -11,6 +11,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -11,7 +11,9 @@
 pub mod error;
 pub mod id;
 pub mod model;
+pub mod tool;
 
 pub use error::{AgentError, Result};
 pub use id::{CallId, MessageId, SessionId, StepId, TurnId};
 pub use model::{Message, Role, Session};
+pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -1,0 +1,145 @@
+//! The tool contract: how the agent invokes a capability.
+//!
+//! Every tool is a typed args/result pair with a JSON Schema — no
+//! stringly-typed tools. Tools come from three sources (built-in, skill-backed,
+//! MCP-mounted) but all implement this one trait so the registry treats them
+//! uniformly.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::Result;
+use crate::id::SessionId;
+
+/// The approval policy class a tool declares for itself.
+///
+/// Policy maps class → auto-approve / ask / deny. In v1: `ReadOnly` auto;
+/// `Workspace` auto inside the session workspace, ask outside; `Sensitive`
+/// always asks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalClass {
+    /// Never mutates anything (e.g. `read_file`, `list_dir`, `search`).
+    ReadOnly,
+    /// Mutates the session workspace (e.g. `write_file`).
+    Workspace,
+    /// Escapes the workspace or reaches the network / external services
+    /// (connector writes, networked `exec`, writes outside the workspace).
+    Sensitive,
+}
+
+/// A tool's public contract: name, description, and the JSON Schema its
+/// arguments must satisfy. This is what gets advertised to the model.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolSpec {
+    /// Unique tool name (MCP-mounted tools are namespaced `mcp__{server}__{tool}`).
+    pub name: String,
+    /// Human- and model-readable description of what the tool does.
+    pub description: String,
+    /// JSON Schema (draft 2020-12) describing the argument object.
+    pub input_schema: Value,
+}
+
+/// The result of executing a tool.
+///
+/// `content` is the model-readable result folded back into the conversation;
+/// `data` is an optional structured payload for clients that can render it
+/// (e.g. a tool-call card). A failing tool returns `is_error = true` rather than
+/// an `Err` so the model sees the failure and can adapt.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolOutput {
+    /// Result text fed back to the model.
+    pub content: String,
+    /// Optional structured payload for richer client rendering.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+    /// Whether the tool reported a failure.
+    #[serde(default)]
+    pub is_error: bool,
+}
+
+impl ToolOutput {
+    /// A successful text result.
+    pub fn text(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            data: None,
+            is_error: false,
+        }
+    }
+
+    /// A failure the model should see and react to.
+    pub fn error(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            data: None,
+            is_error: true,
+        }
+    }
+
+    /// Attach a structured payload to this output.
+    #[must_use]
+    pub fn with_data(mut self, data: Value) -> Self {
+        self.data = Some(data);
+        self
+    }
+}
+
+/// Execution context handed to a tool for one invocation.
+///
+/// Deliberately minimal in this slice — it grows (cancellation, store handles)
+/// as the agent loop lands.
+#[derive(Debug, Clone)]
+pub struct ToolCtx {
+    /// The session this call belongs to.
+    pub session_id: SessionId,
+    /// Absolute path to the session's workspace directory. Workspace-class
+    /// tools stay within it without prompting.
+    pub workspace_dir: PathBuf,
+}
+
+/// A capability the agent can invoke. Implementors are held as trait objects in
+/// the registry, so this trait must stay object-safe (hence `#[async_trait]`).
+#[async_trait]
+pub trait Tool: Send + Sync {
+    /// The tool's advertised contract.
+    fn spec(&self) -> ToolSpec;
+
+    /// The approval class governing this tool's calls.
+    fn approval_class(&self) -> ApprovalClass;
+
+    /// Execute the tool with JSON `args` matching [`ToolSpec::input_schema`].
+    async fn execute(&self, ctx: &ToolCtx, args: Value) -> Result<ToolOutput>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_output_constructors_set_error_flag() {
+        assert!(!ToolOutput::text("ok").is_error);
+        assert!(ToolOutput::error("boom").is_error);
+    }
+
+    #[test]
+    fn tool_output_omits_absent_data_when_serialized() {
+        let json = serde_json::to_string(&ToolOutput::text("ok")).unwrap();
+        assert!(
+            !json.contains("data"),
+            "absent data should be skipped: {json}"
+        );
+
+        let with = ToolOutput::text("ok").with_data(serde_json::json!({"k": 1}));
+        assert_eq!(with.data, Some(serde_json::json!({"k": 1})));
+    }
+
+    #[test]
+    fn approval_class_serializes_snake_case() {
+        let json = serde_json::to_string(&ApprovalClass::ReadOnly).unwrap();
+        assert_eq!(json, "\"read_only\"");
+    }
+}


### PR DESCRIPTION
The schema-first tool model — the object-safe `Tool` trait every built-in / skill-backed / MCP-mounted tool implements.

- **ApprovalClass** — `ReadOnly | Workspace | Sensitive`
- **ToolSpec** — name + description + JSON Schema for args (no stringly-typed tools)
- **ToolOutput** — model-readable `content`, optional structured `data`, `is_error` (tool failures come back as data the model can react to, not an `Err`)
- **ToolCtx** — per-call context (session id + workspace dir); grows with the loop
- **Tool** — async, object-safe (`#[async_trait]`) so the registry can hold trait objects

Adds `async-trait` to the workspace deps.

Verified: `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test -p openwave-core` (5 tests) all green.

---
Next in the stack: the provider model (`ModelProvider` / `ChatRequest` / `ProviderEvent`), then the `AgentEvent` stream.