### PR TITLE
fix(server): reject non-absolute workspace_dir on chat creation

### DIFF
--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -252,6 +252,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn relative_workspace_dir_is_rejected() {
+        let (router, token, _dir) = test_app().await;
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/chats")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"workspace_dir": "relative/dir"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, "bad_request");
+    }
+
+    #[tokio::test]
     async fn unknown_chat_is_404() {
         let (router, token, _dir) = test_app().await;
         let response = router

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -33,6 +33,16 @@ pub async fn create_chat(
     State(state): State<AppState>,
     Json(body): Json<CreateChat>,
 ) -> Result<impl IntoResponse, ServerError> {
+    // The workspace path must be absolute: a relative one is resolved against
+    // the server process's CWD only later (when a tool canonicalizes it), so the
+    // same chat would map to different directories across restarts or launch
+    // dirs. Reject it here rather than persist an ambiguous path.
+    if !body.workspace_dir.is_absolute() {
+        return Err(ServerError::bad_request(format!(
+            "workspace_dir must be an absolute path, got {:?}",
+            body.workspace_dir
+        )));
+    }
     let chat = Chat {
         id: ChatId::new(),
         title: body.title,


### PR DESCRIPTION
`CreateChat` and the `Chat` model both document `workspace_dir` as an **absolute** path, but `POST /chats` persisted whatever was sent.

A relative value (e.g. `"myproject"`) was stored as-is and only resolved later — against the **server process's CWD** — when a file tool canonicalized it. So the same chat could map to different directories across a server restart, or when the server was launched from a different working directory. The persisted path was ambiguous.

## Fix
Enforce the contract at the HTTP boundary: a non-absolute `workspace_dir` is rejected with `400 bad_request` (the usual `{ kind, message }` body) and never persisted. `Path::is_absolute()` is a pure lexical check, so it's portable and doesn't touch the filesystem. Added a test asserting a relative path is rejected.

Found in review of the `openwave-server` crate.