### PR TITLE
feat: composite router — model selects the provider

### DIFF
--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openwave-router"
-description = "OpenWave model routing: provider adapters and (later) the composite Router."
+description = "OpenWave model routing: provider adapters and the composite Router."
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -1,14 +1,14 @@
 //! OpenWave model routing.
 //!
 //! Home of the concrete [`ModelProvider`](openwave_core::ModelProvider) adapters
-//! (and, later, the composite `Router` that does config-gated selection and
-//! health-based failover). Each adapter's job is to normalize one provider's
-//! streaming quirks into the shared
-//! [`ProviderEvent`](openwave_core::ProviderEvent) vocabulary.
+//! and the composite [`Router`] that does config-gated model→provider selection.
+//! Each adapter's job is to normalize one provider's streaming quirks into the
+//! shared [`ProviderEvent`](openwave_core::ProviderEvent) vocabulary.
 //!
 //! The `ModelProvider` contract itself lives in `openwave-core`; only the
-//! implementations live here.
+//! implementations live here. Health-based failover is a later slice.
 
+pub mod router;
 mod sse;
 
 #[cfg(feature = "anthropic")]
@@ -21,3 +21,4 @@ pub mod openai_compat;
 pub use anthropic::AnthropicProvider;
 #[cfg(feature = "openai-compat")]
 pub use openai_compat::OpenAiCompatProvider;
+pub use router::{Route, RouteKind, Router};

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -81,7 +81,13 @@ impl ModelProvider for OpenAiCompatProvider {
     }
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
-        let body = build_request_json(&req)?;
+        let mut body = build_request_json(&req)?;
+        // Native OpenAI omits usage on streaming chunks unless asked. Local
+        // openai_compatible servers often reject unknown fields, so only set
+        // this for the openai provider id.
+        if self.provider_id == "openai" {
+            body["stream_options"] = json!({ "include_usage": true });
+        }
         let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
 
         let response = self
@@ -158,15 +164,19 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         extend_openai_messages(&mut messages, message)?;
     }
 
+    let max_tokens = req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
     let mut body = json!({
         "model": req.model,
         "messages": messages,
-        "max_tokens": req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
         "stream": true,
-        // OpenAI omits usage on streaming chunks unless asked; harmless on
-        // gateways that ignore unknown fields.
-        "stream_options": { "include_usage": true },
     });
+    // Reasoning models (o-series) reject `max_tokens` — they want
+    // `max_completion_tokens`. Everything else still speaks `max_tokens`.
+    if is_reasoning_model(&req.model) {
+        body["max_completion_tokens"] = json!(max_tokens);
+    } else {
+        body["max_tokens"] = json!(max_tokens);
+    }
 
     if !req.tools.is_empty() {
         body["tools"] = Value::Array(
@@ -189,6 +199,15 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         body["temperature"] = json!(temperature);
     }
     Ok(body)
+}
+
+/// OpenAI reasoning models reject `max_tokens` in favor of
+/// `max_completion_tokens`. Match the common `o`-prefix ids (o1, o3, o4-mini, …).
+fn is_reasoning_model(model: &str) -> bool {
+    let base = model.split('/').next_back().unwrap_or(model);
+    let base = base.strip_prefix("openai.").unwrap_or(base);
+    matches!(base.as_bytes().first(), Some(b'o'))
+        && base.as_bytes().get(1).is_some_and(|b| b.is_ascii_digit())
 }
 
 /// Append one normalized message as one or more OpenAI Chat Completions messages.
@@ -444,13 +463,32 @@ mod tests {
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["model"], "gpt-4o");
         assert_eq!(body["stream"], true);
-        assert_eq!(body["stream_options"]["include_usage"], true);
         assert_eq!(body["max_tokens"], DEFAULT_MAX_TOKENS);
