### PR TITLE
feat: approval park-and-resume for Sensitive tools

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -327,24 +327,24 @@ impl Agent {
             return ToolOutput::error(format!("unknown tool: {}", call.name));
         };
         // v1 policy: ReadOnly/Workspace auto; Sensitive parks on the approval gate.
+        // Arm *before* emitting ApprovalRequired so a client that sees the event
+        // can never race a 404 against a not-yet-parked call.
         if matches!(tool.approval_class(), ApprovalClass::Sensitive) {
             let summary = format!("{} requires approval", call.name);
-            let _ = events.unbounded_send(AgentEvent::ApprovalRequired {
+            let pending = self.approvals.arm(ApprovalRequest {
                 call_id: call.call_id,
+                chat_id: chat.id,
+                turn_id,
+                tool_name: call.name.clone(),
                 class: ApprovalClass::Sensitive,
                 summary: summary.clone(),
             });
-            let decision = self
-                .approvals
-                .decide(ApprovalRequest {
-                    call_id: call.call_id,
-                    chat_id: chat.id,
-                    turn_id,
-                    tool_name: call.name.clone(),
-                    class: ApprovalClass::Sensitive,
-                    summary,
-                })
-                .await;
+            let _ = events.unbounded_send(AgentEvent::ApprovalRequired {
+                call_id: call.call_id,
+                class: ApprovalClass::Sensitive,
+                summary,
+            });
+            let decision = pending.await;
             let approved = matches!(decision, ApprovalDecision::Approve);
             let _ = events.unbounded_send(AgentEvent::ApprovalDecided {
                 call_id: call.call_id,

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -10,8 +10,8 @@
 //!
 //! v1 scope (deliberately small; each is a tracked follow-up):
 //! - tool calls run **sequentially** (concurrency for independent calls later);
-//! - approval is **auto** for `ReadOnly`/`Workspace`; `Sensitive` is refused
-//!   (the park-and-resume approval flow lands next);
+//! - approval is **auto** for `ReadOnly`/`Workspace`; `Sensitive` parks via an
+//!   [`ApprovalGate`] until approve/reject (standing grants / auto-judge later);
 //! - cross-turn context is the stored text messages (structured tool-call
 //!   persistence + context summarization come later).
 
@@ -23,6 +23,7 @@ use futures::channel::mpsc::UnboundedSender;
 use futures::StreamExt;
 use serde_json::Value;
 
+use crate::approval::{ApprovalDecision, ApprovalGate, ApprovalRequest, RefuseGate};
 use crate::error::{AgentError, Result};
 use crate::event::AgentEvent;
 use crate::id::{CallId, MessageId, TurnId};
@@ -119,6 +120,7 @@ pub struct Agent {
     tools: Arc<ToolRegistry>,
     store: Arc<dyn Store>,
     config: AgentConfig,
+    approvals: Arc<dyn ApprovalGate>,
 }
 
 /// A tool call accumulated from the provider stream.
@@ -131,6 +133,9 @@ struct PendingCall {
 
 impl Agent {
     /// Assemble an agent from its dependencies and config.
+    ///
+    /// Sensitive tools are refused by default ([`RefuseGate`]). Wire a real
+    /// gate with [`with_approvals`](Self::with_approvals) for park-and-resume.
     pub fn new(
         provider: Arc<dyn ModelProvider>,
         tools: Arc<ToolRegistry>,
@@ -142,7 +147,15 @@ impl Agent {
             tools,
             store,
             config,
+            approvals: Arc::new(RefuseGate),
         }
+    }
+
+    /// Use `gate` for Sensitive-tool decisions (park-and-resume on the server).
+    #[must_use]
+    pub fn with_approvals(mut self, gate: Arc<dyn ApprovalGate>) -> Self {
+        self.approvals = gate;
+        self
     }
 
     /// Run one turn: submit `user_input`, drive the loop to a final answer,
@@ -278,7 +291,7 @@ impl Agent {
             // Run the tool calls and feed the results back for the next step.
             let mut results: Vec<ContentBlock> = Vec::new();
             for call in &calls {
-                let output = self.run_tool(chat, call, events).await;
+                let output = self.run_tool(chat, turn_id, call, events).await;
                 let _ = events.unbounded_send(AgentEvent::ToolCallCompleted {
                     call_id: call.call_id,
                     output: output.clone(),
@@ -306,21 +319,40 @@ impl Agent {
     async fn run_tool(
         &self,
         chat: &Chat,
+        turn_id: TurnId,
         call: &PendingCall,
         events: &UnboundedSender<AgentEvent>,
     ) -> ToolOutput {
         let Some(tool) = self.tools.get(&call.name) else {
             return ToolOutput::error(format!("unknown tool: {}", call.name));
         };
-        // v1 policy: ReadOnly/Workspace auto; Sensitive refused until the
-        // park-and-resume approval flow lands.
+        // v1 policy: ReadOnly/Workspace auto; Sensitive parks on the approval gate.
         if matches!(tool.approval_class(), ApprovalClass::Sensitive) {
+            let summary = format!("{} requires approval", call.name);
             let _ = events.unbounded_send(AgentEvent::ApprovalRequired {
                 call_id: call.call_id,
                 class: ApprovalClass::Sensitive,
-                summary: format!("{} requires approval", call.name),
+                summary: summary.clone(),
             });
-            return ToolOutput::error("this tool requires approval, which is not yet supported");
+            let decision = self
+                .approvals
+                .decide(ApprovalRequest {
+                    call_id: call.call_id,
+                    chat_id: chat.id,
+                    turn_id,
+                    tool_name: call.name.clone(),
+                    class: ApprovalClass::Sensitive,
+                    summary,
+                })
+                .await;
+            let approved = matches!(decision, ApprovalDecision::Approve);
+            let _ = events.unbounded_send(AgentEvent::ApprovalDecided {
+                call_id: call.call_id,
+                approved,
+            });
+            if let ApprovalDecision::Reject { reason } = decision {
+                return ToolOutput::error(reason);
+            }
         }
         let ctx = ToolCtx {
             chat_id: chat.id,
@@ -645,5 +677,178 @@ mod tests {
         assert!(!output.is_error);
         assert!(output.content.len() < 10_000, "result should be capped");
         assert!(output.content.contains("[truncated:"));
+    }
+
+    /// A Sensitive tool that records whether it ran.
+    struct BoomTool {
+        ran: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for BoomTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: "boom".into(),
+                description: "a sensitive tool".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::Sensitive
+        }
+        async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+            self.ran.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolOutput::text("boomed"))
+        }
+    }
+
+    /// Provider that always asks for the `boom` tool once, then finishes.
+    struct BoomProvider {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ModelProvider for BoomProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("boom")
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let events = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "call_boom".into(),
+                        name: "boom".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: "{}".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta { text: "ok".into() },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    #[tokio::test]
+    async fn sensitive_tool_parks_until_approved() {
+        use crate::approval::AutoApproveGate;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            workspace_dir: workspace.path().to_path_buf(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let tools = Arc::new(ToolRegistry::new().with(Box::new(BoomTool { ran: ran.clone() })));
+        let agent = Agent::new(
+            Arc::new(BoomProvider {
+                calls: AtomicUsize::new(0),
+            }),
+            tools,
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        )
+        .with_approvals(Arc::new(AutoApproveGate));
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ApprovalRequired { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ApprovalDecided { approved: true, .. })));
+        assert_eq!(ran.load(Ordering::SeqCst), 1);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolCallCompleted { output, .. }
+                if output.content == "boomed" && !output.is_error
+        )));
+    }
+
+    #[tokio::test]
+    async fn sensitive_tool_is_refused_without_a_gate() {
+        let workspace = tempfile::tempdir().unwrap();
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            workspace_dir: workspace.path().to_path_buf(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let agent = Agent::new(
+            Arc::new(BoomProvider {
+                calls: AtomicUsize::new(0),
+            }),
+            Arc::new(ToolRegistry::new().with(Box::new(BoomTool { ran: ran.clone() }))),
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        );
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert_eq!(ran.load(Ordering::SeqCst), 0);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ApprovalDecided {
+                approved: false,
+                ..
+            }
+        )));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolCallCompleted { output, .. } if output.is_error
+        )));
     }
 }

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -1,12 +1,18 @@
 //! Approval park-and-resume for Sensitive tools.
 //!
 //! When the agent hits a tool whose [`ApprovalClass`](crate::tool::ApprovalClass)
-//! requires a human decision, it emits `ApprovalRequired` and awaits an
-//! [`ApprovalGate`]. The server's gate parks the turn on a oneshot channel until
+//! requires a human decision, it arms an [`ApprovalGate`] (so the call is
+//! resolvable), emits `ApprovalRequired`, then awaits the decision. The
+//! server's gate parks the turn on a oneshot channel until
 //! `POST /chats/{id}/approvals/{call_id}` decides; tests inject an auto-approve
 //! or refuse gate instead.
+//!
+//! **Ordering invariant:** the gate must make the call resolvable *before*
+//! returning from [`ApprovalGate::arm`], so a client that sees
+//! `ApprovalRequired` can never race a 404 against a not-yet-parked call.
 
-use async_trait::async_trait;
+use std::future::Future;
+use std::pin::Pin;
 
 use crate::id::{CallId, ChatId, TurnId};
 use crate::tool::ApprovalClass;
@@ -40,39 +46,46 @@ pub struct ApprovalRequest {
     pub summary: String,
 }
 
+/// A future that resolves to an [`ApprovalDecision`].
+pub type ApprovalFuture<'a> = Pin<Box<dyn Future<Output = ApprovalDecision> + Send + 'a>>;
+
 /// Decides whether a Sensitive tool call may run.
 ///
 /// Object-safe and held behind `Arc` so the server can park on a channel while
 /// tests inject an immediate approve/reject.
-#[async_trait]
 pub trait ApprovalGate: Send + Sync {
-    /// Await a decision for `request`. Must not return until the call is
-    /// approved or rejected (or the turn is abandoned).
-    async fn decide(&self, request: ApprovalRequest) -> ApprovalDecision;
+    /// Synchronously arm a pending approval, returning a future that resolves
+    /// when decided.
+    ///
+    /// Parking implementations MUST register the call (so HTTP resolve can find
+    /// it) before returning. The agent emits `ApprovalRequired` only after
+    /// `arm` returns, then awaits the future — closing the race where a client
+    /// sees the event before the call is parked.
+    fn arm(&self, request: ApprovalRequest) -> ApprovalFuture<'_>;
 }
 
 /// Always rejects — the default when no gate is wired. Keeps fail-closed
 /// behavior for Sensitive tools outside the server's park-and-resume path.
 pub struct RefuseGate;
 
-#[async_trait]
 impl ApprovalGate for RefuseGate {
-    async fn decide(&self, request: ApprovalRequest) -> ApprovalDecision {
-        ApprovalDecision::Reject {
-            reason: format!(
-                "{} requires approval, which is not configured",
-                request.tool_name
-            ),
-        }
+    fn arm(&self, request: ApprovalRequest) -> ApprovalFuture<'_> {
+        Box::pin(async move {
+            ApprovalDecision::Reject {
+                reason: format!(
+                    "{} requires approval, which is not configured",
+                    request.tool_name
+                ),
+            }
+        })
     }
 }
 
 /// Always approves — for tests that exercise Sensitive tools without a UI.
 pub struct AutoApproveGate;
 
-#[async_trait]
 impl ApprovalGate for AutoApproveGate {
-    async fn decide(&self, _request: ApprovalRequest) -> ApprovalDecision {
-        ApprovalDecision::Approve
+    fn arm(&self, _request: ApprovalRequest) -> ApprovalFuture<'_> {
+        Box::pin(async { ApprovalDecision::Approve })
     }
 }

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -1,0 +1,78 @@
+//! Approval park-and-resume for Sensitive tools.
+//!
+//! When the agent hits a tool whose [`ApprovalClass`](crate::tool::ApprovalClass)
+//! requires a human decision, it emits `ApprovalRequired` and awaits an
+//! [`ApprovalGate`]. The server's gate parks the turn on a oneshot channel until
+//! `POST /chats/{id}/approvals/{call_id}` decides; tests inject an auto-approve
+//! or refuse gate instead.
+
+use async_trait::async_trait;
+
+use crate::id::{CallId, ChatId, TurnId};
+use crate::tool::ApprovalClass;
+
+/// The human's decision on a parked tool call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApprovalDecision {
+    /// Run the tool.
+    Approve,
+    /// Skip the tool; feed an error result back to the model.
+    Reject {
+        /// Why it was rejected (shown to the model / UI).
+        reason: String,
+    },
+}
+
+/// What the agent asks the gate to decide.
+#[derive(Debug, Clone)]
+pub struct ApprovalRequest {
+    /// Correlates with `ApprovalRequired` / the HTTP path.
+    pub call_id: CallId,
+    /// Chat the turn belongs to.
+    pub chat_id: ChatId,
+    /// Turn that is parked.
+    pub turn_id: TurnId,
+    /// Tool name the model invoked.
+    pub tool_name: String,
+    /// Approval class that triggered the park.
+    pub class: ApprovalClass,
+    /// Short human-readable summary of what will happen.
+    pub summary: String,
+}
+
+/// Decides whether a Sensitive tool call may run.
+///
+/// Object-safe and held behind `Arc` so the server can park on a channel while
+/// tests inject an immediate approve/reject.
+#[async_trait]
+pub trait ApprovalGate: Send + Sync {
+    /// Await a decision for `request`. Must not return until the call is
+    /// approved or rejected (or the turn is abandoned).
+    async fn decide(&self, request: ApprovalRequest) -> ApprovalDecision;
+}
+
+/// Always rejects — the default when no gate is wired. Keeps fail-closed
+/// behavior for Sensitive tools outside the server's park-and-resume path.
+pub struct RefuseGate;
+
+#[async_trait]
+impl ApprovalGate for RefuseGate {
+    async fn decide(&self, request: ApprovalRequest) -> ApprovalDecision {
+        ApprovalDecision::Reject {
+            reason: format!(
+                "{} requires approval, which is not configured",
+                request.tool_name
+            ),
+        }
+    }
+}
+
+/// Always approves — for tests that exercise Sensitive tools without a UI.
+pub struct AutoApproveGate;
+
+#[async_trait]
+impl ApprovalGate for AutoApproveGate {
+    async fn decide(&self, _request: ApprovalRequest) -> ApprovalDecision {
+        ApprovalDecision::Approve
+    }
+}

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -65,6 +65,13 @@ pub enum AgentEvent {
         /// A short, human-readable summary of what will happen.
         summary: String,
     },
+    /// The human decided on a parked tool call.
+    ApprovalDecided {
+        /// The call that was decided.
+        call_id: CallId,
+        /// `true` if approved, `false` if rejected.
+        approved: bool,
+    },
     /// A tool call finished; its result is attached.
     ToolCallCompleted {
         /// The call that completed.

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -14,6 +14,7 @@
 //! contract).
 
 pub mod agent;
+pub mod approval;
 pub mod config;
 #[cfg(feature = "sqlite")]
 pub mod db;
@@ -30,6 +31,7 @@ pub mod tool;
 pub mod tools;
 
 pub use agent::{Agent, AgentConfig, ToolRegistry};
+pub use approval::{ApprovalDecision, ApprovalGate, ApprovalRequest, AutoApproveGate, RefuseGate};
 pub use config::{Config, Profile};
 #[cfg(feature = "sqlite")]
 pub use db::DbStore;

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -31,7 +31,9 @@ pub mod tool;
 pub mod tools;
 
 pub use agent::{Agent, AgentConfig, ToolRegistry};
-pub use approval::{ApprovalDecision, ApprovalGate, ApprovalRequest, AutoApproveGate, RefuseGate};
+pub use approval::{
+    ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalRequest, AutoApproveGate, RefuseGate,
+};
 pub use config::{Config, Profile};
 #[cfg(feature = "sqlite")]
 pub use db::DbStore;

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -16,9 +16,9 @@ use crate::id::ChatId;
 
 /// The approval policy class a tool declares for itself.
 ///
-/// Policy maps class → auto-approve / ask / deny. In v1: `ReadOnly` auto;
-/// `Workspace` auto inside the chat workspace, ask outside; `Sensitive`
-/// always asks.
+/// Policy maps class → auto-approve / ask / deny. In v1: `ReadOnly` and
+/// `Workspace` auto-approve; `Sensitive` always parks on the approval gate.
+/// (Workspace-outside prompting and standing grants are deferred.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ApprovalClass {

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -1,0 +1,148 @@
+//! In-process approval broker: parks Sensitive tool calls until a decision.
+//!
+//! The agent awaits [`ApprovalGate::decide`](openwave_core::ApprovalGate); this
+//! broker fulfills that by parking on a oneshot keyed by `call_id`. The HTTP
+//! handler (`POST /chats/{id}/approvals/{call_id}`) resolves the oneshot.
+//! Pending entries are dropped when the turn finishes without a decision
+//! (channel closed → reject).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use tokio::sync::oneshot;
+
+use openwave_core::{ApprovalDecision, ApprovalGate, ApprovalRequest, CallId, ChatId};
+
+/// Parks Sensitive tool calls until `decide` is called from the HTTP surface.
+#[derive(Default)]
+pub struct ApprovalBroker {
+    pending: Mutex<HashMap<CallId, Pending>>,
+}
+
+struct Pending {
+    chat_id: ChatId,
+    tx: oneshot::Sender<ApprovalDecision>,
+}
+
+impl ApprovalBroker {
+    /// A fresh broker with no pending approvals.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve a parked call. Returns `Ok(())` on success, `Err` if the call
+    /// isn't pending or belongs to a different chat.
+    pub fn resolve(
+        &self,
+        chat_id: ChatId,
+        call_id: CallId,
+        decision: ApprovalDecision,
+    ) -> Result<(), DecideError> {
+        let mut pending = self.pending.lock().unwrap();
+        let entry = pending.remove(&call_id).ok_or(DecideError::NotPending)?;
+        if entry.chat_id != chat_id {
+            // Put it back — wrong chat shouldn't steal another chat's park.
+            pending.insert(call_id, entry);
+            return Err(DecideError::WrongChat);
+        }
+        // If the turn already dropped, the send fails; treat as not pending.
+        entry
+            .tx
+            .send(decision)
+            .map_err(|_| DecideError::NotPending)?;
+        Ok(())
+    }
+}
+
+/// Why a decide call failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecideError {
+    /// No parked call with that id (already decided, never parked, or turn ended).
+    NotPending,
+    /// The call is parked under a different chat.
+    WrongChat,
+}
+
+#[async_trait]
+impl ApprovalGate for ApprovalBroker {
+    async fn decide(&self, request: ApprovalRequest) -> ApprovalDecision {
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut pending = self.pending.lock().unwrap();
+            // A duplicate park for the same call_id shouldn't happen; if it
+            // does, the newer oneshot wins and the old waiter gets a closed rx.
+            pending.insert(
+                request.call_id,
+                Pending {
+                    chat_id: request.chat_id,
+                    tx,
+                },
+            );
+        }
+        match rx.await {
+            Ok(decision) => decision,
+            // Turn dropped / broker cleared without a decision → reject.
+            Err(_) => ApprovalDecision::Reject {
+                reason: "approval cancelled".into(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::{ApprovalClass, ApprovalGate, TurnId};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn approve_unparks_the_waiter() {
+        let broker = Arc::new(ApprovalBroker::new());
+        let chat_id = ChatId::new();
+        let call_id = CallId::new();
+        let gate = broker.clone() as Arc<dyn ApprovalGate>;
+        let waiter = tokio::spawn(async move {
+            gate.decide(ApprovalRequest {
+                call_id,
+                chat_id,
+                turn_id: TurnId::new(),
+                tool_name: "shell".into(),
+                class: ApprovalClass::Sensitive,
+                summary: "run shell".into(),
+            })
+            .await
+        });
+        // Yield so the waiter parks.
+        tokio::task::yield_now().await;
+        broker
+            .resolve(chat_id, call_id, ApprovalDecision::Approve)
+            .unwrap();
+        assert_eq!(waiter.await.unwrap(), ApprovalDecision::Approve);
+    }
+
+    #[tokio::test]
+    async fn wrong_chat_is_refused() {
+        let broker = Arc::new(ApprovalBroker::new());
+        let chat_id = ChatId::new();
+        let other = ChatId::new();
+        let call_id = CallId::new();
+        let gate = broker.clone() as Arc<dyn ApprovalGate>;
+        let _waiter = tokio::spawn(async move {
+            gate.decide(ApprovalRequest {
+                call_id,
+                chat_id,
+                turn_id: TurnId::new(),
+                tool_name: "shell".into(),
+                class: ApprovalClass::Sensitive,
+                summary: "run".into(),
+            })
+            .await
+        });
+        tokio::task::yield_now().await;
+        assert_eq!(
+            broker.resolve(other, call_id, ApprovalDecision::Approve),
+            Err(DecideError::WrongChat)
+        );
+    }
+}

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -1,20 +1,21 @@
 //! In-process approval broker: parks Sensitive tool calls until a decision.
 //!
-//! The agent awaits [`ApprovalGate::decide`](openwave_core::ApprovalGate); this
-//! broker fulfills that by parking on a oneshot keyed by `call_id`. The HTTP
-//! handler (`POST /chats/{id}/approvals/{call_id}`) resolves the oneshot.
-//! Pending entries are dropped when the turn finishes without a decision
-//! (channel closed → reject).
+//! The agent arms this gate (registering a oneshot keyed by `call_id`) *before*
+//! emitting `ApprovalRequired`, then awaits the future. The HTTP handler
+//! (`POST /chats/{id}/approvals/{call_id}`) resolves the oneshot. Pending
+//! entries are dropped when the turn finishes without a decision (channel
+//! closed → reject).
 
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use async_trait::async_trait;
 use tokio::sync::oneshot;
 
-use openwave_core::{ApprovalDecision, ApprovalGate, ApprovalRequest, CallId, ChatId};
+use openwave_core::{
+    ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalRequest, CallId, ChatId,
+};
 
-/// Parks Sensitive tool calls until `decide` is called from the HTTP surface.
+/// Parks Sensitive tool calls until `resolve` is called from the HTTP surface.
 #[derive(Default)]
 pub struct ApprovalBroker {
     pending: Mutex<HashMap<CallId, Pending>>,
@@ -55,7 +56,7 @@ impl ApprovalBroker {
     }
 }
 
-/// Why a decide call failed.
+/// Why a resolve call failed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecideError {
     /// No parked call with that id (already decided, never parked, or turn ended).
@@ -64,9 +65,8 @@ pub enum DecideError {
     WrongChat,
 }
 
-#[async_trait]
 impl ApprovalGate for ApprovalBroker {
-    async fn decide(&self, request: ApprovalRequest) -> ApprovalDecision {
+    fn arm(&self, request: ApprovalRequest) -> ApprovalFuture<'_> {
         let (tx, rx) = oneshot::channel();
         {
             let mut pending = self.pending.lock().unwrap();
@@ -80,13 +80,17 @@ impl ApprovalGate for ApprovalBroker {
                 },
             );
         }
-        match rx.await {
-            Ok(decision) => decision,
-            // Turn dropped / broker cleared without a decision → reject.
-            Err(_) => ApprovalDecision::Reject {
-                reason: "approval cancelled".into(),
-            },
-        }
+        // Entry is registered *before* this future is returned, so the agent
+        // can safely emit ApprovalRequired and a client can resolve immediately.
+        Box::pin(async move {
+            match rx.await {
+                Ok(decision) => decision,
+                // Turn dropped / broker cleared without a decision → reject.
+                Err(_) => ApprovalDecision::Reject {
+                    reason: "approval cancelled".into(),
+                },
+            }
+        })
     }
 }
 
@@ -102,23 +106,19 @@ mod tests {
         let chat_id = ChatId::new();
         let call_id = CallId::new();
         let gate = broker.clone() as Arc<dyn ApprovalGate>;
-        let waiter = tokio::spawn(async move {
-            gate.decide(ApprovalRequest {
-                call_id,
-                chat_id,
-                turn_id: TurnId::new(),
-                tool_name: "shell".into(),
-                class: ApprovalClass::Sensitive,
-                summary: "run shell".into(),
-            })
-            .await
+        let pending = gate.arm(ApprovalRequest {
+            call_id,
+            chat_id,
+            turn_id: TurnId::new(),
+            tool_name: "shell".into(),
+            class: ApprovalClass::Sensitive,
+            summary: "run shell".into(),
         });
-        // Yield so the waiter parks.
-        tokio::task::yield_now().await;
+        // Resolvable immediately after arm — before the waiter is polled.
         broker
             .resolve(chat_id, call_id, ApprovalDecision::Approve)
             .unwrap();
-        assert_eq!(waiter.await.unwrap(), ApprovalDecision::Approve);
+        assert_eq!(pending.await, ApprovalDecision::Approve);
     }
 
     #[tokio::test]
@@ -128,21 +128,37 @@ mod tests {
         let other = ChatId::new();
         let call_id = CallId::new();
         let gate = broker.clone() as Arc<dyn ApprovalGate>;
-        let _waiter = tokio::spawn(async move {
-            gate.decide(ApprovalRequest {
-                call_id,
-                chat_id,
-                turn_id: TurnId::new(),
-                tool_name: "shell".into(),
-                class: ApprovalClass::Sensitive,
-                summary: "run".into(),
-            })
-            .await
+        let _pending = gate.arm(ApprovalRequest {
+            call_id,
+            chat_id,
+            turn_id: TurnId::new(),
+            tool_name: "shell".into(),
+            class: ApprovalClass::Sensitive,
+            summary: "run".into(),
         });
-        tokio::task::yield_now().await;
         assert_eq!(
             broker.resolve(other, call_id, ApprovalDecision::Approve),
             Err(DecideError::WrongChat)
         );
+    }
+
+    #[tokio::test]
+    async fn arm_makes_call_resolvable_before_await() {
+        // Regression for the emit-before-park race: after arm returns, resolve
+        // must succeed even if the waiter hasn't been polled yet.
+        let broker = ApprovalBroker::new();
+        let chat_id = ChatId::new();
+        let call_id = CallId::new();
+        let _pending = broker.arm(ApprovalRequest {
+            call_id,
+            chat_id,
+            turn_id: TurnId::new(),
+            tool_name: "shell".into(),
+            class: ApprovalClass::Sensitive,
+            summary: "run".into(),
+        });
+        assert!(broker
+            .resolve(chat_id, call_id, ApprovalDecision::Approve)
+            .is_ok());
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -11,6 +11,7 @@
 //! `WS /chats/{id}/events` to watch it — journaled events are replayed on connect
 //! and then streamed live (snapshot → replay → live).
 
+mod approvals;
 mod auth;
 mod bus;
 mod error;
@@ -73,6 +74,10 @@ pub fn app(state: AppState) -> Router {
             axum::routing::put(routes::put_api_key).delete(routes::delete_api_key),
         )
         .route("/chats/{id}/messages", post(routes::post_message))
+        .route(
+            "/chats/{id}/approvals/{call_id}",
+            post(routes::post_approval),
+        )
         .route("/chats/{id}/events", get(routes::chat_events))
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
@@ -198,8 +203,9 @@ mod tests {
     use axum::http::{header, Request, StatusCode};
     use futures::stream::{self, BoxStream, StreamExt};
     use openwave_core::{
-        AgentErrorInfo, AgentEvent, Chat, ChatId, ChatRequest, ModelProvider, Project, ProjectId,
-        ProviderEvent, ProviderId, SecretProvider, SequencedEvent, StopReason, Usage,
+        AgentErrorInfo, AgentEvent, ApprovalClass, Chat, ChatId, ChatRequest, ModelProvider,
+        Project, ProjectId, ProviderEvent, ProviderId, SecretProvider, SequencedEvent, StopReason,
+        Tool, ToolCtx, ToolOutput, ToolSpec, Usage,
     };
     use resolver::ProviderResolver;
     use serde::de::DeserializeOwned;
@@ -1506,6 +1512,177 @@ mod tests {
             events.last().unwrap().event,
             AgentEvent::TurnFailed { .. }
         ));
+    }
+
+    /// Sensitive tool that records whether it ran.
+    struct SensitiveProbe {
+        ran: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for SensitiveProbe {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: "probe".into(),
+                description: "sensitive probe".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::Sensitive
+        }
+        async fn execute(
+            &self,
+            _ctx: &ToolCtx,
+            _args: serde_json::Value,
+        ) -> openwave_core::Result<ToolOutput> {
+            self.ran.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(ToolOutput::text("probed"))
+        }
+    }
+
+    /// Provider that asks for `probe` once, then finishes.
+    struct ProbeProvider {
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for ProbeProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("probe")
+        }
+        async fn stream(
+            &self,
+            _req: ChatRequest,
+        ) -> openwave_core::Result<BoxStream<'static, ProviderEvent>> {
+            let events = if self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "call_probe".into(),
+                        name: "probe".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: "{}".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta {
+                        text: "done".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn approval_endpoint_unparks_a_sensitive_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let ran = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let tools =
+            Arc::new(ToolRegistry::new().with(Box::new(SensitiveProbe { ran: ran.clone() })));
+        let state = AppState::new(
+            Config::desktop(dir.path()),
+            store.clone(),
+            Arc::new(FixedResolver(Arc::new(ProbeProvider {
+                calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            }))),
+            Arc::new(MemSecrets::default()),
+            tools,
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        );
+        let token = state.token.clone();
+        let router = app(state);
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "probe it").await,
+            StatusCode::ACCEPTED
+        );
+
+        // Wait until the turn parks on ApprovalRequired.
+        let call_id = {
+            let mut found = None;
+            for _ in 0..200 {
+                let events = store.list_events(chat.id, 0).await.unwrap();
+                if let Some(id) = events.iter().find_map(|e| match &e.event {
+                    AgentEvent::ApprovalRequired { call_id, .. } => Some(*call_id),
+                    _ => None,
+                }) {
+                    found = Some(id);
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            found.expect("turn should park on ApprovalRequired")
+        };
+        assert_eq!(ran.load(std::sync::atomic::Ordering::SeqCst), 0);
+
+        // Approve via the HTTP endpoint.
+        let decide = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/chats/{}/approvals/{call_id}", chat.id))
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"decision": "approve"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(decide.status(), StatusCode::NO_CONTENT);
+
+        let events = wait_for_turn(&store, chat.id).await;
+        assert!(events
+            .iter()
+            .any(|e| matches!(e.event, AgentEvent::ApprovalDecided { approved: true, .. })));
+        assert_eq!(ran.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert!(matches!(
+            events.last().unwrap().event,
+            AgentEvent::TurnCompleted { .. }
+        ));
+
+        // A second decide for the same call is 404 (already resolved).
+        let again = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/chats/{}/approvals/{call_id}", chat.id))
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"decision": "approve"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(again.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -14,7 +14,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{
-    Agent, Chat, ChatId, Project, ProjectId, SecretProvider, SequencedEvent, Store,
+    Agent, ApprovalDecision, CallId, Chat, ChatId, Project, ProjectId, SecretProvider,
+    SequencedEvent, Store,
 };
 
 use crate::error::ServerError;
@@ -444,7 +445,8 @@ pub async fn post_message(
         state.tools.clone(),
         state.store.clone(),
         agent_config,
-    );
+    )
+    .with_approvals(state.approvals.clone());
     let store = state.store.clone();
     let events = state.events.clone();
     tokio::spawn(async move {
@@ -454,6 +456,57 @@ pub async fn post_message(
     });
 
     Ok(StatusCode::ACCEPTED)
+}
+
+/// Body of `POST /chats/{id}/approvals/{call_id}`.
+#[derive(Debug, Deserialize)]
+pub struct ApprovalBody {
+    /// `approve` or `reject`.
+    pub decision: ApprovalChoice,
+    /// Optional reject reason (ignored on approve).
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Wire form of an approval decision.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalChoice {
+    Approve,
+    Reject,
+}
+
+/// `POST /chats/{id}/approvals/{call_id}` — decide a parked Sensitive tool call.
+///
+/// `204` on success. `404` if the chat or call isn't pending. The turn stays
+/// holding its slot until it finishes after the decision.
+pub async fn post_approval(
+    State(state): State<AppState>,
+    Path((chat_id, call_id)): Path<(ChatId, CallId)>,
+    Json(body): Json<ApprovalBody>,
+) -> Result<StatusCode, ServerError> {
+    // Confirm the chat exists so a typo'd id doesn't look like "not pending".
+    if state.store.get_chat(chat_id).await?.is_none() {
+        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
+    }
+    let decision = match body.decision {
+        ApprovalChoice::Approve => ApprovalDecision::Approve,
+        ApprovalChoice::Reject => ApprovalDecision::Reject {
+            reason: body
+                .reason
+                .filter(|r| !r.is_empty())
+                .unwrap_or_else(|| "user denied approval".into()),
+        },
+    };
+    match state.approvals.resolve(chat_id, call_id, decision) {
+        Ok(()) => Ok(StatusCode::NO_CONTENT),
+        Err(crate::approvals::DecideError::NotPending) => Err(ServerError::not_found(format!(
+            "no pending approval for call {call_id}"
+        ))),
+        Err(crate::approvals::DecideError::WrongChat) => Err(ServerError::not_found(format!(
+            "no pending approval for call {call_id}"
+        ))),
+    }
 }
 
 /// Query for `GET /chats/{id}/events`.

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use openwave_core::{AgentConfig, ChatId, Config, SecretProvider, Store, ToolRegistry};
 use uuid::Uuid;
 
+use crate::approvals::ApprovalBroker;
 use crate::bus::EventBus;
 use crate::resolver::ProviderResolver;
 
@@ -35,6 +36,8 @@ pub struct AppState {
     pub active_turns: Arc<TurnGuard>,
     /// Live fan-out of turn events to connected WebSocket clients.
     pub events: Arc<EventBus>,
+    /// Parks Sensitive tool calls until `POST .../approvals/{call_id}` decides.
+    pub approvals: Arc<ApprovalBroker>,
 }
 
 impl AppState {
@@ -57,6 +60,7 @@ impl AppState {
             token: Uuid::new_v4().to_string().into(),
             active_turns: Arc::new(TurnGuard::default()),
             events: Arc::new(EventBus::default()),
+            approvals: Arc::new(ApprovalBroker::new()),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add an `ApprovalGate` seam in core: Sensitive tools emit `ApprovalRequired`, await a decision, then emit `ApprovalDecided` before running or returning an error result. Default `RefuseGate` keeps fail-closed behavior when no gate is wired.
- Server `ApprovalBroker` parks on a oneshot keyed by `call_id`. `POST /chats/{id}/approvals/{call_id}` with `{ "decision": "approve" | "reject", "reason"? }` resolves it; the turn keeps its slot until it finishes.
- Standing grants, auto-judge, Workspace-outside policy, and durable pending rows are deferred.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] Manual: register a Sensitive tool, start a turn, confirm WS shows `approval_required`, `POST .../approvals/{call_id}` with approve resumes and completes the tool
