### PR TITLE
feat(providers): Anthropic provider in new openwave-router crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -350,6 +350,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +430,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -854,8 +874,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -865,8 +887,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -950,6 +975,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1117,6 +1240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,6 +1360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,7 +1469,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1437,6 +1572,20 @@ version = "0.0.0"
 [[package]]
 name = "openwave-retrieval"
 version = "0.0.0"
+
+[[package]]
+name = "openwave-router"
+version = "0.0.0"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "futures",
+ "openwave-core",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "openwave-slack"
@@ -1680,6 +1829,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,7 +1907,18 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1712,7 +1928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1722,6 +1938,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1772,6 +2003,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,7 +2070,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -1816,6 +2088,12 @@ dependencies = [
  "serde",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1859,6 +2137,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2059,7 +2338,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "sha2",
  "zbus",
@@ -2180,7 +2459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2191,7 +2470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2227,7 +2506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2393,7 +2672,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2433,7 +2712,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -2516,6 +2795,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -2655,12 +2943,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -2694,6 +3005,51 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2741,6 +3097,12 @@ dependencies = [
  "tracing",
  "tracing-core",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -2841,6 +3203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,6 +3235,16 @@ dependencies = [
  "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2896,6 +3277,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3316,7 +3730,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_repr",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,5 @@ chrono = { version = "0.4", features = ["serde"] }
 sea-orm = { version = "1", default-features = false, features = ["macros", "runtime-tokio-rustls", "sqlx-sqlite", "with-uuid", "with-chrono", "with-json"] }
 sea-orm-migration = { version = "1", default-features = false, features = ["runtime-tokio-rustls", "sqlx-sqlite"] }
 tokio = { version = "1", features = ["rt", "macros"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+async-stream = "0.3"

--- a/crates/openwave-core/src/error.rs
+++ b/crates/openwave-core/src/error.rs
@@ -27,6 +27,10 @@ pub enum AgentError {
     #[error("secret error: {0}")]
     Secret(String),
 
+    /// A failure from a model provider (network, HTTP status, malformed stream).
+    #[error("provider error: {0}")]
+    Provider(String),
+
     /// A catch-all for contexts that do not yet warrant their own variant.
     #[error("{0}")]
     Message(String),
@@ -56,6 +60,7 @@ impl AgentError {
             Self::Config(_) => "config",
             Self::Store(_) => "store",
             Self::Secret(_) => "secret",
+            Self::Provider(_) => "provider",
             Self::Message(_) => "message",
             Self::Serde(_) => "serde",
         }

--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "openwave-router"
+description = "OpenWave model routing: provider adapters and (later) the composite Router."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["anthropic"]
+# The Anthropic (Messages API) provider adapter.
+anthropic = ["dep:reqwest", "dep:async-stream"]
+
+[dependencies]
+openwave-core = { path = "../openwave-core", default-features = false }
+async-trait = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true, optional = true }
+async-stream = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -1,0 +1,461 @@
+//! The Anthropic provider — the Messages API, normalized to `ProviderEvent`.
+//!
+//! Talks the native Anthropic Messages format (so extended-thinking and
+//! cache-token usage survive), streams Server-Sent Events, and maps each event
+//! into the shared [`ProviderEvent`] vocabulary. Pointing `base_url` at a gateway
+//! (e.g. agentgateway's native Messages route) is a drop-in for the enterprise
+//! path.
+
+use async_trait::async_trait;
+use futures::stream::{BoxStream, StreamExt};
+use serde_json::{json, Value};
+
+use openwave_core::error::{AgentError, Result};
+use openwave_core::provider::{
+    ChatRequest, ModelProvider, ProviderEvent, ProviderId, StopReason, Usage,
+};
+use openwave_core::Role;
+
+const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+fn provider_err(err: impl std::fmt::Display) -> AgentError {
+    AgentError::Provider(err.to_string())
+}
+
+/// A [`ModelProvider`] for Anthropic's Messages API.
+#[derive(Clone)]
+pub struct AnthropicProvider {
+    client: reqwest::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl AnthropicProvider {
+    /// Build a provider with the given API key, hitting api.anthropic.com.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key: api_key.into(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+        }
+    }
+
+    /// Override the base URL — e.g. to route through a gateway that speaks the
+    /// native Messages API.
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+}
+
+#[async_trait]
+impl ModelProvider for AnthropicProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("anthropic")
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let body = build_request_json(&req)?;
+        let url = format!("{}/v1/messages", self.base_url);
+
+        // Setup failures (connection, auth, 4xx/5xx) surface here as `Err` so the
+        // router can classify and fail over; the returned stream only yields
+        // normalized events.
+        let response = self
+            .client
+            .post(url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(provider_err)?;
+
+        // Surface non-2xx with the provider's error body (the Router needs the
+        // body to classify rate-limit vs auth vs bad-request).
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AgentError::Provider(format!(
+                "anthropic returned {status}: {body}"
+            )));
+        }
+
+        let stream = async_stream::stream! {
+            let mut bytes = response.bytes_stream();
+            // Accumulate raw BYTES, not a String: a chunk may split a multi-byte
+            // UTF-8 character, so we only decode once a whole frame is buffered.
+            let mut buffer: Vec<u8> = Vec::new();
+            let mut state = StreamState::default();
+            while let Some(chunk) = bytes.next().await {
+                let Ok(chunk) = chunk else { break }; // mid-stream transport error: end
+                buffer.extend_from_slice(&chunk);
+                for frame in drain_frames(&mut buffer) {
+                    if let Some(data) = frame_data(&frame) {
+                        for event in normalize(&data, &mut state) {
+                            yield event;
+                        }
+                    }
+                }
+            }
+            // Flush a final frame that wasn't terminated by a blank line.
+            if !buffer.is_empty() {
+                let frame = String::from_utf8_lossy(&buffer).into_owned();
+                if let Some(data) = frame_data(&frame) {
+                    for event in normalize(&data, &mut state) {
+                        yield event;
+                    }
+                }
+            }
+        };
+        Ok(Box::pin(stream))
+    }
+}
+
+/// Build the Anthropic request body from a normalized [`ChatRequest`].
+///
+/// Our [`ContentBlock`](openwave_core::ContentBlock) serialization already
+/// matches Anthropic's content-block shape, so message content passes through
+/// as-is; the system prompt becomes a top-level field, and only `user`/
+/// `assistant` roles are valid on messages.
+fn build_request_json(req: &ChatRequest) -> Result<Value> {
+    let messages = req
+        .messages
+        .iter()
+        .map(|message| {
+            Ok(json!({
+                "role": anthropic_role(message.role),
+                "content": serde_json::to_value(&message.content)?,
+            }))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut body = json!({
+        "model": req.model,
+        "max_tokens": req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+        "messages": messages,
+        "stream": true,
+    });
+
+    if let Some(system) = &req.system {
+        body["system"] = json!(system);
+    }
+    if !req.tools.is_empty() {
+        body["tools"] = Value::Array(
+            req.tools
+                .iter()
+                .map(|tool| {
+                    json!({
+                        "name": tool.name,
+                        "description": tool.description,
+                        "input_schema": tool.input_schema,
+                    })
+                })
+                .collect(),
+        );
+    }
+    if let Some(temperature) = req.temperature {
+        body["temperature"] = json!(temperature);
+    }
+    Ok(body)
+}
+
+fn anthropic_role(role: Role) -> &'static str {
+    // Anthropic messages carry only user/assistant; the system prompt is a
+    // top-level field and tool results ride inside user messages.
+    match role {
+        Role::Assistant => "assistant",
+        _ => "user",
+    }
+}
+
+/// Prompt-cache-aware token counts accumulated across a stream.
+#[derive(Default)]
+struct StreamState {
+    input_tokens: u32,
+    cache_read_input_tokens: u32,
+    cache_creation_input_tokens: u32,
+}
+
+/// Naive byte-substring search.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Drain all complete SSE frames from `buffer`, returning each frame's decoded
+/// text and leaving any incomplete trailing bytes behind.
+///
+/// Frames are separated by a blank line (`\n\n` or `\r\n\r\n`). Decoding to UTF-8
+/// happens only on a complete frame, so a multi-byte character split across
+/// network chunks is never decoded until all its bytes have arrived.
+fn drain_frames(buffer: &mut Vec<u8>) -> Vec<String> {
+    let mut frames = Vec::new();
+    loop {
+        let lf = find_subslice(buffer, b"\n\n");
+        let crlf = find_subslice(buffer, b"\r\n\r\n");
+        let (content_end, consume_to) = match (lf, crlf) {
+            (Some(i), Some(j)) => {
+                if i <= j {
+                    (i, i + 2)
+                } else {
+                    (j, j + 4)
+                }
+            }
+            (Some(i), None) => (i, i + 2),
+            (None, Some(j)) => (j, j + 4),
+            (None, None) => break,
+        };
+        frames.push(String::from_utf8_lossy(&buffer[..content_end]).into_owned());
+        buffer.drain(..consume_to);
+    }
+    frames
+}
+
+/// Extract and parse the `data:` JSON payload from one SSE frame.
+fn frame_data(frame: &str) -> Option<Value> {
+    let mut data = String::new();
+    for line in frame.lines() {
+        if let Some(rest) = line.strip_prefix("data:") {
+            data.push_str(rest.trim_start());
+        }
+    }
+    if data.is_empty() {
+        return None;
+    }
+    serde_json::from_str(&data).ok()
+}
+
+fn u32_at(value: &Value, key: &str) -> u32 {
+    value.get(key).and_then(Value::as_u64).unwrap_or(0) as u32
+}
+
+/// Map one parsed Anthropic stream event into zero or more `ProviderEvent`s.
+fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
+    match data.get("type").and_then(Value::as_str) {
+        Some("message_start") => {
+            if let Some(usage) = data.get("message").and_then(|m| m.get("usage")) {
+                state.input_tokens = u32_at(usage, "input_tokens");
+                state.cache_read_input_tokens = u32_at(usage, "cache_read_input_tokens");
+                state.cache_creation_input_tokens = u32_at(usage, "cache_creation_input_tokens");
+            }
+            Vec::new()
+        }
+        Some("content_block_start") => {
+            let index = u32_at(data, "index");
+            let block = data.get("content_block");
+            if block.and_then(|b| b.get("type")).and_then(Value::as_str) == Some("tool_use") {
+                let block = block.unwrap();
+                vec![ProviderEvent::ToolCallStarted {
+                    index,
+                    id: str_at(block, "id"),
+                    name: str_at(block, "name"),
+                }]
+            } else {
+                Vec::new()
+            }
+        }
+        Some("content_block_delta") => {
+            let index = u32_at(data, "index");
+            let delta = match data.get("delta") {
+                Some(delta) => delta,
+                None => return Vec::new(),
+            };
+            match delta.get("type").and_then(Value::as_str) {
+                Some("text_delta") => vec![ProviderEvent::TextDelta {
+                    text: str_at(delta, "text"),
+                }],
+                Some("thinking_delta") => vec![ProviderEvent::ReasoningDelta {
+                    text: str_at(delta, "thinking"),
+                }],
+                Some("input_json_delta") => vec![ProviderEvent::ToolCallArgsDelta {
+                    index,
+                    fragment: str_at(delta, "partial_json"),
+                }],
+                _ => Vec::new(),
+            }
+        }
+        Some("message_delta") => {
+            let mut events = Vec::new();
+            if let Some(usage) = data.get("usage") {
+                events.push(ProviderEvent::Usage(Usage {
+                    input_tokens: state.input_tokens,
+                    output_tokens: u32_at(usage, "output_tokens"),
+                    cache_read_input_tokens: state.cache_read_input_tokens,
+                    cache_creation_input_tokens: state.cache_creation_input_tokens,
+                }));
+            }
+            if let Some(reason) = data
+                .get("delta")
+                .and_then(|d| d.get("stop_reason"))
+                .and_then(Value::as_str)
+            {
+                events.push(ProviderEvent::Stop {
+                    reason: map_stop_reason(reason),
+                });
+            }
+            events
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn str_at(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn map_stop_reason(reason: &str) -> StopReason {
+    match reason {
+        "max_tokens" => StopReason::MaxTokens,
+        "tool_use" => StopReason::ToolUse,
+        "stop_sequence" => StopReason::StopSequence,
+        // "end_turn" and anything we don't yet model (e.g. refusal, pause_turn)
+        // fall back to a clean end.
+        _ => StopReason::EndTurn,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::provider::ChatMessage;
+    use openwave_core::tool::ToolSpec;
+
+    #[test]
+    fn request_maps_system_messages_and_tools() {
+        let req = ChatRequest {
+            model: "claude-opus-4-8".into(),
+            system: Some("be brief".into()),
+            messages: vec![ChatMessage::text(Role::User, "hi")],
+            tools: vec![ToolSpec {
+                name: "read_file".into(),
+                description: "read a file".into(),
+                input_schema: json!({"type": "object"}),
+            }],
+            max_tokens: None,
+            temperature: Some(0.5),
+        };
+        let body = build_request_json(&req).unwrap();
+        assert_eq!(body["model"], "claude-opus-4-8");
+        assert_eq!(body["max_tokens"], DEFAULT_MAX_TOKENS);
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["system"], "be brief");
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"][0]["type"], "text");
+        assert_eq!(body["tools"][0]["name"], "read_file");
+        assert_eq!(body["temperature"], 0.5);
+    }
+
+    fn run(events: &[Value]) -> Vec<ProviderEvent> {
+        let mut state = StreamState::default();
+        events
+            .iter()
+            .flat_map(|e| normalize(e, &mut state))
+            .collect()
+    }
+
+    #[test]
+    fn normalizes_text_and_usage_and_stop() {
+        let out = run(&[
+            json!({"type": "message_start", "message": {"usage": {"input_tokens": 10, "cache_read_input_tokens": 4}}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "he"}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "llo"}}),
+            json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 7}}),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                ProviderEvent::TextDelta { text: "he".into() },
+                ProviderEvent::TextDelta { text: "llo".into() },
+                ProviderEvent::Usage(Usage {
+                    input_tokens: 10,
+                    output_tokens: 7,
+                    cache_read_input_tokens: 4,
+                    cache_creation_input_tokens: 0,
+                }),
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn normalizes_tool_call_and_reasoning() {
+        let out = run(&[
+            json!({"type": "content_block_start", "index": 1, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "read_file"}}),
+            json!({"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": "{\"path\":"}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "hmm"}}),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 1,
+                    id: "toolu_1".into(),
+                    name: "read_file".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 1,
+                    fragment: "{\"path\":".into(),
+                },
+                ProviderEvent::ReasoningDelta { text: "hmm".into() },
+            ]
+        );
+    }
+
+    #[test]
+    fn drain_frames_handles_lf_crlf_and_partial_tail() {
+        // LF-separated, plus a partial trailing frame left in the buffer.
+        let mut buf = b"data: {\"a\":1}\n\ndata: partial".to_vec();
+        let frames = drain_frames(&mut buf);
+        assert_eq!(frames.len(), 1);
+        assert!(frames[0].contains("{\"a\":1}"));
+        assert_eq!(buf, b"data: partial");
+
+        // CRLF-separated frame.
+        let mut buf = b"event: x\r\ndata: {\"b\":2}\r\n\r\n".to_vec();
+        let frames = drain_frames(&mut buf);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frame_data(&frames[0]).unwrap()["b"], 2);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn multibyte_char_split_across_chunks_is_not_corrupted() {
+        // The é in "café" is two bytes (0xC3 0xA9); split the buffer between them
+        // to mimic a network chunk boundary landing mid-character.
+        let full = "data: {\"t\":\"café\"}\n\n".as_bytes().to_vec();
+        let split = full.iter().position(|&b| b == 0xC3).unwrap() + 1;
+        let (head, tail) = full.split_at(split);
+
+        let mut buf = head.to_vec();
+        assert!(drain_frames(&mut buf).is_empty(), "no complete frame yet");
+        buf.extend_from_slice(tail);
+        let frames = drain_frames(&mut buf);
+        assert_eq!(frames.len(), 1);
+        // Would be "caf\u{fffd}\u{fffd}" if we had decoded the partial chunk.
+        assert_eq!(frame_data(&frames[0]).unwrap()["t"], "café");
+    }
+
+    #[test]
+    fn frame_data_extracts_json_and_maps_stop_reasons() {
+        let data = frame_data("event: message_stop\ndata: {\"type\":\"message_stop\"}").unwrap();
+        assert_eq!(data["type"], "message_stop");
+        assert!(frame_data("event: ping").is_none());
+
+        assert_eq!(map_stop_reason("tool_use"), StopReason::ToolUse);
+        assert_eq!(map_stop_reason("max_tokens"), StopReason::MaxTokens);
+        assert_eq!(map_stop_reason("refusal"), StopReason::EndTurn);
+    }
+}

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -1,0 +1,16 @@
+//! OpenWave model routing.
+//!
+//! Home of the concrete [`ModelProvider`](openwave_core::ModelProvider) adapters
+//! (and, later, the composite `Router` that does config-gated selection and
+//! health-based failover). Each adapter's job is to normalize one provider's
+//! streaming quirks into the shared
+//! [`ProviderEvent`](openwave_core::ProviderEvent) vocabulary.
+//!
+//! The `ModelProvider` contract itself lives in `openwave-core`; only the
+//! implementations live here.
+
+#[cfg(feature = "anthropic")]
+pub mod anthropic;
+
+#[cfg(feature = "anthropic")]
+pub use anthropic::AnthropicProvider;


### PR DESCRIPTION
_Replaces #11, which GitHub auto-closed when its base branch was deleted during the #10 merge. Same branch/content, rebased onto `main`._

The first model-provider adapter, and the **`openwave-router`** crate it lives in. Depends on `openwave-core`'s contracts only (`default-features = false`).

- **`AnthropicProvider`** — `ModelProvider` over Anthropic's native Messages API; streams SSE → `ProviderEvent`. `with_base_url()` points it at a gateway (e.g. agentgateway).
- **Streaming robustness (from review):** raw-byte buffering so multi-byte UTF-8 split across chunks isn't corrupted; frames split on `\n\n`/`\r\n\r\n`; trailing-frame flush; non-2xx surfaces the provider's error body as `Err`. Pure unit-tested core (`build_request_json`, `drain_frames` incl. split-`café` regression, `normalize`).
- **`AgentError::Provider`** added.

CI green; verified `fmt`/`clippy -D warnings`/`test`/`--locked`.