+        assert!(body.get("max_completion_tokens").is_none());
         assert_eq!(body["messages"][0]["role"], "system");
         assert_eq!(body["messages"][1]["role"], "user");
         assert_eq!(body["tools"][0]["type"], "function");
         assert_eq!(body["tools"][0]["function"]["name"], "read_file");
         assert!((body["temperature"].as_f64().unwrap() - 0.2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn reasoning_models_use_max_completion_tokens() {
+        let req = ChatRequest {
+            model: "o3".into(),
+            system: None,
+            messages: vec![ChatMessage::text(Role::User, "hi")],
+            tools: vec![],
+            max_tokens: Some(1024),
+            temperature: None,
+        };
+        let body = build_request_json(&req).unwrap();
+        assert_eq!(body["max_completion_tokens"], 1024);
+        assert!(body.get("max_tokens").is_none());
+        assert!(is_reasoning_model("o4-mini"));
+        assert!(is_reasoning_model("o1-preview"));
+        assert!(!is_reasoning_model("gpt-4o"));
+        assert!(!is_reasoning_model("claude-opus-4-8"));
     }
 
     #[test]

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -1,0 +1,286 @@
+//! Composite model router — select a concrete adapter from the request's model.
+//!
+//! The [`Router`] is itself a [`ModelProvider`]: the agent loop holds one
+//! provider and never knows whether it's a single backend or a configured set.
+//! Selection is config-gated and fail-closed — no enabled+credentialed candidate
+//! ⇒ the stream errors without egress.
+//!
+//! Health-based failover (circuit breaker, retry) is deliberately out of scope
+//! here; this slice is selection only.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+
+use openwave_core::error::{AgentError, Result};
+use openwave_core::provider::{ChatRequest, ModelProvider, ProviderEvent, ProviderId};
+
+#[cfg(feature = "anthropic")]
+use crate::AnthropicProvider;
+#[cfg(feature = "openai-compat")]
+use crate::OpenAiCompatProvider;
+
+/// Which concrete adapter a [`Route`] builds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum RouteKind {
+    /// Anthropic Messages API.
+    Anthropic,
+    /// OpenAI Chat Completions (api.openai.com).
+    Openai,
+    /// Any OpenAI-compatible Chat Completions gateway.
+    OpenaiCompatible,
+}
+
+impl RouteKind {
+    /// Stable id string matching the server's provider kind wire form.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RouteKind::Anthropic => "anthropic",
+            RouteKind::Openai => "openai",
+            RouteKind::OpenaiCompatible => "openai_compatible",
+        }
+    }
+}
+
+/// One enabled, credentialed provider endpoint the router may select.
+#[derive(Debug, Clone)]
+pub struct Route {
+    /// Which adapter to build.
+    pub kind: RouteKind,
+    /// API key / bearer token.
+    pub api_key: String,
+    /// Optional base URL override (required in practice for `OpenaiCompatible`).
+    pub base_url: Option<String>,
+    /// Curated model ids this route claims. Used for preferential selection;
+    /// `OpenaiCompatible` typically passes an empty list (free-form fallback).
+    pub curated_models: Vec<String>,
+}
+
+/// A composite [`ModelProvider`] that picks a backend from `ChatRequest.model`.
+///
+/// Selection order:
+/// 1. Prefer a route whose curated catalog contains the model.
+/// 2. Else, if an `OpenaiCompatible` route is present, use it (free-form /
+///    aggregator / local).
+/// 3. Else fail closed — no network call.
+pub struct Router {
+    adapters: HashMap<RouteKind, Arc<dyn ModelProvider>>,
+    /// model id → preferred route kind (first curated claim wins).
+    curated: HashMap<String, RouteKind>,
+    has_openai_compat: bool,
+    /// Fingerprint of the routes this was built from, for cache invalidation.
+    fingerprint: String,
+}
+
+impl Router {
+    /// Build a router from the given routes. Empty input ⇒ a router that always
+    /// fails closed on `stream`.
+    pub fn build(routes: Vec<Route>) -> Self {
+        let fingerprint = fingerprint_routes(&routes);
+        let mut adapters: HashMap<RouteKind, Arc<dyn ModelProvider>> = HashMap::new();
+        let mut curated: HashMap<String, RouteKind> = HashMap::new();
+        let mut has_openai_compat = false;
+
+        for route in routes {
+            if route.kind == RouteKind::OpenaiCompatible {
+                has_openai_compat = true;
+            }
+            for model in &route.curated_models {
+                curated.entry(model.clone()).or_insert(route.kind);
+            }
+            if let Some(adapter) = build_adapter(&route) {
+                adapters.insert(route.kind, adapter);
+            }
+        }
+
+        Self {
+            adapters,
+            curated,
+            has_openai_compat,
+            fingerprint,
+        }
+    }
+
+    /// Opaque fingerprint of the route set this router was built from. Equal
+    /// fingerprints mean the same enabled providers / keys / base URLs.
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    /// Select the route kind for `model`, if any candidate can serve it.
+    pub fn select(&self, model: &str) -> Option<RouteKind> {
+        if let Some(kind) = self.curated.get(model) {
+            if self.adapters.contains_key(kind) {
+                return Some(*kind);
+            }
+        }
+        if self.has_openai_compat && self.adapters.contains_key(&RouteKind::OpenaiCompatible) {
+            return Some(RouteKind::OpenaiCompatible);
+        }
+        None
+    }
+}
+
+#[async_trait]
+impl ModelProvider for Router {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("router")
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let Some(kind) = self.select(&req.model) else {
+            return Err(AgentError::config(format!(
+                "no enabled provider can serve model `{}`",
+                req.model
+            )));
+        };
+        let Some(adapter) = self.adapters.get(&kind) else {
+            return Err(AgentError::config(format!(
+                "no enabled provider can serve model `{}`",
+                req.model
+            )));
+        };
+        adapter.stream(req).await
+    }
+}
+
+fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
+    if route.api_key.is_empty() {
+        return None;
+    }
+    match route.kind {
+        #[cfg(feature = "anthropic")]
+        RouteKind::Anthropic => {
+            let mut p = AnthropicProvider::new(route.api_key.clone());
+            if let Some(base) = &route.base_url {
+                p = p.with_base_url(base.clone());
+            }
+            Some(Arc::new(p))
+        }
+        #[cfg(not(feature = "anthropic"))]
+        RouteKind::Anthropic => None,
+
+        #[cfg(feature = "openai-compat")]
+        RouteKind::Openai => {
+            let mut p = OpenAiCompatProvider::new(route.api_key.clone());
+            if let Some(base) = &route.base_url {
+                p = p.with_base_url(base.clone());
+            }
+            Some(Arc::new(p))
+        }
+        #[cfg(feature = "openai-compat")]
+        RouteKind::OpenaiCompatible => {
+            let base = route.base_url.as_deref()?;
+            // Refuse non-http(s) schemes so a stored base_url can't point the
+            // adapter at an arbitrary scheme handler.
+            if !(base.starts_with("https://") || base.starts_with("http://")) {
+                return None;
+            }
+            Some(Arc::new(OpenAiCompatProvider::compatible(
+                route.api_key.clone(),
+                base.to_string(),
+            )))
+        }
+        #[cfg(not(feature = "openai-compat"))]
+        RouteKind::Openai | RouteKind::OpenaiCompatible => None,
+    }
+}
+
+fn fingerprint_routes(routes: &[Route]) -> String {
+    let mut parts: Vec<String> = routes
+        .iter()
+        .map(|r| {
+            format!(
+                "{}|{}|{}",
+                r.kind.as_str(),
+                r.api_key,
+                r.base_url.as_deref().unwrap_or("")
+            )
+        })
+        .collect();
+    parts.sort();
+    parts.join(";")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn route(kind: RouteKind, key: &str, models: &[&str], base: Option<&str>) -> Route {
+        Route {
+            kind,
+            api_key: key.into(),
+            base_url: base.map(str::to_owned),
+            curated_models: models.iter().map(|m| (*m).to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn selects_curated_anthropic_over_compat_fallback() {
+        let router = Router::build(vec![
+            route(RouteKind::Anthropic, "sk-a", &["claude-opus-4-8"], None),
+            route(
+                RouteKind::OpenaiCompatible,
+                "sk-c",
+                &[],
+                Some("http://127.0.0.1:1234/v1"),
+            ),
+        ]);
+        assert_eq!(router.select("claude-opus-4-8"), Some(RouteKind::Anthropic));
+        // Unknown model falls through to openai_compatible.
+        assert_eq!(router.select("llama-3"), Some(RouteKind::OpenaiCompatible));
+    }
+
+    #[test]
+    fn curated_openai_model_selects_openai() {
+        let router = Router::build(vec![route(RouteKind::Openai, "sk-o", &["gpt-4o"], None)]);
+        assert_eq!(router.select("gpt-4o"), Some(RouteKind::Openai));
+        assert_eq!(router.select("unknown"), None);
+    }
+
+    #[test]
+    fn empty_router_selects_nothing() {
+        let router = Router::build(vec![]);
+        assert_eq!(router.select("claude-opus-4-8"), None);
+    }
+
+    #[test]
+    fn openai_compatible_rejects_non_http_base_url() {
+        let router = Router::build(vec![route(
+            RouteKind::OpenaiCompatible,
+            "sk-c",
+            &[],
+            Some("file:///etc/passwd"),
+        )]);
+        assert_eq!(router.select("anything"), None);
+    }
+
+    #[test]
+    fn fingerprint_changes_with_key() {
+        let a = Router::build(vec![route(RouteKind::Anthropic, "sk-1", &[], None)]);
+        let b = Router::build(vec![route(RouteKind::Anthropic, "sk-2", &[], None)]);
+        assert_ne!(a.fingerprint(), b.fingerprint());
+    }
+
+    #[tokio::test]
+    async fn stream_fails_closed_with_no_match() {
+        let router = Router::build(vec![]);
+        let result = router
+            .stream(ChatRequest {
+                model: "nope".into(),
+                system: None,
+                messages: vec![],
+                tools: vec![],
+                max_tokens: None,
+                temperature: None,
+            })
+            .await;
+        match result {
+            Err(err) => assert!(err.to_string().contains("no enabled provider")),
+            Ok(_) => panic!("expected fail-closed error"),
+        }
+    }
+}

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -46,7 +46,7 @@ impl RouteKind {
 }
 
 /// One enabled, credentialed provider endpoint the router may select.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Route {
     /// Which adapter to build.
     pub kind: RouteKind,
@@ -57,6 +57,17 @@ pub struct Route {
     /// Curated model ids this route claims. Used for preferential selection;
     /// `OpenaiCompatible` typically passes an empty list (free-form fallback).
     pub curated_models: Vec<String>,
+}
+
+impl std::fmt::Debug for Route {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Route")
+            .field("kind", &self.kind)
+            .field("api_key", &"***")
+            .field("base_url", &self.base_url)
+            .field("curated_models", &self.curated_models)
+            .finish()
+    }
 }
 
 /// A composite [`ModelProvider`] that picks a backend from `ChatRequest.model`.
@@ -190,19 +201,32 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
 }
 
 fn fingerprint_routes(routes: &[Route]) -> String {
+    // Hash key material so the fingerprint (cached on the resolver) never
+    // retains a cleartext API key.
     let mut parts: Vec<String> = routes
         .iter()
         .map(|r| {
             format!(
-                "{}|{}|{}",
+                "{}|{:x}|{}",
                 r.kind.as_str(),
-                r.api_key,
+                fnv1a64(&r.api_key),
                 r.base_url.as_deref().unwrap_or("")
             )
         })
         .collect();
     parts.sort();
     parts.join(";")
+}
+
+/// Tiny non-crypto FNV-1a 64-bit hash — enough to invalidate the cache when a
+/// key changes without storing the key itself.
+fn fnv1a64(s: &str) -> u64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in s.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
 }
 
 #[cfg(test)]
