### PR TITLE
refactor: rename Session -> Chat across core + server

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -26,7 +26,7 @@ use serde_json::Value;
 use crate::error::{AgentError, Result};
 use crate::event::AgentEvent;
 use crate::id::{CallId, MessageId, TurnId};
-use crate::model::{Message, Role, Session};
+use crate::model::{Chat, Message, Role};
 use crate::provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, StopReason, Usage,
 };
@@ -113,7 +113,7 @@ impl Default for AgentConfig {
     }
 }
 
-/// Drives turns for a session over a provider, tool set, and store.
+/// Drives turns for a chat over a provider, tool set, and store.
 pub struct Agent {
     provider: Arc<dyn ModelProvider>,
     tools: Arc<ToolRegistry>,
@@ -153,13 +153,13 @@ impl Agent {
     /// not errors — they come back to the model as failed tool output.
     pub async fn run_turn(
         &self,
-        session: &Session,
+        chat: &Chat,
         user_input: &str,
         events: &UnboundedSender<AgentEvent>,
     ) -> Result<()> {
         let turn_id = TurnId::new();
         let _ = events.unbounded_send(AgentEvent::TurnStarted { turn_id });
-        match self.drive(session, turn_id, user_input, events).await {
+        match self.drive(chat, turn_id, user_input, events).await {
             Ok(()) => Ok(()),
             Err(err) => {
                 let _ = events.unbounded_send(AgentEvent::TurnFailed {
@@ -172,16 +172,16 @@ impl Agent {
 
     async fn drive(
         &self,
-        session: &Session,
+        chat: &Chat,
         turn_id: TurnId,
         user_input: &str,
         events: &UnboundedSender<AgentEvent>,
     ) -> Result<()> {
-        self.persist(session.id, turn_id, Role::User, user_input)
+        self.persist(chat.id, turn_id, Role::User, user_input)
             .await?;
         // The provider transcript for this turn: prior stored text + the blocks
         // we build up as the loop runs.
-        let mut transcript = self.load_transcript(session.id).await?;
+        let mut transcript = self.load_transcript(chat.id).await?;
         let mut total_usage = Usage::default();
 
         for step in 0..self.config.max_steps {
@@ -243,7 +243,7 @@ impl Agent {
             let mut blocks: Vec<ContentBlock> = Vec::new();
             if !text.is_empty() {
                 blocks.push(ContentBlock::Text { text: text.clone() });
-                self.persist(session.id, turn_id, Role::Assistant, &text)
+                self.persist(chat.id, turn_id, Role::Assistant, &text)
                     .await?;
             }
             for call in &calls {
@@ -278,12 +278,12 @@ impl Agent {
             // Run the tool calls and feed the results back for the next step.
             let mut results: Vec<ContentBlock> = Vec::new();
             for call in &calls {
-                let output = self.run_tool(session, call, events).await;
+                let output = self.run_tool(chat, call, events).await;
                 let _ = events.unbounded_send(AgentEvent::ToolCallCompleted {
                     call_id: call.call_id,
                     output: output.clone(),
                 });
-                self.persist(session.id, turn_id, Role::Tool, &output.content)
+                self.persist(chat.id, turn_id, Role::Tool, &output.content)
                     .await?;
                 results.push(ContentBlock::ToolResult {
                     tool_use_id: call.provider_id.clone(),
@@ -305,7 +305,7 @@ impl Agent {
     /// approval failures surface as error output, never `Err`.
     async fn run_tool(
         &self,
-        session: &Session,
+        chat: &Chat,
         call: &PendingCall,
         events: &UnboundedSender<AgentEvent>,
     ) -> ToolOutput {
@@ -323,8 +323,8 @@ impl Agent {
             return ToolOutput::error("this tool requires approval, which is not yet supported");
         }
         let ctx = ToolCtx {
-            session_id: session.id,
-            workspace_dir: session.workspace_dir.clone(),
+            chat_id: chat.id,
+            workspace_dir: chat.workspace_dir.clone(),
         };
         let mut output = match tool.execute(&ctx, parse_args(&call.args)).await {
             Ok(output) => output,
@@ -340,7 +340,7 @@ impl Agent {
 
     async fn persist(
         &self,
-        session_id: crate::id::SessionId,
+        chat_id: crate::id::ChatId,
         turn_id: TurnId,
         role: Role,
         content: &str,
@@ -348,7 +348,7 @@ impl Agent {
         self.store
             .append_message(&Message {
                 id: MessageId::new(),
-                session_id,
+                chat_id,
                 turn_id,
                 role,
                 content: content.to_string(),
@@ -357,10 +357,10 @@ impl Agent {
             .await
     }
 
-    async fn load_transcript(&self, session_id: crate::id::SessionId) -> Result<Vec<ChatMessage>> {
+    async fn load_transcript(&self, chat_id: crate::id::ChatId) -> Result<Vec<ChatMessage>> {
         Ok(self
             .store
-            .list_messages(session_id)
+            .list_messages(chat_id)
             .await?
             .into_iter()
             .map(|message| ChatMessage::text(message.role, message.content))
@@ -406,7 +406,7 @@ mod tests {
 
     use super::*;
     use crate::db::DbStore;
-    use crate::id::SessionId;
+    use crate::id::ChatId;
     use crate::provider::ProviderId;
     use crate::tools::ReadFile;
 
@@ -474,13 +474,13 @@ mod tests {
             .await
             .unwrap(),
         );
-        let session = Session {
-            id: SessionId::new(),
+        let chat = Chat {
+            id: ChatId::new(),
             title: None,
             workspace_dir: workspace.path().to_path_buf(),
             created_at: Utc::now(),
         };
-        store.create_session(&session).await.unwrap();
+        store.create_chat(&chat).await.unwrap();
 
         let tools = Arc::new(ToolRegistry::new().with(Box::new(ReadFile)));
         let agent = Agent::new(
@@ -496,10 +496,7 @@ mod tests {
         );
 
         let (tx, rx) = unbounded();
-        agent
-            .run_turn(&session, "read note.txt", &tx)
-            .await
-            .unwrap();
+        agent.run_turn(&chat, "read note.txt", &tx).await.unwrap();
         drop(tx);
         let events: Vec<AgentEvent> = rx.collect().await;
 
@@ -531,7 +528,7 @@ mod tests {
         );
 
         // User input, the tool result, and the final answer were persisted.
-        let stored = store.list_messages(session.id).await.unwrap();
+        let stored = store.list_messages(chat.id).await.unwrap();
         let roles: Vec<Role> = stored.iter().map(|m| m.role).collect();
         assert_eq!(roles, vec![Role::User, Role::Tool, Role::Assistant]);
     }
@@ -549,13 +546,13 @@ mod tests {
             .await
             .unwrap(),
         );
-        let session = Session {
-            id: SessionId::new(),
+        let chat = Chat {
+            id: ChatId::new(),
             title: None,
             workspace_dir: workspace.path().to_path_buf(),
             created_at: Utc::now(),
         };
-        store.create_session(&session).await.unwrap();
+        store.create_chat(&chat).await.unwrap();
 
         // Only one step allowed, but step 0 returns a tool call — there's no
         // step left to consume the result, so the tool must NOT run.
@@ -573,7 +570,7 @@ mod tests {
         );
 
         let (tx, rx) = unbounded();
-        let result = agent.run_turn(&session, "read note.txt", &tx).await;
+        let result = agent.run_turn(&chat, "read note.txt", &tx).await;
         drop(tx);
         let events: Vec<AgentEvent> = rx.collect().await;
 
@@ -584,7 +581,7 @@ mod tests {
             .iter()
             .any(|e| matches!(e, AgentEvent::ToolCallCompleted { .. })));
         let roles: Vec<Role> = store
-            .list_messages(session.id)
+            .list_messages(chat.id)
             .await
             .unwrap()
             .iter()
@@ -606,13 +603,13 @@ mod tests {
             .await
             .unwrap(),
         );
-        let session = Session {
-            id: SessionId::new(),
+        let chat = Chat {
+            id: ChatId::new(),
             title: None,
             workspace_dir: workspace.path().to_path_buf(),
             created_at: Utc::now(),
         };
-        store.create_session(&session).await.unwrap();
+        store.create_chat(&chat).await.unwrap();
 
         let agent = Agent::new(
             Arc::new(FakeProvider {
@@ -628,10 +625,7 @@ mod tests {
         );
 
         let (tx, rx) = unbounded();
-        agent
-            .run_turn(&session, "read note.txt", &tx)
-            .await
-            .unwrap();
+        agent.run_turn(&chat, "read note.txt", &tx).await.unwrap();
         drop(tx);
         let events: Vec<AgentEvent> = rx.collect().await;
 

--- a/crates/openwave-core/src/db.rs
+++ b/crates/openwave-core/src/db.rs
@@ -20,8 +20,8 @@ use serde_json::Value;
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{MessageId, SessionId, TurnId};
-use crate::model::{Message, Role, Session};
+use crate::id::{ChatId, MessageId, TurnId};
+use crate::model::{Chat, Message, Role};
 use crate::storage::Store;
 
 /// Map any SeaORM failure into an [`AgentError::Store`].
@@ -41,7 +41,7 @@ impl DbStore {
     /// `sqlite:///path/openwave.db?mode=rwc`).
     pub async fn connect(url: &str) -> Result<Self> {
         let conn = Database::connect(url).await.map_err(store_err)?;
-        // WAL lets a reader (e.g. the UI listing sessions) proceed concurrently
+        // WAL lets a reader (e.g. the UI listing chats) proceed concurrently
         // with a writer (a turn appending messages). SQLite-only; it's a
         // persistent, file-level setting, so running it once at connect suffices.
         if conn.get_database_backend() == sea_orm::DatabaseBackend::Sqlite {
@@ -58,12 +58,12 @@ impl DbStore {
 
 #[async_trait]
 impl Store for DbStore {
-    async fn create_session(&self, session: &Session) -> Result<()> {
-        entities::session::ActiveModel {
-            id: Set(session.id.0),
-            title: Set(session.title.clone()),
-            workspace_dir: Set(session.workspace_dir.to_string_lossy().into_owned()),
-            created_at: Set(session.created_at),
+    async fn create_chat(&self, chat: &Chat) -> Result<()> {
+        entities::chat::ActiveModel {
+            id: Set(chat.id.0),
+            title: Set(chat.title.clone()),
+            workspace_dir: Set(chat.workspace_dir.to_string_lossy().into_owned()),
+            created_at: Set(chat.created_at),
         }
         .insert(&self.conn)
         .await
@@ -71,29 +71,29 @@ impl Store for DbStore {
         Ok(())
     }
 
-    async fn get_session(&self, id: SessionId) -> Result<Option<Session>> {
-        Ok(entities::session::Entity::find_by_id(id.0)
+    async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
+        Ok(entities::chat::Entity::find_by_id(id.0)
             .one(&self.conn)
             .await
             .map_err(store_err)?
-            .map(session_from_model))
+            .map(chat_from_model))
     }
 
-    async fn list_sessions(&self) -> Result<Vec<Session>> {
-        Ok(entities::session::Entity::find()
-            .order_by_desc(entities::session::Column::CreatedAt)
+    async fn list_chats(&self) -> Result<Vec<Chat>> {
+        Ok(entities::chat::Entity::find()
+            .order_by_desc(entities::chat::Column::CreatedAt)
             .all(&self.conn)
             .await
             .map_err(store_err)?
             .into_iter()
-            .map(session_from_model)
+            .map(chat_from_model)
             .collect())
     }
 
     async fn append_message(&self, message: &Message) -> Result<()> {
         entities::message::ActiveModel {
             id: Set(message.id.0),
-            session_id: Set(message.session_id.0),
+            chat_id: Set(message.chat_id.0),
             turn_id: Set(message.turn_id.0),
             role: Set(role_to_db(message.role).to_string()),
             content: Set(message.content.clone()),
@@ -105,9 +105,9 @@ impl Store for DbStore {
         Ok(())
     }
 
-    async fn list_messages(&self, session_id: SessionId) -> Result<Vec<Message>> {
+    async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>> {
         entities::message::Entity::find()
-            .filter(entities::message::Column::SessionId.eq(session_id.0))
+            .filter(entities::message::Column::ChatId.eq(chat_id.0))
             .order_by_asc(entities::message::Column::CreatedAt)
             .all(&self.conn)
             .await
@@ -142,15 +142,15 @@ impl Store for DbStore {
         Ok(())
     }
 
-    async fn append_event(&self, session_id: SessionId, event: &AgentEvent) -> Result<i64> {
-        // Next seq for this session. This assumes a single writer per session —
-        // the server enforces it by allowing only one active turn per session at
+    async fn append_event(&self, chat_id: ChatId, event: &AgentEvent) -> Result<i64> {
+        // Next seq for this chat. This assumes a single writer per chat —
+        // the server enforces it by allowing only one active turn per chat at
         // a time (a concurrent message is refused, not queued behind a second
         // writer). Under that invariant read-then-insert is race-free; the
-        // composite (session_id, seq) primary key is the backstop that turns any
+        // composite (chat_id, seq) primary key is the backstop that turns any
         // concurrent double-write into an error, never a silent dup or lost seq.
         let last = entities::event::Entity::find()
-            .filter(entities::event::Column::SessionId.eq(session_id.0))
+            .filter(entities::event::Column::ChatId.eq(chat_id.0))
             .order_by_desc(entities::event::Column::Seq)
             .one(&self.conn)
             .await
@@ -158,7 +158,7 @@ impl Store for DbStore {
         let seq = last.map_or(0, |model| model.seq) + 1;
 
         entities::event::ActiveModel {
-            session_id: Set(session_id.0),
+            chat_id: Set(chat_id.0),
             seq: Set(seq),
             payload: Set(serde_json::to_value(event)?),
             created_at: Set(Utc::now()),
@@ -169,9 +169,9 @@ impl Store for DbStore {
         Ok(seq)
     }
 
-    async fn list_events(&self, session_id: SessionId, after: i64) -> Result<Vec<SequencedEvent>> {
+    async fn list_events(&self, chat_id: ChatId, after: i64) -> Result<Vec<SequencedEvent>> {
         entities::event::Entity::find()
-            .filter(entities::event::Column::SessionId.eq(session_id.0))
+            .filter(entities::event::Column::ChatId.eq(chat_id.0))
             .filter(entities::event::Column::Seq.gt(after))
             .order_by_asc(entities::event::Column::Seq)
             .all(&self.conn)
@@ -188,9 +188,9 @@ impl Store for DbStore {
     }
 }
 
-fn session_from_model(model: entities::session::Model) -> Session {
-    Session {
-        id: SessionId(model.id),
+fn chat_from_model(model: entities::chat::Model) -> Chat {
+    Chat {
+        id: ChatId(model.id),
         title: model.title,
         workspace_dir: PathBuf::from(model.workspace_dir),
         created_at: model.created_at,
@@ -200,7 +200,7 @@ fn session_from_model(model: entities::session::Model) -> Session {
 fn message_from_model(model: entities::message::Model) -> Result<Message> {
     Ok(Message {
         id: MessageId(model.id),
-        session_id: SessionId(model.session_id),
+        chat_id: ChatId(model.chat_id),
         turn_id: TurnId(model.turn_id),
         role: role_from_db(&model.role)?,
         content: model.content,
@@ -229,14 +229,14 @@ fn role_from_db(text: &str) -> Result<Role> {
 }
 
 /// SeaORM entity models. Kept internal — the public `Store` API speaks the domain
-/// types (`Session`, `Message`), never these, so the ORM never leaks into the
+/// types (`Chat`, `Message`), never these, so the ORM never leaks into the
 /// crate's contract.
 mod entities {
-    pub mod session {
+    pub mod chat {
         use sea_orm::entity::prelude::*;
 
         #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
-        #[sea_orm(table_name = "session")]
+        #[sea_orm(table_name = "chat")]
         pub struct Model {
             #[sea_orm(primary_key, auto_increment = false)]
             pub id: Uuid,
@@ -259,7 +259,7 @@ mod entities {
         pub struct Model {
             #[sea_orm(primary_key, auto_increment = false)]
             pub id: Uuid,
-            pub session_id: Uuid,
+            pub chat_id: Uuid,
             pub turn_id: Uuid,
             pub role: String,
             pub content: String,
@@ -294,14 +294,14 @@ mod entities {
     pub mod event {
         use sea_orm::entity::prelude::*;
 
-        // Composite primary key `(session_id, seq)`: `seq` is monotonic *per
-        // session*, and the pair both enforces uniqueness and indexes the
-        // "this session's events after a cursor" replay query.
+        // Composite primary key `(chat_id, seq)`: `seq` is monotonic *per
+        // chat*, and the pair both enforces uniqueness and indexes the
+        // "this chat's events after a cursor" replay query.
         #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
         #[sea_orm(table_name = "event")]
         pub struct Model {
             #[sea_orm(primary_key, auto_increment = false)]
-            pub session_id: Uuid,
+            pub chat_id: Uuid,
             #[sea_orm(primary_key, auto_increment = false)]
             pub seq: i64,
             #[sea_orm(column_type = "JsonBinary")]
@@ -344,13 +344,13 @@ mod migration {
             manager
                 .create_table(
                     Table::create()
-                        .table(Session::Table)
+                        .table(Chat::Table)
                         .if_not_exists()
-                        .col(ColumnDef::new(Session::Id).uuid().not_null().primary_key())
-                        .col(ColumnDef::new(Session::Title).text())
-                        .col(ColumnDef::new(Session::WorkspaceDir).text().not_null())
+                        .col(ColumnDef::new(Chat::Id).uuid().not_null().primary_key())
+                        .col(ColumnDef::new(Chat::Title).text())
+                        .col(ColumnDef::new(Chat::WorkspaceDir).text().not_null())
                         .col(
-                            ColumnDef::new(Session::CreatedAt)
+                            ColumnDef::new(Chat::CreatedAt)
                                 .timestamp_with_time_zone()
                                 .not_null(),
                         )
@@ -364,7 +364,7 @@ mod migration {
                         .table(Message::Table)
                         .if_not_exists()
                         .col(ColumnDef::new(Message::Id).uuid().not_null().primary_key())
-                        .col(ColumnDef::new(Message::SessionId).uuid().not_null())
+                        .col(ColumnDef::new(Message::ChatId).uuid().not_null())
                         .col(ColumnDef::new(Message::TurnId).uuid().not_null())
                         .col(ColumnDef::new(Message::Role).text().not_null())
                         .col(ColumnDef::new(Message::Content).text().not_null())
@@ -375,9 +375,9 @@ mod migration {
                         )
                         .foreign_key(
                             ForeignKey::create()
-                                .name("fk_message_session")
-                                .from(Message::Table, Message::SessionId)
-                                .to(Session::Table, Session::Id),
+                                .name("fk_message_chat")
+                                .from(Message::Table, Message::ChatId)
+                                .to(Chat::Table, Chat::Id),
                         )
                         .to_owned(),
                 )
@@ -386,9 +386,9 @@ mod migration {
             manager
                 .create_index(
                     Index::create()
-                        .name("idx_message_session")
+                        .name("idx_message_chat")
                         .table(Message::Table)
-                        .col(Message::SessionId)
+                        .col(Message::ChatId)
                         .col(Message::CreatedAt)
                         .to_owned(),
                 )
@@ -416,13 +416,13 @@ mod migration {
                 .drop_table(Table::drop().table(Setting::Table).to_owned())
                 .await?;
             manager
-                .drop_table(Table::drop().table(Session::Table).to_owned())
+                .drop_table(Table::drop().table(Chat::Table).to_owned())
                 .await?;
             Ok(())
         }
     }
 
-    /// Adds the per-session event journal that clients replay from on connect.
+    /// Adds the per-chat event journal that clients replay from on connect.
     struct AddEventJournal;
 
     impl MigrationName for AddEventJournal {
@@ -439,7 +439,7 @@ mod migration {
                     Table::create()
                         .table(Event::Table)
                         .if_not_exists()
-                        .col(ColumnDef::new(Event::SessionId).uuid().not_null())
+                        .col(ColumnDef::new(Event::ChatId).uuid().not_null())
                         .col(ColumnDef::new(Event::Seq).big_integer().not_null())
                         .col(ColumnDef::new(Event::Payload).json_binary().not_null())
                         .col(
@@ -447,12 +447,12 @@ mod migration {
                                 .timestamp_with_time_zone()
                                 .not_null(),
                         )
-                        .primary_key(Index::create().col(Event::SessionId).col(Event::Seq))
+                        .primary_key(Index::create().col(Event::ChatId).col(Event::Seq))
                         .foreign_key(
                             ForeignKey::create()
-                                .name("fk_event_session")
-                                .from(Event::Table, Event::SessionId)
-                                .to(Session::Table, Session::Id),
+                                .name("fk_event_chat")
+                                .from(Event::Table, Event::ChatId)
+                                .to(Chat::Table, Chat::Id),
                         )
                         .to_owned(),
                 )
@@ -469,7 +469,7 @@ mod migration {
     }
 
     #[derive(DeriveIden)]
-    enum Session {
+    enum Chat {
         Table,
         Id,
         Title,
@@ -481,7 +481,7 @@ mod migration {
     enum Message {
         Table,
         Id,
-        SessionId,
+        ChatId,
         TurnId,
         Role,
         Content,
@@ -498,7 +498,7 @@ mod migration {
     #[derive(DeriveIden)]
     enum Event {
         Table,
-        SessionId,
+        ChatId,
         Seq,
         Payload,
         CreatedAt,
@@ -517,9 +517,9 @@ mod tests {
         (dir, store)
     }
 
-    fn sample_session() -> Session {
-        Session {
-            id: SessionId::new(),
+    fn sample_chat() -> Chat {
+        Chat {
+            id: ChatId::new(),
             title: Some("hello".into()),
             workspace_dir: PathBuf::from("/tmp/ws"),
             created_at: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
@@ -527,28 +527,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sessions_and_messages_roundtrip() {
+    async fn chats_and_messages_roundtrip() {
         let (_dir, store) = temp_store().await;
-        let session = sample_session();
-        store.create_session(&session).await.unwrap();
+        let chat = sample_chat();
+        store.create_chat(&chat).await.unwrap();
 
-        assert_eq!(
-            store.get_session(session.id).await.unwrap().as_ref(),
-            Some(&session)
-        );
-        assert_eq!(store.list_sessions().await.unwrap(), vec![session.clone()]);
-        assert_eq!(store.get_session(SessionId::new()).await.unwrap(), None);
+        assert_eq!(store.get_chat(chat.id).await.unwrap().as_ref(), Some(&chat));
+        assert_eq!(store.list_chats().await.unwrap(), vec![chat.clone()]);
+        assert_eq!(store.get_chat(ChatId::new()).await.unwrap(), None);
 
         let msg = Message {
             id: MessageId::new(),
-            session_id: session.id,
+            chat_id: chat.id,
             turn_id: TurnId::new(),
             role: Role::User,
             content: "hi there".into(),
             created_at: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),
         };
         store.append_message(&msg).await.unwrap();
-        assert_eq!(store.list_messages(session.id).await.unwrap(), vec![msg]);
+        assert_eq!(store.list_messages(chat.id).await.unwrap(), vec![msg]);
     }
 
     #[tokio::test]
@@ -574,24 +571,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_sessions_is_newest_first_and_messages_oldest_first() {
+    async fn list_chats_is_newest_first_and_messages_oldest_first() {
         let (_dir, store) = temp_store().await;
-        let mut older = sample_session();
+        let mut older = sample_chat();
         older.created_at = DateTime::<Utc>::from_timestamp(1_000, 0).unwrap();
-        let mut newer = sample_session();
+        let mut newer = sample_chat();
         newer.created_at = DateTime::<Utc>::from_timestamp(2_000, 0).unwrap();
-        store.create_session(&older).await.unwrap();
-        store.create_session(&newer).await.unwrap();
-        // list_sessions is newest-first.
+        store.create_chat(&older).await.unwrap();
+        store.create_chat(&newer).await.unwrap();
+        // list_chats is newest-first.
         assert_eq!(
-            store.list_sessions().await.unwrap(),
+            store.list_chats().await.unwrap(),
             vec![newer.clone(), older.clone()]
         );
 
         // Messages come back oldest-first regardless of insert order.
         let msg = |ts: i64| Message {
             id: MessageId::new(),
-            session_id: newer.id,
+            chat_id: newer.id,
             turn_id: TurnId::new(),
             role: Role::User,
             content: format!("t{ts}"),
@@ -605,14 +602,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn event_journal_assigns_per_session_seq_and_replays_after_cursor() {
+    async fn event_journal_assigns_per_chat_seq_and_replays_after_cursor() {
         use crate::event::AgentEvent;
         use crate::id::TurnId;
         use crate::provider::{StopReason, Usage};
 
         let (_dir, store) = temp_store().await;
-        let session = sample_session();
-        store.create_session(&session).await.unwrap();
+        let chat = sample_chat();
+        store.create_chat(&chat).await.unwrap();
 
         let started = AgentEvent::TurnStarted {
             turn_id: TurnId::new(),
@@ -621,53 +618,53 @@ mod tests {
             usage: Usage::default(),
             stop_reason: StopReason::EndTurn,
         };
-        assert_eq!(store.append_event(session.id, &started).await.unwrap(), 1);
-        assert_eq!(store.append_event(session.id, &completed).await.unwrap(), 2);
+        assert_eq!(store.append_event(chat.id, &started).await.unwrap(), 1);
+        assert_eq!(store.append_event(chat.id, &completed).await.unwrap(), 2);
 
         // From the start: both events, in order, with their seq.
-        let all = store.list_events(session.id, 0).await.unwrap();
+        let all = store.list_events(chat.id, 0).await.unwrap();
         assert_eq!(all.len(), 2);
         assert_eq!((all[0].seq, all[1].seq), (1, 2));
         assert_eq!(all[0].event, started);
 
         // After a cursor: only the newer event (what a reconnecting client needs).
-        let tail = store.list_events(session.id, 1).await.unwrap();
+        let tail = store.list_events(chat.id, 1).await.unwrap();
         assert_eq!(tail.len(), 1);
         assert_eq!(tail[0].seq, 2);
         assert_eq!(tail[0].event, completed);
 
-        // A second session's seq restarts at 1 and its journal is isolated.
-        let other = sample_session();
-        store.create_session(&other).await.unwrap();
+        // A second chat's seq restarts at 1 and its journal is isolated.
+        let other = sample_chat();
+        store.create_chat(&other).await.unwrap();
         assert_eq!(store.append_event(other.id, &started).await.unwrap(), 1);
-        assert_eq!(store.list_events(session.id, 0).await.unwrap().len(), 2);
+        assert_eq!(store.list_events(chat.id, 0).await.unwrap().len(), 2);
     }
 
     #[tokio::test]
-    async fn event_for_unknown_session_is_rejected() {
+    async fn event_for_unknown_chat_is_rejected() {
         use crate::event::AgentEvent;
 
         let (_dir, store) = temp_store().await;
-        // No create_session first: the `event -> session` foreign key must reject
+        // No create_chat first: the `event -> chat` foreign key must reject
         // the orphan write. (The in-memory MemStore test double does *not* model
         // this constraint, so orphan-rejection is only guaranteed by DbStore.)
         let event = AgentEvent::TurnStarted {
             turn_id: TurnId::new(),
         };
-        assert!(store.append_event(SessionId::new(), &event).await.is_err());
+        assert!(store.append_event(ChatId::new(), &event).await.is_err());
     }
 
     #[tokio::test]
     async fn all_roles_round_trip() {
         let (_dir, store) = temp_store().await;
-        let session = sample_session();
-        store.create_session(&session).await.unwrap();
+        let chat = sample_chat();
+        store.create_chat(&chat).await.unwrap();
         let roles = [Role::System, Role::User, Role::Assistant, Role::Tool];
         for (i, role) in roles.iter().enumerate() {
             store
                 .append_message(&Message {
                     id: MessageId::new(),
-                    session_id: session.id,
+                    chat_id: chat.id,
                     turn_id: TurnId::new(),
                     role: *role,
                     content: String::new(),
@@ -677,7 +674,7 @@ mod tests {
                 .unwrap();
         }
         let got: Vec<Role> = store
-            .list_messages(session.id)
+            .list_messages(chat.id)
             .await
             .unwrap()
             .into_iter()

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -86,7 +86,7 @@ pub enum AgentEvent {
     },
 }
 
-/// An [`AgentEvent`] paired with its per-session sequence number, as stored in
+/// An [`AgentEvent`] paired with its per-chat sequence number, as stored in
 /// the journal.
 ///
 /// The journal is what makes reconnect work: a client tracks the highest `seq`
@@ -94,9 +94,9 @@ pub enum AgentEvent {
 /// connection catches up without gaps and without replaying what it already has.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SequencedEvent {
-    /// Monotonic per-session sequence number; the first event in a session is 1.
+    /// Monotonic per-chat sequence number; the first event in a chat is 1.
     pub seq: i64,
-    /// The event at this position in the session's stream.
+    /// The event at this position in the chat's stream.
     pub event: AgentEvent,
 }
 

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -1,7 +1,7 @@
 //! Strongly-typed identifiers.
 //!
 //! Every entity gets its own newtype over a UUID so the compiler stops us from,
-//! say, passing a [`TurnId`] where a [`SessionId`] is expected. All ids
+//! say, passing a [`TurnId`] where a [`ChatId`] is expected. All ids
 //! serialize transparently (as the bare UUID string), so on the wire and in the
 //! `Store` they are indistinguishable from a plain UUID.
 
@@ -60,10 +60,10 @@ macro_rules! id_type {
 
 id_type!(
     /// Identifies a persistent conversation (owns a workspace directory).
-    SessionId
+    ChatId
 );
 id_type!(
-    /// Identifies a persisted message within a session.
+    /// Identifies a persisted message within a chat.
     MessageId
 );
 id_type!(
@@ -85,19 +85,19 @@ mod tests {
 
     #[test]
     fn ids_of_different_types_are_distinct_uuids() {
-        let session = SessionId::new();
+        let chat = ChatId::new();
         let turn = TurnId::new();
-        assert_ne!(session.0, turn.0);
+        assert_ne!(chat.0, turn.0);
     }
 
     #[test]
     fn roundtrips_through_string_and_json() {
-        let id = SessionId::new();
-        assert_eq!(id.to_string().parse::<SessionId>().unwrap(), id);
+        let id = ChatId::new();
+        assert_eq!(id.to_string().parse::<ChatId>().unwrap(), id);
 
         let json = serde_json::to_string(&id).unwrap();
         // Transparent: serializes as the bare quoted UUID, no wrapper.
         assert_eq!(json, format!("\"{id}\""));
-        assert_eq!(serde_json::from_str::<SessionId>(&json).unwrap(), id);
+        assert_eq!(serde_json::from_str::<ChatId>(&json).unwrap(), id);
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -9,7 +9,7 @@
 //! publishable on crates.io.
 //!
 //! Built incrementally with the M0 walking skeleton. Present so far: [`id`]
-//! (typed identifiers), [`error`], [`model`] (the persisted session/message
+//! (typed identifiers), [`error`], [`model`] (the persisted chat/message
 //! model), [`tool`] (the tool contract), and [`provider`] (the model-provider
 //! contract).
 
@@ -35,10 +35,10 @@ pub use config::{Config, Profile};
 pub use db::DbStore;
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
-pub use id::{CallId, MessageId, SessionId, StepId, TurnId};
+pub use id::{CallId, ChatId, MessageId, StepId, TurnId};
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
-pub use model::{Message, Role, Session};
+pub use model::{Chat, Message, Role};
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
     Usage,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1,7 +1,7 @@
 //! The persisted conversation model.
 //!
-//! Mirrors the `session` and `message` tables of `Store` schema v1. A
-//! [`Session`] is a durable conversation that owns a workspace directory; a
+//! Mirrors the `chat` and `message` tables of `Store` schema v1. A
+//! [`Chat`] is a durable conversation that owns a workspace directory; a
 //! [`Message`] is one user input or assistant answer within it.
 //!
 //! Turns and steps are runtime concepts of the agent loop (schema v1 has no
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::id::{MessageId, SessionId, TurnId};
+use crate::id::{ChatId, MessageId, TurnId};
 
 /// Who authored a message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -31,18 +31,18 @@ pub enum Role {
 
 /// A persistent conversation. Owns a workspace directory the agent operates in.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Session {
+pub struct Chat {
     /// Stable identifier.
-    pub id: SessionId,
+    pub id: ChatId,
     /// Human-facing title; `None` until one is set or derived.
     pub title: Option<String>,
-    /// Absolute path to this session's workspace directory.
+    /// Absolute path to this chat's workspace directory.
     pub workspace_dir: PathBuf,
-    /// When the session was created.
+    /// When the chat was created.
     pub created_at: DateTime<Utc>,
 }
 
-/// One message in a session: user input or assistant text.
+/// One message in a chat: user input or assistant text.
 ///
 /// Tool calls are not messages; they persist separately (the `tool_call` table)
 /// and are correlated by `turn_id`.
@@ -50,8 +50,8 @@ pub struct Session {
 pub struct Message {
     /// Stable identifier.
     pub id: MessageId,
-    /// The session this message belongs to.
-    pub session_id: SessionId,
+    /// The chat this message belongs to.
+    pub chat_id: ChatId,
     /// The turn this message was produced in.
     pub turn_id: TurnId,
     /// Who authored it.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -3,7 +3,7 @@
 //! Three traits, deliberately backend-agnostic so a profile can wire different
 //! implementations without touching callers:
 //!
-//! - [`Store`] — durable metadata/state (sessions, messages, settings). The
+//! - [`Store`] — durable metadata/state (chats, messages, settings). The
 //!   default impl is SQLite; the same trait maps to Postgres for self-host.
 //! - [`SecretProvider`] — credentials (model API keys, connection tokens). These
 //!   live in the OS keychain (desktop) or a KMS/Vault (server) and are **never**
@@ -20,8 +20,8 @@ use serde_json::Value;
 
 use crate::error::Result;
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::SessionId;
-use crate::model::{Message, Session};
+use crate::id::ChatId;
+use crate::model::{Chat, Message};
 
 /// Durable metadata and conversation state.
 ///
@@ -29,20 +29,20 @@ use crate::model::{Message, Session};
 /// held behind `Arc<dyn Store>`, so this trait stays object-safe.
 #[async_trait]
 pub trait Store: Send + Sync {
-    /// Persist a new session.
-    async fn create_session(&self, session: &Session) -> Result<()>;
+    /// Persist a new chat.
+    async fn create_chat(&self, chat: &Chat) -> Result<()>;
 
-    /// Fetch a session by id, or `None` if it doesn't exist.
-    async fn get_session(&self, id: SessionId) -> Result<Option<Session>>;
+    /// Fetch a chat by id, or `None` if it doesn't exist.
+    async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>>;
 
-    /// List sessions, most-recently-created first.
-    async fn list_sessions(&self) -> Result<Vec<Session>>;
+    /// List chats, most-recently-created first.
+    async fn list_chats(&self) -> Result<Vec<Chat>>;
 
-    /// Append a message to its session.
+    /// Append a message to its chat.
     async fn append_message(&self, message: &Message) -> Result<()>;
 
-    /// List a session's messages in creation order.
-    async fn list_messages(&self, session_id: SessionId) -> Result<Vec<Message>>;
+    /// List a chat's messages in creation order.
+    async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>>;
 
     /// Read a setting (profile, model prefs, approval policy), or `None`.
     async fn get_setting(&self, key: &str) -> Result<Option<Value>>;
@@ -50,14 +50,14 @@ pub trait Store: Send + Sync {
     /// Write a setting.
     async fn set_setting(&self, key: &str, value: &Value) -> Result<()>;
 
-    /// Append an event to a session's journal, returning its assigned sequence
-    /// number. Sequence numbers are per-session and monotonic (starting at 1),
+    /// Append an event to a chat's journal, returning its assigned sequence
+    /// number. Sequence numbers are per-chat and monotonic (starting at 1),
     /// so a client can replay the stream with [`list_events`](Self::list_events).
-    async fn append_event(&self, session_id: SessionId, event: &AgentEvent) -> Result<i64>;
+    async fn append_event(&self, chat_id: ChatId, event: &AgentEvent) -> Result<i64>;
 
-    /// List a session's journaled events with `seq` greater than `after`, in
+    /// List a chat's journaled events with `seq` greater than `after`, in
     /// sequence order. Pass `0` to replay from the start.
-    async fn list_events(&self, session_id: SessionId, after: i64) -> Result<Vec<SequencedEvent>>;
+    async fn list_events(&self, chat_id: ChatId, after: i64) -> Result<Vec<SequencedEvent>>;
 }
 
 /// Credential custody: secrets keyed by a stable reference string (e.g.
@@ -102,30 +102,27 @@ mod tests {
     /// behind `Arc<dyn Store>`, and exercises the signatures.
     #[derive(Default)]
     struct MemStore {
-        sessions: Mutex<HashMap<SessionId, Session>>,
+        chats: Mutex<HashMap<ChatId, Chat>>,
         settings: Mutex<HashMap<String, Value>>,
-        events: Mutex<Vec<(SessionId, SequencedEvent)>>,
+        events: Mutex<Vec<(ChatId, SequencedEvent)>>,
     }
 
     #[async_trait]
     impl Store for MemStore {
-        async fn create_session(&self, session: &Session) -> Result<()> {
-            self.sessions
-                .lock()
-                .unwrap()
-                .insert(session.id, session.clone());
+        async fn create_chat(&self, chat: &Chat) -> Result<()> {
+            self.chats.lock().unwrap().insert(chat.id, chat.clone());
             Ok(())
         }
-        async fn get_session(&self, id: SessionId) -> Result<Option<Session>> {
-            Ok(self.sessions.lock().unwrap().get(&id).cloned())
+        async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
+            Ok(self.chats.lock().unwrap().get(&id).cloned())
         }
-        async fn list_sessions(&self) -> Result<Vec<Session>> {
-            Ok(self.sessions.lock().unwrap().values().cloned().collect())
+        async fn list_chats(&self) -> Result<Vec<Chat>> {
+            Ok(self.chats.lock().unwrap().values().cloned().collect())
         }
         async fn append_message(&self, _message: &Message) -> Result<()> {
             Ok(())
         }
-        async fn list_messages(&self, _session_id: SessionId) -> Result<Vec<Message>> {
+        async fn list_messages(&self, _chat_id: ChatId) -> Result<Vec<Message>> {
             Ok(vec![])
         }
         async fn get_setting(&self, key: &str) -> Result<Option<Value>> {
@@ -138,11 +135,11 @@ mod tests {
                 .insert(key.to_string(), value.clone());
             Ok(())
         }
-        async fn append_event(&self, session_id: SessionId, event: &AgentEvent) -> Result<i64> {
+        async fn append_event(&self, chat_id: ChatId, event: &AgentEvent) -> Result<i64> {
             let mut events = self.events.lock().unwrap();
-            let seq = events.iter().filter(|(id, _)| *id == session_id).count() as i64 + 1;
+            let seq = events.iter().filter(|(id, _)| *id == chat_id).count() as i64 + 1;
             events.push((
-                session_id,
+                chat_id,
                 SequencedEvent {
                     seq,
                     event: event.clone(),
@@ -150,17 +147,13 @@ mod tests {
             ));
             Ok(seq)
         }
-        async fn list_events(
-            &self,
-            session_id: SessionId,
-            after: i64,
-        ) -> Result<Vec<SequencedEvent>> {
+        async fn list_events(&self, chat_id: ChatId, after: i64) -> Result<Vec<SequencedEvent>> {
             Ok(self
                 .events
                 .lock()
                 .unwrap()
                 .iter()
-                .filter(|(id, e)| *id == session_id && e.seq > after)
+                .filter(|(id, e)| *id == chat_id && e.seq > after)
                 .map(|(_, e)| e.clone())
                 .collect())
         }
@@ -169,15 +162,15 @@ mod tests {
     #[test]
     fn store_is_object_safe_and_roundtrips() {
         let store: Arc<dyn Store> = Arc::new(MemStore::default());
-        let session = Session {
-            id: SessionId::new(),
+        let chat = Chat {
+            id: ChatId::new(),
             title: None,
             workspace_dir: "/tmp/ws".into(),
             created_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
         };
-        block_on(store.create_session(&session)).unwrap();
-        let fetched = block_on(store.get_session(session.id)).unwrap();
-        assert_eq!(fetched.as_ref(), Some(&session));
+        block_on(store.create_chat(&chat)).unwrap();
+        let fetched = block_on(store.get_chat(chat.id)).unwrap();
+        assert_eq!(fetched.as_ref(), Some(&chat));
 
         block_on(store.set_setting("model", &serde_json::json!("claude"))).unwrap();
         assert_eq!(

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -12,19 +12,19 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::error::Result;
-use crate::id::SessionId;
+use crate::id::ChatId;
 
 /// The approval policy class a tool declares for itself.
 ///
 /// Policy maps class → auto-approve / ask / deny. In v1: `ReadOnly` auto;
-/// `Workspace` auto inside the session workspace, ask outside; `Sensitive`
+/// `Workspace` auto inside the chat workspace, ask outside; `Sensitive`
 /// always asks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ApprovalClass {
     /// Never mutates anything (e.g. `read_file`, `list_dir`, `search`).
     ReadOnly,
-    /// Mutates the session workspace (e.g. `write_file`).
+    /// Mutates the chat workspace (e.g. `write_file`).
     Workspace,
     /// Escapes the workspace or reaches the network / external services
     /// (connector writes, networked `exec`, writes outside the workspace).
@@ -94,9 +94,9 @@ impl ToolOutput {
 /// as the agent loop lands.
 #[derive(Debug, Clone)]
 pub struct ToolCtx {
-    /// The session this call belongs to.
-    pub session_id: SessionId,
-    /// Absolute path to the session's workspace directory. Workspace-class
+    /// The chat this call belongs to.
+    pub chat_id: ChatId,
+    /// Absolute path to the chat's workspace directory. Workspace-class
     /// tools stay within it without prompting.
     pub workspace_dir: PathBuf,
 }

--- a/crates/openwave-core/src/tools.rs
+++ b/crates/openwave-core/src/tools.rs
@@ -1,7 +1,7 @@
 //! Built-in filesystem tools: `read_file`, `list_dir`, `write_file`.
 //!
 //! These are the M0 Workspace-class tools. Every path is resolved **relative to
-//! the session's workspace directory** and may not escape it (no absolute paths,
+//! the chat's workspace directory** and may not escape it (no absolute paths,
 //! no `..`); there is no sandbox yet, so that lexical confinement is the only
 //! guard. Failures the model should see and react to (missing file, bad path)
 //! come back as [`ToolOutput::error`], not `Err` — `Err` is reserved for
@@ -248,11 +248,11 @@ impl Tool for WriteFile {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::id::SessionId;
+    use crate::id::ChatId;
 
     fn ctx(dir: &std::path::Path) -> ToolCtx {
         ToolCtx {
-            session_id: SessionId::new(),
+            chat_id: ChatId::new(),
             workspace_dir: dir.to_path_buf(),
         }
     }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -6,8 +6,8 @@
 //! binds to an ephemeral **loopback** port and mints a per-launch **bearer
 //! token**: only the local process it was handed to can reach it.
 //!
-//! This slice is the session surface — create / list / get, behind the token.
-//! Posting a message and streaming the turn over `WS /sessions/{id}/events`
+//! This slice is the chat surface — create / list / get, behind the token.
+//! Posting a message and streaming the turn over `WS /chats/{id}/events`
 //! lands next, on top of this skeleton.
 
 mod auth;
@@ -33,11 +33,8 @@ pub fn app(state: AppState) -> Router {
     // `route_layer` applies the token check to matched API routes only, so an
     // unknown path still answers `404` (not `401`), and `/healthz` stays open.
     let api = Router::new()
-        .route(
-            "/sessions",
-            post(routes::create_session).get(routes::list_sessions),
-        )
-        .route("/sessions/{id}", get(routes::get_session))
+        .route("/chats", post(routes::create_chat).get(routes::list_chats))
+        .route("/chats/{id}", get(routes::get_chat))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_token,
@@ -126,7 +123,7 @@ mod tests {
 
     use axum::body::{to_bytes, Body};
     use axum::http::{header, Request, StatusCode};
-    use openwave_core::{AgentErrorInfo, Profile, Session, SessionId};
+    use openwave_core::{AgentErrorInfo, Chat, ChatId, Profile};
     use serde::de::DeserializeOwned;
     use tower::ServiceExt;
 
@@ -172,7 +169,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri("/sessions")
+                    .uri("/chats")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -183,7 +180,7 @@ mod tests {
         let wrong = router
             .oneshot(
                 Request::builder()
-                    .uri("/sessions")
+                    .uri("/chats")
                     .header(header::AUTHORIZATION, "Bearer not-the-token")
                     .body(Body::empty())
                     .unwrap(),
@@ -198,13 +195,13 @@ mod tests {
         let (router, token, _dir) = test_app().await;
         let bearer = format!("Bearer {token}");
 
-        let created: Session = {
+        let created: Chat = {
             let response = router
                 .clone()
                 .oneshot(
                     Request::builder()
                         .method("POST")
-                        .uri("/sessions")
+                        .uri("/chats")
                         .header(header::AUTHORIZATION, &bearer)
                         .header(header::CONTENT_TYPE, "application/json")
                         .body(Body::from(
@@ -220,12 +217,12 @@ mod tests {
         };
         assert_eq!(created.title.as_deref(), Some("hi"));
 
-        let fetched: Session = {
+        let fetched: Chat = {
             let response = router
                 .clone()
                 .oneshot(
                     Request::builder()
-                        .uri(format!("/sessions/{}", created.id))
+                        .uri(format!("/chats/{}", created.id))
                         .header(header::AUTHORIZATION, &bearer)
                         .body(Body::empty())
                         .unwrap(),
@@ -237,11 +234,11 @@ mod tests {
         };
         assert_eq!(fetched, created);
 
-        let listed: Vec<Session> = {
+        let listed: Vec<Chat> = {
             let response = router
                 .oneshot(
                     Request::builder()
-                        .uri("/sessions")
+                        .uri("/chats")
                         .header(header::AUTHORIZATION, &bearer)
                         .body(Body::empty())
                         .unwrap(),
@@ -255,12 +252,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unknown_session_is_404() {
+    async fn unknown_chat_is_404() {
         let (router, token, _dir) = test_app().await;
         let response = router
             .oneshot(
                 Request::builder()
-                    .uri(format!("/sessions/{}", SessionId::new()))
+                    .uri(format!("/chats/{}", ChatId::new()))
                     .header(header::AUTHORIZATION, format!("Bearer {token}"))
                     .body(Body::empty())
                     .unwrap(),
@@ -289,7 +286,7 @@ mod tests {
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri("/sessions/not-a-uuid")
+                    .uri("/chats/not-a-uuid")
                     .header(header::AUTHORIZATION, &bearer)
                     .body(Body::empty())
                     .unwrap(),
@@ -305,7 +302,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/sessions")
+                    .uri("/chats")
                     .header(header::AUTHORIZATION, &bearer)
                     .body(Body::from(r#"{"workspace_dir":"/tmp/ws"}"#))
                     .unwrap(),
@@ -348,19 +345,19 @@ mod tests {
         assert_eq!(health.status(), reqwest::StatusCode::OK);
 
         let unauthed = client
-            .get(format!("http://{addr}/sessions"))
+            .get(format!("http://{addr}/chats"))
             .send()
             .await
             .unwrap();
         assert_eq!(unauthed.status(), reqwest::StatusCode::UNAUTHORIZED);
 
         let authed = client
-            .get(format!("http://{addr}/sessions"))
+            .get(format!("http://{addr}/chats"))
             .bearer_auth(&token)
             .send()
             .await
             .unwrap();
         assert_eq!(authed.status(), reqwest::StatusCode::OK);
-        assert_eq!(authed.json::<Vec<Session>>().await.unwrap(), vec![]);
+        assert_eq!(authed.json::<Vec<Chat>>().await.unwrap(), vec![]);
     }
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1,7 +1,7 @@
-//! Session HTTP handlers.
+//! Chat HTTP handlers.
 //!
-//! The conversation CRUD surface: create a session (which owns a workspace
-//! directory), list them, fetch one. Driving a session — posting a message and
+//! The conversation CRUD surface: create a chat (which owns a workspace
+//! directory), list them, fetch one. Driving a chat — posting a message and
 //! streaming the turn's events over WebSocket — lands in the next slice.
 
 use std::path::PathBuf;
@@ -12,15 +12,15 @@ use axum::response::IntoResponse;
 use chrono::Utc;
 use serde::Deserialize;
 
-use openwave_core::{Session, SessionId};
+use openwave_core::{Chat, ChatId};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use crate::state::AppState;
 
-/// Body of `POST /sessions`.
+/// Body of `POST /chats`.
 #[derive(Debug, Deserialize)]
-pub struct CreateSession {
+pub struct CreateChat {
     /// Absolute path to the workspace directory the agent operates in.
     pub workspace_dir: PathBuf,
     /// Optional human-facing title.
@@ -28,37 +28,35 @@ pub struct CreateSession {
     pub title: Option<String>,
 }
 
-/// `POST /sessions` — create a session and return it (`201 Created`).
-pub async fn create_session(
+/// `POST /chats` — create a chat and return it (`201 Created`).
+pub async fn create_chat(
     State(state): State<AppState>,
-    Json(body): Json<CreateSession>,
+    Json(body): Json<CreateChat>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let session = Session {
-        id: SessionId::new(),
+    let chat = Chat {
+        id: ChatId::new(),
         title: body.title,
         workspace_dir: body.workspace_dir,
         created_at: Utc::now(),
     };
-    state.store.create_session(&session).await?;
-    Ok((StatusCode::CREATED, Json(session)))
+    state.store.create_chat(&chat).await?;
+    Ok((StatusCode::CREATED, Json(chat)))
 }
 
-/// `GET /sessions` — list sessions, most-recently-created first.
-pub async fn list_sessions(
-    State(state): State<AppState>,
-) -> Result<Json<Vec<Session>>, ServerError> {
-    Ok(Json(state.store.list_sessions().await?))
+/// `GET /chats` — list chats, most-recently-created first.
+pub async fn list_chats(State(state): State<AppState>) -> Result<Json<Vec<Chat>>, ServerError> {
+    Ok(Json(state.store.list_chats().await?))
 }
 
-/// `GET /sessions/{id}` — fetch one session, or `404`.
-pub async fn get_session(
+/// `GET /chats/{id}` — fetch one chat, or `404`.
+pub async fn get_chat(
     State(state): State<AppState>,
-    Path(id): Path<SessionId>,
-) -> Result<Json<Session>, ServerError> {
+    Path(id): Path<ChatId>,
+) -> Result<Json<Chat>, ServerError> {
     state
         .store
-        .get_session(id)
+        .get_chat(id)
         .await?
         .map(Json)
-        .ok_or_else(|| ServerError::not_found(format!("session {id} not found")))
+        .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))
 }

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -35,9 +35,9 @@ Present today:
 
 | Module | What it is |
 | --- | --- |
-| `id` | Typed identifiers (`SessionId`, `TurnId`, `CallId`, …) — newtypes so the compiler stops you mixing them up. |
+| `id` | Typed identifiers (`ChatId`, `TurnId`, `CallId`, …) — newtypes so the compiler stops you mixing them up. |
 | `error` | The crate-wide `AgentError` + `Result`. |
-| `model` | The persisted conversation model (`Session`, `Message`, `Role`). |
+| `model` | The persisted conversation model (`Chat`, `Message`, `Role`). |
 | `tool` | The tool contract (`Tool`, `ToolSpec`, `ToolOutput`, `ToolCtx`, `ApprovalClass`). |
 | `provider` | The model-provider contract (`ModelProvider`, `ChatRequest`, `ProviderEvent`, `Usage`). |
 


### PR DESCRIPTION
Renames the conversation entity from `Session` to `Chat` across the core and server crates.

## Why
`Session` reads like an ephemeral runtime/login object, but these are **durable conversations** — a thread of messages that owns a workspace. `Chat` matches how we actually talk about it and fits the local-first cowork tone (vs. the more enterprise "conversation"). Doing it now, while only a few PRs deep, is cheap; later it's a painful public-API break.

This also sets up the next slice: an **optional** `Project` parent (`chat.project_id: Option<ProjectId>`) — chats that may or may not be grouped into projects. (Deliberately unlike the alpha model, which mandates a project per conversation; keeping projectless chats is the cowork choice.)

## What changed
Mechanical, whole-vocabulary rename — no behavioral change:
- **core**: `Chat` / `ChatId`, `chat_id` columns, `create_chat`/`get_chat`/`list_chats`, threaded through the `Store` trait, agent loop, file tools' `ChatCtx`, and the event journal (`append_event`/`list_events` take `chat_id`).
- **server**: `/chats`, `/chats/{id}`, `CreateChat`.
- **schema**: `chat` table, `chat_id` foreign keys (`fk_message_chat`, `fk_event_chat`).

## Migration note
No `ALTER TABLE` rename migration: this is pre-release (`0.0.0`, no deployed databases), so the v1 migrations (`m0001`/`m0002`) are rewritten to emit `chat` from the start — a fresh `connect()` creates the `chat` table directly. Any throwaway local dev DB is simply recreated.

`Turn`/`Step` (the runtime concepts *inside* a chat) are unchanged.

## Verification
Full workspace `build` + `test` (37 core + 8 server) + `clippy` + `fmt` all green; a repo-wide sweep confirms zero residual `Session`/`session` references.