### PR TITLE
feat(server): stream chat turn events over WS /chats/{id}/events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,6 +1694,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "uuid",
 ]

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools"] }
 openwave-router = { path = "../openwave-router" }
 axum = { workspace = true }
-tokio = { workspace = true, features = ["net", "rt"] }
+tokio = { workspace = true, features = ["net", "rt", "sync", "macros"] }
 futures = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -26,4 +26,5 @@ chrono = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 tower = { version = "0.5", features = ["util"] }
 reqwest = { workspace = true }
+tokio-tungstenite = "0.29"
 tempfile = "3"

--- a/crates/openwave-server/src/bus.rs
+++ b/crates/openwave-server/src/bus.rs
@@ -1,0 +1,44 @@
+//! In-memory live event fan-out, keyed by chat.
+//!
+//! The journal (in the store) is the durable record a client replays on connect;
+//! this bus is the *live* tail. As a turn runs, the hub appends each event to the
+//! journal and republishes it here with its assigned `seq`, so a connected
+//! WebSocket sees it immediately. A client that isn't connected misses nothing —
+//! it replays from the journal when it connects.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use tokio::sync::broadcast;
+
+use openwave_core::{ChatId, SequencedEvent};
+
+/// How many live events a slow subscriber may fall behind before it's dropped
+/// (`Lagged`). A lagging client is expected to reconnect and replay from the
+/// journal with an `after` cursor, so this only bounds memory, not correctness.
+const LIVE_BUFFER: usize = 256;
+
+/// Per-chat broadcast channels for live turn events.
+#[derive(Default)]
+pub struct EventBus {
+    channels: Mutex<HashMap<ChatId, broadcast::Sender<SequencedEvent>>>,
+}
+
+impl EventBus {
+    /// The broadcast sender for a chat, created on first use. Kept in the map so
+    /// the channel outlives any individual turn or subscriber.
+    pub fn sender(&self, chat: ChatId) -> broadcast::Sender<SequencedEvent> {
+        self.channels
+            .lock()
+            .unwrap()
+            .entry(chat)
+            .or_insert_with(|| broadcast::channel(LIVE_BUFFER).0)
+            .clone()
+    }
+
+    /// Subscribe to a chat's live events. Events published after this call are
+    /// delivered; a client pairs this with a journal replay to cover the past.
+    pub fn subscribe(&self, chat: ChatId) -> broadcast::Receiver<SequencedEvent> {
+        self.sender(chat).subscribe()
+    }
+}

--- a/crates/openwave-server/src/extract.rs
+++ b/crates/openwave-server/src/extract.rs
@@ -6,7 +6,7 @@
 //! unparseable body, wrong/absent `Content-Type` — answers with the same
 //! `{ kind, message }` JSON a client can always parse.
 
-use axum::extract::rejection::{JsonRejection, PathRejection};
+use axum::extract::rejection::{JsonRejection, PathRejection, QueryRejection};
 use axum::extract::{FromRequest, FromRequestParts, Request};
 use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
@@ -56,6 +56,28 @@ where
         let axum::extract::Path(value) = axum::extract::Path::<T>::from_request_parts(parts, state)
             .await
             .map_err(|rejection: PathRejection| ServerError::bad_request(rejection.body_text()))?;
+        Ok(Self(value))
+    }
+}
+
+/// Like [`axum::extract::Query`], but an unparseable query string (e.g. a
+/// non-integer `after`) becomes a `400` with a JSON `{ kind, message }` body.
+pub struct Query<T>(pub T);
+
+impl<T, S> FromRequestParts<S> for Query<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ServerError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let axum::extract::Query(value) =
+            axum::extract::Query::<T>::from_request_parts(parts, state)
+                .await
+                .map_err(|rejection: QueryRejection| {
+                    ServerError::bad_request(rejection.body_text())
+                })?;
         Ok(Self(value))
     }
 }

