### PR TITLE
feat(retrieval): atomic document replace on re-ingest (no stale chunks)

### DIFF
--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -56,16 +56,17 @@ impl Retriever {
         &self.store
     }
 
-    /// Ingest one document: parse its bytes, chunk, embed, and upsert.
+    /// Ingest one document: parse its bytes, chunk, embed, and store.
     ///
-    /// Idempotent for [`DocumentSource::Uri`] sources: the document id is derived
-    /// from the URI, so re-ingesting the *same* bytes from the same URI reuses the
-    /// document id, re-derives identical chunk ids, and upserts in place rather
-    /// than duplicating. (Re-ingesting *changed* content at the same URI upserts
-    /// the new chunks but does not yet delete chunks the old version left behind —
-    /// stale-chunk cleanup is a later slice.) [`DocumentSource::Inline`] sources
-    /// get a fresh id every call. A document that chunks to nothing (empty or
-    /// whitespace-only) stores nothing and reports zero chunks.
+    /// A full **replace** for [`DocumentSource::Uri`] sources: the document id is
+    /// derived from the URI, so re-ingesting the same URI targets the same
+    /// document — its previously-stored chunks are pruned first, then the new ones
+    /// are stored. Re-ingesting identical content is therefore idempotent, and
+    /// re-ingesting *changed* (even shorter, or now-empty) content leaves no stale
+    /// chunks behind for search to surface. [`DocumentSource::Inline`] sources get
+    /// a fresh id every call, so they never collide with a prior ingest. A document
+    /// that chunks to nothing (empty or whitespace-only) stores nothing and reports
+    /// zero chunks — after clearing any prior version.
     pub async fn ingest(
         &self,
         source: DocumentSource,
@@ -82,6 +83,10 @@ impl Retriever {
         let document = Document::with_id(id, source, media_type, parsed.text);
 
         let chunks = self.chunker.chunk(&document)?;
+        // Prune any prior version of this document before storing the new chunks,
+        // so a shrunk or rewritten document doesn't leave stale chunks indexed.
+        // A first ingest (or a fresh inline id) removes nothing.
+        self.store.delete_by_document(document.id).await?;
         if chunks.is_empty() {
             return Ok(IngestOutcome {
                 document,
@@ -238,6 +243,50 @@ The Great Barrier Reef is the world's largest coral reef system.";
         let hits = r.search("three four five", 10).await.unwrap();
         let unique: std::collections::HashSet<_> = hits.iter().map(|h| h.chunk_id).collect();
         assert_eq!(unique.len(), hits.len());
+    }
+
+    #[tokio::test]
+    async fn re_ingesting_shorter_content_prunes_stale_chunks() {
+        let r = retriever();
+        let uri = || DocumentSource::uri("file:///doc.txt");
+        // Long enough (and multi-line) to split into several chunks.
+        let long = "alpha alpha alpha alpha alpha alpha alpha\n\
+                    beta beta beta beta beta beta beta\n\
+                    gamma gamma gamma gamma gamma gamma";
+        let first = r
+            .ingest(uri(), "text/plain", long.as_bytes())
+            .await
+            .unwrap();
+        assert!(first.chunks >= 2);
+
+        // Re-ingest much shorter content at the same URI.
+        let second = r
+            .ingest(uri(), "text/plain", b"alpha alpha alpha")
+            .await
+            .unwrap();
+        assert_eq!(second.document.id, first.document.id);
+        // The store holds only the new chunks — the old beta/gamma ones are pruned.
+        assert_eq!(r.store().len().await.unwrap(), second.chunks);
+        let hits = r.search("gamma", 10).await.unwrap();
+        assert!(
+            hits.iter().all(|h| !h.snippet.contains("gamma")),
+            "stale chunks from the longer version must be gone"
+        );
+    }
+
+    #[tokio::test]
+    async fn re_ingesting_empty_content_clears_the_document() {
+        let r = retriever();
+        let uri = || DocumentSource::uri("file:///doc.txt");
+        r.ingest(uri(), "text/plain", b"alpha beta gamma delta epsilon")
+            .await
+            .unwrap();
+        assert!(r.store().len().await.unwrap() > 0);
+
+        // Re-ingesting empty content at the same URI clears its chunks entirely.
+        let out = r.ingest(uri(), "text/plain", b"   ").await.unwrap();
+        assert_eq!(out.chunks, 0);
+        assert!(r.store().is_empty().await.unwrap());
     }
 
     #[tokio::test]

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -58,15 +58,16 @@ impl Retriever {
 
     /// Ingest one document: parse its bytes, chunk, embed, and store.
     ///
-    /// A full **replace** for [`DocumentSource::Uri`] sources: the document id is
-    /// derived from the URI, so re-ingesting the same URI targets the same
-    /// document — its previously-stored chunks are pruned first, then the new ones
-    /// are stored. Re-ingesting identical content is therefore idempotent, and
-    /// re-ingesting *changed* (even shorter, or now-empty) content leaves no stale
-    /// chunks behind for search to surface. [`DocumentSource::Inline`] sources get
-    /// a fresh id every call, so they never collide with a prior ingest. A document
-    /// that chunks to nothing (empty or whitespace-only) stores nothing and reports
-    /// zero chunks — after clearing any prior version.
+    /// A full, **atomic replace** for [`DocumentSource::Uri`] sources: the document
+    /// id is derived from the URI, so re-ingesting the same URI targets the same
+    /// document, and the store swaps its chunks in one operation (see
+    /// [`VectorStore::replace_document`]). Re-ingesting identical content is
+    /// idempotent; re-ingesting *changed* (even shorter, or now-empty) content
+    /// leaves no stale chunks behind; and two concurrent re-ingests of the same URI
+    /// resolve to one version rather than a mix. [`DocumentSource::Inline`] sources
+    /// get a fresh id every call, so they never collide with a prior ingest. A
+    /// document that chunks to nothing (empty or whitespace-only) stores nothing and
+    /// reports zero chunks — after clearing any prior version.
     pub async fn ingest(
         &self,
         source: DocumentSource,
@@ -83,37 +84,38 @@ impl Retriever {
         let document = Document::with_id(id, source, media_type, parsed.text);
 
         let chunks = self.chunker.chunk(&document)?;
-        // Prune any prior version of this document before storing the new chunks,
-        // so a shrunk or rewritten document doesn't leave stale chunks indexed.
-        // A first ingest (or a fresh inline id) removes nothing.
-        self.store.delete_by_document(document.id).await?;
-        if chunks.is_empty() {
-            return Ok(IngestOutcome {
-                document,
-                chunks: 0,
-            });
-        }
 
-        let texts: Vec<String> = chunks.iter().map(|c| c.text.clone()).collect();
-        let embeddings = self.embedder.embed_documents(&texts).await?;
-        if embeddings.len() != chunks.len() {
-            return Err(RetrievalError::embed(format!(
-                "embedder returned {} vectors for {} chunks",
-                embeddings.len(),
-                chunks.len()
-            )));
-        }
+        // Embed first (the slow, awaited step), then hand the store a single
+        // atomic replace. Doing the delete+insert as one store operation — rather
+        // than a separate prune then upsert with an embed await in between — is
+        // what keeps two concurrent re-ingests of the same document from
+        // interleaving and leaving a mix of versions. Empty content yields an
+        // empty record set, which clears any prior version of the document.
+        let records: Vec<VectorRecord> = if chunks.is_empty() {
+            Vec::new()
+        } else {
+            let texts: Vec<String> = chunks.iter().map(|c| c.text.clone()).collect();
+            let embeddings = self.embedder.embed_documents(&texts).await?;
+            if embeddings.len() != chunks.len() {
+                return Err(RetrievalError::embed(format!(
+                    "embedder returned {} vectors for {} chunks",
+                    embeddings.len(),
+                    chunks.len()
+                )));
+            }
+            chunks
+                .into_iter()
+                .zip(embeddings)
+                .map(|(chunk, embedding)| VectorRecord { chunk, embedding })
+                .collect()
+        };
 
-        let records = chunks
-            .into_iter()
-            .zip(embeddings)
-            .map(|(chunk, embedding)| VectorRecord { chunk, embedding })
-            .collect();
-        self.store.upsert(records).await?;
+        let count = records.len();
+        self.store.replace_document(document.id, records).await?;
 
         Ok(IngestOutcome {
             document,
-            chunks: texts.len(),
+            chunks: count,
         })
     }
 

--- a/crates/openwave-retrieval/src/vector.rs
+++ b/crates/openwave-retrieval/src/vector.rs
@@ -45,13 +45,20 @@ pub trait VectorStore: Send + Sync {
     /// yields an empty result.
     async fn query(&self, query: &Embedding, k: usize) -> Result<Vec<ScoredChunk>>;
 
-    /// Remove every chunk belonging to `document_id`, returning how many were
-    /// removed. Removing a document that isn't present is a no-op (`Ok(0)`).
+    /// Atomically replace every chunk of `document_id` with `records`: remove the
+    /// document's existing chunks and store the new ones as one operation.
     ///
-    /// This is what lets re-ingesting *changed* content be a true replacement:
-    /// prune the document's old chunks, then upsert the new ones, so a shrunk or
-    /// rewritten document leaves no stale chunks behind to be surfaced by search.
-    async fn delete_by_document(&self, document_id: DocumentId) -> Result<usize>;
+    /// This is what lets re-ingesting *changed* content be a true replacement. It
+    /// must be atomic with respect to other store operations — two concurrent
+    /// re-ingests of the same document must not interleave a partial delete and
+    /// insert and leave a mix of versions. Passing an empty `records` clears the
+    /// document. Implementations validate each record's dimensionality, as
+    /// [`VectorStore::upsert`] does.
+    async fn replace_document(
+        &self,
+        document_id: DocumentId,
+        records: Vec<VectorRecord>,
+    ) -> Result<()>;
 
     /// The number of records currently stored.
     async fn len(&self) -> Result<usize>;
@@ -144,14 +151,23 @@ impl VectorStore for InMemoryVectorStore {
         Ok(scored)
     }
 
-    async fn delete_by_document(&self, document_id: DocumentId) -> Result<usize> {
+    async fn replace_document(
+        &self,
+        document_id: DocumentId,
+        records: Vec<VectorRecord>,
+    ) -> Result<()> {
+        for record in &records {
+            self.check_dims(&record.embedding)?;
+        }
+        // Delete + insert under a single write lock, so a concurrent ingest can't
+        // observe or race a half-applied replacement.
         let mut store = self
             .records
             .write()
             .map_err(|_| RetrievalError::vector_store("in-memory store lock poisoned"))?;
-        let before = store.len();
         store.retain(|r| r.chunk.document_id != document_id);
-        Ok(before - store.len())
+        store.extend(records);
+        Ok(())
     }
 
     async fn len(&self) -> Result<usize> {
@@ -252,7 +268,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_by_document_removes_only_that_document() {
+    async fn replace_document_swaps_only_that_documents_chunks() {
         let store = InMemoryVectorStore::new(2);
         let a = DocumentId::new();
         let b = DocumentId::new();
@@ -265,15 +281,48 @@ mod tests {
             .await
             .unwrap();
 
-        let removed = store.delete_by_document(a).await.unwrap();
-        assert_eq!(removed, 2);
-        assert_eq!(store.len().await.unwrap(), 1);
-        // Document b's chunk is untouched.
-        let hits = store.query(&Embedding(vec![1.0, 1.0]), 5).await.unwrap();
-        assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].chunk.document_id, b);
+        // Replace document a's two chunks with a single new one.
+        store
+            .replace_document(a, vec![record(a, 0, "a-new", vec![1.0, 0.0])])
+            .await
+            .unwrap();
+        assert_eq!(store.len().await.unwrap(), 2); // one a, one b
+        let hits = store.query(&Embedding(vec![1.0, 0.0]), 5).await.unwrap();
+        assert!(hits.iter().any(|h| h.chunk.text == "a-new"));
+        assert!(
+            !hits.iter().any(|h| h.chunk.text == "a1"),
+            "old a chunk gone"
+        );
+        // Document b is untouched.
+        assert!(hits.iter().any(|h| h.chunk.document_id == b));
+    }
 
-        // Deleting an absent document is a no-op.
-        assert_eq!(store.delete_by_document(a).await.unwrap(), 0);
+    #[tokio::test]
+    async fn replace_document_with_no_records_clears_it() {
+        let store = InMemoryVectorStore::new(2);
+        let a = DocumentId::new();
+        store
+            .upsert(vec![record(a, 0, "a0", vec![1.0, 0.0])])
+            .await
+            .unwrap();
+        store.replace_document(a, vec![]).await.unwrap();
+        assert!(store.is_empty().await.unwrap());
+        // Replacing an absent document with nothing is a no-op.
+        store
+            .replace_document(DocumentId::new(), vec![])
+            .await
+            .unwrap();
+        assert!(store.is_empty().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn replace_document_validates_dimensionality() {
+        let store = InMemoryVectorStore::new(2);
+        let a = DocumentId::new();
+        let err = store
+            .replace_document(a, vec![record(a, 0, "bad", vec![1.0, 0.0, 0.0])])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RetrievalError::DimensionMismatch { .. }));
     }
 }

--- a/crates/openwave-retrieval/src/vector.rs
+++ b/crates/openwave-retrieval/src/vector.rs
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 use crate::document::{Chunk, ScoredChunk};
 use crate::embed::Embedding;
 use crate::error::{Result, RetrievalError};
+use crate::id::DocumentId;
 
 /// A chunk together with its embedding, ready to store.
 #[derive(Debug, Clone)]
@@ -43,6 +44,14 @@ pub trait VectorStore: Send + Sync {
     /// Fewer than `k` come back when the store holds fewer records. `k == 0`
     /// yields an empty result.
     async fn query(&self, query: &Embedding, k: usize) -> Result<Vec<ScoredChunk>>;
+
+    /// Remove every chunk belonging to `document_id`, returning how many were
+    /// removed. Removing a document that isn't present is a no-op (`Ok(0)`).
+    ///
+    /// This is what lets re-ingesting *changed* content be a true replacement:
+    /// prune the document's old chunks, then upsert the new ones, so a shrunk or
+    /// rewritten document leaves no stale chunks behind to be surfaced by search.
+    async fn delete_by_document(&self, document_id: DocumentId) -> Result<usize>;
 
     /// The number of records currently stored.
     async fn len(&self) -> Result<usize>;
@@ -133,6 +142,16 @@ impl VectorStore for InMemoryVectorStore {
         });
         scored.truncate(k);
         Ok(scored)
+    }
+
+    async fn delete_by_document(&self, document_id: DocumentId) -> Result<usize> {
+        let mut store = self
+            .records
+            .write()
+            .map_err(|_| RetrievalError::vector_store("in-memory store lock poisoned"))?;
+        let before = store.len();
+        store.retain(|r| r.chunk.document_id != document_id);
+        Ok(before - store.len())
     }
 
     async fn len(&self) -> Result<usize> {
@@ -230,5 +249,31 @@ mod tests {
         // The second upsert's vector won.
         let hits = store.query(&Embedding(vec![0.0, 1.0]), 1).await.unwrap();
         assert!((hits[0].score - 1.0).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn delete_by_document_removes_only_that_document() {
+        let store = InMemoryVectorStore::new(2);
+        let a = DocumentId::new();
+        let b = DocumentId::new();
+        store
+            .upsert(vec![
+                record(a, 0, "a0", vec![1.0, 0.0]),
+                record(a, 1, "a1", vec![0.0, 1.0]),
+                record(b, 0, "b0", vec![1.0, 1.0]),
+            ])
+            .await
+            .unwrap();
+
+        let removed = store.delete_by_document(a).await.unwrap();
+        assert_eq!(removed, 2);
+        assert_eq!(store.len().await.unwrap(), 1);
+        // Document b's chunk is untouched.
+        let hits = store.query(&Embedding(vec![1.0, 1.0]), 5).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].chunk.document_id, b);
+
+        // Deleting an absent document is a no-op.
+        assert_eq!(store.delete_by_document(a).await.unwrap(), 0);
     }
 }


### PR DESCRIPTION
## What

Makes re-ingesting a document an **atomic replace**, so a shrunk or rewritten document leaves no stale chunks — and concurrent re-ingests of the same URI can't interleave into a mix of versions. `POST /documents` (#43) is a real caller that can re-ingest edited content, so this closes a reachable correctness gap.

## Changes

- **`VectorStore::replace_document(document_id, records)`** — atomically removes the document's existing chunks and stores `records` in one operation (a single write lock for `InMemoryVectorStore`). An empty `records` clears the document. Validates each record's dimensionality, like `upsert`.
- **`Retriever::ingest` embeds first, then does one atomic replace.** The slow, awaited embed step happens before the store mutation, and the delete+insert are a single store operation — so two concurrent re-ingests of the same URI resolve to one version, last-write-wins, rather than interleaving a delete and an insert.

## Why not delete-then-upsert

The first cut used a separate `delete_by_document` then `upsert`, with the embed `await` between them. Review flagged that two concurrent same-URI ingests could interleave (A deletes, B deletes, A's slow embed finishes and upserts stale content after B upserted the newer version), reintroducing the stale-chunk bug. The atomic `replace_document` removes the interleaving window.

## Tests

Replaced the delete tests with `replace_document` coverage (49 total in the crate): swaps only the target document's chunks (others untouched, old chunks gone), empty records clears the document (and is a no-op when absent), and dimensionality is validated. The end-to-end prune tests via `Retriever::ingest` (shorter content prunes, empty content clears, same-URI idempotent) still pass through the new atomic path. `cargo test -p openwave-retrieval`, `clippy` (both feature sets), and `fmt --all --check` green.

Independent of #43 (touches only the retrieval crate); the server picks up the corrected behavior through `Retriever::ingest`.