### PR TITLE
feat(core): persist structured tool calls and rebuild transcripts

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -12,8 +12,8 @@
 //! - tool calls run **sequentially** (concurrency for independent calls later);
 //! - approval is **auto** for `ReadOnly`/`Workspace`; `Sensitive` parks via an
 //!   [`ApprovalGate`] until approve/reject (standing grants / auto-judge later);
-//! - cross-turn context is the stored text messages (structured tool-call
-//!   persistence + context summarization come later).
+//! - cross-turn context rebuilds text messages plus structured tool-call rows
+//!   (context summarization comes later).
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -29,7 +29,7 @@ use crate::cancel::CancelToken;
 use crate::error::{AgentError, Result};
 use crate::event::AgentEvent;
 use crate::id::{CallId, MessageId, TurnId};
-use crate::model::{Chat, Message, Role};
+use crate::model::{Chat, Message, Role, ToolCallRecord};
 use crate::provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, StopReason, Usage,
 };
@@ -325,11 +325,28 @@ impl Agent {
                     .await?;
             }
             for call in &calls {
+                let args = parse_args(&call.args);
                 blocks.push(ContentBlock::ToolUse {
                     id: call.provider_id.clone(),
                     name: call.name.clone(),
-                    input: parse_args(&call.args),
+                    input: args.clone(),
                 });
+                // Persist the call as soon as args are known so a crash mid-tool
+                // still leaves a reconstructable ToolUse on the next turn.
+                self.store
+                    .upsert_tool_call(&ToolCallRecord {
+                        id: call.call_id,
+                        chat_id: chat.id,
+                        turn_id,
+                        provider_id: call.provider_id.clone(),
+                        name: call.name.clone(),
+                        arguments: args,
+                        result: None,
+                        is_error: false,
+                        created_at: Utc::now(),
+                        completed_at: None,
+                    })
+                    .await?;
             }
             if !blocks.is_empty() {
                 transcript.push(ChatMessage {
@@ -382,7 +399,19 @@ impl Agent {
                     call_id: call.call_id,
                     output: output.clone(),
                 });
-                self.persist(chat.id, turn_id, Role::Tool, &output.content)
+                self.store
+                    .upsert_tool_call(&ToolCallRecord {
+                        id: call.call_id,
+                        chat_id: chat.id,
+                        turn_id,
+                        provider_id: call.provider_id.clone(),
+                        name: call.name.clone(),
+                        arguments: parse_args(&call.args),
+                        result: Some(output.content.clone()),
+                        is_error: output.is_error,
+                        created_at: Utc::now(),
+                        completed_at: Some(Utc::now()),
+                    })
                     .await?;
                 results.push(ContentBlock::ToolResult {
                     tool_use_id: call.provider_id.clone(),
@@ -543,13 +572,155 @@ impl Agent {
     }
 
     async fn load_transcript(&self, chat_id: crate::id::ChatId) -> Result<Vec<ChatMessage>> {
-        Ok(self
-            .store
-            .list_messages(chat_id)
-            .await?
-            .into_iter()
-            .map(|message| ChatMessage::text(message.role, message.content))
-            .collect())
+        let messages = self.store.list_messages(chat_id).await?;
+        let tool_calls = self.store.list_tool_calls(chat_id).await?;
+        Ok(rebuild_transcript(&messages, &tool_calls))
+    }
+}
+
+/// Merge text messages and structured tool-call rows into the provider transcript.
+///
+/// Tool calls are partitioned into *batches*: a new batch starts when a call's
+/// `created_at` is at or after the previous batch's latest `completed_at`. That
+/// matches the agent loop (upsert all args for a model step, then complete them,
+/// then the next model step). Batches that fall after an assistant text message
+/// and before the next message attach as `ToolUse` on that assistant; otherwise
+/// they become a tool-only assistant step. `ToolResult` blocks follow as a user
+/// message. Legacy `Role::Tool` rows are ignored.
+fn rebuild_transcript(messages: &[Message], tool_calls: &[ToolCallRecord]) -> Vec<ChatMessage> {
+    let messages: Vec<&Message> = messages
+        .iter()
+        .filter(|message| message.role != Role::Tool)
+        .collect();
+    let batches = batch_tool_calls(tool_calls);
+    let mut batch_i = 0;
+    let mut out: Vec<ChatMessage> = Vec::new();
+
+    for (i, message) in messages.iter().enumerate() {
+        // Batches that started before this message are prior tool-only steps.
+        while batch_i < batches.len() && batches[batch_i][0].created_at < message.created_at {
+            push_tool_batch(&mut out, &batches[batch_i], None);
+            batch_i += 1;
+        }
+
+        if message.role == Role::Assistant {
+            let next_ts = messages.get(i + 1).map(|m| m.created_at);
+            let text = if message.content.is_empty() {
+                None
+            } else {
+                Some(message.content.as_str())
+            };
+            // Same model step: tools upserted right after the assistant text.
+            if batch_i < batches.len()
+                && next_ts.is_none_or(|end| batches[batch_i][0].created_at < end)
+            {
+                push_tool_batch(&mut out, &batches[batch_i], text);
+                batch_i += 1;
+                while batch_i < batches.len()
+                    && next_ts.is_none_or(|end| batches[batch_i][0].created_at < end)
+                {
+                    push_tool_batch(&mut out, &batches[batch_i], None);
+                    batch_i += 1;
+                }
+            } else if let Some(text) = text {
+                out.push(ChatMessage::text(Role::Assistant, text.to_string()));
+            }
+        } else {
+            out.push(ChatMessage::text(message.role, message.content.clone()));
+            // Tool-only steps between this message and the next non-assistant
+            // (e.g. user → tools → user steer). If the next message is
+            // assistant, that branch claims the batch instead.
+            let next_ts = messages.get(i + 1).map(|m| m.created_at);
+            let next_is_assistant = messages
+                .get(i + 1)
+                .is_some_and(|m| m.role == Role::Assistant);
+            if !next_is_assistant {
+                while batch_i < batches.len()
+                    && next_ts.is_none_or(|end| batches[batch_i][0].created_at < end)
+                {
+                    push_tool_batch(&mut out, &batches[batch_i], None);
+                    batch_i += 1;
+                }
+            }
+        }
+    }
+
+    while batch_i < batches.len() {
+        push_tool_batch(&mut out, &batches[batch_i], None);
+        batch_i += 1;
+    }
+
+    out
+}
+
+/// Partition calls into per-model-step batches (see [`rebuild_transcript`]).
+fn batch_tool_calls(tool_calls: &[ToolCallRecord]) -> Vec<Vec<&ToolCallRecord>> {
+    let mut batches: Vec<Vec<&ToolCallRecord>> = Vec::new();
+    let mut current: Vec<&ToolCallRecord> = Vec::new();
+    let mut batch_done_at: Option<chrono::DateTime<Utc>> = None;
+
+    for call in tool_calls {
+        if let Some(done) = batch_done_at {
+            if call.created_at >= done {
+                batches.push(std::mem::take(&mut current));
+                batch_done_at = None;
+            }
+        }
+        current.push(call);
+        if let Some(completed) = call.completed_at {
+            batch_done_at = Some(match batch_done_at {
+                Some(done) => done.max(completed),
+                None => completed,
+            });
+        }
+    }
+    if !current.is_empty() {
+        batches.push(current);
+    }
+    batches
+}
+
+fn push_tool_batch(
+    out: &mut Vec<ChatMessage>,
+    batch: &[&ToolCallRecord],
+    assistant_text: Option<&str>,
+) {
+    let mut blocks: Vec<ContentBlock> = Vec::new();
+    if let Some(text) = assistant_text.filter(|t| !t.is_empty()) {
+        blocks.push(ContentBlock::Text {
+            text: text.to_string(),
+        });
+    }
+    for call in batch {
+        blocks.push(ContentBlock::ToolUse {
+            id: call.provider_id.clone(),
+            name: call.name.clone(),
+            input: call.arguments.clone(),
+        });
+    }
+    if !blocks.is_empty() {
+        out.push(ChatMessage {
+            role: Role::Assistant,
+            content: blocks,
+        });
+    }
+    let results: Vec<ContentBlock> = batch
+        .iter()
+        .filter_map(|call| {
+            call.result
+                .as_ref()
+                .map(|content| ContentBlock::ToolResult {
+                    tool_use_id: call.provider_id.clone(),
+                    content: content.clone(),
+                    is_error: call.is_error,
+                })
+        })
+        .collect();
+    if !results.is_empty() {
+        out.push(ChatMessage {
+            role: Role::User,
+            content: results,
+        });
     }
 }
 
@@ -584,8 +755,10 @@ fn parse_args(raw: &str) -> Value {
 #[cfg(all(test, feature = "sqlite", feature = "tools"))]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
 
     use async_trait::async_trait;
+    use chrono::DateTime;
     use futures::channel::mpsc::unbounded;
     use futures::stream::{self, BoxStream};
 
@@ -714,10 +887,17 @@ mod tests {
             Some((8, 6))
         );
 
-        // User input, the tool result, and the final answer were persisted.
+        // User input and the final answer are text messages; the tool call is
+        // a structured row (not Role::Tool).
         let stored = store.list_messages(chat.id).await.unwrap();
         let roles: Vec<Role> = stored.iter().map(|m| m.role).collect();
-        assert_eq!(roles, vec![Role::User, Role::Tool, Role::Assistant]);
+        assert_eq!(roles, vec![Role::User, Role::Assistant]);
+        let calls = store.list_tool_calls(chat.id).await.unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "read_file");
+        assert_eq!(calls[0].result.as_deref(), Some("hello from disk"));
+        assert!(!calls[0].is_error);
+        assert!(calls[0].completed_at.is_some());
     }
 
     #[tokio::test]
@@ -1395,5 +1575,252 @@ mod tests {
             e,
             AgentEvent::ToolCallCompleted { output, .. } if output.is_error
         )));
