### PR TITLE
feat(server): runtime-configurable model via /settings

### DIFF
--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -42,6 +42,10 @@ pub fn app(state: AppState) -> Router {
     // unknown path still answers `404` (not `401`), and `/healthz` stays open.
     let api = Router::new()
         .route(
+            "/settings",
+            get(routes::get_settings).put(routes::put_settings),
+        )
+        .route(
             "/projects",
             post(routes::create_project).get(routes::list_projects),
         )
@@ -203,6 +207,27 @@ mod tests {
                     reason: StopReason::EndTurn,
                 },
             ])
+            .boxed())
+        }
+    }
+
+    /// A provider that records the model each request asked for, then answers
+    /// like `FakeProvider`. Lets a test assert which model a turn ran against.
+    #[derive(Clone, Default)]
+    struct RecordingProvider {
+        models: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for RecordingProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("recording")
+        }
+        async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            self.models.lock().unwrap().push(req.model);
+            Ok(stream::iter(vec![ProviderEvent::Stop {
+                reason: StopReason::EndTurn,
+            }])
             .boxed())
         }
     }
@@ -544,6 +569,104 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let info: AgentErrorInfo = json_body(response).await;
         assert_eq!(info.kind, "bad_request");
+    }
+
+    #[tokio::test]
+    async fn settings_default_then_update_roundtrips() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+
+        // Default: no model configured.
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/settings")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let settings: serde_json::Value = json_body(response).await;
+        assert!(settings["model"].is_null());
+
+        // PUT a model, and it comes back.
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/settings")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"model": "claude-x"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let settings: serde_json::Value = json_body(response).await;
+        assert_eq!(settings["model"], "claude-x");
+
+        // GET reflects the update.
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/settings")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let settings: serde_json::Value = json_body(response).await;
+        assert_eq!(settings["model"], "claude-x");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn configured_model_is_used_for_the_turn() {
+        let recorder = RecordingProvider::default();
+        let (router, token, store, _dir) = test_app_with(Arc::new(recorder.clone())).await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        // Configure the model, then run a turn.
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/settings")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"model": "claude-configured"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "hi").await,
+            StatusCode::ACCEPTED
+        );
+        wait_for_turn(&store, chat.id).await;
+
+        assert!(
+            recorder
+                .models
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|m| m == "claude-configured"),
+            "the turn should run against the configured model"
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -627,6 +627,70 @@ mod tests {
         assert_eq!(settings["model"], "claude-x");
     }
 
+    /// PUT /settings with a raw JSON body, returning the response.
+    async fn put_settings(
+        router: &Router,
+        bearer: &str,
+        body: serde_json::Value,
+    ) -> axum::response::Response {
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/settings")
+                    .header(header::AUTHORIZATION, bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn put_empty_model_is_rejected() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let response = put_settings(&router, &bearer, serde_json::json!({"model": ""})).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, "bad_request");
+    }
+
+    #[tokio::test]
+    async fn put_non_string_model_is_rejected() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        // A number where a string is expected fails extraction as a JSON 400.
+        let response = put_settings(&router, &bearer, serde_json::json!({"model": 5})).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, "bad_request");
+    }
+
+    #[tokio::test]
+    async fn explicit_null_model_clears_a_configured_one() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+
+        // Set, then clear with an explicit null.
+        let set = put_settings(&router, &bearer, serde_json::json!({"model": "claude-x"})).await;
+        assert_eq!(set.status(), StatusCode::OK);
+        let cleared = put_settings(&router, &bearer, serde_json::json!({"model": null})).await;
+        assert_eq!(cleared.status(), StatusCode::OK);
+        let settings: serde_json::Value = json_body(cleared).await;
+        assert!(
+            settings["model"].is_null(),
+            "explicit null resets the model"
+        );
+
+        // An empty body leaves the (now-cleared) value unchanged.
+        let untouched = put_settings(&router, &bearer, serde_json::json!({})).await;
+        let settings: serde_json::Value = json_body(untouched).await;
+        assert!(settings["model"].is_null());
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn configured_model_is_used_for_the_turn() {
         let recorder = RecordingProvider::default();

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -10,7 +10,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use chrono::Utc;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{Agent, Chat, ChatId, Project, ProjectId, SequencedEvent, Store};
@@ -18,6 +18,50 @@ use openwave_core::{Agent, Chat, ChatId, Project, ProjectId, SequencedEvent, Sto
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 use crate::state::AppState;
+
+/// The store-settings key for the selected model.
+const MODEL_SETTING: &str = "model";
+
+/// Runtime settings a client can read and change. Secrets (e.g. API keys) are
+/// never included here — they live in the `SecretProvider`, not the store.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Settings {
+    /// The model turns run against, or `None` to use the server's default.
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+/// `GET /settings` — the current runtime settings.
+pub async fn get_settings(State(state): State<AppState>) -> Result<Json<Settings>, ServerError> {
+    Ok(Json(Settings {
+        model: read_model(&*state.store).await?,
+    }))
+}
+
+/// `PUT /settings` — update runtime settings, returning the new state. Only the
+/// fields present in the body are changed.
+pub async fn put_settings(
+    State(state): State<AppState>,
+    Json(body): Json<Settings>,
+) -> Result<Json<Settings>, ServerError> {
+    if let Some(model) = &body.model {
+        state
+            .store
+            .set_setting(MODEL_SETTING, &serde_json::json!(model))
+            .await?;
+    }
+    Ok(Json(Settings {
+        model: read_model(&*state.store).await?,
+    }))
+}
+
+/// The configured model, if any.
+async fn read_model(store: &dyn Store) -> Result<Option<String>, ServerError> {
+    Ok(store
+        .get_setting(MODEL_SETTING)
+        .await?
+        .and_then(|value| value.as_str().map(str::to_owned)))
+}
 
 /// Body of `POST /projects`.
 #[derive(Debug, Deserialize)]
@@ -165,11 +209,17 @@ pub async fn post_message(
         ServerError::conflict(format!("chat {id} already has a turn in progress"))
     })?;
 
+    // The model is reconfigurable at runtime via PUT /settings; a stored value
+    // overrides the boot default for this turn.
+    let mut agent_config = state.agent_config.clone();
+    if let Some(model) = read_model(&*state.store).await? {
+        agent_config.model = model;
+    }
     let agent = Agent::new(
         state.provider.clone(),
         state.tools.clone(),
         state.store.clone(),
-        state.agent_config.clone(),
+        agent_config,
     );
     let store = state.store.clone();
     let events = state.events.clone();

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -22,13 +22,32 @@ use crate::state::AppState;
 /// The store-settings key for the selected model.
 const MODEL_SETTING: &str = "model";
 
-/// Runtime settings a client can read and change. Secrets (e.g. API keys) are
-/// never included here — they live in the `SecretProvider`, not the store.
+/// Runtime settings a client can read. Secrets (e.g. API keys) are never
+/// included here — they live in the `SecretProvider`, not the store.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Settings {
     /// The model turns run against, or `None` to use the server's default.
     #[serde(default)]
     pub model: Option<String>,
+}
+
+/// Body of `PUT /settings`. Each field is a *double* option so an absent key is
+/// distinguished from an explicit `null`: absent leaves the value unchanged,
+/// `null` resets it to the server default, and a value sets it.
+#[derive(Debug, Deserialize)]
+pub struct SettingsUpdate {
+    #[serde(default, deserialize_with = "double_option")]
+    pub model: Option<Option<String>>,
+}
+
+/// Deserialize a present field (including JSON `null`) as `Some(..)`; `#[serde(default)]`
+/// supplies `None` when the field is absent.
+fn double_option<'de, D, T>(deserializer: D) -> std::result::Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(Some)
 }
 
 /// `GET /settings` — the current runtime settings.
