### PR TITLE
feat(server): wire retrieval into the API — ingest and search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,7 @@ dependencies = [
  "chrono",
  "futures",
  "openwave-core",
+ "openwave-retrieval",
  "openwave-router",
  "reqwest 0.12.28",
  "serde",

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools", "keychain"] }
 openwave-router = { path = "../openwave-router" }
+openwave-retrieval = { path = "../openwave-retrieval" }
 axum = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "sync", "macros"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -54,6 +54,19 @@ impl ServerError {
             },
         }
     }
+
+    /// A `500 Internal Server Error` for an unexpected server-side failure that
+    /// isn't an [`AgentError`] (e.g. a retrieval backend fault). Carries a stable
+    /// `kind` so a client sees the same `{ kind, message }` shape as any error.
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            info: AgentErrorInfo {
+                kind: "internal".to_string(),
+                message: message.into(),
+            },
+        }
+    }
 }
 
 /// Core errors surfacing from a handler are internal failures (a store write

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -36,6 +36,10 @@ use openwave_core::{
     AgentConfig, AgentError, Config, DbStore, KeychainSecretProvider, ListDir, Profile, ReadFile,
     Result, SecretProvider, Store, ToolRegistry, WriteFile,
 };
+use openwave_retrieval::{
+    Embedder, HashEmbedder, InMemoryVectorStore, PlainTextParser, Retriever, SearchTool,
+    TextChunker, VectorStore,
+};
 
 use resolver::KeyedResolver;
 
@@ -66,6 +70,8 @@ pub fn app(state: AppState) -> Router {
             "/providers/{kind}/credential",
             axum::routing::delete(routes::delete_provider_credential),
         )
+        .route("/documents", post(routes::ingest_document))
+        .route("/search", post(routes::search_documents))
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
         .route(
             "/chats/{id}",
@@ -155,8 +161,16 @@ pub async fn bind(config: Config) -> Result<Server> {
     // so `KeyedResolver`'s enabled check doesn't fail-closed on upgrade.
     providers::migrate_legacy_anthropic(&*store, &*secrets).await?;
     let resolver = Arc::new(KeyedResolver::new(store.clone(), secrets.clone()));
-    let (tools, agent_config) = agent_deps();
-    let state = AppState::new(config, store, resolver, secrets, tools, agent_config);
+    let (retrieval, tools, agent_config) = agent_deps();
+    let state = AppState::new(
+        config,
+        store,
+        resolver,
+        secrets,
+        tools,
+        retrieval,
+        agent_config,
+    );
     let token = state.token.clone();
     let router = app(state);
 
@@ -175,25 +189,47 @@ pub async fn bind(config: Config) -> Result<Server> {
     })
 }
 