@@ -263,6 +287,23 @@ mod tests {
         let a = Router::build(vec![route(RouteKind::Anthropic, "sk-1", &[], None)]);
         let b = Router::build(vec![route(RouteKind::Anthropic, "sk-2", &[], None)]);
         assert_ne!(a.fingerprint(), b.fingerprint());
+    }
+
+    #[test]
+    fn fingerprint_does_not_contain_raw_key() {
+        let router = Router::build(vec![route(
+            RouteKind::Anthropic,
+            "sk-super-secret",
+            &[],
+            None,
+        )]);
+        assert!(!router.fingerprint().contains("sk-super-secret"));
+    }
+
+    #[test]
+    fn route_debug_redacts_api_key() {
+        let r = route(RouteKind::Anthropic, "sk-super-secret", &[], None);
+        assert!(!format!("{r:?}").contains("sk-super-secret"));
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -150,10 +150,10 @@ pub async fn bind(config: Config) -> Result<Server> {
 
 /// Assemble the static agent dependencies for a real launch: the tool set and
 /// the per-turn tuning. The model **provider** is not built here — it is resolved
-/// per turn by the [`KeyedResolver`] from the configured API key (see
-/// [`resolver`]), so setting a key at runtime takes effect without a restart. The
-/// model *name* comes from `OPENWAVE_MODEL` (or the built-in default) and can be
-/// overridden at runtime via `PUT /settings`.
+/// per turn by the [`KeyedResolver`] (a composite router over enabled providers;
+/// see [`resolver`]), so configuring a provider at runtime takes effect without a
+/// restart. The model *name* comes from `OPENWAVE_MODEL` (or the built-in default)
+/// and can be overridden at runtime via `PUT /settings` or per-chat.
 fn agent_deps() -> (Arc<ToolRegistry>, AgentConfig) {
     let tools = Arc::new(
         ToolRegistry::new()
@@ -1184,8 +1184,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolver_builds_a_real_provider_when_a_key_is_set() {
-        // Typed credential blob + enabled config — the primary write path.
+    async fn resolver_builds_a_router_from_enabled_providers() {
         let dir = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -1216,9 +1215,10 @@ mod tests {
 
         let resolver = resolver::KeyedResolver::new(store.clone(), secrets.clone());
         let resolved = resolver.resolve().await;
-        assert_eq!(resolved.id().0, "anthropic");
+        // Composite router — selection happens on stream from req.model.
+        assert_eq!(resolved.id().0, "router");
 
-        // Same key ⇒ the cached provider is reused (not rebuilt every turn).
+        // Same route set ⇒ the cached provider is reused.
         let again = resolver.resolve().await;
         assert!(Arc::ptr_eq(&resolved, &again));
 
@@ -1232,8 +1232,9 @@ mod tests {
         .unwrap();
         let rebuilt = resolver.resolve().await;
         assert!(!Arc::ptr_eq(&resolved, &rebuilt));
+        assert_eq!(rebuilt.id().0, "router");
 
-        // Disabling Anthropic fails closed even with a key present.
+        // Disabling Anthropic with no other providers fails closed.
         providers::write_config(
             &*store,
             providers::ProviderKind::Anthropic,
@@ -1245,6 +1246,92 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(resolver.resolve().await.id().0, "unconfigured");
+    }
+
+    #[tokio::test]
+    async fn resolver_includes_openai_when_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}/test.db?mode=rwc",
+                dir.path().display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+        providers::write_credential(
+            &*secrets,
+            providers::ProviderKind::Openai,
+            &providers::ProviderCredential::api_key("sk-openai"),
+        )
+        .await
+        .unwrap();
+        providers::write_config(
+            &*store,
+            providers::ProviderKind::Openai,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let routes = providers::collect_routes(&*store, &*secrets).await;
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].kind, openwave_router::RouteKind::Openai);
+
+        let resolver = resolver::KeyedResolver::new(store, secrets);
+        let provider = resolver.resolve().await;
+        assert_eq!(provider.id().0, "router");
+
+        // A curated openai model is selectable; an anthropic model is not
+        // (no anthropic route, no openai_compatible fallback).
+        let router = openwave_router::Router::build(routes);
+        assert_eq!(
+            router.select("gpt-4o"),
+            Some(openwave_router::RouteKind::Openai)
+        );
+        assert_eq!(router.select("claude-opus-4-8"), None);
+    }
+
+    #[tokio::test]
+    async fn openai_compatible_route_is_free_form_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}/test.db?mode=rwc",
+                dir.path().display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+        providers::write_credential(
+            &*secrets,
+            providers::ProviderKind::OpenaiCompatible,
+            &providers::ProviderCredential::api_key("sk-local"),
+        )
+        .await
+        .unwrap();
+        providers::write_config(
+            &*store,
+            providers::ProviderKind::OpenaiCompatible,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: Some("http://127.0.0.1:1234/v1".into()),
+            },
+        )
+        .await
+        .unwrap();
+
+        let routes = providers::collect_routes(&*store, &*secrets).await;
+        let router = openwave_router::Router::build(routes);
+        assert_eq!(
+            router.select("llama-3-local"),
+            Some(openwave_router::RouteKind::OpenaiCompatible)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -116,8 +116,8 @@ impl Server {
     }
 }
 
-/// Placeholder default model, used until the settings-driven model selection and
-/// the composite router land. Overridable with `OPENWAVE_MODEL`.
+/// Default model when none is configured via settings or per-chat. Overridable
+/// with `OPENWAVE_MODEL`.
 const DEFAULT_MODEL: &str = "claude-opus-4-8";
 
 /// Wire the store from `config` and bind the API to an ephemeral loopback port.

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -347,19 +347,84 @@ pub async fn update_provider(
     })
 }
 
-/// Resolve the Anthropic API key the turn path uses today: stored credential
-/// (new blob or legacy), then `ANTHROPIC_API_KEY` env.
-pub async fn resolve_anthropic_api_key(secrets: &dyn SecretProvider) -> Option<String> {
-    if let Ok(Some(cred)) = read_credential(secrets, ProviderKind::Anthropic).await {
+/// Resolve an API-key credential for `kind`: stored blob (or Anthropic legacy),
+/// then the matching env fallback.
+pub async fn resolve_api_key(secrets: &dyn SecretProvider, kind: ProviderKind) -> Option<String> {
+    if let Ok(Some(cred)) = read_credential(secrets, kind).await {
         if let Some(key) = cred.as_api_key() {
             if !key.is_empty() {
                 return Some(key.to_string());
             }
         }
     }
-    std::env::var("ANTHROPIC_API_KEY")
-        .ok()
-        .filter(|k| !k.is_empty())
+    match kind {
+        ProviderKind::Anthropic => std::env::var("ANTHROPIC_API_KEY")
+            .ok()
+            .filter(|k| !k.is_empty()),
+        ProviderKind::Openai => std::env::var("OPENAI_API_KEY")
+            .ok()
+            .filter(|k| !k.is_empty()),
+        ProviderKind::OpenaiCompatible => None,
+    }
+}
+
+/// Resolve the Anthropic API key (stored / legacy / env). Thin wrapper kept for
+/// call sites that are Anthropic-specific.
+pub async fn resolve_anthropic_api_key(secrets: &dyn SecretProvider) -> Option<String> {
+    resolve_api_key(secrets, ProviderKind::Anthropic).await
+}
+
+/// Map a server [`ProviderKind`] to the router's [`openwave_router::RouteKind`].
+pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
+    match kind {
+        ProviderKind::Anthropic => openwave_router::RouteKind::Anthropic,
+        ProviderKind::Openai => openwave_router::RouteKind::Openai,
+        ProviderKind::OpenaiCompatible => openwave_router::RouteKind::OpenaiCompatible,
+    }
+}
+
+/// Collect enabled, credentialed routes for the composite router.
+///
+/// A kind with no usable API key is skipped. `openai_compatible` also requires
+/// a `base_url`. Store-read failures for a single kind skip that kind (fail
+/// closed for it) rather than aborting the whole list.
+pub async fn collect_routes(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+) -> Vec<openwave_router::Route> {
+    let mut routes = Vec::new();
+    for &kind in ProviderKind::ALL {
+        let config = match read_config(store, kind).await {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if !config.enabled {
+            continue;
+        }
+        let Some(api_key) = resolve_api_key(secrets, kind).await else {
+            continue;
+        };
+        if kind == ProviderKind::OpenaiCompatible && config.base_url.is_none() {
+            continue;
+        }
+        if kind == ProviderKind::OpenaiCompatible {
+            let base = config.base_url.as_deref().unwrap_or("");
+            if !(base.starts_with("https://") || base.starts_with("http://")) {
+                continue;
+            }
+        }
+        routes.push(openwave_router::Route {
+            kind: route_kind(kind),
+            api_key,
+            base_url: config.base_url,
+            curated_models: kind
+                .curated_models()
+                .iter()
+                .map(|m| (*m).to_string())
+                .collect(),
+        });
+    }
+    routes
 }
 
 /// One-shot boot migration: if Anthropic has no stored config yet but a key is

--- a/crates/openwave-server/src/resolver.rs
+++ b/crates/openwave-server/src/resolver.rs
@@ -1,30 +1,26 @@
 //! Resolving the model provider for a turn from configured credentials.
 //!
-//! The provider is built *per turn* rather than once at boot, so setting an API
-//! key at runtime (`PUT /providers/anthropic` or the legacy
-//! `PUT /settings/api-key`) takes effect on the next turn without a restart.
+//! Builds a composite [`openwave_router::Router`] from every enabled,
+//! credentialed provider so the turn's model selects the right adapter
+//! (Anthropic / OpenAI / openai_compatible). The router is rebuilt when the
+//! route set changes (enable/disable, key, base_url); otherwise the cached
+//! instance — and its connection pools — is reused.
+//!
 //! The [`ProviderResolver`] seam also lets tests inject a provider directly
 //! instead of standing up a real backend.
-//!
-//! Today this still resolves Anthropic only — the composite router (model →
-//! provider selection across configured kinds) is the next slice. Credentials
-//! are read through the providers module so the new typed blob and the legacy
-//! plain-string key both work.
 
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 
 use openwave_core::{ModelProvider, SecretProvider, Store};
-use openwave_router::AnthropicProvider;
+use openwave_router::Router;
 
 use crate::provider::UnconfiguredProvider;
-use crate::providers::{self, ProviderKind};
+use crate::providers;
 
-/// Cache key: whether Anthropic is enabled + the resolved API key. Either
-/// changing rebuilds the provider.
-type CacheKey = (bool, Option<String>);
-type CachedProvider = Option<(CacheKey, Arc<dyn ModelProvider>)>;
+/// Cache: fingerprint of the route set + the built provider.
+type CachedProvider = Option<(String, Arc<dyn ModelProvider>)>;
 
 /// Builds the model provider for the next turn.
 #[async_trait]
@@ -34,24 +30,20 @@ pub trait ProviderResolver: Send + Sync {
     async fn resolve(&self) -> Arc<dyn ModelProvider>;
 }
 
-/// Resolves an Anthropic provider when the Anthropic provider is enabled and an
-/// API key is available (stored credential or `ANTHROPIC_API_KEY` env) — or a
-/// fail-closed provider otherwise.
+/// Resolves a composite [`Router`] from enabled, credentialed providers — or a
+/// fail-closed provider when none are configured.
 ///
-/// The built provider is cached and reused while the key and enabled flag are
-/// unchanged, so a provider (and its `reqwest` connection pool) isn't rebuilt
-/// every turn; a key or enabled change rebuilds it on the next turn.
-///
-/// OpenAI / openai_compatible credentials are accepted by the `/providers` API
-/// but not yet selected here — the composite router is the next slice.
-pub struct KeyedResolver {
+/// Selection happens inside the router on `stream(req)` from `req.model`
+/// (curated catalog match, else openai_compatible free-form fallback). No
+/// default provider: empty config ⇒ no egress.
+pub struct ConfiguredResolver {
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
     cached: Mutex<CachedProvider>,
 }
 
-impl KeyedResolver {
-    /// A resolver that reads Anthropic config from `store` and the API key from
+impl ConfiguredResolver {
+    /// A resolver that reads provider config from `store` and credentials from
     /// `secrets`.
     pub fn new(store: Arc<dyn Store>, secrets: Arc<dyn SecretProvider>) -> Self {
         Self {
@@ -62,36 +54,32 @@ impl KeyedResolver {
     }
 }
 
-#[async_trait]
-impl ProviderResolver for KeyedResolver {
-    async fn resolve(&self) -> Arc<dyn ModelProvider> {
-        let enabled = providers::read_config(&*self.store, ProviderKind::Anthropic)
-            .await
-            .map(|c| c.enabled)
-            // Store read failure → treat as disabled (fail closed).
-            .unwrap_or(false);
-        let key = if enabled {
-            providers::resolve_anthropic_api_key(&*self.secrets).await
-        } else {
-            None
-        };
-        let cache_key = (enabled, key.clone());
+/// Backward-compatible alias — earlier slices called this `KeyedResolver`.
+pub type KeyedResolver = ConfiguredResolver;
 
-        // Reuse the cached provider while the key/enabled are unchanged. The
-        // lock is held only across the cheap, synchronous build below — never
-        // over an await.
+#[async_trait]
+impl ProviderResolver for ConfiguredResolver {
+    async fn resolve(&self) -> Arc<dyn ModelProvider> {
+        let routes = providers::collect_routes(&*self.store, &*self.secrets).await;
+        let router = Router::build(routes);
+        let fingerprint = router.fingerprint().to_string();
+
+        // Reuse the cached provider while the route set is unchanged. The lock
+        // is held only across the cheap clone below — never over an await.
         let mut cached = self.cached.lock().unwrap();
-        if let Some((cached_key, provider)) = cached.as_ref() {
-            if *cached_key == cache_key {
+        if let Some((cached_fp, provider)) = cached.as_ref() {
+            if *cached_fp == fingerprint {
                 return provider.clone();
             }
         }
-        let provider: Arc<dyn ModelProvider> = match &key {
-            Some(key) => Arc::new(AnthropicProvider::new(key.clone())),
-            // Fail closed: disabled or no key ⇒ refuse without any network call.
-            None => Arc::new(UnconfiguredProvider),
+
+        let provider: Arc<dyn ModelProvider> = if fingerprint.is_empty() {
+            // No enabled+credentialed routes ⇒ fail closed without egress.
+            Arc::new(UnconfiguredProvider)
+        } else {
+            Arc::new(router)
         };
-        *cached = Some((cache_key, provider.clone()));
+        *cached = Some((fingerprint, provider.clone()));
         provider
     }
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -105,10 +105,16 @@ async fn read_model(store: &dyn Store) -> Result<Option<String>, ServerError> {
         .and_then(|value| value.as_str().map(str::to_owned)))
 }
 
-/// Whether a model API key is configured — in the secret store or the
-/// environment fallback the resolver also honors.
+/// Whether any model provider credential is configured — stored or via the
+/// env fallbacks the resolver also honors. Prefer `GET /providers` for
+/// per-kind detail; this field is the legacy "is anything ready?" signal.
 async fn has_api_key(secrets: &dyn SecretProvider) -> bool {
-    providers::has_credential(secrets, ProviderKind::Anthropic).await
+    for &kind in ProviderKind::ALL {
+        if providers::has_credential(secrets, kind).await {
+            return true;
+        }
+    }
+    false
 }
 
 /// Body of `PUT /settings/api-key`.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -429,8 +429,9 @@ pub async fn post_message(
     if let Some(model) = model {
         agent_config.model = model;
     }
-    // Resolve the provider from the currently-configured key, so a key set via
-    // PUT /settings/api-key takes effect on this turn.
+    // Resolve the provider from currently-configured providers, so a key set via
+    // PUT /providers/{kind} (or the legacy /settings/api-key) takes effect on
+    // this turn. The composite router selects the adapter from the model name.
     let provider = state.resolver.resolve().await;
     let agent = Agent::new(
         provider,


### PR DESCRIPTION
## Summary
- Add a composite `Router` in `openwave-router` that is itself a `ModelProvider`: on `stream`, it selects anthropic / openai / openai_compatible from `ChatRequest.model` (curated catalog match first; otherwise an enabled openai_compatible route as free-form fallback). Empty config fails closed with no egress.
- Replace the Anthropic-only `KeyedResolver` with `ConfiguredResolver`, which builds the router from every enabled+credentialed provider (cached by route-set fingerprint). `KeyedResolver` remains as a type alias.
- openai_compatible base URLs must be `http://` or `https://`. Health-based failover is deliberately out of scope.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] Manual: enable openai via `PUT /providers/openai`, set chat model to `gpt-4o`, confirm the turn routes to OpenAI (or fails with an OpenAI-shaped error, not Anthropic)
- [ ] Manual: enable only openai_compatible with a local base_url; free-form model id is accepted
- [ ] Manual: disable all providers → turn fails closed without egress