--- a/crates/openwave-server/src/hub.rs
+++ b/crates/openwave-server/src/hub.rs
@@ -1,39 +1,49 @@
-//! Running a turn and journaling what it emits.
+//! Running a turn, journaling what it emits, and fanning it out live.
 //!
 //! A turn's [`AgentEvent`](openwave_core::AgentEvent)s flow through an unbounded
 //! channel: the agent drives the turn on one side, and this hub drains the other,
-//! appending each event to the store's per-chat journal as it arrives. The journal
-//! is what a client replays on connect, so persisting here (rather than in the
-//! handler after the fact) is what will let the WebSocket surface do
-//! snapshot → replay → live in the next slice.
+//! appending each event to the store's per-chat journal and republishing it on the
+//! live [`EventBus`](crate::bus::EventBus) with its assigned `seq`. The journal is
+//! what a client replays on connect; the bus is the live tail. Together they let
+//! the WebSocket surface do snapshot → replay → live without gaps.
 
 use std::sync::Arc;
 
 use futures::channel::mpsc::unbounded;
 use futures::{future, StreamExt};
 
-use openwave_core::{Agent, Chat, Store};
+use openwave_core::{Agent, Chat, SequencedEvent, Store};
 
-/// Drive one turn to completion, journaling every event it emits.
+use crate::bus::EventBus;
+
+/// Drive one turn to completion, journaling every event it emits and publishing
+/// it to the live bus.
 ///
