### PR TITLE
feat(cli): openwave serve — boot the local server daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,11 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 [[package]]
 name = "openwave-cli"
 version = "0.0.0"
+dependencies = [
+ "openwave-core",
+ "openwave-server",
+ "tokio",
+]
 
 [[package]]
 name = "openwave-connectors"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,7 @@ version = "0.0.0"
 dependencies = [
  "openwave-core",
  "openwave-server",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -10,4 +10,12 @@ authors.workspace = true
 [lints]
 workspace = true
 
+# The binary is `openwave` (not `openwave-cli`), so `openwave serve` is the command.
+[[bin]]
+name = "openwave"
+path = "src/main.rs"
+
 [dependencies]
+openwave-core = { path = "../openwave-core", default-features = false }
+openwave-server = { path = "../openwave-server" }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -16,6 +16,12 @@ name = "openwave"
 path = "src/main.rs"
 
 [dependencies]
+# `default-features = false`: the CLI itself only needs `Config`/`Result`. The
+# store/tool features it runs on come from `openwave-server` and unify in; this
+# just avoids pulling core's other defaults (e.g. keychain) the CLI doesn't use.
 openwave-core = { path = "../openwave-core", default-features = false }
 openwave-server = { path = "../openwave-server" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -1,7 +1,32 @@
-//! OpenWave CLI — the headless daemon (`openwave serve`) and command-line client.
+//! OpenWave CLI — the headless daemon.
 //!
-//! Scaffolding only. Implementation lands in Phase 2.
+//! `openwave serve` boots the in-process HTTP/WebSocket surface on a loopback
+//! port and prints the address and per-launch bearer token it minted, so a local
+//! client (the desktop shell, or a script) can connect. Configuration comes from
+//! the environment via [`Config::from_env`] (`OPENWAVE_PROFILE`,
+//! `OPENWAVE_DATA_DIR`); the model API key comes from `ANTHROPIC_API_KEY`.
 
-fn main() {
-    println!("openwave-cli: not yet implemented");
+use openwave_core::{Config, Result};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    match std::env::args().nth(1).as_deref() {
+        // Default to `serve` so a bare `openwave` runs the daemon.
+        Some("serve") | None => serve().await,
+        Some(other) => {
+            eprintln!("openwave: unknown command {other:?}\n\nusage: openwave serve");
+            std::process::exit(2);
+        }
+    }
+}
+
+/// Bind the server and run its accept loop, announcing where to reach it.
+async fn serve() -> Result<()> {
+    let config = Config::from_env()?;
+    let server = openwave_server::bind(config).await?;
+    // The address and token are the client's entry point; the parent process that
+    // launched the daemon reads them from stdout to connect.
+    println!("openwave: listening on http://{}", server.local_addr());
+    println!("openwave: token {}", server.token());
+    server.serve().await
 }

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -9,7 +9,16 @@
 use openwave_core::{Config, Result};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
+    if let Err(error) = run().await {
+        // Print the error's `Display` (e.g. "configuration error: …"), not the
+        // `Debug` form the stdlib `Termination` impl would show, and exit non-zero.
+        eprintln!("openwave: {error}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<()> {
     match std::env::args().nth(1).as_deref() {
         // Default to `serve` so a bare `openwave` runs the daemon.
         Some("serve") | None => serve().await,
@@ -24,8 +33,10 @@ async fn main() -> Result<()> {
 async fn serve() -> Result<()> {
     let config = Config::from_env()?;
     let server = openwave_server::bind(config).await?;
-    // The address and token are the client's entry point; the parent process that
-    // launched the daemon reads them from stdout to connect.
+    // The address and token are the client's entry point: the parent process that
+    // launched the daemon reads them from stdout to connect. The token is a secret,
+    // so an integrator should capture this process's stdout directly (a piped
+    // child) rather than run the daemon under a logging supervisor.
     println!("openwave: listening on http://{}", server.local_addr());
     println!("openwave: token {}", server.token());
     server.serve().await

--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -1,0 +1,58 @@
+//! End-to-end test of the `openwave serve` daemon: spawn the built binary, read
+//! the address it announces on stdout, and confirm the server actually answers.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::process::{Child, Command, Stdio};
+
+/// Kills the daemon on drop — including on an assertion panic, since
+/// `std::process::Child` does not reap on its own.
+struct Reaper(Child);
+
+impl Drop for Reaper {
+    fn drop(&mut self) {
+        self.0.kill().ok();
+        self.0.wait().ok();
+    }
+}
+
+#[test]
+fn serve_announces_its_address_and_answers_health() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .arg("serve")
+        .env("OPENWAVE_DATA_DIR", dir.path())
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave serve");
+
+    let stdout = child.stdout.take().unwrap();
+    let _reaper = Reaper(child);
+
+    // The address is printed only after the listener is bound, so reading these
+    // two lines also synchronizes the test with a server ready to accept.
+    let mut lines = BufReader::new(stdout).lines();
+    let addr_line = lines.next().unwrap().unwrap();
+    let token_line = lines.next().unwrap().unwrap();
+
+    assert!(
+        addr_line.contains("listening on http://127.0.0.1:"),
+        "unexpected addr line: {addr_line:?}"
+    );
+    assert!(
+        token_line.starts_with("openwave: token "),
+        "unexpected token line: {token_line:?}"
+    );
+
+    let addr = addr_line.rsplit("http://").next().unwrap().trim();
+    let mut stream = TcpStream::connect(addr).unwrap();
+    stream
+        .write_all(b"GET /healthz HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+
+    assert!(response.contains("200 OK"), "response: {response}");
+    assert!(response.trim_end().ends_with("ok"), "response: {response}");
+}


### PR DESCRIPTION
Turns the library stack into a runnable process — the "walking" the skeleton was missing.

`openwave serve` (also the default when run with no args) reads `Config::from_env`, binds the loopback HTTP/WebSocket server, prints the address and per-launch bearer token to stdout for a local client to connect, and runs the accept loop until exit.

## Details
- The binary is named `openwave` (so the command is `openwave serve`), built from `openwave-cli`.
- Config from the environment: `OPENWAVE_PROFILE`, `OPENWAVE_DATA_DIR`; model key from `ANTHROPIC_API_KEY` (absent ⇒ turns fail closed, per the server slice).
- The addr + token on stdout are the handoff: the parent process (desktop shell, or a script) reads them to connect.

## Verified end to end
Launched the built binary against a temp data dir:
```
openwave: listening on http://127.0.0.1:53344
openwave: token 78e50496-…
```
- `GET /healthz` → `ok`
- `GET /chats` with no token → `401`
- `POST /chats` with the token → `201`, persisted to SQLite under the data dir
- `GET /chats` → lists the created chat

No automated bin test: it's thin glue over `openwave_server::bind`/`serve`, which are covered by the server crate's tests; the end-to-end behavior is verified manually above.