### PR TITLE
fix(retrieval): make Lance document replacement atomic

### DIFF
--- a/crates/openwave-retrieval/Cargo.toml
+++ b/crates/openwave-retrieval/Cargo.toml
@@ -20,10 +20,10 @@ tool = ["dep:openwave-core"]
 # A real OpenAI-compatible embedding provider (network, via reqwest). The offline
 # HashEmbedder is always available regardless.
 embed-openai = ["dep:reqwest"]
-# A durable, embedded vector store backed by LanceDB (pure-Rust, on-disk). NOT a
-# default feature: LanceDB needs `protoc` at build time, which the CI runner does
-# not have, so building it by default would break CI. Enable locally with
-# `PROTOC` set. See docs/notes on wiring this as the server default.
+# A durable, embedded vector store backed by LanceDB (pure-Rust, on-disk). Not a
+# default feature for library consumers because it pulls a large dependency tree
+# and needs `protoc` at build time. OpenWave's workspace CI installs `protoc`, and
+# the server enables this feature explicitly.
 vec-lance = ["dep:lancedb", "dep:arrow-array", "dep:arrow-schema", "dep:futures"]
 
 [dependencies]

--- a/crates/openwave-retrieval/src/lance_store.rs
+++ b/crates/openwave-retrieval/src/lance_store.rs
@@ -6,24 +6,26 @@
 //! with room for an ANN index and multimodal columns later.
 //!
 //! Chunks live in one table with a fixed-width vector column; scalar columns carry
-//! the citation data (ids, ordinal, text, byte span). Cosine distance; LanceDB does
-//! a flat (brute-force) scan until an index is built, which is fine for the corpus
-//! sizes this targets today.
+//! the citation data (ids, ordinal, text, byte span). Writes use Lance's
+//! transactional merge-insert operation, so replacing a document is published as
+//! one dataset version. Cosine distance; LanceDB does a flat (brute-force) scan
+//! until an index is built, which is fine for the corpus sizes this targets today.
 //!
 //! **Build note:** enabled by the non-default `vec-lance` feature. LanceDB pulls a
 //! large Arrow/DataFusion tree and needs `protoc` at build time — hence off by
-//! default (the CI runner has no `protoc`). Build/test locally with `PROTOC` set.
+//! default for library consumers. OpenWave's workspace CI installs `protoc`.
 
 use std::sync::Arc;
 
 use arrow_array::types::Float32Type;
 use arrow_array::{
-    Array, ArrayRef, FixedSizeListArray, Float32Array, RecordBatch, StringArray, UInt64Array,
+    Array, ArrayRef, FixedSizeListArray, Float32Array, RecordBatch, RecordBatchIterator,
+    StringArray, UInt64Array,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use futures::TryStreamExt;
-use lancedb::query::{ExecutableQuery, QueryBase};
+use lancedb::query::{ExecutableQuery, QueryBase, Select};
 use lancedb::{DistanceType, Table};
 
 use crate::document::{ByteSpan, Chunk, ScoredChunk};
@@ -38,6 +40,13 @@ const TABLE: &str = "chunks";
 const VECTOR_COL: &str = "vector";
 /// LanceDB's distance column on query results.
 const DISTANCE_COL: &str = "_distance";
+/// Lance dataset configuration marker for the one-time legacy duplicate repair.
+const UNIQUE_CHUNK_IDS_V1: &str = "openwave.unique_chunk_ids_v1";
+/// Lance's version-relative row-id meta column, used only within one repair scan.
+const ROW_ID_COL: &str = "_rowid";
+/// Bound repair predicates so a badly duplicated legacy dataset does not produce
+/// one pathological SQL expression.
+const REPAIR_DELETE_BATCH: usize = 500;
 
 /// A persistent [`VectorStore`] backed by a local LanceDB dataset.
 pub struct LanceVectorStore {
@@ -87,6 +96,7 @@ impl LanceVectorStore {
                 .await
                 .map_err(lance_err)?,
         };
+        ensure_unique_chunk_ids(&table).await?;
         Ok(Self {
             table,
             schema,
@@ -107,16 +117,6 @@ impl LanceVectorStore {
                 actual: embedding.dim(),
             });
         }
-        Ok(())
-    }
-
-    /// Append records to the table (no dedupe; callers delete first as needed).
-    async fn append(&self, records: &[VectorRecord]) -> Result<()> {
-        if records.is_empty() {
-            return Ok(());
-        }
-        let batch = self.to_batch(records)?;
-        self.table.add(batch).execute().await.map_err(lance_err)?;
         Ok(())
     }
 
@@ -151,6 +151,71 @@ impl LanceVectorStore {
     }
 }
 
