### PR TITLE
feat(server): DELETE /documents/{id} to remove a document from the index

### DIFF
--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -125,6 +125,12 @@ impl Retriever {
         let hits = self.store.query(&embedding, k).await?;
         Ok(hits.into_iter().map(Citation::from).collect())
     }
+
+    /// Remove a document and all its chunks from the index. Idempotent — deleting a
+    /// document that was never ingested (or already removed) is a no-op.
+    pub async fn delete(&self, document_id: DocumentId) -> Result<()> {
+        self.store.replace_document(document_id, Vec::new()).await
+    }
 }
 
 #[cfg(test)]
@@ -289,6 +295,26 @@ The Great Barrier Reef is the world's largest coral reef system.";
         let out = r.ingest(uri(), "text/plain", b"   ").await.unwrap();
         assert_eq!(out.chunks, 0);
         assert!(r.store().is_empty().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_a_documents_chunks_and_is_idempotent() {
+        let r = retriever();
+        let outcome = r
+            .ingest(
+                DocumentSource::uri("file:///doc.txt"),
+                "text/plain",
+                b"alpha beta gamma delta epsilon",
+            )
+            .await
+            .unwrap();
+        assert!(r.store().len().await.unwrap() > 0);
+
+        r.delete(outcome.document.id).await.unwrap();
+        assert!(r.store().is_empty().await.unwrap());
+        // Deleting again (or an unknown document) is a no-op, not an error.
+        r.delete(outcome.document.id).await.unwrap();
+        r.delete(DocumentId::new()).await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -71,6 +71,10 @@ pub fn app(state: AppState) -> Router {
             axum::routing::delete(routes::delete_provider_credential),
         )
         .route("/documents", post(routes::ingest_document))
+        .route(
+            "/documents/{id}",
+            axum::routing::delete(routes::delete_document),
+        )
         .route("/search", post(routes::search_documents))
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
         .route(
@@ -885,6 +889,58 @@ mod tests {
             .unwrap()
             .contains("Jupiter"));
         assert_eq!(citations[0]["document_id"], ingest["document_id"]);
+    }
+
+    #[tokio::test]
+    async fn deleting_a_document_removes_it_from_the_index() {
+        let (router, token, _store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let ingest: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({ "uri": "file:///doc.txt", "content": "Jupiter is a gas giant." }),
+            )
+            .await,
+        )
+        .await;
+        let id = ingest["document_id"].as_str().unwrap().to_string();
+
+        let delete = |id: String| {
+            let router = router.clone();
+            let bearer = bearer.clone();
+            async move {
+                router
+                    .oneshot(
+                        Request::builder()
+                            .method("DELETE")
+                            .uri(format!("/documents/{id}"))
+                            .header(header::AUTHORIZATION, &bearer)
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap()
+                    .status()
+            }
+        };
+
+        assert_eq!(delete(id.clone()).await, StatusCode::NO_CONTENT);
+        // Gone from the index.
+        let results: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/search",
+                serde_json::json!({ "query": "gas giant" }),
+            )
+            .await,
+        )
+        .await;
+        assert!(results["citations"].as_array().unwrap().is_empty());
+        // Idempotent: deleting again is still 204.
+        assert_eq!(delete(id).await, StatusCode::NO_CONTENT);
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -356,6 +356,17 @@ pub async fn ingest_document(
     ))
 }
 
+/// `DELETE /documents/{id}` — remove a document and its chunks from the index
+/// (`204 No Content`). Idempotent: deleting an unknown or already-removed document
+/// still returns `204`. `id` is the `document_id` returned by `POST /documents`.
+pub async fn delete_document(
+    State(state): State<AppState>,
+    Path(id): Path<DocumentId>,
+) -> Result<StatusCode, ServerError> {
+    state.retrieval.delete(id).await.map_err(retrieval_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 /// Body of `POST /search`.
 #[derive(Debug, Deserialize)]
 pub struct SearchRequest {


### PR DESCRIPTION
## Summary

Rounds out the document CRUD on the retrieval surface with `DELETE /documents/{id}`, so a client can remove a previously ingested document and its chunks from the index.

## Changes

- `Retriever::delete(document_id)` clears a document by calling the vector store's `replace_document` with no records. Idempotent: deleting a document that was never ingested (or already removed) is a no-op.
- `DELETE /documents/{id}` returns `204 No Content`. `id` is the `document_id` returned by `POST /documents`. Deleting an unknown or already-removed document still returns `204`.

## Tests

A retrieval-crate test covers `Retriever::delete` (removes the chunks; idempotent for repeated and unknown ids). A server test ingests a document, deletes it, confirms search then returns nothing, and confirms a repeat delete is still `204`. `cargo test`, `clippy --all-targets -D warnings`, and `fmt --all --check` pass.
