### PR TITLE
feat(core): storage trait signatures

### DIFF
--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod event;
 pub mod id;
 pub mod model;
 pub mod provider;
+pub mod storage;
 pub mod tool;
 
 pub use error::{AgentError, AgentErrorInfo, Result};
@@ -28,4 +29,5 @@ pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
     Usage,
 };
+pub use storage::{BlobStore, SecretProvider, Store};
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1,0 +1,151 @@
+//! The storage seams every client sits on.
+//!
+//! Three traits, deliberately backend-agnostic so a profile can wire different
+//! implementations without touching callers:
+//!
+//! - [`Store`] — durable metadata/state (sessions, messages, settings). The
+//!   default impl is SQLite; the same trait maps to Postgres for self-host.
+//! - [`SecretProvider`] — credentials (model API keys, connection tokens). These
+//!   live in the OS keychain (desktop) or a KMS/Vault (server) and are **never**
+//!   written to the [`Store`]; the store only holds opaque secret references.
+//! - [`BlobStore`] — bytes (documents, images, exports), served locally or from
+//!   object storage.
+//!
+//! Only the entities that exist today are modeled here. Persistence for tool
+//! calls, connections, documents, and skills is added alongside the slices that
+//! introduce those record types.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::error::Result;
+use crate::id::SessionId;
+use crate::model::{Message, Session};
+
+/// Durable metadata and conversation state.
+///
+/// Implementations must be safe to share across threads (`Send + Sync`) and are
+/// held behind `Arc<dyn Store>`, so this trait stays object-safe.
+#[async_trait]
+pub trait Store: Send + Sync {
+    /// Persist a new session.
+    async fn create_session(&self, session: &Session) -> Result<()>;
+
+    /// Fetch a session by id, or `None` if it doesn't exist.
+    async fn get_session(&self, id: SessionId) -> Result<Option<Session>>;
+
+    /// List sessions, most-recently-created first.
+    async fn list_sessions(&self) -> Result<Vec<Session>>;
+
+    /// Append a message to its session.
+    async fn append_message(&self, message: &Message) -> Result<()>;
+
+    /// List a session's messages in creation order.
+    async fn list_messages(&self, session_id: SessionId) -> Result<Vec<Message>>;
+
+    /// Read a setting (profile, model prefs, approval policy), or `None`.
+    async fn get_setting(&self, key: &str) -> Result<Option<Value>>;
+
+    /// Write a setting.
+    async fn set_setting(&self, key: &str, value: &Value) -> Result<()>;
+}
+
+/// Credential custody: secrets keyed by a stable reference string (e.g.
+/// `provider.anthropic.api_key`). Backed by the OS keychain on desktop, a
+/// KMS/Vault on a server — never the [`Store`].
+#[async_trait]
+pub trait SecretProvider: Send + Sync {
+    /// Fetch a secret by key, or `None` if unset.
+    async fn get_secret(&self, key: &str) -> Result<Option<String>>;
+
+    /// Store (or overwrite) a secret.
+    async fn set_secret(&self, key: &str, value: &str) -> Result<()>;
+
+    /// Remove a secret; a no-op if it doesn't exist.
+    async fn delete_secret(&self, key: &str) -> Result<()>;
+}
+
+/// Opaque byte storage for documents, images, and exports.
+#[async_trait]
+pub trait BlobStore: Send + Sync {
+    /// Store bytes under `id`, overwriting any existing blob.
+    async fn put(&self, id: &str, bytes: Vec<u8>) -> Result<()>;
+
+    /// Fetch bytes by `id`, or `None` if absent.
+    async fn get(&self, id: &str) -> Result<Option<Vec<u8>>>;
+
+    /// Delete a blob; a no-op if it doesn't exist.
+    async fn delete(&self, id: &str) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use futures::executor::block_on;
+
+    use super::*;
+
+    /// Minimal in-memory `Store` — proves the trait is object-safe and usable
+    /// behind `Arc<dyn Store>`, and exercises the signatures.
+    #[derive(Default)]
+    struct MemStore {
+        sessions: Mutex<HashMap<SessionId, Session>>,
+        settings: Mutex<HashMap<String, Value>>,
+    }
+
+    #[async_trait]
+    impl Store for MemStore {
+        async fn create_session(&self, session: &Session) -> Result<()> {
+            self.sessions
+                .lock()
+                .unwrap()
+                .insert(session.id, session.clone());
+            Ok(())
+        }
+        async fn get_session(&self, id: SessionId) -> Result<Option<Session>> {
+            Ok(self.sessions.lock().unwrap().get(&id).cloned())
+        }
+        async fn list_sessions(&self) -> Result<Vec<Session>> {
+            Ok(self.sessions.lock().unwrap().values().cloned().collect())
+        }
+        async fn append_message(&self, _message: &Message) -> Result<()> {
+            Ok(())
+        }
+        async fn list_messages(&self, _session_id: SessionId) -> Result<Vec<Message>> {
+            Ok(vec![])
+        }
+        async fn get_setting(&self, key: &str) -> Result<Option<Value>> {
+            Ok(self.settings.lock().unwrap().get(key).cloned())
+        }
+        async fn set_setting(&self, key: &str, value: &Value) -> Result<()> {
+            self.settings
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.clone());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn store_is_object_safe_and_roundtrips() {
+        let store: Arc<dyn Store> = Arc::new(MemStore::default());
+        let session = Session {
+            id: SessionId::new(),
+            title: None,
+            workspace_dir: "/tmp/ws".into(),
+            created_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
+        };
+        block_on(store.create_session(&session)).unwrap();
+        let fetched = block_on(store.get_session(session.id)).unwrap();
+        assert_eq!(fetched.as_ref(), Some(&session));
+
+        block_on(store.set_setting("model", &serde_json::json!("claude"))).unwrap();
+        assert_eq!(
+            block_on(store.get_setting("model")).unwrap(),
+            Some(serde_json::json!("claude"))
+        );
+    }
+}


### PR DESCRIPTION
The backend-agnostic storage seams every client sits on — **signatures only**; the SQLite / keychain / local-FS implementations land in later slices.

- **`Store`** — durable metadata/state: sessions, messages, and a settings KV. Object-safe (`Arc<dyn Store>`); the default impl will be SQLite, and the same trait maps to Postgres for self-host.
- **`SecretProvider`** — credential custody keyed by a stable ref string (e.g. `provider.anthropic.api_key`); OS keychain on desktop, KMS/Vault on a server. Secrets **never** touch the `Store` — it only holds opaque references.
- **`BlobStore`** — opaque byte storage for documents / images / exports.

Scoped to today's entities (`Session`, `Message`, settings). Persistence for tool calls, connections, documents, and skills is added alongside the slices that introduce those record types (grow-as-producers-land). `Auth` stays out — M0 desktop is single-user.

Includes a minimal in-memory `Store` test proving the trait is object-safe and the signatures round-trip.

Verified: `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test -p openwave-core` (**16 tests**), `RUSTDOCFLAGS="-D warnings" cargo doc` all clean.

---
This is the last of the pure contracts. Next: the first **implementation** — the SQLite `Store` (sqlx + migrations, schema v1).