### PR TITLE
feat(mcp): MCP server face exposing the tool registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5682,6 +5682,13 @@ dependencies = [
 [[package]]
 name = "openwave-mcp"
 version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "openwave-core",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "openwave-retrieval"

--- a/crates/openwave-mcp/Cargo.toml
+++ b/crates/openwave-mcp/Cargo.toml
@@ -11,3 +11,13 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["io-std", "io-util"] }
+# Only the tool contracts (Tool / ToolRegistry / ToolCtx / …), not the SQLite /
+# keychain / agent-loop machinery — hence default-features = false.
+openwave-core = { path = "../openwave-core", default-features = false }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/openwave-mcp/src/lib.rs
+++ b/crates/openwave-mcp/src/lib.rs
@@ -26,8 +26,9 @@
 //! # }
 //! ```
 //!
-//! The client side (mounting *external* MCP tool servers into the agent) lands as a
-//! later slice.
+//! Not yet enforced: the MCP session lifecycle (gating `tools/*` on a completed
+//! `initialize`) — the server answers each request statelessly for now. The client
+//! side (mounting *external* MCP tool servers into the agent) is a later slice.
 
 pub mod protocol;
 mod server;

--- a/crates/openwave-mcp/src/lib.rs
+++ b/crates/openwave-mcp/src/lib.rs
@@ -1,4 +1,38 @@
-//! OpenWave MCP — the Model Context Protocol server face (core tools exposed to
-//! external agents) and the client that mounts external MCP tool servers.
+//! OpenWave MCP — the Model Context Protocol server face.
 //!
-//! Scaffolding only. Implementation lands in Phase 2.
+//! Exposes OpenWave's tools (the same `ToolRegistry` the agent uses) to an external
+//! MCP client, so any MCP-speaking host can drive OpenWave's capabilities — for
+//! example the `search` tool over a document index.
+//!
+//! [`McpServer`] answers `initialize`, `tools/list`, and `tools/call` and is
+//! transport-agnostic; [`serve_stdio`] runs it over the standard newline-delimited
+//! JSON-RPC stdio transport that MCP clients launch servers with.
+//!
+//! The protocol layer is hand-rolled ([`protocol`]) rather than pulling a full MCP
+//! SDK — the surface a tool server needs is small, and this keeps the crate light
+//! and fully unit-testable in-process.
+//!
+//! ```
+//! use std::sync::Arc;
+//! use openwave_core::{ChatId, ToolCtx, ToolRegistry};
+//! use openwave_mcp::McpServer;
+//!
+//! # fn demo() {
+//! let tools = Arc::new(ToolRegistry::new());
+//! let ctx = ToolCtx { chat_id: ChatId::new(), workspace_dir: "/work".into() };
+//! let server = McpServer::new(tools, ctx);
+//! // then: `openwave_mcp::serve_stdio(server).await` inside an async runtime.
+//! # let _ = server;
+//! # }
+//! ```
+//!
+//! The client side (mounting *external* MCP tool servers into the agent) lands as a
+//! later slice.
+
+pub mod protocol;
+mod server;
+mod stdio;
+
+pub use protocol::PROTOCOL_VERSION;
+pub use server::McpServer;
+pub use stdio::{serve, serve_stdio};

