### PR TITLE
fix(core): empty config env vars bypass defaults; non-portable config test

### DIFF
--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -11,6 +11,7 @@
 //!   policy, preferences). Reached with `Store::get_setting` / `set_setting`;
 //!   they change while the app runs, so they don't belong here.
 
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -53,12 +54,26 @@ impl Config {
     /// `./.openwave` under the current directory — desktop/CLI clients should set
     /// this to the platform's app-data location).
     pub fn from_env() -> Result<Self> {
-        let profile = match std::env::var("OPENWAVE_PROFILE").ok().as_deref() {
+        Self::from_vars(
+            std::env::var("OPENWAVE_PROFILE").ok(),
+            std::env::var_os("OPENWAVE_DATA_DIR"),
+        )
+    }
+
+    /// Resolve a config from raw variable values. Split out from [`from_env`] so
+    /// the empty-vs-unset handling is testable without mutating process-global
+    /// environment (which races other threads' `getenv` in a shared test binary).
+    ///
+    /// An **empty** value is treated as unset: a caller that exports
+    /// `OPENWAVE_DATA_DIR=` (or an empty profile) gets the documented defaults,
+    /// not an empty path rooted at the current directory.
+    fn from_vars(profile: Option<String>, data_dir: Option<OsString>) -> Result<Self> {
+        let profile = match profile.filter(|value| !value.is_empty()).as_deref() {
             None | Some("desktop") => Profile::Desktop,
             Some("self_host" | "selfhost") => Profile::SelfHost,
             Some(other) => return Err(AgentError::config(format!("unknown profile: {other}"))),
         };
-        let data_dir = match std::env::var_os("OPENWAVE_DATA_DIR") {
+        let data_dir = match data_dir.filter(|dir| !dir.is_empty()) {
             Some(dir) => PathBuf::from(dir),
             None => std::env::current_dir()
                 .map_err(|e| AgentError::config(format!("no working directory: {e}")))?
@@ -89,12 +104,47 @@ mod tests {
 
     #[test]
     fn desktop_derives_a_sqlite_url_under_data_dir() {
-        let config = Config::desktop("/tmp/ow");
+        // A real, platform-correct absolute path (hard-coded `/tmp/...` isn't
+        // portable to Windows); assert the SQLite wrapper around it.
+        let dir = tempfile::tempdir().unwrap();
+        let config = Config::desktop(dir.path());
         assert_eq!(config.profile, Profile::Desktop);
         assert_eq!(
             config.database_url().unwrap(),
-            "sqlite:///tmp/ow/openwave.db?mode=rwc"
+            format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("openwave.db").display()
+            )
         );
+    }
+
+    #[test]
+    fn empty_data_dir_var_falls_back_to_the_default() {
+        // `OPENWAVE_DATA_DIR=` (set but empty) must behave like unset, not point
+        // the store at `openwave.db` in the current directory.
+        let config = Config::from_vars(None, Some(OsString::new())).unwrap();
+        let expected = std::env::current_dir().unwrap().join(".openwave");
+        assert_eq!(config.data_dir, expected);
+        assert_eq!(config.profile, Profile::Desktop);
+    }
+
+    #[test]
+    fn empty_profile_var_defaults_to_desktop() {
+        let config = Config::from_vars(Some(String::new()), Some(OsString::from("/data"))).unwrap();
+        assert_eq!(config.profile, Profile::Desktop);
+    }
+
+    #[test]
+    fn explicit_vars_are_honored() {
+        let config =
+            Config::from_vars(Some("self_host".into()), Some(OsString::from("/data"))).unwrap();
+        assert_eq!(config.profile, Profile::SelfHost);
+        assert_eq!(config.data_dir, PathBuf::from("/data"));
+    }
+
+    #[test]
+    fn unknown_profile_var_is_an_error() {
+        assert!(Config::from_vars(Some("bogus".into()), None).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Two fixes to `Config::from_env` and its tests (follow-up to #15).

## Bug 1 — empty `OPENWAVE_DATA_DIR` bypasses the default
`from_env` read `OPENWAVE_DATA_DIR` with `var_os`, which returns `Some("")` when the variable is exported but empty. That empty `OsString` became an empty `PathBuf`, so `database_url()` resolved to `openwave.db` in the current working directory instead of the documented `./.openwave` default. `OPENWAVE_PROFILE=` (empty) hit the same class of bug — it fell through to the `unknown profile` error instead of defaulting to `desktop`.

Fix: an empty value is now treated as unset for both variables (`.filter(|v| !v.is_empty())`), so exporting either as empty yields the documented defaults.

## Bug 2 — non-portable config test
`desktop_derives_a_sqlite_url_under_data_dir` hard-coded `/tmp/ow` and asserted the exact string `sqlite:///tmp/ow/openwave.db?mode=rwc`, which isn't valid on Windows. It now derives the path from a `tempfile::tempdir()` (matching the crate's other tests) and asserts the SQLite wrapper around a real, platform-correct path.

## Refactor enabling the tests
The env read is split into a thin `from_env` plus a pure `from_vars(profile, data_dir)` resolver, so the empty-vs-unset behavior is covered deterministically without `set_var`/`remove_var` — which would race `getenv` on other threads in the shared core test binary. New tests cover empty data-dir fallback, empty-profile default, explicit values, and the unknown-profile error.