+/// Repair duplicate chunk ids that an older delete-then-append writer could leave
+/// behind after concurrent writes.
+///
+/// Lance merge-insert treats multiple target matches as undefined, so the new
+/// transactional writer must establish uniqueness before using `chunk_id` as its
+/// merge key. This scans only ids and row ids once per existing dataset, keeps the
+/// newest physical row for each id, deletes older duplicates in bounded commits,
+/// and records a dataset marker so normal startups do not rescan the corpus.
+async fn ensure_unique_chunk_ids(table: &Table) -> Result<()> {
+    let native = table
+        .as_native()
+        .ok_or_else(|| RetrievalError::vector_store("Lance table is not a local dataset"))?;
+    let manifest = native.manifest().await.map_err(lance_err)?;
+    if manifest.config.get(UNIQUE_CHUNK_IDS_V1).map(String::as_str) == Some("1") {
+        return Ok(());
+    }
+
+    let mut stream = table
+        .query()
+        .select(Select::columns(&["chunk_id"]))
+        .with_row_id()
+        .execute()
+        .await
+        .map_err(lance_err)?;
+    let mut newest_by_id = std::collections::HashMap::<String, u64>::new();
+    let mut stale_row_ids = Vec::new();
+    while let Some(batch) = stream.try_next().await.map_err(lance_err)? {
+        let chunk_ids = str_col(&batch, "chunk_id")?;
+        let row_ids = u64_col(&batch, ROW_ID_COL)?;
+        for i in 0..batch.num_rows() {
+            let id = chunk_ids.value(i).to_string();
+            let row_id = row_ids.value(i);
+            if let Some(kept) = newest_by_id.get_mut(&id) {
+                // Query order is deliberately irrelevant: the highest physical
+                // row id is the last append from the legacy writer. Concurrent
+                // repair scans therefore choose the same survivor.
+                if row_id > *kept {
+                    stale_row_ids.push(*kept);
+                    *kept = row_id;
+                } else {
+                    stale_row_ids.push(row_id);
+                }
+            } else {
+                newest_by_id.insert(id, row_id);
+            }
+        }
+    }
+
+    for batch in stale_row_ids.chunks(REPAIR_DELETE_BATCH) {
+        let ids = batch
+            .iter()
+            .map(u64::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        table
+            .delete(&format!("{ROW_ID_COL} IN ({ids})"))
+            .await
+            .map_err(lance_err)?;
+    }
+    native
+        .update_config([(UNIQUE_CHUNK_IDS_V1.to_string(), "1".to_string())])
+        .await
+        .map_err(lance_err)
+}
+
 #[async_trait]
 impl VectorStore for LanceVectorStore {
     async fn upsert(&self, records: Vec<VectorRecord>) -> Result<()> {
@@ -158,22 +223,20 @@ impl VectorStore for LanceVectorStore {
             self.check_dims(&record.embedding)?;
         }
         // Collapse duplicate chunk ids within the batch (last wins) so this backend
-        // matches InMemoryVectorStore's by-id dedupe — appending blindly would
-        // otherwise leave two rows for one chunk. Then delete any existing rows with
-        // these ids and append. Chunk ids are UUIDs (hex + hyphens only), so
-        // interpolating them into the SQL predicate is injection-safe.
+        // matches InMemoryVectorStore's by-id dedupe. Merge-insert updates existing
+        // rows and inserts new rows in one Lance dataset version.
         let records = dedupe_by_chunk_id(records);
-        let ids: Vec<String> = records
-            .iter()
-            .map(|r| format!("'{}'", r.chunk.id))
-            .collect();
-        if !ids.is_empty() {
-            self.table
-                .delete(&format!("chunk_id IN ({})", ids.join(", ")))
-                .await
-                .map_err(lance_err)?;
+        if records.is_empty() {
+            return Ok(());
         }
-        self.append(&records).await
+        let batch = self.to_batch(&records)?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], self.schema.clone());
+        let mut merge = self.table.merge_insert(&["chunk_id"]);
+        merge
+            .when_matched_update_all(None)
+            .when_not_matched_insert_all();
+        merge.execute(Box::new(reader)).await.map_err(lance_err)?;
+        Ok(())
     }
 
     async fn query(&self, query: &Embedding, k: usize) -> Result<Vec<ScoredChunk>> {
@@ -207,21 +270,30 @@ impl VectorStore for LanceVectorStore {
     ) -> Result<()> {
         for record in &records {
             self.check_dims(&record.embedding)?;
+            if record.chunk.document_id != document_id {
+                return Err(RetrievalError::vector_store(format!(
+                    "replacement record {} belongs to document {}, expected {document_id}",
+                    record.chunk.id, record.chunk.document_id
+                )));
+            }
         }
         let records = dedupe_by_chunk_id(records);
-        // Delete the document's rows, then append the new ones. This is NOT a
-        // single atomic write: LanceDB commits the delete and the append as
-        // separate dataset versions, so (a) a concurrent `query` landing between
-        // them sees the document as empty, and (b) if the append fails after the
-        // delete commits (I/O error, cancellation), the document's old chunks are
-        // gone with nothing to replace them — data loss until the next successful
-        // re-ingest, not a mix of versions. Callers must serialize re-ingests of
-        // the same document (the server ingests one request at a time).
-        self.table
-            .delete(&format!("document_id = '{document_id}'"))
-            .await
-            .map_err(lance_err)?;
-        self.append(&records).await
+        let batch = self.to_batch(&records)?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], self.schema.clone());
+
+        // One merge transaction replaces matching chunk ids, inserts new chunks,
+        // and deletes stale chunks belonging to this document. Readers see either
+        // the previous dataset version or the committed replacement, never the
+        // delete half of a two-step write. The target filter prevents rows from
+        // other documents being deleted merely because they are absent from this
+        // replacement's source batch.
+        let mut merge = self.table.merge_insert(&["chunk_id"]);
+        merge
+            .when_matched_update_all(None)
+            .when_not_matched_insert_all()
+            .when_not_matched_by_source_delete(Some(format!("document_id = '{document_id}'")));
+        merge.execute(Box::new(reader)).await.map_err(lance_err)?;
+        Ok(())
     }
 
     async fn len(&self) -> Result<usize> {
@@ -369,11 +441,16 @@ mod tests {
             assert_eq!(hits[0].chunk.document_id, doc);
             assert!(hits[0].score > 0.9);
 
-            // replace_document swaps the document's rows atomically-enough.
+            // A replacement is published as exactly one Lance dataset version.
+            let version_before_replace = store.table.version().await.unwrap();
             store
                 .replace_document(doc, vec![record(doc, 0, "south", vec![1.0, 0.0])])
                 .await
                 .unwrap();
+            assert_eq!(
+                store.table.version().await.unwrap(),
+                version_before_replace + 1
+            );
             assert_eq!(store.len().await.unwrap(), 1);
             let hits = store.query(&Embedding(vec![1.0, 0.0]), 5).await.unwrap();
             assert_eq!(hits[0].chunk.text, "south");
@@ -398,7 +475,9 @@ mod tests {
         let b = record(doc, 0, "new", vec![0.0, 1.0]);
         assert_eq!(a.chunk.id, b.chunk.id);
 
+        let version = store.table.version().await.unwrap();
         store.upsert(vec![a.clone(), b.clone()]).await.unwrap();
+        assert_eq!(store.table.version().await.unwrap(), version + 1);
         assert_eq!(store.len().await.unwrap(), 1);
 
         store.replace_document(doc, vec![a, b]).await.unwrap();
@@ -473,5 +552,161 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn empty_replacement_is_one_commit_and_preserves_other_documents() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
+            .await
+            .unwrap();
+        let removed = DocumentId::new();
+        let kept = DocumentId::new();
+        store
+            .upsert(vec![
+                record(removed, 0, "remove me", vec![1.0, 0.0]),
+                record(kept, 0, "keep me", vec![0.0, 1.0]),
+            ])
+            .await
+            .unwrap();
+
+        let version = store.table.version().await.unwrap();
+        store.replace_document(removed, Vec::new()).await.unwrap();
+
+        assert_eq!(store.table.version().await.unwrap(), version + 1);
+        assert_eq!(store.len().await.unwrap(), 1);
+        let hits = store.query(&Embedding(vec![0.0, 1.0]), 10).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].chunk.document_id, kept);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_replacements_leave_one_complete_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
+            .await
+            .unwrap();
+        let doc = DocumentId::new();
+        store
+            .upsert(vec![record(doc, 0, "old", vec![1.0, 0.0])])
+            .await
+            .unwrap();
+
+        let version_a = vec![
+            record(doc, 1, "a-one", vec![1.0, 0.0]),
+            record(doc, 2, "a-two", vec![1.0, 0.0]),
+        ];
+        let version_b = vec![
+            record(doc, 3, "b-one", vec![1.0, 0.0]),
+            record(doc, 4, "b-two", vec![1.0, 0.0]),
+        ];
+
+        let (a, b) = tokio::join!(
+            store.replace_document(doc, version_a),
+            store.replace_document(doc, version_b)
+        );
+        a.unwrap();
+        b.unwrap();
+
+        let texts: std::collections::BTreeSet<_> = store
+            .query(&Embedding(vec![1.0, 0.0]), 10)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|hit| hit.chunk.text)
+            .collect();
+        let expected_a = ["a-one".to_string(), "a-two".to_string()].into();
+        let expected_b = ["b-one".to_string(), "b-two".to_string()].into();
+        assert!(texts == expected_a || texts == expected_b, "got {texts:?}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn replacement_rejects_records_from_another_document_before_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
+            .await
+            .unwrap();
+        let existing = DocumentId::new();
+        let wrong = DocumentId::new();
+        store
+            .upsert(vec![record(existing, 0, "original", vec![1.0, 0.0])])
+            .await
+            .unwrap();
+        let version = store.table.version().await.unwrap();
+
+        let err = store
+            .replace_document(existing, vec![record(wrong, 0, "wrong", vec![0.0, 1.0])])
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("belongs to document"));
+        assert_eq!(store.table.version().await.unwrap(), version);
+        let hits = store.query(&Embedding(vec![1.0, 0.0]), 10).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].chunk.text, "original");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn connect_repairs_duplicate_ids_from_the_legacy_writer_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+        let schema = build_schema(2);
+        let db = lancedb::connect(uri).execute().await.unwrap();
+        let table = db
+            .create_empty_table(TABLE, schema.clone())
+            .execute()
+            .await
+            .unwrap();
+        let legacy = LanceVectorStore {
+            table: table.clone(),
+            schema,
+            dims: 2,
+        };
+        let doc = DocumentId::new();
+        let old = record(doc, 0, "old", vec![1.0, 0.0]);
+        let new = record(doc, 0, "new", vec![0.0, 1.0]);
+        assert_eq!(old.chunk.id, new.chunk.id);
+        table
+            .add(legacy.to_batch(&[old]).unwrap())
+            .execute()
+            .await
+            .unwrap();
+        table
+            .add(legacy.to_batch(&[new]).unwrap())
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(table.count_rows(None).await.unwrap(), 2);
+        drop(legacy);
+        drop(table);
+        drop(db);
+
+        let repaired = LanceVectorStore::connect(uri, 2).await.unwrap();
+        assert_eq!(repaired.len().await.unwrap(), 1);
+        let hits = repaired
+            .query(&Embedding(vec![0.0, 1.0]), 10)
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].chunk.text, "new");
+        let version = repaired.table.version().await.unwrap();
+
+        // The migration marker prevents a second scan/write on reopen.
+        drop(repaired);
+        let reopened = LanceVectorStore::connect(uri, 2).await.unwrap();
+        assert_eq!(reopened.table.version().await.unwrap(), version);
+
+        // With target uniqueness restored, merge-insert keeps it unique.
+        reopened
+            .replace_document(doc, vec![record(doc, 0, "final", vec![1.0, 0.0])])
+            .await
+            .unwrap();
+        assert_eq!(reopened.len().await.unwrap(), 1);
+        let hits = reopened
+            .query(&Embedding(vec![1.0, 0.0]), 10)
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].chunk.text, "final");
     }
 }