--- a/crates/openwave-mcp/src/protocol.rs
+++ b/crates/openwave-mcp/src/protocol.rs
@@ -1,0 +1,221 @@
+//! The wire types: JSON-RPC 2.0 framing and the MCP messages layered on it.
+//!
+//! MCP is JSON-RPC 2.0. A message with an `id` is a request that expects a
+//! response; one without an `id` is a notification (no reply). We keep the types
+//! minimal — just what the server face needs to `initialize`, list tools, and call
+//! them — rather than pulling a full MCP SDK.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The MCP protocol revision this server implements.
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// JSON-RPC standard error codes.
+pub mod error_code {
+    /// Invalid JSON was received.
+    pub const PARSE_ERROR: i64 = -32700;
+    /// The JSON is not a valid request object.
+    pub const INVALID_REQUEST: i64 = -32600;
+    /// The method does not exist.
+    pub const METHOD_NOT_FOUND: i64 = -32601;
+    /// Invalid method parameters.
+    pub const INVALID_PARAMS: i64 = -32602;
+    /// Internal server error.
+    pub const INTERNAL_ERROR: i64 = -32603;
+}
+
+/// An incoming JSON-RPC message. `id` absent ⇒ a notification (no response).
+#[derive(Debug, Clone, Deserialize)]
+pub struct Request {
+    /// Must be `"2.0"`; retained so a response can echo the framing verbatim.
+    #[serde(default)]
+    pub jsonrpc: String,
+    /// Request id. Absent for notifications.
+    #[serde(default)]
+    pub id: Option<Value>,
+    /// The method name (e.g. `"tools/list"`).
+    pub method: String,
+    /// Method parameters; `Null` when omitted.
+    #[serde(default)]
+    pub params: Value,
+}
+
+impl Request {
+    /// Whether this is a notification (no `id`, so no reply is sent).
+    #[must_use]
+    pub fn is_notification(&self) -> bool {
+        self.id.is_none()
+    }
+}
+
+/// A JSON-RPC response — exactly one of `result` or `error` is set.
+#[derive(Debug, Clone, Serialize)]
+pub struct Response {
+    pub jsonrpc: &'static str,
+    /// Echoes the request id (JSON `null` when the id was absent/unknown).
+    pub id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+}
+
+impl Response {
+    /// A success response carrying `result`.
+    #[must_use]
+    pub fn result(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    /// An error response.
+    #[must_use]
+    pub fn error(id: Value, error: RpcError) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: None,
+            error: Some(error),
+        }
+    }
+}
+
+/// A JSON-RPC error object.
+#[derive(Debug, Clone, Serialize)]
+pub struct RpcError {
+    pub code: i64,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl RpcError {
+    /// Build an error with a code and message.
+    #[must_use]
+    pub fn new(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    /// `-32601 Method not found`.
+    #[must_use]
+    pub fn method_not_found(method: &str) -> Self {
+        Self::new(
+            error_code::METHOD_NOT_FOUND,
+            format!("method not found: {method}"),
+        )
+    }
+
+    /// `-32602 Invalid params`.
+    #[must_use]
+    pub fn invalid_params(message: impl Into<String>) -> Self {
+        Self::new(error_code::INVALID_PARAMS, message)
+    }
+}
+
+// --- MCP message payloads ---
+
+/// Result of `initialize`.
+#[derive(Debug, Clone, Serialize)]
+pub struct InitializeResult {
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: &'static str,
+    pub capabilities: ServerCapabilities,
+    #[serde(rename = "serverInfo")]
+    pub server_info: ServerInfo,
+}
+
+/// Advertised server capabilities. Only tools for now.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerCapabilities {
+    pub tools: ToolsCapability,
+}
+
+/// The tools capability (empty object today; may carry flags like `listChanged`).
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ToolsCapability {}
+
+/// Server identity reported at `initialize`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerInfo {
+    pub name: String,
+    pub version: String,
+}
+
+/// Result of `tools/list`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ListToolsResult {
+    pub tools: Vec<ToolDescriptor>,
+}
+
+/// One tool as advertised to an MCP client (mirrors the agent's `ToolSpec`).
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolDescriptor {
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "inputSchema")]
+    pub input_schema: Value,
+}
+
+/// Params of `tools/call`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CallToolParams {
+    pub name: String,
+    #[serde(default)]
+    pub arguments: Value,
+}
+
+/// Result of `tools/call`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CallToolResult {
+    pub content: Vec<Content>,
+    #[serde(rename = "isError")]
+    pub is_error: bool,
+}
+
+/// A content block in a tool result. Only text today.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum Content {
+    #[serde(rename = "text")]
+    Text { text: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn notification_has_no_id() {
+        let req: Request =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
+                .unwrap();
+        assert!(req.is_notification());
+
+        let req: Request =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#).unwrap();
+        assert!(!req.is_notification());
+    }
+
+    #[test]
+    fn response_serializes_result_xor_error() {
+        let ok = Response::result(serde_json::json!(1), serde_json::json!({"k": 1}));
+        let s = serde_json::to_string(&ok).unwrap();
+        assert!(s.contains("\"result\""));
+        assert!(!s.contains("\"error\""));
+
+        let err = Response::error(serde_json::json!(1), RpcError::method_not_found("x"));
+        let s = serde_json::to_string(&err).unwrap();
+        assert!(s.contains("\"error\""));
+        assert!(!s.contains("\"result\""));
+        assert!(s.contains("-32601"));
+    }
+}

