### PR TITLE
feat(server): run a chat turn and journal it via POST /chats/{id}/messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,9 +1683,12 @@ dependencies = [
 name = "openwave-server"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "axum",
  "chrono",
+ "futures",
  "openwave-core",
+ "openwave-router",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -11,16 +11,19 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite"] }
+openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools"] }
+openwave-router = { path = "../openwave-router" }
 axum = { workspace = true }
-tokio = { workspace = true, features = ["net"] }
+tokio = { workspace = true, features = ["net", "rt"] }
+futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 tower = { version = "0.5", features = ["util"] }
 reqwest = { workspace = true }
+async-trait = { workspace = true }
 tempfile = "3"

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -16,6 +16,7 @@ openwave-router = { path = "../openwave-router" }
 axum = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt"] }
 futures = { workspace = true }
+async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
@@ -25,5 +26,4 @@ chrono = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 tower = { version = "0.5", features = ["util"] }
 reqwest = { workspace = true }
-async-trait = { workspace = true }
 tempfile = "3"

--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -42,6 +42,18 @@ impl ServerError {
             },
         }
     }
+
+    /// A `409 Conflict` for a request that clashes with current state (e.g. a
+    /// turn is already running for the chat).
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            info: AgentErrorInfo {
+                kind: "conflict".to_string(),
+                message: message.into(),
+            },
+        }
+    }
 }
 
 /// Core errors surfacing from a handler are internal failures (a store write

