### PR TITLE
feat(core): add authoritative document catalog

### DIFF
--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -26,7 +26,7 @@ futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v5"] }
 chrono = { workspace = true }
 sea-orm = { workspace = true, optional = true }
 sea-orm-migration = { workspace = true, optional = true }

--- a/crates/openwave-core/src/db.rs
+++ b/crates/openwave-core/src/db.rs
@@ -20,8 +20,8 @@ use serde_json::Value;
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{CallId, ChatId, MessageId, ProjectId, TurnId};
-use crate::model::{Chat, Message, Project, Role, ToolCallRecord};
+use crate::id::{CallId, ChatId, DocumentId, MessageId, ProjectId, TurnId};
+use crate::model::{Chat, DocumentRecord, DocumentScope, Message, Project, Role, ToolCallRecord};
 use crate::storage::Store;
 
 /// Map any SeaORM failure into an [`AgentError::Store`].
@@ -88,6 +88,65 @@ impl Store for DbStore {
             .into_iter()
             .map(project_from_model)
             .collect())
+    }
+
+    async fn create_document(&self, document: &DocumentRecord) -> Result<()> {
+        entities::document::ActiveModel {
+            id: Set(document.id.0),
+            project_id: Set(document.project_id.map(|id| id.0)),
+            source_uri: Set(document.source_uri.clone()),
+            media_type: Set(document.media_type.clone()),
+            title: Set(document.title.clone()),
+            canonical_text: Set(document.canonical_text.clone()),
+            content_revision: Set(document.content_revision),
+            revision_token: Set(document.revision_token),
+            indexed_revision: Set(document.indexed_revision),
+            index_fingerprint: Set(document.index_fingerprint.clone()),
+            created_at: Set(document.created_at),
+            updated_at: Set(document.updated_at),
+            indexed_at: Set(document.indexed_at),
+        }
+        .insert(&self.conn)
+        .await
+        .map_err(store_err)?;
+        Ok(())
+    }
+
+    async fn get_document(&self, id: DocumentId) -> Result<Option<DocumentRecord>> {
+        Ok(entities::document::Entity::find_by_id(id.0)
+            .one(&self.conn)
+            .await
+            .map_err(store_err)?
+            .map(document_from_model))
+    }
+
+    async fn list_documents(&self, scope: DocumentScope) -> Result<Vec<DocumentRecord>> {
+        let mut query = entities::document::Entity::find();
+        query = match scope {
+            DocumentScope::All => query,
+            DocumentScope::Unscoped => {
+                query.filter(entities::document::Column::ProjectId.is_null())
+            }
+            DocumentScope::Project(id) => {
+                query.filter(entities::document::Column::ProjectId.eq(id.0))
+            }
+        };
+        Ok(query
+            .order_by_desc(entities::document::Column::CreatedAt)
+            .all(&self.conn)
+            .await
+            .map_err(store_err)?
+            .into_iter()
+            .map(document_from_model)
+            .collect())
+    }
+
+    async fn delete_document(&self, id: DocumentId) -> Result<()> {
+        entities::document::Entity::delete_by_id(id.0)
+            .exec(&self.conn)
+            .await
+            .map_err(store_err)?;
+        Ok(())
     }
 
     async fn create_chat(&self, chat: &Chat) -> Result<()> {
@@ -286,6 +345,24 @@ fn project_from_model(model: entities::project::Model) -> Project {
     }
 }
 