+    }
+
+    #[test]
+    fn rebuild_attaches_tools_to_assistant_text() {
+        let turn = TurnId::new();
+        let chat = ChatId::new();
+        let t0 = DateTime::<Utc>::from_timestamp(1_000, 0).unwrap();
+        let t1 = DateTime::<Utc>::from_timestamp(1_001, 0).unwrap();
+        let t2 = DateTime::<Utc>::from_timestamp(1_002, 0).unwrap();
+        let messages = vec![
+            Message {
+                id: MessageId::new(),
+                chat_id: chat,
+                turn_id: turn,
+                role: Role::User,
+                content: "read it".into(),
+                created_at: t0,
+            },
+            Message {
+                id: MessageId::new(),
+                chat_id: chat,
+                turn_id: turn,
+                role: Role::Assistant,
+                content: "looking…".into(),
+                created_at: t1,
+            },
+        ];
+        let calls = vec![ToolCallRecord {
+            id: CallId::new(),
+            chat_id: chat,
+            turn_id: turn,
+            provider_id: "tu_1".into(),
+            name: "read_file".into(),
+            arguments: serde_json::json!({"path": "a"}),
+            result: Some("ok".into()),
+            is_error: false,
+            created_at: t2,
+            completed_at: Some(DateTime::<Utc>::from_timestamp(1_003, 0).unwrap()),
+        }];
+        let rebuilt = rebuild_transcript(&messages, &calls);
+        assert_eq!(rebuilt.len(), 3);
+        assert_eq!(rebuilt[0].role, Role::User);
+        assert!(matches!(
+            &rebuilt[1].content[..],
+            [
+                ContentBlock::Text { text },
+                ContentBlock::ToolUse { id, name, .. }
+            ] if text == "looking…" && id == "tu_1" && name == "read_file"
+        ));
+        assert!(matches!(
+            &rebuilt[2].content[..],
+            [ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error: false
+            }] if tool_use_id == "tu_1" && content == "ok"
+        ));
+    }
+
+    #[test]
+    fn rebuild_emits_tool_only_step_before_final_text() {
+        let turn = TurnId::new();
+        let chat = ChatId::new();
+        let t0 = DateTime::<Utc>::from_timestamp(1_000, 0).unwrap();
+        let t1 = DateTime::<Utc>::from_timestamp(1_001, 0).unwrap();
+        let t2 = DateTime::<Utc>::from_timestamp(1_002, 0).unwrap();
+        let messages = vec![
+            Message {
+                id: MessageId::new(),
+                chat_id: chat,
+                turn_id: turn,
+                role: Role::User,
+                content: "go".into(),
+                created_at: t0,
+            },
+            Message {
+                id: MessageId::new(),
+                chat_id: chat,
+                turn_id: turn,
+                role: Role::Assistant,
+                content: "done".into(),
+                created_at: t2,
+            },
+        ];
+        let calls = vec![ToolCallRecord {
+            id: CallId::new(),
+            chat_id: chat,
+            turn_id: turn,
+            provider_id: "tu_1".into(),
+            name: "read_file".into(),
+            arguments: serde_json::json!({}),
+            result: Some("data".into()),
+            is_error: false,
+            created_at: t1,
+            completed_at: Some(t1),
+        }];
+        let rebuilt = rebuild_transcript(&messages, &calls);
+        assert_eq!(rebuilt.len(), 4);
+        assert_eq!(rebuilt[0].role, Role::User);
+        assert!(matches!(
+            &rebuilt[1].content[..],
+            [ContentBlock::ToolUse { .. }]
+        ));
+        assert!(matches!(
+            &rebuilt[2].content[..],
+            [ContentBlock::ToolResult { .. }]
+        ));
+        assert_eq!(rebuilt[3].role, Role::Assistant);
+    }
+
+    #[test]
+    fn rebuild_skips_legacy_tool_role_rows() {
+        let turn = TurnId::new();
+        let chat = ChatId::new();
+        let messages = vec![
+            Message {
+                id: MessageId::new(),
+                chat_id: chat,
+                turn_id: turn,
+                role: Role::User,
+                content: "hi".into(),
+                created_at: DateTime::<Utc>::from_timestamp(1, 0).unwrap(),
+            },
+            Message {
+                id: MessageId::new(),
+                chat_id: chat,
+                turn_id: turn,
+                role: Role::Tool,
+                content: "legacy".into(),
+                created_at: DateTime::<Utc>::from_timestamp(2, 0).unwrap(),
+            },
+            Message {
+                id: MessageId::new(),
+                chat_id: chat,
+                turn_id: turn,
+                role: Role::Assistant,
+                content: "bye".into(),
+                created_at: DateTime::<Utc>::from_timestamp(3, 0).unwrap(),
+            },
+        ];
+        let rebuilt = rebuild_transcript(&messages, &[]);
+        assert_eq!(rebuilt.len(), 2);
+        assert_eq!(rebuilt[0].role, Role::User);
+        assert_eq!(rebuilt[1].role, Role::Assistant);
+    }
+
+    #[tokio::test]
+    async fn second_turn_rebuilds_prior_tool_calls_into_transcript() {
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::write(workspace.path().join("note.txt"), "hello from disk").unwrap();
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            workspace_dir: workspace.path().to_path_buf(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+
+        // Turn 1: tool call then finish (FakeProvider).
+        let agent = Agent::new(
+            Arc::new(FakeProvider {
+                calls: AtomicUsize::new(0),
+            }),
+            Arc::new(ToolRegistry::new().with(Box::new(ReadFile))),
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        );
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "read note.txt", &tx).await.unwrap();
+        drop(tx);
+        let _: Vec<AgentEvent> = rx.collect().await;
+
+        // Turn 2: provider that records the request so we can assert ToolUse/Result
+        // blocks were rebuilt from the store.
+        let seen: Arc<Mutex<Vec<ChatMessage>>> = Arc::new(Mutex::new(Vec::new()));
+        struct CaptureProvider {
+            seen: Arc<Mutex<Vec<ChatMessage>>>,
+        }
+        #[async_trait]
+        impl ModelProvider for CaptureProvider {
+            fn id(&self) -> ProviderId {
+                ProviderId::new("capture")
+            }
+            async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+                *self.seen.lock().unwrap() = req.messages;
+                Ok(stream::iter(vec![
+                    ProviderEvent::TextDelta { text: "ok".into() },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ])
+                .boxed())
+            }
+        }
+        let agent = Agent::new(
+            Arc::new(CaptureProvider { seen: seen.clone() }),
+            Arc::new(ToolRegistry::new()),
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        );
+        let (tx, rx) = unbounded();
+        agent
+            .run_turn(&chat, "what did you find?", &tx)
+            .await
+            .unwrap();
+        drop(tx);
+        let _: Vec<AgentEvent> = rx.collect().await;
+
+        let messages = seen.lock().unwrap().clone();
+        assert!(
+            messages.iter().any(|m| {
+                m.role == Role::Assistant
+                    && m.content.iter().any(
+                        |b| matches!(b, ContentBlock::ToolUse { name, .. } if name == "read_file"),
+                    )
+            }),
+            "expected rebuilt ToolUse in cross-turn transcript: {messages:?}"
+        );
+        assert!(
+            messages.iter().any(|m| {
+                m.role == Role::User
+                    && m.content.iter().any(|b| {
+                        matches!(
+                            b,
+                            ContentBlock::ToolResult { content, .. } if content == "hello from disk"
+                        )
+                    })
+            }),
+            "expected rebuilt ToolResult in cross-turn transcript: {messages:?}"
+        );
     }
 }

