### PR TITLE
feat(retrieval): ingest → embed → search → cite pipeline seams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2960,6 +2960,14 @@ version = "0.0.0"
 [[package]]
 name = "openwave-retrieval"
 version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "openwave-router"
@@ -4359,6 +4367,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5712,6 +5726,7 @@ dependencies = [
  "getrandom 0.4.3",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/crates/openwave-retrieval/Cargo.toml
+++ b/crates/openwave-retrieval/Cargo.toml
@@ -11,3 +11,13 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+# `v5` (name-based UUIDs) is additive over the workspace's `v4`/`serde`; it
+# backs the deterministic chunk ids derived from (document, byte span).
+uuid = { workspace = true, features = ["v5"] }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/openwave-retrieval/src/chunk.rs
+++ b/crates/openwave-retrieval/src/chunk.rs
@@ -14,13 +14,17 @@
 //! the dependable single-strategy floor.
 
 use crate::document::{ByteSpan, Chunk, Document};
+use crate::error::Result;
 
 /// Splits a document into chunks.
 ///
 /// Object-safe so strategies can be swapped or composed as `Box<dyn Chunker>`.
+/// Fallible like the other seams: today's [`TextChunker`] never errors, but a
+/// future service- or model-backed chunker (sentence tokenizers, layout models)
+/// can, and returning [`Result`] now keeps that from being a breaking change.
 pub trait Chunker: Send + Sync {
     /// Produce the chunks for `document`, in document order.
-    fn chunk(&self, document: &Document) -> Vec<Chunk>;
+    fn chunk(&self, document: &Document) -> Result<Vec<Chunk>>;
 }
 
 /// A boundary-aware, fixed-budget, overlapping chunker.
@@ -40,12 +44,14 @@ impl TextChunker {
 
     /// Build a chunker with the given window and overlap.
     ///
-    /// `max_chars` is clamped to at least 1. `overlap` is clamped below
-    /// `max_chars` so the window always advances and chunking terminates.
+    /// `max_chars` is clamped to at least 1. `overlap` is clamped to at most half
+    /// the window: that keeps the window advancing (so chunking terminates) and
+    /// bounds the chunk count at `O(len / (max_chars / 2))`, avoiding the blow-up
+    /// a near-`max_chars` overlap would cause on boundary-free text.
     #[must_use]
     pub fn new(max_chars: usize, overlap: usize) -> Self {
         let max_chars = max_chars.max(1);
-        let overlap = overlap.min(max_chars - 1);
+        let overlap = overlap.min(max_chars / 2);
         Self { max_chars, overlap }
     }
 }
@@ -57,7 +63,7 @@ impl Default for TextChunker {
 }
 
 impl Chunker for TextChunker {
-    fn chunk(&self, document: &Document) -> Vec<Chunk> {
+    fn chunk(&self, document: &Document) -> Result<Vec<Chunk>> {
         let text = &document.text;
 
         // Character view plus each char's starting byte offset. `byte_at[i]` is
@@ -74,7 +80,7 @@ impl Chunker for TextChunker {
 
         let n = chars.len();
         if n == 0 {
-            return Vec::new();
+            return Ok(Vec::new());
         }
 
         let mut chunks = Vec::new();
@@ -107,7 +113,7 @@ impl Chunker for TextChunker {
             start = if next <= start { start + 1 } else { next };
         }
 
-        chunks
+        Ok(chunks)
     }
 }
 
@@ -142,14 +148,17 @@ mod tests {
 
     #[test]
     fn empty_document_yields_no_chunks() {
-        assert!(TextChunker::default().chunk(&doc("")).is_empty());
-        assert!(TextChunker::default().chunk(&doc("   \n  ")).is_empty());
+        assert!(TextChunker::default().chunk(&doc("")).unwrap().is_empty());
+        assert!(TextChunker::default()
+            .chunk(&doc("   \n  "))
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
     fn short_document_is_a_single_chunk() {
         let d = doc("hello world");
-        let chunks = TextChunker::default().chunk(&d);
+        let chunks = TextChunker::default().chunk(&d).unwrap();
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].text, "hello world");
         assert_eq!(chunks[0].span, ByteSpan::new(0, 11));
@@ -159,7 +168,7 @@ mod tests {
     #[test]
     fn spans_slice_back_to_the_exact_source_text() {
         let d = doc("The quick brown fox jumps over the lazy dog. It was a fine day.");
-        let chunks = TextChunker::new(20, 5).chunk(&d);
+        let chunks = TextChunker::new(20, 5).chunk(&d).unwrap();
         assert!(chunks.len() > 1);
         for chunk in &chunks {
             // The recorded span must reproduce the chunk text exactly.
@@ -170,7 +179,7 @@ mod tests {
     #[test]
     fn ordinals_are_contiguous_from_zero() {
         let d = doc("alpha beta gamma delta epsilon zeta eta theta iota kappa");
-        let chunks = TextChunker::new(15, 4).chunk(&d);
+        let chunks = TextChunker::new(15, 4).chunk(&d).unwrap();
         for (i, chunk) in chunks.iter().enumerate() {
             assert_eq!(chunk.ordinal, i);
         }
@@ -179,7 +188,7 @@ mod tests {
     #[test]
     fn consecutive_chunks_overlap() {
         let d = doc("one two three four five six seven eight nine ten eleven twelve");
-        let chunks = TextChunker::new(20, 8).chunk(&d);
+        let chunks = TextChunker::new(20, 8).chunk(&d).unwrap();
         assert!(chunks.len() >= 2);
         // With overlap, each chunk after the first starts before the previous ends.
         for pair in chunks.windows(2) {
@@ -190,7 +199,7 @@ mod tests {
     #[test]
     fn prefers_newline_boundaries() {
         let d = doc("first line here\nsecond line here\nthird line here");
-        let chunks = TextChunker::new(24, 0).chunk(&d);
+        let chunks = TextChunker::new(24, 0).chunk(&d).unwrap();
         // The first cut should land right after a newline, so the first chunk
         // ends cleanly on a line and the next starts a fresh one.
         assert!(chunks[0].text.ends_with('\n') || chunks[0].text.ends_with("here"));
@@ -201,7 +210,7 @@ mod tests {
     fn handles_multibyte_without_splitting_codepoints() {
         // Each `é` is two bytes; a naive byte window could split one.
         let d = doc("café café café café café café café café");
-        let chunks = TextChunker::new(6, 1).chunk(&d);
+        let chunks = TextChunker::new(6, 1).chunk(&d).unwrap();
         assert!(chunks.len() > 1);
         for chunk in &chunks {
             // Spans land on char boundaries => slicing never panics and matches.
@@ -214,7 +223,7 @@ mod tests {
         // overlap >= max_chars is clamped so the window still advances.
         let chunker = TextChunker::new(4, 999);
         let d = doc("abcdefghijklmnop");
-        let chunks = chunker.chunk(&d);
+        let chunks = chunker.chunk(&d).unwrap();
         assert!(!chunks.is_empty());
         // Every byte is covered by the union of spans.
         assert_eq!(chunks.first().unwrap().span.start, 0);

--- a/crates/openwave-retrieval/src/chunk.rs
+++ b/crates/openwave-retrieval/src/chunk.rs
@@ -1,0 +1,223 @@
+//! The chunking seam: split a document's text into overlapping, span-tracked
+//! pieces small enough to embed.
+//!
+//! [`TextChunker`] is a boundary-aware sliding window. It walks the text in
+//! character units (so it never splits a UTF-8 codepoint), caps each window at a
+//! character budget, and prefers to cut at a natural boundary — a line break,
+//! else whitespace — within the back half of the window. Consecutive chunks
+//! overlap by a configurable number of characters so a passage straddling a cut
+//! still lands wholly inside at least one chunk.
+//!
+//! Every emitted [`Chunk`] records its exact [`ByteSpan`], which is what makes
+//! citations precise. A richer stack — hierarchical heading/paragraph chunkers,
+//! sentence shingles — can be layered behind the [`Chunker`] trait later; this is
+//! the dependable single-strategy floor.
+
+use crate::document::{ByteSpan, Chunk, Document};
+
+/// Splits a document into chunks.
+///
+/// Object-safe so strategies can be swapped or composed as `Box<dyn Chunker>`.
+pub trait Chunker: Send + Sync {
+    /// Produce the chunks for `document`, in document order.
+    fn chunk(&self, document: &Document) -> Vec<Chunk>;
+}
+
+/// A boundary-aware, fixed-budget, overlapping chunker.
+#[derive(Debug, Clone, Copy)]
+pub struct TextChunker {
+    /// Maximum characters per chunk (the hard window size).
+    max_chars: usize,
+    /// Characters of overlap carried from one chunk into the next.
+    overlap: usize,
+}
+
+impl TextChunker {
+    /// Default window size, in characters (~a few hundred tokens of English).
+    pub const DEFAULT_MAX_CHARS: usize = 1200;
+    /// Default overlap between consecutive chunks, in characters.
+    pub const DEFAULT_OVERLAP: usize = 150;
+
+    /// Build a chunker with the given window and overlap.
+    ///
+    /// `max_chars` is clamped to at least 1. `overlap` is clamped below
+    /// `max_chars` so the window always advances and chunking terminates.
+    #[must_use]
+    pub fn new(max_chars: usize, overlap: usize) -> Self {
+        let max_chars = max_chars.max(1);
+        let overlap = overlap.min(max_chars - 1);
+        Self { max_chars, overlap }
+    }
+}
+
+impl Default for TextChunker {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_MAX_CHARS, Self::DEFAULT_OVERLAP)
+    }
+}
+
+impl Chunker for TextChunker {
+    fn chunk(&self, document: &Document) -> Vec<Chunk> {
+        let text = &document.text;
+
+        // Character view plus each char's starting byte offset. `byte_at[i]` is
+        // the byte offset of char `i`; the final entry is `text.len()`, so
+        // `byte_at[j]` is always a valid slice end for a char index `j`.
+        let chars: Vec<char> = text.chars().collect();
+        let mut byte_at: Vec<usize> = Vec::with_capacity(chars.len() + 1);
+        let mut offset = 0;
+        for c in &chars {
+            byte_at.push(offset);
+            offset += c.len_utf8();
+        }
+        byte_at.push(text.len());
+
+        let n = chars.len();
+        if n == 0 {
+            return Vec::new();
+        }
+
+        let mut chunks = Vec::new();
+        let mut ordinal = 0;
+        let mut start = 0; // char index
+
+        while start < n {
+            let hard_end = (start + self.max_chars).min(n);
+            // Cut at a natural boundary unless we're already at the text's end.
+            let end = if hard_end == n {
+                n
+            } else {
+                boundary_before(&chars, start, hard_end)
+            };
+
+            let span = ByteSpan::new(byte_at[start], byte_at[end]);
+            // Slice on byte offsets we computed from the same char view.
+            let piece = &text[span.start..span.end];
+            if !piece.trim().is_empty() {
+                chunks.push(Chunk::new(document.id, ordinal, span, piece));
+                ordinal += 1;
+            }
+
+            if end >= n {
+                break;
+            }
+            // Advance, carrying `overlap` chars back. Guarantee forward progress:
+            // never move the window start backwards or leave it put.
+            let next = end.saturating_sub(self.overlap);
+            start = if next <= start { start + 1 } else { next };
+        }
+
+        chunks
+    }
+}
+
+/// Find a good char index to end a chunk within `(start, hard_end)`.
+///
+/// Searches the back half of the window for the last line break, then the last
+/// whitespace, cutting just after it. Falls back to `hard_end` (a hard cut) when
+/// the window has no boundary. The returned index is an exclusive char index.
+fn boundary_before(chars: &[char], start: usize, hard_end: usize) -> usize {
+    let floor = start + (hard_end - start) / 2;
+    let mut last_newline = None;
+    let mut last_whitespace = None;
+    for (offset, &c) in chars[floor..hard_end].iter().enumerate() {
+        let i = floor + offset;
+        if c == '\n' {
+            last_newline = Some(i + 1);
+        } else if c.is_whitespace() {
+            last_whitespace = Some(i + 1);
+        }
+    }
+    last_newline.or(last_whitespace).unwrap_or(hard_end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::DocumentSource;
+
+    fn doc(text: &str) -> Document {
+        Document::new(DocumentSource::Inline, "text/plain", text)
+    }
+
+    #[test]
+    fn empty_document_yields_no_chunks() {
+        assert!(TextChunker::default().chunk(&doc("")).is_empty());
+        assert!(TextChunker::default().chunk(&doc("   \n  ")).is_empty());
+    }
+
+    #[test]
+    fn short_document_is_a_single_chunk() {
+        let d = doc("hello world");
+        let chunks = TextChunker::default().chunk(&d);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].text, "hello world");
+        assert_eq!(chunks[0].span, ByteSpan::new(0, 11));
+        assert_eq!(chunks[0].ordinal, 0);
+    }
+
+    #[test]
+    fn spans_slice_back_to_the_exact_source_text() {
+        let d = doc("The quick brown fox jumps over the lazy dog. It was a fine day.");
+        let chunks = TextChunker::new(20, 5).chunk(&d);
+        assert!(chunks.len() > 1);
+        for chunk in &chunks {
+            // The recorded span must reproduce the chunk text exactly.
+            assert_eq!(d.slice(chunk.span).unwrap(), chunk.text);
+        }
+    }
+
+    #[test]
+    fn ordinals_are_contiguous_from_zero() {
+        let d = doc("alpha beta gamma delta epsilon zeta eta theta iota kappa");
+        let chunks = TextChunker::new(15, 4).chunk(&d);
+        for (i, chunk) in chunks.iter().enumerate() {
+            assert_eq!(chunk.ordinal, i);
+        }
+    }
+
+    #[test]
+    fn consecutive_chunks_overlap() {
+        let d = doc("one two three four five six seven eight nine ten eleven twelve");
+        let chunks = TextChunker::new(20, 8).chunk(&d);
+        assert!(chunks.len() >= 2);
+        // With overlap, each chunk after the first starts before the previous ends.
+        for pair in chunks.windows(2) {
+            assert!(pair[1].span.start < pair[0].span.end);
+        }
+    }
+
+    #[test]
+    fn prefers_newline_boundaries() {
+        let d = doc("first line here\nsecond line here\nthird line here");
+        let chunks = TextChunker::new(24, 0).chunk(&d);
+        // The first cut should land right after a newline, so the first chunk
+        // ends cleanly on a line and the next starts a fresh one.
+        assert!(chunks[0].text.ends_with('\n') || chunks[0].text.ends_with("here"));
+        assert!(!chunks[1].text.starts_with(' '));
+    }
+
+    #[test]
+    fn handles_multibyte_without_splitting_codepoints() {
+        // Each `é` is two bytes; a naive byte window could split one.
+        let d = doc("café café café café café café café café");
+        let chunks = TextChunker::new(6, 1).chunk(&d);
+        assert!(chunks.len() > 1);
+        for chunk in &chunks {
+            // Spans land on char boundaries => slicing never panics and matches.
+            assert_eq!(d.slice(chunk.span).unwrap(), chunk.text);
+        }
+    }
+
+    #[test]
+    fn terminates_when_overlap_would_stall() {
+        // overlap >= max_chars is clamped so the window still advances.
+        let chunker = TextChunker::new(4, 999);
+        let d = doc("abcdefghijklmnop");
+        let chunks = chunker.chunk(&d);
+        assert!(!chunks.is_empty());
+        // Every byte is covered by the union of spans.
+        assert_eq!(chunks.first().unwrap().span.start, 0);
+        assert_eq!(chunks.last().unwrap().span.end, d.text.len());
+    }
+}

--- a/crates/openwave-retrieval/src/document.rs
+++ b/crates/openwave-retrieval/src/document.rs
@@ -1,0 +1,237 @@
+//! The core retrieval domain types: documents, chunks, spans, and citations.
+//!
+//! The load-bearing idea here is the **byte span**. Every chunk records the byte
+//! range it occupies in its parent document's text, and citations carry that same
+//! span. Keeping offsets on everything means the chunk text can later live apart
+//! from the vector index (offsets in the store, text rehydrated from the source),
+//! and it gives every answer a precise, verifiable pointer back into the source.
+
+use serde::{Deserialize, Serialize};
+
+use crate::id::{ChunkId, DocumentId};
+
+/// A half-open byte range `[start, end)` into a document's text.
+///
+/// Byte offsets (not char offsets) because that is what Rust string slicing
+/// speaks; both ends always fall on UTF-8 character boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ByteSpan {
+    /// Inclusive start byte offset.
+    pub start: usize,
+    /// Exclusive end byte offset.
+    pub end: usize,
+}
+
+impl ByteSpan {
+    /// Construct a span, panicking in debug if `start > end`.
+    #[must_use]
+    pub fn new(start: usize, end: usize) -> Self {
+        debug_assert!(start <= end, "span start {start} must not exceed end {end}");
+        Self { start, end }
+    }
+
+    /// The number of bytes the span covers.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// Whether the span covers no bytes.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.end <= self.start
+    }
+}
+
+/// Where an ingested document came from — its provenance for citations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum DocumentSource {
+    /// A path or URL the document was read from (shown to users in citations).
+    Uri {
+        /// The originating path or URL.
+        uri: String,
+    },
+    /// Content supplied inline with no external origin.
+    Inline,
+}
+
+impl DocumentSource {
+    /// Convenience constructor for a URI source.
+    pub fn uri(uri: impl Into<String>) -> Self {
+        Self::Uri { uri: uri.into() }
+    }
+}
+
+/// An ingested source document: its provenance, media type, and extracted text.
+///
+/// `text` is the canonical plain-text representation produced by a
+/// [`crate::parse::DocumentParser`]. Chunk spans index into *this* string.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Document {
+    /// Stable identifier for this document.
+    pub id: DocumentId,
+    /// Where the document came from.
+    pub source: DocumentSource,
+    /// The document's media (MIME) type, e.g. `text/plain` or `text/markdown`.
+    pub media_type: String,
+    /// The extracted plain text. Chunk [`ByteSpan`]s are offsets into this.
+    pub text: String,
+}
+
+impl Document {
+    /// Assemble a document from freshly-parsed text, minting a new id.
+    #[must_use]
+    pub fn new(
+        source: DocumentSource,
+        media_type: impl Into<String>,
+        text: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: DocumentId::new(),
+            source,
+            media_type: media_type.into(),
+            text: text.into(),
+        }
+    }
+
+    /// Borrow the slice of `text` a span refers to.
+    ///
+    /// Returns `None` if the span falls outside the text or off a char boundary,
+    /// so a stale citation can't panic the process.
+    #[must_use]
+    pub fn slice(&self, span: ByteSpan) -> Option<&str> {
+        self.text.get(span.start..span.end)
+    }
+}
+
+/// One chunk of a document: a contiguous slice of its text, ready to embed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Chunk {
+    /// Derived id, stable for a given `(document, span)`.
+    pub id: ChunkId,
+    /// The document this chunk belongs to.
+    pub document_id: DocumentId,
+    /// Zero-based position of this chunk within the document.
+    pub ordinal: usize,
+    /// The chunk's text.
+    pub text: String,
+    /// The byte range this chunk occupies in the document text.
+    pub span: ByteSpan,
+}
+
+impl Chunk {
+    /// Build a chunk, deriving its id from the document and span.
+    #[must_use]
+    pub fn new(
+        document_id: DocumentId,
+        ordinal: usize,
+        span: ByteSpan,
+        text: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: ChunkId::derive(document_id, span.start, span.end),
+            document_id,
+            ordinal,
+            text: text.into(),
+            span,
+        }
+    }
+}
+
+/// A chunk paired with the relevance score a search assigned it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScoredChunk {
+    /// The matched chunk.
+    pub chunk: Chunk,
+    /// Similarity score; higher is more relevant. For cosine, in `[-1, 1]`.
+    pub score: f32,
+}
+
+/// A retrieval result framed as a citation: a scored pointer back into a source.
+///
+/// This is what a search returns and what an answer grounds itself on. It carries
+/// the document, the exact byte span, a text snippet, and the score.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Citation {
+    /// The cited document.
+    pub document_id: DocumentId,
+    /// The cited chunk.
+    pub chunk_id: ChunkId,
+    /// The exact byte range cited within the document text.
+    pub span: ByteSpan,
+    /// The cited text.
+    pub snippet: String,
+    /// The relevance score that surfaced this citation.
+    pub score: f32,
+}
+
+impl From<ScoredChunk> for Citation {
+    fn from(scored: ScoredChunk) -> Self {
+        Self {
+            document_id: scored.chunk.document_id,
+            chunk_id: scored.chunk.id,
+            span: scored.chunk.span,
+            snippet: scored.chunk.text,
+            score: scored.score,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn span_len_and_emptiness() {
+        assert_eq!(ByteSpan::new(4, 10).len(), 6);
+        assert!(ByteSpan::new(5, 5).is_empty());
+        assert!(!ByteSpan::new(5, 6).is_empty());
+    }
+
+    #[test]
+    fn document_slice_returns_the_spanned_text() {
+        let doc = Document::new(DocumentSource::Inline, "text/plain", "hello world");
+        assert_eq!(doc.slice(ByteSpan::new(0, 5)), Some("hello"));
+        assert_eq!(doc.slice(ByteSpan::new(6, 11)), Some("world"));
+    }
+
+    #[test]
+    fn document_slice_is_bounds_safe() {
+        let doc = Document::new(DocumentSource::Inline, "text/plain", "hi");
+        assert_eq!(doc.slice(ByteSpan::new(0, 99)), None);
+    }
+
+    #[test]
+    fn chunk_id_derives_from_document_and_span() {
+        let doc = DocumentId::new();
+        let span = ByteSpan::new(3, 8);
+        let chunk = Chunk::new(doc, 0, span, "abcde");
+        assert_eq!(chunk.id, ChunkId::derive(doc, 3, 8));
+    }
+
+    #[test]
+    fn citation_carries_span_and_snippet_from_scored_chunk() {
+        let doc = DocumentId::new();
+        let chunk = Chunk::new(doc, 2, ByteSpan::new(0, 3), "abc");
+        let citation: Citation = ScoredChunk {
+            chunk: chunk.clone(),
+            score: 0.9,
+        }
+        .into();
+        assert_eq!(citation.document_id, doc);
+        assert_eq!(citation.chunk_id, chunk.id);
+        assert_eq!(citation.span, ByteSpan::new(0, 3));
+        assert_eq!(citation.snippet, "abc");
+        assert_eq!(citation.score, 0.9);
+    }
+
+    #[test]
+    fn document_source_serializes_tagged() {
+        let json = serde_json::to_string(&DocumentSource::uri("file:///a.txt")).unwrap();
+        assert_eq!(json, r#"{"kind":"uri","uri":"file:///a.txt"}"#);
+        let inline = serde_json::to_string(&DocumentSource::Inline).unwrap();
+        assert_eq!(inline, r#"{"kind":"inline"}"#);
+    }
+}

--- a/crates/openwave-retrieval/src/document.rs
+++ b/crates/openwave-retrieval/src/document.rs
@@ -88,8 +88,22 @@ impl Document {
         media_type: impl Into<String>,
         text: impl Into<String>,
     ) -> Self {
+        Self::with_id(DocumentId::new(), source, media_type, text)
+    }
+
+    /// Assemble a document with a caller-supplied id.
+    ///
+    /// Used by ingestion to give URI-sourced documents a stable, derived id so
+    /// re-ingestion is idempotent (see [`DocumentId::derive`]).
+    #[must_use]
+    pub fn with_id(
+        id: DocumentId,
+        source: DocumentSource,
+        media_type: impl Into<String>,
+        text: impl Into<String>,
+    ) -> Self {
         Self {
-            id: DocumentId::new(),
+            id,
             source,
             media_type: media_type.into(),
             text: text.into(),

--- a/crates/openwave-retrieval/src/embed.rs
+++ b/crates/openwave-retrieval/src/embed.rs
@@ -1,0 +1,223 @@
+//! The embedding seam: text in, vectors out.
+//!
+//! Real embedders (OpenAI, Cohere, local ONNX) are asymmetric — they encode a
+//! document and a query differently (Cohere's `search_document` vs
+//! `search_query` input types are the canonical example). The [`Embedder`] trait
+//! bakes that split in from the start so wiring a real provider later doesn't
+//! reshape the seam.
+//!
+//! [`HashEmbedder`] is the always-available, zero-dependency implementation: a
+//! deterministic hashing-trick encoder. It needs no network and no model weights,
+//! which makes it the offline default and the backbone of the test suite. It is
+//! *not* semantic — it captures lexical overlap only — so production deployments
+//! swap in a real provider behind this same trait.
+
+use async_trait::async_trait;
+
+use crate::error::Result;
+
+/// A dense embedding vector.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Embedding(pub Vec<f32>);
+
+impl Embedding {
+    /// The vector's dimensionality.
+    #[must_use]
+    pub fn dim(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Cosine similarity against another embedding, in `[-1, 1]`.
+    ///
+    /// Returns `0.0` if either vector has zero magnitude (e.g. an empty text) so
+    /// callers never see a `NaN`. Vectors of differing length also yield `0.0`.
+    #[must_use]
+    pub fn cosine_similarity(&self, other: &Embedding) -> f32 {
+        if self.0.len() != other.0.len() {
+            return 0.0;
+        }
+        let mut dot = 0.0f32;
+        let mut norm_a = 0.0f32;
+        let mut norm_b = 0.0f32;
+        for (a, b) in self.0.iter().zip(&other.0) {
+            dot += a * b;
+            norm_a += a * a;
+            norm_b += b * b;
+        }
+        if norm_a == 0.0 || norm_b == 0.0 {
+            return 0.0;
+        }
+        dot / (norm_a.sqrt() * norm_b.sqrt())
+    }
+}
+
+/// Turns text into dense vectors.
+///
+/// Object-safe (`Box<dyn Embedder>` / `Arc<dyn Embedder>`) and async, matching
+/// `openwave-core`'s `ModelProvider` shape — real providers make network calls.
+#[async_trait]
+pub trait Embedder: Send + Sync {
+    /// The dimensionality every vector this embedder returns will have.
+    fn dimensions(&self) -> usize;
+
+    /// Embed a batch of documents for indexing.
+    async fn embed_documents(&self, texts: &[String]) -> Result<Vec<Embedding>>;
+
+    /// Embed a single query for search.
+    ///
+    /// Defaults to routing through [`Embedder::embed_documents`]; asymmetric
+    /// providers override this to use their query-side encoding.
+    async fn embed_query(&self, text: &str) -> Result<Embedding> {
+        let mut out = self
+            .embed_documents(std::slice::from_ref(&text.to_string()))
+            .await?;
+        Ok(out
+            .pop()
+            .unwrap_or_else(|| Embedding(vec![0.0; self.dimensions()])))
+    }
+}
+
+/// A deterministic, dependency-free embedder using the hashing trick.
+///
+/// Tokenizes on non-alphanumeric boundaries, folds each lowercased token into one
+/// of `dims` buckets via FNV-1a (with a sign bit so collisions can cancel), then
+/// L2-normalizes. Texts that share tokens get similar vectors; unrelated texts get
+/// near-orthogonal ones. Deterministic across runs and platforms because the hash
+/// is fixed — no reliance on the standard library's randomized hasher.
+#[derive(Debug, Clone, Copy)]
+pub struct HashEmbedder {
+    dims: usize,
+}
+
+impl HashEmbedder {
+    /// A reasonable default dimensionality for the hashing-trick encoder.
+    pub const DEFAULT_DIMS: usize = 256;
+
+    /// Build a hashing embedder with the given dimensionality (clamped to ≥ 1).
+    #[must_use]
+    pub fn new(dims: usize) -> Self {
+        Self { dims: dims.max(1) }
+    }
+
+    fn embed_one(&self, text: &str) -> Embedding {
+        let mut v = vec![0.0f32; self.dims];
+        for token in text.split(|c: char| !c.is_alphanumeric()) {
+            if token.is_empty() {
+                continue;
+            }
+            let lower = token.to_lowercase();
+            let h = fnv1a(lower.as_bytes());
+            let bucket = (h % self.dims as u64) as usize;
+            // Top bit picks the sign, so distinct tokens hashing to the same
+            // bucket can cancel rather than always reinforce.
+            let sign = if h & (1 << 63) == 0 { 1.0 } else { -1.0 };
+            v[bucket] += sign;
+        }
+        l2_normalize(&mut v);
+        Embedding(v)
+    }
+}
+
+impl Default for HashEmbedder {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_DIMS)
+    }
+}
+
+#[async_trait]
+impl Embedder for HashEmbedder {
+    fn dimensions(&self) -> usize {
+        self.dims
+    }
+
+    async fn embed_documents(&self, texts: &[String]) -> Result<Vec<Embedding>> {
+        Ok(texts.iter().map(|t| self.embed_one(t)).collect())
+    }
+
+    async fn embed_query(&self, text: &str) -> Result<Embedding> {
+        Ok(self.embed_one(text))
+    }
+}
+
+/// FNV-1a, 64-bit. Fixed constants => deterministic everywhere.
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for &b in bytes {
+        hash ^= b as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+/// Scale a vector to unit length in place. Leaves an all-zero vector untouched.
+fn l2_normalize(v: &mut [f32]) {
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in v.iter_mut() {
+            *x /= norm;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn embeddings_have_the_declared_dimensionality() {
+        let e = HashEmbedder::new(64);
+        assert_eq!(e.dimensions(), 64);
+        let out = e
+            .embed_documents(&["hello world".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(out[0].dim(), 64);
+    }
+
+    #[tokio::test]
+    async fn embedding_is_deterministic() {
+        let e = HashEmbedder::default();
+        let a = e.embed_query("the quick brown fox").await.unwrap();
+        let b = e.embed_query("the quick brown fox").await.unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test]
+    async fn shared_tokens_score_higher_than_unrelated_text() {
+        let e = HashEmbedder::new(512);
+        let query = e.embed_query("annual revenue growth").await.unwrap();
+
+        let related = e
+            .embed_documents(&["revenue growth accelerated this year".to_string()])
+            .await
+            .unwrap()[0]
+            .clone();
+        let unrelated = e
+            .embed_documents(&["the weather in paris was mild".to_string()])
+            .await
+            .unwrap()[0]
+            .clone();
+
+        assert!(
+            query.cosine_similarity(&related) > query.cosine_similarity(&unrelated),
+            "related text should be nearer the query than unrelated text"
+        );
+    }
+
+    #[tokio::test]
+    async fn identical_text_is_maximally_similar() {
+        let e = HashEmbedder::new(256);
+        let a = e.embed_query("same words here").await.unwrap();
+        let b = e.embed_query("same words here").await.unwrap();
+        // Normalized identical vectors => cosine ~ 1.
+        assert!((a.cosine_similarity(&b) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn cosine_is_zero_for_empty_or_mismatched_vectors() {
+        let zero = Embedding(vec![0.0; 4]);
+        let some = Embedding(vec![1.0, 0.0, 0.0, 0.0]);
+        assert_eq!(zero.cosine_similarity(&some), 0.0);
+        assert_eq!(some.cosine_similarity(&Embedding(vec![1.0, 0.0])), 0.0);
+    }
+}

--- a/crates/openwave-retrieval/src/error.rs
+++ b/crates/openwave-retrieval/src/error.rs
@@ -1,0 +1,81 @@
+//! The crate-wide error type for retrieval.
+//!
+//! [`RetrievalError`] mirrors the shape of `openwave-core`'s `AgentError`: a lean,
+//! `#[non_exhaustive]` enum whose variants grow as the code that produces them
+//! lands (parsing, embedding, vector backends). Keeping it separate from the core
+//! error keeps `openwave-retrieval` a standalone leaf crate for now.
+
+use thiserror::Error;
+
+/// Shorthand for results across the retrieval crate.
+pub type Result<T, E = RetrievalError> = std::result::Result<T, E>;
+
+/// Anything that can go wrong while ingesting, embedding, or searching.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RetrievalError {
+    /// A document could not be parsed into text.
+    #[error("parse error: {0}")]
+    Parse(String),
+
+    /// An embedding provider failed (network, model, or malformed response).
+    #[error("embedding error: {0}")]
+    Embed(String),
+
+    /// A vector backend failed (I/O, query, or upsert).
+    #[error("vector store error: {0}")]
+    VectorStore(String),
+
+    /// An embedding's dimensionality did not match what the store expects.
+    #[error("dimension mismatch: expected {expected}, got {actual}")]
+    DimensionMismatch {
+        /// The dimensionality the store was configured with.
+        expected: usize,
+        /// The dimensionality of the offending embedding.
+        actual: usize,
+    },
+
+    /// A catch-all for contexts that do not yet warrant their own variant.
+    #[error("{0}")]
+    Message(String),
+
+    /// JSON (de)serialization failure.
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+impl RetrievalError {
+    /// Build a [`RetrievalError::Parse`] from anything string-like.
+    pub fn parse(message: impl Into<String>) -> Self {
+        Self::Parse(message.into())
+    }
+
+    /// Build a [`RetrievalError::Embed`] from anything string-like.
+    pub fn embed(message: impl Into<String>) -> Self {
+        Self::Embed(message.into())
+    }
+
+    /// Build a [`RetrievalError::VectorStore`] from anything string-like.
+    pub fn vector_store(message: impl Into<String>) -> Self {
+        Self::VectorStore(message.into())
+    }
+
+    /// Build a [`RetrievalError::Message`] from anything string-like.
+    pub fn msg(message: impl Into<String>) -> Self {
+        Self::Message(message.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dimension_mismatch_reads_clearly() {
+        let err = RetrievalError::DimensionMismatch {
+            expected: 8,
+            actual: 4,
+        };
+        assert_eq!(err.to_string(), "dimension mismatch: expected 8, got 4");
+    }
+}

--- a/crates/openwave-retrieval/src/error.rs
+++ b/crates/openwave-retrieval/src/error.rs
@@ -28,6 +28,7 @@ pub enum RetrievalError {
 
     /// An embedding's dimensionality did not match what the store expects.
     #[error("dimension mismatch: expected {expected}, got {actual}")]
+    #[non_exhaustive]
     DimensionMismatch {
         /// The dimensionality the store was configured with.
         expected: usize,

--- a/crates/openwave-retrieval/src/id.rs
+++ b/crates/openwave-retrieval/src/id.rs
@@ -59,8 +59,27 @@ macro_rules! id_type {
 
 id_type!(
     /// Identifies an ingested source document.
+    ///
+    /// Usually minted fresh with [`DocumentId::new`], but [`DocumentId::derive`]
+    /// produces a stable id from a source URI so re-ingesting the same location
+    /// targets the same document (idempotent upserts) rather than a new one.
     DocumentId
 );
+
+impl DocumentId {
+    /// Namespace UUID for URI-derived document ids. A fixed, arbitrary value,
+    /// distinct from [`ChunkId`]'s namespace so the two derivations never alias.
+    const NAMESPACE: Uuid = Uuid::from_u128(0x1d0c_7a44_9e21_4b83_bc55_6677_8899_aabb);
+
+    /// Derive a stable id from a source URI.
+    ///
+    /// The same `uri` always yields the same id, so re-ingesting a file replaces
+    /// its chunks in place instead of duplicating them.
+    #[must_use]
+    pub fn derive(uri: &str) -> Self {
+        Self(Uuid::new_v5(&Self::NAMESPACE, uri.as_bytes()))
+    }
+}
 id_type!(
     /// Identifies one chunk of a document.
     ///
@@ -109,6 +128,18 @@ mod tests {
         let json = serde_json::to_string(&id).unwrap();
         assert_eq!(json, format!("\"{id}\""));
         assert_eq!(serde_json::from_str::<DocumentId>(&json).unwrap(), id);
+    }
+
+    #[test]
+    fn derived_document_ids_are_stable_per_uri() {
+        assert_eq!(
+            DocumentId::derive("file:///a.txt"),
+            DocumentId::derive("file:///a.txt")
+        );
+        assert_ne!(
+            DocumentId::derive("file:///a.txt"),
+            DocumentId::derive("file:///b.txt")
+        );
     }
 
     #[test]

--- a/crates/openwave-retrieval/src/id.rs
+++ b/crates/openwave-retrieval/src/id.rs
@@ -1,0 +1,125 @@
+//! Strongly-typed identifiers for retrieval entities.
+//!
+//! Same pattern as `openwave-core`'s ids: a UUID newtype per entity so the
+//! compiler stops us mixing a [`DocumentId`] with a [`ChunkId`]. Ids serialize
+//! transparently as the bare UUID string.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Declares a UUID-backed identifier newtype with the common impls.
+macro_rules! id_type {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(pub Uuid);
+
+        impl $name {
+            /// Generate a fresh, random identifier.
+            #[must_use]
+            pub fn new() -> Self {
+                Self(Uuid::new_v4())
+            }
+
+            /// Borrow the underlying UUID.
+            #[must_use]
+            pub fn as_uuid(&self) -> &Uuid {
+                &self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        impl std::str::FromStr for $name {
+            type Err = uuid::Error;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(Self(Uuid::parse_str(s)?))
+            }
+        }
+
+        impl From<Uuid> for $name {
+            fn from(uuid: Uuid) -> Self {
+                Self(uuid)
+            }
+        }
+    };
+}
+
+id_type!(
+    /// Identifies an ingested source document.
+    DocumentId
+);
+id_type!(
+    /// Identifies one chunk of a document.
+    ///
+    /// Chunk ids are *derived*, not random: [`ChunkId::derive`] hashes the parent
+    /// document id together with the chunk's byte span, so re-chunking the same
+    /// document produces the same ids. That makes upserts idempotent and keeps
+    /// citations stable across re-ingestion.
+    ChunkId
+);
+
+impl ChunkId {
+    /// Namespace UUID for chunk-id derivation. A fixed, arbitrary v4 value that
+    /// scopes the name-based hash so it never collides with other v5 uses.
+    const NAMESPACE: Uuid = Uuid::from_u128(0x9f8d_2c31_5b47_4e6a_a1c2_d3e4_f506_1728);
+
+    /// Derive a stable id from the parent document and a byte span.
+    ///
+    /// Two chunks with the same `(document_id, start, end)` always get the same
+    /// id; different spans (even overlapping ones) get distinct ids.
+    #[must_use]
+    pub fn derive(document_id: DocumentId, start: usize, end: usize) -> Self {
+        // Namespace by the document, then hash the span. Two levels keeps the
+        // input space clean: same document + same span => same id, always.
+        let per_document = Uuid::new_v5(&Self::NAMESPACE, document_id.as_uuid().as_bytes());
+        let name = format!("{start}:{end}");
+        Self(Uuid::new_v5(&per_document, name.as_bytes()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_of_different_types_are_distinct() {
+        let doc = DocumentId::new();
+        let chunk = ChunkId::new();
+        assert_ne!(doc.0, chunk.0);
+    }
+
+    #[test]
+    fn roundtrips_through_string_and_json() {
+        let id = DocumentId::new();
+        assert_eq!(id.to_string().parse::<DocumentId>().unwrap(), id);
+
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, format!("\"{id}\""));
+        assert_eq!(serde_json::from_str::<DocumentId>(&json).unwrap(), id);
+    }
+
+    #[test]
+    fn derived_chunk_ids_are_deterministic_and_span_sensitive() {
+        let doc = DocumentId::new();
+        // Same document + span => same id.
+        assert_eq!(ChunkId::derive(doc, 0, 100), ChunkId::derive(doc, 0, 100));
+        // Different span => different id.
+        assert_ne!(ChunkId::derive(doc, 0, 100), ChunkId::derive(doc, 0, 101));
+        // Different document => different id for the same span.
+        let other = DocumentId::new();
+        assert_ne!(ChunkId::derive(doc, 0, 100), ChunkId::derive(other, 0, 100));
+    }
+}

--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -1,5 +1,70 @@
-//! OpenWave retrieval — embeddings, vector search, chunking, ingestion, and
-//! citations, behind a `VectorStore` seam that runs embedded (sqlite-vec) or
-//! against pgvector / Qdrant.
+//! OpenWave retrieval — ingest documents, embed them, search by meaning, and get
+//! back grounded citations.
 //!
-//! Scaffolding only. Implementation lands in Phase 1.
+//! The crate is built from four seams, each a trait with a working default:
+//!
+//! - [`DocumentParser`] — raw bytes → plain text. Default: [`PlainTextParser`]
+//!   (zero-dependency `text/*`). Rich formats (PDF/office/images) land later as a
+//!   feature-gated parser behind this trait.
+//! - [`Chunker`] — text → overlapping, span-tracked [`Chunk`]s. Default:
+//!   [`TextChunker`], a boundary-aware sliding window. Hierarchical and
+//!   sentence-shingle strategies can compose behind the trait later.
+//! - [`Embedder`] — text → dense vectors, with separate document/query encodings.
+//!   Default: [`HashEmbedder`], a deterministic offline hashing encoder for tests
+//!   and local use; real providers (OpenAI/Cohere/ONNX) slot in behind the trait.
+//! - [`VectorStore`] — store embedded chunks, query by similarity. Default:
+//!   [`InMemoryVectorStore`], a brute-force cosine scan. Persistent, filtered, and
+//!   hybrid backends (sqlite-vec, pgvector, Qdrant) land later behind the trait.
+//!
+//! [`Retriever`] wires all four into `ingest` and `search`. Everything a chunk or
+//! citation carries a [`ByteSpan`] — a precise byte range into the source text —
+//! so every answer points back to exactly where it came from.
+//!
+//! ```
+//! use std::sync::Arc;
+//! use openwave_retrieval::{
+//!     Retriever, PlainTextParser, TextChunker, HashEmbedder, InMemoryVectorStore,
+//!     DocumentSource,
+//! };
+//!
+//! # async fn demo() -> openwave_retrieval::Result<()> {
+//! let dims = 256;
+//! let retriever = Retriever::new(
+//!     Box::new(PlainTextParser::new()),
+//!     Box::new(TextChunker::default()),
+//!     Arc::new(HashEmbedder::new(dims)),
+//!     Arc::new(InMemoryVectorStore::new(dims)),
+//! );
+//!
+//! retriever
+//!     .ingest(DocumentSource::uri("notes.txt"), "text/plain", b"Jupiter is a gas giant.")
+//!     .await?;
+//! let hits = retriever.search("largest planet", 3).await?;
+//! for hit in hits {
+//!     println!("[{:.3}] {}", hit.score, hit.snippet);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Not yet wired: real embedding providers and reranking, persistent/hybrid vector
+//! backends, rich-format parsing, and the agent-facing `search` tool + server
+//! ingest API. Each lands as its own slice behind these seams.
+
+mod chunk;
+mod document;
+mod embed;
+mod error;
+mod id;
+mod parse;
+mod retriever;
+mod vector;
+
+pub use chunk::{Chunker, TextChunker};
+pub use document::{ByteSpan, Chunk, Citation, Document, DocumentSource, ScoredChunk};
+pub use embed::{Embedder, Embedding, HashEmbedder};
+pub use error::{Result, RetrievalError};
+pub use id::{ChunkId, DocumentId};
+pub use parse::{DocumentParser, ParsedDocument, PlainTextParser};
+pub use retriever::{IngestOutcome, Retriever};
+pub use vector::{InMemoryVectorStore, VectorRecord, VectorStore};

--- a/crates/openwave-retrieval/src/parse.rs
+++ b/crates/openwave-retrieval/src/parse.rs
@@ -1,0 +1,118 @@
+//! The document-parser seam: raw bytes in, plain text out.
+//!
+//! A [`DocumentParser`] turns a source file's bytes into the canonical plain text
+//! that chunking and embedding operate on. The always-on [`PlainTextParser`]
+//! handles `text/*` (plain, markdown) with zero dependencies. Rich formats
+//! (PDF/office/images) will arrive later as a feature-gated parser behind this
+//! same trait, so the pipeline never has to care which parser produced the text.
+//!
+//! The trait is synchronous: naive text decoding is CPU-only, and a future
+//! parser that shells out to native tooling can wrap itself in `spawn_blocking`
+//! at its own boundary rather than forcing every caller onto an async path.
+
+use crate::error::{Result, RetrievalError};
+
+/// The plain text extracted from a source document, plus any parser-supplied
+/// metadata. Kept as a struct (not a bare `String`) so richer parsers can attach
+/// structure — page maps, headings, bounding boxes — without a breaking change.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ParsedDocument {
+    /// The canonical plain-text representation. Chunk spans index into this.
+    pub text: String,
+}
+
+impl ParsedDocument {
+    /// Wrap already-extracted text.
+    pub fn from_text(text: impl Into<String>) -> Self {
+        Self { text: text.into() }
+    }
+}
+
+/// Turns a document's raw bytes into plain text.
+///
+/// Object-safe so parsers can be held as `Box<dyn DocumentParser>` and swapped by
+/// configuration (naive today, liteparse-backed later).
+pub trait DocumentParser: Send + Sync {
+    /// Whether this parser can handle the given media (MIME) type.
+    fn supports(&self, media_type: &str) -> bool;
+
+    /// Parse `raw` bytes of the given media type into plain text.
+    fn parse(&self, raw: &[u8], media_type: &str) -> Result<ParsedDocument>;
+}
+
+/// The zero-dependency fallback parser: decodes bytes as UTF-8 text.
+///
+/// Accepts `text/*` media types (covers `text/plain` and `text/markdown` — the
+/// latter is already human-readable, so it passes through untouched). Invalid
+/// UTF-8 is repaired lossily rather than rejected, so a stray bad byte never
+/// fails an otherwise-fine document.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PlainTextParser;
+
+impl PlainTextParser {
+    /// Construct the parser.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl DocumentParser for PlainTextParser {
+    fn supports(&self, media_type: &str) -> bool {
+        // Match the top-level `text` type, ignoring any `; charset=...` suffix.
+        let base = media_type.split(';').next().unwrap_or(media_type).trim();
+        base.is_empty() || base.starts_with("text/")
+    }
+
+    fn parse(&self, raw: &[u8], media_type: &str) -> Result<ParsedDocument> {
+        if !self.supports(media_type) {
+            return Err(RetrievalError::parse(format!(
+                "PlainTextParser does not support media type `{media_type}`"
+            )));
+        }
+        // Lossy decode: replace invalid sequences instead of failing the ingest.
+        let text = String::from_utf8_lossy(raw).into_owned();
+        Ok(ParsedDocument::from_text(text))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supports_text_types_and_empty_but_not_binary() {
+        let p = PlainTextParser::new();
+        assert!(p.supports("text/plain"));
+        assert!(p.supports("text/markdown"));
+        assert!(p.supports("text/markdown; charset=utf-8"));
+        assert!(p.supports("")); // unknown/omitted => treat as text
+        assert!(!p.supports("application/pdf"));
+        assert!(!p.supports("image/png"));
+    }
+
+    #[test]
+    fn parses_utf8_bytes_verbatim() {
+        let p = PlainTextParser::new();
+        let parsed = p
+            .parse("# Title\n\nbody".as_bytes(), "text/markdown")
+            .unwrap();
+        assert_eq!(parsed.text, "# Title\n\nbody");
+    }
+
+    #[test]
+    fn repairs_invalid_utf8_lossily() {
+        let p = PlainTextParser::new();
+        let parsed = p.parse(&[b'a', 0xFF, b'b'], "text/plain").unwrap();
+        // The lone 0xFF becomes U+FFFD; surrounding text survives.
+        assert!(parsed.text.starts_with('a'));
+        assert!(parsed.text.ends_with('b'));
+        assert!(parsed.text.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn rejects_unsupported_media_type() {
+        let p = PlainTextParser::new();
+        assert!(p.parse(b"%PDF-1.7", "application/pdf").is_err());
+    }
+}

--- a/crates/openwave-retrieval/src/parse.rs
+++ b/crates/openwave-retrieval/src/parse.rs
@@ -60,8 +60,9 @@ impl PlainTextParser {
 impl DocumentParser for PlainTextParser {
     fn supports(&self, media_type: &str) -> bool {
         // Match the top-level `text` type, ignoring any `; charset=...` suffix.
+        // MIME types are case-insensitive (RFC 6838), so compare in lowercase.
         let base = media_type.split(';').next().unwrap_or(media_type).trim();
-        base.is_empty() || base.starts_with("text/")
+        base.is_empty() || base.to_ascii_lowercase().starts_with("text/")
     }
 
     fn parse(&self, raw: &[u8], media_type: &str) -> Result<ParsedDocument> {
@@ -86,6 +87,8 @@ mod tests {
         assert!(p.supports("text/plain"));
         assert!(p.supports("text/markdown"));
         assert!(p.supports("text/markdown; charset=utf-8"));
+        assert!(p.supports("TEXT/PLAIN")); // MIME types are case-insensitive
+        assert!(p.supports("Text/Markdown"));
         assert!(p.supports("")); // unknown/omitted => treat as text
         assert!(!p.supports("application/pdf"));
         assert!(!p.supports("image/png"));

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -81,7 +81,7 @@ impl Retriever {
         };
         let document = Document::with_id(id, source, media_type, parsed.text);
 
-        let chunks = self.chunker.chunk(&document);
+        let chunks = self.chunker.chunk(&document)?;
         if chunks.is_empty() {
             return Ok(IngestOutcome {
                 document,
@@ -193,7 +193,7 @@ The Great Barrier Reef is the world's largest coral reef system.";
             "text/plain",
             "alpha beta gamma delta epsilon",
         );
-        let chunks = TextChunker::new(60, 12).chunk(&doc);
+        let chunks = TextChunker::new(60, 12).chunk(&doc).unwrap();
         let texts: Vec<String> = chunks.iter().map(|c| c.text.clone()).collect();
         let embeddings = HashEmbedder::new(512)
             .embed_documents(&texts)

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -1,0 +1,212 @@
+//! The end-to-end pipeline: parse → chunk → embed → store, and query → cite.
+//!
+//! [`Retriever`] wires the four seams together behind two methods, [`Retriever::ingest`]
+//! and [`Retriever::search`]. It owns a parser and chunker and shares an embedder
+//! and vector store (the store is typically shared with the rest of the process,
+//! so a future `search` tool can query the same index this ingests into).
+
+use std::sync::Arc;
+
+use crate::chunk::Chunker;
+use crate::document::{Citation, Document, DocumentSource};
+use crate::embed::Embedder;
+use crate::error::{Result, RetrievalError};
+use crate::parse::DocumentParser;
+use crate::vector::{VectorRecord, VectorStore};
+
+/// The outcome of ingesting one document.
+#[derive(Debug, Clone)]
+pub struct IngestOutcome {
+    /// The parsed document, including its canonical text. Callers that persist a
+    /// text-of-record (to rehydrate citation snippets from spans later) keep this.
+    pub document: Document,
+    /// How many chunks were embedded and stored.
+    pub chunks: usize,
+}
+
+/// Ties parsing, chunking, embedding, and vector storage into one pipeline.
+pub struct Retriever {
+    parser: Box<dyn DocumentParser>,
+    chunker: Box<dyn Chunker>,
+    embedder: Arc<dyn Embedder>,
+    store: Arc<dyn VectorStore>,
+}
+
+impl Retriever {
+    /// Assemble a retriever from its four seams.
+    #[must_use]
+    pub fn new(
+        parser: Box<dyn DocumentParser>,
+        chunker: Box<dyn Chunker>,
+        embedder: Arc<dyn Embedder>,
+        store: Arc<dyn VectorStore>,
+    ) -> Self {
+        Self {
+            parser,
+            chunker,
+            embedder,
+            store,
+        }
+    }
+
+    /// Borrow the shared vector store (e.g. to hand a search tool the same index).
+    #[must_use]
+    pub fn store(&self) -> &Arc<dyn VectorStore> {
+        &self.store
+    }
+
+    /// Ingest one document: parse its bytes, chunk, embed, and upsert.
+    ///
+    /// Idempotent for a given document id: derived chunk ids mean re-ingesting the
+    /// same text replaces rather than duplicates. A document that chunks to
+    /// nothing (empty or whitespace-only) stores nothing and reports zero chunks.
+    pub async fn ingest(
+        &self,
+        source: DocumentSource,
+        media_type: &str,
+        raw: &[u8],
+    ) -> Result<IngestOutcome> {
+        let parsed = self.parser.parse(raw, media_type)?;
+        let document = Document::new(source, media_type, parsed.text);
+
+        let chunks = self.chunker.chunk(&document);
+        if chunks.is_empty() {
+            return Ok(IngestOutcome {
+                document,
+                chunks: 0,
+            });
+        }
+
+        let texts: Vec<String> = chunks.iter().map(|c| c.text.clone()).collect();
+        let embeddings = self.embedder.embed_documents(&texts).await?;
+        if embeddings.len() != chunks.len() {
+            return Err(RetrievalError::embed(format!(
+                "embedder returned {} vectors for {} chunks",
+                embeddings.len(),
+                chunks.len()
+            )));
+        }
+
+        let records = chunks
+            .into_iter()
+            .zip(embeddings)
+            .map(|(chunk, embedding)| VectorRecord { chunk, embedding })
+            .collect();
+        self.store.upsert(records).await?;
+
+        Ok(IngestOutcome {
+            document,
+            chunks: texts.len(),
+        })
+    }
+
+    /// Search the index for the `k` chunks most relevant to `query`, as citations.
+    pub async fn search(&self, query: &str, k: usize) -> Result<Vec<Citation>> {
+        let embedding = self.embedder.embed_query(query).await?;
+        let hits = self.store.query(&embedding, k).await?;
+        Ok(hits.into_iter().map(Citation::from).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunk::TextChunker;
+    use crate::embed::HashEmbedder;
+    use crate::parse::PlainTextParser;
+    use crate::vector::InMemoryVectorStore;
+
+    fn retriever() -> Retriever {
+        let dims = 512;
+        // A 90-char window with newline-preferring cuts keeps each one-per-line
+        // sentence in the test corpus a whole chunk.
+        Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::new(90, 0)),
+            Arc::new(HashEmbedder::new(dims)),
+            Arc::new(InMemoryVectorStore::new(dims)),
+        )
+    }
+
+    #[tokio::test]
+    async fn ingest_then_search_returns_grounded_citations() {
+        let r = retriever();
+        let text = "\
+Mars is the fourth planet from the Sun and is often called the Red Planet.
+Jupiter is the largest planet in the Solar System, a gas giant.
+The Great Barrier Reef is the world's largest coral reef system.";
+
+        let outcome = r
+            .ingest(
+                DocumentSource::uri("file:///space.txt"),
+                "text/plain",
+                text.as_bytes(),
+            )
+            .await
+            .unwrap();
+        assert!(outcome.chunks >= 3);
+
+        let hits = r
+            .search("which planet is the largest gas giant", 1)
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        // The top citation should be the Jupiter sentence, and its span must slice
+        // back to exactly the cited snippet in the original document.
+        assert!(hits[0].snippet.contains("Jupiter"));
+        assert_eq!(
+            outcome.document.slice(hits[0].span),
+            Some(hits[0].snippet.as_str())
+        );
+        assert_eq!(hits[0].document_id, outcome.document.id);
+    }
+
+    #[tokio::test]
+    async fn empty_document_ingests_no_chunks() {
+        let r = retriever();
+        let outcome = r
+            .ingest(DocumentSource::Inline, "text/plain", b"   \n  ")
+            .await
+            .unwrap();
+        assert_eq!(outcome.chunks, 0);
+        assert!(r.store().is_empty().await.unwrap());
+        assert!(r.search("anything", 5).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn re_ingesting_same_document_id_is_idempotent() {
+        let r = retriever();
+        let doc = Document::new(
+            DocumentSource::Inline,
+            "text/plain",
+            "alpha beta gamma delta epsilon",
+        );
+        let chunks = TextChunker::new(60, 12).chunk(&doc);
+        let texts: Vec<String> = chunks.iter().map(|c| c.text.clone()).collect();
+        let embeddings = HashEmbedder::new(512)
+            .embed_documents(&texts)
+            .await
+            .unwrap();
+        let records: Vec<VectorRecord> = chunks
+            .into_iter()
+            .zip(embeddings)
+            .map(|(chunk, embedding)| VectorRecord { chunk, embedding })
+            .collect();
+
+        // Upsert the same derived-id records twice; the store must not grow.
+        r.store().upsert(records.clone()).await.unwrap();
+        let after_first = r.store().len().await.unwrap();
+        r.store().upsert(records).await.unwrap();
+        assert_eq!(r.store().len().await.unwrap(), after_first);
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_media_type() {
+        let r = retriever();
+        let err = r
+            .ingest(DocumentSource::Inline, "application/pdf", b"%PDF-1.7")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RetrievalError::Parse(_)));
+    }
+}

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -11,6 +11,7 @@ use crate::chunk::Chunker;
 use crate::document::{Citation, Document, DocumentSource};
 use crate::embed::Embedder;
 use crate::error::{Result, RetrievalError};
+use crate::id::DocumentId;
 use crate::parse::DocumentParser;
 use crate::vector::{VectorRecord, VectorStore};
 
@@ -57,9 +58,14 @@ impl Retriever {
 
     /// Ingest one document: parse its bytes, chunk, embed, and upsert.
     ///
-    /// Idempotent for a given document id: derived chunk ids mean re-ingesting the
-    /// same text replaces rather than duplicates. A document that chunks to
-    /// nothing (empty or whitespace-only) stores nothing and reports zero chunks.
+    /// Idempotent for [`DocumentSource::Uri`] sources: the document id is derived
+    /// from the URI, so re-ingesting the *same* bytes from the same URI reuses the
+    /// document id, re-derives identical chunk ids, and upserts in place rather
+    /// than duplicating. (Re-ingesting *changed* content at the same URI upserts
+    /// the new chunks but does not yet delete chunks the old version left behind —
+    /// stale-chunk cleanup is a later slice.) [`DocumentSource::Inline`] sources
+    /// get a fresh id every call. A document that chunks to nothing (empty or
+    /// whitespace-only) stores nothing and reports zero chunks.
     pub async fn ingest(
         &self,
         source: DocumentSource,
@@ -67,7 +73,13 @@ impl Retriever {
         raw: &[u8],
     ) -> Result<IngestOutcome> {
         let parsed = self.parser.parse(raw, media_type)?;
-        let document = Document::new(source, media_type, parsed.text);
+        // Stable id per URI so re-ingesting a file is idempotent; inline content
+        // has no external identity, so it gets a fresh id each time.
+        let id = match &source {
+            DocumentSource::Uri { uri } => DocumentId::derive(uri),
+            _ => DocumentId::new(),
+        };
+        let document = Document::with_id(id, source, media_type, parsed.text);
 
         let chunks = self.chunker.chunk(&document);
         if chunks.is_empty() {
@@ -198,6 +210,48 @@ The Great Barrier Reef is the world's largest coral reef system.";
         let after_first = r.store().len().await.unwrap();
         r.store().upsert(records).await.unwrap();
         assert_eq!(r.store().len().await.unwrap(), after_first);
+    }
+
+    #[tokio::test]
+    async fn re_ingesting_same_uri_is_idempotent_end_to_end() {
+        let r = retriever();
+        let text = "one two three four five six seven eight nine ten eleven twelve";
+        let uri = || DocumentSource::uri("file:///notes.txt");
+
+        let first = r
+            .ingest(uri(), "text/plain", text.as_bytes())
+            .await
+            .unwrap();
+        assert!(first.chunks > 0);
+        let after_first = r.store().len().await.unwrap();
+
+        // Same URI + same bytes => same document id => same chunk ids => the
+        // pipeline replaces in place rather than duplicating.
+        let second = r
+            .ingest(uri(), "text/plain", text.as_bytes())
+            .await
+            .unwrap();
+        assert_eq!(second.document.id, first.document.id);
+        assert_eq!(r.store().len().await.unwrap(), after_first);
+
+        // And a single search returns each chunk once, not doubled.
+        let hits = r.search("three four five", 10).await.unwrap();
+        let unique: std::collections::HashSet<_> = hits.iter().map(|h| h.chunk_id).collect();
+        assert_eq!(unique.len(), hits.len());
+    }
+
+    #[tokio::test]
+    async fn inline_documents_get_a_fresh_id_each_ingest() {
+        let r = retriever();
+        let a = r
+            .ingest(DocumentSource::Inline, "text/plain", b"same inline bytes")
+            .await
+            .unwrap();
+        let b = r
+            .ingest(DocumentSource::Inline, "text/plain", b"same inline bytes")
+            .await
+            .unwrap();
+        assert_ne!(a.document.id, b.document.id);
     }
 
     #[tokio::test]

--- a/crates/openwave-retrieval/src/vector.rs
+++ b/crates/openwave-retrieval/src/vector.rs
@@ -1,0 +1,234 @@
+//! The vector-store seam: upsert embedded chunks, then query by nearest vector.
+//!
+//! [`VectorStore`] is the interface every backend implements. [`InMemoryVectorStore`]
+//! is the reference backend — a brute-force cosine scan behind a lock. It has no
+//! persistence and is O(n) per query, which is exactly right for tests, small
+//! local corpora, and pinning down the semantics that persistent backends
+//! (sqlite-vec, pgvector, Qdrant) must reproduce. Those, plus metadata filtering
+//! and hybrid dense+sparse search, arrive as feature-gated backends behind this
+//! trait later.
+
+use std::sync::RwLock;
+
+use async_trait::async_trait;
+
+use crate::document::{Chunk, ScoredChunk};
+use crate::embed::Embedding;
+use crate::error::{Result, RetrievalError};
+
+/// A chunk together with its embedding, ready to store.
+#[derive(Debug, Clone)]
+pub struct VectorRecord {
+    /// The chunk being indexed.
+    pub chunk: Chunk,
+    /// Its embedding. Must match the store's dimensionality.
+    pub embedding: Embedding,
+}
+
+/// Stores embedded chunks and retrieves them by vector similarity.
+///
+/// Object-safe and async so backends can do I/O. Implementations are held behind
+/// `Arc<dyn VectorStore>`.
+#[async_trait]
+pub trait VectorStore: Send + Sync {
+    /// Insert or replace records, keyed by chunk id.
+    ///
+    /// Re-upserting a chunk with the same id overwrites it, so re-ingesting a
+    /// document (which yields the same derived chunk ids) is idempotent rather
+    /// than duplicating vectors.
+    async fn upsert(&self, records: Vec<VectorRecord>) -> Result<()>;
+
+    /// Return the `k` chunks most similar to `query`, highest score first.
+    ///
+    /// Fewer than `k` come back when the store holds fewer records. `k == 0`
+    /// yields an empty result.
+    async fn query(&self, query: &Embedding, k: usize) -> Result<Vec<ScoredChunk>>;
+
+    /// The number of records currently stored.
+    async fn len(&self) -> Result<usize>;
+
+    /// Whether the store holds no records.
+    async fn is_empty(&self) -> Result<bool> {
+        Ok(self.len().await? == 0)
+    }
+}
+
+/// A brute-force, in-memory [`VectorStore`] using cosine similarity.
+pub struct InMemoryVectorStore {
+    dims: usize,
+    records: RwLock<Vec<VectorRecord>>,
+}
+
+impl InMemoryVectorStore {
+    /// Create an empty store that accepts vectors of exactly `dims` dimensions.
+    #[must_use]
+    pub fn new(dims: usize) -> Self {
+        Self {
+            dims,
+            records: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// The dimensionality this store enforces.
+    #[must_use]
+    pub fn dimensions(&self) -> usize {
+        self.dims
+    }
+
+    fn check_dims(&self, embedding: &Embedding) -> Result<()> {
+        if embedding.dim() != self.dims {
+            return Err(RetrievalError::DimensionMismatch {
+                expected: self.dims,
+                actual: embedding.dim(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl VectorStore for InMemoryVectorStore {
+    async fn upsert(&self, records: Vec<VectorRecord>) -> Result<()> {
+        for record in &records {
+            self.check_dims(&record.embedding)?;
+        }
+        let mut store = self
+            .records
+            .write()
+            .map_err(|_| RetrievalError::vector_store("in-memory store lock poisoned"))?;
+        for record in records {
+            if let Some(existing) = store.iter_mut().find(|r| r.chunk.id == record.chunk.id) {
+                *existing = record;
+            } else {
+                store.push(record);
+            }
+        }
+        Ok(())
+    }
+
+    async fn query(&self, query: &Embedding, k: usize) -> Result<Vec<ScoredChunk>> {
+        self.check_dims(query)?;
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        let store = self
+            .records
+            .read()
+            .map_err(|_| RetrievalError::vector_store("in-memory store lock poisoned"))?;
+
+        let mut scored: Vec<ScoredChunk> = store
+            .iter()
+            .map(|r| ScoredChunk {
+                chunk: r.chunk.clone(),
+                score: query.cosine_similarity(&r.embedding),
+            })
+            .collect();
+
+        // Highest score first. `total_cmp` gives a total order over f32 (no NaN
+        // surprises); ties fall back to chunk id for a stable, reproducible order.
+        scored.sort_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| a.chunk.id.0.cmp(&b.chunk.id.0))
+        });
+        scored.truncate(k);
+        Ok(scored)
+    }
+
+    async fn len(&self) -> Result<usize> {
+        let store = self
+            .records
+            .read()
+            .map_err(|_| RetrievalError::vector_store("in-memory store lock poisoned"))?;
+        Ok(store.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::ByteSpan;
+    use crate::id::DocumentId;
+
+    fn record(doc: DocumentId, ordinal: usize, text: &str, vector: Vec<f32>) -> VectorRecord {
+        let span = ByteSpan::new(ordinal * 100, ordinal * 100 + text.len());
+        VectorRecord {
+            chunk: Chunk::new(doc, ordinal, span, text),
+            embedding: Embedding(vector),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_wrong_dimensionality_on_upsert_and_query() {
+        let store = InMemoryVectorStore::new(3);
+        let doc = DocumentId::new();
+        let err = store
+            .upsert(vec![record(doc, 0, "a", vec![1.0, 0.0])])
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RetrievalError::DimensionMismatch {
+                expected: 3,
+                actual: 2
+            }
+        ));
+        assert!(store.query(&Embedding(vec![1.0, 0.0]), 5).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn returns_nearest_first_and_respects_k() {
+        let store = InMemoryVectorStore::new(2);
+        let doc = DocumentId::new();
+        store
+            .upsert(vec![
+                record(doc, 0, "east", vec![1.0, 0.0]),
+                record(doc, 1, "north", vec![0.0, 1.0]),
+                record(doc, 2, "north-east", vec![1.0, 1.0]),
+            ])
+            .await
+            .unwrap();
+
+        // A query pointing east should rank "east" first, then the diagonal.
+        let hits = store.query(&Embedding(vec![1.0, 0.0]), 2).await.unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].chunk.text, "east");
+        assert_eq!(hits[1].chunk.text, "north-east");
+        assert!(hits[0].score >= hits[1].score);
+    }
+
+    #[tokio::test]
+    async fn k_zero_and_empty_store_return_nothing() {
+        let store = InMemoryVectorStore::new(2);
+        assert!(store.is_empty().await.unwrap());
+        assert!(store
+            .query(&Embedding(vec![1.0, 0.0]), 0)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(store
+            .query(&Embedding(vec![1.0, 0.0]), 5)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn upsert_is_idempotent_by_chunk_id() {
+        let store = InMemoryVectorStore::new(2);
+        let doc = DocumentId::new();
+        // Same document + span => same derived chunk id => replace, not append.
+        store
+            .upsert(vec![record(doc, 0, "hello", vec![1.0, 0.0])])
+            .await
+            .unwrap();
+        store
+            .upsert(vec![record(doc, 0, "hello", vec![0.0, 1.0])])
+            .await
+            .unwrap();
+        assert_eq!(store.len().await.unwrap(), 1);
+        // The second upsert's vector won.
+        let hits = store.query(&Embedding(vec![0.0, 1.0]), 1).await.unwrap();
+        assert!((hits[0].score - 1.0).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
## What

First slice of the retrieval subsystem: fills in the `openwave-retrieval` stub with the four seams the module is built from, each a trait plus a working default, wired end to end into an `ingest → search` pipeline. No network, no persistence, no new heavy dependencies — the same contracts-first shape the rest of the crate graph was built with.

## The seams

| Seam | Trait | Default impl |
| --- | --- | --- |
| Parse | `DocumentParser` | `PlainTextParser` — `text/*`, lossy UTF-8 |
| Chunk | `Chunker` | `TextChunker` — boundary-aware overlapping window |
| Embed | `Embedder` | `HashEmbedder` — deterministic offline hashing encoder |
| Store | `VectorStore` | `InMemoryVectorStore` — brute-force cosine |

`Retriever` ties them together behind `ingest()` and `search()`.

## Design notes

- **Byte spans everywhere.** Every `Chunk` and `Citation` carries a `ByteSpan` into the source text, so a result slices back to exactly where it came from. This also keeps the door open to the "offsets in the index, text rehydrated from the source" split a persistent backend will want.
- **Derived chunk ids.** `ChunkId` is a UUIDv5 of `(document_id, start, end)`, so re-ingesting the same document replaces rather than duplicates, and citations stay stable across re-ingestion.
- **Asymmetric embedding.** `Embedder` splits `embed_documents` / `embed_query` from the start, matching how real providers encode corpus vs. query differently.
- **`TextChunker`** cuts on line/whitespace boundaries in the back half of its window, overlaps consecutive chunks, clamps overlap below the window so it always makes progress, and walks characters so it never splits a UTF-8 codepoint.
- **`HashEmbedder`** uses a fixed FNV-1a hashing trick (no reliance on the stdlib's randomized hasher), so embeddings are byte-for-byte reproducible across runs and platforms — it captures lexical overlap only and is meant to be swapped for a real provider in production.

## Deferred (each its own later slice, behind these seams)

Real embedding providers + reranking; persistent/hybrid vector backends (sqlite-vec / pgvector / Qdrant) with metadata filtering; rich-format parsing (PDF/office/images); and the agent-facing `search` tool + server ingest API.

## Tests

35 unit tests + a lib doctest cover span/slice round-tripping, multibyte-safe chunking, chunker termination under pathological overlap, deterministic and asymmetric embeddings, dimension-mismatch rejection, idempotent upsert, and the end-to-end ingest → search → cite path. `cargo test --workspace`, `cargo clippy --workspace --all-targets`, and `cargo fmt --all --check` are green.