-/// Assemble the static agent dependencies for a real launch: the tool set and
-/// the per-turn tuning. The model **provider** is not built here — it is resolved
-/// per turn by the [`KeyedResolver`] (a composite router over enabled providers;
-/// see [`resolver`]), so configuring a provider at runtime takes effect without a
-/// restart. The model *name* comes from `OPENWAVE_MODEL` (or the built-in default)
-/// and can be overridden at runtime via `PUT /settings` or per-chat.
-fn agent_deps() -> (Arc<ToolRegistry>, AgentConfig) {
+/// Assemble the agent dependencies for a real launch: the retrieval pipeline, the
+/// tool set, and the per-turn tuning. The model **provider** is not built here — it
+/// is resolved per turn by the [`KeyedResolver`] (a composite router over enabled
+/// providers; see [`resolver`]), so configuring a provider at runtime takes effect
+/// without a restart. The model *name* comes from `OPENWAVE_MODEL` (or the built-in
+/// default) and can be overridden at runtime via `PUT /settings` or per-chat.
+fn agent_deps() -> (Arc<Retriever>, Arc<ToolRegistry>, AgentConfig) {
+    let (retrieval, search) = build_retrieval();
     let tools = Arc::new(
         ToolRegistry::new()
             .with(Box::new(ReadFile))
             .with(Box::new(ListDir))
-            .with(Box::new(WriteFile)),
+            .with(Box::new(WriteFile))
+            .with(search),
     );
     let model = std::env::var("OPENWAVE_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string());
     let agent_config = AgentConfig {
         model,
         ..AgentConfig::default()
     };
-    (tools, agent_config)
+    (retrieval, tools, agent_config)
+}
+
+/// Build the retrieval pipeline and the `search` tool that shares its index.
+///
+/// The [`Retriever`] (used to ingest and to serve `POST /search`) and the returned
+/// [`SearchTool`] (registered for the agent) hold the **same** embedder and vector
+/// store, so a document ingested through the API is immediately visible to the
+/// agent's search. The store is in-memory today — durable/hybrid backends and real
+/// embedding providers are later slices — so an index does not survive a restart.
+fn build_retrieval() -> (Arc<Retriever>, Box<SearchTool>) {
+    let embedder: Arc<dyn Embedder> = Arc::new(HashEmbedder::default());
+    let store: Arc<dyn VectorStore> = Arc::new(InMemoryVectorStore::new(embedder.dimensions()));
+    let retrieval = Arc::new(Retriever::new(
+        Box::new(PlainTextParser::new()),
+        Box::new(TextChunker::default()),
+        embedder.clone(),
+        store.clone(),
+    ));
+    let search = Box::new(SearchTool::new(embedder, store));
+    (retrieval, search)
 }
 
 /// Open the durable store the profile selects.
@@ -435,12 +471,14 @@ mod tests {
             .await
             .unwrap(),
         );
+        let (retrieval, _search) = build_retrieval();
         let state = AppState::new(
             Config::desktop(dir.path()),
             store.clone(),
             Arc::new(FixedResolver(provider)),
             Arc::new(MemSecrets::default()),
             Arc::new(ToolRegistry::new()),
+            retrieval,
             AgentConfig {
                 model: "fake".into(),
                 ..AgentConfig::default()
@@ -721,6 +759,174 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e.event, AgentEvent::TurnCancelled { .. })),
             "steer continues the turn"
+        );
+    }
+
+    /// POST a JSON body to `uri`, returning the response.
+    async fn post_json(
+        router: &Router,
+        bearer: &str,
+        uri: &str,
+        body: serde_json::Value,
+    ) -> axum::response::Response {
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header(header::AUTHORIZATION, bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn ingest_then_search_finds_the_passage() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+
+        let ingest = post_json(
+            &router,
+            &bearer,
+            "/documents",
+            serde_json::json!({
+                "uri": "file:///solar.txt",
+                "content": "Jupiter is the largest planet in the Solar System, a gas giant.",
+            }),
+        )
+        .await;
+        assert_eq!(ingest.status(), StatusCode::CREATED);
+        let ingest: serde_json::Value = json_body(ingest).await;
+        assert!(ingest["chunks"].as_u64().unwrap() >= 1);
+        assert!(ingest["document_id"].is_string());
+
+        // The ingested chunk is immediately searchable over the shared index.
+        let search = post_json(
+            &router,
+            &bearer,
+            "/search",
+            serde_json::json!({ "query": "largest gas giant planet", "k": 1 }),
+        )
+        .await;
+        assert_eq!(search.status(), StatusCode::OK);
+        let results: serde_json::Value = json_body(search).await;
+        let citations = results["citations"].as_array().unwrap();
+        assert_eq!(citations.len(), 1);
+        assert!(citations[0]["snippet"]
+            .as_str()
+            .unwrap()
+            .contains("Jupiter"));
+        assert_eq!(citations[0]["document_id"], ingest["document_id"]);
+    }
+
+    #[tokio::test]
+    async fn re_ingesting_the_same_uri_is_idempotent() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let doc = serde_json::json!({
+            "uri": "file:///notes.txt",
+            "content": "one two three four five six seven eight nine ten",
+        });
+
+        let first: serde_json::Value =
+            json_body(post_json(&router, &bearer, "/documents", doc.clone()).await).await;
+        let second: serde_json::Value =
+            json_body(post_json(&router, &bearer, "/documents", doc).await).await;
+        // Same URI => same derived document id => replaced in place.
+        assert_eq!(first["document_id"], second["document_id"]);
+
+        // A broad search still returns each chunk once, not doubled.
+        let results: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/search",
+                serde_json::json!({ "query": "three four five", "k": 50 }),
+            )
+            .await,
+        )
+        .await;
+        let citations = results["citations"].as_array().unwrap();
+        let ids: std::collections::HashSet<_> = citations
+            .iter()
+            .map(|c| c["chunk_id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids.len(), citations.len());
+    }
+
+    #[tokio::test]
+    async fn ingest_rejects_empty_content_and_search_rejects_empty_query() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+
+        let bad_ingest = post_json(
+            &router,
+            &bearer,
+            "/documents",
+            serde_json::json!({ "content": "   " }),
+        )
+        .await;
+        assert_eq!(bad_ingest.status(), StatusCode::BAD_REQUEST);
+
+        let bad_search = post_json(
+            &router,
+            &bearer,
+            "/search",
+            serde_json::json!({ "query": "  " }),
+        )
+        .await;
+        assert_eq!(bad_search.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn ingest_rejects_unsupported_media_type() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let response = post_json(
+            &router,
+            &bearer,
+            "/documents",
+            serde_json::json!({ "content": "%PDF-1.7", "media_type": "application/pdf" }),
+        )
+        .await;
+        // A parser that can't handle the media type is the caller's problem: 400.
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, "bad_request");
+    }
+
+    #[tokio::test]
+    async fn search_on_an_empty_index_returns_no_citations() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let results: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/search",
+                serde_json::json!({ "query": "anything" }),
+            )
+            .await,
+        )
+        .await;
+        assert!(results["citations"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn agent_deps_registers_the_search_tool_alongside_the_file_tools() {
+        let (_retrieval, tools, _config) = agent_deps();
+        let names: Vec<String> = tools.specs().into_iter().map(|s| s.name).collect();
+        assert!(
+            names.iter().any(|n| n == "search"),
+            "search tool registered"
+        );
+        assert!(
+            names.iter().any(|n| n == "read_file"),
+            "file tools still present"
         );
     }
 
@@ -1827,6 +2033,7 @@ mod tests {
             Arc::new(FixedResolver(Arc::new(FakeProvider))),
             Arc::new(MemSecrets::default()),
             Arc::new(ToolRegistry::new()),
+            build_retrieval().0,
             AgentConfig {
                 model: "fake".into(),
                 ..AgentConfig::default()
@@ -1981,6 +2188,7 @@ mod tests {
             }))),
             Arc::new(MemSecrets::default()),
             tools,
+            build_retrieval().0,
             AgentConfig {
                 model: "fake".into(),
                 ..AgentConfig::default()

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -859,6 +859,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_padded_uri_targets_the_same_document() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+
+        // Surrounding whitespace must not change the derived document id, or
+        // "re-ingest the same file" would silently create a second document.
+        let padded: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({ "uri": "  file:///a.txt  ", "content": "hello world" }),
+            )
+            .await,
+        )
+        .await;
+        let clean: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({ "uri": "file:///a.txt", "content": "hello world" }),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(padded["document_id"], clean["document_id"]);
+    }
+
+    #[tokio::test]
     async fn ingest_rejects_empty_content_and_search_rejects_empty_query() {
         let (router, token, _store, _dir) = test_app().await;
         let bearer = format!("Bearer {token}");
@@ -971,6 +1001,32 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(wrong.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn retrieval_routes_require_a_token() {
+        let (router, _token, _store, _dir) = test_app().await;
+        // Both retrieval routes sit behind the bearer-token layer, not out in the
+        // open like /healthz — a request with no token is rejected before it runs.
+        for uri in ["/documents", "/search"] {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(uri)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(serde_json::json!({}).to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "{uri} must require a token"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -17,6 +17,7 @@ use openwave_core::{
     Agent, ApprovalDecision, CallId, Chat, ChatId, Project, ProjectId, SecretProvider,
     SequencedEvent, Store,
 };
+use openwave_retrieval::{Citation, DocumentId, DocumentSource, RetrievalError, SearchTool};
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::error::ServerError;
@@ -289,6 +290,109 @@ pub async fn get_project(
         .await?
         .map(Json)
         .ok_or_else(|| ServerError::not_found(format!("project {id} not found")))
+}
+
+/// Body of `POST /documents`.
+#[derive(Debug, Deserialize)]
+pub struct IngestDocument {
+    /// The document's text/content, as a UTF-8 string.
+    pub content: String,
+    /// Optional source URI, recorded for provenance and used to make re-ingesting
+    /// the same location idempotent. Omitted for inline content.
+    #[serde(default)]
+    pub uri: Option<String>,
+    /// Media (MIME) type; defaults to `text/plain` when omitted.
+    #[serde(default)]
+    pub media_type: Option<String>,
+}
+
+/// Result of `POST /documents`.
+#[derive(Debug, Serialize)]
+pub struct IngestResult {
+    /// The ingested document's id (derived from the URI when one is given).
+    pub document_id: DocumentId,
+    /// How many chunks were embedded and indexed.
+    pub chunks: usize,
+}
+
+/// Map a retrieval failure to an HTTP error: a parse problem is the caller's
+/// (unsupported media type / bad content), everything else is server-side.
+fn retrieval_error(err: RetrievalError) -> ServerError {
+    match err {
+        RetrievalError::Parse(_) => ServerError::bad_request(err.to_string()),
+        _ => ServerError::internal(err.to_string()),
+    }
+}
+
+/// `POST /documents` — ingest a document into the shared retrieval index
+/// (`201 Created`). The index is in-memory for now, so it does not survive a
+/// restart. The ingested chunks are immediately searchable via `POST /search` and
+/// the agent's `search` tool.
+pub async fn ingest_document(
+    State(state): State<AppState>,
+    Json(body): Json<IngestDocument>,
+) -> Result<impl IntoResponse, ServerError> {
+    if body.content.trim().is_empty() {
+        return Err(ServerError::bad_request("content must not be empty"));
+    }
+    let source = match body.uri {
+        Some(uri) if !uri.trim().is_empty() => DocumentSource::uri(uri),
+        _ => DocumentSource::Inline,
+    };
+    let media_type = body.media_type.as_deref().unwrap_or("text/plain");
+    let outcome = state
+        .retrieval
+        .ingest(source, media_type, body.content.as_bytes())
+        .await
+        .map_err(retrieval_error)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(IngestResult {
+            document_id: outcome.document.id,
+            chunks: outcome.chunks,
+        }),
+    ))
+}
+
+/// Body of `POST /search`.
+#[derive(Debug, Deserialize)]
+pub struct SearchRequest {
+    /// The natural-language query.
+    pub query: String,
+    /// How many passages to return (optional; clamped to `[1, SearchTool::MAX_K]`).
+    #[serde(default)]
+    pub k: Option<usize>,
+}
+
+/// Result of `POST /search`.
+#[derive(Debug, Serialize)]
+pub struct SearchResults {
+    /// Ranked citations, most relevant first.
+    pub citations: Vec<Citation>,
+}
+
+/// `POST /search` — search the shared index and return grounded citations. This
+/// is the direct HTTP counterpart to the agent's `search` tool; both read the
+/// same index. `k` defaults to [`SearchTool::DEFAULT_K`] and is clamped, never
+/// rejected.
+pub async fn search_documents(
+    State(state): State<AppState>,
+    Json(body): Json<SearchRequest>,
+) -> Result<Json<SearchResults>, ServerError> {
+    let query = body.query.trim();
+    if query.is_empty() {
+        return Err(ServerError::bad_request("query must not be empty"));
+    }
+    let k = body
+        .k
+        .unwrap_or(SearchTool::DEFAULT_K)
+        .clamp(1, SearchTool::MAX_K);
+    let citations = state
+        .retrieval
+        .search(query, k)
+        .await
+        .map_err(retrieval_error)?;
+    Ok(Json(SearchResults { citations }))
 }
 
 /// Body of `POST /chats`.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -335,8 +335,10 @@ pub async fn ingest_document(
     if body.content.trim().is_empty() {
         return Err(ServerError::bad_request("content must not be empty"));
     }
-    let source = match body.uri {
-        Some(uri) if !uri.trim().is_empty() => DocumentSource::uri(uri),
+    let source = match body.uri.as_deref().map(str::trim) {
+        // Trim before deriving the document id: a padded URI must resolve to the
+        // same document as its unpadded form, or idempotent re-ingest breaks.
+        Some(uri) if !uri.is_empty() => DocumentSource::uri(uri),
         _ => DocumentSource::Inline,
     };
     let media_type = body.media_type.as_deref().unwrap_or("text/plain");

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use openwave_core::{
     AgentConfig, CancelToken, ChatId, Config, SecretProvider, SteerInbox, Store, ToolRegistry,
 };
+use openwave_retrieval::Retriever;
 use uuid::Uuid;
 
 use crate::approvals::ApprovalBroker;
@@ -29,6 +30,10 @@ pub struct AppState {
     pub secrets: Arc<dyn SecretProvider>,
     /// The tools available to the agent.
     pub tools: Arc<ToolRegistry>,
+    /// The retrieval pipeline: ingest documents and search the shared index that
+    /// backs the agent's `search` tool. Its vector store is the same one the
+    /// registered `SearchTool` queries, so an ingest is immediately searchable.
+    pub retrieval: Arc<Retriever>,
     /// Per-turn agent tuning (model, limits, …).
     pub agent_config: AgentConfig,
     /// The secret every request must present as `Authorization: Bearer <token>`.
@@ -44,12 +49,14 @@ pub struct AppState {
 
 impl AppState {
     /// Assemble state, minting a fresh random bearer token for this launch.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: Config,
         store: Arc<dyn Store>,
         resolver: Arc<dyn ProviderResolver>,
         secrets: Arc<dyn SecretProvider>,
         tools: Arc<ToolRegistry>,
+        retrieval: Arc<Retriever>,
         agent_config: AgentConfig,
     ) -> Self {
         Self {
@@ -58,6 +65,7 @@ impl AppState {
             resolver,
             secrets,
             tools,
+            retrieval,
             agent_config,
             token: Uuid::new_v4().to_string().into(),
             active_turns: Arc::new(TurnGuard::default()),


### PR DESCRIPTION
## What

Wires the retrieval subsystem (from #40/#41) into the HTTP surface, so a document can be **ingested** and then **searched** — by a client directly, or by the agent through its `search` tool reading the same index.

## Changes

- **`AppState` gains a shared `Retriever`.** `agent_deps()` now builds the retrieval pipeline (`PlainTextParser` + `TextChunker` + `HashEmbedder` + `InMemoryVectorStore`) and registers a `SearchTool` over the **same** embedder and vector store. So a document ingested via the API is immediately visible to the agent's `search` tool — one index, two front doors.
- **`POST /documents`** — ingest `{ content, uri?, media_type? }`, returns `{ document_id, chunks }`. Re-ingesting the same `uri` is idempotent (derived document id → derived chunk ids → upsert-in-place). Defaults `media_type` to `text/plain`.
- **`POST /search`** — run a query over the shared index, returns ranked `citations`. The direct HTTP counterpart to the agent's `search` tool. `k` defaults to `SearchTool::DEFAULT_K` and is clamped to `[1, MAX_K]`, never rejected.
- **`ServerError::internal`** for retrieval faults; a parse failure (unsupported media type) maps to **400**, everything else to **500**.

Both routes sit behind the existing bearer-token auth layer.

## Scope / deferred

The index is **in-memory and per-launch** — durable/hybrid backends (sqlite-vec/pgvector/Qdrant) and real embedding providers are later slices, so an ingested corpus does not survive a restart. Retrieval is **global** (not yet scoped per chat/project). `HashEmbedder` is the offline placeholder encoder (lexical only).

## Tests

6 new server tests (74 total): ingest→search roundtrip over the shared index, idempotent re-ingest by URI (no duplicate citations), empty-content / empty-query rejections, unsupported-media-type → 400, empty-index → no citations, and that `agent_deps()` registers `search` alongside the file tools. `cargo test --workspace`, `clippy --workspace --all-targets`, and `fmt --all --check` are green.