--- a/crates/openwave-core/src/db.rs
+++ b/crates/openwave-core/src/db.rs
@@ -20,8 +20,8 @@ use serde_json::Value;
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{ChatId, MessageId, ProjectId, TurnId};
-use crate::model::{Chat, Message, Project, Role};
+use crate::id::{CallId, ChatId, MessageId, ProjectId, TurnId};
+use crate::model::{Chat, Message, Project, Role, ToolCallRecord};
 use crate::storage::Store;
 
 /// Map any SeaORM failure into an [`AgentError::Store`].
@@ -164,6 +164,48 @@ impl Store for DbStore {
             .collect()
     }
 
+    async fn upsert_tool_call(&self, call: &ToolCallRecord) -> Result<()> {
+        let model = entities::tool_call::ActiveModel {
+            id: Set(call.id.0),
+            chat_id: Set(call.chat_id.0),
+            turn_id: Set(call.turn_id.0),
+            provider_id: Set(call.provider_id.clone()),
+            name: Set(call.name.clone()),
+            arguments: Set(call.arguments.clone()),
+            result: Set(call.result.clone()),
+            is_error: Set(call.is_error),
+            created_at: Set(call.created_at),
+            completed_at: Set(call.completed_at),
+        };
+        entities::tool_call::Entity::insert(model)
+            .on_conflict(
+                OnConflict::column(entities::tool_call::Column::Id)
+                    .update_columns([
+                        entities::tool_call::Column::Arguments,
+                        entities::tool_call::Column::Result,
+                        entities::tool_call::Column::IsError,
+                        entities::tool_call::Column::CompletedAt,
+                    ])
+                    .to_owned(),
+            )
+            .exec(&self.conn)
+            .await
+            .map_err(store_err)?;
+        Ok(())
+    }
+
+    async fn list_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {
+        Ok(entities::tool_call::Entity::find()
+            .filter(entities::tool_call::Column::ChatId.eq(chat_id.0))
+            .order_by_asc(entities::tool_call::Column::CreatedAt)
+            .all(&self.conn)
+            .await
+            .map_err(store_err)?
+            .into_iter()
+            .map(tool_call_from_model)
+            .collect())
+    }
+
     async fn get_setting(&self, key: &str) -> Result<Option<Value>> {
         Ok(entities::setting::Entity::find_by_id(key.to_string())
             .one(&self.conn)
@@ -266,6 +308,21 @@ fn message_from_model(model: entities::message::Model) -> Result<Message> {
     })
 }
 
