### PR TITLE
feat: providers API + OpenAI-compatible adapter

### DIFF
--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -80,7 +80,7 @@ pub trait Store: Send + Sync {
 }
 
 /// Credential custody: secrets keyed by a stable reference string (e.g.
-/// `provider.anthropic.api_key`). Backed by the OS keychain on desktop, a
+/// `provider.anthropic.credential`). Backed by the OS keychain on desktop, a
 /// KMS/Vault on a server — never the [`Store`].
 #[async_trait]
 pub trait SecretProvider: Send + Sync {

--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -11,9 +11,11 @@ authors.workspace = true
 workspace = true
 
 [features]
-default = ["anthropic"]
+default = ["anthropic", "openai-compat"]
 # The Anthropic (Messages API) provider adapter.
 anthropic = ["dep:reqwest", "dep:async-stream"]
+# OpenAI-compatible Chat Completions adapter (OpenAI, OpenRouter, vLLM, …).
+openai-compat = ["dep:reqwest", "dep:async-stream"]
 
 [dependencies]
 openwave-core = { path = "../openwave-core", default-features = false }

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -16,6 +16,8 @@ use openwave_core::provider::{
 };
 use openwave_core::Role;
 
+use crate::sse::{drain_frames, frame_data};
+
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
@@ -179,57 +181,6 @@ struct StreamState {
     input_tokens: u32,
     cache_read_input_tokens: u32,
     cache_creation_input_tokens: u32,
-}
-
-/// Naive byte-substring search.
-fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.is_empty() || haystack.len() < needle.len() {
-        return None;
-    }
-    haystack.windows(needle.len()).position(|w| w == needle)
-}
-
-/// Drain all complete SSE frames from `buffer`, returning each frame's decoded
-/// text and leaving any incomplete trailing bytes behind.
-///
-/// Frames are separated by a blank line (`\n\n` or `\r\n\r\n`). Decoding to UTF-8
-/// happens only on a complete frame, so a multi-byte character split across
-/// network chunks is never decoded until all its bytes have arrived.
-fn drain_frames(buffer: &mut Vec<u8>) -> Vec<String> {
-    let mut frames = Vec::new();
-    loop {
-        let lf = find_subslice(buffer, b"\n\n");
-        let crlf = find_subslice(buffer, b"\r\n\r\n");
-        let (content_end, consume_to) = match (lf, crlf) {
-            (Some(i), Some(j)) => {
-                if i <= j {
-                    (i, i + 2)
-                } else {
-                    (j, j + 4)
-                }
-            }
-            (Some(i), None) => (i, i + 2),
-            (None, Some(j)) => (j, j + 4),
-            (None, None) => break,
-        };
-        frames.push(String::from_utf8_lossy(&buffer[..content_end]).into_owned());
-        buffer.drain(..consume_to);
-    }
-    frames
-}
-
-/// Extract and parse the `data:` JSON payload from one SSE frame.
-fn frame_data(frame: &str) -> Option<Value> {
-    let mut data = String::new();
-    for line in frame.lines() {
-        if let Some(rest) = line.strip_prefix("data:") {
-            data.push_str(rest.trim_start());
-        }
-    }
-    if data.is_empty() {
-        return None;
-    }
-    serde_json::from_str(&data).ok()
 }
 
 fn u32_at(value: &Value, key: &str) -> u32 {
@@ -415,45 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn drain_frames_handles_lf_crlf_and_partial_tail() {
-        // LF-separated, plus a partial trailing frame left in the buffer.
-        let mut buf = b"data: {\"a\":1}\n\ndata: partial".to_vec();
-        let frames = drain_frames(&mut buf);
-        assert_eq!(frames.len(), 1);
-        assert!(frames[0].contains("{\"a\":1}"));
-        assert_eq!(buf, b"data: partial");
-
-        // CRLF-separated frame.
-        let mut buf = b"event: x\r\ndata: {\"b\":2}\r\n\r\n".to_vec();
-        let frames = drain_frames(&mut buf);
-        assert_eq!(frames.len(), 1);
-        assert_eq!(frame_data(&frames[0]).unwrap()["b"], 2);
-        assert!(buf.is_empty());
-    }
-
-    #[test]
-    fn multibyte_char_split_across_chunks_is_not_corrupted() {
-        // The é in "café" is two bytes (0xC3 0xA9); split the buffer between them
-        // to mimic a network chunk boundary landing mid-character.
-        let full = "data: {\"t\":\"café\"}\n\n".as_bytes().to_vec();
-        let split = full.iter().position(|&b| b == 0xC3).unwrap() + 1;
-        let (head, tail) = full.split_at(split);
-
-        let mut buf = head.to_vec();
-        assert!(drain_frames(&mut buf).is_empty(), "no complete frame yet");
-        buf.extend_from_slice(tail);
-        let frames = drain_frames(&mut buf);
-        assert_eq!(frames.len(), 1);
-        // Would be "caf\u{fffd}\u{fffd}" if we had decoded the partial chunk.
-        assert_eq!(frame_data(&frames[0]).unwrap()["t"], "café");
-    }
-
-    #[test]
-    fn frame_data_extracts_json_and_maps_stop_reasons() {
-        let data = frame_data("event: message_stop\ndata: {\"type\":\"message_stop\"}").unwrap();
-        assert_eq!(data["type"], "message_stop");
-        assert!(frame_data("event: ping").is_none());
-
+    fn maps_stop_reasons() {
         assert_eq!(map_stop_reason("tool_use"), StopReason::ToolUse);
         assert_eq!(map_stop_reason("max_tokens"), StopReason::MaxTokens);
         assert_eq!(map_stop_reason("refusal"), StopReason::EndTurn);

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -16,7 +16,7 @@ use openwave_core::provider::{
 };
 use openwave_core::Role;
 
-use crate::sse::{drain_frames, frame_data};
+use crate::sse::{drain_frames, frame_data, safe_http_error};
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -77,13 +77,16 @@ impl ModelProvider for AnthropicProvider {
             .await
             .map_err(provider_err)?;
 
-        // Surface non-2xx with the provider's error body (the Router needs the
-        // body to classify rate-limit vs auth vs bad-request).
+        // Surface non-2xx without the raw body — it can echo key material, and
+        // `AgentError` strings reach the client via TurnFailed. Status (+ a
+        // stable error type/code when present) is enough for classification.
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(AgentError::Provider(format!(
-                "anthropic returned {status}: {body}"
+            return Err(AgentError::Provider(safe_http_error(
+                "anthropic",
+                status.as_u16(),
+                &body,
             )));
         }
 

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -9,8 +9,15 @@
 //! The `ModelProvider` contract itself lives in `openwave-core`; only the
 //! implementations live here.
 
+mod sse;
+
 #[cfg(feature = "anthropic")]
 pub mod anthropic;
 
+#[cfg(feature = "openai-compat")]
+pub mod openai_compat;
+
 #[cfg(feature = "anthropic")]
 pub use anthropic::AnthropicProvider;
+#[cfg(feature = "openai-compat")]
+pub use openai_compat::OpenAiCompatProvider;

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -1,0 +1,561 @@
+//! OpenAI-compatible Chat Completions provider.
+//!
+//! Speaks the widely-supported `/v1/chat/completions` streaming protocol so the
+//! same adapter covers OpenAI itself, OpenRouter, Fireworks, vLLM, LM Studio,
+//! and other OpenAI-compatible gateways. Point `base_url` at the gateway's
+//! `/v1` root (default: `https://api.openai.com/v1`).
+//!
+//! Native OpenAI's Responses API is a separate concern; this adapter deliberately
+//! targets the Chat Completions shape that local and third-party runtimes share.
+
+use async_trait::async_trait;
+use futures::stream::{BoxStream, StreamExt};
+use serde_json::{json, Value};
+
+use openwave_core::error::{AgentError, Result};
+use openwave_core::provider::{
+    ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason, Usage,
+};
+use openwave_core::Role;
+
+use crate::sse::{drain_frames, frame_data};
+
+const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+fn provider_err(err: impl std::fmt::Display) -> AgentError {
+    AgentError::Provider(err.to_string())
+}
+
+/// A [`ModelProvider`] for any OpenAI-compatible Chat Completions endpoint.
+#[derive(Clone)]
+pub struct OpenAiCompatProvider {
+    client: reqwest::Client,
+    api_key: String,
+    base_url: String,
+    /// Stable id reported by [`ModelProvider::id`] — `"openai"` or
+    /// `"openai_compatible"` depending on how the caller configured it.
+    provider_id: String,
+}
+
+impl OpenAiCompatProvider {
+    /// Build a provider hitting OpenAI's Chat Completions API.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key: api_key.into(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+            provider_id: "openai".to_string(),
+        }
+    }
+
+    /// Build a provider for a custom OpenAI-compatible gateway.
+    pub fn compatible(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key: api_key.into(),
+            base_url: base_url.into(),
+            provider_id: "openai_compatible".to_string(),
+        }
+    }
+
+    /// Override the base URL (the `/v1` root; `/chat/completions` is appended).
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// Override the reported provider id.
+    #[must_use]
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.provider_id = id.into();
+        self
+    }
+}
+
+#[async_trait]
+impl ModelProvider for OpenAiCompatProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new(self.provider_id.clone())
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let body = build_request_json(&req)?;
+        let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+
+        let response = self
+            .client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(provider_err)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AgentError::Provider(format!(
+                "openai-compat returned {status}: {body}"
+            )));
+        }
+
+        let stream = async_stream::stream! {
+            let mut bytes = response.bytes_stream();
+            let mut buffer: Vec<u8> = Vec::new();
+            let mut state = StreamState::default();
+            while let Some(chunk) = bytes.next().await {
+                let Ok(chunk) = chunk else { break };
+                buffer.extend_from_slice(&chunk);
+                for frame in drain_frames(&mut buffer) {
+                    if let Some(data) = frame_data(&frame) {
+                        for event in normalize(&data, &mut state) {
+                            yield event;
+                        }
+                    }
+                }
+            }
+            if !buffer.is_empty() {
+                let frame = String::from_utf8_lossy(&buffer).into_owned();
+                if let Some(data) = frame_data(&frame) {
+                    for event in normalize(&data, &mut state) {
+                        yield event;
+                    }
+                }
+            }
+            // Emit a Stop if the stream ended without a finish_reason (some
+            // local servers omit it on clean close).
+            if !state.stopped {
+                yield ProviderEvent::Stop {
+                    reason: if state.saw_tool_call {
+                        StopReason::ToolUse
+                    } else {
+                        StopReason::EndTurn
+                    },
+                };
+            }
+        };
+        Ok(Box::pin(stream))
+    }
+}
+
+/// Build the Chat Completions request body from a normalized [`ChatRequest`].
+fn build_request_json(req: &ChatRequest) -> Result<Value> {
+    let mut messages = Vec::new();
+    if let Some(system) = &req.system {
+        messages.push(json!({
+            "role": "system",
+            "content": system,
+        }));
+    }
+    for message in &req.messages {
+        extend_openai_messages(&mut messages, message)?;
+    }
+
+    let mut body = json!({
+        "model": req.model,
+        "messages": messages,
+        "max_tokens": req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+        "stream": true,
+    });
+
+    if !req.tools.is_empty() {
+        body["tools"] = Value::Array(
+            req.tools
+                .iter()
+                .map(|tool| {
+                    json!({
+                        "type": "function",
+                        "function": {
+                            "name": tool.name,
+                            "description": tool.description,
+                            "parameters": tool.input_schema,
+                        }
+                    })
+                })
+                .collect(),
+        );
+    }
+    if let Some(temperature) = req.temperature {
+        body["temperature"] = json!(temperature);
+    }
+    Ok(body)
+}
+
+/// Append one normalized message as one or more OpenAI Chat Completions messages.
+///
+/// Tool results become individual `role: tool` messages (the wire format requires
+/// one per `tool_call_id`); everything else collapses into a single message.
+fn extend_openai_messages(
+    out: &mut Vec<Value>,
+    message: &openwave_core::ChatMessage,
+) -> Result<()> {
+    let tool_results: Vec<_> = message
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                ..
+            } => Some(json!({
+                "role": "tool",
+                "tool_call_id": tool_use_id,
+                "content": content,
+            })),
+            _ => None,
+        })
+        .collect();
+
+    // Pure tool-result message(s): emit one OpenAI tool message per result.
+    if !tool_results.is_empty()
+        && tool_results.len()
+            == message
+                .content
+                .iter()
+                .filter(|b| matches!(b, ContentBlock::ToolResult { .. }))
+                .count()
+        && message
+            .content
+            .iter()
+            .all(|b| matches!(b, ContentBlock::ToolResult { .. }))
+    {
+        out.extend(tool_results);
+        return Ok(());
+    }
+
+    let tool_calls: Vec<Value> = message
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::ToolUse { id, name, input } => Some(json!({
+                "id": id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": serde_json::to_string(input).unwrap_or_else(|_| "{}".into()),
+                }
+            })),
+            _ => None,
+        })
+        .collect();
+
+    let text: String = message
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("");
+
+    let role = match message.role {
+        Role::Assistant => "assistant",
+        Role::User | Role::System | Role::Tool => "user",
+    };
+
+    let mut msg = json!({ "role": role });
+    if !text.is_empty() {
+        msg["content"] = json!(text);
+    } else if tool_calls.is_empty() {
+        msg["content"] = json!("");
+    }
+    if !tool_calls.is_empty() {
+        msg["tool_calls"] = Value::Array(tool_calls);
+    }
+    out.push(msg);
+    Ok(())
+}
+
+#[derive(Default)]
+struct StreamState {
+    /// Tool-call argument buffers keyed by the stream-local index.
+    tool_calls: std::collections::BTreeMap<u32, ToolCallBuf>,
+    usage: Usage,
+    stopped: bool,
+    saw_tool_call: bool,
+}
+
+#[derive(Default)]
+struct ToolCallBuf {
+    id: String,
+    name: String,
+    started: bool,
+}
+
+/// Map one parsed Chat Completions stream chunk into zero or more events.
+fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
+    let mut events = Vec::new();
+
+    if let Some(usage) = data.get("usage") {
+        // Chat Completions usage often arrives on the final chunk. OpenAI's
+        // `prompt_tokens` is the full prompt; cached details are optional.
+        let prompt = u32_at(usage, "prompt_tokens");
+        let cached = usage
+            .get("prompt_tokens_details")
+            .map(|d| u32_at(d, "cached_tokens"))
+            .unwrap_or(0);
+        state.usage = Usage {
+            input_tokens: prompt.saturating_sub(cached),
+            output_tokens: u32_at(usage, "completion_tokens"),
+            cache_read_input_tokens: cached,
+            cache_creation_input_tokens: 0,
+        };
+    }
+
+    let Some(choice) = data
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|c| c.first())
+    else {
+        return events;
+    };
+
+    if let Some(delta) = choice.get("delta") {
+        if let Some(content) = delta.get("content").and_then(Value::as_str) {
+            if !content.is_empty() {
+                events.push(ProviderEvent::TextDelta {
+                    text: content.to_string(),
+                });
+            }
+        }
+        // Some gateways stream reasoning as `reasoning_content` or `reasoning`.
+        for key in ["reasoning_content", "reasoning"] {
+            if let Some(text) = delta.get(key).and_then(Value::as_str) {
+                if !text.is_empty() {
+                    events.push(ProviderEvent::ReasoningDelta {
+                        text: text.to_string(),
+                    });
+                }
+            }
+        }
+        if let Some(tool_calls) = delta.get("tool_calls").and_then(Value::as_array) {
+            for tc in tool_calls {
+                let index = u32_at(tc, "index");
+                let buf = state.tool_calls.entry(index).or_default();
+                if let Some(id) = tc.get("id").and_then(Value::as_str) {
+                    if !id.is_empty() {
+                        buf.id = id.to_string();
+                    }
+                }
+                if let Some(name) = tc
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(Value::as_str)
+                {
+                    if !name.is_empty() {
+                        buf.name = name.to_string();
+                    }
+                }
+                if !buf.started && !buf.id.is_empty() && !buf.name.is_empty() {
+                    buf.started = true;
+                    state.saw_tool_call = true;
+                    events.push(ProviderEvent::ToolCallStarted {
+                        index,
+                        id: buf.id.clone(),
+                        name: buf.name.clone(),
+                    });
+                }
+                if let Some(args) = tc
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(Value::as_str)
+                {
+                    if !args.is_empty() {
+                        // Name/id can arrive on a later chunk than the first
+                        // arguments fragment; start the call lazily if needed.
+                        if !buf.started {
+                            buf.started = true;
+                            state.saw_tool_call = true;
+                            events.push(ProviderEvent::ToolCallStarted {
+                                index,
+                                id: if buf.id.is_empty() {
+                                    format!("call_{index}")
+                                } else {
+                                    buf.id.clone()
+                                },
+                                name: buf.name.clone(),
+                            });
+                        }
+                        events.push(ProviderEvent::ToolCallArgsDelta {
+                            index,
+                            fragment: args.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(reason) = choice.get("finish_reason").and_then(Value::as_str) {
+        if state.usage.input_tokens > 0 || state.usage.output_tokens > 0 {
+            events.push(ProviderEvent::Usage(state.usage));
+        }
+        events.push(ProviderEvent::Stop {
+            reason: map_stop_reason(reason),
+        });
+        state.stopped = true;
+    }
+
+    events
+}
+
+fn u32_at(value: &Value, key: &str) -> u32 {
+    value.get(key).and_then(Value::as_u64).unwrap_or(0) as u32
+}
+
+fn map_stop_reason(reason: &str) -> StopReason {
+    match reason {
+        "length" => StopReason::MaxTokens,
+        "tool_calls" | "function_call" => StopReason::ToolUse,
+        _ => StopReason::EndTurn,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::provider::ChatMessage;
+    use openwave_core::tool::ToolSpec;
+
+    #[test]
+    fn request_maps_system_tools_and_messages() {
+        let req = ChatRequest {
+            model: "gpt-4o".into(),
+            system: Some("be brief".into()),
+            messages: vec![ChatMessage::text(Role::User, "hi")],
+            tools: vec![ToolSpec {
+                name: "read_file".into(),
+                description: "read a file".into(),
+                input_schema: json!({"type": "object"}),
+            }],
+            max_tokens: None,
+            temperature: Some(0.2),
+        };
+        let body = build_request_json(&req).unwrap();
+        assert_eq!(body["model"], "gpt-4o");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["max_tokens"], DEFAULT_MAX_TOKENS);
+        assert_eq!(body["messages"][0]["role"], "system");
+        assert_eq!(body["messages"][1]["role"], "user");
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["function"]["name"], "read_file");
+        assert!((body["temperature"].as_f64().unwrap() - 0.2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn assistant_tool_use_becomes_tool_calls() {
+        let msg = openwave_core::ChatMessage {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Text {
+                    text: "calling".into(),
+                },
+                ContentBlock::ToolUse {
+                    id: "call_1".into(),
+                    name: "read_file".into(),
+                    input: json!({"path": "a"}),
+                },
+            ],
+        };
+        let mut out = Vec::new();
+        extend_openai_messages(&mut out, &msg).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["role"], "assistant");
+        assert_eq!(out[0]["content"], "calling");
+        assert_eq!(out[0]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(out[0]["tool_calls"][0]["function"]["name"], "read_file");
+    }
+
+    #[test]
+    fn tool_result_becomes_tool_role() {
+        let msg = openwave_core::ChatMessage {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: "call_1".into(),
+                content: "ok".into(),
+                is_error: false,
+            }],
+        };
+        let mut out = Vec::new();
+        extend_openai_messages(&mut out, &msg).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["role"], "tool");
+        assert_eq!(out[0]["tool_call_id"], "call_1");
+        assert_eq!(out[0]["content"], "ok");
+    }
+
+    fn run(chunks: &[Value]) -> Vec<ProviderEvent> {
+        let mut state = StreamState::default();
+        chunks
+            .iter()
+            .flat_map(|c| normalize(c, &mut state))
+            .collect()
+    }
+
+    #[test]
+    fn normalizes_text_usage_and_stop() {
+        let out = run(&[
+            json!({"choices":[{"delta":{"content":"he"}}]}),
+            json!({"choices":[{"delta":{"content":"llo"}}]}),
+            json!({"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2,"prompt_tokens_details":{"cached_tokens":4}}}),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                ProviderEvent::TextDelta { text: "he".into() },
+                ProviderEvent::TextDelta { text: "llo".into() },
+                ProviderEvent::Usage(Usage {
+                    input_tokens: 6,
+                    output_tokens: 2,
+                    cache_read_input_tokens: 4,
+                    cache_creation_input_tokens: 0,
+                }),
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn normalizes_streaming_tool_calls() {
+        let out = run(&[
+            json!({"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"read_file","arguments":""}}]}}]}),
+            json!({"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"p\""}}]}}]}),
+            json!({"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":":1}"}}]}}]}),
+            json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "call_1".into(),
+                    name: "read_file".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{\"p\"".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: ":1}".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn map_stop_reasons() {
+        assert_eq!(map_stop_reason("tool_calls"), StopReason::ToolUse);
+        assert_eq!(map_stop_reason("length"), StopReason::MaxTokens);
+        assert_eq!(map_stop_reason("stop"), StopReason::EndTurn);
+    }
+}

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -18,7 +18,7 @@ use openwave_core::provider::{
 };
 use openwave_core::Role;
 
-use crate::sse::{drain_frames, frame_data};
+use crate::sse::{drain_frames, frame_data, safe_http_error};
 
 const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
@@ -96,9 +96,13 @@ impl ModelProvider for OpenAiCompatProvider {
 
         let status = response.status();
         if !status.is_success() {
+            // Never forward the raw body — gateways sometimes echo key material
+            // or request fragments, and `AgentError` strings reach the client.
             let body = response.text().await.unwrap_or_default();
-            return Err(AgentError::Provider(format!(
-                "openai-compat returned {status}: {body}"
+            return Err(AgentError::Provider(safe_http_error(
+                "openai-compat",
+                status.as_u16(),
+                &body,
             )));
         }
 
@@ -159,6 +163,9 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         "messages": messages,
         "max_tokens": req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
         "stream": true,
+        // OpenAI omits usage on streaming chunks unless asked; harmless on
+        // gateways that ignore unknown fields.
+        "stream_options": { "include_usage": true },
     });
 
     if !req.tools.is_empty() {
@@ -284,6 +291,10 @@ struct ToolCallBuf {
     id: String,
     name: String,
     started: bool,
+    /// Argument fragments that arrived before id+name were known. Flushed as
+    /// `ToolCallArgsDelta`s once [`Self::started`] flips true — never invent a
+    /// synthetic call id the gateway won't accept on the tool-result round-trip.
+    pending_args: String,
 }
 
 /// Map one parsed Chat Completions stream chunk into zero or more events.
@@ -350,6 +361,24 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                         buf.name = name.to_string();
                     }
                 }
+                if let Some(args) = tc
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(Value::as_str)
+                {
+                    if !args.is_empty() {
+                        if buf.started {
+                            events.push(ProviderEvent::ToolCallArgsDelta {
+                                index,
+                                fragment: args.to_string(),
+                            });
+                        } else {
+                            buf.pending_args.push_str(args);
+                        }
+                    }
+                }
+                // Emit ToolCallStarted only once both id and name are known —
+                // never invent a synthetic id. Flush any buffered args after.
                 if !buf.started && !buf.id.is_empty() && !buf.name.is_empty() {
                     buf.started = true;
                     state.saw_tool_call = true;
@@ -358,32 +387,9 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                         id: buf.id.clone(),
                         name: buf.name.clone(),
                     });
-                }
-                if let Some(args) = tc
-                    .get("function")
-                    .and_then(|f| f.get("arguments"))
-                    .and_then(Value::as_str)
-                {
-                    if !args.is_empty() {
-                        // Name/id can arrive on a later chunk than the first
-                        // arguments fragment; start the call lazily if needed.
-                        if !buf.started {
-                            buf.started = true;
-                            state.saw_tool_call = true;
-                            events.push(ProviderEvent::ToolCallStarted {
-                                index,
-                                id: if buf.id.is_empty() {
-                                    format!("call_{index}")
-                                } else {
-                                    buf.id.clone()
-                                },
-                                name: buf.name.clone(),
-                            });
-                        }
-                        events.push(ProviderEvent::ToolCallArgsDelta {
-                            index,
-                            fragment: args.to_string(),
-                        });
+                    if !buf.pending_args.is_empty() {
+                        let fragment = std::mem::take(&mut buf.pending_args);
+                        events.push(ProviderEvent::ToolCallArgsDelta { index, fragment });
                     }
                 }
             }
@@ -438,6 +444,7 @@ mod tests {
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["model"], "gpt-4o");
         assert_eq!(body["stream"], true);
+        assert_eq!(body["stream_options"]["include_usage"], true);
         assert_eq!(body["max_tokens"], DEFAULT_MAX_TOKENS);
         assert_eq!(body["messages"][0]["role"], "system");
         assert_eq!(body["messages"][1]["role"], "user");
@@ -550,6 +557,45 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn buffers_args_until_id_and_name_are_known() {
+        // Some gateways send argument fragments before id/name. Never invent a
+        // synthetic call id — buffer args and flush once both are present.
+        let out = run(&[
+            json!({"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"p\":"}}]}}]}),
+            json!({"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_real","function":{"name":"read_file","arguments":"1}"}}]}}]}),
+            json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "call_real".into(),
+                    name: "read_file".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{\"p\":1}".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn safe_http_error_omits_raw_body() {
+        let msg = crate::sse::safe_http_error(
+            "openai-compat",
+            401,
+            r#"{"error":{"type":"invalid_api_key","message":"sk-leaked"}}"#,
+        );
+        assert_eq!(msg, "openai-compat returned 401 (invalid_api_key)");
+        assert!(!msg.contains("sk-leaked"));
     }
 
     #[test]

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -64,6 +64,25 @@ pub fn frame_data(frame: &str) -> Option<serde_json::Value> {
     frame_data_raw(frame).and_then(|data| serde_json::from_str(&data).ok())
 }
 
+/// Build a client-safe provider error: status + optional stable `error.type` /
+/// `error.code` from the JSON body. Never include the raw body (it can echo
+/// secrets, and `AgentError` strings reach the client via `TurnFailed`).
+pub fn safe_http_error(provider: &str, status: u16, body: &str) -> String {
+    let detail = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|v| {
+            let err = v.get("error").unwrap_or(&v);
+            err.get("type")
+                .or_else(|| err.get("code"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        });
+    match detail {
+        Some(code) => format!("{provider} returned {status} ({code})"),
+        None => format!("{provider} returned {status}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -1,0 +1,105 @@
+//! Shared Server-Sent Events framing helpers for streaming provider adapters.
+//!
+//! Provider streams arrive as byte chunks that may split mid-frame or mid-UTF-8
+//! character. These helpers accumulate raw bytes, drain complete frames, and
+//! extract the `data:` JSON payload — the same shape Anthropic and OpenAI-compat
+//! both speak.
+
+/// Naive byte-substring search.
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Drain all complete SSE frames from `buffer`, returning each frame's decoded
+/// text and leaving any incomplete trailing bytes behind.
+///
+/// Frames are separated by a blank line (`\n\n` or `\r\n\r\n`). Decoding to UTF-8
+/// happens only on a complete frame, so a multi-byte character split across
+/// network chunks is never decoded until all its bytes have arrived.
+pub fn drain_frames(buffer: &mut Vec<u8>) -> Vec<String> {
+    let mut frames = Vec::new();
+    loop {
+        let lf = find_subslice(buffer, b"\n\n");
+        let crlf = find_subslice(buffer, b"\r\n\r\n");
+        let (content_end, consume_to) = match (lf, crlf) {
+            (Some(i), Some(j)) => {
+                if i <= j {
+                    (i, i + 2)
+                } else {
+                    (j, j + 4)
+                }
+            }
+            (Some(i), None) => (i, i + 2),
+            (None, Some(j)) => (j, j + 4),
+            (None, None) => break,
+        };
+        frames.push(String::from_utf8_lossy(&buffer[..content_end]).into_owned());
+        buffer.drain(..consume_to);
+    }
+    frames
+}
+
+/// Extract the concatenated `data:` payload from one SSE frame.
+///
+/// Returns `None` for comment/ping frames with no data, or when the payload is
+/// the OpenAI stream terminator `[DONE]`.
+pub fn frame_data_raw(frame: &str) -> Option<String> {
+    let mut data = String::new();
+    for line in frame.lines() {
+        if let Some(rest) = line.strip_prefix("data:") {
+            data.push_str(rest.trim_start());
+        }
+    }
+    if data.is_empty() || data == "[DONE]" {
+        return None;
+    }
+    Some(data)
+}
+
+/// Extract and parse the `data:` JSON payload from one SSE frame.
+pub fn frame_data(frame: &str) -> Option<serde_json::Value> {
+    frame_data_raw(frame).and_then(|data| serde_json::from_str(&data).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drain_frames_handles_lf_crlf_and_partial_tail() {
+        let mut buf = b"data: {\"a\":1}\n\ndata: partial".to_vec();
+        let frames = drain_frames(&mut buf);
+        assert_eq!(frames.len(), 1);
+        assert!(frames[0].contains("{\"a\":1}"));
+        assert_eq!(buf, b"data: partial");
+
+        let mut buf = b"event: x\r\ndata: {\"b\":2}\r\n\r\n".to_vec();
+        let frames = drain_frames(&mut buf);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frame_data(&frames[0]).unwrap()["b"], 2);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn multibyte_char_split_across_chunks_is_not_corrupted() {
+        let full = "data: {\"t\":\"café\"}\n\n".as_bytes().to_vec();
+        let split = full.iter().position(|&b| b == 0xC3).unwrap() + 1;
+        let (head, tail) = full.split_at(split);
+
+        let mut buf = head.to_vec();
+        assert!(drain_frames(&mut buf).is_empty(), "no complete frame yet");
+        buf.extend_from_slice(tail);
+        let frames = drain_frames(&mut buf);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frame_data(&frames[0]).unwrap()["t"], "café");
+    }
+
+    #[test]
+    fn frame_data_skips_done_terminator() {
+        assert!(frame_data_raw("data: [DONE]").is_none());
+        assert!(frame_data("event: ping").is_none());
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -17,6 +17,7 @@ mod error;
 mod extract;
 mod hub;
 mod provider;
+mod providers;
 mod resolver;
 mod routes;
 mod state;
@@ -53,6 +54,15 @@ pub fn app(state: AppState) -> Router {
         )
         .route("/projects/{id}", get(routes::get_project))
         .route("/models", get(routes::list_models))
+        .route("/providers", get(routes::list_providers))
+        .route(
+            "/providers/{kind}",
+            axum::routing::put(routes::put_provider),
+        )
+        .route(
+            "/providers/{kind}/credential",
+            axum::routing::delete(routes::delete_provider_credential),
+        )
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
         .route(
             "/chats/{id}",
@@ -987,12 +997,176 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn providers_list_and_put_roundtrip() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+
+        let list = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/providers")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(list.status(), StatusCode::OK);
+        let body: serde_json::Value = json_body(list).await;
+        let providers = body["providers"].as_array().unwrap();
+        assert!(providers.iter().any(|p| p["kind"] == "anthropic"));
+        assert!(providers.iter().any(|p| p["kind"] == "openai"));
+        assert!(providers.iter().any(|p| p["kind"] == "openai_compatible"));
+
+        let put = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/providers/openai")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "enabled": true,
+                            "credential": {"type": "api_key", "key": "sk-openai"}
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(put.status(), StatusCode::OK);
+        let info: serde_json::Value = json_body(put).await;
+        assert_eq!(info["kind"], "openai");
+        assert_eq!(info["enabled"], true);
+        assert_eq!(info["has_credential"], true);
+        assert!(info.get("credential").is_none());
+
+        // Credential never appears on the list either.
+        let list = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/providers")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body: serde_json::Value = json_body(list).await;
+        let openai = body["providers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["kind"] == "openai")
+            .unwrap();
+        assert_eq!(openai["has_credential"], true);
+        assert!(openai.get("credential").is_none());
+
+        let delete = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/providers/openai/credential")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(delete.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn openai_compatible_requires_base_url_when_enabled() {
+        let (router, token, _store, _dir) = test_app().await;
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/providers/openai_compatible")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::json!({"enabled": true}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn unknown_provider_kind_is_404() {
+        let (router, token, _store, _dir) = test_app().await;
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/providers/not-a-provider")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::json!({"enabled": true}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn models_catalog_includes_enabled_credentialed_providers() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+
+        let put = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/providers/openai")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "enabled": true,
+                            "credential": {"type": "api_key", "key": "sk-openai"}
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(put.status(), StatusCode::OK);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/models")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let catalog: serde_json::Value = json_body(response).await;
+        let models = catalog["models"].as_array().unwrap();
+        assert!(models.iter().any(|m| m["provider"] == "openai"));
+    }
+
+    #[tokio::test]
     async fn resolver_builds_a_real_provider_when_a_key_is_set() {
         // A stored key takes precedence over the env fallback, so this is
         // deterministic regardless of the ambient environment.
         let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
         secrets
-            .set_secret(resolver::ANTHROPIC_API_KEY, "sk-test")
+            .set_secret(providers::LEGACY_ANTHROPIC_API_KEY, "sk-test")
             .await
             .unwrap();
         let resolver = resolver::KeyedResolver::new(secrets.clone());
@@ -1005,7 +1179,7 @@ mod tests {
 
         // Changing the key rebuilds it.
         secrets
-            .set_secret(resolver::ANTHROPIC_API_KEY, "sk-different")
+            .set_secret(providers::LEGACY_ANTHROPIC_API_KEY, "sk-different")
             .await
             .unwrap();
         let rebuilt = resolver.resolve().await;

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -124,7 +124,10 @@ const DEFAULT_MODEL: &str = "claude-opus-4-8";
 pub async fn bind(config: Config) -> Result<Server> {
     let store = connect_store(&config).await?;
     let secrets: Arc<dyn SecretProvider> = Arc::new(KeychainSecretProvider::new());
-    let resolver = Arc::new(KeyedResolver::new(secrets.clone()));
+    // Pre-providers installs may only have an env/legacy key — enable Anthropic
+    // so `KeyedResolver`'s enabled check doesn't fail-closed on upgrade.
+    providers::migrate_legacy_anthropic(&*store, &*secrets).await?;
+    let resolver = Arc::new(KeyedResolver::new(store.clone(), secrets.clone()));
     let (tools, agent_config) = agent_deps();
     let state = AppState::new(config, store, resolver, secrets, tools, agent_config);
     let token = state.token.clone();
@@ -1080,6 +1083,26 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(delete.status(), StatusCode::NO_CONTENT);
+
+        let list = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/providers")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body: serde_json::Value = json_body(list).await;
+        let openai = body["providers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["kind"] == "openai")
+            .unwrap();
+        assert_eq!(openai["has_credential"], false);
     }
 
     #[tokio::test]
@@ -1162,14 +1185,36 @@ mod tests {
 
     #[tokio::test]
     async fn resolver_builds_a_real_provider_when_a_key_is_set() {
-        // A stored key takes precedence over the env fallback, so this is
-        // deterministic regardless of the ambient environment.
-        let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
-        secrets
-            .set_secret(providers::LEGACY_ANTHROPIC_API_KEY, "sk-test")
+        // Typed credential blob + enabled config — the primary write path.
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}/test.db?mode=rwc",
+                dir.path().display()
+            ))
             .await
-            .unwrap();
-        let resolver = resolver::KeyedResolver::new(secrets.clone());
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+        providers::write_credential(
+            &*secrets,
+            providers::ProviderKind::Anthropic,
+            &providers::ProviderCredential::api_key("sk-test"),
+        )
+        .await
+        .unwrap();
+        providers::write_config(
+            &*store,
+            providers::ProviderKind::Anthropic,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let resolver = resolver::KeyedResolver::new(store.clone(), secrets.clone());
         let resolved = resolver.resolve().await;
         assert_eq!(resolved.id().0, "anthropic");
 
@@ -1178,12 +1223,28 @@ mod tests {
         assert!(Arc::ptr_eq(&resolved, &again));
 
         // Changing the key rebuilds it.
-        secrets
-            .set_secret(providers::LEGACY_ANTHROPIC_API_KEY, "sk-different")
-            .await
-            .unwrap();
+        providers::write_credential(
+            &*secrets,
+            providers::ProviderKind::Anthropic,
+            &providers::ProviderCredential::api_key("sk-different"),
+        )
+        .await
+        .unwrap();
         let rebuilt = resolver.resolve().await;
         assert!(!Arc::ptr_eq(&resolved, &rebuilt));
+
+        // Disabling Anthropic fails closed even with a key present.
+        providers::write_config(
+            &*store,
+            providers::ProviderKind::Anthropic,
+            &providers::ProviderConfig {
+                enabled: false,
+                base_url: None,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(resolver.resolve().await.id().0, "unconfigured");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/openwave-server/src/provider.rs
+++ b/crates/openwave-server/src/provider.rs
@@ -21,7 +21,7 @@ impl ModelProvider for UnconfiguredProvider {
 
     async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         Err(AgentError::config(
-            "no model provider is configured (set ANTHROPIC_API_KEY)",
+            "no model provider is configured (enable a provider and set its credential)",
         ))
     }
 }

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -1,0 +1,421 @@
+//! Configurable model providers.
+//!
+//! A provider is `{ kind, enabled, base_url? }` plus a credential held in the
+//! [`SecretProvider`](openwave_core::SecretProvider) (never the DB). Credentials
+//! are a typed JSON blob (`{"type":"api_key","key":"…"}` today; `oauth` later)
+//! so new auth shapes don't force a schema redesign.
+//!
+//! Non-secret config lives in the [`Store`](openwave_core::Store) under
+//! `provider.<kind>`. The legacy `provider.anthropic.api_key` secret and the
+//! `PUT /settings/api-key` shim still work — they read/write the anthropic
+//! credential in the new blob shape.
+
+use serde::{Deserialize, Serialize};
+
+use openwave_core::{Result, SecretProvider, Store};
+
+use crate::error::ServerError;
+
+/// Setting-key prefix for per-provider non-secret config (`provider.<kind>`).
+const PROVIDER_SETTING_PREFIX: &str = "provider.";
+
+/// Secret-key suffix for the typed credential blob (`provider.<kind>.credential`).
+const CREDENTIAL_SUFFIX: &str = ".credential";
+
+/// Legacy Anthropic API-key secret (pre-providers). Still read as a fallback.
+pub const LEGACY_ANTHROPIC_API_KEY: &str = "provider.anthropic.api_key";
+
+/// The known provider kinds. `#[non_exhaustive]` so new kinds can land without
+/// breaking wire clients that match on the string form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ProviderKind {
+    /// Anthropic Messages API.
+    Anthropic,
+    /// OpenAI Chat Completions (api.openai.com).
+    Openai,
+    /// Any OpenAI-compatible Chat Completions gateway (OpenRouter, vLLM, …).
+    OpenaiCompatible,
+}
+
+impl ProviderKind {
+    /// All kinds the server knows about, in display order.
+    pub const ALL: &'static [ProviderKind] = &[
+        ProviderKind::Anthropic,
+        ProviderKind::Openai,
+        ProviderKind::OpenaiCompatible,
+    ];
+
+    /// Wire/path form (`anthropic`, `openai`, `openai_compatible`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProviderKind::Anthropic => "anthropic",
+            ProviderKind::Openai => "openai",
+            ProviderKind::OpenaiCompatible => "openai_compatible",
+        }
+    }
+
+    /// Parse a path segment into a kind.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "anthropic" => Some(Self::Anthropic),
+            "openai" => Some(Self::Openai),
+            "openai_compatible" => Some(Self::OpenaiCompatible),
+            _ => None,
+        }
+    }
+
+    /// Store setting key for this kind's non-secret config.
+    pub fn setting_key(self) -> String {
+        format!("{PROVIDER_SETTING_PREFIX}{}", self.as_str())
+    }
+
+    /// SecretProvider key for this kind's credential blob.
+    pub fn credential_key(self) -> String {
+        format!(
+            "{PROVIDER_SETTING_PREFIX}{}{CREDENTIAL_SUFFIX}",
+            self.as_str()
+        )
+    }
+
+    /// Curated model ids this kind contributes to `GET /models`.
+    ///
+    /// `openai_compatible` is free-form (local / custom gateways) — it contributes
+    /// nothing to the curated catalog; the chat model field accepts any string.
+    pub fn curated_models(self) -> &'static [&'static str] {
+        match self {
+            ProviderKind::Anthropic => &[
+                "claude-opus-4-8",
+                "claude-sonnet-5",
+                "claude-haiku-4-5-20251001",
+            ],
+            ProviderKind::Openai => &["gpt-4o", "gpt-4o-mini", "o3", "o4-mini"],
+            ProviderKind::OpenaiCompatible => &[],
+        }
+    }
+}
+
+impl std::fmt::Display for ProviderKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A credential stored in the keychain. Tagged so new auth types (`oauth`, …)
+/// are additive.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ProviderCredential {
+    /// A bearer / API key.
+    ApiKey {
+        /// The secret key material.
+        key: String,
+    },
+}
+
+impl ProviderCredential {
+    /// Build an API-key credential.
+    pub fn api_key(key: impl Into<String>) -> Self {
+        Self::ApiKey { key: key.into() }
+    }
+
+    /// The API key, if this is an `api_key` credential.
+    pub fn as_api_key(&self) -> Option<&str> {
+        match self {
+            Self::ApiKey { key } => Some(key.as_str()),
+        }
+    }
+}
+
+// Redact key material in Debug.
+impl std::fmt::Debug for ProviderCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ApiKey { .. } => f.debug_struct("ApiKey").field("key", &"***").finish(),
+        }
+    }
+}
+
+/// Non-secret provider configuration persisted in the store.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderConfig {
+    /// Whether this provider is a routing candidate.
+    pub enabled: bool,
+    /// Optional base URL override (required for `openai_compatible`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+}
+
+impl ProviderConfig {
+    /// Default config when nothing is stored: disabled, no base URL.
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            base_url: None,
+        }
+    }
+}
+
+/// Public view of a provider — never includes the credential itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProviderInfo {
+    /// Provider kind.
+    pub kind: ProviderKind,
+    /// Whether the provider is enabled for routing.
+    pub enabled: bool,
+    /// Configured base URL, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    /// Whether a credential is stored (never the credential itself).
+    pub has_credential: bool,
+}
+
+/// Deserialize a present field (including JSON `null`) as `Some(..)`;
+/// `#[serde(default)]` supplies `None` when the field is absent.
+fn double_option<'de, D, T>(deserializer: D) -> std::result::Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(Some)
+}
+
+/// Body of `PUT /providers/{kind}`. Absent fields are left unchanged; an
+/// explicit `null` `base_url` clears it; `credential` replaces the stored blob
+/// when present (omit to leave the credential alone).
+#[derive(Debug, Deserialize)]
+pub struct ProviderUpdate {
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default, deserialize_with = "double_option")]
+    pub base_url: Option<Option<String>>,
+    #[serde(default)]
+    pub credential: Option<ProviderCredential>,
+}
+
+/// Read the stored config for `kind`, or the disabled default.
+pub async fn read_config(store: &dyn Store, kind: ProviderKind) -> Result<ProviderConfig> {
+    Ok(store
+        .get_setting(&kind.setting_key())
+        .await?
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_else(ProviderConfig::disabled))
+}
+
+/// Persist non-secret config for `kind`.
+pub async fn write_config(
+    store: &dyn Store,
+    kind: ProviderKind,
+    config: &ProviderConfig,
+) -> Result<()> {
+    store
+        .set_setting(&kind.setting_key(), &serde_json::to_value(config)?)
+        .await
+}
+
+/// Read the typed credential for `kind`, if any.
+///
+/// For Anthropic, falls back to the legacy plain-string
+/// `provider.anthropic.api_key` secret so existing installs keep working.
+pub async fn read_credential(
+    secrets: &dyn SecretProvider,
+    kind: ProviderKind,
+) -> Result<Option<ProviderCredential>> {
+    if let Some(raw) = secrets.get_secret(&kind.credential_key()).await? {
+        if raw.is_empty() {
+            return Ok(None);
+        }
+        // Prefer the typed blob; a bare string is treated as an api_key for
+        // resilience against hand-edited keychain entries.
+        if let Ok(cred) = serde_json::from_str::<ProviderCredential>(&raw) {
+            return Ok(Some(cred));
+        }
+        return Ok(Some(ProviderCredential::api_key(raw)));
+    }
+    if kind == ProviderKind::Anthropic {
+        if let Some(key) = secrets.get_secret(LEGACY_ANTHROPIC_API_KEY).await? {
+            if !key.is_empty() {
+                return Ok(Some(ProviderCredential::api_key(key)));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Store a typed credential for `kind`.
+pub async fn write_credential(
+    secrets: &dyn SecretProvider,
+    kind: ProviderKind,
+    credential: &ProviderCredential,
+) -> Result<()> {
+    let raw = serde_json::to_string(credential)?;
+    secrets.set_secret(&kind.credential_key(), &raw).await
+}
+
+/// Delete the credential for `kind` (new key + legacy Anthropic key).
+pub async fn delete_credential(secrets: &dyn SecretProvider, kind: ProviderKind) -> Result<()> {
+    secrets.delete_secret(&kind.credential_key()).await?;
+    if kind == ProviderKind::Anthropic {
+        secrets.delete_secret(LEGACY_ANTHROPIC_API_KEY).await?;
+    }
+    Ok(())
+}
+
+/// Whether `kind` has a usable credential — stored, or (for Anthropic/OpenAI)
+/// the matching env fallback the resolver also honors.
+pub async fn has_credential(secrets: &dyn SecretProvider, kind: ProviderKind) -> bool {
+    if matches!(
+        read_credential(secrets, kind).await,
+        Ok(Some(cred)) if cred.as_api_key().is_some_and(|k| !k.is_empty())
+    ) {
+        return true;
+    }
+    match kind {
+        ProviderKind::Anthropic => std::env::var("ANTHROPIC_API_KEY").is_ok_and(|k| !k.is_empty()),
+        ProviderKind::Openai => std::env::var("OPENAI_API_KEY").is_ok_and(|k| !k.is_empty()),
+        ProviderKind::OpenaiCompatible => false,
+    }
+}
+
+/// Build the public [`ProviderInfo`] for every known kind.
+pub async fn list_providers(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+) -> Result<Vec<ProviderInfo>> {
+    let mut out = Vec::with_capacity(ProviderKind::ALL.len());
+    for &kind in ProviderKind::ALL {
+        let config = read_config(store, kind).await?;
+        out.push(ProviderInfo {
+            kind,
+            enabled: config.enabled,
+            base_url: config.base_url,
+            has_credential: has_credential(secrets, kind).await,
+        });
+    }
+    Ok(out)
+}
+
+/// Apply a [`ProviderUpdate`] and return the resulting [`ProviderInfo`].
+pub async fn update_provider(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    kind: ProviderKind,
+    update: ProviderUpdate,
+) -> std::result::Result<ProviderInfo, ServerError> {
+    let mut config = read_config(store, kind).await?;
+
+    if let Some(enabled) = update.enabled {
+        config.enabled = enabled;
+    }
+    match update.base_url {
+        None => {}
+        Some(None) => config.base_url = None,
+        Some(Some(url)) => {
+            if url.is_empty() {
+                return Err(ServerError::bad_request("base_url must not be empty"));
+            }
+            config.base_url = Some(url);
+        }
+    }
+
+    // openai_compatible needs a base URL to be useful when enabled.
+    if kind == ProviderKind::OpenaiCompatible && config.enabled && config.base_url.is_none() {
+        return Err(ServerError::bad_request(
+            "openai_compatible requires a base_url when enabled",
+        ));
+    }
+
+    if let Some(credential) = update.credential {
+        match &credential {
+            ProviderCredential::ApiKey { key } if key.is_empty() => {
+                return Err(ServerError::bad_request("credential key must not be empty"));
+            }
+            _ => {}
+        }
+        write_credential(secrets, kind, &credential).await?;
+    }
+
+    write_config(store, kind, &config).await?;
+
+    Ok(ProviderInfo {
+        kind,
+        enabled: config.enabled,
+        base_url: config.base_url,
+        has_credential: has_credential(secrets, kind).await,
+    })
+}
+
+/// Resolve the Anthropic API key the turn path uses today: stored credential
+/// (new blob or legacy), then `ANTHROPIC_API_KEY` env.
+pub async fn resolve_anthropic_api_key(secrets: &dyn SecretProvider) -> Option<String> {
+    if let Ok(Some(cred)) = read_credential(secrets, ProviderKind::Anthropic).await {
+        if let Some(key) = cred.as_api_key() {
+            if !key.is_empty() {
+                return Some(key.to_string());
+            }
+        }
+    }
+    std::env::var("ANTHROPIC_API_KEY")
+        .ok()
+        .filter(|k| !k.is_empty())
+}
+
+/// Models from providers that are both enabled and credentialed.
+pub async fn catalog_models(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+) -> Result<Vec<(ProviderKind, &'static str)>> {
+    let mut models = Vec::new();
+    for &kind in ProviderKind::ALL {
+        let config = read_config(store, kind).await?;
+        if !config.enabled {
+            continue;
+        }
+        if !has_credential(secrets, kind).await {
+            continue;
+        }
+        for id in kind.curated_models() {
+            models.push((kind, *id));
+        }
+    }
+    // If nothing is enabled+credentialed yet, still surface Anthropic's curated
+    // list so a fresh install's model selector isn't empty before the user
+    // finishes provider setup (turns still fail-closed without a key).
+    if models.is_empty() {
+        for id in ProviderKind::Anthropic.curated_models() {
+            models.push((ProviderKind::Anthropic, *id));
+        }
+    }
+    Ok(models)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credential_roundtrips_and_redacts_debug() {
+        let cred = ProviderCredential::api_key("sk-secret");
+        let json = serde_json::to_string(&cred).unwrap();
+        assert!(json.contains("api_key"));
+        assert!(json.contains("sk-secret"));
+        let back: ProviderCredential = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.as_api_key(), Some("sk-secret"));
+        assert!(!format!("{cred:?}").contains("sk-secret"));
+    }
+
+    #[test]
+    fn kind_parse_and_keys() {
+        assert_eq!(
+            ProviderKind::parse("openai_compatible"),
+            Some(ProviderKind::OpenaiCompatible)
+        );
+        assert_eq!(
+            ProviderKind::Anthropic.credential_key(),
+            "provider.anthropic.credential"
+        );
+        assert_eq!(ProviderKind::Openai.setting_key(), "provider.openai");
+    }
+}

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -362,6 +362,37 @@ pub async fn resolve_anthropic_api_key(secrets: &dyn SecretProvider) -> Option<S
         .filter(|k| !k.is_empty())
 }
 
+/// One-shot boot migration: if Anthropic has no stored config yet but a key is
+/// available (legacy secret or `ANTHROPIC_API_KEY` env), enable it.
+///
+/// Preserves pre-providers behavior where an env key alone was enough to run
+/// turns. An explicit `enabled: false` written later wins; this only fills in
+/// a missing row.
+pub async fn migrate_legacy_anthropic(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+) -> Result<()> {
+    if store
+        .get_setting(&ProviderKind::Anthropic.setting_key())
+        .await?
+        .is_some()
+    {
+        return Ok(());
+    }
+    if resolve_anthropic_api_key(secrets).await.is_some() {
+        write_config(
+            store,
+            ProviderKind::Anthropic,
+            &ProviderConfig {
+                enabled: true,
+                base_url: None,
+            },
+        )
+        .await?;
+    }
+    Ok(())
+}
+
 /// Models from providers that are both enabled and credentialed.
 pub async fn catalog_models(
     store: &dyn Store,

--- a/crates/openwave-server/src/resolver.rs
+++ b/crates/openwave-server/src/resolver.rs
@@ -15,15 +15,16 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
-use openwave_core::{ModelProvider, SecretProvider};
+use openwave_core::{ModelProvider, SecretProvider, Store};
 use openwave_router::AnthropicProvider;
 
 use crate::provider::UnconfiguredProvider;
-use crate::providers;
+use crate::providers::{self, ProviderKind};
 
-/// The provider last built by a [`KeyedResolver`], tagged with the key it was
-/// built from so it can be reused until the key changes.
-type CachedProvider = Option<(Option<String>, Arc<dyn ModelProvider>)>;
+/// Cache key: whether Anthropic is enabled + the resolved API key. Either
+/// changing rebuilds the provider.
+type CacheKey = (bool, Option<String>);
+type CachedProvider = Option<(CacheKey, Arc<dyn ModelProvider>)>;
 
 /// Builds the model provider for the next turn.
 #[async_trait]
@@ -33,21 +34,28 @@ pub trait ProviderResolver: Send + Sync {
     async fn resolve(&self) -> Arc<dyn ModelProvider>;
 }
 
-/// Resolves an Anthropic provider from the stored API key — falling back to the
-/// `ANTHROPIC_API_KEY` environment variable — or a fail-closed provider if none.
+/// Resolves an Anthropic provider when the Anthropic provider is enabled and an
+/// API key is available (stored credential or `ANTHROPIC_API_KEY` env) — or a
+/// fail-closed provider otherwise.
 ///
-/// The built provider is cached and reused while the key is unchanged, so a
-/// provider (and its `reqwest` connection pool) isn't rebuilt every turn; a key
-/// change rebuilds it on the next turn.
+/// The built provider is cached and reused while the key and enabled flag are
+/// unchanged, so a provider (and its `reqwest` connection pool) isn't rebuilt
+/// every turn; a key or enabled change rebuilds it on the next turn.
+///
+/// OpenAI / openai_compatible credentials are accepted by the `/providers` API
+/// but not yet selected here — the composite router is the next slice.
 pub struct KeyedResolver {
+    store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
     cached: Mutex<CachedProvider>,
 }
 
 impl KeyedResolver {
-    /// A resolver that reads the API key from `secrets`.
-    pub fn new(secrets: Arc<dyn SecretProvider>) -> Self {
+    /// A resolver that reads Anthropic config from `store` and the API key from
+    /// `secrets`.
+    pub fn new(store: Arc<dyn Store>, secrets: Arc<dyn SecretProvider>) -> Self {
         Self {
+            store,
             secrets,
             cached: Mutex::new(None),
         }
@@ -57,22 +65,33 @@ impl KeyedResolver {
 #[async_trait]
 impl ProviderResolver for KeyedResolver {
     async fn resolve(&self) -> Arc<dyn ModelProvider> {
-        let key = providers::resolve_anthropic_api_key(&*self.secrets).await;
+        let enabled = providers::read_config(&*self.store, ProviderKind::Anthropic)
+            .await
+            .map(|c| c.enabled)
+            // Store read failure → treat as disabled (fail closed).
+            .unwrap_or(false);
+        let key = if enabled {
+            providers::resolve_anthropic_api_key(&*self.secrets).await
+        } else {
+            None
+        };
+        let cache_key = (enabled, key.clone());
 
-        // Reuse the cached provider while the key is unchanged. The lock is held
-        // only across the cheap, synchronous build below — never over an await.
+        // Reuse the cached provider while the key/enabled are unchanged. The
+        // lock is held only across the cheap, synchronous build below — never
+        // over an await.
         let mut cached = self.cached.lock().unwrap();
         if let Some((cached_key, provider)) = cached.as_ref() {
-            if *cached_key == key {
+            if *cached_key == cache_key {
                 return provider.clone();
             }
         }
         let provider: Arc<dyn ModelProvider> = match &key {
             Some(key) => Arc::new(AnthropicProvider::new(key.clone())),
-            // Fail closed: no key ⇒ a provider that refuses without any network call.
+            // Fail closed: disabled or no key ⇒ refuse without any network call.
             None => Arc::new(UnconfiguredProvider),
         };
-        *cached = Some((key, provider.clone()));
+        *cached = Some((cache_key, provider.clone()));
         provider
     }
 }

--- a/crates/openwave-server/src/resolver.rs
+++ b/crates/openwave-server/src/resolver.rs
@@ -1,9 +1,15 @@
 //! Resolving the model provider for a turn from configured credentials.
 //!
 //! The provider is built *per turn* rather than once at boot, so setting an API
-//! key at runtime (`PUT /settings/api-key`) takes effect on the next turn without
-//! a restart. The [`ProviderResolver`] seam also lets tests inject a provider
-//! directly instead of standing up a real backend.
+//! key at runtime (`PUT /providers/anthropic` or the legacy
+//! `PUT /settings/api-key`) takes effect on the next turn without a restart.
+//! The [`ProviderResolver`] seam also lets tests inject a provider directly
+//! instead of standing up a real backend.
+//!
+//! Today this still resolves Anthropic only — the composite router (model →
+//! provider selection across configured kinds) is the next slice. Credentials
+//! are read through the providers module so the new typed blob and the legacy
+//! plain-string key both work.
 
 use std::sync::{Arc, Mutex};
 
@@ -13,9 +19,7 @@ use openwave_core::{ModelProvider, SecretProvider};
 use openwave_router::AnthropicProvider;
 
 use crate::provider::UnconfiguredProvider;
-
-/// Secret key under which the Anthropic API key is stored.
-pub const ANTHROPIC_API_KEY: &str = "provider.anthropic.api_key";
+use crate::providers;
 
 /// The provider last built by a [`KeyedResolver`], tagged with the key it was
 /// built from so it can be reused until the key changes.
@@ -34,7 +38,7 @@ pub trait ProviderResolver: Send + Sync {
 ///
 /// The built provider is cached and reused while the key is unchanged, so a
 /// provider (and its `reqwest` connection pool) isn't rebuilt every turn; a key
-/// change (via `PUT /settings/api-key`) rebuilds it on the next turn.
+/// change rebuilds it on the next turn.
 pub struct KeyedResolver {
     secrets: Arc<dyn SecretProvider>,
     cached: Mutex<CachedProvider>,
@@ -53,14 +57,7 @@ impl KeyedResolver {
 #[async_trait]
 impl ProviderResolver for KeyedResolver {
     async fn resolve(&self) -> Arc<dyn ModelProvider> {
-        let key = self
-            .secrets
-            .get_secret(ANTHROPIC_API_KEY)
-            .await
-            .ok()
-            .flatten()
-            .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
-            .filter(|key| !key.is_empty());
+        let key = providers::resolve_anthropic_api_key(&*self.secrets).await;
 
         // Reuse the cached provider while the key is unchanged. The lock is held
         // only across the cheap, synchronous build below — never over an await.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -19,7 +19,7 @@ use openwave_core::{
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
-use crate::resolver::ANTHROPIC_API_KEY;
+use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
 use crate::state::AppState;
 
 /// The store-settings key for the selected model.
@@ -108,13 +108,13 @@ async fn read_model(store: &dyn Store) -> Result<Option<String>, ServerError> {
 /// Whether a model API key is configured — in the secret store or the
 /// environment fallback the resolver also honors.
 async fn has_api_key(secrets: &dyn SecretProvider) -> bool {
-    if matches!(secrets.get_secret(ANTHROPIC_API_KEY).await, Ok(Some(key)) if !key.is_empty()) {
-        return true;
-    }
-    std::env::var("ANTHROPIC_API_KEY").is_ok_and(|key| !key.is_empty())
+    providers::has_credential(secrets, ProviderKind::Anthropic).await
 }
 
 /// Body of `PUT /settings/api-key`.
+///
+/// Legacy shim: writes the Anthropic credential in the typed blob shape and
+/// enables the Anthropic provider. Prefer `PUT /providers/anthropic`.
 #[derive(Deserialize)]
 pub struct ApiKey {
     /// The provider API key to store. Written to the `SecretProvider` (the OS
@@ -122,14 +122,14 @@ pub struct ApiKey {
     pub api_key: String,
 }
 
-// Redact the key so it can't leak through a `{:?}` (logging, error context, …).
+// Redact the key so it can't leak through a `{:?}`.
 impl std::fmt::Debug for ApiKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ApiKey").field("api_key", &"***").finish()
     }
 }
 
-/// `PUT /settings/api-key` — store the model provider's API key. `204 No Content`.
+/// `PUT /settings/api-key` — store the Anthropic API key. `204 No Content`.
 pub async fn put_api_key(
     State(state): State<AppState>,
     Json(body): Json<ApiKey>,
@@ -137,21 +137,66 @@ pub async fn put_api_key(
     if body.api_key.is_empty() {
         return Err(ServerError::bad_request("api_key must not be empty"));
     }
-    state
-        .secrets
-        .set_secret(ANTHROPIC_API_KEY, &body.api_key)
-        .await?;
+    // Write the typed credential and enable Anthropic so the new providers
+    // surface and the legacy shim stay equivalent.
+    providers::write_credential(
+        &*state.secrets,
+        ProviderKind::Anthropic,
+        &ProviderCredential::api_key(&body.api_key),
+    )
+    .await?;
+    let mut config = providers::read_config(&*state.store, ProviderKind::Anthropic).await?;
+    config.enabled = true;
+    providers::write_config(&*state.store, ProviderKind::Anthropic, &config).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// `DELETE /settings/api-key` — remove the stored API key. `204 No Content`.
+/// `DELETE /settings/api-key` — remove the stored Anthropic API key. `204`.
 ///
 /// Clears only the stored key. If the daemon was launched with an
 /// `ANTHROPIC_API_KEY` in its environment, that fallback still applies — so
 /// `has_api_key` may stay `true` and turns keep resolving a provider after a
 /// delete. The environment is a deploy-time default the API doesn't override.
 pub async fn delete_api_key(State(state): State<AppState>) -> Result<StatusCode, ServerError> {
-    state.secrets.delete_secret(ANTHROPIC_API_KEY).await?;
+    providers::delete_credential(&*state.secrets, ProviderKind::Anthropic).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Response for `GET /providers`.
+#[derive(Debug, Serialize)]
+pub struct ProvidersList {
+    pub providers: Vec<ProviderInfo>,
+}
+
+/// `GET /providers` — every known provider kind and its current config.
+pub async fn list_providers(
+    State(state): State<AppState>,
+) -> Result<Json<ProvidersList>, ServerError> {
+    Ok(Json(ProvidersList {
+        providers: providers::list_providers(&*state.store, &*state.secrets).await?,
+    }))
+}
+
+/// `PUT /providers/{kind}` — update a provider's config and/or credential.
+pub async fn put_provider(
+    State(state): State<AppState>,
+    Path(kind): Path<String>,
+    Json(body): Json<ProviderUpdate>,
+) -> Result<Json<ProviderInfo>, ServerError> {
+    let kind = ProviderKind::parse(&kind)
+        .ok_or_else(|| ServerError::not_found(format!("unknown provider kind: {kind}")))?;
+    let info = providers::update_provider(&*state.store, &*state.secrets, kind, body).await?;
+    Ok(Json(info))
+}
+
+/// `DELETE /providers/{kind}/credential` — remove the stored credential. `204`.
+pub async fn delete_provider_credential(
+    State(state): State<AppState>,
+    Path(kind): Path<String>,
+) -> Result<StatusCode, ServerError> {
+    let kind = ProviderKind::parse(&kind)
+        .ok_or_else(|| ServerError::not_found(format!("unknown provider kind: {kind}")))?;
+    providers::delete_credential(&*state.secrets, kind).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -159,9 +204,9 @@ pub async fn delete_api_key(State(state): State<AppState>) -> Result<StatusCode,
 #[derive(Debug, Serialize)]
 pub struct ModelInfo {
     /// The identifier passed to the provider and stored as `chat.model`.
-    pub id: &'static str,
+    pub id: String,
     /// The provider that serves the model.
-    pub provider: &'static str,
+    pub provider: String,
 }
 
 /// Response for `GET /models`.
@@ -173,24 +218,18 @@ pub struct ModelCatalog {
 
 /// `GET /models` — the catalog a chat's model selector chooses from.
 ///
-/// A curated static list for now (Anthropic only, matching the single provider
-/// wired today). When multiple providers are configurable this becomes
-/// provider-driven — the enabled, credentialed providers' models.
-pub async fn list_models() -> Json<ModelCatalog> {
-    const ANTHROPIC_MODELS: &[&str] = &[
-        "claude-opus-4-8",
-        "claude-sonnet-5",
-        "claude-haiku-4-5-20251001",
-    ];
-    Json(ModelCatalog {
-        models: ANTHROPIC_MODELS
-            .iter()
-            .map(|id| ModelInfo {
-                id,
-                provider: "anthropic",
-            })
-            .collect(),
-    })
+/// Models of enabled, credentialed providers. Falls back to Anthropic's curated
+/// list when nothing is configured yet so the selector isn't empty on first run.
+pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCatalog>, ServerError> {
+    let models = providers::catalog_models(&*state.store, &*state.secrets)
+        .await?
+        .into_iter()
+        .map(|(kind, id)| ModelInfo {
+            id: id.to_string(),
+            provider: kind.as_str().to_string(),
+        })
+        .collect();
+    Ok(Json(ModelCatalog { models }))
 }
 
 /// Body of `POST /projects`.


### PR DESCRIPTION
## Summary
- Add `GET /providers`, `PUT /providers/{kind}`, and `DELETE /providers/{kind}/credential` so clients can configure anthropic / openai / openai_compatible providers. Non-secret config lives in the store; credentials are a typed keychain blob (`{"type":"api_key","key":"…"}`) that never appears in responses.
- Add `OpenAiCompatProvider` in `openwave-router` (Chat Completions streaming) for OpenAI and OpenAI-compatible gateways (OpenRouter, vLLM, LM Studio, …). Shared SSE framing extracted for both Anthropic and OpenAI-compat adapters.
- `GET /models` now lists curated models from enabled, credentialed providers. Legacy `PUT/DELETE /settings/api-key` remains as a shim that writes the anthropic credential and enables the provider. Turn routing is still Anthropic-only via `KeyedResolver` — composite model→provider selection is the next slice.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] Manual: `openwave serve`, `PUT /providers/openai` with a key, confirm `GET /providers` shows `has_credential: true` and no secret material, `GET /models` includes openai models when enabled
- [ ] Manual: `PUT /providers/openai_compatible` with `enabled: true` and no `base_url` → 400; with base_url succeeds
- [ ] Manual: legacy `PUT /settings/api-key` still sets anthropic credential + enables the provider
