### PR TITLE
feat(retrieval): OpenAI-compatible embedding provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,6 +2963,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "openwave-core",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/openwave-retrieval/Cargo.toml
+++ b/crates/openwave-retrieval/Cargo.toml
@@ -11,11 +11,15 @@ authors.workspace = true
 workspace = true
 
 [features]
-default = ["tool"]
-# The agent-facing `search` Tool. Pulls in `openwave-core` for the `Tool` trait;
-# turn it off (`default-features = false`) to use the retrieval pipeline as a
-# standalone library with no dependency on the core crate.
+# On by default (like openwave-router's adapters) so both are built and tested in
+# CI. Depend with `default-features = false` for the lean, offline pipeline: just
+# the seams plus HashEmbedder/InMemoryVectorStore, no openwave-core and no reqwest.
+default = ["tool", "embed-openai"]
+# The agent-facing `search` Tool. Pulls in `openwave-core` for the `Tool` trait.
 tool = ["dep:openwave-core"]
+# A real OpenAI-compatible embedding provider (network, via reqwest). The offline
+# HashEmbedder is always available regardless.
+embed-openai = ["dep:reqwest"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -28,6 +32,8 @@ uuid = { workspace = true, features = ["v5"] }
 # Only the trait contracts (Tool/ToolSpec/…), not the SQLite/keychain/file-tool
 # machinery — hence default-features = false.
 openwave-core = { path = "../openwave-core", default-features = false, optional = true }
+# HTTP client for the OpenAI-compatible embedder (embed-openai feature only).
+reqwest = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -52,16 +52,21 @@
 //! shared index. Turn the feature off to use the pipeline as a standalone library
 //! with no dependency on the core crate.
 //!
-//! Not yet wired: real embedding providers and reranking, persistent/hybrid vector
-//! backends, rich-format parsing, and the server ingest API + `AppState` wiring
-//! that hands the agent a live index. Each lands as its own slice behind these
-//! seams.
+//! For real semantic embeddings, the `embed-openai` feature adds [`OpenAiEmbedder`],
+//! an [`Embedder`] backed by the OpenAI-compatible `/embeddings` endpoint — a
+//! drop-in for [`HashEmbedder`] behind the same seam.
+//!
+//! Not yet wired: embedding reranking, persistent/hybrid vector backends,
+//! rich-format parsing, per-chat/project index scoping, and choosing the embedder
+//! from server configuration. Each lands as its own slice behind these seams.
 
 mod chunk;
 mod document;
 mod embed;
 mod error;
 mod id;
+#[cfg(feature = "embed-openai")]
+mod openai_embed;
 mod parse;
 mod retriever;
 #[cfg(feature = "tool")]
@@ -73,6 +78,8 @@ pub use document::{ByteSpan, Chunk, Citation, Document, DocumentSource, ScoredCh
 pub use embed::{Embedder, Embedding, HashEmbedder};
 pub use error::{Result, RetrievalError};
 pub use id::{ChunkId, DocumentId};
+#[cfg(feature = "embed-openai")]
+pub use openai_embed::OpenAiEmbedder;
 pub use parse::{DocumentParser, ParsedDocument, PlainTextParser};
 pub use retriever::{IngestOutcome, Retriever};
 #[cfg(feature = "tool")]

--- a/crates/openwave-retrieval/src/openai_embed.rs
+++ b/crates/openwave-retrieval/src/openai_embed.rs
@@ -1,0 +1,217 @@
+//! A real embedding provider: the OpenAI-compatible `/embeddings` endpoint.
+//!
+//! [`OpenAiEmbedder`] speaks the widely-supported OpenAI embeddings protocol, so
+//! the same adapter covers OpenAI itself and any OpenAI-compatible gateway (point
+//! `base_url` at its `/v1` root). It's the production counterpart to the offline
+//! [`crate::HashEmbedder`]: same [`Embedder`] seam, real semantic vectors.
+//!
+//! The request/response handling is split into pure helpers ([`build_request_body`]
+//! and [`parse_response`]) so the wire format is unit-tested without a network —
+//! the same approach `openwave-router` takes for its provider adapters. The live
+//! HTTP path isn't exercised in CI.
+//!
+//! Enabled by the `embed-openai` feature.
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::embed::{Embedder, Embedding};
+use crate::error::{Result, RetrievalError};
+
+const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+
+/// An [`Embedder`] backed by an OpenAI-compatible `/embeddings` endpoint.
+///
+/// `dimensions` is sent as the request's `dimensions` parameter (supported by the
+/// `text-embedding-3` family, which can project to a smaller size) and is the size
+/// every returned vector is validated against — so it always matches what a
+/// [`crate::VectorStore`] is configured to expect.
+#[derive(Clone)]
+pub struct OpenAiEmbedder {
+    client: reqwest::Client,
+    api_key: String,
+    base_url: String,
+    model: String,
+    dimensions: usize,
+}
+
+impl OpenAiEmbedder {
+    /// Build an embedder hitting OpenAI's embeddings API with the given model and
+    /// output dimensionality (e.g. `"text-embedding-3-small"`, `1536`).
+    #[must_use]
+    pub fn new(api_key: impl Into<String>, model: impl Into<String>, dimensions: usize) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key: api_key.into(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+            model: model.into(),
+            dimensions,
+        }
+    }
+
+    /// Point at a custom OpenAI-compatible gateway (its `/v1` root; `/embeddings`
+    /// is appended).
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+}
+
+#[async_trait]
+impl Embedder for OpenAiEmbedder {
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    async fn embed_documents(&self, texts: &[String]) -> Result<Vec<Embedding>> {
+        // Don't make a request for nothing — the API rejects an empty input.
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let url = format!("{}/embeddings", self.base_url.trim_end_matches('/'));
+        let body = build_request_body(&self.model, texts, self.dimensions);
+
+        let response = self
+            .client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(embed_err)?;
+
+        let status = response.status();
+        let bytes = response.bytes().await.map_err(embed_err)?;
+        if !status.is_success() {
+            // Never forward the raw body — a gateway may echo key material or
+            // request fragments, and the error string can reach a client.
+            return Err(RetrievalError::embed(format!(
+                "embeddings request failed with HTTP {}",
+                status.as_u16()
+            )));
+        }
+        parse_response(&bytes, texts.len(), self.dimensions)
+    }
+}
+
+/// Build the JSON request body for an embeddings call.
+fn build_request_body(model: &str, texts: &[String], dimensions: usize) -> Value {
+    json!({
+        "model": model,
+        "input": texts,
+        "encoding_format": "float",
+        "dimensions": dimensions,
+    })
+}
+
+/// The subset of the embeddings response we consume.
+#[derive(Deserialize)]
+struct EmbeddingsResponse {
+    data: Vec<EmbeddingData>,
+}
+
+#[derive(Deserialize)]
+struct EmbeddingData {
+    index: usize,
+    embedding: Vec<f32>,
+}
+
+/// Parse an embeddings response into vectors, one per input in order.
+///
+/// The API returns each vector tagged with its input `index`; this sorts by that
+/// index (order isn't guaranteed), and validates that the count and each vector's
+/// dimensionality match what was requested — so a malformed or truncated response
+/// is an error rather than a silently-misaligned result.
+fn parse_response(body: &[u8], expected: usize, dimensions: usize) -> Result<Vec<Embedding>> {
+    let parsed: EmbeddingsResponse = serde_json::from_slice(body)
+        .map_err(|e| RetrievalError::embed(format!("malformed embeddings response: {e}")))?;
+    if parsed.data.len() != expected {
+        return Err(RetrievalError::embed(format!(
+            "expected {expected} embeddings, got {}",
+            parsed.data.len()
+        )));
+    }
+    let mut data = parsed.data;
+    data.sort_by_key(|d| d.index);
+    let mut out = Vec::with_capacity(expected);
+    for (position, item) in data.into_iter().enumerate() {
+        if item.index != position {
+            return Err(RetrievalError::embed(format!(
+                "embeddings response indices are not contiguous (saw {} at position {position})",
+                item.index
+            )));
+        }
+        if item.embedding.len() != dimensions {
+            return Err(RetrievalError::embed(format!(
+                "embedding {position} has {} dimensions, expected {dimensions}",
+                item.embedding.len()
+            )));
+        }
+        out.push(Embedding(item.embedding));
+    }
+    Ok(out)
+}
+
+fn embed_err(err: impl std::fmt::Display) -> RetrievalError {
+    RetrievalError::embed(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_body_has_the_expected_shape() {
+        let texts = vec!["hello".to_string(), "world".to_string()];
+        let body = build_request_body("text-embedding-3-small", &texts, 1536);
+        assert_eq!(body["model"], "text-embedding-3-small");
+        assert_eq!(body["encoding_format"], "float");
+        assert_eq!(body["dimensions"], 1536);
+        assert_eq!(body["input"], json!(["hello", "world"]));
+    }
+
+    #[test]
+    fn parses_and_orders_embeddings_by_index() {
+        // Deliberately out of order: index 1 before index 0.
+        let body = json!({
+            "data": [
+                { "index": 1, "embedding": [0.3, 0.4] },
+                { "index": 0, "embedding": [0.1, 0.2] },
+            ]
+        })
+        .to_string();
+        let out = parse_response(body.as_bytes(), 2, 2).unwrap();
+        assert_eq!(out[0], Embedding(vec![0.1, 0.2]));
+        assert_eq!(out[1], Embedding(vec![0.3, 0.4]));
+    }
+
+    #[test]
+    fn rejects_a_wrong_embedding_count() {
+        let body = json!({ "data": [ { "index": 0, "embedding": [0.1, 0.2] } ] }).to_string();
+        let err = parse_response(body.as_bytes(), 2, 2).unwrap_err();
+        assert!(matches!(err, RetrievalError::Embed(_)));
+    }
+
+    #[test]
+    fn rejects_a_wrong_dimensionality() {
+        let body = json!({ "data": [ { "index": 0, "embedding": [0.1, 0.2, 0.3] } ] }).to_string();
+        let err = parse_response(body.as_bytes(), 1, 2).unwrap_err();
+        assert!(err.to_string().contains("expected 2"));
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        assert!(parse_response(b"not json", 1, 2).is_err());
+    }
+
+    #[tokio::test]
+    async fn empty_input_makes_no_request_and_reports_configured_dims() {
+        let embedder = OpenAiEmbedder::new("sk-test", "text-embedding-3-small", 1536)
+            .with_base_url("http://127.0.0.1:1/v1");
+        assert_eq!(embedder.dimensions(), 1536);
+        // No network call for an empty batch, so this resolves without a server.
+        assert!(embedder.embed_documents(&[]).await.unwrap().is_empty());
+    }
+}


### PR DESCRIPTION
## What

Adds `OpenAiEmbedder` — a real, semantic `Embedder` backed by the OpenAI-compatible `/embeddings` endpoint. The production counterpart to the offline `HashEmbedder`, behind the same seam, so it's a drop-in wherever an `Arc<dyn Embedder>` is used.

## Design

- Speaks the widely-supported OpenAI embeddings protocol; `base_url` points at any OpenAI-compatible gateway (`/embeddings` is appended to its `/v1` root).
- The configured `dimensions` are sent as the request's `dimensions` parameter (the `text-embedding-3` family can project to a smaller size) **and** validated on every returned vector — so the embedder's output always matches what a `VectorStore` is configured to expect.
- Request building (`build_request_body`) and response parsing (`parse_response`) are **pure helpers**, unit-tested without a network: request-body shape, index-ordered parsing (the API doesn't guarantee order), and count / dimension / malformed-JSON validation. This mirrors how `openwave-router` tests its provider adapters; the live HTTP path isn't exercised in CI.
- Non-2xx responses **never forward the raw body** (a gateway can echo key material or request fragments); the error carries only the status code.

## Feature-gating / CI

Behind an **`embed-openai` feature, on by default** — like `openwave-router`'s `anthropic`/`openai-compat` adapters — so the code is compiled and tested under the default-features CI run. `default-features = false` keeps the lean offline pipeline (seams + `HashEmbedder`/`InMemoryVectorStore`, no `reqwest`, no `openwave-core`).

## Not in this slice

Server wiring — choosing the embedder (offline vs OpenAI) from provider config + reading the credential from the keychain, and matching the vector store's dimensionality to it — is a later slice. `HashEmbedder` remains the server default until then.

## Tests

6 new (50 total in the crate): request-body shape, out-of-order parse, wrong-count, wrong-dimension, malformed-JSON, and empty-input-makes-no-request. `cargo test -p openwave-retrieval`, `clippy` (default and `--no-default-features`), and `fmt --all --check` green; the workspace (server included) builds with the new default feature.