+fn tool_call_from_model(model: entities::tool_call::Model) -> ToolCallRecord {
+    ToolCallRecord {
+        id: CallId(model.id),
+        chat_id: ChatId(model.chat_id),
+        turn_id: TurnId(model.turn_id),
+        provider_id: model.provider_id,
+        name: model.name,
+        arguments: model.arguments,
+        result: model.result,
+        is_error: model.is_error,
+        created_at: model.created_at,
+        completed_at: model.completed_at,
+    }
+}
+
 /// `Role` is persisted as its snake_case name (matching its serde encoding).
 fn role_to_db(role: Role) -> &'static str {
     match role {
@@ -351,6 +408,32 @@ mod entities {
         impl ActiveModelBehavior for ActiveModel {}
     }
 
+    pub mod tool_call {
+        use sea_orm::entity::prelude::*;
+
+        #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+        #[sea_orm(table_name = "tool_call")]
+        pub struct Model {
+            #[sea_orm(primary_key, auto_increment = false)]
+            pub id: Uuid,
+            pub chat_id: Uuid,
+            pub turn_id: Uuid,
+            pub provider_id: String,
+            pub name: String,
+            #[sea_orm(column_type = "JsonBinary")]
+            pub arguments: Json,
+            pub result: Option<String>,
+            pub is_error: bool,
+            pub created_at: DateTimeUtc,
+            pub completed_at: Option<DateTimeUtc>,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+    }
+
     pub mod setting {
         use sea_orm::entity::prelude::*;
 
@@ -410,6 +493,7 @@ mod migration {
                 Box::new(AddEventJournal),
                 Box::new(AddProjects),
                 Box::new(AddChatModel),
+                Box::new(AddToolCalls),
             ]
         }
     }
@@ -647,6 +731,73 @@ mod migration {
         }
     }
 