--- a/crates/openwave-server/src/hub.rs
+++ b/crates/openwave-server/src/hub.rs
@@ -1,0 +1,47 @@
+//! Running a turn and journaling what it emits.
+//!
+//! A turn's [`AgentEvent`](openwave_core::AgentEvent)s flow through an unbounded
+//! channel: the agent drives the turn on one side, and this hub drains the other,
+//! appending each event to the store's per-chat journal as it arrives. The journal
+//! is what a client replays on connect, so persisting here (rather than in the
+//! handler after the fact) is what will let the WebSocket surface do
+//! snapshot → replay → live in the next slice.
+
+use std::sync::Arc;
+
+use futures::channel::mpsc::unbounded;
+use futures::{future, StreamExt};
+
+use openwave_core::{Agent, Chat, Store};
+
+/// Drive one turn to completion, journaling every event it emits.
+///
+/// The drive and the journal run concurrently, so events land in the store as the
+/// turn produces them. Returns once the turn has finished and every event is
+/// persisted.
+pub(crate) async fn drive_and_journal(
+    agent: Agent,
+    chat: Chat,
+    input: String,
+    store: Arc<dyn Store>,
+) {
+    let (events_tx, mut events_rx) = unbounded();
+    let chat_id = chat.id;
+
+    let journal = async move {
+        while let Some(event) = events_rx.next().await {
+            // A journal write failure can't be surfaced to the (already-returned)
+            // client; the turn continues and the live stream still carries the
+            // event once the WS surface lands.
+            let _ = store.append_event(chat_id, &event).await;
+        }
+    };
+
+    let drive = async move {
+        // Dropping `events_tx` at the end of this future closes the channel,
+        // which ends the journal loop.
+        let _ = agent.run_turn(&chat, &input, &events_tx).await;
+    };
+
+    future::join(drive, journal).await;
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -14,6 +14,7 @@ mod auth;
 mod error;
 mod extract;
 mod hub;
+mod provider;
 mod routes;
 mod state;
 
@@ -112,13 +113,18 @@ pub async fn bind(config: Config) -> Result<Server> {
 
 /// Assemble the agent's dependencies for a real launch.
 ///
-/// The provider is Anthropic for now, keyed from `ANTHROPIC_API_KEY` in the
-/// environment (a keychain-backed secrets flow and the composite router land in
-/// later slices). No key means egress fails closed at turn time — surfaced as a
-/// `TurnFailed` event — rather than a silent default.
+/// The provider is Anthropic for now, keyed from `ANTHROPIC_API_KEY` (a
+/// keychain-backed secrets flow and the composite router land in later slices).
+/// **Fail closed:** an egressing provider is wired only when a key is actually
+/// present; with no key we wire [`UnconfiguredProvider`](provider::UnconfiguredProvider),
+/// which refuses without any network call, so the transcript never leaves the
+/// machine. A turn then surfaces a `TurnFailed`, never a silent default or a
+/// request sent with an empty key.
 fn agent_deps() -> (Arc<dyn ModelProvider>, Arc<ToolRegistry>, AgentConfig) {
-    let api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_default();
-    let provider: Arc<dyn ModelProvider> = Arc::new(AnthropicProvider::new(api_key));
+    let provider: Arc<dyn ModelProvider> = match std::env::var("ANTHROPIC_API_KEY") {
+        Ok(key) if !key.is_empty() => Arc::new(AnthropicProvider::new(key)),
+        _ => Arc::new(provider::UnconfiguredProvider),
+    };
     let tools = Arc::new(
         ToolRegistry::new()
             .with(Box::new(ReadFile))
@@ -512,6 +518,45 @@ mod tests {
 
         // Release the first turn so it can finish and free the slot.
         gate.notify_one();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn slot_frees_after_a_turn_completes() {
+        let (router, token, store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "one").await,
+            StatusCode::ACCEPTED
+        );
+        wait_for_turn(&store, chat.id).await;
+
+        // The turn finished, so its slot is released and a follow-up is accepted.
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "two").await,
+            StatusCode::ACCEPTED
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn turn_fails_closed_with_no_provider_configured() {
+        // The unconfigured provider errors without any network call; the turn must
+        // end in TurnFailed, not hang or egress.
+        let (router, token, store, _dir) =
+            test_app_with(Arc::new(crate::provider::UnconfiguredProvider)).await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "hello").await,
+            StatusCode::ACCEPTED
+        );
+        let events = wait_for_turn(&store, chat.id).await;
+        assert!(matches!(
+            events.last().unwrap().event,
+            AgentEvent::TurnFailed { .. }
+        ));
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -6,13 +6,14 @@
 //! binds to an ephemeral **loopback** port and mints a per-launch **bearer
 //! token**: only the local process it was handed to can reach it.
 //!
-//! This slice is the chat surface — create / list / get, behind the token.
-//! Posting a message and streaming the turn over `WS /chats/{id}/events`
-//! lands next, on top of this skeleton.
+//! This slice runs turns: the chat CRUD surface plus `POST /chats/{id}/messages`,
+//! which starts a turn (one per chat at a time) and journals its events. Streaming
+//! those events live over `WS /chats/{id}/events` lands next, on top of the journal.
 
 mod auth;
 mod error;
 mod extract;
+mod hub;
 mod routes;
 mod state;
 
@@ -23,7 +24,11 @@ use axum::routing::{get, post};
 use axum::Router;
 use tokio::net::TcpListener;
 
-use openwave_core::{AgentError, Config, DbStore, Profile, Result, Store};
+use openwave_core::{
+    AgentConfig, AgentError, Config, DbStore, ListDir, ModelProvider, Profile, ReadFile, Result,
+    Store, ToolRegistry, WriteFile,
+};
+use openwave_router::AnthropicProvider;
 
 pub use error::ServerError;
 pub use state::AppState;
@@ -35,6 +40,7 @@ pub fn app(state: AppState) -> Router {
     let api = Router::new()
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
         .route("/chats/{id}", get(routes::get_chat))
+        .route("/chats/{id}/messages", post(routes::post_message))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_token,
@@ -77,10 +83,15 @@ impl Server {
     }
 }
 
+/// Placeholder default model, used until the settings-driven model selection and
+/// the composite router land. Overridable with `OPENWAVE_MODEL`.
+const DEFAULT_MODEL: &str = "claude-opus-4-8";
+
 /// Wire the store from `config` and bind the API to an ephemeral loopback port.
 pub async fn bind(config: Config) -> Result<Server> {
     let store = connect_store(&config).await?;
-    let state = AppState::new(config, store);
+    let (provider, tools, agent_config) = agent_deps();
+    let state = AppState::new(config, store, provider, tools, agent_config);
     let token = state.token.clone();
     let router = app(state);
 
@@ -97,6 +108,29 @@ pub async fn bind(config: Config) -> Result<Server> {
         listener,
         router,
     })
+}
+
+/// Assemble the agent's dependencies for a real launch.
+///
+/// The provider is Anthropic for now, keyed from `ANTHROPIC_API_KEY` in the
+/// environment (a keychain-backed secrets flow and the composite router land in
+/// later slices). No key means egress fails closed at turn time — surfaced as a
+/// `TurnFailed` event — rather than a silent default.
+fn agent_deps() -> (Arc<dyn ModelProvider>, Arc<ToolRegistry>, AgentConfig) {
+    let api_key = std::env::var("ANTHROPIC_API_KEY").unwrap_or_default();
+    let provider: Arc<dyn ModelProvider> = Arc::new(AnthropicProvider::new(api_key));
+    let tools = Arc::new(
+        ToolRegistry::new()
+            .with(Box::new(ReadFile))
+            .with(Box::new(ListDir))
+            .with(Box::new(WriteFile)),
+    );
+    let model = std::env::var("OPENWAVE_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+    let agent_config = AgentConfig {
+        model,
+        ..AgentConfig::default()
+    };
+    (provider, tools, agent_config)
 }
 
 /// Open the durable store the profile selects.
@@ -121,25 +155,97 @@ async fn connect_store(config: &Config) -> Result<Arc<dyn Store>> {
 mod tests {
     use super::*;
 
+    use std::time::Duration;
+
+    use async_trait::async_trait;
     use axum::body::{to_bytes, Body};
     use axum::http::{header, Request, StatusCode};
-    use openwave_core::{AgentErrorInfo, Chat, ChatId, Profile};
+    use futures::stream::{self, BoxStream, StreamExt};
+    use openwave_core::{
+        AgentErrorInfo, AgentEvent, Chat, ChatId, ChatRequest, ProviderEvent, ProviderId,
+        SequencedEvent, StopReason, Usage,
+    };
     use serde::de::DeserializeOwned;
+    use tokio::sync::Notify;
     use tower::ServiceExt;
 
-    /// A router backed by a fresh temp SQLite store, plus its token and the
-    /// tempdir (kept alive for the test's duration).
-    async fn test_app() -> (Router, Arc<str>, tempfile::TempDir) {
+    /// A provider that answers with a one-line completion and no tool calls.
+    struct FakeProvider;
+
+    #[async_trait]
+    impl ModelProvider for FakeProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("fake")
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta { text: "hi".into() },
+                ProviderEvent::Usage(Usage {
+                    input_tokens: 1,
+                    output_tokens: 1,
+                    ..Default::default()
+                }),
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    /// A provider whose completion blocks on `gate` until the test releases it —
+    /// so a turn stays active while the test checks concurrency behavior.
+    struct GatedProvider {
+        gate: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for GatedProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("gated")
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let gate = self.gate.clone();
+            Ok(stream::once(async move {
+                gate.notified().await;
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                }
+            })
+            .boxed())
+        }
+    }
+
+    /// A router over a fresh temp SQLite store with the given provider; returns
+    /// the router, token, the store (to inspect the journal), and the tempdir.
+    async fn test_app_with(
+        provider: Arc<dyn ModelProvider>,
+    ) -> (Router, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
-        let store = DbStore::connect(&format!(
-            "sqlite://{}?mode=rwc",
-            dir.path().join("t.db").display()
-        ))
-        .await
-        .unwrap();
-        let state = AppState::new(Config::desktop(dir.path()), Arc::new(store));
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let state = AppState::new(
+            Config::desktop(dir.path()),
+            store.clone(),
+            provider,
+            Arc::new(ToolRegistry::new()),
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        );
         let token = state.token.clone();
-        (app(state), token, dir)
+        (app(state), token, store, dir)
+    }
+
+    async fn test_app() -> (Router, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
+        test_app_with(Arc::new(FakeProvider)).await
     }
 
     async fn json_body<T: DeserializeOwned>(response: axum::response::Response) -> T {
@@ -147,9 +253,73 @@ mod tests {
         serde_json::from_slice(&bytes).unwrap()
     }
 
+    /// Create a chat and return it.
+    async fn make_chat(router: &Router, bearer: &str) -> Chat {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/chats")
+                    .header(header::AUTHORIZATION, bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"workspace_dir": "/tmp/ws"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        json_body(response).await
+    }
+
+    /// POST a message to a chat, returning the response status.
+    async fn send_message(
+        router: &Router,
+        bearer: &str,
+        chat: ChatId,
+        content: &str,
+    ) -> StatusCode {
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/chats/{chat}/messages"))
+                    .header(header::AUTHORIZATION, bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"content": content}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+    }
+
+    /// Poll the journal until the turn terminates (or time out), returning its
+    /// events in sequence order.
+    async fn wait_for_turn(store: &Arc<dyn Store>, chat: ChatId) -> Vec<SequencedEvent> {
+        for _ in 0..200 {
+            let events = store.list_events(chat, 0).await.unwrap();
+            if events.iter().any(|e| {
+                matches!(
+                    e.event,
+                    AgentEvent::TurnCompleted { .. } | AgentEvent::TurnFailed { .. }
+                )
+            }) {
+                return events;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("turn did not finish within the timeout");
+    }
+
     #[tokio::test]
     async fn health_needs_no_token() {
-        let (router, _token, _dir) = test_app().await;
+        let (router, _token, _store, _dir) = test_app().await;
         let response = router
             .oneshot(
                 Request::builder()
@@ -164,7 +334,7 @@ mod tests {
 
     #[tokio::test]
     async fn api_rejects_missing_and_wrong_tokens() {
-        let (router, _token, _dir) = test_app().await;
+        let (router, _token, _store, _dir) = test_app().await;
         let missing = router
             .clone()
             .oneshot(
@@ -192,7 +362,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_then_get_and_list() {
-        let (router, token, _dir) = test_app().await;
+        let (router, token, _store, _dir) = test_app().await;
         let bearer = format!("Bearer {token}");
 
         let created: Chat = {
@@ -253,7 +423,7 @@ mod tests {
 
     #[tokio::test]
     async fn relative_workspace_dir_is_rejected() {
-        let (router, token, _dir) = test_app().await;
+        let (router, token, _store, _dir) = test_app().await;
         let response = router
             .oneshot(
                 Request::builder()
@@ -275,7 +445,7 @@ mod tests {
 
     #[tokio::test]
     async fn unknown_chat_is_404() {
-        let (router, token, _dir) = test_app().await;
+        let (router, token, _store, _dir) = test_app().await;
         let response = router
             .oneshot(
                 Request::builder()
@@ -289,6 +459,61 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn post_message_runs_a_turn_and_journals_its_events() {
+        let (router, token, store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "hello").await,
+            StatusCode::ACCEPTED
+        );
+
+        let events = wait_for_turn(&store, chat.id).await;
+        assert!(matches!(events[0].event, AgentEvent::TurnStarted { .. }));
+        assert!(events
+            .iter()
+            .any(|e| matches!(&e.event, AgentEvent::TextDelta { text } if text == "hi")));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.event, AgentEvent::TurnCompleted { .. })));
+    }
+
+    #[tokio::test]
+    async fn message_to_unknown_chat_is_404() {
+        let (router, token, _store, _dir) = test_app().await;
+        assert_eq!(
+            send_message(&router, &format!("Bearer {token}"), ChatId::new(), "hi").await,
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_second_turn_on_the_same_chat_is_refused() {
+        // A gated provider keeps the first turn active (blocked on the gate) while
+        // we submit a second one, which must be refused with 409.
+        let gate = Arc::new(Notify::new());
+        let (router, token, _store, _dir) =
+            test_app_with(Arc::new(GatedProvider { gate: gate.clone() })).await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        // The handler claims the chat's slot synchronously before returning, so by
+        // the time this 202 is observed the turn is holding the slot.
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "one").await,
+            StatusCode::ACCEPTED
+        );
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "two").await,
+            StatusCode::CONFLICT
+        );
+
+        // Release the first turn so it can finish and free the slot.
+        gate.notify_one();
+    }
+
     #[tokio::test]
     async fn bind_yields_a_loopback_addr_and_token() {
         let dir = tempfile::tempdir().unwrap();
@@ -299,7 +524,7 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_requests_get_json_errors_not_plaintext() {
-        let (router, token, _dir) = test_app().await;
+        let (router, token, _store, _dir) = test_app().await;
         let bearer = format!("Bearer {token}");
 
         // A non-UUID path segment: 400 with a parseable `{ kind, message }` body,

--- a/crates/openwave-server/src/provider.rs
+++ b/crates/openwave-server/src/provider.rs
@@ -1,0 +1,27 @@
+//! A fail-closed provider for when no model credentials are configured.
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+
+use openwave_core::{AgentError, ChatRequest, ModelProvider, ProviderEvent, ProviderId, Result};
+
+/// Stands in when no provider is configured (e.g. no API key present).
+///
+/// Its `stream` returns an error immediately, **without opening any connection or
+/// sending the request**, so a turn fails closed — the transcript never leaves the
+/// machine — instead of egressing to a provider with an empty key and failing only
+/// after the round-trip.
+pub struct UnconfiguredProvider;
+
+#[async_trait]
+impl ModelProvider for UnconfiguredProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("unconfigured")
+    }
+
+    async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        Err(AgentError::config(
+            "no model provider is configured (set ANTHROPIC_API_KEY)",
+        ))
+    }
+}

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -12,7 +12,7 @@ use axum::response::IntoResponse;
 use chrono::Utc;
 use serde::Deserialize;
 
-use openwave_core::{Chat, ChatId};
+use openwave_core::{Agent, Chat, ChatId};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
@@ -69,4 +69,49 @@ pub async fn get_chat(
         .await?
         .map(Json)
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))
+}
+
+/// Body of `POST /chats/{id}/messages`.
+#[derive(Debug, Deserialize)]
+pub struct PostMessage {
+    /// The user's input for this turn.
+    pub content: String,
+}
+
+/// `POST /chats/{id}/messages` — submit a message and start a turn.
+///
+/// Returns `202 Accepted` immediately; the turn runs in the background and its
+/// events are journaled as they emit (a client watches them over the event
+/// stream). `404` if the chat doesn't exist, `409` if a turn is already running
+/// for it (one turn per chat at a time).
+pub async fn post_message(
+    State(state): State<AppState>,
+    Path(id): Path<ChatId>,
+    Json(body): Json<PostMessage>,
+) -> Result<StatusCode, ServerError> {
+    let chat = state
+        .store
+        .get_chat(id)
+        .await?
+        .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
+
+    // Claim the chat's single turn slot up front; a concurrent turn is refused.
+    let active = state.active_turns.try_acquire(id).ok_or_else(|| {
+        ServerError::conflict(format!("chat {id} already has a turn in progress"))
+    })?;
+
+    let agent = Agent::new(
+        state.provider.clone(),
+        state.tools.clone(),
+        state.store.clone(),
+        state.agent_config.clone(),
+    );
+    let store = state.store.clone();
+    tokio::spawn(async move {
+        // Hold the slot for the turn's lifetime; dropping it frees the chat.
+        let _active = active;
+        crate::hub::drive_and_journal(agent, chat, body.content, store).await;
+    });
+
+    Ok(StatusCode::ACCEPTED)
 }

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -1,35 +1,115 @@
 //! Shared application state handed to every request handler.
 
-use std::sync::Arc;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
 
-use openwave_core::{Config, Store};
+use openwave_core::{AgentConfig, ChatId, Config, ModelProvider, Store, ToolRegistry};
 use uuid::Uuid;
 
-/// The state cloned into each handler: the boot config, the durable store, and
-/// the per-launch bearer token that guards the API.
+/// The state cloned into each handler: the boot config, the durable store, the
+/// agent's dependencies (provider + tools + tuning), the per-launch bearer token,
+/// and the guard that keeps a chat to one running turn at a time.
 ///
 /// Cheap to clone — everything shared is behind an `Arc`.
 #[derive(Clone)]
 pub struct AppState {
     /// Boot configuration for this launch.
     pub config: Arc<Config>,
-    /// Durable metadata and conversation state.
+    /// Durable metadata, conversation state, and the event journal.
     pub store: Arc<dyn Store>,
+    /// The model backend turns stream completions from.
+    pub provider: Arc<dyn ModelProvider>,
+    /// The tools available to the agent.
+    pub tools: Arc<ToolRegistry>,
+    /// Per-turn agent tuning (model, limits, …).
+    pub agent_config: AgentConfig,
     /// The secret every request must present as `Authorization: Bearer <token>`.
     pub token: Arc<str>,
+    /// Tracks which chats have a turn in flight, so a second concurrent turn on
+    /// the same chat is refused rather than racing the event journal.
+    pub active_turns: Arc<TurnGuard>,
 }
 
 impl AppState {
     /// Assemble state, minting a fresh random bearer token for this launch.
-    ///
-    /// The token is generated per launch (not persisted): the server binds to a
-    /// loopback port, and the token is handed to the local client that spawned
-    /// it, so a fresh secret each run is exactly what we want.
-    pub fn new(config: Config, store: Arc<dyn Store>) -> Self {
+    pub fn new(
+        config: Config,
+        store: Arc<dyn Store>,
+        provider: Arc<dyn ModelProvider>,
+        tools: Arc<ToolRegistry>,
+        agent_config: AgentConfig,
+    ) -> Self {
         Self {
             config: Arc::new(config),
             store,
+            provider,
+            tools,
+            agent_config,
             token: Uuid::new_v4().to_string().into(),
+            active_turns: Arc::new(TurnGuard::default()),
         }
+    }
+}
+
+/// Admits one running turn per chat.
+///
+/// The agent's per-chat sequence numbering assumes a single writer; this guard
+/// upholds that at the API edge — a turn holds its chat's slot until it finishes,
+/// and a concurrent request for the same chat is refused (never queued behind it).
+#[derive(Default)]
+pub struct TurnGuard {
+    active: Mutex<HashSet<ChatId>>,
+}
+
+impl TurnGuard {
+    /// Claim the chat's turn slot, or `None` if a turn is already running for it.
+    /// The returned [`ActiveTurn`] releases the slot when dropped — including on
+    /// panic — so a failed turn never wedges the chat.
+    pub fn try_acquire(self: &Arc<Self>, chat_id: ChatId) -> Option<ActiveTurn> {
+        if self.active.lock().unwrap().insert(chat_id) {
+            Some(ActiveTurn {
+                guard: Arc::clone(self),
+                chat_id,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+/// A held turn slot; releases the chat on drop.
+pub struct ActiveTurn {
+    guard: Arc<TurnGuard>,
+    chat_id: ChatId,
+}
+
+impl Drop for ActiveTurn {
+    fn drop(&mut self) {
+        self.guard.active.lock().unwrap().remove(&self.chat_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_turn_per_chat_then_released_on_drop() {
+        let guard = Arc::new(TurnGuard::default());
+        let chat = ChatId::new();
+
+        let held = guard.try_acquire(chat).expect("first acquire succeeds");
+        assert!(
+            guard.try_acquire(chat).is_none(),
+            "a second turn for the same chat is refused"
+        );
+        // A different chat is independent.
+        assert!(guard.try_acquire(ChatId::new()).is_some());
+
+        drop(held);
+        assert!(
+            guard.try_acquire(chat).is_some(),
+            "the slot frees once the turn is dropped"
+        );
     }
 }


### PR DESCRIPTION
Wires the agent into the server so a chat can actually run a turn. `POST /chats/{id}/messages` starts a turn and returns `202 Accepted`; the turn runs in the background and its events are appended to the chat's journal as they emit. The WebSocket surface replays + streams those events in the next slice.

## Endpoint
`POST /chats/{id}/messages` — body `{ "content": "…" }`
- `202` — turn started (watch the journal / upcoming WS stream for progress)
- `404` — no such chat
- `409` — a turn is already running for this chat

## What's wired
- **`AppState`** now carries the agent's dependencies — `provider`, `tools`, `AgentConfig` — plus a per-chat `TurnGuard`. `bind()` assembles an Anthropic provider (keyed from `ANTHROPIC_API_KEY`) and the built-in file tools.
- **One active turn per chat.** The handler claims the chat's turn slot *synchronously* before spawning, and a concurrent message is refused with `409`. This upholds the single-writer invariant the journal's per-chat `seq` assignment assumes (the seq-race flagged when the journal landed). The slot is an RAII guard released on drop — including on panic — so a failed turn never wedges the chat.
- **`hub::drive_and_journal`** runs the turn and persists its events concurrently, so events land in the journal as the turn produces them (the shape the live WS stream builds on).

## Deliberate scoping (flagged, not baked into code beyond a comment)
- **Provider is Anthropic keyed from the env for now.** No key ⇒ egress fails closed at turn time (surfaced as a `TurnFailed` event), never a silent default — consistent with the fail-closed-egress principle. The keychain-backed secrets flow, settings-driven model selection, and the composite router are separate later slices; `OPENWAVE_MODEL` overrides a placeholder default until then.
- **Turn is fire-and-forget (202).** Progress is observed via the journal now, and the WS stream next. No cancel/steer yet.

## Tests
Turn runs end-to-end and journals `TurnStarted` → text delta → `TurnCompleted` (fake provider); message to an unknown chat is `404`; a second concurrent turn is a deterministic `409` (a gated provider holds the first turn open while the second is submitted); plus a `TurnGuard` unit test for acquire/refuse/release. 13 tests, clippy + fmt green.