### PR TITLE
feat(server): in-process HTTP surface — session CRUD + bearer auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,6 +1686,7 @@ dependencies = [
  "axum",
  "chrono",
  "openwave-core",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +571,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dbus"
@@ -882,6 +943,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -889,7 +962,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -1017,6 +1090,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1108,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1386,6 +1466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1495,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -1585,6 +1677,21 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "openwave-server"
+version = "0.0.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "openwave-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tower",
+ "uuid",
 ]
 
 [[package]]
@@ -1895,6 +2002,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1906,8 +2019,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1932,12 +2055,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2427,6 +2569,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2964,6 +3117,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,6 +3184,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3103,6 +3269,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror",
+]
 
 [[package]]
 name = "typenum"
@@ -3216,6 +3398,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasite"
@@ -3660,6 +3851,12 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ sea-orm-migration = { version = "1", default-features = false, features = ["runt
 tokio = { version = "1", features = ["rt", "macros", "fs"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 async-stream = "0.3"
+axum = { version = "0.8", features = ["ws"] }

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "openwave-server"
+description = "OpenWave in-process HTTP/WebSocket surface: the local API the desktop and CLI clients drive the agent through."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite"] }
+axum = { workspace = true }
+tokio = { workspace = true, features = ["net"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }
+tower = { version = "0.5", features = ["util"] }
+tempfile = "3"

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -20,6 +20,7 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tower = { version = "0.5", features = ["util"] }
+reqwest = { workspace = true }
 tempfile = "3"

--- a/crates/openwave-server/src/auth.rs
+++ b/crates/openwave-server/src/auth.rs
@@ -1,0 +1,46 @@
+//! Bearer-token authentication for the local API.
+//!
+//! The server binds to loopback with a per-launch token (see [`AppState`]); a
+//! middleware layer rejects any request that doesn't present it. It's the one
+//! thing standing between the agent and any other local process that finds the
+//! port, so the check is mandatory on every non-health route.
+
+use axum::extract::{Request, State};
+use axum::http::{header::AUTHORIZATION, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+
+use crate::state::AppState;
+
+/// Reject requests without a valid `Authorization: Bearer <token>` header.
+pub async fn require_token(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let presented = request
+        .headers()
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "));
+
+    match presented {
+        Some(token) if constant_time_eq(token.as_bytes(), state.token.as_bytes()) => {
+            next.run(request).await
+        }
+        _ => StatusCode::UNAUTHORIZED.into_response(),
+    }
+}
+
+/// Compare two byte strings without an early-out, so a caller can't learn the
+/// token prefix-by-prefix from response timing.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}

--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -1,0 +1,48 @@
+//! The HTTP error type.
+//!
+//! Handlers return `Result<_, ServerError>`; a [`ServerError`] carries an HTTP
+//! status plus the serializable [`AgentErrorInfo`] (the same error projection the
+//! event stream uses), so a failed request answers with a stable
+//! `{ "kind", "message" }` body a client can branch on.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+
+use openwave_core::{AgentError, AgentErrorInfo};
+
+/// An HTTP-facing error: a status code and a serializable description.
+pub struct ServerError {
+    status: StatusCode,
+    info: AgentErrorInfo,
+}
+
+impl ServerError {
+    /// A `404 Not Found` for a missing resource.
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            info: AgentErrorInfo {
+                kind: "not_found".to_string(),
+                message: message.into(),
+            },
+        }
+    }
+}
+
+/// Core errors surfacing from a handler are internal failures (a store write
+/// failed, a provider errored); map them to `500` with their info preserved.
+impl From<AgentError> for ServerError {
+    fn from(err: AgentError) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            info: (&err).into(),
+        }
+    }
+}
+
+impl IntoResponse for ServerError {
+    fn into_response(self) -> Response {
+        (self.status, Json(self.info)).into_response()
+    }
+}

--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -28,6 +28,20 @@ impl ServerError {
             },
         }
     }
