### PR TITLE
feat(server): resolve provider per turn from a stored API key

### DIFF
--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools"] }
+openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools", "keychain"] }
 openwave-router = { path = "../openwave-router" }
 axum = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "sync", "macros"] }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -817,8 +817,21 @@ mod tests {
             .set_secret(resolver::ANTHROPIC_API_KEY, "sk-test")
             .await
             .unwrap();
-        let resolved = resolver::KeyedResolver::new(secrets).resolve().await;
+        let resolver = resolver::KeyedResolver::new(secrets.clone());
+        let resolved = resolver.resolve().await;
         assert_eq!(resolved.id().0, "anthropic");
+
+        // Same key ⇒ the cached provider is reused (not rebuilt every turn).
+        let again = resolver.resolve().await;
+        assert!(Arc::ptr_eq(&resolved, &again));
+
+        // Changing the key rebuilds it.
+        secrets
+            .set_secret(resolver::ANTHROPIC_API_KEY, "sk-different")
+            .await
+            .unwrap();
+        let rebuilt = resolver.resolve().await;
+        assert!(!Arc::ptr_eq(&resolved, &rebuilt));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -17,6 +17,7 @@ mod error;
 mod extract;
 mod hub;
 mod provider;
+mod resolver;
 mod routes;
 mod state;
 
@@ -28,10 +29,11 @@ use axum::Router;
 use tokio::net::TcpListener;
 
 use openwave_core::{
-    AgentConfig, AgentError, Config, DbStore, ListDir, ModelProvider, Profile, ReadFile, Result,
-    Store, ToolRegistry, WriteFile,
+    AgentConfig, AgentError, Config, DbStore, KeychainSecretProvider, ListDir, Profile, ReadFile,
+    Result, SecretProvider, Store, ToolRegistry, WriteFile,
 };
-use openwave_router::AnthropicProvider;
+
+use resolver::KeyedResolver;
 
 pub use error::ServerError;
 pub use state::AppState;
@@ -52,6 +54,10 @@ pub fn app(state: AppState) -> Router {
         .route("/projects/{id}", get(routes::get_project))
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
         .route("/chats/{id}", get(routes::get_chat))
+        .route(
+            "/settings/api-key",
+            axum::routing::put(routes::put_api_key).delete(routes::delete_api_key),
+        )
         .route("/chats/{id}/messages", post(routes::post_message))
         .route("/chats/{id}/events", get(routes::chat_events))
         .route_layer(axum::middleware::from_fn_with_state(
@@ -103,8 +109,10 @@ const DEFAULT_MODEL: &str = "claude-opus-4-8";
 /// Wire the store from `config` and bind the API to an ephemeral loopback port.
 pub async fn bind(config: Config) -> Result<Server> {
     let store = connect_store(&config).await?;
-    let (provider, tools, agent_config) = agent_deps();
-    let state = AppState::new(config, store, provider, tools, agent_config);
+    let secrets: Arc<dyn SecretProvider> = Arc::new(KeychainSecretProvider::new());
+    let resolver = Arc::new(KeyedResolver::new(secrets.clone()));
+    let (tools, agent_config) = agent_deps();
+    let state = AppState::new(config, store, resolver, secrets, tools, agent_config);
     let token = state.token.clone();
     let router = app(state);
 
@@ -123,20 +131,13 @@ pub async fn bind(config: Config) -> Result<Server> {
     })
 }
 
-/// Assemble the agent's dependencies for a real launch.
-///
-/// The provider is Anthropic for now, keyed from `ANTHROPIC_API_KEY` (a
-/// keychain-backed secrets flow and the composite router land in later slices).
-/// **Fail closed:** an egressing provider is wired only when a key is actually
-/// present; with no key we wire [`UnconfiguredProvider`](provider::UnconfiguredProvider),
-/// which refuses without any network call, so the transcript never leaves the
-/// machine. A turn then surfaces a `TurnFailed`, never a silent default or a
-/// request sent with an empty key.
-fn agent_deps() -> (Arc<dyn ModelProvider>, Arc<ToolRegistry>, AgentConfig) {
-    let provider: Arc<dyn ModelProvider> = match std::env::var("ANTHROPIC_API_KEY") {
-        Ok(key) if !key.is_empty() => Arc::new(AnthropicProvider::new(key)),
-        _ => Arc::new(provider::UnconfiguredProvider),
-    };
+/// Assemble the static agent dependencies for a real launch: the tool set and
+/// the per-turn tuning. The model **provider** is not built here — it is resolved
+/// per turn by the [`KeyedResolver`] from the configured API key (see
+/// [`resolver`]), so setting a key at runtime takes effect without a restart. The
+/// model *name* comes from `OPENWAVE_MODEL` (or the built-in default) and can be
+/// overridden at runtime via `PUT /settings`.
+fn agent_deps() -> (Arc<ToolRegistry>, AgentConfig) {
     let tools = Arc::new(
         ToolRegistry::new()
             .with(Box::new(ReadFile))
@@ -148,7 +149,7 @@ fn agent_deps() -> (Arc<dyn ModelProvider>, Arc<ToolRegistry>, AgentConfig) {
         model,
         ..AgentConfig::default()
     };
-    (provider, tools, agent_config)
+    (tools, agent_config)
 }
 
 /// Open the durable store the profile selects.
@@ -180,9 +181,10 @@ mod tests {
     use axum::http::{header, Request, StatusCode};
     use futures::stream::{self, BoxStream, StreamExt};
     use openwave_core::{
-        AgentErrorInfo, AgentEvent, Chat, ChatId, ChatRequest, Project, ProjectId, ProviderEvent,
-        ProviderId, SequencedEvent, StopReason, Usage,
+        AgentErrorInfo, AgentEvent, Chat, ChatId, ChatRequest, ModelProvider, Project, ProjectId,
+        ProviderEvent, ProviderId, SecretProvider, SequencedEvent, StopReason, Usage,
     };
+    use resolver::ProviderResolver;
     use serde::de::DeserializeOwned;
     use tokio::sync::Notify;
     use tower::ServiceExt;
@@ -255,6 +257,39 @@ mod tests {
         }
     }
 
+    /// A resolver that always hands back a fixed provider — lets a test inject a
+    /// fake in place of the real credential-driven resolution.
+    struct FixedResolver(Arc<dyn ModelProvider>);
+
+    #[async_trait]
+    impl ProviderResolver for FixedResolver {
+        async fn resolve(&self) -> Arc<dyn ModelProvider> {
+            self.0.clone()
+        }
+    }
+
+    /// An in-memory `SecretProvider` for tests (no OS keychain).
+    #[derive(Default)]
+    struct MemSecrets(std::sync::Mutex<std::collections::HashMap<String, String>>);
+
+    #[async_trait]
+    impl SecretProvider for MemSecrets {
+        async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+            Ok(self.0.lock().unwrap().get(key).cloned())
+        }
+        async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
+            self.0
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.to_string());
+            Ok(())
+        }
+        async fn delete_secret(&self, key: &str) -> Result<()> {
+            self.0.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
     /// A router over a fresh temp SQLite store with the given provider; returns
     /// the router, token, the store (to inspect the journal), and the tempdir.
     async fn test_app_with(
@@ -272,7 +307,8 @@ mod tests {
         let state = AppState::new(
             Config::desktop(dir.path()),
             store.clone(),
-            provider,
+            Arc::new(FixedResolver(provider)),
+            Arc::new(MemSecrets::default()),
             Arc::new(ToolRegistry::new()),
             AgentConfig {
                 model: "fake".into(),
@@ -689,6 +725,100 @@ mod tests {
         let untouched = put_settings(&router, &bearer, serde_json::json!({})).await;
         let settings: serde_json::Value = json_body(untouched).await;
         assert!(settings["model"].is_null());
+    }
+
+    /// `has_api_key` from `GET /settings`.
+    async fn api_key_configured(router: &Router, bearer: &str) -> bool {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/settings")
+                    .header(header::AUTHORIZATION, bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        json_body::<serde_json::Value>(response).await["has_api_key"]
+            .as_bool()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn api_key_put_configures_it_and_delete_reverts() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+
+        // Capture the env-dependent baseline so the test is deterministic wherever
+        // it runs, then assert the transitions the API drives.
+        let baseline = api_key_configured(&router, &bearer).await;
+
+        let put = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/settings/api-key")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"api_key": "sk-test"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(put.status(), StatusCode::NO_CONTENT);
+        assert!(api_key_configured(&router, &bearer).await);
+
+        let delete = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/settings/api-key")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(delete.status(), StatusCode::NO_CONTENT);
+        assert_eq!(api_key_configured(&router, &bearer).await, baseline);
+    }
+
+    #[tokio::test]
+    async fn put_empty_api_key_is_rejected() {
+        let (router, token, _store, _dir) = test_app().await;
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/settings/api-key")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::json!({"api_key": ""}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, "bad_request");
+    }
+
+    #[tokio::test]
+    async fn resolver_builds_a_real_provider_when_a_key_is_set() {
+        // A stored key takes precedence over the env fallback, so this is
+        // deterministic regardless of the ambient environment.
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+        secrets
+            .set_secret(resolver::ANTHROPIC_API_KEY, "sk-test")
+            .await
+            .unwrap();
+        let resolved = resolver::KeyedResolver::new(secrets).resolve().await;
+        assert_eq!(resolved.id().0, "anthropic");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/openwave-server/src/resolver.rs
+++ b/crates/openwave-server/src/resolver.rs
@@ -1,0 +1,58 @@
+//! Resolving the model provider for a turn from configured credentials.
+//!
+//! The provider is built *per turn* rather than once at boot, so setting an API
+//! key at runtime (`PUT /settings/api-key`) takes effect on the next turn without
+//! a restart. The [`ProviderResolver`] seam also lets tests inject a provider
+//! directly instead of standing up a real backend.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use openwave_core::{ModelProvider, SecretProvider};
+use openwave_router::AnthropicProvider;
+
+use crate::provider::UnconfiguredProvider;
+
+/// Secret key under which the Anthropic API key is stored.
+pub const ANTHROPIC_API_KEY: &str = "provider.anthropic.api_key";
+
+/// Builds the model provider for the next turn.
+#[async_trait]
+pub trait ProviderResolver: Send + Sync {
+    /// Resolve the provider. Infallible: with no credentials it returns a
+    /// fail-closed provider, so a turn surfaces `TurnFailed` instead of egressing.
+    async fn resolve(&self) -> Arc<dyn ModelProvider>;
+}
+
+/// Resolves an Anthropic provider from the stored API key — falling back to the
+/// `ANTHROPIC_API_KEY` environment variable — or a fail-closed provider if none.
+pub struct KeyedResolver {
+    secrets: Arc<dyn SecretProvider>,
+}
+
+impl KeyedResolver {
+    /// A resolver that reads the API key from `secrets`.
+    pub fn new(secrets: Arc<dyn SecretProvider>) -> Self {
+        Self { secrets }
+    }
+}
+
+#[async_trait]
+impl ProviderResolver for KeyedResolver {
+    async fn resolve(&self) -> Arc<dyn ModelProvider> {
+        let key = self
+            .secrets
+            .get_secret(ANTHROPIC_API_KEY)
+            .await
+            .ok()
+            .flatten()
+            .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
+            .filter(|key| !key.is_empty());
+        match key {
+            Some(key) => Arc::new(AnthropicProvider::new(key)),
+            // Fail closed: no key ⇒ a provider that refuses without any network call.
+            None => Arc::new(UnconfiguredProvider),
+        }
+    }
+}

--- a/crates/openwave-server/src/resolver.rs
+++ b/crates/openwave-server/src/resolver.rs
@@ -5,7 +5,7 @@
 //! a restart. The [`ProviderResolver`] seam also lets tests inject a provider
 //! directly instead of standing up a real backend.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
@@ -17,6 +17,10 @@ use crate::provider::UnconfiguredProvider;
 /// Secret key under which the Anthropic API key is stored.
 pub const ANTHROPIC_API_KEY: &str = "provider.anthropic.api_key";
 
+/// The provider last built by a [`KeyedResolver`], tagged with the key it was
+/// built from so it can be reused until the key changes.
+type CachedProvider = Option<(Option<String>, Arc<dyn ModelProvider>)>;
+
 /// Builds the model provider for the next turn.
 #[async_trait]
 pub trait ProviderResolver: Send + Sync {
@@ -27,14 +31,22 @@ pub trait ProviderResolver: Send + Sync {
 
 /// Resolves an Anthropic provider from the stored API key — falling back to the
 /// `ANTHROPIC_API_KEY` environment variable — or a fail-closed provider if none.
+///
+/// The built provider is cached and reused while the key is unchanged, so a
+/// provider (and its `reqwest` connection pool) isn't rebuilt every turn; a key
+/// change (via `PUT /settings/api-key`) rebuilds it on the next turn.
 pub struct KeyedResolver {
     secrets: Arc<dyn SecretProvider>,
+    cached: Mutex<CachedProvider>,
 }
 
 impl KeyedResolver {
     /// A resolver that reads the API key from `secrets`.
     pub fn new(secrets: Arc<dyn SecretProvider>) -> Self {
-        Self { secrets }
+        Self {
+            secrets,
+            cached: Mutex::new(None),
+        }
     }
 }
 
@@ -49,10 +61,21 @@ impl ProviderResolver for KeyedResolver {
             .flatten()
             .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
             .filter(|key| !key.is_empty());
-        match key {
-            Some(key) => Arc::new(AnthropicProvider::new(key)),
+
+        // Reuse the cached provider while the key is unchanged. The lock is held
+        // only across the cheap, synchronous build below — never over an await.
+        let mut cached = self.cached.lock().unwrap();
+        if let Some((cached_key, provider)) = cached.as_ref() {
+            if *cached_key == key {
+                return provider.clone();
+            }
+        }
+        let provider: Arc<dyn ModelProvider> = match &key {
+            Some(key) => Arc::new(AnthropicProvider::new(key.clone())),
             // Fail closed: no key ⇒ a provider that refuses without any network call.
             None => Arc::new(UnconfiguredProvider),
-        }
+        };
+        *cached = Some((key, provider.clone()));
+        provider
     }
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -115,11 +115,18 @@ async fn has_api_key(secrets: &dyn SecretProvider) -> bool {
 }
 
 /// Body of `PUT /settings/api-key`.
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub struct ApiKey {
     /// The provider API key to store. Written to the `SecretProvider` (the OS
     /// keychain on desktop), never to the database, and never read back out.
     pub api_key: String,
+}
+
+// Redact the key so it can't leak through a `{:?}` (logging, error context, …).
+impl std::fmt::Debug for ApiKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ApiKey").field("api_key", &"***").finish()
+    }
 }
 
 /// `PUT /settings/api-key` — store the model provider's API key. `204 No Content`.
@@ -138,6 +145,11 @@ pub async fn put_api_key(
 }
 
 /// `DELETE /settings/api-key` — remove the stored API key. `204 No Content`.
+///
+/// Clears only the stored key. If the daemon was launched with an
+/// `ANTHROPIC_API_KEY` in its environment, that fallback still applies — so
+/// `has_api_key` may stay `true` and turns keep resolving a provider after a
+/// delete. The environment is a deploy-time default the API doesn't override.
 pub async fn delete_api_key(State(state): State<AppState>) -> Result<StatusCode, ServerError> {
     state.secrets.delete_secret(ANTHROPIC_API_KEY).await?;
     Ok(StatusCode::NO_CONTENT)

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -13,22 +13,27 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 
-use openwave_core::{Agent, Chat, ChatId, Project, ProjectId, SequencedEvent, Store};
+use openwave_core::{
+    Agent, Chat, ChatId, Project, ProjectId, SecretProvider, SequencedEvent, Store,
+};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
+use crate::resolver::ANTHROPIC_API_KEY;
 use crate::state::AppState;
 
 /// The store-settings key for the selected model.
 const MODEL_SETTING: &str = "model";
 
-/// Runtime settings a client can read. Secrets (e.g. API keys) are never
-/// included here — they live in the `SecretProvider`, not the store.
+/// Runtime settings a client can read. The API key itself is never returned —
+/// it lives in the `SecretProvider`, not the store — only whether one is set.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Settings {
     /// The model turns run against, or `None` to use the server's default.
     #[serde(default)]
     pub model: Option<String>,
+    /// Whether a model API key is configured (never the key itself).
+    pub has_api_key: bool,
 }
 
 /// Body of `PUT /settings`. Each field is a *double* option so an absent key is
@@ -54,6 +59,7 @@ where
 pub async fn get_settings(State(state): State<AppState>) -> Result<Json<Settings>, ServerError> {
     Ok(Json(Settings {
         model: read_model(&*state.store).await?,
+        has_api_key: has_api_key(&*state.secrets).await,
     }))
 }
 
@@ -87,6 +93,7 @@ pub async fn put_settings(
     }
     Ok(Json(Settings {
         model: read_model(&*state.store).await?,
+        has_api_key: has_api_key(&*state.secrets).await,
     }))
 }
 
@@ -96,6 +103,44 @@ async fn read_model(store: &dyn Store) -> Result<Option<String>, ServerError> {
         .get_setting(MODEL_SETTING)
         .await?
         .and_then(|value| value.as_str().map(str::to_owned)))
+}
+
+/// Whether a model API key is configured — in the secret store or the
+/// environment fallback the resolver also honors.
+async fn has_api_key(secrets: &dyn SecretProvider) -> bool {
+    if matches!(secrets.get_secret(ANTHROPIC_API_KEY).await, Ok(Some(key)) if !key.is_empty()) {
+        return true;
+    }
+    std::env::var("ANTHROPIC_API_KEY").is_ok_and(|key| !key.is_empty())
+}
+
+/// Body of `PUT /settings/api-key`.
+#[derive(Debug, Deserialize)]
+pub struct ApiKey {
+    /// The provider API key to store. Written to the `SecretProvider` (the OS
+    /// keychain on desktop), never to the database, and never read back out.
+    pub api_key: String,
+}
+
+/// `PUT /settings/api-key` — store the model provider's API key. `204 No Content`.
+pub async fn put_api_key(
+    State(state): State<AppState>,
+    Json(body): Json<ApiKey>,
+) -> Result<StatusCode, ServerError> {
+    if body.api_key.is_empty() {
+        return Err(ServerError::bad_request("api_key must not be empty"));
+    }
+    state
+        .secrets
+        .set_secret(ANTHROPIC_API_KEY, &body.api_key)
+        .await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /settings/api-key` — remove the stored API key. `204 No Content`.
+pub async fn delete_api_key(State(state): State<AppState>) -> Result<StatusCode, ServerError> {
+    state.secrets.delete_secret(ANTHROPIC_API_KEY).await?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// Body of `POST /projects`.
@@ -250,8 +295,11 @@ pub async fn post_message(
     if let Some(model) = read_model(&*state.store).await? {
         agent_config.model = model;
     }
+    // Resolve the provider from the currently-configured key, so a key set via
+    // PUT /settings/api-key takes effect on this turn.
+    let provider = state.resolver.resolve().await;
     let agent = Agent::new(
-        state.provider.clone(),
+        provider,
         state.tools.clone(),
         state.store.clone(),
         agent_config,

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -3,10 +3,11 @@
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
-use openwave_core::{AgentConfig, ChatId, Config, ModelProvider, Store, ToolRegistry};
+use openwave_core::{AgentConfig, ChatId, Config, SecretProvider, Store, ToolRegistry};
 use uuid::Uuid;
 
 use crate::bus::EventBus;
+use crate::resolver::ProviderResolver;
 
 /// The state cloned into each handler: the boot config, the durable store, the
 /// agent's dependencies (provider + tools + tuning), the per-launch bearer token,
@@ -19,8 +20,10 @@ pub struct AppState {
     pub config: Arc<Config>,
     /// Durable metadata, conversation state, and the event journal.
     pub store: Arc<dyn Store>,
-    /// The model backend turns stream completions from.
-    pub provider: Arc<dyn ModelProvider>,
+    /// Builds the model provider for each turn from the configured credentials.
+    pub resolver: Arc<dyn ProviderResolver>,
+    /// Credential custody — where the model API key is read from and written to.
+    pub secrets: Arc<dyn SecretProvider>,
     /// The tools available to the agent.
     pub tools: Arc<ToolRegistry>,
     /// Per-turn agent tuning (model, limits, …).
@@ -39,14 +42,16 @@ impl AppState {
     pub fn new(
         config: Config,
         store: Arc<dyn Store>,
-        provider: Arc<dyn ModelProvider>,
+        resolver: Arc<dyn ProviderResolver>,
+        secrets: Arc<dyn SecretProvider>,
         tools: Arc<ToolRegistry>,
         agent_config: AgentConfig,
     ) -> Self {
         Self {
             config: Arc::new(config),
             store,
-            provider,
+            resolver,
+            secrets,
             tools,
             agent_config,
             token: Uuid::new_v4().to_string().into(),


### PR DESCRIPTION
The model provider is now built **per turn** from the configured credentials instead of once at boot, so an API key set at runtime takes effect on the next turn — no restart.

## The seam
`ProviderResolver` (in `resolver.rs`) is the injectable seam:
- `KeyedResolver` reads the key from a `SecretProvider` (falling back to `ANTHROPIC_API_KEY`); with a key it builds an `AnthropicProvider`, with none it returns the fail-closed `UnconfiguredProvider` (no network call — the transcript never leaves the machine).
- The seam is what keeps the turn/WS tests able to inject a fake provider: they wrap it in a trivial `FixedResolver`.

## Wiring
- `AppState` now holds `resolver: Arc<dyn ProviderResolver>` (replacing the baked provider) plus `secrets: Arc<dyn SecretProvider>` (the keychain, in `bind()`).
- `POST /chats/{id}/messages` resolves the provider per turn.

## Endpoints
- `PUT /settings/api-key` `{ api_key }` → stores the key in the `SecretProvider` (the OS keychain on desktop), **never** the database, and it's never read back out. `204`.
- `DELETE /settings/api-key` → removes it. `204`.
- `GET /settings` now reports `has_api_key` (whether a key is configured, in the store or the env fallback) — never the key itself.
- Empty `api_key` → `400`.

## Deliberately scoped
- Single provider (Anthropic) for now; the multi-provider/composite router is a later slice. The key path is namespaced (`provider.anthropic.api_key`) so adding providers is additive.
- `bind()` constructs the keychain provider lazily (no keychain access until a get/set at request time), so this stays CI-safe; all endpoint tests use an in-memory `SecretProvider`.

## Tests
`PUT` configures / `DELETE` reverts `has_api_key` (deterministic against the env baseline), empty key → `400`, and a `KeyedResolver` unit test that a stored key yields a real provider (stored key takes precedence over env, so it's env-independent). 32 server tests, full workspace + clippy + fmt green.
