### PR TITLE
feat: cancel a running turn

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -20,10 +20,12 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use futures::channel::mpsc::UnboundedSender;
+use futures::future::{self, Either};
 use futures::StreamExt;
 use serde_json::Value;
 
 use crate::approval::{ApprovalDecision, ApprovalGate, ApprovalRequest, RefuseGate};
+use crate::cancel::CancelToken;
 use crate::error::{AgentError, Result};
 use crate::event::AgentEvent;
 use crate::id::{CallId, MessageId, TurnId};
@@ -121,6 +123,7 @@ pub struct Agent {
     store: Arc<dyn Store>,
     config: AgentConfig,
     approvals: Arc<dyn ApprovalGate>,
+    cancel: CancelToken,
 }
 
 /// A tool call accumulated from the provider stream.
@@ -148,6 +151,7 @@ impl Agent {
             store,
             config,
             approvals: Arc::new(RefuseGate),
+            cancel: CancelToken::new(),
         }
     }
 
@@ -155,6 +159,14 @@ impl Agent {
     #[must_use]
     pub fn with_approvals(mut self, gate: Arc<dyn ApprovalGate>) -> Self {
         self.approvals = gate;
+        self
+    }
+
+    /// Watch `cancel` so the turn can be stopped early. Without this the turn
+    /// runs to completion (the default token is never tripped).
+    #[must_use]
+    pub fn with_cancel(mut self, cancel: CancelToken) -> Self {
+        self.cancel = cancel;
         self
     }
 
@@ -198,6 +210,11 @@ impl Agent {
         let mut total_usage = Usage::default();
 
         for step in 0..self.config.max_steps {
+            // Between steps: stop before starting a fresh model call if cancelled.
+            if self.cancel.is_cancelled() {
+                return self.finish_cancelled(events, total_usage);
+            }
+
             let request = ChatRequest {
                 model: self.config.model.clone(),
                 system: self.config.system_prompt.clone(),
@@ -213,7 +230,15 @@ impl Agent {
             let mut by_index: HashMap<u32, usize> = HashMap::new();
             let mut stop_reason = StopReason::EndTurn;
 
-            while let Some(event) = stream.next().await {
+            // Race each stream item against cancellation so a long or hung model
+            // call is preempted promptly. On cancel we discard this step's
+            // partial output — nothing from it has been persisted yet.
+            let cancelled = loop {
+                let event = match future::select(stream.next(), self.cancel.cancelled()).await {
+                    Either::Left((Some(event), _)) => event,
+                    Either::Left((None, _)) => break false,
+                    Either::Right(((), _)) => break true,
+                };
                 match event {
                     ProviderEvent::TextDelta { text: delta } => {
                         let _ = events.unbounded_send(AgentEvent::TextDelta {
@@ -250,6 +275,9 @@ impl Agent {
                     ProviderEvent::Usage(reported) => total_usage += reported,
                     ProviderEvent::Stop { reason } => stop_reason = reason,
                 }
+            };
+            if cancelled {
+                return self.finish_cancelled(events, total_usage);
             }
 
             // Record the assistant message (text + any tool-use blocks).
@@ -303,6 +331,11 @@ impl Agent {
                     content: output.content,
                     is_error: output.is_error,
                 });
+                // A cancel that arrived during this tool (including while it was
+                // parked on approval) stops the turn before the next model call.
+                if self.cancel.is_cancelled() {
+                    return self.finish_cancelled(events, total_usage);
+                }
             }
             // Tool results ride in a user-role message (the Messages convention).
             transcript.push(ChatMessage {
@@ -312,6 +345,13 @@ impl Agent {
         }
 
         Err(AgentError::msg("max steps per turn exceeded"))
+    }
+
+    /// Emit the cancellation terminal event and end the turn as a (non-error)
+    /// success — the client asked for the stop, so it isn't a `TurnFailed`.
+    fn finish_cancelled(&self, events: &UnboundedSender<AgentEvent>, usage: Usage) -> Result<()> {
+        let _ = events.unbounded_send(AgentEvent::TurnCancelled { usage });
+        Ok(())
     }
 
     /// Resolve approval and execute one tool call, returning its output. Tool and
@@ -344,7 +384,20 @@ impl Agent {
                 class: ApprovalClass::Sensitive,
                 summary,
             });
-            let decision = pending.await;
+            // Race the decision against cancellation so a turn parked on approval
+            // can still be stopped. On cancel we close the approval card
+            // (`ApprovalDecided { approved: false }`) and return an error result;
+            // the loop's post-tool check then ends the turn as cancelled.
+            let decision = match future::select(pending, self.cancel.cancelled()).await {
+                Either::Left((decision, _)) => decision,
+                Either::Right(((), _)) => {
+                    let _ = events.unbounded_send(AgentEvent::ApprovalDecided {
+                        call_id: call.call_id,
+                        approved: false,
+                    });
+                    return ToolOutput::error("turn cancelled while awaiting approval");
+                }
+            };
             let approved = matches!(decision, ApprovalDecision::Approve);
             let _ = events.unbounded_send(AgentEvent::ApprovalDecided {
                 call_id: call.call_id,
@@ -796,6 +849,200 @@ mod tests {
             AgentEvent::ToolCallCompleted { output, .. }
                 if output.content == "boomed" && !output.is_error
         )));
+    }
+
+    /// Streams one text delta, then stalls forever — lets a test cancel mid-stream
+    /// at a known point (after the delta lands).
+    struct StallProvider;
+
+    #[async_trait]
+    impl ModelProvider for StallProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("stall")
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let head = stream::iter(vec![ProviderEvent::TextDelta {
+                text: "partial".into(),
+            }]);
+            Ok(head.chain(stream::pending()).boxed())
+        }
+    }
+
+    /// Gate that signals once a call is parked, then never resolves — so a test
+    /// can cancel a turn while it is genuinely waiting on approval.
+    struct SignalPendingGate {
+        armed: std::sync::Mutex<Option<futures::channel::oneshot::Sender<()>>>,
+    }
+
+    impl ApprovalGate for SignalPendingGate {
+        fn arm(&self, _request: ApprovalRequest) -> crate::approval::ApprovalFuture<'_> {
+            if let Some(tx) = self.armed.lock().unwrap().take() {
+                let _ = tx.send(());
+            }
+            Box::pin(future::pending())
+        }
+    }
+
+    async fn cancel_test_chat() -> (Arc<dyn Store>, Chat, tempfile::TempDir) {
+        let workspace = tempfile::tempdir().unwrap();
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            workspace_dir: workspace.path().to_path_buf(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        (store, chat, workspace)
+    }
+
+    #[tokio::test]
+    async fn cancel_before_the_turn_stops_before_any_model_call() {
+        let (store, chat, _workspace) = cancel_test_chat().await;
+
+        // A provider whose stream would panic the test if ever polled — proving
+        // the loop-top check short-circuits before the first model call.
+        let provider = FakeProvider {
+            calls: AtomicUsize::new(0),
+        };
+        let cancel = CancelToken::new();
+        cancel.cancel();
+        let agent = Agent::new(
+            Arc::new(provider),
+            Arc::new(ToolRegistry::new()),
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        )
+        .with_cancel(cancel);
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        // Only the lifecycle bookends: started → cancelled, no model work between.
+        assert!(matches!(
+            events.first(),
+            Some(AgentEvent::TurnStarted { .. })
+        ));
+        assert!(matches!(
+            events.last(),
+            Some(AgentEvent::TurnCancelled { .. })
+        ));
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::TextDelta { .. })));
+    }
+
+    #[tokio::test]
+    async fn cancel_mid_stream_preempts_the_model_call() {
+        let (store, chat, _workspace) = cancel_test_chat().await;
+
+        let cancel = CancelToken::new();
+        let agent = Agent::new(
+            Arc::new(StallProvider),
+            Arc::new(ToolRegistry::new()),
+            store.clone(),
+            AgentConfig {
+                model: "stall".into(),
+                ..Default::default()
+            },
+        )
+        .with_cancel(cancel.clone());
+
+        let (tx, mut rx) = unbounded();
+        let chat_id = chat.id;
+        let handle = tokio::spawn(async move {
+            let _ = agent.run_turn(&chat, "go", &tx).await;
+        });
+
+        // Cancel the instant the first delta lands; the stream then stalls, so
+        // only the cancel can end the turn.
+        let mut cancelled = false;
+        while let Some(event) = rx.next().await {
+            match event {
+                AgentEvent::TextDelta { text } if text == "partial" => cancel.cancel(),
+                AgentEvent::TurnCancelled { .. } => cancelled = true,
+                _ => {}
+            }
+        }
+        handle.await.unwrap();
+
+        assert!(cancelled, "a mid-stream cancel ends the turn as cancelled");
+        // The partial assistant text of the preempted step is discarded, not stored.
+        let roles: Vec<Role> = store
+            .list_messages(chat_id)
+            .await
+            .unwrap()
+            .iter()
+            .map(|m| m.role)
+            .collect();
+        assert_eq!(roles, vec![Role::User]);
+    }
+
+    #[tokio::test]
+    async fn cancel_unblocks_a_turn_parked_on_approval() {
+        let (store, chat, _workspace) = cancel_test_chat().await;
+
+        let (armed_tx, armed_rx) = futures::channel::oneshot::channel();
+        let gate = Arc::new(SignalPendingGate {
+            armed: std::sync::Mutex::new(Some(armed_tx)),
+        });
+        let ran = Arc::new(AtomicUsize::new(0));
+        let cancel = CancelToken::new();
+        let agent = Agent::new(
+            Arc::new(BoomProvider {
+                calls: AtomicUsize::new(0),
+            }),
+            Arc::new(ToolRegistry::new().with(Box::new(BoomTool { ran: ran.clone() }))),
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        )
+        .with_approvals(gate)
+        .with_cancel(cancel.clone());
+
+        let (tx, rx) = unbounded();
+        let handle = tokio::spawn(async move {
+            let _ = agent.run_turn(&chat, "go", &tx).await;
+        });
+
+        // Wait until the Sensitive call is genuinely parked, then cancel.
+        armed_rx.await.unwrap();
+        cancel.cancel();
+        handle.await.unwrap();
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert_eq!(ran.load(Ordering::SeqCst), 0, "the parked tool never runs");
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ApprovalRequired { .. })));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ApprovalDecided {
+                approved: false,
+                ..
+            }
+        )));
+        assert!(matches!(
+            events.last(),
+            Some(AgentEvent::TurnCancelled { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/cancel.rs
+++ b/crates/openwave-core/src/cancel.rs
@@ -1,0 +1,131 @@
+//! Cooperative turn cancellation.
+//!
+//! A [`CancelToken`] is the signal a running turn watches to stop early — the
+//! server hands one to each turn and trips it when the client asks to cancel
+//! (`POST /chats/{id}/cancel`). The agent loop checks it between steps and races
+//! it against the long waits (the provider stream, a parked approval), so a
+//! cancel takes effect promptly rather than only at the next natural boundary.
+//!
+//! Deliberately dependency-free: an [`AtomicBool`] for the level-triggered
+//! `is_cancelled` check plus a single [`AtomicWaker`] for the awaitable
+//! [`cancelled`](CancelToken::cancelled), so `openwave-core` needn't pull in a
+//! runtime for this. It is **single-consumer**: one turn task awaits a token at
+//! a time (the loop never races the token from two places at once).
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures::task::AtomicWaker;
+
+/// A shared, cloneable signal that a turn should stop.
+///
+/// Clones share one underlying flag, so cancelling any handle cancels them all.
+/// The default token is never cancelled — the agent uses it when no client-facing
+/// cancellation is wired, so `run_turn` behaves exactly as before.
+#[derive(Clone, Default)]
+pub struct CancelToken {
+    inner: Arc<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    cancelled: AtomicBool,
+    waker: AtomicWaker,
+}
+
+impl CancelToken {
+    /// A fresh, un-cancelled token.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Trip the token. Idempotent — calling it again is a no-op. Wakes a task
+    /// parked on [`cancelled`](Self::cancelled).
+    pub fn cancel(&self) {
+        self.inner.cancelled.store(true, Ordering::Release);
+        self.inner.waker.wake();
+    }
+
+    /// Whether the token has been cancelled. Cheap; use between loop steps.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::Acquire)
+    }
+
+    /// A future that resolves once the token is cancelled. Race it against a
+    /// long wait (e.g. `select`ed against the provider stream) to preempt it.
+    #[must_use]
+    pub fn cancelled(&self) -> Cancelled {
+        Cancelled {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+/// The future returned by [`CancelToken::cancelled`]. `Unpin`, so it can be
+/// dropped into [`futures::future::select`] without pinning.
+pub struct Cancelled {
+    inner: Arc<Inner>,
+}
+
+impl Future for Cancelled {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.inner.cancelled.load(Ordering::Acquire) {
+            return Poll::Ready(());
+        }
+        // Register before the second check so a cancel racing this poll can't
+        // slip between the load and the park without waking us.
+        self.inner.waker.register(cx.waker());
+        if self.inner.cancelled.load(Ordering::Acquire) {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_token_is_not_cancelled() {
+        assert!(!CancelToken::new().is_cancelled());
+    }
+
+    #[test]
+    fn clones_share_the_flag() {
+        let token = CancelToken::new();
+        let clone = token.clone();
+        token.cancel();
+        assert!(clone.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cancelled_future_resolves_when_tripped() {
+        let token = CancelToken::new();
+        let waiter = token.cancelled();
+        token.cancel();
+        // Already tripped, so this returns immediately rather than hanging.
+        waiter.await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_future_wakes_a_parked_waiter() {
+        let token = CancelToken::new();
+        let waiter = token.cancelled();
+        let clone = token.clone();
+        // Trip the token from another task while the waiter is parked.
+        let trip = tokio::spawn(async move {
+            clone.cancel();
+        });
+        waiter.await;
+        trip.await.unwrap();
+    }
+}

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -91,6 +91,13 @@ pub enum AgentEvent {
         /// The serializable error description.
         error: AgentErrorInfo,
     },
+    /// The turn was cancelled at the client's request and stopped early. A
+    /// distinct terminal outcome from `TurnCompleted`/`TurnFailed` so the UI can
+    /// show "stopped" rather than success or error.
+    TurnCancelled {
+        /// Token accounting up to the point of cancellation.
+        usage: Usage,
+    },
 }
 
 /// An [`AgentEvent`] paired with its per-chat sequence number, as stored in

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod agent;
 pub mod approval;
+pub mod cancel;
 pub mod config;
 #[cfg(feature = "sqlite")]
 pub mod db;
@@ -34,6 +35,7 @@ pub use agent::{Agent, AgentConfig, ToolRegistry};
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalRequest, AutoApproveGate, RefuseGate,
 };
+pub use cancel::{CancelToken, Cancelled};
 pub use config::{Config, Profile};
 #[cfg(feature = "sqlite")]
 pub use db::DbStore;

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -76,6 +76,7 @@ pub fn app(state: AppState) -> Router {
             axum::routing::put(routes::put_api_key).delete(routes::delete_api_key),
         )
         .route("/chats/{id}/messages", post(routes::post_message))
+        .route("/chats/{id}/cancel", post(routes::post_cancel))
         .route(
             "/chats/{id}/approvals/{call_id}",
             post(routes::post_approval),
@@ -417,6 +418,23 @@ mod tests {
             .status()
     }
 
+    /// POST `/chats/{id}/cancel`, returning the response status.
+    async fn cancel_turn(router: &Router, bearer: &str, chat: ChatId) -> StatusCode {
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/chats/{chat}/cancel"))
+                    .header(header::AUTHORIZATION, bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+    }
+
     /// Poll the journal until the turn terminates (or time out), returning its
     /// events in sequence order.
     async fn wait_for_turn(store: &Arc<dyn Store>, chat: ChatId) -> Vec<SequencedEvent> {
@@ -425,7 +443,9 @@ mod tests {
             if events.iter().any(|e| {
                 matches!(
                     e.event,
-                    AgentEvent::TurnCompleted { .. } | AgentEvent::TurnFailed { .. }
+                    AgentEvent::TurnCompleted { .. }
+                        | AgentEvent::TurnFailed { .. }
+                        | AgentEvent::TurnCancelled { .. }
                 )
             }) {
                 return events;
@@ -433,6 +453,55 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         panic!("turn did not finish within the timeout");
+    }
+
+    #[tokio::test]
+    async fn cancel_stops_a_running_turn() {
+        // A turn that blocks in the provider (a stand-in for a long model call),
+        // so it stays running until we cancel it.
+        let gate = Arc::new(Notify::new());
+        let (router, token, store, _dir) =
+            test_app_with(Arc::new(GatedProvider { gate: gate.clone() })).await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "go").await,
+            StatusCode::ACCEPTED
+        );
+
+        // The slot is claimed synchronously before the turn is spawned, so a
+        // cancel arriving right after the 202 still finds the running turn.
+        assert_eq!(
+            cancel_turn(&router, &bearer, chat.id).await,
+            StatusCode::ACCEPTED
+        );
+
+        // The turn preempts the blocked provider call and ends as cancelled —
+        // note we never release `gate`, so only the cancel can end it.
+        let events = wait_for_turn(&store, chat.id).await;
+        assert!(matches!(
+            events.last().map(|e| &e.event),
+            Some(AgentEvent::TurnCancelled { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancel_without_a_running_turn_is_a_conflict_and_unknown_chat_is_404() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        // Known chat, nothing running → 409.
+        assert_eq!(
+            cancel_turn(&router, &bearer, chat.id).await,
+            StatusCode::CONFLICT
+        );
+        // Unknown chat → 404.
+        assert_eq!(
+            cancel_turn(&router, &bearer, ChatId::new()).await,
+            StatusCode::NOT_FOUND
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -447,7 +447,9 @@ pub async fn post_message(
         state.store.clone(),
         agent_config,
     )
-    .with_approvals(state.approvals.clone());
+    .with_approvals(state.approvals.clone())
+    // Watch the slot's token so `POST /chats/{id}/cancel` can stop this turn.
+    .with_cancel(active.cancel_token());
     let store = state.store.clone();
     let events = state.events.clone();
     tokio::spawn(async move {
@@ -457,6 +459,30 @@ pub async fn post_message(
     });
 
     Ok(StatusCode::ACCEPTED)
+}
+
+/// `POST /chats/{id}/cancel` — stop the turn currently running for a chat.
+///
+/// `202 Accepted` once the running turn has been signalled to stop; it winds down
+/// asynchronously and emits `TurnCancelled` as its terminal event (watch the
+/// event stream for it). `404` if the chat doesn't exist, `409` if no turn is
+/// currently running for it. Idempotent while a turn is winding down — a repeat
+/// cancel simply re-trips the already-tripped token.
+pub async fn post_cancel(
+    State(state): State<AppState>,
+    Path(id): Path<ChatId>,
+) -> Result<StatusCode, ServerError> {
+    // Distinguish "unknown chat" (404) from "known chat, nothing running" (409).
+    if state.store.get_chat(id).await?.is_none() {
+        return Err(ServerError::not_found(format!("chat {id} not found")));
+    }
+    if state.active_turns.cancel(id) {
+        Ok(StatusCode::ACCEPTED)
+    } else {
+        Err(ServerError::conflict(format!(
+            "chat {id} has no turn in progress"
+        )))
+    }
 }
 
 /// Body of `POST /chats/{id}/approvals/{call_id}`.

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -1,9 +1,11 @@
 //! Shared application state handed to every request handler.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use openwave_core::{AgentConfig, ChatId, Config, SecretProvider, Store, ToolRegistry};
+use openwave_core::{
+    AgentConfig, CancelToken, ChatId, Config, SecretProvider, Store, ToolRegistry,
+};
 use uuid::Uuid;
 
 use crate::approvals::ApprovalBroker;
@@ -65,14 +67,15 @@ impl AppState {
     }
 }
 
-/// Admits one running turn per chat.
+/// Admits one running turn per chat, and holds each running turn's
+/// [`CancelToken`] so a cancel request can find and trip it.
 ///
 /// The agent's per-chat sequence numbering assumes a single writer; this guard
 /// upholds that at the API edge — a turn holds its chat's slot until it finishes,
 /// and a concurrent request for the same chat is refused (never queued behind it).
 #[derive(Default)]
 pub struct TurnGuard {
-    active: Mutex<HashSet<ChatId>>,
+    active: Mutex<HashMap<ChatId, CancelToken>>,
 }
 
 impl TurnGuard {
@@ -80,13 +83,29 @@ impl TurnGuard {
     /// The returned [`ActiveTurn`] releases the slot when dropped — including on
     /// panic — so a failed turn never wedges the chat.
     pub fn try_acquire(self: &Arc<Self>, chat_id: ChatId) -> Option<ActiveTurn> {
-        if self.active.lock().unwrap().insert(chat_id) {
-            Some(ActiveTurn {
-                guard: Arc::clone(self),
-                chat_id,
-            })
-        } else {
-            None
+        let mut active = self.active.lock().unwrap();
+        if active.contains_key(&chat_id) {
+            return None;
+        }
+        let cancel = CancelToken::new();
+        active.insert(chat_id, cancel.clone());
+        Some(ActiveTurn {
+            guard: Arc::clone(self),
+            chat_id,
+            cancel,
+        })
+    }
+
+    /// Trip the cancel token of the turn running for `chat_id`, if any. Returns
+    /// whether a turn was found to cancel. Idempotent — a second cancel while the
+    /// turn winds down just re-trips the already-tripped token.
+    pub fn cancel(&self, chat_id: ChatId) -> bool {
+        match self.active.lock().unwrap().get(&chat_id) {
+            Some(token) => {
+                token.cancel();
+                true
+            }
+            None => false,
         }
     }
 }
@@ -95,6 +114,15 @@ impl TurnGuard {
 pub struct ActiveTurn {
     guard: Arc<TurnGuard>,
     chat_id: ChatId,
+    cancel: CancelToken,
+}
+
+impl ActiveTurn {
+    /// The cancel token for this turn — handed to the agent so a `POST .../cancel`
+    /// routed through [`TurnGuard::cancel`] stops it.
+    pub fn cancel_token(&self) -> CancelToken {
+        self.cancel.clone()
+    }
 }
 
 impl Drop for ActiveTurn {
@@ -125,5 +153,25 @@ mod tests {
             guard.try_acquire(chat).is_some(),
             "the slot frees once the turn is dropped"
         );
+    }
+
+    #[test]
+    fn cancel_trips_the_running_turns_token() {
+        let guard = Arc::new(TurnGuard::default());
+        let chat = ChatId::new();
+
+        // No turn running yet: nothing to cancel.
+        assert!(!guard.cancel(chat));
+
+        let held = guard.try_acquire(chat).expect("acquire");
+        let token = held.cancel_token();
+        assert!(!token.is_cancelled());
+
+        assert!(guard.cancel(chat), "a running turn is found and cancelled");
+        assert!(token.is_cancelled(), "the turn's own token is tripped");
+
+        // Once the slot frees, there's again nothing to cancel.
+        drop(held);
+        assert!(!guard.cancel(chat));
     }
 }


### PR DESCRIPTION
Adds cooperative cancellation so a client can stop a turn while it's running — the Stop button the chat UI needs, and a way to unwedge a turn that's parked waiting on a Sensitive-tool approval.

## Core: a cancel signal the loop watches
A small, dependency-free `CancelToken` (an `AtomicBool` for the cheap `is_cancelled()` check plus a single `AtomicWaker` for the awaitable `cancelled()` future — no new runtime dependency on the core crate). The agent watches one, tripped via a builder (`Agent::with_cancel`); the default token is never tripped, so an agent wired without cancellation behaves exactly as before.

The loop checks the token at three points, so a cancel lands promptly instead of only at the next natural boundary:
- **between steps** — before starting a fresh model call;
- **during the provider stream** — each stream item is raced against the token, so a long or hung model call is preempted;
- **during a parked approval** — the approval wait is raced too, so a turn stuck waiting on a human decision can still be stopped.

On cancel the turn emits a new terminal `TurnCancelled` event and ends as a (non-error) success — the client asked for it, so it isn't a `TurnFailed`. The preempted step's partial output is discarded (nothing half-formed is persisted); an in-flight tool runs to completion before the loop stops (tools are local and short — cooperative mid-tool cancellation is a follow-up).

## Server: route the signal to the running turn
`TurnGuard` already admits one turn per chat; it now also holds each running turn's token. `POST /chats/{id}/cancel` looks it up and trips it:
- `202 Accepted` once signalled (the turn winds down asynchronously and journals `TurnCancelled`);
- `409 Conflict` when the chat has no turn in progress;
- `404` for an unknown chat.

The slot — and thus the token — is claimed synchronously before the turn is spawned, so a cancel arriving right after the `202` from `POST .../messages` still finds the turn.

## Tests
- core: the token primitive (wake a parked waiter, clones share the flag) and all three loop paths — cancel before the turn (no model call happens), mid-stream (partial output discarded, nothing persisted), and parked-on-approval (the tool never runs, turn ends cancelled);
- server: `TurnGuard::cancel` trips the running turn's token; end-to-end `POST /cancel` stops a turn blocked in the provider; the 409/404 cases.

`cargo test --workspace`, `cargo clippy --workspace --all-targets`, and `cargo fmt --all --check` all pass.