@@ -39,16 +58,32 @@ pub async fn get_settings(State(state): State<AppState>) -> Result<Json<Settings
 }
 
 /// `PUT /settings` — update runtime settings, returning the new state. Only the
-/// fields present in the body are changed.
+/// fields present in the body are touched.
 pub async fn put_settings(
     State(state): State<AppState>,
-    Json(body): Json<Settings>,
+    Json(body): Json<SettingsUpdate>,
 ) -> Result<Json<Settings>, ServerError> {
-    if let Some(model) = &body.model {
-        state
-            .store
-            .set_setting(MODEL_SETTING, &serde_json::json!(model))
-            .await?;
+    match body.model {
+        // Absent: leave the model unchanged.
+        None => {}
+        // Explicit null: reset to the server default (stored as JSON null, which
+        // `read_model` reads back as "unset").
+        Some(None) => {
+            state
+                .store
+                .set_setting(MODEL_SETTING, &serde_json::Value::Null)
+                .await?;
+        }
+        // A value: reject empty (it would break every turn), else set it.
+        Some(Some(model)) => {
+            if model.is_empty() {
+                return Err(ServerError::bad_request("model must not be empty"));
+            }
+            state
+                .store
+                .set_setting(MODEL_SETTING, &serde_json::json!(model))
+                .await?;
+        }
     }
     Ok(Json(Settings {
         model: read_model(&*state.store).await?,


### PR DESCRIPTION
Adds a small settings surface so the model can be reconfigured while the daemon runs — no restart, no env var.

## Endpoints
- `GET /settings` → `{ "model": <string|null> }` (null when unset).
- `PUT /settings` → body `{ "model": "..." }`; sets it and returns the new settings. Only fields present in the body change.

## Behavior
`POST /chats/{id}/messages` reads the stored model per turn and overrides the boot default (`OPENWAVE_MODEL` / built-in), so a change takes effect on the very next turn.

## Deliberately scoped out
Secrets (API keys) are **not** in this surface — they belong in the `SecretProvider` (keychain), not the store. The key/provider **resolution seam** — building the provider per turn from the stored key rather than baking it at `bind()` — is a separate follow-up, because it has a real testability tension (the turn tests inject a fake provider into `AppState`) that deserves its own focused design pass. This slice keeps that seam untouched: the provider is still the one wired at boot; only the *model string* is now runtime-configurable.

## Tests
- `GET` default (null) → `PUT` → `GET` reflects the change.
- A `RecordingProvider` proves a configured model is the model the turn actually runs against (asserts the `ChatRequest.model` the provider received).

26 server tests, clippy + fmt green.