+fn document_from_model(model: entities::document::Model) -> DocumentRecord {
+    DocumentRecord {
+        id: DocumentId(model.id),
+        project_id: model.project_id.map(ProjectId),
+        source_uri: model.source_uri,
+        media_type: model.media_type,
+        title: model.title,
+        canonical_text: model.canonical_text,
+        content_revision: model.content_revision,
+        revision_token: model.revision_token,
+        indexed_revision: model.indexed_revision,
+        index_fingerprint: model.index_fingerprint,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+        indexed_at: model.indexed_at,
+    }
+}
+
 fn chat_from_model(model: entities::chat::Model) -> Chat {
     Chat {
         id: ChatId(model.id),
@@ -347,6 +424,35 @@ fn role_from_db(text: &str) -> Result<Role> {
 /// types (`Chat`, `Message`), never these, so the ORM never leaks into the
 /// crate's contract.
 mod entities {
+    pub mod document {
+        use sea_orm::entity::prelude::*;
+
+        #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+        #[sea_orm(table_name = "document")]
+        pub struct Model {
+            #[sea_orm(primary_key, auto_increment = false)]
+            pub id: Uuid,
+            pub project_id: Option<Uuid>,
+            pub source_uri: Option<String>,
+            pub media_type: String,
+            pub title: Option<String>,
+            #[sea_orm(column_type = "Text")]
+            pub canonical_text: String,
+            pub content_revision: i64,
+            pub revision_token: Uuid,
+            pub indexed_revision: Option<i64>,
+            pub index_fingerprint: Option<String>,
+            pub created_at: DateTimeUtc,
+            pub updated_at: DateTimeUtc,
+            pub indexed_at: Option<DateTimeUtc>,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+    }
+
     pub mod project {
         use sea_orm::entity::prelude::*;
 
@@ -494,6 +600,7 @@ mod migration {
                 Box::new(AddProjects),
                 Box::new(AddChatModel),
                 Box::new(AddToolCalls),
+                Box::new(AddDocuments),
             ]
         }
     }
@@ -798,6 +905,105 @@ mod migration {
         }
     }
 
+    /// Adds the authoritative document catalog. The retrieval database remains a
+    /// derived index; this table retains enough canonical content and index
+    /// watermark state to rebuild it safely.
+    struct AddDocuments;
+
+    impl MigrationName for AddDocuments {
+        fn name(&self) -> &str {
+            "m0006_document_catalog"
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MigrationTrait for AddDocuments {
+        async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            let valid_index_revision = Expr::col(Document::IndexedRevision).is_null().or(
+                Expr::col(Document::IndexedRevision).gte(1).and(
+                    Expr::col(Document::IndexedRevision).lte(Expr::col(Document::ContentRevision)),
+                ),
+            );
+            let watermark_absent = Expr::col(Document::IndexedRevision)
+                .is_null()
+                .and(Expr::col(Document::IndexFingerprint).is_null())
+                .and(Expr::col(Document::IndexedAt).is_null());
+            let watermark_present = Expr::col(Document::IndexedRevision)
+                .is_not_null()
+                .and(Expr::col(Document::IndexFingerprint).is_not_null())
+                .and(Expr::col(Document::IndexedAt).is_not_null());
+
+            manager
+                .create_table(
+                    Table::create()
+                        .table(Document::Table)
+                        .if_not_exists()
+                        .col(ColumnDef::new(Document::Id).uuid().not_null().primary_key())
+                        .col(ColumnDef::new(Document::ProjectId).uuid())
+                        .col(ColumnDef::new(Document::SourceUri).text())
+                        .col(ColumnDef::new(Document::MediaType).text().not_null())
+                        .col(ColumnDef::new(Document::Title).text())
+                        .col(ColumnDef::new(Document::CanonicalText).text().not_null())
+                        .col(
+                            ColumnDef::new(Document::ContentRevision)
+                                .big_integer()
+                                .not_null()
+                                .default(1),
+                        )
+                        .col(ColumnDef::new(Document::RevisionToken).uuid().not_null())
+                        .col(ColumnDef::new(Document::IndexedRevision).big_integer())
+                        .col(ColumnDef::new(Document::IndexFingerprint).text())
+                        .col(
+                            ColumnDef::new(Document::CreatedAt)
+                                .timestamp_with_time_zone()
+                                .not_null(),
+                        )
+                        .col(
+                            ColumnDef::new(Document::UpdatedAt)
+                                .timestamp_with_time_zone()
+                                .not_null(),
+                        )
+                        .col(ColumnDef::new(Document::IndexedAt).timestamp_with_time_zone())
+                        .foreign_key(
+                            ForeignKey::create()
+                                .name("fk_document_project")
+                                .from(Document::Table, Document::ProjectId)
+                                .to(Project::Table, Project::Id)
+                                .on_delete(ForeignKeyAction::Cascade),
+                        )
+                        .check(Expr::col(Document::MediaType).ne(""))
+                        .check(
+                            Expr::col(Document::SourceUri)
+                                .is_null()
+                                .or(Expr::col(Document::SourceUri).ne("")),
+                        )
+                        .check(Expr::col(Document::ContentRevision).gte(1))
+                        .check(valid_index_revision)
+                        .check(watermark_absent.or(watermark_present))
+                        .to_owned(),
+                )
+                .await?;
+            manager
+                .create_index(
+                    Index::create()
+                        .name("idx_document_project_created")
+                        .table(Document::Table)
+                        .col(Document::ProjectId)
+                        .col(Document::CreatedAt)
+                        .to_owned(),
+                )
+                .await?;
+            Ok(())
+        }
+
+        async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+            manager
+                .drop_table(Table::drop().table(Document::Table).to_owned())
+                .await?;
+            Ok(())
+        }
+    }
+
     #[derive(DeriveIden)]
     enum Project {
         Table,
@@ -805,6 +1011,24 @@ mod migration {
         Title,
         WorkspaceDir,
         CreatedAt,
+    }
+
+    #[derive(DeriveIden)]
+    enum Document {
+        Table,
+        Id,
+        ProjectId,
+        SourceUri,
+        MediaType,
+        Title,
+        CanonicalText,
+        ContentRevision,
+        RevisionToken,
+        IndexedRevision,
+        IndexFingerprint,
+        CreatedAt,
+        UpdatedAt,
+        IndexedAt,
     }
 
     #[derive(DeriveIden)]
@@ -893,6 +1117,25 @@ mod tests {
         }
     }
 
+    fn sample_document(project_id: Option<ProjectId>) -> DocumentRecord {
+        let created_at = DateTime::<Utc>::from_timestamp(1_700_000_100, 0).unwrap();
+        DocumentRecord {
+            id: DocumentId::new(),
+            project_id,
+            source_uri: Some("file:///資料/notes.md".into()),
+            media_type: "text/markdown".into(),
+            title: Some("Résumé 📈".into()),
+            canonical_text: "# Résumé\n\n売上 grew by 10%.".into(),
+            content_revision: 1,
+            revision_token: uuid::Uuid::new_v4(),
+            indexed_revision: None,
+            index_fingerprint: None,
+            created_at,
+            updated_at: created_at,
+            indexed_at: None,
+        }
+    }
+
     #[tokio::test]
     async fn projects_roundtrip_and_a_chat_can_belong_to_one() {
         let (_dir, store) = temp_store().await;
@@ -975,6 +1218,133 @@ mod tests {
         store.create_project(&older).await.unwrap();
         store.create_project(&newer).await.unwrap();
         assert_eq!(store.list_projects().await.unwrap(), vec![newer, older]);
+    }
+
+    #[tokio::test]
+    async fn documents_roundtrip_and_list_by_corpus_scope() {
+        let (_dir, store) = temp_store().await;
+        let project_a = sample_project();
+        let mut project_b = sample_project();
+        project_b.id = ProjectId::new();
+        store.create_project(&project_a).await.unwrap();
+        store.create_project(&project_b).await.unwrap();
+
+        let mut unscoped = sample_document(None);
+        unscoped.created_at = DateTime::<Utc>::from_timestamp(1_000, 0).unwrap();
+        let mut in_a = sample_document(Some(project_a.id));
+        in_a.created_at = DateTime::<Utc>::from_timestamp(2_000, 0).unwrap();
+        in_a.indexed_revision = Some(1);
+        in_a.index_fingerprint = Some("parser=v1;chunker=v1;embed=test".into());
+        in_a.indexed_at = Some(DateTime::<Utc>::from_timestamp(2_001, 0).unwrap());
+        let mut in_b = sample_document(Some(project_b.id));
+        in_b.created_at = DateTime::<Utc>::from_timestamp(3_000, 0).unwrap();
+
+        for document in [&unscoped, &in_a, &in_b] {
+            store.create_document(document).await.unwrap();
+        }
+
+        assert_eq!(
+            store.get_document(in_a.id).await.unwrap().as_ref(),
+            Some(&in_a)
+        );
+        assert_eq!(store.get_document(DocumentId::new()).await.unwrap(), None);
+        assert_eq!(
+            store
+                .list_documents(DocumentScope::Project(project_a.id))
+                .await
+                .unwrap(),
+            vec![in_a.clone()]
+        );
+        assert_eq!(
+            store
+                .list_documents(DocumentScope::Project(project_b.id))
+                .await
+                .unwrap(),
+            vec![in_b.clone()]
+        );
+        assert_eq!(
+            store.list_documents(DocumentScope::Unscoped).await.unwrap(),
+            vec![unscoped.clone()]
+        );
+        assert_eq!(
+            store.list_documents(DocumentScope::All).await.unwrap(),
+            vec![in_b, in_a, unscoped.clone()]
+        );
+
+        store.delete_document(unscoped.id).await.unwrap();
+        store.delete_document(unscoped.id).await.unwrap();
+        assert_eq!(store.get_document(unscoped.id).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn document_project_fk_rejects_orphans_and_cascades_delete() {
+        let (_dir, store) = temp_store().await;
+        let orphan = sample_document(Some(ProjectId::new()));
+        assert!(store.create_document(&orphan).await.is_err());
+
+        let project = sample_project();
+        store.create_project(&project).await.unwrap();
+        let document = sample_document(Some(project.id));
+        store.create_document(&document).await.unwrap();
+        entities::project::Entity::delete_by_id(project.id.0)
+            .exec(&store.conn)
+            .await
+            .unwrap();
+        assert_eq!(store.get_document(document.id).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn document_constraints_reject_invalid_catalog_state() {
+        let (_dir, store) = temp_store().await;
+
+        let mut empty_media_type = sample_document(None);
+        empty_media_type.media_type.clear();
+        assert!(store.create_document(&empty_media_type).await.is_err());
+
+        let mut empty_source_uri = sample_document(None);
+        empty_source_uri.source_uri = Some(String::new());
+        assert!(store.create_document(&empty_source_uri).await.is_err());
+
+        let mut invalid_revision = sample_document(None);
+        invalid_revision.content_revision = 0;
+        assert!(store.create_document(&invalid_revision).await.is_err());
+
+        let mut future_index = sample_document(None);
+        future_index.indexed_revision = Some(2);
+        future_index.index_fingerprint = Some("v1".into());
+        future_index.indexed_at = Some(Utc::now());
+        assert!(store.create_document(&future_index).await.is_err());
+
+        let mut partial_watermark = sample_document(None);
+        partial_watermark.indexed_revision = Some(1);
+        assert!(store.create_document(&partial_watermark).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn m0006_upgrades_an_existing_store_without_losing_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("upgrade.db").display()
+        );
+        let conn = Database::connect(&url).await.unwrap();
+        conn.execute_unprepared("PRAGMA foreign_keys=ON;")
+            .await
+            .unwrap();
+        migration::Migrator::up(&conn, Some(5)).await.unwrap();
+        let store = DbStore { conn: conn.clone() };
+        let chat = sample_chat();
+        store.create_chat(&chat).await.unwrap();
+
+        migration::Migrator::up(&conn, None).await.unwrap();
+
+        assert_eq!(store.get_chat(chat.id).await.unwrap().as_ref(), Some(&chat));
+        let document = sample_document(None);
+        store.create_document(&document).await.unwrap();
+        assert_eq!(
+            store.get_document(document.id).await.unwrap().as_ref(),
+            Some(&document)
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -63,6 +63,35 @@ id_type!(
     ProjectId
 );
 id_type!(
+    /// Identifies an authoritative source document.
+    ///
+    /// Usually minted fresh with [`DocumentId::new`], but [`DocumentId::derive`]
+    /// preserves the existing stable URI identity used by retrieval ingestion.
+    DocumentId
+);
+
+impl DocumentId {
+    /// Namespace UUID for URI-derived document ids. This value is part of the
+    /// persisted identity contract and must remain stable.
+    const NAMESPACE: Uuid = Uuid::from_u128(0x1d0c_7a44_9e21_4b83_bc55_6677_8899_aabb);
+
+    /// Derive a stable id from a source URI in the unscoped corpus.
+    ///
+    /// Project-owned documents must use [`DocumentId::derive_for_project`] so
+    /// the same URI can belong to more than one corpus without aliasing.
+    #[must_use]
+    pub fn derive(uri: &str) -> Self {
+        Self(Uuid::new_v5(&Self::NAMESPACE, uri.as_bytes()))
+    }
+
+    /// Derive a stable id from a project and source URI.
+    #[must_use]
+    pub fn derive_for_project(project_id: ProjectId, uri: &str) -> Self {
+        let project_namespace = Uuid::new_v5(&Self::NAMESPACE, project_id.as_uuid().as_bytes());
+        Self(Uuid::new_v5(&project_namespace, uri.as_bytes()))
+    }
+}
+id_type!(
     /// Identifies a persistent conversation (owns a workspace directory).
     ChatId
 );
@@ -103,5 +132,32 @@ mod tests {
         // Transparent: serializes as the bare quoted UUID, no wrapper.
         assert_eq!(json, format!("\"{id}\""));
         assert_eq!(serde_json::from_str::<ChatId>(&json).unwrap(), id);
+    }
+
+    #[test]
+    fn document_uri_derivation_is_stable() {
+        assert_eq!(
+            DocumentId::derive("file:///a.txt"),
+            DocumentId::derive("file:///a.txt")
+        );
+        assert_ne!(
+            DocumentId::derive("file:///a.txt"),
+            DocumentId::derive("file:///b.txt")
+        );
+
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        assert_eq!(
+            DocumentId::derive_for_project(project_a, "file:///a.txt"),
+            DocumentId::derive_for_project(project_a, "file:///a.txt")
+        );
+        assert_ne!(
+            DocumentId::derive_for_project(project_a, "file:///a.txt"),
+            DocumentId::derive_for_project(project_b, "file:///a.txt")
+        );
+        assert_ne!(
+            DocumentId::derive_for_project(project_a, "file:///a.txt"),
+            DocumentId::derive("file:///a.txt")
+        );
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -43,10 +43,10 @@ pub use config::{Config, Profile};
 pub use db::DbStore;
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
-pub use id::{CallId, ChatId, MessageId, ProjectId, StepId, TurnId};
+pub use id::{CallId, ChatId, DocumentId, MessageId, ProjectId, StepId, TurnId};
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
-pub use model::{Chat, Message, Project, Role, ToolCallRecord};
+pub use model::{Chat, DocumentRecord, DocumentScope, Message, Project, Role, ToolCallRecord};
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
     Usage,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -12,8 +12,9 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
-use crate::id::{ChatId, MessageId, ProjectId, TurnId};
+use crate::id::{ChatId, DocumentId, MessageId, ProjectId, TurnId};
 
 /// An optional grouping of chats that share a workspace and (later) a document
 /// corpus. A chat may belong to a project or stand alone — unlike some designs
@@ -28,6 +29,56 @@ pub struct Project {
     pub workspace_dir: PathBuf,
     /// When the project was created.
     pub created_at: DateTime<Utc>,
+}
+
+/// An authoritative source document whose derived chunks live in the retrieval
+/// index. Canonical text stays in the operational store so an index can be
+/// rebuilt after an embedding or chunking change. Reprocessing with a different
+/// parser additionally requires the original bytes, which belong in `BlobStore`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentRecord {
+    /// Stable identifier shared with the retrieval index.
+    pub id: DocumentId,
+    /// Owning project, or `None` for an explicitly unscoped document.
+    pub project_id: Option<ProjectId>,
+    /// Source path or URL, or `None` for content supplied inline.
+    pub source_uri: Option<String>,
+    /// Media type of the canonical content.
+    pub media_type: String,
+    /// Optional human-facing title.
+    pub title: Option<String>,
+    /// Parsed text-of-record used to rechunk, re-embed, and verify citations.
+    pub canonical_text: String,
+    /// Monotonic content revision, starting at one.
+    pub content_revision: i64,
+    /// Opaque identity for this exact content revision.
+    ///
+    /// Unlike the integer revision, this token cannot be reused after a hard
+    /// delete and recreation of the same document id, so stale index writers
+    /// cannot confuse two document lifecycles.
+    pub revision_token: Uuid,
+    /// Revision currently represented in the retrieval index, if any.
+    pub indexed_revision: Option<i64>,
+    /// Canonical-text/chunker/embedder fingerprint for the indexed revision.
+    pub index_fingerprint: Option<String>,
+    /// When this record was first created.
+    pub created_at: DateTime<Utc>,
+    /// When authoritative content or metadata last changed.
+    pub updated_at: DateTime<Utc>,
+    /// When the current index watermark was recorded.
+    pub indexed_at: Option<DateTime<Utc>>,
+}
+
+/// Corpus ownership filter for document listings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DocumentScope {
+    /// Every document, for maintenance and reindexing only.
+    All,
+    /// Only explicitly projectless documents.
+    Unscoped,
+    /// Only documents owned by this project.
+    Project(ProjectId),
 }
 
 /// Who authored a message.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -18,10 +18,16 @@
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::error::Result;
+use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{ChatId, ProjectId};
-use crate::model::{Chat, Message, Project, ToolCallRecord};
+use crate::id::{ChatId, DocumentId, ProjectId};
+use crate::model::{Chat, DocumentRecord, DocumentScope, Message, Project, ToolCallRecord};
+
+fn document_storage_unavailable<T>() -> Result<T> {
+    Err(AgentError::Store(
+        "document storage is not implemented by this Store".into(),
+    ))
+}
 
 /// Durable metadata and conversation state.
 ///
@@ -37,6 +43,29 @@ pub trait Store: Send + Sync {
 
     /// List projects, most-recently-created first.
     async fn list_projects(&self) -> Result<Vec<Project>>;
+
+    /// Persist a new authoritative document record.
+    ///
+    /// `project_id`, when present, must identify an existing project. The default
+    /// database store enforces this with a cascading foreign key.
+    async fn create_document(&self, _document: &DocumentRecord) -> Result<()> {
+        document_storage_unavailable()
+    }
+
+    /// Fetch an authoritative document by id, or `None` if it does not exist.
+    async fn get_document(&self, _id: DocumentId) -> Result<Option<DocumentRecord>> {
+        document_storage_unavailable()
+    }
+
+    /// List documents in `scope`, most-recently-created first.
+    async fn list_documents(&self, _scope: DocumentScope) -> Result<Vec<DocumentRecord>> {
+        document_storage_unavailable()
+    }
+
+    /// Delete an authoritative document record. Idempotent for unknown ids.
+    async fn delete_document(&self, _id: DocumentId) -> Result<()> {
+        document_storage_unavailable()
+    }
 
     /// Persist a new chat.
     ///
@@ -128,6 +157,7 @@ mod tests {
     #[derive(Default)]
     struct MemStore {
         projects: Mutex<HashMap<ProjectId, Project>>,
+        documents: Mutex<HashMap<DocumentId, DocumentRecord>>,
         chats: Mutex<HashMap<ChatId, Chat>>,
         settings: Mutex<HashMap<String, Value>>,
         events: Mutex<Vec<(ChatId, SequencedEvent)>>,
@@ -148,6 +178,34 @@ mod tests {
         }
         async fn list_projects(&self) -> Result<Vec<Project>> {
             Ok(self.projects.lock().unwrap().values().cloned().collect())
+        }
+        async fn create_document(&self, document: &DocumentRecord) -> Result<()> {
+            self.documents
+                .lock()
+                .unwrap()
+                .insert(document.id, document.clone());
+            Ok(())
+        }
+        async fn get_document(&self, id: DocumentId) -> Result<Option<DocumentRecord>> {
+            Ok(self.documents.lock().unwrap().get(&id).cloned())
+        }
+        async fn list_documents(&self, scope: DocumentScope) -> Result<Vec<DocumentRecord>> {
+            Ok(self
+                .documents
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|document| match scope {
+                    DocumentScope::All => true,
+                    DocumentScope::Unscoped => document.project_id.is_none(),
+                    DocumentScope::Project(id) => document.project_id == Some(id),
+                })
+                .cloned()
+                .collect())
+        }
+        async fn delete_document(&self, id: DocumentId) -> Result<()> {
+            self.documents.lock().unwrap().remove(&id);
+            Ok(())
         }
         async fn create_chat(&self, chat: &Chat) -> Result<()> {
             self.chats.lock().unwrap().insert(chat.id, chat.clone());

--- a/crates/openwave-retrieval/Cargo.toml
+++ b/crates/openwave-retrieval/Cargo.toml
@@ -12,11 +12,12 @@ workspace = true
 
 [features]
 # On by default (like openwave-router's adapters) so both are built and tested in
-# CI. Depend with `default-features = false` for the lean, offline pipeline: just
-# the seams plus HashEmbedder/InMemoryVectorStore, no openwave-core and no reqwest.
+# CI. Depend with `default-features = false` for the lean, offline pipeline: the
+# seams, core-owned IDs, and HashEmbedder/InMemoryVectorStore, with no reqwest.
 default = ["tool", "embed-openai"]
-# The agent-facing `search` Tool. Pulls in `openwave-core` for the `Tool` trait.
-tool = ["dep:openwave-core"]
+# The agent-facing `search` Tool implementation. Core is already a lean dependency
+# for DocumentId; this feature controls only the adapter module.
+tool = []
 # A real OpenAI-compatible embedding provider (network, via reqwest). The offline
 # HashEmbedder is always available regardless.
 embed-openai = ["dep:reqwest"]
@@ -34,9 +35,10 @@ thiserror = { workspace = true }
 # `v5` (name-based UUIDs) is additive over the workspace's `v4`/`serde`; it
 # backs the deterministic chunk ids derived from (document, byte span).
 uuid = { workspace = true, features = ["v5"] }
-# Only the trait contracts (Tool/ToolSpec/…), not the SQLite/keychain/file-tool
-# machinery — hence default-features = false.
-openwave-core = { path = "../openwave-core", default-features = false, optional = true }
+# Core owns DocumentId so the authoritative catalog and derived vector index use
+# one persisted identity. Default features stay off: no SQLite, keychain, or file
+# tools are pulled into this library.
+openwave-core = { path = "../openwave-core", default-features = false }
 # HTTP client for the OpenAI-compatible embedder (embed-openai feature only).
 reqwest = { workspace = true, optional = true }
 # The LanceDB vector backend (vec-lance feature only). arrow-array/-schema are

--- a/crates/openwave-retrieval/src/error.rs
+++ b/crates/openwave-retrieval/src/error.rs
@@ -3,7 +3,8 @@
 //! [`RetrievalError`] mirrors the shape of `openwave-core`'s `AgentError`: a lean,
 //! `#[non_exhaustive]` enum whose variants grow as the code that produces them
 //! lands (parsing, embedding, vector backends). Keeping it separate from the core
-//! error keeps `openwave-retrieval` a standalone leaf crate for now.
+//! error keeps retrieval failures separate from agent/runtime failures even though
+//! both crates share the persisted [`openwave_core::DocumentId`] type.
 
 use thiserror::Error;
 

--- a/crates/openwave-retrieval/src/id.rs
+++ b/crates/openwave-retrieval/src/id.rs
@@ -4,6 +4,7 @@
 //! compiler stops us mixing a [`DocumentId`] with a [`ChunkId`]. Ids serialize
 //! transparently as the bare UUID string.
 
+pub use openwave_core::DocumentId;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -58,29 +59,6 @@ macro_rules! id_type {
 }
 
 id_type!(
-    /// Identifies an ingested source document.
-    ///
-    /// Usually minted fresh with [`DocumentId::new`], but [`DocumentId::derive`]
-    /// produces a stable id from a source URI so re-ingesting the same location
-    /// targets the same document (idempotent upserts) rather than a new one.
-    DocumentId
-);
-
-impl DocumentId {
-    /// Namespace UUID for URI-derived document ids. A fixed, arbitrary value,
-    /// distinct from [`ChunkId`]'s namespace so the two derivations never alias.
-    const NAMESPACE: Uuid = Uuid::from_u128(0x1d0c_7a44_9e21_4b83_bc55_6677_8899_aabb);
-
-    /// Derive a stable id from a source URI.
-    ///
-    /// The same `uri` always yields the same id, so re-ingesting a file replaces
-    /// its chunks in place instead of duplicating them.
-    #[must_use]
-    pub fn derive(uri: &str) -> Self {
-        Self(Uuid::new_v5(&Self::NAMESPACE, uri.as_bytes()))
-    }
-}
-id_type!(
     /// Identifies one chunk of a document.
     ///
     /// Chunk ids are *derived*, not random: [`ChunkId::derive`] hashes the parent
@@ -132,6 +110,8 @@ mod tests {
 
     #[test]
     fn derived_document_ids_are_stable_per_uri() {
+        let core_id: openwave_core::DocumentId = DocumentId::derive("file:///a.txt");
+        assert_eq!(core_id, DocumentId::derive("file:///a.txt"));
         assert_eq!(
             DocumentId::derive("file:///a.txt"),
             DocumentId::derive("file:///a.txt")

--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -49,16 +49,17 @@
 //!
 //! The agent-facing [`SearchTool`] (behind the default `tool` feature) adapts the
 //! query side to `openwave-core`'s `Tool` contract, so the agent loop can search a
-//! shared index. Turn the feature off to use the pipeline as a standalone library
-//! with no dependency on the core crate.
+//! shared index. Turn the feature off to omit that adapter. The crate retains a
+//! lean, default-feature-free dependency on `openwave-core` because core owns the
+//! persisted [`DocumentId`] shared by the catalog and index.
 //!
 //! For real semantic embeddings, the `embed-openai` feature adds [`OpenAiEmbedder`],
 //! an [`Embedder`] backed by the OpenAI-compatible `/embeddings` endpoint — a
 //! drop-in for [`HashEmbedder`] behind the same seam.
 //!
-//! Not yet wired: embedding reranking, persistent/hybrid vector backends,
-//! rich-format parsing, per-chat/project index scoping, and choosing the embedder
-//! from server configuration. Each lands as its own slice behind these seams.
+//! Not yet wired: embedding reranking, hybrid retrieval, rich-format parsing,
+//! per-chat/project index scoping, and ANN index management. Each lands as its own
+//! slice behind these seams.
 
 mod chunk;
 mod document;

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -468,6 +468,24 @@ mod tests {
         async fn list_projects(&self) -> Result<Vec<Project>> {
             self.inner.list_projects().await
         }
+        async fn create_document(&self, document: &openwave_core::DocumentRecord) -> Result<()> {
+            self.inner.create_document(document).await
+        }
+        async fn get_document(
+            &self,
+            id: openwave_core::DocumentId,
+        ) -> Result<Option<openwave_core::DocumentRecord>> {
+            self.inner.get_document(id).await
+        }
+        async fn list_documents(
+            &self,
+            scope: openwave_core::DocumentScope,
+        ) -> Result<Vec<openwave_core::DocumentRecord>> {
+            self.inner.list_documents(scope).await
+        }
+        async fn delete_document(&self, id: openwave_core::DocumentId) -> Result<()> {
+            self.inner.delete_document(id).await
+        }
         async fn create_chat(&self, chat: &Chat) -> Result<()> {
             self.inner.create_chat(chat).await
         }


### PR DESCRIPTION
## Summary

- add an authoritative document catalog to the operational store with optional project ownership and canonical text
- track content revisions, per-revision identity tokens, and complete index watermarks for safe rebuild and retry orchestration
- add cross-database `m0006_document_catalog` constraints, project cascade behavior, and scoped listing
- move `DocumentId` into core while preserving retrieval's public re-export and adding project-aware URI identity
- provide default unsupported document methods so existing external `Store` implementations remain source-compatible
- cover upgrades, Unicode content, scope isolation, ordering, deletion, foreign keys, and invalid states

## Validation

- `bw --repo-root "$PWD" dev lint --rust`
- `cargo clippy -p openwave-core -p openwave-retrieval -p openwave-server --all-targets -- -D warnings`
- `cargo test -p openwave-core --no-default-features --features sqlite,tools`
- `cargo test -p openwave-retrieval --features vec-lance`
- `cargo test -p openwave-server --lib`
