### PR TITLE
feat(core): model-provider contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,10 +77,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -94,8 +153,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -199,6 +263,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "futures",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ all = { level = "warn", priority = -1 }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
+futures = "0.3"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -11,9 +11,14 @@
 pub mod error;
 pub mod id;
 pub mod model;
+pub mod provider;
 pub mod tool;
 
 pub use error::{AgentError, Result};
 pub use id::{CallId, MessageId, SessionId, StepId, TurnId};
 pub use model::{Message, Role, Session};
+pub use provider::{
+    ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
+    Usage,
+};
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -1,0 +1,298 @@
+//! The model-provider contract.
+//!
+//! A [`ModelProvider`] normalizes one LLM API's streaming quirks into a single
+//! [`ProviderEvent`] stream. Everything above the adapter — the agent loop, the
+//! clients — speaks only this vocabulary, never a provider's native wire format.
+//!
+//! Messages use a normalized content-block model (text / tool-use / tool-result)
+//! so tool-calling round-trips the same way across providers.
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::Result;
+use crate::model::Role;
+
+/// Stable identifier for a provider adapter (e.g. `anthropic`, `openai-compat`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ProviderId(pub String);
+
+impl ProviderId {
+    /// Wrap a provider name.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::fmt::Display for ProviderId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// One piece of a message. Assistant messages carry text (and, when the model
+/// calls tools, `ToolUse` blocks); tool results come back as `ToolResult`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ContentBlock {
+    /// Plain text.
+    Text {
+        /// The text body.
+        text: String,
+    },
+    /// A tool invocation emitted by the model.
+    ToolUse {
+        /// Provider-assigned id correlating this call to its result.
+        id: String,
+        /// The tool name.
+        name: String,
+        /// The arguments (JSON) the model produced.
+        input: Value,
+    },
+    /// The result of a tool call, fed back to the model.
+    ToolResult {
+        /// The `ToolUse::id` this result answers.
+        tool_use_id: String,
+        /// Result text.
+        content: String,
+        /// Whether the tool failed.
+        #[serde(default)]
+        is_error: bool,
+    },
+}
+
+/// A single message in the conversation sent to a provider.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChatMessage {
+    /// Who authored the message.
+    pub role: Role,
+    /// The ordered content blocks.
+    pub content: Vec<ContentBlock>,
+}
+
+impl ChatMessage {
+    /// A single-text-block message.
+    pub fn text(role: Role, text: impl Into<String>) -> Self {
+        Self {
+            role,
+            content: vec![ContentBlock::Text { text: text.into() }],
+        }
+    }
+}
+
+/// A request for one streamed model completion.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChatRequest {
+    /// Provider-specific model identifier (e.g. `claude-opus-4-8`).
+    pub model: String,
+    /// System prompt, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    /// Conversation history.
+    pub messages: Vec<ChatMessage>,
+    /// Tools advertised to the model this turn.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<crate::tool::ToolSpec>,
+    /// Upper bound on tokens to generate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    /// Sampling temperature.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+}
+
+/// Token accounting for a completion.
+///
+/// Prompt tokens are split so prompt-cache cost is legible: `input_tokens` is the
+/// fresh (uncached) prompt, `cache_read_input_tokens` is what was served from the
+/// provider's cache, and `cache_creation_input_tokens` is what was written to it
+/// (Anthropic-style). Providers that don't report caching leave the cache fields
+/// at zero.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Usage {
+    /// Fresh (uncached) prompt tokens.
+    pub input_tokens: u32,
+    /// Tokens generated.
+    pub output_tokens: u32,
+    /// Prompt tokens served from the provider's cache (a read hit).
+    #[serde(default)]
+    pub cache_read_input_tokens: u32,
+    /// Prompt tokens written to the provider's cache.
+    #[serde(default)]
+    pub cache_creation_input_tokens: u32,
+}
+
+/// Why a completion stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum StopReason {
+    /// The model finished its turn naturally.
+    EndTurn,
+    /// The output token cap was hit.
+    MaxTokens,
+    /// The model stopped to call tools.
+    ToolUse,
+    /// A stop sequence was produced.
+    StopSequence,
+    /// The caller cancelled the turn.
+    Cancelled,
+}
+
+/// A normalized streaming event from a provider. Adapters translate each API's
+/// native stream into this; the loop reduces these into [`crate::model`] rows
+/// and `AgentEvent`s.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ProviderEvent {
+    /// A chunk of assistant text.
+    TextDelta {
+        /// The text fragment.
+        text: String,
+    },
+    /// A chunk of reasoning/thinking text, where the provider exposes it.
+    ReasoningDelta {
+        /// The reasoning fragment.
+        text: String,
+    },
+    /// A tool call has begun; name and id are known.
+    ToolCallStarted {
+        /// Stream-local index correlating this call's arg deltas.
+        index: u32,
+        /// Provider-assigned call id.
+        id: String,
+        /// The tool being called.
+        name: String,
+    },
+    /// A fragment of a tool call's JSON arguments.
+    ToolCallArgsDelta {
+        /// The index from the matching `ToolCallStarted`.
+        index: u32,
+        /// Partial JSON to concatenate.
+        fragment: String,
+    },
+    /// Final token usage for the completion.
+    Usage(Usage),
+    /// The completion has stopped.
+    Stop {
+        /// Why it stopped.
+        reason: StopReason,
+    },
+}
+
+/// An LLM backend the agent streams completions from. Held as a trait object,
+/// so it must stay object-safe (`#[async_trait]`).
+#[async_trait]
+pub trait ModelProvider: Send + Sync {
+    /// This adapter's stable identifier.
+    fn id(&self) -> ProviderId;
+
+    /// Stream a completion, normalizing the provider's events into
+    /// [`ProviderEvent`]s.
+    ///
+    /// The stream is `'static`: it must not borrow `self`, so the agent loop can
+    /// hold a provider behind `Arc<dyn ModelProvider>` and keep polling the
+    /// stream across awaits. Adapters move (or cheaply `Arc`-clone, e.g.
+    /// `reqwest::Client`) whatever they need into the returned stream.
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use futures::stream::{self, StreamExt};
+
+    use super::*;
+
+    struct Dummy;
+
+    #[async_trait]
+    impl ModelProvider for Dummy {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("dummy")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            Ok(stream::empty().boxed())
+        }
+    }
+
+    /// The returned stream must be `'static` — holdable after the provider it
+    /// came from is dropped, as the agent loop needs when the provider lives in
+    /// an `Arc<dyn ModelProvider>` registry.
+    #[test]
+    fn provider_stream_outlives_the_provider_borrow() {
+        let provider: Arc<dyn ModelProvider> = Arc::new(Dummy);
+        let stream = futures::executor::block_on(provider.stream(ChatRequest {
+            model: "m".into(),
+            system: None,
+            messages: vec![],
+            tools: vec![],
+            max_tokens: None,
+            temperature: None,
+        }))
+        .unwrap();
+        drop(provider);
+        // Holding the stream after dropping `provider` only compiles if it is
+        // `'static` and did not borrow `self`.
+        let _held: BoxStream<'static, ProviderEvent> = stream;
+    }
+
+    #[test]
+    fn content_block_tags_its_variant() {
+        let json = serde_json::to_value(ContentBlock::Text { text: "hi".into() }).unwrap();
+        assert_eq!(json["type"], "text");
+        assert_eq!(json["text"], "hi");
+    }
+
+    #[test]
+    fn chat_request_omits_empty_optionals() {
+        let req = ChatRequest {
+            model: "m".into(),
+            system: None,
+            messages: vec![ChatMessage::text(Role::User, "hello")],
+            tools: vec![],
+            max_tokens: None,
+            temperature: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("system"), "{json}");
+        assert!(!json.contains("tools"), "{json}");
+        assert!(!json.contains("max_tokens"), "{json}");
+    }
+
+    #[test]
+    fn usage_cache_fields_default_to_zero_and_roundtrip() {
+        // Absent cache fields (e.g. a provider that doesn't report caching)
+        // deserialize to zero.
+        let u: Usage = serde_json::from_str(r#"{"input_tokens":10,"output_tokens":5}"#).unwrap();
+        assert_eq!(u.cache_read_input_tokens, 0);
+        assert_eq!(u.cache_creation_input_tokens, 0);
+
+        let full = Usage {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: 100,
+            cache_creation_input_tokens: 20,
+        };
+        assert_eq!(
+            serde_json::from_str::<Usage>(&serde_json::to_string(&full).unwrap()).unwrap(),
+            full
+        );
+    }
+
+    #[test]
+    fn provider_event_roundtrips() {
+        let ev = ProviderEvent::Stop {
+            reason: StopReason::ToolUse,
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        assert_eq!(serde_json::from_str::<ProviderEvent>(&json).unwrap(), ev);
+    }
+}


### PR DESCRIPTION
The provider seam — one normalized vocabulary the loop and clients speak, so a provider's native wire format never leaks upward. The adapter's whole job is translating each API's streaming quirks into these types.

- **ProviderId** — stable adapter identifier (`anthropic`, `openai-compat`, …)
- **ContentBlock** (`text` / `tool_use` / `tool_result`) + **ChatMessage** — normalized, tag-per-variant message model so tool-calling round-trips across providers
- **ChatRequest** — model, system, messages, advertised tools, max_tokens, temperature (empty optionals skipped on the wire)
- **Usage** — cache-aware token accounting: fresh `input_tokens` + `cache_read_input_tokens` + `cache_creation_input_tokens`, so prompt-cache cost is legible; providers that don't report caching leave the cache fields at zero
- **StopReason**, **ProviderEvent** (`TextDelta` / `ReasoningDelta` / `ToolCallStarted` / `ToolCallArgsDelta` / `Usage` / `Stop`) — the streamed events adapters emit
- **ModelProvider** — async, object-safe; `stream() -> BoxStream<'static, ProviderEvent>` (the stream must not borrow `self`, so the loop can poll it while the provider lives behind `Arc<dyn ModelProvider>`)

The provider-vocabulary enums (`ContentBlock`, `StopReason`, `ProviderEvent`) are `#[non_exhaustive]` so provider quirks (e.g. a `refusal` stop, thinking/image content blocks) can be added later without breaking the published crate's API.

Adds `futures` to the workspace deps (`BoxStream`).

Verified: `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test -p openwave-core` (10 tests) all green.

---
The cache-token split and the `'static` stream + `#[non_exhaustive]` decisions are informed by studying alpha's provider layer (cross-provider token accounting; tool-call streaming). Deferred to the Anthropic-adapter slice (where the real API forces the exact shape): a thinking/`signature` content block for extended-thinking round-trips, and additional stop reasons (`refusal`, `pause_turn`).