+    /// Structured tool-call rows (args + result), distinct from text messages.
+    struct AddToolCalls;
+
+    impl MigrationName for AddToolCalls {
+        fn name(&self) -> &str {
+            "m0005_tool_calls"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for AddToolCalls {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .create_table(
+                    Table::create()
+                        .table(ToolCall::Table)
+                        .if_not_exists()
+                        .col(ColumnDef::new(ToolCall::Id).uuid().not_null().primary_key())
+                        .col(ColumnDef::new(ToolCall::ChatId).uuid().not_null())
+                        .col(ColumnDef::new(ToolCall::TurnId).uuid().not_null())
+                        .col(ColumnDef::new(ToolCall::ProviderId).text().not_null())
+                        .col(ColumnDef::new(ToolCall::Name).text().not_null())
+                        .col(ColumnDef::new(ToolCall::Arguments).json_binary().not_null())
+                        .col(ColumnDef::new(ToolCall::Result).text())
+                        .col(
+                            ColumnDef::new(ToolCall::IsError)
+                                .boolean()
+                                .not_null()
+                                .default(false),
+                        )
+                        .col(
+                            ColumnDef::new(ToolCall::CreatedAt)
+                                .timestamp_with_time_zone()
+                                .not_null(),
+                        )
+                        .col(ColumnDef::new(ToolCall::CompletedAt).timestamp_with_time_zone())
+                        .foreign_key(
+                            ForeignKey::create()
+                                .name("fk_tool_call_chat")
+                                .from(ToolCall::Table, ToolCall::ChatId)
+                                .to(Chat::Table, Chat::Id),
+                        )
+                        .to_owned(),
+                )
+                .await?;
+
+            manager
+                .create_index(
+                    Index::create()
+                        .name("idx_tool_call_chat")
+                        .table(ToolCall::Table)
+                        .col(ToolCall::ChatId)
+                        .col(ToolCall::CreatedAt)
+                        .to_owned(),
+                )
+                .await?;
+            Ok(())
+        }
+
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .drop_table(Table::drop().table(ToolCall::Table).to_owned())
+                .await?;
+            Ok(())
+        }
+    }
+
     #[derive(DeriveIden)]
     enum Project {
         Table,
@@ -676,6 +827,21 @@ mod migration {
         Role,
         Content,
         CreatedAt,
+    }
+
+    #[derive(DeriveIden)]
+    enum ToolCall {
+        Table,
+        Id,
+        ChatId,
+        TurnId,
+        ProviderId,
+        Name,
+        Arguments,
+        Result,
+        IsError,
+        CreatedAt,
+        CompletedAt,
     }
 
     #[derive(DeriveIden)]
@@ -966,5 +1132,46 @@ mod tests {
             .map(|m| m.role)
             .collect();
         assert_eq!(got, roles);
+    }
+
+    #[tokio::test]
+    async fn tool_calls_roundtrip_and_upsert_preserves_created_at() {
+        let (_dir, store) = temp_store().await;
+        let chat = sample_chat();
+        store.create_chat(&chat).await.unwrap();
+
+        let created = DateTime::<Utc>::from_timestamp(1_700_000_010, 0).unwrap();
+        let call = ToolCallRecord {
+            id: CallId::new(),
+            chat_id: chat.id,
+            turn_id: TurnId::new(),
+            provider_id: "tu_1".into(),
+            name: "read_file".into(),
+            arguments: serde_json::json!({"path": "note.txt"}),
+            result: None,
+            is_error: false,
+            created_at: created,
+            completed_at: None,
+        };
+        store.upsert_tool_call(&call).await.unwrap();
+
+        let completed = DateTime::<Utc>::from_timestamp(1_700_000_011, 0).unwrap();
+        store
+            .upsert_tool_call(&ToolCallRecord {
+                result: Some("hello".into()),
+                is_error: false,
+                created_at: Utc::now(), // must not overwrite the original
+                completed_at: Some(completed),
+                ..call.clone()
+            })
+            .await
+            .unwrap();
+
+        let listed = store.list_tool_calls(chat.id).await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].created_at, created);
+        assert_eq!(listed[0].completed_at, Some(completed));
+        assert_eq!(listed[0].result.as_deref(), Some("hello"));
+        assert_eq!(listed[0].arguments, serde_json::json!({"path": "note.txt"}));
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -45,7 +45,7 @@ pub use event::{AgentEvent, SequencedEvent};
 pub use id::{CallId, ChatId, MessageId, ProjectId, StepId, TurnId};
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
-pub use model::{Chat, Message, Project, Role};
+pub use model::{Chat, Message, Project, Role, ToolCallRecord};
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
     Usage,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -80,3 +80,33 @@ pub struct Message {
     /// When it was created.
     pub created_at: DateTime<Utc>,
 }