--- a/crates/openwave-retrieval/src/vector.rs
+++ b/crates/openwave-retrieval/src/vector.rs
@@ -52,8 +52,9 @@ pub trait VectorStore: Send + Sync {
     /// must be atomic with respect to other store operations — two concurrent
     /// re-ingests of the same document must not interleave a partial delete and
     /// insert and leave a mix of versions. Passing an empty `records` clears the
-    /// document. Implementations validate each record's dimensionality, as
-    /// [`VectorStore::upsert`] does.
+    /// document. Every record must belong to `document_id`; implementations reject
+    /// cross-document records and validate each embedding's dimensionality, as
+    /// [`VectorStore::upsert`] does, before mutating the store.
     async fn replace_document(
         &self,
         document_id: DocumentId,
@@ -158,6 +159,12 @@ impl VectorStore for InMemoryVectorStore {
     ) -> Result<()> {
         for record in &records {
             self.check_dims(&record.embedding)?;
+            if record.chunk.document_id != document_id {
+                return Err(RetrievalError::vector_store(format!(
+                    "replacement record {} belongs to document {}, expected {document_id}",
+                    record.chunk.id, record.chunk.document_id
+                )));
+            }
         }
         // Delete + insert under a single write lock, so a concurrent ingest can't
         // observe or race a half-applied replacement.
@@ -354,5 +361,26 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, RetrievalError::DimensionMismatch { .. }));
+    }
+
+    #[tokio::test]
+    async fn replace_document_rejects_records_from_another_document() {
+        let store = InMemoryVectorStore::new(2);
+        let existing = DocumentId::new();
+        let wrong = DocumentId::new();
+        store
+            .upsert(vec![record(existing, 0, "original", vec![1.0, 0.0])])
+            .await
+            .unwrap();
+
+        let err = store
+            .replace_document(existing, vec![record(wrong, 0, "wrong", vec![0.0, 1.0])])
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("belongs to document"));
+        let hits = store.query(&Embedding(vec![1.0, 0.0]), 10).await.unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].chunk.text, "original");
     }
 }


### PR DESCRIPTION
## Summary

- replace LanceDB's delete-then-append writes with transactional merge-insert operations
- publish whole-document replacement as one dataset version while retaining batch deduplication
- repair duplicate chunk IDs left by the legacy writer once when an existing dataset opens
- reject cross-document replacement records before writing
- cover legacy repair, empty, concurrent, durable, and single-version replacement behavior with production-backend tests

## Validation

- `bw --repo-root "$PWD" dev lint --rust`
- `cargo test -p openwave-retrieval --features vec-lance`
