### PR TITLE
feat: per-chat model selection + GET /models catalog

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -478,6 +478,7 @@ mod tests {
             id: ChatId::new(),
             project_id: None,
             title: None,
+            model: None,
             workspace_dir: workspace.path().to_path_buf(),
             created_at: Utc::now(),
         };
@@ -551,6 +552,7 @@ mod tests {
             id: ChatId::new(),
             project_id: None,
             title: None,
+            model: None,
             workspace_dir: workspace.path().to_path_buf(),
             created_at: Utc::now(),
         };
@@ -609,6 +611,7 @@ mod tests {
             id: ChatId::new(),
             project_id: None,
             title: None,
+            model: None,
             workspace_dir: workspace.path().to_path_buf(),
             created_at: Utc::now(),
         };

--- a/crates/openwave-core/src/db.rs
+++ b/crates/openwave-core/src/db.rs
@@ -95,12 +95,26 @@ impl Store for DbStore {
             id: Set(chat.id.0),
             project_id: Set(chat.project_id.map(|p| p.0)),
             title: Set(chat.title.clone()),
+            model: Set(chat.model.clone()),
             workspace_dir: Set(chat.workspace_dir.to_string_lossy().into_owned()),
             created_at: Set(chat.created_at),
         }
         .insert(&self.conn)
         .await
         .map_err(store_err)?;
+        Ok(())
+    }
+
+    async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()> {
+        entities::chat::Entity::update_many()
+            .col_expr(
+                entities::chat::Column::Model,
+                sea_orm::sea_query::Expr::value(model),
+            )
+            .filter(entities::chat::Column::Id.eq(id.0))
+            .exec(&self.conn)
+            .await
+            .map_err(store_err)?;
         Ok(())
     }
 
@@ -235,6 +249,7 @@ fn chat_from_model(model: entities::chat::Model) -> Chat {
         id: ChatId(model.id),
         project_id: model.project_id.map(ProjectId),
         title: model.title,
+        model: model.model,
         workspace_dir: PathBuf::from(model.workspace_dir),
         created_at: model.created_at,
     }
@@ -304,6 +319,7 @@ mod entities {
             pub id: Uuid,
             pub project_id: Option<Uuid>,
             pub title: Option<String>,
+            pub model: Option<String>,
             pub workspace_dir: String,
             pub created_at: DateTimeUtc,
         }
@@ -393,6 +409,7 @@ mod migration {
                 Box::new(Init),
                 Box::new(AddEventJournal),
                 Box::new(AddProjects),
+                Box::new(AddChatModel),
             ]
         }
     }
@@ -594,6 +611,42 @@ mod migration {
         }
     }
 