--- a/crates/openwave-mcp/src/protocol.rs
+++ b/crates/openwave-mcp/src/protocol.rs
@@ -25,14 +25,18 @@ pub mod error_code {
     pub const INTERNAL_ERROR: i64 = -32603;
 }
 
-/// An incoming JSON-RPC message. `id` absent ⇒ a notification (no response).
+/// An incoming JSON-RPC message. An **absent** `id` ⇒ a notification (no
+/// response); a present `id` (including the literal `null`) ⇒ a request that must
+/// be answered.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Request {
-    /// Must be `"2.0"`; retained so a response can echo the framing verbatim.
+    /// The JSON-RPC version; must be `"2.0"` (validated by the server).
     #[serde(default)]
     pub jsonrpc: String,
-    /// Request id. Absent for notifications.
-    #[serde(default)]
+    /// Request id. The outer option distinguishes an *absent* id (`None`, a
+    /// notification) from a present `null` id (`Some(Null)`, still a request), via
+    /// [`present_or_absent`] — serde's plain `Option` collapses both to `None`.
+    #[serde(default, deserialize_with = "present_or_absent")]
     pub id: Option<Value>,
     /// The method name (e.g. `"tools/list"`).
     pub method: String,
@@ -42,11 +46,28 @@ pub struct Request {
 }
 
 impl Request {
-    /// Whether this is a notification (no `id`, so no reply is sent).
+    /// Whether this is a notification (no `id` at all, so no reply is sent).
     #[must_use]
     pub fn is_notification(&self) -> bool {
         self.id.is_none()
     }
+
+    /// The id to echo in the response (the present value, or `null` if `id` was
+    /// the literal `null`). Only meaningful when this is not a notification.
+    #[must_use]
+    pub fn reply_id(&self) -> Value {
+        self.id.clone().unwrap_or(Value::Null)
+    }
+}
+
+/// Deserialize a present field (including JSON `null`) as `Some(..)`; the
+/// `#[serde(default)]` on the field supplies `None` when it is absent. This lets a
+/// present-but-`null` `id` be told apart from a missing one.
+fn present_or_absent<'de, D>(deserializer: D) -> std::result::Result<Option<Value>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Value::deserialize(deserializer).map(Some)
 }
 
 /// A JSON-RPC response — exactly one of `result` or `error` is set.