+
+    /// A `400 Bad Request` for a malformed request (bad path segment, or an
+    /// unparseable / wrong-typed / wrong-content-type body). Used to map axum's
+    /// built-in extractor rejections into the same `{ kind, message }` shape as
+    /// every other error, so a client can always parse the body as JSON.
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            info: AgentErrorInfo {
+                kind: "bad_request".to_string(),
+                message: message.into(),
+            },
+        }
+    }
 }
 
 /// Core errors surfacing from a handler are internal failures (a store write

--- a/crates/openwave-server/src/extract.rs
+++ b/crates/openwave-server/src/extract.rs
@@ -1,0 +1,61 @@
+//! Request extractors that map axum's built-in rejections into [`ServerError`].
+//!
+//! axum's stock `Json`/`Path` reject a malformed request with a plain-text body
+//! and a bare status. These thin wrappers delegate to them but convert any
+//! rejection into a `ServerError`, so *every* failure — bad path segment,
+//! unparseable body, wrong/absent `Content-Type` — answers with the same
+//! `{ kind, message }` JSON a client can always parse.
+
+use axum::extract::rejection::{JsonRejection, PathRejection};
+use axum::extract::{FromRequest, FromRequestParts, Request};
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::error::ServerError;
+
+/// Like [`axum::Json`], but a parse or content-type failure becomes a `400` with
+/// a JSON `{ kind, message }` body. Also serializes as a JSON response body, so
+/// handlers use this one type for both request and response.
+pub struct Json<T>(pub T);
+
+impl<T, S> FromRequest<S> for Json<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ServerError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let axum::Json(value) = axum::Json::<T>::from_request(req, state)
+            .await
+            .map_err(|rejection: JsonRejection| ServerError::bad_request(rejection.body_text()))?;
+        Ok(Self(value))
+    }
+}
+
+impl<T: Serialize> IntoResponse for Json<T> {
+    fn into_response(self) -> Response {
+        axum::Json(self.0).into_response()
+    }
+}
+
+/// Like [`axum::extract::Path`], but an unparseable path segment (e.g. a
+/// non-UUID id) becomes a `400` with a JSON `{ kind, message }` body.
+pub struct Path<T>(pub T);
+
+impl<T, S> FromRequestParts<S> for Path<T>
+where
+    T: DeserializeOwned + Send,
+    S: Send + Sync,
+{
+    type Rejection = ServerError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let axum::extract::Path(value) = axum::extract::Path::<T>::from_request_parts(parts, state)
+            .await
+            .map_err(|rejection: PathRejection| ServerError::bad_request(rejection.body_text()))?;
+        Ok(Self(value))
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod auth;
 mod error;
+mod extract;
 mod routes;
 mod state;
 
@@ -125,7 +126,7 @@ mod tests {
 
     use axum::body::{to_bytes, Body};
     use axum::http::{header, Request, StatusCode};
-    use openwave_core::{Session, SessionId};
+    use openwave_core::{AgentErrorInfo, Profile, Session, SessionId};
     use serde::de::DeserializeOwned;
     use tower::ServiceExt;
 
@@ -275,5 +276,91 @@ mod tests {
         let server = bind(Config::desktop(dir.path())).await.unwrap();
         assert!(server.local_addr().ip().is_loopback());
         assert!(!server.token().is_empty());
+    }
+
+    #[tokio::test]
+    async fn malformed_requests_get_json_errors_not_plaintext() {
+        let (router, token, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+
+        // A non-UUID path segment: 400 with a parseable `{ kind, message }` body,
+        // not axum's default plain-text rejection.
+        let bad_path = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/sessions/not-a-uuid")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(bad_path.status(), StatusCode::BAD_REQUEST);
+        let info: AgentErrorInfo = json_body(bad_path).await;
+        assert_eq!(info.kind, "bad_request");
+
+        // A body with no `Content-Type: application/json`: also a JSON 400.
+        let no_content_type = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sessions")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::from(r#"{"workspace_dir":"/tmp/ws"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(no_content_type.status(), StatusCode::BAD_REQUEST);
+        let info: AgentErrorInfo = json_body(no_content_type).await;
+        assert_eq!(info.kind, "bad_request");
+    }
+
+    #[tokio::test]
+    async fn self_host_profile_is_not_yet_supported() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = Config {
+            profile: Profile::SelfHost,
+            data_dir: dir.path().to_path_buf(),
+        };
+        assert!(bind(config).await.is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn serve_answers_over_a_real_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = bind(Config::desktop(dir.path())).await.unwrap();
+        let addr = server.local_addr();
+        let token = server.token().to_string();
+        // The listener is already bound, so connections queue immediately; drive
+        // the accept loop in the background for the duration of the test.
+        tokio::spawn(async move {
+            let _ = server.serve().await;
+        });
+
+        let client = reqwest::Client::new();
+        let health = client
+            .get(format!("http://{addr}/healthz"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(health.status(), reqwest::StatusCode::OK);
+
+        let unauthed = client
+            .get(format!("http://{addr}/sessions"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(unauthed.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+        let authed = client
+            .get(format!("http://{addr}/sessions"))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(authed.status(), reqwest::StatusCode::OK);
+        assert_eq!(authed.json::<Vec<Session>>().await.unwrap(), vec![]);
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -1,0 +1,279 @@
+//! OpenWave's in-process HTTP/WebSocket surface.
+//!
+//! Every client — the desktop webview, the CLI — drives the agent through this
+//! one local API rather than linking the loop directly, so all surfaces share a
+//! single wiring of `Config`, `Store`, and (next slice) the agent. The server
+//! binds to an ephemeral **loopback** port and mints a per-launch **bearer
+//! token**: only the local process it was handed to can reach it.
+//!
+//! This slice is the session surface — create / list / get, behind the token.
+//! Posting a message and streaming the turn over `WS /sessions/{id}/events`
+//! lands next, on top of this skeleton.
+
+mod auth;
+mod error;
+mod routes;
+mod state;
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use axum::routing::{get, post};
+use axum::Router;
+use tokio::net::TcpListener;
+
+use openwave_core::{AgentError, Config, DbStore, Profile, Result, Store};
+
+pub use error::ServerError;
+pub use state::AppState;
+
+/// Build the router: unauthenticated health check plus the token-guarded API.
+pub fn app(state: AppState) -> Router {
+    // `route_layer` applies the token check to matched API routes only, so an
+    // unknown path still answers `404` (not `401`), and `/healthz` stays open.
+    let api = Router::new()
+        .route(
+            "/sessions",
+            post(routes::create_session).get(routes::list_sessions),
+        )
+        .route("/sessions/{id}", get(routes::get_session))
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::require_token,
+        ))
+        .with_state(state);
+
+    Router::new().route("/healthz", get(healthz)).merge(api)
+}
+
+/// Liveness probe — no auth, no state.
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+/// A bound server: the loopback address and per-launch token are known, so the
+/// spawning client can be told where to connect before the accept loop starts.
+pub struct Server {
+    local_addr: SocketAddr,
+    token: Arc<str>,
+    listener: TcpListener,
+    router: Router,
+}
+
+impl Server {
+    /// The loopback address the server is listening on.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    /// The bearer token clients must present.
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    /// Run the accept loop until the process exits.
+    pub async fn serve(self) -> Result<()> {
+        axum::serve(self.listener, self.router)
+            .await
+            .map_err(|e| AgentError::msg(format!("server error: {e}")))
+    }
+}
+
+/// Wire the store from `config` and bind the API to an ephemeral loopback port.
+pub async fn bind(config: Config) -> Result<Server> {
+    let store = connect_store(&config).await?;
+    let state = AppState::new(config, store);
+    let token = state.token.clone();
+    let router = app(state);
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .map_err(|e| AgentError::config(format!("failed to bind loopback: {e}")))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|e| AgentError::config(format!("no local address: {e}")))?;
+
+    Ok(Server {
+        local_addr,
+        token,
+        listener,
+        router,
+    })
+}
+
+/// Open the durable store the profile selects.
+///
+/// Only the desktop profile (SQLite under `data_dir`) is wired today; the
+/// self-host Postgres store lands with that profile's slice.
+async fn connect_store(config: &Config) -> Result<Arc<dyn Store>> {
+    match config.profile {
+        Profile::Desktop => {
+            std::fs::create_dir_all(&config.data_dir)
+                .map_err(|e| AgentError::config(format!("failed to create data dir: {e}")))?;
+            let store = DbStore::connect(&config.database_url()?).await?;
+            Ok(Arc::new(store))
+        }
+        _ => Err(AgentError::config(
+            "only the desktop profile is supported for now",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::body::{to_bytes, Body};
+    use axum::http::{header, Request, StatusCode};
+    use openwave_core::{Session, SessionId};
+    use serde::de::DeserializeOwned;
+    use tower::ServiceExt;
+
+    /// A router backed by a fresh temp SQLite store, plus its token and the
+    /// tempdir (kept alive for the test's duration).
+    async fn test_app() -> (Router, Arc<str>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap();
+        let state = AppState::new(Config::desktop(dir.path()), Arc::new(store));
+        let token = state.token.clone();
+        (app(state), token, dir)
+    }
+
+    async fn json_body<T: DeserializeOwned>(response: axum::response::Response) -> T {
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn health_needs_no_token() {
+        let (router, _token, _dir) = test_app().await;
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn api_rejects_missing_and_wrong_tokens() {
+        let (router, _token, _dir) = test_app().await;
+        let missing = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/sessions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+
+        let wrong = router
+            .oneshot(
+                Request::builder()
+                    .uri("/sessions")
+                    .header(header::AUTHORIZATION, "Bearer not-the-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn create_then_get_and_list() {
+        let (router, token, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+
+        let created: Session = {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/sessions")
+                        .header(header::AUTHORIZATION, &bearer)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(
+                            serde_json::json!({"workspace_dir": "/tmp/ws", "title": "hi"})
+                                .to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::CREATED);
+            json_body(response).await
+        };
+        assert_eq!(created.title.as_deref(), Some("hi"));
+
+        let fetched: Session = {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(format!("/sessions/{}", created.id))
+                        .header(header::AUTHORIZATION, &bearer)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            json_body(response).await
+        };
+        assert_eq!(fetched, created);
+
+        let listed: Vec<Session> = {
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .uri("/sessions")
+                        .header(header::AUTHORIZATION, &bearer)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            json_body(response).await
+        };
+        assert_eq!(listed, vec![created]);
+    }
+
+    #[tokio::test]
+    async fn unknown_session_is_404() {
+        let (router, token, _dir) = test_app().await;
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/sessions/{}", SessionId::new()))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn bind_yields_a_loopback_addr_and_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = bind(Config::desktop(dir.path())).await.unwrap();
+        assert!(server.local_addr().ip().is_loopback());
+        assert!(!server.token().is_empty());
+    }
+}

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1,0 +1,64 @@
+//! Session HTTP handlers.
+//!
+//! The conversation CRUD surface: create a session (which owns a workspace
+//! directory), list them, fetch one. Driving a session — posting a message and
+//! streaming the turn's events over WebSocket — lands in the next slice.
+
+use std::path::PathBuf;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use chrono::Utc;
+use serde::Deserialize;
+
+use openwave_core::{Session, SessionId};
+
+use crate::error::ServerError;
+use crate::state::AppState;
+
+/// Body of `POST /sessions`.
+#[derive(Debug, Deserialize)]
+pub struct CreateSession {
+    /// Absolute path to the workspace directory the agent operates in.
+    pub workspace_dir: PathBuf,
+    /// Optional human-facing title.
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+/// `POST /sessions` — create a session and return it (`201 Created`).
+pub async fn create_session(
+    State(state): State<AppState>,
+    Json(body): Json<CreateSession>,
+) -> Result<impl IntoResponse, ServerError> {
+    let session = Session {
+        id: SessionId::new(),
+        title: body.title,
+        workspace_dir: body.workspace_dir,
+        created_at: Utc::now(),
+    };
+    state.store.create_session(&session).await?;
+    Ok((StatusCode::CREATED, Json(session)))
+}
+
+/// `GET /sessions` — list sessions, most-recently-created first.
+pub async fn list_sessions(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<Session>>, ServerError> {
+    Ok(Json(state.store.list_sessions().await?))
+}
+
+/// `GET /sessions/{id}` — fetch one session, or `404`.
+pub async fn get_session(
+    State(state): State<AppState>,
+    Path(id): Path<SessionId>,
+) -> Result<Json<Session>, ServerError> {
+    state
+        .store
+        .get_session(id)
+        .await?
+        .map(Json)
+        .ok_or_else(|| ServerError::not_found(format!("session {id} not found")))
+}

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -6,16 +6,16 @@
 
 use std::path::PathBuf;
 
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::Json;
 use chrono::Utc;
 use serde::Deserialize;
 
 use openwave_core::{Session, SessionId};
 
 use crate::error::ServerError;
+use crate::extract::{Json, Path};
 use crate::state::AppState;
 
 /// Body of `POST /sessions`.

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -1,0 +1,35 @@
+//! Shared application state handed to every request handler.
+
+use std::sync::Arc;
+
+use openwave_core::{Config, Store};
+use uuid::Uuid;
+
+/// The state cloned into each handler: the boot config, the durable store, and
+/// the per-launch bearer token that guards the API.
+///
+/// Cheap to clone — everything shared is behind an `Arc`.
+#[derive(Clone)]
+pub struct AppState {
+    /// Boot configuration for this launch.
+    pub config: Arc<Config>,
+    /// Durable metadata and conversation state.
+    pub store: Arc<dyn Store>,
+    /// The secret every request must present as `Authorization: Bearer <token>`.
+    pub token: Arc<str>,
+}
+
+impl AppState {
+    /// Assemble state, minting a fresh random bearer token for this launch.
+    ///
+    /// The token is generated per launch (not persisted): the server binds to a
+    /// loopback port, and the token is handed to the local client that spawned
+    /// it, so a fresh secret each run is exactly what we want.
+    pub fn new(config: Config, store: Arc<dyn Store>) -> Self {
+        Self {
+            config: Arc::new(config),
+            store,
+            token: Uuid::new_v4().to_string().into(),
+        }
+    }
+}


### PR DESCRIPTION
New `openwave-server` crate: the local API every client (desktop, CLI) drives the agent through, instead of linking the agent loop directly. Binds to an ephemeral **loopback** port and mints a **per-launch bearer token**, so only the local process it was handed to can reach it.

## This slice
The session surface, behind the token:

- `POST /sessions` → create (owns a workspace dir), returns `201`
- `GET /sessions` → list
- `GET /sessions/{id}` → fetch, `404` if missing
- `GET /healthz` → unauthenticated liveness
- `AppState` wires `Config` → `Store`; `bind(config)` opens the SQLite store under `data_dir` for the desktop profile and binds `127.0.0.1:0`
- token check is a `route_layer` (unknown paths still `404`, not `401`) with a constant-time comparison

## Design notes
- **Own crate, not in -cli/-core.** Shared by desktop + CLI; keeps core web-free and avoids a bin-depends-on-bin shape. `openwave-cli` becomes a thin `serve` bin in a later slice.
- **Desktop profile only for now.** Self-host wires the Postgres store when that profile's slice lands; `connect_store` returns a clear error otherwise.
- Errors map through the existing `AgentErrorInfo` projection, so a failed request answers with the same stable `{ kind, message }` shape the event stream uses.

## Tests
Router exercised via `tower::oneshot` against a temp SQLite store: health is open, the API rejects missing/wrong tokens, create→get→list round-trips, unknown id is `404`, and `bind` yields a loopback addr + token.

## Next
`POST /sessions/{id}/messages` + `WS /sessions/{id}/events` streaming the turn.