-/// The drive and the journal run concurrently, so events land in the store as the
-/// turn produces them. Returns once the turn has finished and every event is
-/// persisted.
+/// The drive and the journal run concurrently, so events land in the store — and
+/// on the bus — as the turn produces them. Returns once the turn has finished and
+/// every event is persisted.
 pub(crate) async fn drive_and_journal(
     agent: Agent,
     chat: Chat,
     input: String,
     store: Arc<dyn Store>,
+    events: Arc<EventBus>,
 ) {
     let (events_tx, mut events_rx) = unbounded();
     let chat_id = chat.id;
+    let live = events.sender(chat_id);
 
     let journal = async move {
         while let Some(event) = events_rx.next().await {
-            // A journal write failure can't be surfaced to the (already-returned)
-            // client; the turn continues and the live stream still carries the
-            // event once the WS surface lands.
-            let _ = store.append_event(chat_id, &event).await;
+            // The seq the journal assigns is the same one the live event carries,
+            // so a client can dedup replay vs. live by seq. A write failure can't
+            // be surfaced to the (already-returned) client; skip publishing it so
+            // the live stream never carries an event that isn't in the journal.
+            if let Ok(seq) = store.append_event(chat_id, &event).await {
+                // `send` errors only when no one is subscribed — fine, that client
+                // will replay from the journal when it connects.
+                let _ = live.send(SequencedEvent { seq, event });
+            }
         }
     };
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -6,11 +6,13 @@
 //! binds to an ephemeral **loopback** port and mints a per-launch **bearer
 //! token**: only the local process it was handed to can reach it.
 //!
-//! This slice runs turns: the chat CRUD surface plus `POST /chats/{id}/messages`,
-//! which starts a turn (one per chat at a time) and journals its events. Streaming
-//! those events live over `WS /chats/{id}/events` lands next, on top of the journal.
+//! The surface runs turns end to end: the chat CRUD routes, `POST
+//! /chats/{id}/messages` to start a turn (one per chat at a time), and
+//! `WS /chats/{id}/events` to watch it — journaled events are replayed on connect
+//! and then streamed live (snapshot → replay → live).
 
 mod auth;
+mod bus;
 mod error;
 mod extract;
 mod hub;
@@ -42,6 +44,7 @@ pub fn app(state: AppState) -> Router {
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
         .route("/chats/{id}", get(routes::get_chat))
         .route("/chats/{id}/messages", post(routes::post_message))
+        .route("/chats/{id}/events", get(routes::chat_events))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_token,
@@ -651,5 +654,165 @@ mod tests {
             .unwrap();
         assert_eq!(authed.status(), reqwest::StatusCode::OK);
         assert_eq!(authed.json::<Vec<Chat>>().await.unwrap(), vec![]);
+    }
+
+    // --- WebSocket event stream ---
+
+    use std::net::SocketAddr;
+
+    use tokio_tungstenite::connect_async;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+    use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+    /// Serve a router (with the given provider) over a real loopback socket.
+    async fn serve_app_with(
+        provider: Arc<dyn ModelProvider>,
+    ) -> (SocketAddr, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
+        let (router, token, store, dir) = test_app_with(provider).await;
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, router).await;
+        });
+        (addr, token, store, dir)
+    }
+
+    async fn make_chat_http(client: &reqwest::Client, addr: SocketAddr, token: &str) -> Chat {
+        client
+            .post(format!("http://{addr}/chats"))
+            .bearer_auth(token)
+            .json(&serde_json::json!({"workspace_dir": "/tmp/ws"}))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap()
+    }
+
+    async fn send_message_http(
+        client: &reqwest::Client,
+        addr: SocketAddr,
+        token: &str,
+        chat: ChatId,
+    ) {
+        let response = client
+            .post(format!("http://{addr}/chats/{chat}/messages"))
+            .bearer_auth(token)
+            .json(&serde_json::json!({"content": "hi"}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::ACCEPTED);
+    }
+
+    /// Connect to a chat's event socket (authenticated) and read frames until the
+    /// turn ends (or a timeout), returning the decoded events in arrival order.
+    async fn read_until_turn_end(
+        addr: SocketAddr,
+        token: &str,
+        chat: ChatId,
+        after: i64,
+    ) -> Vec<SequencedEvent> {
+        let mut request = format!("ws://{addr}/chats/{chat}/events?after={after}")
+            .into_client_request()
+            .unwrap();
+        request
+            .headers_mut()
+            .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+        let (mut socket, _response) = connect_async(request).await.unwrap();
+
+        let mut events = Vec::new();
+        let read = async {
+            while let Some(frame) = socket.next().await {
+                let WsMessage::Text(text) = frame.unwrap() else {
+                    continue;
+                };
+                let event: SequencedEvent = serde_json::from_str(text.as_str()).unwrap();
+                let done = matches!(
+                    event.event,
+                    AgentEvent::TurnCompleted { .. } | AgentEvent::TurnFailed { .. }
+                );
+                events.push(event);
+                if done {
+                    break;
+                }
+            }
+        };
+        tokio::time::timeout(Duration::from_secs(5), read)
+            .await
+            .expect("turn did not complete over the socket");
+        events
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ws_replays_a_finished_turn_from_the_journal() {
+        let (addr, token, store, _dir) = serve_app_with(Arc::new(FakeProvider)).await;
+        let client = reqwest::Client::new();
+        let chat = make_chat_http(&client, addr, &token).await;
+
+        // Run the turn to completion, then connect — everything comes from replay.
+        send_message_http(&client, addr, &token, chat.id).await;
+        wait_for_turn(&store, chat.id).await;
+
+        let events = read_until_turn_end(addr, &token, chat.id, 0).await;
+        assert_eq!(events.first().unwrap().seq, 1, "replay starts at seq 1");
+        assert!(matches!(events[0].event, AgentEvent::TurnStarted { .. }));
+        assert!(events
+            .iter()
+            .any(|e| matches!(&e.event, AgentEvent::TextDelta { text } if text == "hi")));
+        assert!(matches!(
+            events.last().unwrap().event,
+            AgentEvent::TurnCompleted { .. }
+        ));
+        // Sequence numbers are strictly increasing.
+        assert!(events.windows(2).all(|w| w[0].seq < w[1].seq));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ws_streams_a_turn_started_after_connecting() {
+        let (addr, token, _store, _dir) = serve_app_with(Arc::new(FakeProvider)).await;
+        let client = reqwest::Client::new();
+        let chat = make_chat_http(&client, addr, &token).await;
+
+        // Connect first (journal empty), then trigger the turn — events arrive live.
+        let reader = {
+            let token = token.clone();
+            tokio::spawn(async move { read_until_turn_end(addr, &token, chat.id, 0).await })
+        };
+        send_message_http(&client, addr, &token, chat.id).await;
+
+        let events = reader.await.unwrap();
+        assert!(matches!(events[0].event, AgentEvent::TurnStarted { .. }));
+        assert!(matches!(
+            events.last().unwrap().event,
+            AgentEvent::TurnCompleted { .. }
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ws_after_cursor_replays_only_newer_events() {
+        let (addr, token, store, _dir) = serve_app_with(Arc::new(FakeProvider)).await;
+        let client = reqwest::Client::new();
+        let chat = make_chat_http(&client, addr, &token).await;
+        send_message_http(&client, addr, &token, chat.id).await;
+        wait_for_turn(&store, chat.id).await;
+
+        // Resume after seq 1: the first replayed event must be seq 2, and seq 1 is
+        // not re-sent.
+        let events = read_until_turn_end(addr, &token, chat.id, 1).await;
+        assert_eq!(events.first().unwrap().seq, 2);
+        assert!(events.iter().all(|e| e.seq > 1));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ws_without_a_token_is_rejected() {
+        let (addr, _token, _store, _dir) = serve_app_with(Arc::new(FakeProvider)).await;
+        let chat = ChatId::new();
+        let request = format!("ws://{addr}/chats/{chat}/events")
+            .into_client_request()
+            .unwrap();
+        // No Authorization header: the handshake must fail (auth runs before upgrade).
+        assert!(connect_async(request).await.is_err());
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -706,13 +706,15 @@ mod tests {
         assert_eq!(response.status(), reqwest::StatusCode::ACCEPTED);
     }
 
-    /// Connect to a chat's event socket (authenticated) and read frames until the
-    /// turn ends (or a timeout), returning the decoded events in arrival order.
-    async fn read_until_turn_end(
+    /// Connect to a chat's event socket (authenticated) and read frames until
+    /// `want` turns have ended (or a timeout), returning the decoded events in
+    /// arrival order.
+    async fn read_until_turns_end(
         addr: SocketAddr,
         token: &str,
         chat: ChatId,
         after: i64,
+        want: usize,
     ) -> Vec<SequencedEvent> {
         let mut request = format!("ws://{addr}/chats/{chat}/events?after={after}")
             .into_client_request()
@@ -723,26 +725,39 @@ mod tests {
         let (mut socket, _response) = connect_async(request).await.unwrap();
 
         let mut events = Vec::new();
+        let mut completed = 0;
         let read = async {
             while let Some(frame) = socket.next().await {
                 let WsMessage::Text(text) = frame.unwrap() else {
                     continue;
                 };
                 let event: SequencedEvent = serde_json::from_str(text.as_str()).unwrap();
-                let done = matches!(
+                if matches!(
                     event.event,
                     AgentEvent::TurnCompleted { .. } | AgentEvent::TurnFailed { .. }
-                );
+                ) {
+                    completed += 1;
+                }
                 events.push(event);
-                if done {
+                if completed >= want {
                     break;
                 }
             }
         };
         tokio::time::timeout(Duration::from_secs(5), read)
             .await
-            .expect("turn did not complete over the socket");
+            .expect("turns did not complete over the socket");
         events
+    }
+
+    /// Read one turn's worth of events over a fresh connection.
+    async fn read_until_turn_end(
+        addr: SocketAddr,
+        token: &str,
+        chat: ChatId,
+        after: i64,
+    ) -> Vec<SequencedEvent> {
+        read_until_turns_end(addr, token, chat, after, 1).await
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -803,6 +818,59 @@ mod tests {
         let events = read_until_turn_end(addr, &token, chat.id, 1).await;
         assert_eq!(events.first().unwrap().seq, 2);
         assert!(events.iter().all(|e| e.seq > 1));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ws_replays_one_turn_then_streams_the_next_live() {
+        let (addr, token, store, _dir) = serve_app_with(Arc::new(FakeProvider)).await;
+        let client = reqwest::Client::new();
+        let chat = make_chat_http(&client, addr, &token).await;
+
+        // Turn 1 runs to completion and is journaled.
+        send_message_http(&client, addr, &token, chat.id).await;
+        wait_for_turn(&store, chat.id).await;
+
+        // Connect (replays turn 1) and keep reading; then run turn 2, whose events
+        // arrive live on the same connection. Assert both turns come through in
+        // one gap-free, duplicate-free, strictly-increasing stream.
+        let reader = {
+            let token = token.clone();
+            tokio::spawn(async move { read_until_turns_end(addr, &token, chat.id, 0, 2).await })
+        };
+        // Let the reader connect, subscribe, and drain the replay before turn 2.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        send_message_http(&client, addr, &token, chat.id).await;
+
+        let events = reader.await.unwrap();
+        assert!(matches!(events[0].event, AgentEvent::TurnStarted { .. }));
+        assert_eq!(events[0].seq, 1);
+        assert!(events.windows(2).all(|w| w[0].seq < w[1].seq));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e.event, AgentEvent::TurnCompleted { .. }))
+                .count(),
+            2,
+            "both turns completed over one connection"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ws_bad_after_cursor_is_a_json_400() {
+        let (addr, token, _store, _dir) = serve_app_with(Arc::new(FakeProvider)).await;
+        let client = reqwest::Client::new();
+        let chat = make_chat_http(&client, addr, &token).await;
+        // A non-integer `after` fails extraction; it must answer the API-wide
+        // `{ kind, message }` JSON, not axum's plain-text rejection.
+        let response = client
+            .get(format!("http://{addr}/chats/{}/events?after=abc", chat.id))
+            .bearer_auth(&token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+        let info: AgentErrorInfo = response.json().await.unwrap();
+        assert_eq!(info.kind, "bad_request");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -6,17 +6,17 @@
 use std::path::PathBuf;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::{Query, State};
+use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use chrono::Utc;
 use serde::Deserialize;
 use tokio::sync::broadcast::error::RecvError;
 
-use openwave_core::{Agent, Chat, ChatId, SequencedEvent};
+use openwave_core::{Agent, Chat, ChatId, SequencedEvent, Store};
 
 use crate::error::ServerError;
-use crate::extract::{Json, Path};
+use crate::extract::{Json, Path, Query};
 use crate::state::AppState;
 
 /// Body of `POST /chats`.
@@ -152,17 +152,13 @@ async fn stream_events(mut socket: WebSocket, state: AppState, chat: ChatId, aft
     // the live channel rather than lost in the gap between the two.
     let mut live = state.events.subscribe(chat);
 
-    let replay = match state.store.list_events(chat, after).await {
-        Ok(events) => events,
-        // A store failure mid-replay: drop the connection; the client reconnects.
-        Err(_) => return,
-    };
+    // Replay everything the client hasn't seen yet from the durable journal.
     let mut last_seq = after;
-    for event in replay {
-        last_seq = event.seq;
-        if send_event(&mut socket, &event).await.is_err() {
-            return;
-        }
+    if replay_after(&mut socket, &*state.store, chat, &mut last_seq)
+        .await
+        .is_err()
+    {
+        return;
     }
 
     loop {
@@ -182,16 +178,45 @@ async fn stream_events(mut socket: WebSocket, state: AppState, chat: ChatId, aft
                         break;
                     }
                 }
-                // Fell behind the live buffer: close so the client reconnects with
-                // an `after` cursor and replays the gap from the journal.
-                Err(RecvError::Lagged(_)) | Err(RecvError::Closed) => break,
+                // Fell behind the live buffer. Rather than drop the client, catch
+                // up from the journal (durable truth) and resume live — the seq
+                // dedup above absorbs any overlap. A long/fast turn can outrun the
+                // 256-slot buffer, so this keeps an ordinary client connected.
+                Err(RecvError::Lagged(_)) => {
+                    if replay_after(&mut socket, &*state.store, chat, &mut last_seq)
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(RecvError::Closed) => break,
             },
         }
     }
 }
 
-/// Send one event as a JSON text frame.
+/// Send journaled events with `seq > *last_seq` to the socket, advancing
+/// `*last_seq`. `Err(())` means the connection should end (send or store failure).
+async fn replay_after(
+    socket: &mut WebSocket,
+    store: &dyn Store,
+    chat: ChatId,
+    last_seq: &mut i64,
+) -> Result<(), ()> {
+    let events = store.list_events(chat, *last_seq).await.map_err(|_| ())?;
+    for event in events {
+        *last_seq = event.seq;
+        send_event(socket, &event).await.map_err(|_| ())?;
+    }
+    Ok(())
+}
+
+/// Send one event as a JSON text frame. An event that fails to serialize is
+/// skipped rather than sent as an empty frame (which a client couldn't decode).
 async fn send_event(socket: &mut WebSocket, event: &SequencedEvent) -> Result<(), axum::Error> {
-    let json = serde_json::to_string(event).unwrap_or_default();
+    let Ok(json) = serde_json::to_string(event) else {
+        return Ok(());
+    };
     socket.send(Message::Text(json.into())).await
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1,18 +1,19 @@
 //! Chat HTTP handlers.
 //!
-//! The conversation CRUD surface: create a chat (which owns a workspace
-//! directory), list them, fetch one. Driving a chat — posting a message and
-//! streaming the turn's events over WebSocket — lands in the next slice.
+//! The conversation CRUD surface (create / list / get), posting a message to
+//! start a turn, and the WebSocket stream of a chat's turn events.
 
 use std::path::PathBuf;
 
-use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use chrono::Utc;
 use serde::Deserialize;
+use tokio::sync::broadcast::error::RecvError;
 
-use openwave_core::{Agent, Chat, ChatId};
+use openwave_core::{Agent, Chat, ChatId, SequencedEvent};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
@@ -107,11 +108,90 @@ pub async fn post_message(
         state.agent_config.clone(),
     );
     let store = state.store.clone();
+    let events = state.events.clone();
     tokio::spawn(async move {
         // Hold the slot for the turn's lifetime; dropping it frees the chat.
         let _active = active;
-        crate::hub::drive_and_journal(agent, chat, body.content, store).await;
+        crate::hub::drive_and_journal(agent, chat, body.content, store, events).await;
     });
 
     Ok(StatusCode::ACCEPTED)
+}
+
+/// Query for `GET /chats/{id}/events`.
+#[derive(Debug, Deserialize)]
+pub struct EventsQuery {
+    /// Resume after this journal sequence number; `0` (the default) replays from
+    /// the start.
+    #[serde(default)]
+    pub after: i64,
+}
+
+/// `GET /chats/{id}/events` (WebSocket) — stream a chat's turn events.
+///
+/// On connect the client gets **snapshot → replay → live**: journaled events with
+/// `seq > after` are replayed, then live events stream as they occur. Subscribing
+/// to the live tail *before* replaying, and dropping any live event whose `seq`
+/// was already replayed, means nothing is missed or duplicated across the handoff.
+/// `404` if the chat doesn't exist.
+pub async fn chat_events(
+    State(state): State<AppState>,
+    Path(id): Path<ChatId>,
+    Query(query): Query<EventsQuery>,
+    upgrade: WebSocketUpgrade,
+) -> Result<Response, ServerError> {
+    if state.store.get_chat(id).await?.is_none() {
+        return Err(ServerError::not_found(format!("chat {id} not found")));
+    }
+    Ok(upgrade.on_upgrade(move |socket| stream_events(socket, state, id, query.after)))
+}
+
+/// Serve one client's event stream for `chat`: replay from the journal, then live.
+async fn stream_events(mut socket: WebSocket, state: AppState, chat: ChatId, after: i64) {
+    // Subscribe before replaying, so an event emitted during replay is buffered on
+    // the live channel rather than lost in the gap between the two.
+    let mut live = state.events.subscribe(chat);
+
+    let replay = match state.store.list_events(chat, after).await {
+        Ok(events) => events,
+        // A store failure mid-replay: drop the connection; the client reconnects.
+        Err(_) => return,
+    };
+    let mut last_seq = after;
+    for event in replay {
+        last_seq = event.seq;
+        if send_event(&mut socket, &event).await.is_err() {
+            return;
+        }
+    }
+
+    loop {
+        tokio::select! {
+            // Watch the socket so a client disconnect ends the task promptly.
+            incoming = socket.recv() => match incoming {
+                None | Some(Err(_)) | Some(Ok(Message::Close(_))) => break,
+                _ => {}
+            },
+            live_event = live.recv() => match live_event {
+                Ok(event) => {
+                    if event.seq <= last_seq {
+                        continue; // already covered by replay
+                    }
+                    last_seq = event.seq;
+                    if send_event(&mut socket, &event).await.is_err() {
+                        break;
+                    }
+                }
+                // Fell behind the live buffer: close so the client reconnects with
+                // an `after` cursor and replays the gap from the journal.
+                Err(RecvError::Lagged(_)) | Err(RecvError::Closed) => break,
+            },
+        }
+    }
+}
+
+/// Send one event as a JSON text frame.
+async fn send_event(socket: &mut WebSocket, event: &SequencedEvent) -> Result<(), axum::Error> {
+    let json = serde_json::to_string(event).unwrap_or_default();
+    socket.send(Message::Text(json.into())).await
 }

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -6,6 +6,8 @@ use std::sync::{Arc, Mutex};
 use openwave_core::{AgentConfig, ChatId, Config, ModelProvider, Store, ToolRegistry};
 use uuid::Uuid;
 
+use crate::bus::EventBus;
+
 /// The state cloned into each handler: the boot config, the durable store, the
 /// agent's dependencies (provider + tools + tuning), the per-launch bearer token,
 /// and the guard that keeps a chat to one running turn at a time.
@@ -28,6 +30,8 @@ pub struct AppState {
     /// Tracks which chats have a turn in flight, so a second concurrent turn on
     /// the same chat is refused rather than racing the event journal.
     pub active_turns: Arc<TurnGuard>,
+    /// Live fan-out of turn events to connected WebSocket clients.
+    pub events: Arc<EventBus>,
 }
 
 impl AppState {
@@ -47,6 +51,7 @@ impl AppState {
             agent_config,
             token: Uuid::new_v4().to_string().into(),
             active_turns: Arc::new(TurnGuard::default()),
+            events: Arc::new(EventBus::default()),
         }
     }
 }


### PR DESCRIPTION
Adds the WebSocket surface that watches a chat's turns. On connect a client gets **snapshot → replay → live**: journaled events with `seq > after` are replayed, then live events stream as the turn produces them.

> Stacked on #21 (`POST /chats/{id}/messages` + the journal). Base will retarget to `main` once #21 merges; review the top commit.

## Endpoint
`GET /chats/{id}/events` (WebSocket, bearer-authenticated) — query `?after=<seq>` resumes past what the client already has (default `0` = from the start). `404` if the chat doesn't exist.

## How the handoff stays gapless
- **`EventBus`** — a per-chat `tokio::broadcast` of `SequencedEvent`. The hub publishes each event to it with the *same* `seq` the journal assigned, so replay and live can be deduplicated by `seq`.
- The handler **subscribes to the live tail _before_ replaying** the journal, so an event emitted during replay is buffered on the live channel rather than lost in the gap. It then **drops any live event whose `seq` was already replayed**, so nothing is missed or duplicated across the handoff.
- A subscriber that falls behind the live buffer is closed, so it reconnects with an `after` cursor and replays the gap from the journal (durable truth is the journal; the bus is only the live tail).
- The socket is polled alongside the live channel so a client disconnect ends the task promptly.

## Deliberate scoping
- **Live buffer is bounded (256).** A lagging client recovers by reconnecting with `after`, not by unbounded buffering.
- **No per-chat channel GC yet** — the bus keeps one broadcast sender per chat seen this launch. Fine for a local single-user process; a cleanup pass can come with multi-tenant self-host.
- Events are read-only here; cancel/steer over the same socket is a later slice.

## Tests
Real loopback socket + a `tokio-tungstenite` client: replay of a finished turn (seqs start at 1, strictly increasing, `TurnStarted`→text→`TurnCompleted`), live streaming of a turn started *after* connecting, the `after` cursor skipping already-seen events, and an unauthenticated connect being rejected. 19 tests total, clippy + fmt green.