### PR TITLE
feat: mid-turn steer — inject a message into a running turn

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -33,6 +33,7 @@ use crate::model::{Chat, Message, Role};
 use crate::provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, StopReason, Usage,
 };
+use crate::steer::SteerInbox;
 use crate::storage::Store;
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 
@@ -124,6 +125,7 @@ pub struct Agent {
     config: AgentConfig,
     approvals: Arc<dyn ApprovalGate>,
     cancel: CancelToken,
+    steer: SteerInbox,
 }
 
 /// A tool call accumulated from the provider stream.
@@ -152,6 +154,7 @@ impl Agent {
             config,
             approvals: Arc::new(RefuseGate),
             cancel: CancelToken::new(),
+            steer: SteerInbox::new(),
         }
     }
 
@@ -167,6 +170,14 @@ impl Agent {
     #[must_use]
     pub fn with_cancel(mut self, cancel: CancelToken) -> Self {
         self.cancel = cancel;
+        self
+    }
+
+    /// Drain mid-turn steer messages from `steer`. Without this the turn ignores
+    /// any steer pushes (the default inbox stays empty).
+    #[must_use]
+    pub fn with_steer(mut self, steer: SteerInbox) -> Self {
+        self.steer = steer;
         self
     }
 
@@ -214,6 +225,9 @@ impl Agent {
             if self.cancel.is_cancelled() {
                 return self.finish_cancelled(events, total_usage);
             }
+            // Boundary steer: inject any queued messages before the next model call.
+            self.apply_steers(chat, turn_id, &mut transcript, events)
+                .await?;
 
             let request = ChatRequest {
                 model: self.config.model.clone(),
@@ -230,14 +244,25 @@ impl Agent {
             let mut by_index: HashMap<u32, usize> = HashMap::new();
             let mut stop_reason = StopReason::EndTurn;
 
-            // Race each stream item against cancellation so a long or hung model
-            // call is preempted promptly. On cancel we discard this step's
-            // partial output — nothing from it has been persisted yet.
-            let cancelled = loop {
-                let event = match future::select(stream.next(), self.cancel.cancelled()).await {
+            // Race each stream item against cancel and interrupt-steer so a long
+            // model call is preempted promptly. Cancel ends the turn; interrupt
+            // discards this step's partial output and continues after injecting.
+            enum StreamEnd {
+                Done,
+                Cancelled,
+                Steered,
+            }
+            let stream_end = loop {
+                let event = match future::select(
+                    stream.next(),
+                    future::select(self.cancel.cancelled(), self.steer.interrupted()),
+                )
+                .await
+                {
                     Either::Left((Some(event), _)) => event,
-                    Either::Left((None, _)) => break false,
-                    Either::Right(((), _)) => break true,
+                    Either::Left((None, _)) => break StreamEnd::Done,
+                    Either::Right((Either::Left(((), _)), _)) => break StreamEnd::Cancelled,
+                    Either::Right((Either::Right(((), _)), _)) => break StreamEnd::Steered,
                 };
                 match event {
                     ProviderEvent::TextDelta { text: delta } => {
@@ -276,8 +301,17 @@ impl Agent {
                     ProviderEvent::Stop { reason } => stop_reason = reason,
                 }
             };
-            if cancelled {
+            // Prefer cancel when both cancel and interrupt are ready (cancel is
+            // the left arm of the nested select). Also catch a cancel that raced
+            // the final stream event.
+            if matches!(stream_end, StreamEnd::Cancelled) || self.cancel.is_cancelled() {
                 return self.finish_cancelled(events, total_usage);
+            }
+            if matches!(stream_end, StreamEnd::Steered) {
+                // Discard this step's partial output — nothing from it was persisted.
+                self.apply_steers(chat, turn_id, &mut transcript, events)
+                    .await?;
+                continue;
             }
 
             // Record the assistant message (text + any tool-use blocks).
@@ -302,6 +336,14 @@ impl Agent {
             }
 
             if calls.is_empty() {
+                // A steer that arrived as the stream finished should continue the
+                // turn rather than report completion.
+                if self
+                    .apply_steers(chat, turn_id, &mut transcript, events)
+                    .await?
+                {
+                    continue;
+                }
                 let _ = events.unbounded_send(AgentEvent::TurnCompleted {
                     usage: total_usage,
                     stop_reason,
@@ -342,6 +384,9 @@ impl Agent {
                 role: Role::User,
                 content: results,
             });
+            // Boundary steer after tools — injected before the next model step.
+            self.apply_steers(chat, turn_id, &mut transcript, events)
+                .await?;
         }
 
         Err(AgentError::msg("max steps per turn exceeded"))
@@ -352,6 +397,35 @@ impl Agent {
     fn finish_cancelled(&self, events: &UnboundedSender<AgentEvent>, usage: Usage) -> Result<()> {
         let _ = events.unbounded_send(AgentEvent::TurnCancelled { usage });
         Ok(())
+    }
+
+    /// Drain the steer inbox into the transcript. Returns whether any messages
+    /// were injected. Emits [`AgentEvent::UserSteered`] per message.
+    async fn apply_steers(
+        &self,
+        chat: &Chat,
+        turn_id: TurnId,
+        transcript: &mut Vec<ChatMessage>,
+        events: &UnboundedSender<AgentEvent>,
+    ) -> Result<bool> {
+        let msgs = self.steer.drain();
+        if msgs.is_empty() {
+            return Ok(false);
+        }
+        for msg in msgs {
+            self.persist(chat.id, turn_id, Role::User, &msg.content)
+                .await?;
+            transcript.push(ChatMessage {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: msg.content.clone(),
+                }],
+            });
+            let _ = events.unbounded_send(AgentEvent::UserSteered {
+                content: msg.content,
+            });
+        }
+        Ok(true)
     }
 
     /// Resolve approval and execute one tool call, returning its output. Tool and
@@ -1112,6 +1186,137 @@ mod tests {
             events.last(),
             Some(AgentEvent::TurnCancelled { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn interrupt_steer_preempts_mid_stream_and_continues() {
+        let (store, chat, _workspace) = cancel_test_chat().await;
+
+        // First call stalls after "partial"; after steer, second call finishes.
+        struct StallThenFinish {
+            calls: AtomicUsize,
+        }
+        #[async_trait]
+        impl ModelProvider for StallThenFinish {
+            fn id(&self) -> ProviderId {
+                ProviderId::new("stall-then-finish")
+            }
+            async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+                if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    let head = stream::iter(vec![ProviderEvent::TextDelta {
+                        text: "partial".into(),
+                    }]);
+                    return Ok(head.chain(stream::pending()).boxed());
+                }
+                Ok(stream::iter(vec![
+                    ProviderEvent::TextDelta {
+                        text: "after steer".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ])
+                .boxed())
+            }
+        }
+
+        let steer = SteerInbox::new();
+        let agent = Agent::new(
+            Arc::new(StallThenFinish {
+                calls: AtomicUsize::new(0),
+            }),
+            Arc::new(ToolRegistry::new()),
+            store.clone(),
+            AgentConfig {
+                model: "stall".into(),
+                ..Default::default()
+            },
+        )
+        .with_steer(steer.clone());
+
+        let chat_id = chat.id;
+        let (tx, mut rx) = unbounded();
+        let handle = tokio::spawn(async move {
+            let _ = agent.run_turn(&chat, "go", &tx).await;
+        });
+
+        let mut steered = false;
+        let mut completed = false;
+        while let Some(event) = rx.next().await {
+            match event {
+                AgentEvent::TextDelta { text } if text == "partial" => {
+                    steer.push("please change course", true);
+                }
+                AgentEvent::UserSteered { content } => {
+                    assert_eq!(content, "please change course");
+                    steered = true;
+                }
+                AgentEvent::TurnCompleted { .. } => completed = true,
+                AgentEvent::TurnCancelled { .. } => {
+                    panic!("steer must continue the turn, not cancel it")
+                }
+                _ => {}
+            }
+        }
+        handle.await.unwrap();
+
+        assert!(steered, "steer event emitted");
+        assert!(completed, "turn completes after steer");
+        let roles: Vec<_> = store
+            .list_messages(chat_id)
+            .await
+            .unwrap()
+            .iter()
+            .map(|m| (m.role, m.content.clone()))
+            .collect();
+        // Initial user + steered user + final assistant (partial discarded).
+        assert!(roles.iter().any(|(r, c)| *r == Role::User && c == "go"));
+        assert!(roles
+            .iter()
+            .any(|(r, c)| *r == Role::User && c == "please change course"));
+        assert!(roles
+            .iter()
+            .any(|(r, c)| *r == Role::Assistant && c == "after steer"));
+        assert!(!roles.iter().any(|(_, c)| c == "partial"));
+    }
+
+    #[tokio::test]
+    async fn cancel_wins_over_steer_when_both_ready() {
+        let (store, chat, _workspace) = cancel_test_chat().await;
+
+        let cancel = CancelToken::new();
+        let steer = SteerInbox::new();
+        // Trip both before the turn starts racing the stream.
+        cancel.cancel();
+        steer.push("ignored", true);
+
+        let agent = Agent::new(
+            Arc::new(StallProvider),
+            Arc::new(ToolRegistry::new()),
+            store,
+            AgentConfig {
+                model: "stall".into(),
+                ..Default::default()
+            },
+        )
+        .with_cancel(cancel)
+        .with_steer(steer);
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert!(matches!(
+            events.last(),
+            Some(AgentEvent::TurnCancelled { .. })
+        ));
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::UserSteered { .. })),
+            "cancel must win; steer is not applied"
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -339,19 +339,29 @@ impl Agent {
             }
 
             if calls.is_empty() {
-                // A steer that arrived as the stream finished should continue the
-                // turn rather than report completion.
-                if self
-                    .apply_steers(chat, turn_id, &mut transcript, events)
-                    .await?
-                {
-                    continue;
+                // Drain steers until the inbox is quiet, then complete. A steer
+                // that arrives as the stream finished must continue the turn
+                // rather than race a TurnCompleted.
+                loop {
+                    if self.cancel.is_cancelled() {
+                        return self.finish_cancelled(events, total_usage);
+                    }
+                    if self
+                        .apply_steers(chat, turn_id, &mut transcript, events)
+                        .await?
+                    {
+                        break; // continue the outer step loop below
+                    }
+                    if self.steer.is_empty() {
+                        let _ = events.unbounded_send(AgentEvent::TurnCompleted {
+                            usage: total_usage,
+                            stop_reason,
+                        });
+                        return Ok(());
+                    }
+                    // Steer arrived between drain and is_empty — loop.
                 }
-                let _ = events.unbounded_send(AgentEvent::TurnCompleted {
-                    usage: total_usage,
-                    stop_reason,
-                });
-                return Ok(());
+                continue;
             }
 
             // Tool calls need a following model call to consume their results. If

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -308,7 +308,10 @@ impl Agent {
                 return self.finish_cancelled(events, total_usage);
             }
             if matches!(stream_end, StreamEnd::Steered) {
-                // Discard this step's partial output — nothing from it was persisted.
+                // Discard this step's partial output — nothing from it was
+                // persisted. The marker lets replay/live clients clear deltas
+                // that were already streamed for this abandoned provider step.
+                let _ = events.unbounded_send(AgentEvent::StreamInterrupted);
                 self.apply_steers(chat, turn_id, &mut transcript, events)
                     .await?;
                 continue;
@@ -1241,11 +1244,15 @@ mod tests {
         });
 
         let mut steered = false;
+        let mut interrupted = false;
         let mut completed = false;
         while let Some(event) = rx.next().await {
             match event {
                 AgentEvent::TextDelta { text } if text == "partial" => {
                     steer.push("please change course", true);
+                }
+                AgentEvent::StreamInterrupted => {
+                    interrupted = true;
                 }
                 AgentEvent::UserSteered { content } => {
                     assert_eq!(content, "please change course");
@@ -1260,6 +1267,10 @@ mod tests {
         }
         handle.await.unwrap();
 
+        assert!(
+            interrupted,
+            "interrupt steer marks the partial provider stream as abandoned"
+        );
         assert!(steered, "steer event emitted");
         assert!(completed, "turn completes after steer");
         let roles: Vec<_> = store

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -341,7 +341,9 @@ impl Agent {
             if calls.is_empty() {
                 // Drain steers until the inbox is quiet, then complete. A steer
                 // that arrives as the stream finished must continue the turn
-                // rather than race a TurnCompleted.
+                // rather than race a TurnCompleted. `try_complete` holds the
+                // queue lock across the empty-check and terminal emit so a
+                // concurrent push cannot 202 and then be orphaned.
                 loop {
                     if self.cancel.is_cancelled() {
                         return self.finish_cancelled(events, total_usage);
@@ -352,14 +354,15 @@ impl Agent {
                     {
                         break; // continue the outer step loop below
                     }
-                    if self.steer.is_empty() {
+                    if self.steer.try_complete(|| {
                         let _ = events.unbounded_send(AgentEvent::TurnCompleted {
                             usage: total_usage,
                             stop_reason,
                         });
+                    }) {
                         return Ok(());
                     }
-                    // Steer arrived between drain and is_empty — loop.
+                    // Steer arrived between drain and try_complete — loop.
                 }
                 continue;
             }

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -98,6 +98,13 @@ pub enum AgentEvent {
         /// Token accounting up to the point of cancellation.
         usage: Usage,
     },
+    /// A mid-turn steer message was injected into the running turn. The turn
+    /// continues (unlike `TurnCancelled`); the content is also persisted as a
+    /// user message.
+    UserSteered {
+        /// The steered user text.
+        content: String,
+    },
 }
 
 /// An [`AgentEvent`] paired with its per-chat sequence number, as stored in

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -41,6 +41,9 @@ pub enum AgentEvent {
         /// The reasoning fragment.
         text: String,
     },
+    /// The current provider stream was preempted and any partial assistant/tool
+    /// deltas since the last stable boundary should be discarded by clients.
+    StreamInterrupted,
     /// The model has begun a tool call; its name is known.
     ToolCallStarted {
         /// Correlates the following args deltas, approval, and result.

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod id;
 pub mod keychain;
 pub mod model;
 pub mod provider;
+pub mod steer;
 pub mod storage;
 pub mod tool;
 #[cfg(feature = "tools")]
@@ -49,6 +50,7 @@ pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
     Usage,
 };
+pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{BlobStore, SecretProvider, Store};
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/steer.rs
+++ b/crates/openwave-core/src/steer.rs
@@ -78,6 +78,12 @@ impl SteerInbox {
         self.inner.interrupt.load(Ordering::Acquire)
     }
 
+    /// Whether the inbox has no queued messages and no pending interrupt.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.queue.lock().unwrap().is_empty() && !self.interrupt_requested()
+    }
+
     /// A future that resolves once an interrupt is requested. Race it against the
     /// provider stream to preempt mid-step.
     #[must_use]

--- a/crates/openwave-core/src/steer.rs
+++ b/crates/openwave-core/src/steer.rs
@@ -6,9 +6,9 @@
 //! the same way cancel does — except the turn **continues** after injecting the
 //! message, rather than ending as [`TurnCancelled`](crate::AgentEvent::TurnCancelled).
 //!
-//! v1 scope: interrupt preempts the model stream only. A turn parked on approval
-//! or mid-`execute` queues the steer until the next boundary. Cancel still wins
-//! over steer when both are signalled.
+//! v1 scope: interrupt preempts the **model stream** only. A turn parked on
+//! approval or mid-`execute` queues the steer until the next boundary (cancel
+//! still unblocks approval). Cancel wins over steer when both are signalled.
 
 use std::collections::VecDeque;
 use std::future::Future;

--- a/crates/openwave-core/src/steer.rs
+++ b/crates/openwave-core/src/steer.rs
@@ -36,6 +36,9 @@ pub struct SteerInbox {
 struct Inner {
     queue: Mutex<VecDeque<SteerMessage>>,
     interrupt: AtomicBool,
+    /// Set when the turn is about to emit `TurnCompleted`, so a concurrent
+    /// [`SteerInbox::push`] cannot land a message that will never be drained.
+    sealed: AtomicBool,
     waker: AtomicWaker,
 }
 
@@ -48,20 +51,24 @@ impl SteerInbox {
 
     /// Enqueue a steer message. When `interrupt` is true, also trip the interrupt
     /// flag so a turn racing the provider stream can preempt promptly.
-    pub fn push(&self, content: impl Into<String>, interrupt: bool) {
+    ///
+    /// Returns `false` when the inbox has been sealed for turn completion (the
+    /// message is not queued).
+    pub fn push(&self, content: impl Into<String>, interrupt: bool) -> bool {
         let content = content.into();
         if content.is_empty() {
-            return;
+            return true;
         }
-        self.inner
-            .queue
-            .lock()
-            .unwrap()
-            .push_back(SteerMessage { content });
+        let mut queue = self.inner.queue.lock().unwrap();
+        if self.inner.sealed.load(Ordering::Acquire) {
+            return false;
+        }
+        queue.push_back(SteerMessage { content });
         if interrupt {
             self.inner.interrupt.store(true, Ordering::Release);
             self.inner.waker.wake();
         }
+        true
     }
 
     /// Drain every queued message (order preserved). Clears the interrupt flag.
@@ -82,6 +89,21 @@ impl SteerInbox {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.inner.queue.lock().unwrap().is_empty() && !self.interrupt_requested()
+    }
+
+    /// If the inbox is quiet, seal it and run `complete` so a concurrent
+    /// [`push`](Self::push) cannot land between the empty check and the terminal
+    /// event (which would 202 a steer that never gets applied).
+    /// Returns `true` when `complete` ran; `false` when the inbox was not empty.
+    pub fn try_complete<F: FnOnce()>(&self, complete: F) -> bool {
+        let queue = self.inner.queue.lock().unwrap();
+        if !queue.is_empty() || self.interrupt_requested() {
+            return false;
+        }
+        self.inner.sealed.store(true, Ordering::Release);
+        drop(queue);
+        complete();
+        true
     }
 
     /// A future that resolves once an interrupt is requested. Race it against the
@@ -140,13 +162,30 @@ mod tests {
         assert!(!inbox.interrupt_requested());
     }
 
+    #[test]
+    fn try_complete_seals_against_late_push() {
+        let inbox = SteerInbox::new();
+        assert!(inbox.try_complete(|| {}));
+        assert!(!inbox.push("too late", true));
+        assert!(inbox.drain().is_empty());
+    }
+
+    #[test]
+    fn try_complete_refuses_when_queue_has_work() {
+        let inbox = SteerInbox::new();
+        assert!(inbox.push("pending", false));
+        assert!(!inbox.try_complete(|| panic!("must not complete")));
+        assert_eq!(inbox.drain()[0].content, "pending");
+        assert!(inbox.push("after", false));
+    }
+
     #[tokio::test]
     async fn interrupted_future_resolves_on_interrupt_push() {
         let inbox = SteerInbox::new();
         let waiter = inbox.interrupted();
         let clone = inbox.clone();
         let push = tokio::spawn(async move {
-            clone.push("steer", true);
+            assert!(clone.push("steer", true));
         });
         waiter.await;
         push.await.unwrap();

--- a/crates/openwave-core/src/steer.rs
+++ b/crates/openwave-core/src/steer.rs
@@ -1,0 +1,149 @@
+//! Mid-turn steer — inject a user message into a running turn.
+//!
+//! A [`SteerInbox`] is the mailbox a running turn drains for steering input.
+//! The server pushes via `POST /chats/{id}/steer`; the agent loop consumes at
+//! step boundaries and (when `interrupt` is set) preempts the provider stream
+//! the same way cancel does — except the turn **continues** after injecting the
+//! message, rather than ending as [`TurnCancelled`](crate::AgentEvent::TurnCancelled).
+//!
+//! v1 scope: interrupt preempts the model stream only. A turn parked on approval
+//! or mid-`execute` queues the steer until the next boundary. Cancel still wins
+//! over steer when both are signalled.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use futures::task::AtomicWaker;
+
+/// One steer message waiting to be injected into the running turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SteerMessage {
+    /// User text to append to the transcript.
+    pub content: String,
+}
+
+/// Shared mailbox for mid-turn steering. Clones share one queue + interrupt flag.
+#[derive(Clone, Default)]
+pub struct SteerInbox {
+    inner: Arc<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    queue: Mutex<VecDeque<SteerMessage>>,
+    interrupt: AtomicBool,
+    waker: AtomicWaker,
+}
+
+impl SteerInbox {
+    /// An empty inbox.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enqueue a steer message. When `interrupt` is true, also trip the interrupt
+    /// flag so a turn racing the provider stream can preempt promptly.
+    pub fn push(&self, content: impl Into<String>, interrupt: bool) {
+        let content = content.into();
+        if content.is_empty() {
+            return;
+        }
+        self.inner
+            .queue
+            .lock()
+            .unwrap()
+            .push_back(SteerMessage { content });
+        if interrupt {
+            self.inner.interrupt.store(true, Ordering::Release);
+            self.inner.waker.wake();
+        }
+    }
+
+    /// Drain every queued message (order preserved). Clears the interrupt flag.
+    pub fn drain(&self) -> Vec<SteerMessage> {
+        let mut queue = self.inner.queue.lock().unwrap();
+        let out: Vec<_> = queue.drain(..).collect();
+        self.inner.interrupt.store(false, Ordering::Release);
+        out
+    }
+
+    /// Whether an interrupt has been requested (level-triggered until [`drain`]).
+    #[must_use]
+    pub fn interrupt_requested(&self) -> bool {
+        self.inner.interrupt.load(Ordering::Acquire)
+    }
+
+    /// A future that resolves once an interrupt is requested. Race it against the
+    /// provider stream to preempt mid-step.
+    #[must_use]
+    pub fn interrupted(&self) -> Interrupted {
+        Interrupted {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+/// Future returned by [`SteerInbox::interrupted`].
+pub struct Interrupted {
+    inner: Arc<Inner>,
+}
+
+impl Future for Interrupted {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.inner.interrupt.load(Ordering::Acquire) {
+            return Poll::Ready(());
+        }
+        self.inner.waker.register(cx.waker());
+        if self.inner.interrupt.load(Ordering::Acquire) {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_and_drain_preserves_order() {
+        let inbox = SteerInbox::new();
+        inbox.push("one", false);
+        inbox.push("two", false);
+        let msgs = inbox.drain();
+        assert_eq!(
+            msgs.iter().map(|m| m.content.as_str()).collect::<Vec<_>>(),
+            vec!["one", "two"]
+        );
+        assert!(inbox.drain().is_empty());
+    }
+
+    #[test]
+    fn empty_content_is_ignored() {
+        let inbox = SteerInbox::new();
+        inbox.push("", true);
+        assert!(inbox.drain().is_empty());
+        assert!(!inbox.interrupt_requested());
+    }
+
+    #[tokio::test]
+    async fn interrupted_future_resolves_on_interrupt_push() {
+        let inbox = SteerInbox::new();
+        let waiter = inbox.interrupted();
+        let clone = inbox.clone();
+        let push = tokio::spawn(async move {
+            clone.push("steer", true);
+        });
+        waiter.await;
+        push.await.unwrap();
+        assert_eq!(inbox.drain()[0].content, "steer");
+    }
+}

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -132,12 +132,23 @@ export default function App() {
       const text = assistantBufRef.current;
       setMessages((prev) => {
         const copy = [...prev];
-        for (let i = copy.length - 1; i >= 0; i -= 1) {
-          const msg = copy[i];
-          if (msg.role === "assistant") {
-            copy[i] = { id: msg.id, role: "assistant", text };
-            break;
-          }
+        const last = copy[copy.length - 1];
+        if (last?.role === "assistant") {
+          copy[copy.length - 1] = { id: last.id, role: "assistant", text };
+        } else {
+          copy.push({ id: nextId(), role: "assistant", text });
+        }
+        return copy;
+      });
+      return;
+    }
+
+    if (event.type === "stream_interrupted") {
+      assistantBufRef.current = "";
+      setMessages((prev) => {
+        const copy = [...prev];
+        if (copy[copy.length - 1]?.role === "assistant") {
+          copy.pop();
         }
         return copy;
       });

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -169,8 +169,25 @@ export default function App() {
       return;
     }
 
+    if (event.type === "user_steered") {
+      setMessages((prev) => [
+        ...prev,
+        { id: nextId(), role: "user", text: event.content },
+      ]);
+      return;
+    }
+
     if (event.type === "turn_completed") {
       setBusy(false);
+      return;
+    }
+
+    if (event.type === "turn_cancelled") {
+      setBusy(false);
+      setMessages((prev) => [
+        ...prev,
+        { id: nextId(), role: "system", text: "turn cancelled" },
+      ]);
       return;
     }
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -48,7 +48,9 @@ export type AgentEvent =
   | { type: "approval_decided"; call_id: string; approved: boolean }
   | { type: "tool_call_completed"; call_id: string; output: unknown }
   | { type: "turn_completed"; usage: unknown; stop_reason: string }
-  | { type: "turn_failed"; error: { kind: string; message: string } };
+  | { type: "turn_failed"; error: { kind: string; message: string } }
+  | { type: "turn_cancelled"; usage: unknown }
+  | { type: "user_steered"; content: string };
 
 const WS_HANDSHAKE = "openwave-v1";
 const WS_TOKEN_PREFIX = "openwave-token.";
@@ -139,6 +141,25 @@ export class ApiClient {
       method: "POST",
       headers: this.headers(true),
       body: JSON.stringify({ content }),
+    });
+  }
+
+  steer(
+    chatId: string,
+    content: string,
+    interrupt = false,
+  ): Promise<void> {
+    return this.json(`/chats/${chatId}/steer`, {
+      method: "POST",
+      headers: this.headers(true),
+      body: JSON.stringify({ content, interrupt }),
+    });
+  }
+
+  cancel(chatId: string): Promise<void> {
+    return this.json(`/chats/${chatId}/cancel`, {
+      method: "POST",
+      headers: this.headers(),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -37,6 +37,7 @@ export type AgentEvent =
   | { type: "turn_started"; turn_id: string }
   | { type: "text_delta"; text: string }
   | { type: "reasoning_delta"; text: string }
+  | { type: "stream_interrupted" }
   | { type: "tool_call_started"; call_id: string; name: string }
   | { type: "tool_call_args_delta"; call_id: string; fragment: string }
   | {

--- a/crates/openwave-server/src/hub.rs
+++ b/crates/openwave-server/src/hub.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 
 use futures::channel::mpsc::unbounded;
-use futures::{future, StreamExt};
+use futures::StreamExt;
 
 use openwave_core::{Agent, Chat, SequencedEvent, Store};
 
@@ -24,9 +24,8 @@ use crate::state::ActiveTurn;
 /// on the bus — as the turn produces them. Returns once the turn has finished and
 /// every event is persisted.
 ///
-/// The [`ActiveTurn`] slot is released as soon as `run_turn` returns (before the
-/// journal finishes draining), so a late `POST .../steer` gets `409` rather than
-/// a silent `202` with nowhere to deliver.
+/// The [`ActiveTurn`] slot is held until the agent has returned and the journal
+/// has drained, so the next turn cannot race this turn's sequence assignment.
 pub(crate) async fn drive_and_journal(
     agent: Agent,
     chat: Chat,
@@ -53,14 +52,11 @@ pub(crate) async fn drive_and_journal(
         }
     };
 
-    let drive = async move {
-        // Hold the slot only while the agent is running; drop it before the
-        // journal finishes so cancel/steer stop accepting once the turn ends.
-        let _active = active;
-        // Dropping `events_tx` at the end of this future closes the channel,
-        // which ends the journal loop.
-        let _ = agent.run_turn(&chat, &input, &events_tx).await;
-    };
-
-    future::join(drive, journal).await;
+    // Hold the slot across both phases. Dropping `events_tx` closes the channel,
+    // then awaiting the journal guarantees every queued event has its seq before
+    // another turn for this chat can start.
+    let _active = active;
+    let _ = agent.run_turn(&chat, &input, &events_tx).await;
+    drop(events_tx);
+    journal.await;
 }

--- a/crates/openwave-server/src/hub.rs
+++ b/crates/openwave-server/src/hub.rs
@@ -57,6 +57,9 @@ pub(crate) async fn drive_and_journal(
     // another turn for this chat can start.
     let _active = active;
     let _ = agent.run_turn(&chat, &input, &events_tx).await;
+    // Agent is done — refuse further cancel/steer (would be 202-with-no-effect)
+    // while the slot stays held for journal drain / seq safety.
+    _active.close_ingress();
     drop(events_tx);
     journal.await;
 }

--- a/crates/openwave-server/src/hub.rs
+++ b/crates/openwave-server/src/hub.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 
 use futures::channel::mpsc::unbounded;
+use futures::future::{self, Either};
 use futures::StreamExt;
 
 use openwave_core::{Agent, Chat, SequencedEvent, Store};
@@ -21,11 +22,13 @@ use crate::state::ActiveTurn;
 /// it to the live bus.
 ///
 /// The drive and the journal run concurrently, so events land in the store — and
-/// on the bus — as the turn produces them. Returns once the turn has finished and
-/// every event is persisted.
+/// on the bus — as the turn produces them (including while parked on approval).
+/// Returns once the turn has finished and every event is persisted.
 ///
-/// The [`ActiveTurn`] slot is held until the agent has returned and the journal
+/// The [`ActiveTurn`] slot is held until the agent has returned *and* the journal
 /// has drained, so the next turn cannot race this turn's sequence assignment.
+/// Cancel/steer ingress closes as soon as the agent returns, so late POSTs get
+/// `409` rather than a silent `202` during journal drain.
 pub(crate) async fn drive_and_journal(
     agent: Agent,
     chat: Chat,
@@ -52,14 +55,27 @@ pub(crate) async fn drive_and_journal(
         }
     };
 
-    // Hold the slot across both phases. Dropping `events_tx` closes the channel,
-    // then awaiting the journal guarantees every queued event has its seq before
-    // another turn for this chat can start.
+    // Hold the slot across both phases. Drive and journal run together so a
+    // turn parked on approval still journals `ApprovalRequired` live.
     let _active = active;
-    let _ = agent.run_turn(&chat, &input, &events_tx).await;
-    // Agent is done — refuse further cancel/steer (would be 202-with-no-effect)
-    // while the slot stays held for journal drain / seq safety.
-    _active.close_ingress();
-    drop(events_tx);
-    journal.await;
+    let drive = async move {
+        // Dropping `events_tx` when this future ends closes the channel and
+        // lets the journal finish after draining what was already queued.
+        let _ = agent.run_turn(&chat, &input, &events_tx).await;
+    };
+
+    match future::select(Box::pin(drive), Box::pin(journal)).await {
+        Either::Left(((), journal)) => {
+            // Agent finished — refuse further cancel/steer while the journal
+            // drains under the still-held slot.
+            _active.close_ingress();
+            journal.await;
+        }
+        Either::Right(((), drive)) => {
+            // Journal ended first (channel closed unexpectedly). Still close
+            // ingress and wait for the agent so we don't drop mid-turn.
+            _active.close_ingress();
+            drive.await;
+        }
+    }
 }

--- a/crates/openwave-server/src/hub.rs
+++ b/crates/openwave-server/src/hub.rs
@@ -15,6 +15,7 @@ use futures::{future, StreamExt};
 use openwave_core::{Agent, Chat, SequencedEvent, Store};
 
 use crate::bus::EventBus;
+use crate::state::ActiveTurn;
 
 /// Drive one turn to completion, journaling every event it emits and publishing
 /// it to the live bus.
@@ -22,12 +23,17 @@ use crate::bus::EventBus;
 /// The drive and the journal run concurrently, so events land in the store — and
 /// on the bus — as the turn produces them. Returns once the turn has finished and
 /// every event is persisted.
+///
+/// The [`ActiveTurn`] slot is released as soon as `run_turn` returns (before the
+/// journal finishes draining), so a late `POST .../steer` gets `409` rather than
+/// a silent `202` with nowhere to deliver.
 pub(crate) async fn drive_and_journal(
     agent: Agent,
     chat: Chat,
     input: String,
     store: Arc<dyn Store>,
     events: Arc<EventBus>,
+    active: ActiveTurn,
 ) {
     let (events_tx, mut events_rx) = unbounded();
     let chat_id = chat.id;
@@ -48,6 +54,9 @@ pub(crate) async fn drive_and_journal(
     };
 
     let drive = async move {
+        // Hold the slot only while the agent is running; drop it before the
+        // journal finishes so cancel/steer stop accepting once the turn ends.
+        let _active = active;
         // Dropping `events_tx` at the end of this future closes the channel,
         // which ends the journal loop.
         let _ = agent.run_turn(&chat, &input, &events_tx).await;

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -77,6 +77,7 @@ pub fn app(state: AppState) -> Router {
         )
         .route("/chats/{id}/messages", post(routes::post_message))
         .route("/chats/{id}/cancel", post(routes::post_cancel))
+        .route("/chats/{id}/steer", post(routes::post_steer))
         .route(
             "/chats/{id}/approvals/{call_id}",
             post(routes::post_approval),
@@ -217,6 +218,7 @@ async fn connect_store(config: &Config) -> Result<Arc<dyn Store>> {
 mod tests {
     use super::*;
 
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use async_trait::async_trait;
@@ -501,6 +503,117 @@ mod tests {
         assert_eq!(
             cancel_turn(&router, &bearer, ChatId::new()).await,
             StatusCode::NOT_FOUND
+        );
+    }
+
+    /// POST `/chats/{id}/steer`, returning the response status.
+    async fn steer_turn(
+        router: &Router,
+        bearer: &str,
+        chat: ChatId,
+        content: &str,
+        interrupt: bool,
+    ) -> StatusCode {
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/chats/{chat}/steer"))
+                    .header(header::AUTHORIZATION, bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"content": content, "interrupt": interrupt}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+    }
+
+    #[tokio::test]
+    async fn steer_without_a_running_turn_is_a_conflict_and_unknown_chat_is_404() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        assert_eq!(
+            steer_turn(&router, &bearer, chat.id, "hi", false).await,
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            steer_turn(&router, &bearer, ChatId::new(), "hi", false).await,
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            steer_turn(&router, &bearer, chat.id, "  ", false).await,
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupt_steer_preempts_a_running_turn_and_continues() {
+        // Stall after the first delta so steer can interrupt; then finish.
+        struct StallThenFinish {
+            calls: AtomicUsize,
+        }
+        #[async_trait]
+        impl ModelProvider for StallThenFinish {
+            fn id(&self) -> ProviderId {
+                ProviderId::new("stall-then-finish")
+            }
+            async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+                if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    let head = stream::iter(vec![ProviderEvent::TextDelta {
+                        text: "partial".into(),
+                    }]);
+                    return Ok(head.chain(stream::pending()).boxed());
+                }
+                Ok(stream::iter(vec![
+                    ProviderEvent::TextDelta {
+                        text: "after steer".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ])
+                .boxed())
+            }
+        }
+
+        let (router, token, store, _dir) = test_app_with(Arc::new(StallThenFinish {
+            calls: AtomicUsize::new(0),
+        }))
+        .await;
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "go").await,
+            StatusCode::ACCEPTED
+        );
+        // Give the turn a moment to enter the stalled stream.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert_eq!(
+            steer_turn(&router, &bearer, chat.id, "change course", true).await,
+            StatusCode::ACCEPTED
+        );
+
+        let events = wait_for_turn(&store, chat.id).await;
+        assert!(events.iter().any(|e| matches!(
+            &e.event,
+            AgentEvent::UserSteered { content } if content == "change course"
+        )));
+        assert!(matches!(
+            events.last().map(|e| &e.event),
+            Some(AgentEvent::TurnCompleted { .. })
+        ));
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e.event, AgentEvent::TurnCancelled { .. })),
+            "steer continues the turn"
         );
     }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -227,8 +227,8 @@ mod tests {
     use futures::stream::{self, BoxStream, StreamExt};
     use openwave_core::{
         AgentErrorInfo, AgentEvent, ApprovalClass, Chat, ChatId, ChatRequest, ModelProvider,
-        Project, ProjectId, ProviderEvent, ProviderId, SecretProvider, SequencedEvent, StopReason,
-        Tool, ToolCtx, ToolOutput, ToolSpec, Usage,
+        Message, Project, ProjectId, ProviderEvent, ProviderId, SecretProvider, SequencedEvent,
+        StopReason, Tool, ToolCtx, ToolOutput, ToolSpec, Usage,
     };
     use resolver::ProviderResolver;
     use serde::de::DeserializeOwned;
@@ -333,6 +333,82 @@ mod tests {
         async fn delete_secret(&self, key: &str) -> Result<()> {
             self.0.lock().unwrap().remove(key);
             Ok(())
+        }
+    }
+
+    /// Store wrapper that pauses the first terminal event append. This exposes
+    /// races between `run_turn` returning and the journal finishing.
+    struct PauseTerminalStore {
+        inner: Arc<dyn Store>,
+        entered: Arc<Notify>,
+        release: Arc<Notify>,
+        blocked: std::sync::atomic::AtomicBool,
+    }
+
+    impl PauseTerminalStore {
+        fn new(inner: Arc<dyn Store>, entered: Arc<Notify>, release: Arc<Notify>) -> Self {
+            Self {
+                inner,
+                entered,
+                release,
+                blocked: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Store for PauseTerminalStore {
+        async fn create_project(&self, project: &Project) -> Result<()> {
+            self.inner.create_project(project).await
+        }
+        async fn get_project(&self, id: ProjectId) -> Result<Option<Project>> {
+            self.inner.get_project(id).await
+        }
+        async fn list_projects(&self) -> Result<Vec<Project>> {
+            self.inner.list_projects().await
+        }
+        async fn create_chat(&self, chat: &Chat) -> Result<()> {
+            self.inner.create_chat(chat).await
+        }
+        async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
+            self.inner.get_chat(id).await
+        }
+        async fn list_chats(&self) -> Result<Vec<Chat>> {
+            self.inner.list_chats().await
+        }
+        async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()> {
+            self.inner.set_chat_model(id, model).await
+        }
+        async fn append_message(&self, message: &Message) -> Result<()> {
+            self.inner.append_message(message).await
+        }
+        async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>> {
+            self.inner.list_messages(chat_id).await
+        }
+        async fn get_setting(&self, key: &str) -> Result<Option<serde_json::Value>> {
+            self.inner.get_setting(key).await
+        }
+        async fn set_setting(&self, key: &str, value: &serde_json::Value) -> Result<()> {
+            self.inner.set_setting(key, value).await
+        }
+        async fn append_event(&self, chat_id: ChatId, event: &AgentEvent) -> Result<i64> {
+            if matches!(
+                event,
+                AgentEvent::TurnCompleted { .. }
+                    | AgentEvent::TurnFailed { .. }
+                    | AgentEvent::TurnCancelled { .. }
+            ) && self
+                .blocked
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                self.entered.notify_waiters();
+                self.release.notified().await;
+            }
+            self.inner.append_event(chat_id, event).await
+        }
+        async fn list_events(&self, chat_id: ChatId, after: i64) -> Result<Vec<SequencedEvent>> {
+            self.inner.list_events(chat_id, after).await
         }
     }
 
@@ -601,6 +677,20 @@ mod tests {
         );
 
         let events = wait_for_turn(&store, chat.id).await;
+        let stream_interrupted_at = events.iter().position(|e| {
+            matches!(
+                e.event,
+                AgentEvent::StreamInterrupted
+            )
+        });
+        let user_steered_at = events.iter().position(|e| matches!(
+            &e.event,
+            AgentEvent::UserSteered { content } if content == "change course"
+        ));
+        assert!(
+            matches!((stream_interrupted_at, user_steered_at), (Some(a), Some(b)) if a < b),
+            "interrupted stream is marked before steer is injected"
+        );
         assert!(events.iter().any(|e| matches!(
             &e.event,
             AgentEvent::UserSteered { content } if content == "change course"
@@ -609,6 +699,15 @@ mod tests {
             events.last().map(|e| &e.event),
             Some(AgentEvent::TurnCompleted { .. })
         ));
+        let mut visible_assistant = String::new();
+        for event in events.iter().map(|e| &e.event) {
+            match event {
+                AgentEvent::TextDelta { text } => visible_assistant.push_str(text),
+                AgentEvent::StreamInterrupted => visible_assistant.clear(),
+                _ => {}
+            }
+        }
+        assert_eq!(visible_assistant, "after steer");
         assert!(
             !events
                 .iter()
@@ -1690,6 +1789,62 @@ mod tests {
         wait_for_turn(&store, chat.id).await;
 
         // The turn finished, so its slot is released and a follow-up is accepted.
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "two").await,
+            StatusCode::ACCEPTED
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn slot_stays_held_until_journal_drains() {
+        let dir = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let store: Arc<dyn Store> = Arc::new(PauseTerminalStore::new(
+            inner,
+            entered.clone(),
+            release.clone(),
+        ));
+        let state = AppState::new(
+            Config::desktop(dir.path()),
+            store.clone(),
+            Arc::new(FixedResolver(Arc::new(FakeProvider))),
+            Arc::new(MemSecrets::default()),
+            Arc::new(ToolRegistry::new()),
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        );
+        let token = state.token.clone();
+        let router = app(state);
+        let bearer = format!("Bearer {token}");
+        let chat = make_chat(&router, &bearer).await;
+
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "one").await,
+            StatusCode::ACCEPTED
+        );
+        tokio::time::timeout(Duration::from_secs(2), entered.notified())
+            .await
+            .expect("turn reached blocked terminal journal append");
+
+        assert_eq!(
+            send_message(&router, &bearer, chat.id, "two").await,
+            StatusCode::CONFLICT,
+            "slot must remain held while terminal event is still being journaled"
+        );
+
+        release.notify_waiters();
+        wait_for_turn(&store, chat.id).await;
         assert_eq!(
             send_message(&router, &bearer, chat.id, "two").await,
             StatusCode::ACCEPTED

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -226,9 +226,9 @@ mod tests {
     use axum::http::{header, Request, StatusCode};
     use futures::stream::{self, BoxStream, StreamExt};
     use openwave_core::{
-        AgentErrorInfo, AgentEvent, ApprovalClass, Chat, ChatId, ChatRequest, ModelProvider,
-        Message, Project, ProjectId, ProviderEvent, ProviderId, SecretProvider, SequencedEvent,
-        StopReason, Tool, ToolCtx, ToolOutput, ToolSpec, Usage,
+        AgentErrorInfo, AgentEvent, ApprovalClass, Chat, ChatId, ChatRequest, Message,
+        ModelProvider, Project, ProjectId, ProviderEvent, ProviderId, SecretProvider,
+        SequencedEvent, StopReason, Tool, ToolCtx, ToolOutput, ToolSpec, Usage,
     };
     use resolver::ProviderResolver;
     use serde::de::DeserializeOwned;
@@ -677,16 +677,15 @@ mod tests {
         );
 
         let events = wait_for_turn(&store, chat.id).await;
-        let stream_interrupted_at = events.iter().position(|e| {
+        let stream_interrupted_at = events
+            .iter()
+            .position(|e| matches!(e.event, AgentEvent::StreamInterrupted));
+        let user_steered_at = events.iter().position(|e| {
             matches!(
-                e.event,
-                AgentEvent::StreamInterrupted
+                &e.event,
+                AgentEvent::UserSteered { content } if content == "change course"
             )
         });
-        let user_steered_at = events.iter().position(|e| matches!(
-            &e.event,
-            AgentEvent::UserSteered { content } if content == "change course"
-        ));
         assert!(
             matches!((stream_interrupted_at, user_steered_at), (Some(a), Some(b)) if a < b),
             "interrupted stream is marked before steer is injected"
@@ -1841,6 +1840,16 @@ mod tests {
             send_message(&router, &bearer, chat.id, "two").await,
             StatusCode::CONFLICT,
             "slot must remain held while terminal event is still being journaled"
+        );
+        assert_eq!(
+            steer_turn(&router, &bearer, chat.id, "late", false).await,
+            StatusCode::CONFLICT,
+            "steer must not 202 after the agent finished (journal still draining)"
+        );
+        assert_eq!(
+            cancel_turn(&router, &bearer, chat.id).await,
+            StatusCode::CONFLICT,
+            "cancel must not 202 after the agent finished (journal still draining)"
         );
 
         release.notify_waiters();

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -504,7 +504,8 @@ pub async fn post_steer(
 /// `202 Accepted` once the running turn has been signalled to stop; it winds down
 /// asynchronously and emits `TurnCancelled` as its terminal event (watch the
 /// event stream for it). `404` if the chat doesn't exist, `409` if no turn is
-/// currently running for it. Idempotent while a turn is winding down — a repeat
+/// accepting cancel (idle, or the agent has finished and only the journal is
+/// still draining). Idempotent while the agent is still running — a repeat
 /// cancel simply re-trips the already-tripped token.
 pub async fn post_cancel(
     State(state): State<AppState>,

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -449,7 +449,9 @@ pub async fn post_message(
     )
     .with_approvals(state.approvals.clone())
     // Watch the slot's token so `POST /chats/{id}/cancel` can stop this turn.
-    .with_cancel(active.cancel_token());
+    .with_cancel(active.cancel_token())
+    // Drain the slot's inbox so `POST /chats/{id}/steer` can inject mid-turn.
+    .with_steer(active.steer_inbox());
     let store = state.store.clone();
     let events = state.events.clone();
     tokio::spawn(async move {
@@ -459,6 +461,43 @@ pub async fn post_message(
     });
 
     Ok(StatusCode::ACCEPTED)
+}
+
+/// Body of `POST /chats/{id}/steer`.
+#[derive(Debug, Deserialize)]
+pub struct SteerBody {
+    /// User text to inject into the running turn.
+    pub content: String,
+    /// When true, preempt the provider stream immediately; otherwise the message
+    /// waits for the next step boundary.
+    #[serde(default)]
+    pub interrupt: bool,
+}
+
+/// `POST /chats/{id}/steer` — inject a message into the turn currently running.
+///
+/// `202 Accepted` once the message is queued (and interrupt signalled, if
+/// requested). The turn continues after injecting — watch the event stream for
+/// `UserSteered`. `404` if the chat doesn't exist, `409` if no turn is running,
+/// `400` if `content` is empty.
+pub async fn post_steer(
+    State(state): State<AppState>,
+    Path(id): Path<ChatId>,
+    Json(body): Json<SteerBody>,
+) -> Result<StatusCode, ServerError> {
+    if body.content.trim().is_empty() {
+        return Err(ServerError::bad_request("steer content must not be empty"));
+    }
+    if state.store.get_chat(id).await?.is_none() {
+        return Err(ServerError::not_found(format!("chat {id} not found")));
+    }
+    if state.active_turns.steer(id, body.content, body.interrupt) {
+        Ok(StatusCode::ACCEPTED)
+    } else {
+        Err(ServerError::conflict(format!(
+            "chat {id} has no turn in progress"
+        )))
+    }
 }
 
 /// `POST /chats/{id}/cancel` — stop the turn currently running for a chat.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -455,9 +455,9 @@ pub async fn post_message(
     let store = state.store.clone();
     let events = state.events.clone();
     tokio::spawn(async move {
-        // Hold the slot for the turn's lifetime; dropping it frees the chat.
-        let _active = active;
-        crate::hub::drive_and_journal(agent, chat, body.content, store, events).await;
+        // Slot is released when run_turn returns (inside the hub), so a late
+        // steer/cancel gets 409 rather than a silent accept.
+        crate::hub::drive_and_journal(agent, chat, body.content, store, events, active).await;
     });
 
     Ok(StatusCode::ACCEPTED)

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -455,8 +455,7 @@ pub async fn post_message(
     let store = state.store.clone();
     let events = state.events.clone();
     tokio::spawn(async move {
-        // Slot is released when run_turn returns (inside the hub), so a late
-        // steer/cancel gets 409 rather than a silent accept.
+        // The hub holds the slot until the turn and its journal writes finish.
         crate::hub::drive_and_journal(agent, chat, body.content, store, events, active).await;
     });
 

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -68,10 +68,14 @@ impl AppState {
 }
 
 /// Handles held for one running turn — cancel + steer mailboxes.
+///
+/// `accepting` is cleared when the agent returns so cancel/steer get `409`
+/// during journal drain (the slot stays held for seq safety, but ingress stops).
 #[derive(Clone)]
 struct TurnHandles {
     cancel: CancelToken,
     steer: SteerInbox,
+    accepting: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Admits one running turn per chat, and holds each running turn's
@@ -96,11 +100,13 @@ impl TurnGuard {
         }
         let cancel = CancelToken::new();
         let steer = SteerInbox::new();
+        let accepting = Arc::new(std::sync::atomic::AtomicBool::new(true));
         active.insert(
             chat_id,
             TurnHandles {
                 cancel: cancel.clone(),
                 steer: steer.clone(),
+                accepting: accepting.clone(),
             },
         );
         Some(ActiveTurn {
@@ -108,32 +114,34 @@ impl TurnGuard {
             chat_id,
             cancel,
             steer,
+            accepting,
         })
     }
 
     /// Trip the cancel token of the turn running for `chat_id`, if any. Returns
-    /// whether a turn was found to cancel. Idempotent — a second cancel while the
-    /// turn winds down just re-trips the already-tripped token.
+    /// whether a turn was found and still accepting cancel. Idempotent while the
+    /// agent is running; returns false once ingress is closed (journal drain).
     pub fn cancel(&self, chat_id: ChatId) -> bool {
         match self.active.lock().unwrap().get(&chat_id) {
-            Some(handles) => {
+            Some(handles) if handles.accepting.load(std::sync::atomic::Ordering::Acquire) => {
                 handles.cancel.cancel();
                 true
             }
-            None => false,
+            _ => false,
         }
     }
 
     /// Push a steer message into the turn running for `chat_id`, if any. Returns
-    /// whether a turn was found. When `interrupt` is true the agent preempts the
-    /// provider stream; otherwise the message waits for the next step boundary.
+    /// whether a turn was found and still accepting steer. When `interrupt` is
+    /// true the agent preempts the provider stream; otherwise the message waits
+    /// for the next step boundary.
     pub fn steer(&self, chat_id: ChatId, content: String, interrupt: bool) -> bool {
         match self.active.lock().unwrap().get(&chat_id) {
-            Some(handles) => {
+            Some(handles) if handles.accepting.load(std::sync::atomic::Ordering::Acquire) => {
                 handles.steer.push(content, interrupt);
                 true
             }
-            None => false,
+            _ => false,
         }
     }
 }
@@ -144,6 +152,7 @@ pub struct ActiveTurn {
     chat_id: ChatId,
     cancel: CancelToken,
     steer: SteerInbox,
+    accepting: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl ActiveTurn {
@@ -157,6 +166,13 @@ impl ActiveTurn {
     /// routed through [`TurnGuard::steer`] injects mid-turn.
     pub fn steer_inbox(&self) -> SteerInbox {
         self.steer.clone()
+    }
+
+    /// Stop accepting cancel/steer (agent finished). The slot stays held until
+    /// drop so the journal can finish without a concurrent turn racing seq.
+    pub fn close_ingress(&self) {
+        self.accepting
+            .store(false, std::sync::atomic::Ordering::Release);
     }
 }
 
@@ -200,8 +216,23 @@ mod tests {
         assert!(!held.cancel_token().is_cancelled());
         assert!(guard.cancel(chat));
         assert!(held.cancel_token().is_cancelled());
-        // Idempotent while the turn is still held.
+        // Idempotent while the turn is still accepting.
         assert!(guard.cancel(chat));
+    }
+
+    #[test]
+    fn close_ingress_refuses_further_cancel_and_steer() {
+        let guard = Arc::new(TurnGuard::default());
+        let chat = ChatId::new();
+        let held = guard.try_acquire(chat).expect("acquire");
+        held.close_ingress();
+        assert!(!guard.cancel(chat), "cancel refused after ingress closed");
+        assert!(
+            !guard.steer(chat, "late".into(), false),
+            "steer refused after ingress closed"
+        );
+        // Slot still held for seq safety.
+        assert!(guard.try_acquire(chat).is_none());
     }
 
     #[test]

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use openwave_core::{
-    AgentConfig, CancelToken, ChatId, Config, SecretProvider, Store, ToolRegistry,
+    AgentConfig, CancelToken, ChatId, Config, SecretProvider, SteerInbox, Store, ToolRegistry,
 };
 use uuid::Uuid;
 
@@ -67,15 +67,22 @@ impl AppState {
     }
 }
 
+/// Handles held for one running turn — cancel + steer mailboxes.
+#[derive(Clone)]
+struct TurnHandles {
+    cancel: CancelToken,
+    steer: SteerInbox,
+}
+
 /// Admits one running turn per chat, and holds each running turn's
-/// [`CancelToken`] so a cancel request can find and trip it.
+/// [`CancelToken`] / [`SteerInbox`] so cancel and steer requests can find them.
 ///
 /// The agent's per-chat sequence numbering assumes a single writer; this guard
 /// upholds that at the API edge — a turn holds its chat's slot until it finishes,
 /// and a concurrent request for the same chat is refused (never queued behind it).
 #[derive(Default)]
 pub struct TurnGuard {
-    active: Mutex<HashMap<ChatId, CancelToken>>,
+    active: Mutex<HashMap<ChatId, TurnHandles>>,
 }
 
 impl TurnGuard {
@@ -88,11 +95,19 @@ impl TurnGuard {
             return None;
         }
         let cancel = CancelToken::new();
-        active.insert(chat_id, cancel.clone());
+        let steer = SteerInbox::new();
+        active.insert(
+            chat_id,
+            TurnHandles {
+                cancel: cancel.clone(),
+                steer: steer.clone(),
+            },
+        );
         Some(ActiveTurn {
             guard: Arc::clone(self),
             chat_id,
             cancel,
+            steer,
         })
     }
 
@@ -101,8 +116,21 @@ impl TurnGuard {
     /// turn winds down just re-trips the already-tripped token.
     pub fn cancel(&self, chat_id: ChatId) -> bool {
         match self.active.lock().unwrap().get(&chat_id) {
-            Some(token) => {
-                token.cancel();
+            Some(handles) => {
+                handles.cancel.cancel();
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Push a steer message into the turn running for `chat_id`, if any. Returns
+    /// whether a turn was found. When `interrupt` is true the agent preempts the
+    /// provider stream; otherwise the message waits for the next step boundary.
+    pub fn steer(&self, chat_id: ChatId, content: String, interrupt: bool) -> bool {
+        match self.active.lock().unwrap().get(&chat_id) {
+            Some(handles) => {
+                handles.steer.push(content, interrupt);
                 true
             }
             None => false,
@@ -115,6 +143,7 @@ pub struct ActiveTurn {
     guard: Arc<TurnGuard>,
     chat_id: ChatId,
     cancel: CancelToken,
+    steer: SteerInbox,
 }
 
 impl ActiveTurn {
@@ -122,6 +151,12 @@ impl ActiveTurn {
     /// routed through [`TurnGuard::cancel`] stops it.
     pub fn cancel_token(&self) -> CancelToken {
         self.cancel.clone()
+    }
+
+    /// The steer inbox for this turn — handed to the agent so a `POST .../steer`
+    /// routed through [`TurnGuard::steer`] injects mid-turn.
+    pub fn steer_inbox(&self) -> SteerInbox {
+        self.steer.clone()
     }
 }
 
@@ -151,27 +186,34 @@ mod tests {
         drop(held);
         assert!(
             guard.try_acquire(chat).is_some(),
-            "the slot frees once the turn is dropped"
+            "dropping the slot frees the chat for another turn"
         );
     }
 
     #[test]
-    fn cancel_trips_the_running_turns_token() {
+    fn cancel_trips_the_held_token() {
         let guard = Arc::new(TurnGuard::default());
         let chat = ChatId::new();
 
-        // No turn running yet: nothing to cancel.
-        assert!(!guard.cancel(chat));
-
+        assert!(!guard.cancel(chat), "nothing to cancel yet");
         let held = guard.try_acquire(chat).expect("acquire");
-        let token = held.cancel_token();
-        assert!(!token.is_cancelled());
+        assert!(!held.cancel_token().is_cancelled());
+        assert!(guard.cancel(chat));
+        assert!(held.cancel_token().is_cancelled());
+        // Idempotent while the turn is still held.
+        assert!(guard.cancel(chat));
+    }
 
-        assert!(guard.cancel(chat), "a running turn is found and cancelled");
-        assert!(token.is_cancelled(), "the turn's own token is tripped");
+    #[test]
+    fn steer_pushes_into_the_held_inbox() {
+        let guard = Arc::new(TurnGuard::default());
+        let chat = ChatId::new();
 
-        // Once the slot frees, there's again nothing to cancel.
-        drop(held);
-        assert!(!guard.cancel(chat));
+        assert!(!guard.steer(chat, "x".into(), false));
+        let held = guard.try_acquire(chat).expect("acquire");
+        assert!(guard.steer(chat, "course correct".into(), true));
+        let msgs = held.steer_inbox().drain();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].content, "course correct");
     }
 }

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -138,8 +138,7 @@ impl TurnGuard {
     pub fn steer(&self, chat_id: ChatId, content: String, interrupt: bool) -> bool {
         match self.active.lock().unwrap().get(&chat_id) {
             Some(handles) if handles.accepting.load(std::sync::atomic::Ordering::Acquire) => {
-                handles.steer.push(content, interrupt);
-                true
+                handles.steer.push(content, interrupt)
             }
             _ => false,
         }


### PR DESCRIPTION
## Summary
- Mid-turn **steer**: `SteerInbox` drains at step boundaries; `interrupt: true` preempts the provider stream (same race pattern as cancel) then continues the turn.
- New `UserSteered` event + `POST /chats/{id}/steer` (`202` / `409` / `404` / `400`). Cancel still wins when both are ready.
- Desktop UI recognizes `user_steered` / `turn_cancelled`; API client gains `steer` / `cancel`.

## Test plan
- [ ] `cargo test -p openwave-core interrupt_steer` / `cancel_wins_over_steer`
- [ ] `cargo test -p openwave-server interrupt_steer` / `steer_without_a_running_turn`
- [ ] `cargo test --workspace` / clippy / fmt
- [ ] Manual: start a turn, `POST /chats/{id}/steer` with `interrupt: true`, confirm `UserSteered` then `TurnCompleted` (not cancelled)
