### PR TITLE
feat(core): context reduction — fit transcripts to the context window

### DIFF
--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -22,6 +22,7 @@ fn serve_announces_its_address_and_answers_health() {
     let mut child = Command::new(env!("CARGO_BIN_EXE_openwave"))
         .arg("serve")
         .env("OPENWAVE_DATA_DIR", dir.path())
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
         .env_remove("ANTHROPIC_API_KEY")
         .stdout(Stdio::piped())
         .spawn()

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -12,8 +12,8 @@
 //! - tool calls run **sequentially** (concurrency for independent calls later);
 //! - approval is **auto** for `ReadOnly`/`Workspace`; `Sensitive` parks via an
 //!   [`ApprovalGate`] until approve/reject (standing grants / auto-judge later);
-//! - cross-turn context rebuilds text messages plus structured tool-call rows
-//!   (context summarization comes later).
+//! - context reduction is deterministic floor+restore (no LLM summarization);
+//!   retries with progressive reduction on provider prompt-too-long errors.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -26,6 +26,7 @@ use serde_json::Value;
 
 use crate::approval::{ApprovalDecision, ApprovalGate, ApprovalRequest, RefuseGate};
 use crate::cancel::CancelToken;
+use crate::context;
 use crate::error::{AgentError, Result};
 use crate::event::AgentEvent;
 use crate::id::{CallId, MessageId, TurnId};
@@ -102,7 +103,13 @@ pub struct AgentConfig {
     /// Max bytes of a single tool result fed back to the model; larger results
     /// are truncated with a notice, so one big read can't blow the context.
     pub max_tool_result_bytes: usize,
+    /// The model's context window in tokens. Used to compute the message budget
+    /// for context reduction (default: 200 000).
+    pub context_window: usize,
 }
+
+/// Default context window: 200k tokens (Claude Opus/Sonnet).
+pub const DEFAULT_CONTEXT_WINDOW: usize = 200_000;
 
 impl Default for AgentConfig {
     fn default() -> Self {
@@ -113,6 +120,7 @@ impl Default for AgentConfig {
             temperature: None,
             max_steps: 16,
             max_tool_result_bytes: DEFAULT_MAX_TOOL_RESULT_BYTES,
+            context_window: DEFAULT_CONTEXT_WINDOW,
         }
     }
 }
@@ -219,6 +227,7 @@ impl Agent {
         // we build up as the loop runs.
         let mut transcript = self.load_transcript(chat.id).await?;
         let mut total_usage = Usage::default();
+        let mut reduction_level: u32 = 0;
 
         for step in 0..self.config.max_steps {
             // Between steps: stop before starting a fresh model call if cancelled.
@@ -229,16 +238,32 @@ impl Agent {
             self.apply_steers(chat, turn_id, &mut transcript, events)
                 .await?;
 
-            let request = ChatRequest {
-                model: self.config.model.clone(),
-                system: self.config.system_prompt.clone(),
-                messages: transcript.clone(),
-                tools: self.tools.specs(),
-                max_tokens: self.config.max_tokens,
-                temperature: self.config.temperature,
-            };
+            // Fit the transcript to the context window, retrying with tighter
+            // budgets on prompt-too-long errors from the provider.
+            let mut stream = loop {
+                let fitted = self.fit_transcript(&transcript, reduction_level);
+                let request = ChatRequest {
+                    model: self.config.model.clone(),
+                    system: self.config.system_prompt.clone(),
+                    messages: fitted,
+                    tools: self.tools.specs(),
+                    max_tokens: self.config.max_tokens,
+                    temperature: self.config.temperature,
+                };
 
-            let mut stream = self.provider.stream(request).await?;
+                match self.provider.stream(request).await {
+                    Ok(stream) => {
+                        reduction_level = 0;
+                        break stream;
+                    }
+                    Err(AgentError::PromptTooLong(_))
+                        if reduction_level < context::MAX_REDUCTION_LEVEL =>
+                    {
+                        reduction_level += 1;
+                    }
+                    Err(e) => return Err(e),
+                }
+            };
             let mut text = String::new();
             let mut calls: Vec<PendingCall> = Vec::new();
             let mut by_index: HashMap<u32, usize> = HashMap::new();
@@ -575,6 +600,19 @@ impl Agent {
         let messages = self.store.list_messages(chat_id).await?;
         let tool_calls = self.store.list_tool_calls(chat_id).await?;
         Ok(rebuild_transcript(&messages, &tool_calls))
+    }
+
+    /// Fit the transcript to the context budget at the given reduction level.
+    fn fit_transcript(&self, transcript: &[ChatMessage], reduction_level: u32) -> Vec<ChatMessage> {
+        let budget = context::compute_message_budget(
+            self.config.context_window,
+            reduction_level,
+            self.config.system_prompt.as_deref(),
+            &self.tools.specs(),
+        );
+        let floor = context::content_floor_for_level(reduction_level);
+        let (fitted, _) = context::fit_to_budget(transcript, budget, floor);
+        fitted
     }
 }
 

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -241,7 +241,8 @@ impl Agent {
             // Fit the transcript to the context window, retrying with tighter
             // budgets on prompt-too-long errors from the provider.
             let mut stream = loop {
-                let fitted = self.fit_transcript(&transcript, reduction_level);
+                let (fitted, reduced) = self.fit_transcript(&transcript, reduction_level);
+                let fitted_tokens = context::estimate_transcript_tokens(&fitted);
                 let request = ChatRequest {
                     model: self.config.model.clone(),
                     system: self.config.system_prompt.clone(),
@@ -253,6 +254,16 @@ impl Agent {
 
                 match self.provider.stream(request).await {
                     Ok(stream) => {
+                        // Tell clients the history was shortened for this call so
+                        // a UI can surface it. Emitted only for the request that
+                        // actually went out (after any retry climb).
+                        if reduced {
+                            let _ = events.unbounded_send(AgentEvent::ContextTruncated {
+                                original_tokens: context::estimate_transcript_tokens(&transcript)
+                                    as u32,
+                                fitted_tokens: fitted_tokens as u32,
+                            });
+                        }
                         reduction_level = 0;
                         break stream;
                     }
@@ -603,7 +614,12 @@ impl Agent {
     }
 
     /// Fit the transcript to the context budget at the given reduction level.
-    fn fit_transcript(&self, transcript: &[ChatMessage], reduction_level: u32) -> Vec<ChatMessage> {
+    /// Returns the fitted transcript and whether it was shortened.
+    fn fit_transcript(
+        &self,
+        transcript: &[ChatMessage],
+        reduction_level: u32,
+    ) -> (Vec<ChatMessage>, bool) {
         let budget = context::compute_message_budget(
             self.config.context_window,
             reduction_level,
@@ -611,8 +627,7 @@ impl Agent {
             &self.tools.specs(),
         );
         let floor = context::content_floor_for_level(reduction_level);
-        let (fitted, _) = context::fit_to_budget(transcript, budget, floor);
-        fitted
+        context::fit_to_budget(transcript, budget, floor)
     }
 }
 
@@ -1277,6 +1292,74 @@ mod tests {
         assert!(!events
             .iter()
             .any(|e| matches!(e, AgentEvent::TextDelta { .. })));
+    }
+
+    #[tokio::test]
+    async fn oversized_transcript_emits_context_truncated() {
+        let (store, chat, _workspace) = cancel_test_chat().await;
+
+        // Records what the provider actually received, and answers immediately.
+        struct AnswerProvider {
+            seen_tokens: Arc<AtomicUsize>,
+        }
+        #[async_trait]
+        impl ModelProvider for AnswerProvider {
+            fn id(&self) -> ProviderId {
+                ProviderId::new("answer")
+            }
+            async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+                self.seen_tokens.store(
+                    context::estimate_transcript_tokens(&req.messages),
+                    Ordering::SeqCst,
+                );
+                Ok(stream::iter(vec![
+                    ProviderEvent::TextDelta { text: "ok".into() },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ])
+                .boxed())
+            }
+        }
+
+        let seen_tokens = Arc::new(AtomicUsize::new(0));
+        // A small context window forces reduction of a large input.
+        let context_window = 3000;
+        let agent = Agent::new(
+            Arc::new(AnswerProvider {
+                seen_tokens: seen_tokens.clone(),
+            }),
+            Arc::new(ToolRegistry::new()),
+            store,
+            AgentConfig {
+                model: "answer".into(),
+                context_window,
+                ..Default::default()
+            },
+        );
+
+        let huge = "word ".repeat(2000); // ~3300 tokens, over the ~2250 budget
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, &huge, &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        let truncated = events.iter().find_map(|e| match e {
+            AgentEvent::ContextTruncated {
+                original_tokens,
+                fitted_tokens,
+            } => Some((*original_tokens, *fitted_tokens)),
+            _ => None,
+        });
+        let (original, fitted) = truncated.expect("ContextTruncated emitted for oversized input");
+        assert!(
+            fitted < original,
+            "fitted {fitted} should be < original {original}"
+        );
+        // What actually went to the provider matches the reported fitted size and
+        // is within the reduced budget.
+        assert_eq!(seen_tokens.load(Ordering::SeqCst), fitted as usize);
+        assert!(fitted as usize <= context::compute_message_budget(context_window, 0, None, &[]));
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/context.rs
+++ b/crates/openwave-core/src/context.rs
@@ -300,27 +300,42 @@ fn mark_pair_kept(
 
 fn truncate_message(msg: &ChatMessage, target_tokens: usize) -> ChatMessage {
     let available = target_tokens.saturating_sub(ROLE_OVERHEAD);
-    let total: usize = msg.content.iter().map(estimate_block_tokens).sum();
-    if total == 0 {
+    if msg.content.is_empty() {
         return msg.clone();
     }
 
-    let mut blocks: Vec<ContentBlock> = Vec::new();
-    let mut remaining = available;
+    // Every block costs at least its fixed overhead (it can't shrink below the
+    // JSON envelope + ids), so reserve overheads first, then split whatever
+    // remains across blocks in proportion to their content size. Callers keep
+    // `target_tokens >= message_floor`, so `available >= overhead_total` and the
+    // shares sum to at most `available` — the message never exceeds its budget.
+    let overhead_total: usize = msg.content.iter().map(block_overhead).sum();
+    let content_total: usize = msg
+        .content
+        .iter()
+        .map(|b| estimate_block_tokens(b).saturating_sub(block_overhead(b)))
+        .sum();
+    let content_budget = available.saturating_sub(overhead_total);
 
-    for block in &msg.content {
-        let full = estimate_block_tokens(block);
-        let share = ((available as u64 * full as u64) / total as u64) as usize;
-        let share = share.min(remaining).max(block_overhead(block));
-
-        if share >= full {
-            blocks.push(block.clone());
-            remaining = remaining.saturating_sub(full);
-        } else {
-            blocks.push(truncate_block(block, share));
-            remaining = remaining.saturating_sub(share);
-        }
-    }
+    let blocks: Vec<ContentBlock> = msg
+        .content
+        .iter()
+        .map(|block| {
+            let overhead = block_overhead(block);
+            let block_content = estimate_block_tokens(block).saturating_sub(overhead);
+            let content_share = if content_total == 0 {
+                0
+            } else {
+                (content_budget as u64 * block_content as u64 / content_total as u64) as usize
+            };
+            let share = overhead + content_share;
+            if share >= estimate_block_tokens(block) {
+                block.clone()
+            } else {
+                truncate_block(block, share)
+            }
+        })
+        .collect();
 
     ChatMessage {
         role: msg.role,
@@ -369,7 +384,12 @@ fn truncate_str(s: &str, target_tokens: usize) -> String {
         return s.to_string();
     }
     let suffix_chars = TRUNCATION_SUFFIX.chars().count();
-    let keep = char_budget.saturating_sub(suffix_chars);
+    // When the budget can't even hold the notice, hard-cut to the budget — the
+    // notice itself must never push the block back over `target_tokens`.
+    if char_budget <= suffix_chars {
+        return s.chars().take(char_budget).collect();
+    }
+    let keep = char_budget - suffix_chars;
     let truncated: String = s.chars().take(keep).collect();
     format!("{truncated}{TRUNCATION_SUFFIX}")
 }
@@ -572,6 +592,64 @@ mod tests {
         let (result, reduced) = fit_to_budget(&msgs, budget, 100);
         assert!(reduced);
         assert!(estimate_transcript_tokens(&result) <= budget);
+    }
+
+    #[test]
+    fn multi_block_message_never_exceeds_its_allocation() {
+        // A message with many small blocks used to overshoot its target: each
+        // block was force-allocated its overhead *after* the remaining-budget
+        // cap, so the shares summed above the allocation. Truncating to a tight
+        // target must produce a message at or under that target.
+        let blocks: Vec<ContentBlock> = (0..10)
+            .map(|i| ContentBlock::Text {
+                text: format!("block {i} ").repeat(20),
+            })
+            .collect();
+        let msg = ChatMessage {
+            role: Role::User,
+            content: blocks,
+        };
+        // Callers never allocate below the message's irreducible overhead floor
+        // (role + each block's fixed envelope); test at and above it.
+        let overhead_floor: usize =
+            ROLE_OVERHEAD + msg.content.iter().map(block_overhead).sum::<usize>();
+        for target in [overhead_floor, overhead_floor + 40, 200, 400] {
+            let truncated = truncate_message(&msg, target);
+            assert!(
+                estimate_message_tokens(&truncated) <= target,
+                "target {target}: got {}",
+                estimate_message_tokens(&truncated)
+            );
+        }
+    }
+
+    #[test]
+    fn transcript_with_many_block_messages_fits_budget() {
+        // End-to-end: a transcript of multi-block messages must fit the budget
+        // after reduction, so the proactive path doesn't fall through to the
+        // provider's PromptTooLong retry.
+        let make = |role: Role, n: usize| ChatMessage {
+            role,
+            content: (0..n)
+                .map(|i| ContentBlock::Text {
+                    text: format!("chunk {i} ").repeat(30),
+                })
+                .collect(),
+        };
+        let msgs = vec![
+            user_msg("kick off the conversation here"),
+            make(Role::Assistant, 8),
+            make(Role::User, 6),
+            make(Role::Assistant, 10),
+        ];
+        let budget = estimate_transcript_tokens(&msgs) / 3;
+        let (result, reduced) = fit_to_budget(&msgs, budget, 50);
+        assert!(reduced);
+        assert!(
+            estimate_transcript_tokens(&result) <= budget,
+            "fitted {} > budget {budget}",
+            estimate_transcript_tokens(&result)
+        );
     }
 
     #[test]

--- a/crates/openwave-core/src/context.rs
+++ b/crates/openwave-core/src/context.rs
@@ -1,0 +1,769 @@
+//! Context reduction — fit a transcript to a model's context window.
+//!
+//! When a conversation outgrows the model's input budget the agent can't send
+//! the full history. This module trims the transcript deterministically:
+//! messages are shrunk to floor-sized stubs, surplus budget is restored
+//! newest-first, and orphaned tool-use/result pairs are stripped. No LLM
+//! summarization — the reduction is fast, predictable, and favours recent
+//! context.
+
+use std::collections::HashSet;
+
+use crate::model::Role;
+use crate::provider::{ChatMessage, ContentBlock};
+
+const TEXT_OVERHEAD: usize = 7;
+const TOOL_USE_OVERHEAD: usize = 30;
+const TOOL_RESULT_OVERHEAD: usize = 20;
+const ROLE_OVERHEAD: usize = 4;
+const MAX_SINGLE_BLOCK_TOKENS: usize = 25_000;
+const TRUNCATION_SUFFIX: &str = "\n… [truncated]";
+
+// ── Token estimation ───────────────────────────────────────────────
+
+/// Estimate tokens for a string: `ceil(chars / 3)`.
+pub fn estimate_tokens(s: &str) -> usize {
+    s.chars().count().div_ceil(3)
+}
+
+/// Estimate tokens for one content block (overhead + content).
+pub fn estimate_block_tokens(block: &ContentBlock) -> usize {
+    match block {
+        ContentBlock::Text { text } => TEXT_OVERHEAD + estimate_tokens(text),
+        ContentBlock::ToolUse { id, name, input } => {
+            TOOL_USE_OVERHEAD
+                + estimate_tokens(id)
+                + estimate_tokens(name)
+                + estimate_tokens(&input.to_string())
+        }
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            ..
+        } => TOOL_RESULT_OVERHEAD + estimate_tokens(tool_use_id) + estimate_tokens(content),
+    }
+}
+
+/// Estimate tokens for a full message (role overhead + blocks).
+pub fn estimate_message_tokens(msg: &ChatMessage) -> usize {
+    ROLE_OVERHEAD + msg.content.iter().map(estimate_block_tokens).sum::<usize>()
+}
+
+/// Estimate tokens for an entire transcript.
+pub fn estimate_transcript_tokens(messages: &[ChatMessage]) -> usize {
+    messages.iter().map(estimate_message_tokens).sum()
+}
+
+// ── Context reduction ──────────────────────────────────────────────
+
+/// Fit a transcript into a token `budget`.
+///
+/// `content_floor` is the minimum content tokens per block after shrinking
+/// (e.g. 500 at reduction level 0, 100 at level 3).
+///
+/// Algorithm (floor + newest-first restoration):
+/// 1. Compute each message's full and floor token estimates.
+/// 2. If the sum of floors exceeds the budget, drop oldest messages
+///    (newest-first selection, keeping tool-use/result pairs together).
+/// 3. Distribute remaining budget newest-first — each message reclaims up to
+///    its original size, capped at [`MAX_SINGLE_BLOCK_TOKENS`].
+/// 4. Truncate content blocks that exceed their allocation.
+/// 5. Strip orphaned tool-use/result blocks and merge adjacent same-role
+///    messages.
+///
+/// Returns `(fitted_messages, was_reduced)`.
+pub fn fit_to_budget(
+    messages: &[ChatMessage],
+    budget: usize,
+    content_floor: usize,
+) -> (Vec<ChatMessage>, bool) {
+    if messages.is_empty() || estimate_transcript_tokens(messages) <= budget {
+        return (messages.to_vec(), false);
+    }
+
+    let mut entries: Vec<Entry> = messages
+        .iter()
+        .map(|msg| {
+            let full = estimate_message_tokens(msg);
+            let floor = message_floor(msg, content_floor);
+            Entry {
+                full,
+                floor,
+                allocated: floor,
+                kept: true,
+            }
+        })
+        .collect();
+
+    // Phase 1: if floors exceed budget, select newest messages that fit.
+    let floor_total: usize = entries.iter().map(|e| e.floor).sum();
+    if floor_total > budget {
+        select_newest_to_fit(&mut entries, budget, messages);
+    }
+
+    // Phase 2: distribute surplus newest-first.
+    let current: usize = entries.iter().filter(|e| e.kept).map(|e| e.allocated).sum();
+    let mut surplus = budget.saturating_sub(current);
+    for entry in entries.iter_mut().rev() {
+        if !entry.kept || surplus == 0 {
+            continue;
+        }
+        let headroom = entry
+            .full
+            .saturating_sub(entry.allocated)
+            .min(MAX_SINGLE_BLOCK_TOKENS);
+        let reclaim = headroom.min(surplus);
+        entry.allocated += reclaim;
+        surplus -= reclaim;
+    }
+
+    // Phase 3: build output with truncation.
+    let mut result: Vec<ChatMessage> = Vec::new();
+    for (i, entry) in entries.iter().enumerate() {
+        if !entry.kept {
+            continue;
+        }
+        if entry.allocated >= entry.full {
+            result.push(messages[i].clone());
+        } else {
+            result.push(truncate_message(&messages[i], entry.allocated));
+        }
+    }
+
+    // Phase 4: clean up.
+    strip_orphaned_tool_blocks(&mut result);
+    merge_adjacent_roles(&mut result);
+    ensure_starts_with_user(&mut result);
+
+    (result, true)
+}
+
+struct Entry {
+    full: usize,
+    floor: usize,
+    allocated: usize,
+    kept: bool,
+}
+
+/// Minimum viable token size for a message: role overhead + each block at the
+/// floor.
+fn message_floor(msg: &ChatMessage, content_floor: usize) -> usize {
+    ROLE_OVERHEAD
+        + msg
+            .content
+            .iter()
+            .map(|block| {
+                let overhead = block_overhead(block);
+                let content = estimate_block_tokens(block).saturating_sub(overhead);
+                overhead + content.min(content_floor)
+            })
+            .sum::<usize>()
+}
+
+fn block_overhead(block: &ContentBlock) -> usize {
+    match block {
+        ContentBlock::Text { .. } => TEXT_OVERHEAD,
+        ContentBlock::ToolUse { .. } => TOOL_USE_OVERHEAD,
+        ContentBlock::ToolResult { .. } => TOOL_RESULT_OVERHEAD,
+    }
+}
+
+/// Walk backwards from newest, keeping messages whose floors fit. Marks
+/// messages as `kept = false` when they don't fit. Tool-use/result pairs are
+/// kept or dropped together.
+fn select_newest_to_fit(entries: &mut [Entry], budget: usize, messages: &[ChatMessage]) {
+    // Build pairing maps: tool_use id → message index, tool_result id → index.
+    let mut use_to_msg: Vec<(String, usize)> = Vec::new();
+    let mut result_to_msg: Vec<(String, usize)> = Vec::new();
+    for (i, msg) in messages.iter().enumerate() {
+        for block in &msg.content {
+            match block {
+                ContentBlock::ToolUse { id, .. } => use_to_msg.push((id.clone(), i)),
+                ContentBlock::ToolResult { tool_use_id, .. } => {
+                    result_to_msg.push((tool_use_id.clone(), i));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Mark all as dropped, then select from newest.
+    for entry in entries.iter_mut() {
+        entry.kept = false;
+    }
+
+    let mut remaining = budget;
+    // Walk backwards, greedily selecting.
+    for i in (0..entries.len()).rev() {
+        if entries[i].kept {
+            continue; // already selected as part of a tool pair
+        }
+        let cost = pair_cost(i, entries, messages, &use_to_msg, &result_to_msg);
+        if cost <= remaining {
+            remaining -= mark_pair_kept(i, entries, messages, &use_to_msg, &result_to_msg);
+        }
+    }
+
+    // Guarantee at least one user text message (the Messages API requires
+    // conversations to start with `user`). If none was selected, force-keep
+    // the most recent one — slightly exceeding the budget is better than an
+    // empty or invalid transcript.
+    let has_user_text = entries.iter().enumerate().any(|(i, e)| {
+        e.kept
+            && messages[i].role == Role::User
+            && messages[i]
+                .content
+                .iter()
+                .any(|b| matches!(b, ContentBlock::Text { .. }))
+    });
+    if !has_user_text {
+        for i in (0..entries.len()).rev() {
+            if messages[i].role == Role::User
+                && messages[i]
+                    .content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Text { .. }))
+            {
+                mark_pair_kept(i, entries, messages, &use_to_msg, &result_to_msg);
+                break;
+            }
+        }
+    }
+}
+
+/// Cost of keeping message `i` and its paired tool messages (if any).
+fn pair_cost(
+    i: usize,
+    entries: &[Entry],
+    messages: &[ChatMessage],
+    use_to_msg: &[(String, usize)],
+    result_to_msg: &[(String, usize)],
+) -> usize {
+    let mut cost = entries[i].floor;
+    for block in &messages[i].content {
+        match block {
+            ContentBlock::ToolUse { id, .. } => {
+                if let Some(&(_, ri)) = result_to_msg.iter().find(|(tid, _)| tid == id) {
+                    if !entries[ri].kept {
+                        cost += entries[ri].floor;
+                    }
+                }
+            }
+            ContentBlock::ToolResult { tool_use_id, .. } => {
+                if let Some(&(_, ui)) = use_to_msg.iter().find(|(tid, _)| tid == tool_use_id) {
+                    if !entries[ui].kept {
+                        cost += entries[ui].floor;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    cost
+}
+
+/// Mark message `i` and its tool pair as kept. Returns total floor cost.
+fn mark_pair_kept(
+    i: usize,
+    entries: &mut [Entry],
+    messages: &[ChatMessage],
+    use_to_msg: &[(String, usize)],
+    result_to_msg: &[(String, usize)],
+) -> usize {
+    entries[i].kept = true;
+    let mut cost = entries[i].floor;
+    for block in &messages[i].content {
+        match block {
+            ContentBlock::ToolUse { id, .. } => {
+                if let Some(&(_, ri)) = result_to_msg.iter().find(|(tid, _)| tid == id) {
+                    if !entries[ri].kept {
+                        entries[ri].kept = true;
+                        cost += entries[ri].floor;
+                    }
+                }
+            }
+            ContentBlock::ToolResult { tool_use_id, .. } => {
+                if let Some(&(_, ui)) = use_to_msg.iter().find(|(tid, _)| tid == tool_use_id) {
+                    if !entries[ui].kept {
+                        entries[ui].kept = true;
+                        cost += entries[ui].floor;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    cost
+}
+
+// ── Truncation ─────────────────────────────────────────────────────
+
+fn truncate_message(msg: &ChatMessage, target_tokens: usize) -> ChatMessage {
+    let available = target_tokens.saturating_sub(ROLE_OVERHEAD);
+    let total: usize = msg.content.iter().map(estimate_block_tokens).sum();
+    if total == 0 {
+        return msg.clone();
+    }
+
+    let mut blocks: Vec<ContentBlock> = Vec::new();
+    let mut remaining = available;
+
+    for block in &msg.content {
+        let full = estimate_block_tokens(block);
+        let share = ((available as u64 * full as u64) / total as u64) as usize;
+        let share = share.min(remaining).max(block_overhead(block));
+
+        if share >= full {
+            blocks.push(block.clone());
+            remaining = remaining.saturating_sub(full);
+        } else {
+            blocks.push(truncate_block(block, share));
+            remaining = remaining.saturating_sub(share);
+        }
+    }
+
+    ChatMessage {
+        role: msg.role,
+        content: blocks,
+    }
+}
+
+fn truncate_block(block: &ContentBlock, target_tokens: usize) -> ContentBlock {
+    match block {
+        ContentBlock::Text { text } => {
+            let budget = target_tokens.saturating_sub(TEXT_OVERHEAD);
+            ContentBlock::Text {
+                text: truncate_str(text, budget),
+            }
+        }
+        ContentBlock::ToolUse { id, name, input } => {
+            let fixed = TOOL_USE_OVERHEAD + estimate_tokens(id) + estimate_tokens(name);
+            let budget = target_tokens.saturating_sub(fixed);
+            let input_str = input.to_string();
+            let truncated = truncate_str(&input_str, budget);
+            ContentBlock::ToolUse {
+                id: id.clone(),
+                name: name.clone(),
+                input: serde_json::json!({ "truncated_args": truncated }),
+            }
+        }
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+        } => {
+            let fixed = TOOL_RESULT_OVERHEAD + estimate_tokens(tool_use_id);
+            let budget = target_tokens.saturating_sub(fixed);
+            ContentBlock::ToolResult {
+                tool_use_id: tool_use_id.clone(),
+                content: truncate_str(content, budget),
+                is_error: *is_error,
+            }
+        }
+    }
+}
+
+fn truncate_str(s: &str, target_tokens: usize) -> String {
+    let char_budget = target_tokens * 3;
+    if s.chars().count() <= char_budget {
+        return s.to_string();
+    }
+    let suffix_chars = TRUNCATION_SUFFIX.chars().count();
+    let keep = char_budget.saturating_sub(suffix_chars);
+    let truncated: String = s.chars().take(keep).collect();
+    format!("{truncated}{TRUNCATION_SUFFIX}")
+}
+
+// ── Cleanup ────────────────────────────────────────────────────────
+
+/// Remove ToolUse blocks with no matching ToolResult and vice versa.
+pub fn strip_orphaned_tool_blocks(messages: &mut Vec<ChatMessage>) {
+    let mut use_ids: HashSet<String> = HashSet::new();
+    let mut result_ids: HashSet<String> = HashSet::new();
+
+    for msg in messages.iter() {
+        for block in &msg.content {
+            match block {
+                ContentBlock::ToolUse { id, .. } => {
+                    use_ids.insert(id.clone());
+                }
+                ContentBlock::ToolResult { tool_use_id, .. } => {
+                    result_ids.insert(tool_use_id.clone());
+                }
+                _ => {}
+            }
+        }
+    }
+
+    for msg in messages.iter_mut() {
+        msg.content.retain(|block| match block {
+            ContentBlock::ToolUse { id, .. } => result_ids.contains(id),
+            ContentBlock::ToolResult { tool_use_id, .. } => use_ids.contains(tool_use_id),
+            _ => true,
+        });
+    }
+
+    messages.retain(|msg| !msg.content.is_empty());
+}
+
+/// Merge adjacent messages with the same role.
+fn merge_adjacent_roles(messages: &mut Vec<ChatMessage>) {
+    let mut i = 0;
+    while i + 1 < messages.len() {
+        if messages[i].role == messages[i + 1].role {
+            let next = messages.remove(i + 1);
+            messages[i].content.extend(next.content);
+        } else {
+            i += 1;
+        }
+    }
+}
+
+/// Drop leading messages until the first is a user message with non-tool-result
+/// content. The Messages API requires the conversation to start with `user`.
+fn ensure_starts_with_user(messages: &mut Vec<ChatMessage>) {
+    while let Some(first) = messages.first() {
+        if first.role == Role::User
+            && first
+                .content
+                .iter()
+                .any(|b| matches!(b, ContentBlock::Text { .. }))
+        {
+            break;
+        }
+        messages.remove(0);
+    }
+}
+
+// ── Budget helpers (used by the agent loop) ────────────────────────
+
+/// The maximum reduction level (0 = normal, 3 = nuclear).
+pub const MAX_REDUCTION_LEVEL: u32 = 3;
+
+/// Compute the message-array token budget for a given reduction level.
+///
+/// Subtracts estimated system-prompt and tool-spec tokens from a fraction of
+/// the context window. The fraction shrinks with each level (75% → 63% → 50%
+/// → 38%).
+pub fn compute_message_budget(
+    context_window: usize,
+    reduction_level: u32,
+    system_prompt: Option<&str>,
+    tool_specs: &[crate::tool::ToolSpec],
+) -> usize {
+    let fraction = match reduction_level {
+        0 => 75,
+        1 => 63,
+        2 => 50,
+        _ => 38,
+    };
+    let effective = context_window * fraction / 100;
+    let system_tokens = system_prompt.map(estimate_tokens).unwrap_or(0);
+    let tools_tokens: usize = tool_specs
+        .iter()
+        .map(|t| {
+            30 + estimate_tokens(&t.name)
+                + estimate_tokens(&t.description)
+                + estimate_tokens(&t.input_schema.to_string())
+        })
+        .sum();
+    effective
+        .saturating_sub(system_tokens)
+        .saturating_sub(tools_tokens)
+}
+
+/// Content-floor tokens for a given reduction level.
+pub fn content_floor_for_level(level: u32) -> usize {
+    match level {
+        0 => 500,
+        1 => 300,
+        2 => 200,
+        _ => 100,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn user_msg(text: &str) -> ChatMessage {
+        ChatMessage::text(Role::User, text)
+    }
+
+    fn assistant_msg(text: &str) -> ChatMessage {
+        ChatMessage::text(Role::Assistant, text)
+    }
+
+    fn tool_use_msg(id: &str, name: &str, args: &str) -> ChatMessage {
+        ChatMessage {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: id.into(),
+                name: name.into(),
+                input: json!({ "arg": args }),
+            }],
+        }
+    }
+
+    fn tool_result_msg(tool_use_id: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: tool_use_id.into(),
+                content: content.into(),
+                is_error: false,
+            }],
+        }
+    }
+
+    // ── Token estimation ───────────────────────────────────────────
+
+    #[test]
+    fn estimate_tokens_uses_chars_div_3() {
+        assert_eq!(estimate_tokens("abc"), 1);
+        assert_eq!(estimate_tokens("abcd"), 2);
+        assert_eq!(estimate_tokens(""), 0);
+        assert_eq!(estimate_tokens("hello world"), 4); // ceil(11/3)
+    }
+
+    #[test]
+    fn estimate_message_tokens_sums_blocks() {
+        let msg = ChatMessage {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text {
+                    text: "hello".into(),
+                },
+                ContentBlock::Text {
+                    text: "world".into(),
+                },
+            ],
+        };
+        let tokens = estimate_message_tokens(&msg);
+        assert_eq!(
+            tokens,
+            ROLE_OVERHEAD + (TEXT_OVERHEAD + estimate_tokens("hello")) * 2
+        );
+    }
+
+    // ── fit_to_budget ──────────────────────────────────────────────
+
+    #[test]
+    fn no_reduction_when_within_budget() {
+        let msgs = vec![user_msg("hello"), assistant_msg("hi")];
+        let budget = estimate_transcript_tokens(&msgs) + 100;
+        let (result, reduced) = fit_to_budget(&msgs, budget, 500);
+        assert!(!reduced);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn reduces_when_over_budget() {
+        let big = "x".repeat(3000);
+        let msgs = vec![
+            user_msg("start"),
+            assistant_msg(&big),
+            user_msg("follow up"),
+            assistant_msg("recent answer"),
+        ];
+        let full = estimate_transcript_tokens(&msgs);
+        let budget = full / 2;
+        let (result, reduced) = fit_to_budget(&msgs, budget, 100);
+        assert!(reduced);
+        assert!(estimate_transcript_tokens(&result) <= budget);
+    }
+
+    #[test]
+    fn newest_messages_get_more_budget() {
+        let big = "x".repeat(3000);
+        let msgs = vec![
+            user_msg("old"),
+            assistant_msg(&big),
+            user_msg("recent"),
+            assistant_msg("answer"),
+        ];
+        let full = estimate_transcript_tokens(&msgs);
+        // Budget enough for the newest messages at full + oldest shrunk.
+        let budget = full * 2 / 3;
+        let (result, reduced) = fit_to_budget(&msgs, budget, 50);
+        assert!(reduced);
+        // The recent answer should be intact (or close to it).
+        let last = result.last().unwrap();
+        if let ContentBlock::Text { text } = &last.content[0] {
+            assert_eq!(text, "answer");
+        }
+    }
+
+    #[test]
+    fn tool_pairs_kept_together() {
+        let msgs = vec![
+            user_msg("go"),
+            tool_use_msg("tu_1", "read_file", "a"),
+            tool_result_msg("tu_1", &"data ".repeat(500)),
+            user_msg("now what"),
+            assistant_msg("done"),
+        ];
+        let budget = estimate_transcript_tokens(&msgs) / 3;
+        let (result, reduced) = fit_to_budget(&msgs, budget, 50);
+        assert!(reduced);
+        // If tool_use is present, its result must be too (and vice versa).
+        let has_use = result.iter().any(|m| {
+            m.content
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolUse { id, .. } if id == "tu_1"))
+        });
+        let has_result = result.iter().any(|m| {
+            m.content.iter().any(
+                |b| matches!(b, ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "tu_1"),
+            )
+        });
+        assert_eq!(
+            has_use, has_result,
+            "tool pair must be kept or dropped together"
+        );
+    }
+
+    #[test]
+    fn result_starts_with_user_text() {
+        let msgs = vec![
+            user_msg("hi"),
+            assistant_msg("hey"),
+            user_msg("question"),
+            assistant_msg("answer"),
+        ];
+        let budget = estimate_transcript_tokens(&msgs) / 2;
+        let (result, _) = fit_to_budget(&msgs, budget, 50);
+        assert!(!result.is_empty());
+        let first = &result[0];
+        assert_eq!(first.role, Role::User);
+        assert!(first
+            .content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::Text { .. })));
+    }
+
+    #[test]
+    fn empty_transcript_is_noop() {
+        let (result, reduced) = fit_to_budget(&[], 1000, 500);
+        assert!(!reduced);
+        assert!(result.is_empty());
+    }
+
+    // ── strip_orphaned_tool_blocks ─────────────────────────────────
+
+    #[test]
+    fn strips_orphaned_tool_use() {
+        let mut msgs = vec![
+            user_msg("go"),
+            tool_use_msg("tu_1", "read_file", "a"),
+            // No matching ToolResult for tu_1.
+            user_msg("next"),
+        ];
+        strip_orphaned_tool_blocks(&mut msgs);
+        assert!(!msgs.iter().any(|m| m
+            .content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::ToolUse { .. }))));
+    }
+
+    #[test]
+    fn strips_orphaned_tool_result() {
+        let mut msgs = vec![
+            user_msg("go"),
+            // No matching ToolUse for tu_1.
+            tool_result_msg("tu_1", "data"),
+            assistant_msg("done"),
+        ];
+        strip_orphaned_tool_blocks(&mut msgs);
+        assert!(!msgs.iter().any(|m| m
+            .content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::ToolResult { .. }))));
+    }
+
+    #[test]
+    fn keeps_paired_tool_blocks() {
+        let mut msgs = vec![
+            user_msg("go"),
+            tool_use_msg("tu_1", "read_file", "a"),
+            tool_result_msg("tu_1", "data"),
+            assistant_msg("done"),
+        ];
+        strip_orphaned_tool_blocks(&mut msgs);
+        assert!(msgs.iter().any(|m| m
+            .content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::ToolUse { id, .. } if id == "tu_1"))));
+        assert!(msgs.iter().any(|m| m.content.iter().any(
+            |b| matches!(b, ContentBlock::ToolResult { tool_use_id, .. } if tool_use_id == "tu_1")
+        )));
+    }
+
+    // ── Budget helpers ─────────────────────────────────────────────
+
+    #[test]
+    fn budget_shrinks_with_level() {
+        let b0 = compute_message_budget(200_000, 0, None, &[]);
+        let b1 = compute_message_budget(200_000, 1, None, &[]);
+        let b2 = compute_message_budget(200_000, 2, None, &[]);
+        let b3 = compute_message_budget(200_000, 3, None, &[]);
+        assert!(b0 > b1);
+        assert!(b1 > b2);
+        assert!(b2 > b3);
+    }
+
+    #[test]
+    fn budget_subtracts_system_and_tools() {
+        let bare = compute_message_budget(200_000, 0, None, &[]);
+        let with_system = compute_message_budget(200_000, 0, Some("be brief and helpful"), &[]);
+        assert!(with_system < bare);
+    }
+
+    #[test]
+    fn content_floor_decreases_with_level() {
+        assert!(content_floor_for_level(0) > content_floor_for_level(1));
+        assert!(content_floor_for_level(1) > content_floor_for_level(2));
+        assert!(content_floor_for_level(2) > content_floor_for_level(3));
+    }
+
+    // ── Truncation helpers ─────────────────────────────────────────
+
+    #[test]
+    fn truncate_str_appends_notice() {
+        let s = "a".repeat(3000);
+        let result = truncate_str(&s, 100);
+        assert!(result.contains(TRUNCATION_SUFFIX));
+        assert!(result.len() < s.len());
+    }
+
+    #[test]
+    fn truncate_str_noop_when_fits() {
+        let s = "hello";
+        let result = truncate_str(s, 100);
+        assert_eq!(result, s);
+    }
+
+    // ── merge / ensure_starts_with_user ────────────────────────────
+
+    #[test]
+    fn merge_adjacent_same_role() {
+        let mut msgs = vec![user_msg("a"), user_msg("b"), assistant_msg("c")];
+        merge_adjacent_roles(&mut msgs);
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role, Role::User);
+        assert_eq!(msgs[0].content.len(), 2);
+    }
+
+    #[test]
+    fn ensure_starts_with_user_drops_leading_assistant() {
+        let mut msgs = vec![
+            assistant_msg("stale"),
+            user_msg("fresh"),
+            assistant_msg("reply"),
+        ];
+        ensure_starts_with_user(&mut msgs);
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role, Role::User);
+    }
+}

--- a/crates/openwave-core/src/error.rs
+++ b/crates/openwave-core/src/error.rs
@@ -31,6 +31,11 @@ pub enum AgentError {
     #[error("provider error: {0}")]
     Provider(String),
 
+    /// The prompt exceeded the model's context window. The agent loop retries
+    /// with a tighter context budget before giving up.
+    #[error("prompt too long: {0}")]
+    PromptTooLong(String),
+
     /// A catch-all for contexts that do not yet warrant their own variant.
     #[error("{0}")]
     Message(String),
@@ -61,6 +66,7 @@ impl AgentError {
             Self::Store(_) => "store",
             Self::Secret(_) => "secret",
             Self::Provider(_) => "provider",
+            Self::PromptTooLong(_) => "prompt_too_long",
             Self::Message(_) => "message",
             Self::Serde(_) => "serde",
         }

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -108,6 +108,14 @@ pub enum AgentEvent {
         /// The steered user text.
         content: String,
     },
+    /// The transcript was truncated to fit the model's context window before a
+    /// model call. Informational — the turn continues with reduced context.
+    ContextTruncated {
+        /// Estimated tokens of the full transcript before reduction.
+        original_tokens: u32,
+        /// Estimated tokens after fitting to the budget.
+        fitted_tokens: u32,
+    },
 }
 
 /// An [`AgentEvent`] paired with its per-chat sequence number, as stored in

--- a/crates/openwave-core/src/keychain.rs
+++ b/crates/openwave-core/src/keychain.rs
@@ -28,8 +28,21 @@ pub struct KeychainSecretProvider {
 
 impl KeychainSecretProvider {
     /// Use the default service name (`openwave`).
+    ///
+    /// When the `OPENWAVE_KEYCHAIN_MOCK` env var is set (any non-empty value),
+    /// all keyring operations are routed to an in-memory mock so no OS
+    /// keychain prompt appears — useful for integration tests and CI.
     #[must_use]
     pub fn new() -> Self {
+        use std::sync::Once;
+        static MOCK: Once = Once::new();
+        if std::env::var("OPENWAVE_KEYCHAIN_MOCK").is_ok_and(|v| !v.is_empty()) {
+            MOCK.call_once(|| {
+                keyring::set_default_credential_builder(
+                    keyring::mock::default_credential_builder(),
+                );
+            });
+        }
         Self {
             service: DEFAULT_SERVICE.to_string(),
         }

--- a/crates/openwave-core/src/keychain.rs
+++ b/crates/openwave-core/src/keychain.rs
@@ -8,6 +8,8 @@
 //! The blocking `keyring` calls run on a blocking thread (`spawn_blocking`) so
 //! they don't stall the async runtime.
 
+use std::sync::Once;
+
 use async_trait::async_trait;
 
 use crate::error::{AgentError, Result};
@@ -26,22 +28,20 @@ pub struct KeychainSecretProvider {
     service: String,
 }
 
+static MOCK_INIT: Once = Once::new();
+
 impl KeychainSecretProvider {
     /// Use the default service name (`openwave`).
     ///
-    /// When the `OPENWAVE_KEYCHAIN_MOCK` env var is set (any non-empty value),
-    /// all keyring operations are routed to an in-memory mock so no OS
-    /// keychain prompt appears — useful for integration tests and CI.
+    /// If [`use_mock`](Self::use_mock) was called earlier in the process, all
+    /// operations go to an in-memory store instead of the OS keychain. The
+    /// `OPENWAVE_KEYCHAIN_MOCK` env var (any non-empty value) has the same
+    /// effect — useful for subprocess-based integration tests where you can't
+    /// call `use_mock` before `main`.
     #[must_use]
     pub fn new() -> Self {
-        use std::sync::Once;
-        static MOCK: Once = Once::new();
         if std::env::var("OPENWAVE_KEYCHAIN_MOCK").is_ok_and(|v| !v.is_empty()) {
-            MOCK.call_once(|| {
-                keyring::set_default_credential_builder(
-                    keyring::mock::default_credential_builder(),
-                );
-            });
+            Self::use_mock();
         }
         Self {
             service: DEFAULT_SERVICE.to_string(),
@@ -53,6 +53,15 @@ impl KeychainSecretProvider {
         Self {
             service: service.into(),
         }
+    }
+
+    /// Route all keyring operations to an in-memory mock. Call this before any
+    /// `KeychainSecretProvider` is used. Safe to call from multiple threads;
+    /// only the first call has effect.
+    pub fn use_mock() {
+        MOCK_INIT.call_once(|| {
+            keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
+        });
     }
 }
 
@@ -107,25 +116,10 @@ impl SecretProvider for KeychainSecretProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Once;
 
-    // Route all keyring access to the in-memory mock store so tests need no real
-    // OS keychain (and pass on headless CI).
-    static MOCK: Once = Once::new();
-    fn use_mock() {
-        MOCK.call_once(|| {
-            keyring::set_default_credential_builder(keyring::mock::default_credential_builder());
-        });
-    }
-
-    // A smoke test only: keyring's mock credential is per-`Entry`, not a shared
-    // store, so it can't verify set-then-get *persistence* (that needs a real OS
-    // keychain and is validated manually / on a real desktop). This checks the
-    // three operations are wired correctly and that a missing secret reads as
-    // `None` and a missing delete is a no-op.
     #[tokio::test]
     async fn operations_succeed_and_missing_reads_as_none() {
-        use_mock();
+        KeychainSecretProvider::use_mock();
         let secrets = KeychainSecretProvider::with_service("openwave-test");
         let key = "provider.anthropic.api_key";
 

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod agent;
 pub mod approval;
 pub mod cancel;
 pub mod config;
+pub mod context;
 #[cfg(feature = "sqlite")]
 pub mod db;
 pub mod error;

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -16,7 +16,7 @@ use openwave_core::provider::{
 };
 use openwave_core::Role;
 
-use crate::sse::{drain_frames, frame_data, safe_http_error};
+use crate::sse::{classify_provider_error, drain_frames, frame_data};
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -83,11 +83,7 @@ impl ModelProvider for AnthropicProvider {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            return Err(AgentError::Provider(safe_http_error(
-                "anthropic",
-                status.as_u16(),
-                &body,
-            )));
+            return Err(classify_provider_error("anthropic", status.as_u16(), &body));
         }
 
         let stream = async_stream::stream! {

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -18,7 +18,7 @@ use openwave_core::provider::{
 };
 use openwave_core::Role;
 
-use crate::sse::{drain_frames, frame_data, safe_http_error};
+use crate::sse::{classify_provider_error, drain_frames, frame_data};
 
 const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
@@ -105,11 +105,11 @@ impl ModelProvider for OpenAiCompatProvider {
             // Never forward the raw body — gateways sometimes echo key material
             // or request fragments, and `AgentError` strings reach the client.
             let body = response.text().await.unwrap_or_default();
-            return Err(AgentError::Provider(safe_http_error(
+            return Err(classify_provider_error(
                 "openai-compat",
                 status.as_u16(),
                 &body,
-            )));
+            ));
         }
 
         let stream = async_stream::stream! {

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -83,6 +83,35 @@ pub fn safe_http_error(provider: &str, status: u16, body: &str) -> String {
     }
 }
 
+/// Classify a provider HTTP error, detecting prompt-too-long patterns that the
+/// agent loop can retry with a tighter context budget.
+pub fn classify_provider_error(
+    provider: &str,
+    status: u16,
+    body: &str,
+) -> openwave_core::error::AgentError {
+    use openwave_core::error::AgentError;
+
+    if status == 400 {
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+            let err = parsed.get("error").unwrap_or(&parsed);
+            let code = err
+                .get("code")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+            let message = err
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+
+            if code == "context_length_exceeded" || message.contains("prompt is too long") {
+                return AgentError::PromptTooLong(safe_http_error(provider, status, body));
+            }
+        }
+    }
+    AgentError::Provider(safe_http_error(provider, status, body))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -120,5 +149,49 @@ mod tests {
     fn frame_data_skips_done_terminator() {
         assert!(frame_data_raw("data: [DONE]").is_none());
         assert!(frame_data("event: ping").is_none());
+    }
+
+    #[test]
+    fn classify_detects_anthropic_prompt_too_long() {
+        use openwave_core::error::AgentError;
+        let body = r#"{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 250000 tokens > 200000 maximum"}}"#;
+        let err = classify_provider_error("anthropic", 400, body);
+        assert!(
+            matches!(err, AgentError::PromptTooLong(_)),
+            "expected PromptTooLong, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_detects_openai_context_length_exceeded() {
+        use openwave_core::error::AgentError;
+        let body = r#"{"error":{"message":"maximum context length","type":"invalid_request_error","code":"context_length_exceeded"}}"#;
+        let err = classify_provider_error("openai-compat", 400, body);
+        assert!(
+            matches!(err, AgentError::PromptTooLong(_)),
+            "expected PromptTooLong, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_returns_provider_for_other_400s() {
+        use openwave_core::error::AgentError;
+        let body = r#"{"error":{"type":"invalid_request_error","message":"invalid api key"}}"#;
+        let err = classify_provider_error("anthropic", 400, body);
+        assert!(
+            matches!(err, AgentError::Provider(_)),
+            "expected Provider, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn classify_returns_provider_for_non_400_status() {
+        use openwave_core::error::AgentError;
+        let body = r#"{"error":{"type":"overloaded_error"}}"#;
+        let err = classify_provider_error("anthropic", 529, body);
+        assert!(
+            matches!(err, AgentError::Provider(_)),
+            "expected Provider, got {err:?}"
+        );
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -2062,7 +2062,7 @@ mod tests {
 
     #[tokio::test]
     async fn bind_yields_a_loopback_addr_and_token() {
-        std::env::set_var("OPENWAVE_KEYCHAIN_MOCK", "1");
+        openwave_core::KeychainSecretProvider::use_mock();
         let dir = tempfile::tempdir().unwrap();
         let server = bind(Config::desktop(dir.path())).await.unwrap();
         assert!(server.local_addr().ip().is_loopback());
@@ -2120,7 +2120,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn serve_answers_over_a_real_socket() {
-        std::env::set_var("OPENWAVE_KEYCHAIN_MOCK", "1");
+        openwave_core::KeychainSecretProvider::use_mock();
         let dir = tempfile::tempdir().unwrap();
         let server = bind(Config::desktop(dir.path())).await.unwrap();
         let addr = server.local_addr();
@@ -2158,7 +2158,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn cors_preflight_allows_localhost_origin() {
-        std::env::set_var("OPENWAVE_KEYCHAIN_MOCK", "1");
+        openwave_core::KeychainSecretProvider::use_mock();
         let dir = tempfile::tempdir().unwrap();
         let server = bind(Config::desktop(dir.path())).await.unwrap();
         let addr = server.local_addr();

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -2062,6 +2062,7 @@ mod tests {
 
     #[tokio::test]
     async fn bind_yields_a_loopback_addr_and_token() {
+        std::env::set_var("OPENWAVE_KEYCHAIN_MOCK", "1");
         let dir = tempfile::tempdir().unwrap();
         let server = bind(Config::desktop(dir.path())).await.unwrap();
         assert!(server.local_addr().ip().is_loopback());
@@ -2119,6 +2120,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn serve_answers_over_a_real_socket() {
+        std::env::set_var("OPENWAVE_KEYCHAIN_MOCK", "1");
         let dir = tempfile::tempdir().unwrap();
         let server = bind(Config::desktop(dir.path())).await.unwrap();
         let addr = server.local_addr();
@@ -2156,6 +2158,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn cors_preflight_allows_localhost_origin() {
+        std::env::set_var("OPENWAVE_KEYCHAIN_MOCK", "1");
         let dir = tempfile::tempdir().unwrap();
         let server = bind(Config::desktop(dir.path())).await.unwrap();
         let addr = server.local_addr();


### PR DESCRIPTION
## Summary

- Deterministic context reduction (floor + newest-first restoration, no LLM summarization) so the agent loop handles long conversations without blowing the provider's context window.
- Progressive retry on `PromptTooLong` errors: 4 levels tighten the budget from 75% down to 38% of the context window, with shrinking content floors (500 → 100 tokens).
- `classify_provider_error` in the router detects Anthropic (`prompt is too long`) and OpenAI (`context_length_exceeded`) patterns, surfacing them as `AgentError::PromptTooLong` so the agent loop can retry.
- `OPENWAVE_KEYCHAIN_MOCK` env var routes keyring operations to an in-memory mock — eliminates macOS Keychain password prompts during tests and CI.

## Test plan

- [x] `context` module: 17 unit tests covering token estimation, fit_to_budget (within budget, over budget, newest-first priority, tool-pair preservation, starts-with-user), orphan stripping, truncation, budget helpers
- [x] `classify_provider_error`: 4 tests (Anthropic prompt-too-long, OpenAI context_length_exceeded, other 400s, non-400)
- [x] All 177 existing tests pass (including agent loop integration tests with the new context reduction wired in)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo fmt --all --check` clean
