### PR TITLE
feat(core): agent event stream

### DIFF
--- a/crates/openwave-core/src/error.rs
+++ b/crates/openwave-core/src/error.rs
@@ -5,6 +5,7 @@
 //! `#[non_exhaustive]` so growing it is never a breaking change for downstream
 //! matches.
 
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Shorthand for results across the core crate.
@@ -36,5 +37,64 @@ impl AgentError {
     /// Build an [`AgentError::Config`] from anything string-like.
     pub fn config(message: impl Into<String>) -> Self {
         Self::Config(message.into())
+    }
+
+    /// A short, stable machine-readable category for this error.
+    ///
+    /// Used to tag the serializable [`AgentErrorInfo`] that rides the event
+    /// stream, so clients can branch on the kind without parsing the message.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Config(_) => "config",
+            Self::Message(_) => "message",
+            Self::Serde(_) => "serde",
+        }
+    }
+
+    /// Convert into the serializable form carried by `AgentEvent::TurnFailed`.
+    pub fn to_info(&self) -> AgentErrorInfo {
+        AgentErrorInfo {
+            kind: self.kind().to_string(),
+            message: self.to_string(),
+        }
+    }
+}
+
+/// The wire-facing representation of an error.
+///
+/// [`AgentError`] itself is not `Serialize` (it wraps non-serializable source
+/// errors like [`serde_json::Error`]), but the `AgentEvent` stream that clients
+/// consume must serialize. `AgentErrorInfo` is that serializable projection: a
+/// stable `kind` plus a human-readable `message`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentErrorInfo {
+    /// Machine-readable category (see [`AgentError::kind`]).
+    pub kind: String,
+    /// Human-readable description.
+    pub message: String,
+}
+
+impl From<&AgentError> for AgentErrorInfo {
+    fn from(err: &AgentError) -> Self {
+        err.to_info()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_carries_kind_and_message() {
+        let info = AgentError::config("bad path").to_info();
+        assert_eq!(info.kind, "config");
+        assert_eq!(info.message, "configuration error: bad path");
+    }
+
+    #[test]
+    fn info_is_serializable_and_roundtrips() {
+        let info: AgentErrorInfo = (&AgentError::msg("boom")).into();
+        let json = serde_json::to_string(&info).unwrap();
+        assert_eq!(serde_json::from_str::<AgentErrorInfo>(&json).unwrap(), info);
     }
 }

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -1,0 +1,122 @@
+//! The agent event stream — the one contract every client consumes.
+//!
+//! A running turn emits [`AgentEvent`]s on a broadcast bus. The chat UI renders
+//! from this stream plus the persisted store — the desktop forwards it to the
+//! webview, the headless mode serves it over WebSocket, Slack renders coarse
+//! updates, the MCP face maps it to progress notifications. Because every surface
+//! reads the *same* stream, adding a client is mechanical.
+//!
+//! Every variant is serializable so it can cross a WebSocket to the UI. Note the
+//! failure case carries [`AgentErrorInfo`] (the serializable projection of
+//! [`AgentError`](crate::AgentError)), not the error type itself.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::AgentErrorInfo;
+use crate::id::{CallId, TurnId};
+use crate::provider::{StopReason, Usage};
+use crate::tool::{ApprovalClass, ToolOutput};
+
+/// One event in a turn's lifecycle, streamed to every client surface.
+///
+/// Serialized as an internally-tagged union (a `type` field selects the
+/// variant), and `#[non_exhaustive]` so new event kinds can be added without
+/// breaking downstream consumers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AgentEvent {
+    /// A new turn has begun.
+    TurnStarted {
+        /// The turn being processed.
+        turn_id: TurnId,
+    },
+    /// A chunk of assistant text.
+    TextDelta {
+        /// The text fragment to append.
+        text: String,
+    },
+    /// A chunk of reasoning/thinking text, where the provider exposes it.
+    ReasoningDelta {
+        /// The reasoning fragment.
+        text: String,
+    },
+    /// The model has begun a tool call; its name is known.
+    ToolCallStarted {
+        /// Correlates the following args deltas, approval, and result.
+        call_id: CallId,
+        /// The tool being called.
+        name: String,
+    },
+    /// A fragment of a tool call's JSON arguments.
+    ToolCallArgsDelta {
+        /// The call these args belong to.
+        call_id: CallId,
+        /// Partial JSON to concatenate.
+        fragment: String,
+    },
+    /// A tool call needs explicit approval before it can run; the turn parks
+    /// until an approval decision arrives.
+    ApprovalRequired {
+        /// The call awaiting a decision.
+        call_id: CallId,
+        /// The approval class that triggered the prompt.
+        class: ApprovalClass,
+        /// A short, human-readable summary of what will happen.
+        summary: String,
+    },
+    /// A tool call finished; its result is attached.
+    ToolCallCompleted {
+        /// The call that completed.
+        call_id: CallId,
+        /// The tool's output.
+        output: ToolOutput,
+    },
+    /// The turn finished successfully.
+    TurnCompleted {
+        /// Token accounting for the turn.
+        usage: Usage,
+        /// Why the final model call stopped.
+        stop_reason: StopReason,
+    },
+    /// The turn failed and was abandoned.
+    TurnFailed {
+        /// The serializable error description.
+        error: AgentErrorInfo,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::AgentError;
+
+    #[test]
+    fn event_is_internally_tagged() {
+        let ev = AgentEvent::TextDelta { text: "hi".into() };
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["type"], "text_delta");
+        assert_eq!(json["text"], "hi");
+    }
+
+    #[test]
+    fn turn_failed_carries_serializable_error() {
+        // The whole point of the DTO: an AgentEvent built from an AgentError
+        // (which is not itself Serialize) serializes and round-trips.
+        let ev = AgentEvent::TurnFailed {
+            error: (&AgentError::config("no provider")).into(),
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        assert_eq!(serde_json::from_str::<AgentEvent>(&json).unwrap(), ev);
+    }
+
+    #[test]
+    fn tool_call_completed_roundtrips() {
+        let ev = AgentEvent::ToolCallCompleted {
+            call_id: CallId::new(),
+            output: ToolOutput::text("done"),
+        };
+        let json = serde_json::to_string(&ev).unwrap();
+        assert_eq!(serde_json::from_str::<AgentEvent>(&json).unwrap(), ev);
+    }
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -14,12 +14,14 @@
 //! contract).
 
 pub mod error;
+pub mod event;
 pub mod id;
 pub mod model;
 pub mod provider;
 pub mod tool;
 
-pub use error::{AgentError, Result};
+pub use error::{AgentError, AgentErrorInfo, Result};
+pub use event::AgentEvent;
 pub use id::{CallId, MessageId, SessionId, StepId, TurnId};
 pub use model::{Message, Role, Session};
 pub use provider::{


### PR DESCRIPTION
The **one contract every client renders from**. A running turn emits `AgentEvent`s on a broadcast bus; the desktop webview, the headless WebSocket, Slack, and the MCP face all consume the *same* stream, which is what makes adding a client mechanical.

- **`event::AgentEvent`** — `TurnStarted` · `TextDelta` · `ReasoningDelta` · `ToolCallStarted` · `ToolCallArgsDelta` · `ApprovalRequired` · `ToolCallCompleted` · `TurnCompleted` · `TurnFailed`. Internally tagged (`type` field), `#[non_exhaustive]`, and fully serializable so it can cross a WebSocket to the UI. Builds on the already-merged id / tool / provider contracts.
- **`error::AgentErrorInfo`** — resolves the deferred question of how a failed turn crosses the wire. `AgentError` isn't `Serialize` (it wraps sources like `serde_json::Error`), so `TurnFailed` carries this serializable projection: a stable `kind` + human `message`. Adds `AgentError::kind()` / `to_info()` and `From<&AgentError>`.

Verified: `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test -p openwave-core` (**15 tests**), and `RUSTDOCFLAGS="-D warnings" cargo doc` all clean.

---
This completes the core contract trio (tool → provider → event). Next slice: the storage traits (`Store` / `SecretProvider` / `BlobStore`).