+
+/// A persisted tool invocation — name, arguments, and (once finished) result.
+///
+/// Distinct from [`Message`]: the model transcript rebuilds `ToolUse` /
+/// `ToolResult` blocks from these rows so cross-turn context keeps structured
+/// tool activity, not just free text.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolCallRecord {
+    /// Stable id (same as the live [`crate::id::CallId`] on the event stream).
+    pub id: crate::id::CallId,
+    /// Chat this call belongs to.
+    pub chat_id: ChatId,
+    /// Turn that produced the call.
+    pub turn_id: TurnId,
+    /// Provider-facing tool-use id (Anthropic `tool_use.id`, OpenAI `tool_call_id`).
+    pub provider_id: String,
+    /// Tool name.
+    pub name: String,
+    /// Parsed JSON arguments.
+    pub arguments: serde_json::Value,
+    /// Result text fed back to the model, once completed.
+    pub result: Option<String>,
+    /// Whether the tool reported a failure.
+    #[serde(default)]
+    pub is_error: bool,
+    /// When the call was recorded (args known).
+    pub created_at: DateTime<Utc>,
+    /// When the result was written, if completed.
+    pub completed_at: Option<DateTime<Utc>>,
+}

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -11,8 +11,8 @@
 //! - [`BlobStore`] — bytes (documents, images, exports), served locally or from
 //!   object storage.
 //!
