### PR TITLE
feat: optional Project parent for chats

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -476,6 +476,7 @@ mod tests {
         );
         let chat = Chat {
             id: ChatId::new(),
+            project_id: None,
             title: None,
             workspace_dir: workspace.path().to_path_buf(),
             created_at: Utc::now(),
@@ -548,6 +549,7 @@ mod tests {
         );
         let chat = Chat {
             id: ChatId::new(),
+            project_id: None,
             title: None,
             workspace_dir: workspace.path().to_path_buf(),
             created_at: Utc::now(),
@@ -605,6 +607,7 @@ mod tests {
         );
         let chat = Chat {
             id: ChatId::new(),
+            project_id: None,
             title: None,
             workspace_dir: workspace.path().to_path_buf(),
             created_at: Utc::now(),

--- a/crates/openwave-core/src/db.rs
+++ b/crates/openwave-core/src/db.rs
@@ -20,8 +20,8 @@ use serde_json::Value;
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{ChatId, MessageId, TurnId};
-use crate::model::{Chat, Message, Role};
+use crate::id::{ChatId, MessageId, ProjectId, TurnId};
+use crate::model::{Chat, Message, Project, Role};
 use crate::storage::Store;
 
 /// Map any SeaORM failure into an [`AgentError::Store`].
@@ -58,9 +58,42 @@ impl DbStore {
 
 #[async_trait]
 impl Store for DbStore {
+    async fn create_project(&self, project: &Project) -> Result<()> {
+        entities::project::ActiveModel {
+            id: Set(project.id.0),
+            title: Set(project.title.clone()),
+            workspace_dir: Set(project.workspace_dir.to_string_lossy().into_owned()),
+            created_at: Set(project.created_at),
+        }
+        .insert(&self.conn)
+        .await
+        .map_err(store_err)?;
+        Ok(())
+    }
+
+    async fn get_project(&self, id: ProjectId) -> Result<Option<Project>> {
+        Ok(entities::project::Entity::find_by_id(id.0)
+            .one(&self.conn)
+            .await
+            .map_err(store_err)?
+            .map(project_from_model))
+    }
+
+    async fn list_projects(&self) -> Result<Vec<Project>> {
+        Ok(entities::project::Entity::find()
+            .order_by_desc(entities::project::Column::CreatedAt)
+            .all(&self.conn)
+            .await
+            .map_err(store_err)?
+            .into_iter()
+            .map(project_from_model)
+            .collect())
+    }
+
     async fn create_chat(&self, chat: &Chat) -> Result<()> {
         entities::chat::ActiveModel {
             id: Set(chat.id.0),
+            project_id: Set(chat.project_id.map(|p| p.0)),
             title: Set(chat.title.clone()),
             workspace_dir: Set(chat.workspace_dir.to_string_lossy().into_owned()),
             created_at: Set(chat.created_at),
@@ -188,9 +221,19 @@ impl Store for DbStore {
     }
 }
 
+fn project_from_model(model: entities::project::Model) -> Project {
+    Project {
+        id: ProjectId(model.id),
+        title: model.title,
+        workspace_dir: PathBuf::from(model.workspace_dir),
+        created_at: model.created_at,
+    }
+}
+
 fn chat_from_model(model: entities::chat::Model) -> Chat {
     Chat {
         id: ChatId(model.id),
+        project_id: model.project_id.map(ProjectId),
         title: model.title,
         workspace_dir: PathBuf::from(model.workspace_dir),
         created_at: model.created_at,
@@ -232,6 +275,25 @@ fn role_from_db(text: &str) -> Result<Role> {
 /// types (`Chat`, `Message`), never these, so the ORM never leaks into the
 /// crate's contract.
 mod entities {
+    pub mod project {
+        use sea_orm::entity::prelude::*;
+
+        #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+        #[sea_orm(table_name = "project")]
+        pub struct Model {
+            #[sea_orm(primary_key, auto_increment = false)]
+            pub id: Uuid,
+            pub title: Option<String>,
+            pub workspace_dir: String,
+            pub created_at: DateTimeUtc,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+    }
+
     pub mod chat {
         use sea_orm::entity::prelude::*;
 
@@ -240,6 +302,7 @@ mod entities {
         pub struct Model {
             #[sea_orm(primary_key, auto_increment = false)]
             pub id: Uuid,
+            pub project_id: Option<Uuid>,
             pub title: Option<String>,
             pub workspace_dir: String,
             pub created_at: DateTimeUtc,
@@ -326,7 +389,11 @@ mod migration {
     #[async_trait::async_trait]
     impl MigratorTrait for Migrator {
         fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-            vec![Box::new(Init), Box::new(AddEventJournal)]
+            vec![
+                Box::new(Init),
+                Box::new(AddEventJournal),
+                Box::new(AddProjects),
+            ]
         }
     }
 
@@ -468,10 +535,79 @@ mod migration {
         }
     }
 
+    /// Adds the `project` table and the optional `chat.project_id` link.
+    struct AddProjects;
+
+    impl MigrationName for AddProjects {
+        fn name(&self) -> &str {
+            "m0003_projects"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for AddProjects {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .create_table(
+                    Table::create()
+                        .table(Project::Table)
+                        .if_not_exists()
+                        .col(ColumnDef::new(Project::Id).uuid().not_null().primary_key())
+                        .col(ColumnDef::new(Project::Title).text())
+                        .col(ColumnDef::new(Project::WorkspaceDir).text().not_null())
+                        .col(
+                            ColumnDef::new(Project::CreatedAt)
+                                .timestamp_with_time_zone()
+                                .not_null(),
+                        )
+                        .to_owned(),
+                )
+                .await?;
+
+            // A nullable link, no DB-level foreign key: SQLite can't add an FK to
+            // an existing table, so membership is validated at the API edge (the
+            // server checks the project exists before creating the chat).
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Chat::Table)
+                        .add_column(ColumnDef::new(Chat::ProjectId).uuid())
+                        .to_owned(),
+                )
+                .await?;
+            Ok(())
+        }
+
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Chat::Table)
+                        .drop_column(Chat::ProjectId)
+                        .to_owned(),
+                )
+                .await?;
+            manager
+                .drop_table(Table::drop().table(Project::Table).to_owned())
+                .await?;
+            Ok(())
+        }
+    }
+
+    #[derive(DeriveIden)]
+    enum Project {
+        Table,
+        Id,
+        Title,
+        WorkspaceDir,
+        CreatedAt,
+    }
+
     #[derive(DeriveIden)]
     enum Chat {
         Table,
         Id,
+        ProjectId,
         Title,
         WorkspaceDir,
         CreatedAt,
@@ -520,10 +656,55 @@ mod tests {
     fn sample_chat() -> Chat {
         Chat {
             id: ChatId::new(),
+            project_id: None,
             title: Some("hello".into()),
             workspace_dir: PathBuf::from("/tmp/ws"),
             created_at: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
         }
+    }
+
+    fn sample_project() -> Project {
+        Project {
+            id: ProjectId::new(),
+            title: Some("proj".into()),
+            workspace_dir: PathBuf::from("/tmp/proj"),
+            created_at: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
+        }
+    }
+
+    #[tokio::test]
+    async fn projects_roundtrip_and_a_chat_can_belong_to_one() {
+        let (_dir, store) = temp_store().await;
+        let project = sample_project();
+        store.create_project(&project).await.unwrap();
+
+        assert_eq!(
+            store.get_project(project.id).await.unwrap().as_ref(),
+            Some(&project)
+        );
+        assert_eq!(store.list_projects().await.unwrap(), vec![project.clone()]);
+        assert_eq!(store.get_project(ProjectId::new()).await.unwrap(), None);
+
+        // A chat carrying the project link round-trips it; a loose chat stays None.
+        let mut in_project = sample_chat();
+        in_project.project_id = Some(project.id);
+        store.create_chat(&in_project).await.unwrap();
+        assert_eq!(
+            store
+                .get_chat(in_project.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .project_id,
+            Some(project.id)
+        );
+
+        let loose = sample_chat();
+        store.create_chat(&loose).await.unwrap();
+        assert_eq!(
+            store.get_chat(loose.id).await.unwrap().unwrap().project_id,
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/db.rs
+++ b/crates/openwave-core/src/db.rs
@@ -705,6 +705,29 @@ mod tests {
             store.get_chat(loose.id).await.unwrap().unwrap().project_id,
             None
         );
+
+        // The project link survives a list, not just a by-id fetch.
+        let listed = store.list_chats().await.unwrap();
+        let listed_link = |id| {
+            listed
+                .iter()
+                .find(|c| c.id == id)
+                .and_then(|c| c.project_id)
+        };
+        assert_eq!(listed_link(in_project.id), Some(project.id));
+        assert_eq!(listed_link(loose.id), None);
+    }
+
+    #[tokio::test]
+    async fn list_projects_is_newest_first() {
+        let (_dir, store) = temp_store().await;
+        let mut older = sample_project();
+        older.created_at = DateTime::<Utc>::from_timestamp(1_000, 0).unwrap();
+        let mut newer = sample_project();
+        newer.created_at = DateTime::<Utc>::from_timestamp(2_000, 0).unwrap();
+        store.create_project(&older).await.unwrap();
+        store.create_project(&newer).await.unwrap();
+        assert_eq!(store.list_projects().await.unwrap(), vec![newer, older]);
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -59,6 +59,10 @@ macro_rules! id_type {
 }
 
 id_type!(
+    /// Identifies a project: an optional grouping a chat may belong to.
+    ProjectId
+);
+id_type!(
     /// Identifies a persistent conversation (owns a workspace directory).
     ChatId
 );

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -35,10 +35,10 @@ pub use config::{Config, Profile};
 pub use db::DbStore;
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
-pub use id::{CallId, ChatId, MessageId, StepId, TurnId};
+pub use id::{CallId, ChatId, MessageId, ProjectId, StepId, TurnId};
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
-pub use model::{Chat, Message, Role};
+pub use model::{Chat, Message, Project, Role};
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
     Usage,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -13,7 +13,22 @@ use std::path::PathBuf;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::id::{ChatId, MessageId, TurnId};
+use crate::id::{ChatId, MessageId, ProjectId, TurnId};
+
+/// An optional grouping of chats that share a workspace and (later) a document
+/// corpus. A chat may belong to a project or stand alone — unlike some designs
+/// that make a project mandatory, OpenWave keeps loose, projectless chats.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Project {
+    /// Stable identifier.
+    pub id: ProjectId,
+    /// Human-facing title.
+    pub title: Option<String>,
+    /// Absolute path to the project's workspace/corpus root.
+    pub workspace_dir: PathBuf,
+    /// When the project was created.
+    pub created_at: DateTime<Utc>,
+}
 
 /// Who authored a message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -34,6 +49,8 @@ pub enum Role {
 pub struct Chat {
     /// Stable identifier.
     pub id: ChatId,
+    /// The project this chat belongs to, or `None` for a loose (projectless) chat.
+    pub project_id: Option<ProjectId>,
     /// Human-facing title; `None` until one is set or derived.
     pub title: Option<String>,
     /// Absolute path to this chat's workspace directory.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -20,8 +20,8 @@ use serde_json::Value;
 
 use crate::error::Result;
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::ChatId;
-use crate::model::{Chat, Message};
+use crate::id::{ChatId, ProjectId};
+use crate::model::{Chat, Message, Project};
 
 /// Durable metadata and conversation state.
 ///
@@ -29,6 +29,15 @@ use crate::model::{Chat, Message};
 /// held behind `Arc<dyn Store>`, so this trait stays object-safe.
 #[async_trait]
 pub trait Store: Send + Sync {
+    /// Persist a new project.
+    async fn create_project(&self, project: &Project) -> Result<()>;
+
+    /// Fetch a project by id, or `None` if it doesn't exist.
+    async fn get_project(&self, id: ProjectId) -> Result<Option<Project>>;
+
+    /// List projects, most-recently-created first.
+    async fn list_projects(&self) -> Result<Vec<Project>>;
+
     /// Persist a new chat.
     async fn create_chat(&self, chat: &Chat) -> Result<()>;
 
@@ -102,6 +111,7 @@ mod tests {
     /// behind `Arc<dyn Store>`, and exercises the signatures.
     #[derive(Default)]
     struct MemStore {
+        projects: Mutex<HashMap<ProjectId, Project>>,
         chats: Mutex<HashMap<ChatId, Chat>>,
         settings: Mutex<HashMap<String, Value>>,
         events: Mutex<Vec<(ChatId, SequencedEvent)>>,
@@ -109,6 +119,19 @@ mod tests {
 
     #[async_trait]
     impl Store for MemStore {
+        async fn create_project(&self, project: &Project) -> Result<()> {
+            self.projects
+                .lock()
+                .unwrap()
+                .insert(project.id, project.clone());
+            Ok(())
+        }
+        async fn get_project(&self, id: ProjectId) -> Result<Option<Project>> {
+            Ok(self.projects.lock().unwrap().get(&id).cloned())
+        }
+        async fn list_projects(&self) -> Result<Vec<Project>> {
+            Ok(self.projects.lock().unwrap().values().cloned().collect())
+        }
         async fn create_chat(&self, chat: &Chat) -> Result<()> {
             self.chats.lock().unwrap().insert(chat.id, chat.clone());
             Ok(())
@@ -164,6 +187,7 @@ mod tests {
         let store: Arc<dyn Store> = Arc::new(MemStore::default());
         let chat = Chat {
             id: ChatId::new(),
+            project_id: None,
             title: None,
             workspace_dir: "/tmp/ws".into(),
             created_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -39,6 +39,12 @@ pub trait Store: Send + Sync {
     async fn list_projects(&self) -> Result<Vec<Project>>;
 
     /// Persist a new chat.
+    ///
+    /// A chat's `project_id`, when set, is not checked against an existing
+    /// project here — there is no database foreign key on the link (SQLite can't
+    /// add one to an existing table). Callers that accept a `project_id` from
+    /// outside must verify the project exists first (the server does so at its
+    /// API edge) to avoid persisting a dangling reference.
     async fn create_chat(&self, chat: &Chat) -> Result<()>;
 
     /// Fetch a chat by id, or `None` if it doesn't exist.

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -41,6 +41,11 @@ pub fn app(state: AppState) -> Router {
     // `route_layer` applies the token check to matched API routes only, so an
     // unknown path still answers `404` (not `401`), and `/healthz` stays open.
     let api = Router::new()
+        .route(
+            "/projects",
+            post(routes::create_project).get(routes::list_projects),
+        )
+        .route("/projects/{id}", get(routes::get_project))
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
         .route("/chats/{id}", get(routes::get_chat))
         .route("/chats/{id}/messages", post(routes::post_message))
@@ -171,8 +176,8 @@ mod tests {
     use axum::http::{header, Request, StatusCode};
     use futures::stream::{self, BoxStream, StreamExt};
     use openwave_core::{
-        AgentErrorInfo, AgentEvent, Chat, ChatId, ChatRequest, ProviderEvent, ProviderId,
-        SequencedEvent, StopReason, Usage,
+        AgentErrorInfo, AgentEvent, Chat, ChatId, ChatRequest, Project, ProjectId, ProviderEvent,
+        ProviderId, SequencedEvent, StopReason, Usage,
     };
     use serde::de::DeserializeOwned;
     use tokio::sync::Notify;
@@ -428,6 +433,117 @@ mod tests {
             json_body(response).await
         };
         assert_eq!(listed, vec![created]);
+    }
+
+    /// Create a project and return it.
+    async fn make_project(router: &Router, bearer: &str) -> Project {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/projects")
+                    .header(header::AUTHORIZATION, bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"workspace_dir": "/tmp/proj", "title": "p"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        json_body(response).await
+    }
+
+    #[tokio::test]
+    async fn project_create_get_and_list() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let created = make_project(&router, &bearer).await;
+        assert_eq!(created.title.as_deref(), Some("p"));
+
+        let fetched: Project = {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(format!("/projects/{}", created.id))
+                        .header(header::AUTHORIZATION, &bearer)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            json_body(response).await
+        };
+        assert_eq!(fetched, created);
+
+        let listed: Vec<Project> = {
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .uri("/projects")
+                        .header(header::AUTHORIZATION, &bearer)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            json_body(response).await
+        };
+        assert_eq!(listed, vec![created]);
+    }
+
+    #[tokio::test]
+    async fn chat_can_be_filed_under_a_project() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let project = make_project(&router, &bearer).await;
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/chats")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"workspace_dir": "/tmp/ws", "project_id": project.id})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let chat: Chat = json_body(response).await;
+        assert_eq!(chat.project_id, Some(project.id));
+    }
+
+    #[tokio::test]
+    async fn chat_referencing_an_unknown_project_is_rejected() {
+        let (router, token, _store, _dir) = test_app().await;
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/chats")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"workspace_dir": "/tmp/ws", "project_id": ProjectId::new()})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, "bad_request");
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -13,11 +13,62 @@ use chrono::Utc;
 use serde::Deserialize;
 use tokio::sync::broadcast::error::RecvError;
 
-use openwave_core::{Agent, Chat, ChatId, SequencedEvent, Store};
+use openwave_core::{Agent, Chat, ChatId, Project, ProjectId, SequencedEvent, Store};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 use crate::state::AppState;
+
+/// Body of `POST /projects`.
+#[derive(Debug, Deserialize)]
+pub struct CreateProject {
+    /// Absolute path to the project's workspace/corpus root.
+    pub workspace_dir: PathBuf,
+    /// Optional human-facing title.
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+/// `POST /projects` — create a project and return it (`201 Created`).
+pub async fn create_project(
+    State(state): State<AppState>,
+    Json(body): Json<CreateProject>,
+) -> Result<impl IntoResponse, ServerError> {
+    if !body.workspace_dir.is_absolute() {
+        return Err(ServerError::bad_request(format!(
+            "workspace_dir must be an absolute path, got {:?}",
+            body.workspace_dir
+        )));
+    }
+    let project = Project {
+        id: ProjectId::new(),
+        title: body.title,
+        workspace_dir: body.workspace_dir,
+        created_at: Utc::now(),
+    };
+    state.store.create_project(&project).await?;
+    Ok((StatusCode::CREATED, Json(project)))
+}
+
+/// `GET /projects` — list projects, most-recently-created first.
+pub async fn list_projects(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<Project>>, ServerError> {
+    Ok(Json(state.store.list_projects().await?))
+}
+
+/// `GET /projects/{id}` — fetch one project, or `404`.
+pub async fn get_project(
+    State(state): State<AppState>,
+    Path(id): Path<ProjectId>,
+) -> Result<Json<Project>, ServerError> {
+    state
+        .store
+        .get_project(id)
+        .await?
+        .map(Json)
+        .ok_or_else(|| ServerError::not_found(format!("project {id} not found")))
+}
 
 /// Body of `POST /chats`.
 #[derive(Debug, Deserialize)]
@@ -27,6 +78,9 @@ pub struct CreateChat {
     /// Optional human-facing title.
     #[serde(default)]
     pub title: Option<String>,
+    /// Optional project to file this chat under; omitted for a loose chat.
+    #[serde(default)]
+    pub project_id: Option<ProjectId>,
 }
 
 /// `POST /chats` — create a chat and return it (`201 Created`).
@@ -44,8 +98,18 @@ pub async fn create_chat(
             body.workspace_dir
         )));
     }
+    // Membership is validated here (the store has no DB-level foreign key): a
+    // chat can't reference a project that doesn't exist.
+    if let Some(project_id) = body.project_id {
+        if state.store.get_project(project_id).await?.is_none() {
+            return Err(ServerError::bad_request(format!(
+                "project {project_id} not found"
+            )));
+        }
+    }
     let chat = Chat {
         id: ChatId::new(),
+        project_id: body.project_id,
         title: body.title,
         workspace_dir: body.workspace_dir,
         created_at: Utc::now(),


### PR DESCRIPTION
Chats can now be grouped under a **Project** — or stand alone. `Project` is an *optional* parent (`chat.project_id: Option<ProjectId>`), deliberately unlike designs (including alpha's) that mandate a project per conversation; keeping loose, projectless chats is the cowork choice for a local-first tool.

## Core
- New `Project { id, title, workspace_dir, created_at }` entity + `ProjectId`.
- `Store` gains `create_project` / `get_project` / `list_projects`.
- `Chat` gains `project_id: Option<ProjectId>` (a loose chat is `None`).

## Schema — `m0003_projects`
- Creates the `project` table.
- Adds `chat.project_id` as an **additive nullable column** (`ALTER TABLE ADD COLUMN`), so existing databases migrate forward without touching `m0001`/`m0002`.
- **No DB-level foreign key on the link.** SQLite can't add a foreign key to an existing table, so rather than a cross-DB-hostile table rebuild, membership is validated at the API edge — the server checks the project exists before creating the chat. (When the self-host Postgres store lands it can add the constraint natively; the app-level check stays as defense in depth.)

## Server
- `POST /projects`, `GET /projects`, `GET /projects/{id}` (workspace_dir absolute-path check, same as chats).
- `POST /chats` accepts an optional `project_id`; an unknown one is a `400 bad_request`, never a dangling reference.

## Design notes
- **workspace ownership:** for now a chat always has its own `workspace_dir` and `project_id` is just a grouping link; the "a chat in a project uses the project's workspace/corpus" resolution (and project-scoped retrieval) is deferred to when retrieval lands.
- **enterprise layer deferred:** members / permissions / sharing sit *beside* `Project` (a later self-host concern), not in these columns.

## Tests
Store: project CRUD + a chat carrying/omitting the project link round-trips. Server: `/projects` create-get-list, a chat filed under a project comes back with `project_id` set, and a chat referencing an unknown project is rejected `400`. Full workspace green (38 core + 24 server + 1 CLI), clippy + fmt clean.