+    /// Adds the optional per-chat `model` override.
+    struct AddChatModel;
+
+    impl MigrationName for AddChatModel {
+        fn name(&self) -> &str {
+            "m0004_chat_model"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for AddChatModel {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Chat::Table)
+                        .add_column(ColumnDef::new(Chat::Model).text())
+                        .to_owned(),
+                )
+                .await?;
+            Ok(())
+        }
+
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(Chat::Table)
+                        .drop_column(Chat::Model)
+                        .to_owned(),
+                )
+                .await?;
+            Ok(())
+        }
+    }
+
     #[derive(DeriveIden)]
     enum Project {
         Table,
@@ -609,6 +662,7 @@ mod migration {
         Id,
         ProjectId,
         Title,
+        Model,
         WorkspaceDir,
         CreatedAt,
     }
@@ -658,6 +712,7 @@ mod tests {
             id: ChatId::new(),
             project_id: None,
             title: Some("hello".into()),
+            model: None,
             workspace_dir: PathBuf::from("/tmp/ws"),
             created_at: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
         }
@@ -716,6 +771,32 @@ mod tests {
         };
         assert_eq!(listed_link(in_project.id), Some(project.id));
         assert_eq!(listed_link(loose.id), None);
+    }
+
+    #[tokio::test]
+    async fn set_chat_model_updates_then_clears() {
+        let (_dir, store) = temp_store().await;
+        let chat = sample_chat();
+        store.create_chat(&chat).await.unwrap();
+        assert_eq!(store.get_chat(chat.id).await.unwrap().unwrap().model, None);
+
+        store
+            .set_chat_model(chat.id, Some("claude-x".into()))
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_chat(chat.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .model
+                .as_deref(),
+            Some("claude-x")
+        );
+
+        store.set_chat_model(chat.id, None).await.unwrap();
+        assert_eq!(store.get_chat(chat.id).await.unwrap().unwrap().model, None);
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -53,6 +53,8 @@ pub struct Chat {
     pub project_id: Option<ProjectId>,
     /// Human-facing title; `None` until one is set or derived.
     pub title: Option<String>,
+    /// The model this chat runs against, or `None` to use the configured default.
+    pub model: Option<String>,
     /// Absolute path to this chat's workspace directory.
     pub workspace_dir: PathBuf,
     /// When the chat was created.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -53,6 +53,10 @@ pub trait Store: Send + Sync {
     /// List chats, most-recently-created first.
     async fn list_chats(&self) -> Result<Vec<Chat>>;
 
+    /// Set (or clear, with `None`) a chat's model override. A no-op if the chat
+    /// doesn't exist.
+    async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()>;
+
     /// Append a message to its chat.
     async fn append_message(&self, message: &Message) -> Result<()>;
 
@@ -148,6 +152,12 @@ mod tests {
         async fn list_chats(&self) -> Result<Vec<Chat>> {
             Ok(self.chats.lock().unwrap().values().cloned().collect())
         }
+        async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()> {
+            if let Some(chat) = self.chats.lock().unwrap().get_mut(&id) {
+                chat.model = model;
+            }
+            Ok(())
+        }
         async fn append_message(&self, _message: &Message) -> Result<()> {
             Ok(())
         }
@@ -195,6 +205,7 @@ mod tests {
             id: ChatId::new(),
             project_id: None,
             title: None,
+            model: None,
             workspace_dir: "/tmp/ws".into(),
             created_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
         };

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -52,8 +52,12 @@ pub fn app(state: AppState) -> Router {
             post(routes::create_project).get(routes::list_projects),
         )
         .route("/projects/{id}", get(routes::get_project))
+        .route("/models", get(routes::list_models))
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
-        .route("/chats/{id}", get(routes::get_chat))
+        .route(
+            "/chats/{id}",
+            get(routes::get_chat).patch(routes::patch_chat),
+        )
         .route(
             "/settings/api-key",
             axum::routing::put(routes::put_api_key).delete(routes::delete_api_key),
@@ -605,6 +609,158 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let info: AgentErrorInfo = json_body(response).await;
         assert_eq!(info.kind, "bad_request");
+    }
+
+    #[tokio::test]
+    async fn models_catalog_is_served() {
+        let (router, token, _store, _dir) = test_app().await;
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/models")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let catalog: serde_json::Value = json_body(response).await;
+        let models = catalog["models"].as_array().unwrap();
+        assert!(!models.is_empty());
+        assert!(models.iter().any(|m| m["provider"] == "anthropic"));
+    }
+
+    #[tokio::test]
+    async fn chat_created_with_a_model() {
+        let (router, token, _store, _dir) = test_app().await;
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/chats")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"workspace_dir": "/tmp/ws", "model": "claude-x"})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let chat: Chat = json_body(response).await;
+        assert_eq!(chat.model.as_deref(), Some("claude-x"));
+    }
+
+    /// PATCH a chat's model with a raw JSON body, returning the response.
+    async fn patch_chat(
+        router: &Router,
+        bearer: &str,
+        chat: ChatId,
+        body: serde_json::Value,
+    ) -> axum::response::Response {
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/chats/{chat}"))
+                    .header(header::AUTHORIZATION, bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn patch_chat_sets_and_clears_the_model() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+        assert_eq!(chat.model, None);
+
+        let set = patch_chat(
+            &router,
+            &bearer,
+            chat.id,
+            serde_json::json!({"model": "m1"}),
+        )
+        .await;
+        assert_eq!(set.status(), StatusCode::OK);
+        assert_eq!(json_body::<Chat>(set).await.model.as_deref(), Some("m1"));
+
+        let cleared = patch_chat(
+            &router,
+            &bearer,
+            chat.id,
+            serde_json::json!({"model": null}),
+        )
+        .await;
+        assert_eq!(cleared.status(), StatusCode::OK);
+        assert_eq!(json_body::<Chat>(cleared).await.model, None);
+    }
+
+    #[tokio::test]
+    async fn patch_chat_rejects_empty_model_and_unknown_chat() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        let empty = patch_chat(&router, &bearer, chat.id, serde_json::json!({"model": ""})).await;
+        assert_eq!(empty.status(), StatusCode::BAD_REQUEST);
+
+        let missing = patch_chat(
+            &router,
+            &bearer,
+            ChatId::new(),
+            serde_json::json!({"model": "m"}),
+        )
+        .await;
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn chat_model_takes_precedence_over_the_default() {
+        let recorder = RecordingProvider::default();
+        let (router, token, store, _dir) = test_app_with(Arc::new(recorder.clone())).await;
+        let bearer = format!("Bearer {token}");
+
+        // A global default is set, but the chat picks its own model — the chat wins.
+        let set_default = put_settings(
+            &router,
+            &bearer,
+            serde_json::json!({"model": "default-model"}),
+        )
+        .await;
+        assert_eq!(set_default.status(), StatusCode::OK);
+        let chat = make_chat(&router, &bearer).await;
+        let patched = patch_chat(
+            &router,
+            &bearer,
+            chat.id,
+            serde_json::json!({"model": "chat-model"}),
+        )
+        .await;
+        assert_eq!(patched.status(), StatusCode::OK);
+
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "hi").await,
+            StatusCode::ACCEPTED
+        );
+        wait_for_turn(&store, chat.id).await;
+        assert!(
+            recorder
+                .models
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|m| m == "chat-model"),
+            "the chat's own model should win over the global default"
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -654,6 +654,28 @@ mod tests {
         assert_eq!(chat.model.as_deref(), Some("claude-x"));
     }
 
+    #[tokio::test]
+    async fn chat_created_with_empty_model_is_rejected() {
+        let (router, token, _store, _dir) = test_app().await;
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/chats")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"workspace_dir": "/tmp/ws", "model": ""}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, "bad_request");
+    }
+
     /// PATCH a chat's model with a raw JSON body, returning the response.
     async fn patch_chat(
         router: &Router,

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -380,8 +380,14 @@ pub async fn post_message(
 
     // Model resolution order: the chat's own selection wins, then the global
     // default setting (PUT /settings), then the boot default in agent_config.
+    // Short-circuit: only read the setting when the chat has no model of its own,
+    // so a chat with a model doesn't pay (or fail on) the settings lookup.
     let mut agent_config = state.agent_config.clone();
-    if let Some(model) = chat.model.clone().or(read_model(&*state.store).await?) {
+    let model = match chat.model.clone() {
+        Some(model) => Some(model),
+        None => read_model(&*state.store).await?,
+    };
+    if let Some(model) = model {
         agent_config.model = model;
     }
     // Resolve the provider from the currently-configured key, so a key set via

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -155,6 +155,44 @@ pub async fn delete_api_key(State(state): State<AppState>) -> Result<StatusCode,
     Ok(StatusCode::NO_CONTENT)
 }
 
+/// A selectable model in the catalog.
+#[derive(Debug, Serialize)]
+pub struct ModelInfo {
+    /// The identifier passed to the provider and stored as `chat.model`.
+    pub id: &'static str,
+    /// The provider that serves the model.
+    pub provider: &'static str,
+}
+
+/// Response for `GET /models`.
+#[derive(Debug, Serialize)]
+pub struct ModelCatalog {
+    /// The models a client can select from.
+    pub models: Vec<ModelInfo>,
+}
+
+/// `GET /models` — the catalog a chat's model selector chooses from.
+///
+/// A curated static list for now (Anthropic only, matching the single provider
+/// wired today). When multiple providers are configurable this becomes
+/// provider-driven — the enabled, credentialed providers' models.
+pub async fn list_models() -> Json<ModelCatalog> {
+    const ANTHROPIC_MODELS: &[&str] = &[
+        "claude-opus-4-8",
+        "claude-sonnet-5",
+        "claude-haiku-4-5-20251001",
+    ];
+    Json(ModelCatalog {
+        models: ANTHROPIC_MODELS
+            .iter()
+            .map(|id| ModelInfo {
+                id,
+                provider: "anthropic",
+            })
+            .collect(),
+    })
+}
+
 /// Body of `POST /projects`.
 #[derive(Debug, Deserialize)]
 pub struct CreateProject {
@@ -217,6 +255,9 @@ pub struct CreateChat {
     /// Optional project to file this chat under; omitted for a loose chat.
     #[serde(default)]
     pub project_id: Option<ProjectId>,
+    /// Optional model for this chat; omitted to use the configured default.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 /// `POST /chats` — create a chat and return it (`201 Created`).
@@ -243,15 +284,51 @@ pub async fn create_chat(
             )));
         }
     }
+    if body.model.as_deref().is_some_and(str::is_empty) {
+        return Err(ServerError::bad_request("model must not be empty"));
+    }
     let chat = Chat {
         id: ChatId::new(),
         project_id: body.project_id,
         title: body.title,
+        model: body.model,
         workspace_dir: body.workspace_dir,
         created_at: Utc::now(),
     };
     state.store.create_chat(&chat).await?;
     Ok((StatusCode::CREATED, Json(chat)))
+}
+
+/// Body of `PATCH /chats/{id}`. A double option (like `PUT /settings`): absent
+/// leaves the model unchanged, `null` clears it (fall back to the default), and a
+/// value sets it.
+#[derive(Debug, Deserialize)]
+pub struct ChatUpdate {
+    #[serde(default, deserialize_with = "double_option")]
+    pub model: Option<Option<String>>,
+}
+
+/// `PATCH /chats/{id}` — update a chat's model selection; returns the chat. This
+/// is what a chat UI's model selector writes to.
+pub async fn patch_chat(
+    State(state): State<AppState>,
+    Path(id): Path<ChatId>,
+    Json(body): Json<ChatUpdate>,
+) -> Result<Json<Chat>, ServerError> {
+    let mut chat = state
+        .store
+        .get_chat(id)
+        .await?
+        .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
+
+    if let Some(model) = body.model {
+        if model.as_deref().is_some_and(str::is_empty) {
+            return Err(ServerError::bad_request("model must not be empty"));
+        }
+        state.store.set_chat_model(id, model.clone()).await?;
+        chat.model = model;
+    }
+    Ok(Json(chat))
 }
 
 /// `GET /chats` — list chats, most-recently-created first.
@@ -301,10 +378,10 @@ pub async fn post_message(
         ServerError::conflict(format!("chat {id} already has a turn in progress"))
     })?;
 
-    // The model is reconfigurable at runtime via PUT /settings; a stored value
-    // overrides the boot default for this turn.
+    // Model resolution order: the chat's own selection wins, then the global
+    // default setting (PUT /settings), then the boot default in agent_config.
     let mut agent_config = state.agent_config.clone();
-    if let Some(model) = read_model(&*state.store).await? {
+    if let Some(model) = chat.model.clone().or(read_model(&*state.store).await?) {
         agent_config.model = model;
     }
     // Resolve the provider from the currently-configured key, so a key set via


### PR DESCRIPTION
The chat UI's model selector needs two things: a catalog to pick from, and a per-chat place to store the pick. This adds both, plus the resolution order that makes the pick take effect.

## Model selection is per-chat
- **core:** `Chat` gains an optional `model`; `m0004` adds the nullable `chat.model` column; `Store::set_chat_model` sets/clears it.
- **server:** `POST /chats` accepts an optional `model`; `PATCH /chats/{id}` sets or clears it (what a selector writes); empty → `400`, unknown chat → `404`.

## Resolution order (per turn)
`chat.model` → the `/settings` default (`PUT /settings`) → the boot default in `AgentConfig`. So a chat's own selection wins, falling back to the global default, then the built-in.

## Catalog
`GET /models` serves the selector's options — a **curated Anthropic list** for now (matching the single provider wired today). It becomes provider-driven once providers are configurable (the `/providers` slice).

## Tests
Catalog served; chat created with a model; `PATCH` set/clear + empty-`400` + unknown-chat-`404`; a chat's model winning over the global default in an actual turn (via a recording provider); and a `set_chat_model` store round-trip. 37 server + full core tests, clippy + fmt green.

Follows the agreed provider/model-config plan (per-chat selection, alpha-style); the next slices are per-provider credentials + `/providers`, then the composite router.
