### PR TITLE
docs: add a crates overview explaining the workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,21 @@ Requires the Rust toolchain declared in [`rust-toolchain.toml`](rust-toolchain.t
 ## Layout
 
 This is a single Cargo workspace. Libraries never depend on clients — the
-dependency graph only flows downward toward `openwave-core`.
+dependency graph only flows downward toward `openwave-core`. For a fuller
+walkthrough of each crate, see [`docs/crates.md`](docs/crates.md).
 
 | Crate | What it is |
 | --- | --- |
-| [`openwave-core`](crates/openwave-core) | agent loop, tools, providers, storage traits |
+| [`openwave-core`](crates/openwave-core) | agent loop, tools, event stream, storage traits |
 | [`openwave-connectors`](crates/openwave-connectors) | OAuth + source connectors |
 | [`openwave-retrieval`](crates/openwave-retrieval) | embeddings, vector search, citations |
 | [`openwave-mcp`](crates/openwave-mcp) | MCP server & client |
 | [`openwave-desktop`](crates/openwave-desktop) | desktop app (Tauri) |
 | [`openwave-cli`](crates/openwave-cli) | headless daemon + CLI |
 | [`openwave-slack`](crates/openwave-slack) | Slack adapter |
+
+_Model-provider adapters and routing/failover live in a planned `openwave-router`
+crate — see [`docs/crates.md`](docs/crates.md)._
 
 ## License
 

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -1,12 +1,17 @@
-//! OpenWave core — the agent loop, tool registry, provider adapters, and the
-//! `Store` / `BlobStore` / `SecretProvider` / `Auth` traits every client sits
-//! on.
+//! OpenWave core — the open-core seam every client sits on.
 //!
-//! This crate is the open-core seam: it must never depend on a specific client.
+//! Holds the agent loop, tool registry, the `AgentEvent` stream, and the trait
+//! contracts (`Tool`, `ModelProvider`, `Store`, `BlobStore`, `SecretProvider`)
+//! plus their default local impls. Concrete model-provider adapters live in
+//! `openwave-router`, not here.
 //!
-//! Landing incrementally with the M0 walking skeleton. This slice defines the
-//! foundational types — identifiers, the error type, and the persisted
-//! conversation model.
+//! This crate must never depend on a specific client, and is independently
+//! publishable on crates.io.
+//!
+//! Built incrementally with the M0 walking skeleton. Present so far: [`id`]
+//! (typed identifiers), [`error`], [`model`] (the persisted session/message
+//! model), [`tool`] (the tool contract), and [`provider`] (the model-provider
+//! contract).
 
 pub mod error;
 pub mod id;

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# OpenWave documentation
+
+Project documentation, versioned alongside the code.
+
+- [The crates](crates.md) — what each crate in the workspace is and does, and how
+  they fit together.
+
+More to come as the walking skeleton lands (architecture overview, running
+locally, the event stream and store, writing tools).
+
+For API-level docs, `cargo doc --open` renders the module documentation straight
+from the source.

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -1,0 +1,114 @@
+# The OpenWave crates
+
+OpenWave is a single Cargo workspace. It splits into **libraries** (reusable, and
+some independently publishable) and **client binaries** (the apps you run). The
+one rule that keeps it clean: **dependencies only flow downward toward
+`openwave-core`** — a library never depends on a client, and clients compose
+libraries.
+
+```
+      client binaries        openwave-desktop   openwave-cli   openwave-slack
+                                     │               │              │
+                                     └───────────────┼──────────────┘
+      libraries                    openwave-mcp  openwave-connectors  openwave-retrieval  openwave-router
+                                     └───────────────┴──────────────┴──────────────┘
+      the seam                                     openwave-core
+```
+
+**Status legend:** 🟢 in progress · 🔵 planned · ⚪ stub (scaffold only).
+
+---
+
+## `openwave-core` — the open-core seam 🟢
+
+The foundation every client (and, later, the Brightwave Connect control plane)
+sits on. It's independently publishable on crates.io and **never depends on a
+specific client**.
+
+It holds the agent loop, the tool registry, the `AgentEvent` stream that every
+client renders from, and the trait **contracts** — `Tool`, `ModelProvider`,
+`Store`, `BlobStore`, `SecretProvider` — together with their default local
+implementations (SQLite, the local filesystem, the OS keychain). Concrete
+model-provider adapters do **not** live here; they live in `openwave-router`.
+
+Present today:
+
+| Module | What it is |
+| --- | --- |
+| `id` | Typed identifiers (`SessionId`, `TurnId`, `CallId`, …) — newtypes so the compiler stops you mixing them up. |
+| `error` | The crate-wide `AgentError` + `Result`. |
+| `model` | The persisted conversation model (`Session`, `Message`, `Role`). |
+| `tool` | The tool contract (`Tool`, `ToolSpec`, `ToolOutput`, `ToolCtx`, `ApprovalClass`). |
+| `provider` | The model-provider contract (`ModelProvider`, `ChatRequest`, `ProviderEvent`, `Usage`). |
+
+**Depends on:** nothing in the workspace.
+
+---
+
+## `openwave-router` — model providers & routing 🔵
+
+Owns the concrete model-provider adapters (Anthropic, OpenAI, an
+OpenAI-compatible adapter that covers Fireworks / OpenRouter / vLLM / LM Studio,
+and more) plus a composite `Router`.
+
+The `Router` is itself a `ModelProvider`, so the agent loop just holds one
+provider and never knows whether it's a single backend, a failover pool, or a
+remote gateway. Two things define it:
+
+- **Two deployment modes, one crate.** It runs **embedded** (local-first, keys on
+  the device) or as a **central gateway service** (keys stay server-side; clients
+  and sandboxes call it over the network via a thin `RemoteProvider`).
+- **No default provider = fail-closed egress.** It calls no model until one is
+  explicitly configured *and* enabled — nothing leaves your machine by accident.
+
+Health-based failover (circuit breaker + retry) rounds it out.
+
+**Depends on:** `openwave-core`.
+
+---
+
+## `openwave-connectors` — OAuth & source connectors ⚪
+
+Loopback OAuth (RFC 8252 + PKCE), token refresh, and the connector tools that
+list and fetch from sources like Drive and Box.
+
+**Depends on:** `openwave-core`.
+
+## `openwave-retrieval` — embeddings, vector search, citations ⚪
+
+Embeddings, chunking, ingestion, and grounded citations behind a `VectorStore`
+seam that runs embedded (sqlite-vec) or against pgvector / Qdrant.
+
+**Depends on:** `openwave-core`.
+
+## `openwave-mcp` — the MCP face ⚪
+
+Both halves of [MCP](https://modelcontextprotocol.io): a **server** that exposes
+OpenWave's core tools to external agents (Claude Code, Codex, Cursor…), and a
+**client** that mounts external MCP tool servers into the agent, namespaced.
+
+**Depends on:** `openwave-core`.
+
+---
+
+## `openwave-desktop` — the desktop app ⚪
+
+The Tauri application: it compiles `openwave-core` in, hosts the chat UI, and
+talks to it over an in-process HTTP surface on an ephemeral local port. This is
+the primary way most people will run OpenWave.
+
+**Depends on:** `openwave-core` (+ Tauri).
+
+## `openwave-cli` — headless daemon + CLI ⚪
+
+The headless daemon (`openwave serve`) and a command-line client, over the same
+HTTP surface the desktop uses. For servers, scripts, and power users.
+
+**Depends on:** `openwave-core`.
+
+## `openwave-slack` — the Slack adapter ⚪
+
+A Socket Mode adapter (outbound WebSocket, no inbound ports) that drives the
+agent from a Slack workspace.
+
+**Depends on:** `openwave-core`.


### PR DESCRIPTION
Public, in-repo documentation that **explains the crates** — same place the code lives, versioned with it, reviewed in the same PR (GitHub's Wiki tab is a *separate* repo, so it's the one option that doesn't live with the code).

- **`docs/crates.md`** — a readable, per-crate walkthrough: purpose, what's inside, dependencies, and status (🟢 in progress / 🔵 planned / ⚪ stub), plus the "dependencies only flow down to `openwave-core`" layering rule and a small diagram.
- **`docs/README.md`** — a docs index to grow (architecture, running locally, the event stream & store, writing tools).
- **`README.md`** — links to `docs/crates.md`, fixes the `openwave-core` row (event stream, not provider adapters), and notes the planned `openwave-router` crate.
- **`openwave-core` module doc** — refreshed so `cargo doc` explains the crate accurately (trait contracts live here; adapters live in `openwave-router`).

Rendering: GitHub renders `docs/*.md` with navigation as-is; `cargo doc --open` renders the module docs from source. If we ever want a polished site, point GitHub Pages at the same `docs/` folder — source stays in-repo.

Verified: `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, and `RUSTDOCFLAGS="-D warnings" cargo doc` all clean.