-//! Only the entities that exist today are modeled here. Persistence for tool
-//! calls, connections, documents, and skills is added alongside the slices that
+//! Only the entities that exist today are modeled here. Persistence for
+//! connections, documents, and skills is added alongside the slices that
 //! introduce those record types.
 
 use async_trait::async_trait;
@@ -21,7 +21,7 @@ use serde_json::Value;
 use crate::error::Result;
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, ProjectId};
-use crate::model::{Chat, Message, Project};
+use crate::model::{Chat, Message, Project, ToolCallRecord};
 
 /// Durable metadata and conversation state.
 ///
@@ -62,6 +62,12 @@ pub trait Store: Send + Sync {
 
     /// List a chat's messages in creation order.
     async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>>;
+
+    /// Upsert a tool call (insert on first sight, update result on completion).
+    async fn upsert_tool_call(&self, call: &ToolCallRecord) -> Result<()>;
+
+    /// List a chat's tool calls in creation order.
+    async fn list_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>>;
 
     /// Read a setting (profile, model prefs, approval policy), or `None`.
     async fn get_setting(&self, key: &str) -> Result<Option<Value>>;
@@ -125,6 +131,7 @@ mod tests {
         chats: Mutex<HashMap<ChatId, Chat>>,
         settings: Mutex<HashMap<String, Value>>,
         events: Mutex<Vec<(ChatId, SequencedEvent)>>,
+        tool_calls: Mutex<HashMap<crate::id::CallId, ToolCallRecord>>,
     }
 
     #[async_trait]
@@ -163,6 +170,30 @@ mod tests {
         }
         async fn list_messages(&self, _chat_id: ChatId) -> Result<Vec<Message>> {
             Ok(vec![])
+        }
+        async fn upsert_tool_call(&self, call: &ToolCallRecord) -> Result<()> {
+            let mut calls = self.tool_calls.lock().unwrap();
+            if let Some(existing) = calls.get_mut(&call.id) {
+                existing.arguments = call.arguments.clone();
+                existing.result = call.result.clone();
+                existing.is_error = call.is_error;
+                existing.completed_at = call.completed_at;
+            } else {
+                calls.insert(call.id, call.clone());
+            }
+            Ok(())
+        }
+        async fn list_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {
+            let mut calls: Vec<_> = self
+                .tool_calls
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|call| call.chat_id == chat_id)
+                .cloned()
+                .collect();
+            calls.sort_by_key(|call| call.created_at);
+            Ok(calls)
         }
         async fn get_setting(&self, key: &str) -> Result<Option<Value>> {
             Ok(self.settings.lock().unwrap().get(key).cloned())

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -385,6 +385,15 @@ mod tests {
         async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>> {
             self.inner.list_messages(chat_id).await
         }
+        async fn upsert_tool_call(&self, call: &openwave_core::ToolCallRecord) -> Result<()> {
+            self.inner.upsert_tool_call(call).await
+        }
+        async fn list_tool_calls(
+            &self,
+            chat_id: ChatId,
+        ) -> Result<Vec<openwave_core::ToolCallRecord>> {
+            self.inner.list_tool_calls(chat_id).await
+        }
         async fn get_setting(&self, key: &str) -> Result<Option<serde_json::Value>> {
             self.inner.get_setting(key).await
         }


### PR DESCRIPTION
## Summary
- Add `m0005_tool_calls` and a `ToolCallRecord` store API (`upsert_tool_call` / `list_tool_calls`).
- Agent upserts on args-known and on completion instead of writing `Role::Tool` text rows.
- `load_transcript` rebuilds `ToolUse` / `ToolResult` blocks so cross-turn context keeps structured tool activity.

Stacked on #36 (`thet/turn-steer`).

## Test plan
- [x] `cargo test -p openwave-core --lib` (rebuild + roundtrip + cross-turn)
- [x] `cargo clippy -p openwave-core -p openwave-server --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] CI green on this PR
- [ ] Rebase onto `main` after #36 merges