@@ -177,6 +198,10 @@ pub struct CallToolParams {
 #[derive(Debug, Clone, Serialize)]
 pub struct CallToolResult {
     pub content: Vec<Content>,
+    /// A tool's optional structured payload (the agent tool's `data`), surfaced as
+    /// MCP `structuredContent` when present.
+    #[serde(rename = "structuredContent", skip_serializing_if = "Option::is_none")]
+    pub structured_content: Option<Value>,
     #[serde(rename = "isError")]
     pub is_error: bool,
 }

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -56,8 +56,19 @@ impl McpServer {
             // silently; nothing to reply.
             return None;
         }
-        // A request always has an id here (checked above).
-        let id = req.id.clone().unwrap_or(Value::Null);
+        let id = req.reply_id();
+
+        // The version must be exactly "2.0"; anything else (including an absent
+        // field) is a malformed request per JSON-RPC 2.0.
+        if req.jsonrpc != "2.0" {
+            return Some(Response::error(
+                id,
+                RpcError::new(
+                    error_code::INVALID_REQUEST,
+                    "jsonrpc must be \"2.0\"".to_string(),
+                ),
+            ));
+        }
 
         let outcome = match req.method.as_str() {
             "initialize" => Ok(self.initialize_result()),
@@ -86,7 +97,7 @@ impl McpServer {
     }
 
     fn list_tools_result(&self) -> Value {
-        let tools = self
+        let mut tools: Vec<ToolDescriptor> = self
             .tools
             .specs()
             .into_iter()
@@ -96,6 +107,9 @@ impl McpServer {
                 input_schema: spec.input_schema,
             })
             .collect();
+        // The registry is a HashMap; sort by name so the advertised list is stable
+        // across launches (friendlier for clients and snapshot tests).
+        tools.sort_by(|a, b| a.name.cmp(&b.name));
         serde_json::to_value(ListToolsResult { tools })
             .expect("ListToolsResult is always serializable")
     }
@@ -125,6 +139,7 @@ impl McpServer {
             content: vec![Content::Text {
                 text: output.content,
             }],
+            structured_content: output.data,
             is_error: output.is_error,
         };
         serde_json::to_value(result).map_err(|e| {
@@ -166,10 +181,11 @@ mod tests {
         }
         async fn execute(&self, _ctx: &ToolCtx, args: Value) -> openwave_core::Result<ToolOutput> {
             let text = args.get("text").and_then(Value::as_str).unwrap_or("");
-            if text == "boom" {
-                return Ok(ToolOutput::error("asked to fail"));
+            match text {
+                "boom" => Ok(ToolOutput::error("asked to fail")),
+                "withdata" => Ok(ToolOutput::text("ok").with_data(json!({"n": 1}))),
+                _ => Ok(ToolOutput::text(format!("echo: {text}"))),
             }
-            Ok(ToolOutput::text(format!("echo: {text}")))
         }
     }
 
@@ -263,6 +279,51 @@ mod tests {
             unknown_method.error.unwrap().code,
             error_code::METHOD_NOT_FOUND
         );
+    }
+
+    #[tokio::test]
+    async fn structured_output_is_surfaced_as_structured_content() {
+        let resp = server()
+            .handle(request(
+                7,
+                "tools/call",
+                json!({"name": "echo", "arguments": {"text": "withdata"}}),
+            ))
+            .await
+            .unwrap();
+        let result = resp.result.unwrap();
+        assert_eq!(result["structuredContent"], json!({"n": 1}));
+        // Tools without structured data omit the field entirely.
+        let plain = server()
+            .handle(request(
+                8,
+                "tools/call",
+                json!({"name": "echo", "arguments": {"text": "hi"}}),
+            ))
+            .await
+            .unwrap();
+        assert!(plain.result.unwrap().get("structuredContent").is_none());
+    }
+
+    #[tokio::test]
+    async fn a_request_with_explicit_null_id_still_gets_a_reply() {
+        // Present-but-null id is a request (must be answered), not a notification.
+        let req: Request =
+            serde_json::from_value(json!({"jsonrpc": "2.0", "id": null, "method": "tools/list"}))
+                .unwrap();
+        assert!(!req.is_notification());
+        let resp = server().handle(req).await.unwrap();
+        assert_eq!(resp.id, Value::Null);
+        assert!(resp.result.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_wrong_jsonrpc_version_is_an_invalid_request() {
+        let req: Request =
+            serde_json::from_value(json!({"jsonrpc": "1.0", "id": 9, "method": "tools/list"}))
+                .unwrap();
+        let resp = server().handle(req).await.unwrap();
+        assert_eq!(resp.error.unwrap().code, error_code::INVALID_REQUEST);
     }
 
     #[tokio::test]

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -1,0 +1,276 @@
+//! The MCP server face: exposes OpenWave's tools to an external MCP client.
+//!
+//! [`McpServer`] answers `initialize`, `tools/list`, and `tools/call` against a
+//! [`ToolRegistry`]. It's transport-agnostic — [`McpServer::handle`] takes a parsed
+//! request and returns a response (or `None` for a notification); a transport (see
+//! [`crate::serve_stdio`]) just moves bytes.
+//!
+//! Every exposed tool runs within one configured [`ToolCtx`] (a chat id and a
+//! workspace directory), so the whole MCP session operates in a single workspace.
+//! Tool-reported failures come back as a `tools/call` result with `isError = true`
+//! (the MCP convention), not a JSON-RPC error; JSON-RPC errors are reserved for
+//! protocol-level problems (unknown method, bad params, an infrastructure fault).
+
+use std::sync::Arc;
+
+use openwave_core::{ChatId, ToolCtx, ToolRegistry};
+use serde_json::Value;
+
+use crate::protocol::{
+    error_code, CallToolParams, CallToolResult, Content, InitializeResult, ListToolsResult,
+    Request, Response, RpcError, ServerCapabilities, ServerInfo, ToolDescriptor, ToolsCapability,
+    PROTOCOL_VERSION,
+};
+
+/// An MCP server exposing a tool registry over the Model Context Protocol.
+pub struct McpServer {
+    tools: Arc<ToolRegistry>,
+    ctx: ToolCtx,
+    server_name: String,
+    server_version: String,
+}
+
+impl McpServer {
+    /// Build a server exposing `tools`, whose calls run within `ctx`.
+    #[must_use]
+    pub fn new(tools: Arc<ToolRegistry>, ctx: ToolCtx) -> Self {
+        Self {
+            tools,
+            ctx,
+            server_name: "openwave".to_string(),
+            server_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+
+    /// The [`ChatId`] the exposed tools run under (from the configured [`ToolCtx`]).
+    #[must_use]
+    pub fn chat_id(&self) -> ChatId {
+        self.ctx.chat_id
+    }
+
+    /// Handle one request. Returns the response to send, or `None` for a
+    /// notification (which by JSON-RPC gets no reply).
+    pub async fn handle(&self, req: Request) -> Option<Response> {
+        if req.is_notification() {
+            // Accept lifecycle notifications (e.g. `notifications/initialized`)
+            // silently; nothing to reply.
+            return None;
+        }
+        // A request always has an id here (checked above).
+        let id = req.id.clone().unwrap_or(Value::Null);
+
+        let outcome = match req.method.as_str() {
+            "initialize" => Ok(self.initialize_result()),
+            "tools/list" => Ok(self.list_tools_result()),
+            "tools/call" => self.call_tool(req.params).await,
+            other => Err(RpcError::method_not_found(other)),
+        };
+        Some(match outcome {
+            Ok(result) => Response::result(id, result),
+            Err(error) => Response::error(id, error),
+        })
+    }
+
+    fn initialize_result(&self) -> Value {
+        let result = InitializeResult {
+            protocol_version: PROTOCOL_VERSION,
+            capabilities: ServerCapabilities {
+                tools: ToolsCapability::default(),
+            },
+            server_info: ServerInfo {
+                name: self.server_name.clone(),
+                version: self.server_version.clone(),
+            },
+        };
+        serde_json::to_value(result).expect("InitializeResult is always serializable")
+    }
+
+    fn list_tools_result(&self) -> Value {
+        let tools = self
+            .tools
+            .specs()
+            .into_iter()
+            .map(|spec| ToolDescriptor {
+                name: spec.name,
+                description: spec.description,
+                input_schema: spec.input_schema,
+            })
+            .collect();
+        serde_json::to_value(ListToolsResult { tools })
+            .expect("ListToolsResult is always serializable")
+    }
+
+    async fn call_tool(&self, params: Value) -> Result<Value, RpcError> {
+        let params: CallToolParams = serde_json::from_value(params)
+            .map_err(|e| RpcError::invalid_params(format!("invalid tools/call params: {e}")))?;
+
+        let tool = self
+            .tools
+            .get(&params.name)
+            .ok_or_else(|| RpcError::invalid_params(format!("unknown tool: {}", params.name)))?;
+
+        // A tool's own failure is a result with isError = true, not a protocol
+        // error; only an infrastructure fault (Err) becomes a JSON-RPC error.
+        let output = tool
+            .execute(&self.ctx, params.arguments)
+            .await
+            .map_err(|e| {
+                RpcError::new(
+                    error_code::INTERNAL_ERROR,
+                    format!("tool execution failed: {e}"),
+                )
+            })?;
+
+        let result = CallToolResult {
+            content: vec![Content::Text {
+                text: output.content,
+            }],
+            is_error: output.is_error,
+        };
+        serde_json::to_value(result).map_err(|e| {
+            RpcError::new(
+                error_code::INTERNAL_ERROR,
+                format!("failed to encode tool result: {e}"),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    use async_trait::async_trait;
+    use openwave_core::{ApprovalClass, Tool, ToolOutput, ToolSpec};
+    use serde_json::json;
+
+    /// A tool that echoes its `text` argument, or errors when asked.
+    struct EchoTool;
+
+    #[async_trait]
+    impl Tool for EchoTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: "echo".into(),
+                description: "Echo the text argument back.".into(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": { "text": { "type": "string" } },
+                    "required": ["text"]
+                }),
+            }
+        }
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::ReadOnly
+        }
+        async fn execute(&self, _ctx: &ToolCtx, args: Value) -> openwave_core::Result<ToolOutput> {
+            let text = args.get("text").and_then(Value::as_str).unwrap_or("");
+            if text == "boom" {
+                return Ok(ToolOutput::error("asked to fail"));
+            }
+            Ok(ToolOutput::text(format!("echo: {text}")))
+        }
+    }
+
+    fn server() -> McpServer {
+        let tools = Arc::new(ToolRegistry::new().with(Box::new(EchoTool)));
+        let ctx = ToolCtx {
+            chat_id: ChatId::new(),
+            workspace_dir: PathBuf::from("/tmp/ws"),
+        };
+        McpServer::new(tools, ctx)
+    }
+
+    fn request(id: i64, method: &str, params: Value) -> Request {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0", "id": id, "method": method, "params": params
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn initialize_reports_protocol_and_server_info() {
+        let resp = server()
+            .handle(request(1, "initialize", Value::Null))
+            .await
+            .unwrap();
+        let result = resp.result.unwrap();
+        assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(result["serverInfo"]["name"], "openwave");
+        assert!(result["capabilities"]["tools"].is_object());
+    }
+
+    #[tokio::test]
+    async fn tools_list_advertises_the_registry() {
+        let resp = server()
+            .handle(request(2, "tools/list", Value::Null))
+            .await
+            .unwrap();
+        let tools = resp.result.unwrap()["tools"].as_array().unwrap().clone();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["name"], "echo");
+        assert!(tools[0]["inputSchema"]["properties"]["text"].is_object());
+    }
+
+    #[tokio::test]
+    async fn tools_call_runs_the_tool() {
+        let resp = server()
+            .handle(request(
+                3,
+                "tools/call",
+                json!({"name": "echo", "arguments": {"text": "hi"}}),
+            ))
+            .await
+            .unwrap();
+        let result = resp.result.unwrap();
+        assert_eq!(result["isError"], false);
+        assert_eq!(result["content"][0]["type"], "text");
+        assert_eq!(result["content"][0]["text"], "echo: hi");
+    }
+
+    #[tokio::test]
+    async fn tool_failure_is_a_result_with_is_error_not_a_protocol_error() {
+        let resp = server()
+            .handle(request(
+                4,
+                "tools/call",
+                json!({"name": "echo", "arguments": {"text": "boom"}}),
+            ))
+            .await
+            .unwrap();
+        assert!(resp.error.is_none());
+        assert_eq!(resp.result.unwrap()["isError"], true);
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_and_unknown_method_are_protocol_errors() {
+        let unknown_tool = server()
+            .handle(request(
+                5,
+                "tools/call",
+                json!({"name": "nope", "arguments": {}}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(unknown_tool.error.unwrap().code, error_code::INVALID_PARAMS);
+
+        let unknown_method = server()
+            .handle(request(6, "does/not/exist", Value::Null))
+            .await
+            .unwrap();
+        assert_eq!(
+            unknown_method.error.unwrap().code,
+            error_code::METHOD_NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn a_notification_gets_no_response() {
+        let note: Request = serde_json::from_value(
+            json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        )
+        .unwrap();
+        assert!(server().handle(note).await.is_none());
+    }
+}

--- a/crates/openwave-mcp/src/stdio.rs
+++ b/crates/openwave-mcp/src/stdio.rs
@@ -36,18 +36,25 @@ where
         if line.trim().is_empty() {
             continue;
         }
-        let response = match serde_json::from_str::<Request>(&line) {
+        let response = match parse_request(&line) {
             Ok(request) => server.handle(request).await,
-            Err(err) => Some(Response::error(
-                Value::Null,
-                RpcError::new(error_code::PARSE_ERROR, format!("invalid JSON-RPC: {err}")),
-            )),
+            Err(error) => Some(Response::error(Value::Null, error)),
         };
         if let Some(response) = response {
             write_line(&mut writer, &response).await?;
         }
     }
     Ok(())
+}
+
+/// Parse one line into a [`Request`], distinguishing a syntax error (`-32700
+/// Parse error`) from valid JSON that isn't a well-formed request (`-32600 Invalid
+/// Request`, e.g. a missing `method`).
+fn parse_request(line: &str) -> Result<Request, RpcError> {
+    let value: Value = serde_json::from_str(line)
+        .map_err(|e| RpcError::new(error_code::PARSE_ERROR, format!("invalid JSON: {e}")))?;
+    serde_json::from_value(value)
+        .map_err(|e| RpcError::new(error_code::INVALID_REQUEST, format!("invalid request: {e}")))
 }
 
 /// Write a response as one JSON line, then flush.
@@ -111,5 +118,22 @@ mod tests {
             serde_json::from_str(String::from_utf8(output).unwrap().trim()).unwrap();
         assert_eq!(response["error"]["code"], error_code::PARSE_ERROR);
         assert_eq!(response["id"], serde_json::Value::Null);
+    }
+
+    #[tokio::test]
+    async fn serve_reports_invalid_request_for_valid_json_without_method() {
+        // Valid JSON, but not a well-formed request (no `method`) => -32600, not
+        // the -32700 reserved for JSON syntax errors.
+        let mut output = Vec::new();
+        serve(
+            &br#"{"jsonrpc":"2.0","id":1}"#[..],
+            &mut output,
+            empty_server(),
+        )
+        .await
+        .unwrap();
+        let response: serde_json::Value =
+            serde_json::from_str(String::from_utf8(output).unwrap().trim()).unwrap();
+        assert_eq!(response["error"]["code"], error_code::INVALID_REQUEST);
     }
 }

--- a/crates/openwave-mcp/src/stdio.rs
+++ b/crates/openwave-mcp/src/stdio.rs
@@ -1,0 +1,115 @@
+//! The stdio transport: newline-delimited JSON-RPC over stdin/stdout.
+//!
+//! This is the transport MCP clients launch a server with — one JSON message per
+//! line in, one per line out. [`serve_stdio`] wires an [`McpServer`] to the process
+//! stdin/stdout; [`serve`] does the same over any async reader/writer, which is
+//! what makes the loop testable without touching the real console.
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+
+use crate::protocol::{error_code, Request, Response, RpcError};
+use crate::server::McpServer;
+use serde_json::Value;
+
+/// Serve `server` over the process stdin/stdout until stdin reaches EOF.
+pub async fn serve_stdio(server: McpServer) -> std::io::Result<()> {
+    serve(
+        BufReader::new(tokio::io::stdin()),
+        tokio::io::stdout(),
+        server,
+    )
+    .await
+}
+
+/// Serve `server` over an arbitrary reader/writer.
+///
+/// Each non-blank input line is parsed as a JSON-RPC request and dispatched;
+/// responses (and parse errors) are written as one JSON line each. Notifications
+/// and blank lines produce no output. Returns when the reader reaches EOF.
+pub async fn serve<R, W>(reader: R, mut writer: W, server: McpServer) -> std::io::Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut lines = reader.lines();
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let response = match serde_json::from_str::<Request>(&line) {
+            Ok(request) => server.handle(request).await,
+            Err(err) => Some(Response::error(
+                Value::Null,
+                RpcError::new(error_code::PARSE_ERROR, format!("invalid JSON-RPC: {err}")),
+            )),
+        };
+        if let Some(response) = response {
+            write_line(&mut writer, &response).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Write a response as one JSON line, then flush.
+async fn write_line<W: AsyncWrite + Unpin>(
+    out: &mut W,
+    response: &Response,
+) -> std::io::Result<()> {
+    let mut bytes = serde_json::to_vec(response).map_err(std::io::Error::other)?;
+    bytes.push(b'\n');
+    out.write_all(&bytes).await?;
+    out.flush().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use openwave_core::{ChatId, ToolCtx, ToolRegistry};
+
+    fn empty_server() -> McpServer {
+        let ctx = ToolCtx {
+            chat_id: ChatId::new(),
+            workspace_dir: PathBuf::from("/tmp/ws"),
+        };
+        McpServer::new(Arc::new(ToolRegistry::new()), ctx)
+    }
+
+    #[tokio::test]
+    async fn serve_replies_to_requests_and_skips_notifications_and_blanks() {
+        // A request, then a blank line, then a notification (no id).
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#,
+            "\n\n",
+            r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+            "\n",
+        );
+        let mut output = Vec::new();
+        serve(input.as_bytes(), &mut output, empty_server())
+            .await
+            .unwrap();
+
+        // Exactly one response line (the request); the blank and notification
+        // produced nothing.
+        let out = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 1);
+        let response: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(response["id"], 1);
+        assert!(response["result"]["tools"].is_array());
+    }
+
+    #[tokio::test]
+    async fn serve_reports_a_parse_error_for_invalid_json() {
+        let mut output = Vec::new();
+        serve(&b"not json\n"[..], &mut output, empty_server())
+            .await
+            .unwrap();
+        let response: serde_json::Value =
+            serde_json::from_str(String::from_utf8(output).unwrap().trim()).unwrap();
+        assert_eq!(response["error"]["code"], error_code::PARSE_ERROR);
+        assert_eq!(response["id"], serde_json::Value::Null);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Model Context Protocol **server face** in `openwave-mcp`: it exposes OpenWave's tools — the same `ToolRegistry` the agent uses — to an external MCP client over JSON-RPC 2.0. Any MCP-speaking host can then drive OpenWave's capabilities (for example the `search` tool over a document index).

## Design

- **`protocol`** — hand-rolled JSON-RPC 2.0 framing plus the MCP payloads the server needs (`initialize`, `tools/list`, `tools/call`). This is deliberately a small, self-contained protocol layer rather than a full MCP SDK dependency: the surface a tool server needs is minimal, and hand-rolling keeps the crate light and fully unit-testable in-process. It is straightforward to swap for the official SDK later; the message types are reusable.
- **`McpServer::handle`** — transport-agnostic dispatch of `initialize` / `tools/list` / `tools/call` against the registry. Every exposed tool runs within one configured `ToolCtx` (a chat id and workspace directory), so the session operates in a single workspace. A tool's own failure surfaces as a `tools/call` result with `isError = true` (the MCP convention); JSON-RPC errors are reserved for protocol-level problems (unknown method, invalid params, an infrastructure fault).
- **`serve` / `serve_stdio`** — the newline-delimited JSON-RPC stdio transport MCP clients launch servers with. `serve` is generic over the reader/writer, so the request/response loop is tested over in-memory streams rather than the real console.

`openwave-mcp` depends on `openwave-core` with `default-features = false` — just the tool contracts, none of the SQLite/keychain/agent-loop machinery.

## Not in this slice

The **client** side — mounting *external* MCP tool servers into the agent's registry — and wiring the server face into the daemon/CLI as a launchable MCP endpoint.

## Tests

10 unit tests plus a doctest: `initialize` reports the protocol version and server info; `tools/list` advertises the registry; `tools/call` runs a tool and maps its output; a tool failure is a result (not a protocol error); unknown tool/method are protocol errors; a notification gets no reply; and the stdio `serve` loop replies to requests while skipping blanks and notifications and reports a parse error for invalid JSON. `cargo test`, `clippy --all-targets -D warnings`, and `fmt --all --check` pass.
