### PR TITLE
feat(server): persist document source before indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5703,6 +5703,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,6 @@ sea-orm = { version = "1", default-features = false, features = ["macros", "runt
 sea-orm-migration = { version = "1", default-features = false, features = ["runtime-tokio-rustls", "sqlx-sqlite"] }
 tokio = { version = "1", features = ["rt", "macros", "fs"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+sha2 = "0.10"
 async-stream = "0.3"
 axum = { version = "0.8", features = ["ws"] }

--- a/crates/openwave-core/src/db.rs
+++ b/crates/openwave-core/src/db.rs
@@ -291,6 +291,34 @@ impl Store for DbStore {
         Ok(result.rows_affected == 1)
     }
 
+    async fn clear_document_index(
+        &self,
+        id: DocumentId,
+        revision: i64,
+        revision_token: uuid::Uuid,
+    ) -> Result<bool> {
+        let result = entities::document::Entity::update_many()
+            .col_expr(
+                entities::document::Column::IndexedRevision,
+                sea_orm::sea_query::Expr::value(Option::<i64>::None),
+            )
+            .col_expr(
+                entities::document::Column::IndexFingerprint,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entities::document::Column::IndexedAt,
+                sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+            )
+            .filter(entities::document::Column::Id.eq(id.0))
+            .filter(entities::document::Column::ContentRevision.eq(revision))
+            .filter(entities::document::Column::RevisionToken.eq(revision_token))
+            .exec(&self.conn)
+            .await
+            .map_err(store_err)?;
+        Ok(result.rows_affected == 1)
+    }
+
     async fn create_chat(&self, chat: &Chat) -> Result<()> {
         entities::chat::ActiveModel {
             id: Set(chat.id.0),
@@ -1540,6 +1568,18 @@ mod tests {
         assert_eq!(indexed.indexed_revision, Some(2));
         assert_eq!(indexed.index_fingerprint.as_deref(), Some("index-v2"));
         assert_eq!(indexed.indexed_at, Some(second_at));
+        assert!(!store
+            .clear_document_index(id, 2, revision_one.revision_token)
+            .await
+            .unwrap());
+        assert!(store
+            .clear_document_index(id, 2, revision_two.revision_token)
+            .await
+            .unwrap());
+        let cleared = store.get_document(id).await.unwrap().unwrap();
+        assert_eq!(cleared.indexed_revision, None);
+        assert_eq!(cleared.index_fingerprint, None);
+        assert_eq!(cleared.indexed_at, None);
 
         assert!(!store
             .mark_document_indexed(

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -95,6 +95,19 @@ pub trait Store: Send + Sync {
         document_storage_unavailable()
     }
 
+    /// Clear the index watermark for an exact content revision and lifecycle.
+    ///
+    /// Returns `false` without modifying the row when the document or exact
+    /// revision identity is no longer current.
+    async fn clear_document_index(
+        &self,
+        _id: DocumentId,
+        _revision: i64,
+        _revision_token: uuid::Uuid,
+    ) -> Result<bool> {
+        document_storage_unavailable()
+    }
+
     /// Persist a new chat.
     ///
     /// A chat's `project_id`, when set, is not checked against an existing
@@ -303,6 +316,24 @@ mod tests {
             document.indexed_revision = Some(revision);
             document.index_fingerprint = Some(fingerprint.to_string());
             document.indexed_at = Some(indexed_at);
+            Ok(true)
+        }
+        async fn clear_document_index(
+            &self,
+            id: DocumentId,
+            revision: i64,
+            revision_token: uuid::Uuid,
+        ) -> Result<bool> {
+            let mut documents = self.documents.lock().unwrap();
+            let Some(document) = documents.get_mut(&id) else {
+                return Ok(false);
+            };
+            if document.content_revision != revision || document.revision_token != revision_token {
+                return Ok(false);
+            }
+            document.indexed_revision = None;
+            document.index_fingerprint = None;
+            document.indexed_at = None;
             Ok(true)
         }
         async fn create_chat(&self, chat: &Chat) -> Result<()> {

--- a/crates/openwave-retrieval/Cargo.toml
+++ b/crates/openwave-retrieval/Cargo.toml
@@ -20,7 +20,7 @@ default = ["tool", "embed-openai"]
 tool = []
 # A real OpenAI-compatible embedding provider (network, via reqwest). The offline
 # HashEmbedder is always available regardless.
-embed-openai = ["dep:reqwest"]
+embed-openai = ["dep:reqwest", "dep:sha2"]
 # A durable, embedded vector store backed by LanceDB (pure-Rust, on-disk). Not a
 # default feature for library consumers because it pulls a large dependency tree
 # and needs `protoc` at build time. OpenWave's workspace CI installs `protoc`, and
@@ -41,6 +41,7 @@ uuid = { workspace = true, features = ["v5"] }
 openwave-core = { path = "../openwave-core", default-features = false }
 # HTTP client for the OpenAI-compatible embedder (embed-openai feature only).
 reqwest = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
 # The LanceDB vector backend (vec-lance feature only). arrow-array/-schema are
 # pinned to the exact major LanceDB uses (58) so RecordBatch types are compatible.
 lancedb = { version = "0.31", optional = true }

--- a/crates/openwave-retrieval/src/chunk.rs
+++ b/crates/openwave-retrieval/src/chunk.rs
@@ -23,6 +23,15 @@ use crate::error::Result;
 /// future service- or model-backed chunker (sentence tokenizers, layout models)
 /// can, and returning [`Result`] now keeps that from being a breaking change.
 pub trait Chunker: Send + Sync {
+    /// Stable identity for chunk boundaries used in index watermarks.
+    ///
+    /// Custom chunkers should override this whenever an implementation change
+    /// can alter emitted chunks. The value must remain stable for this chunker
+    /// instance's lifetime; runtime reconfiguration requires a new instance.
+    fn fingerprint(&self) -> String {
+        format!("custom-chunker:type={}", std::any::type_name::<Self>())
+    }
+
     /// Produce the chunks for `document`, in document order.
     fn chunk(&self, document: &Document) -> Result<Vec<Chunk>>;
 }
@@ -63,6 +72,13 @@ impl Default for TextChunker {
 }
 
 impl Chunker for TextChunker {
+    fn fingerprint(&self) -> String {
+        format!(
+            "text-window-v1:max_chars={}:overlap={}",
+            self.max_chars, self.overlap
+        )
+    }
+
     fn chunk(&self, document: &Document) -> Result<Vec<Chunk>> {
         let text = &document.text;
 

--- a/crates/openwave-retrieval/src/embed.rs
+++ b/crates/openwave-retrieval/src/embed.rs
@@ -60,6 +60,20 @@ pub trait Embedder: Send + Sync {
     /// The dimensionality every vector this embedder returns will have.
     fn dimensions(&self) -> usize;
 
+    /// Stable identity for document-vector behavior used in index watermarks.
+    ///
+    /// Custom embedders should override this when two configurations with the
+    /// same width can produce incompatible vectors. The value must remain stable
+    /// for this embedder instance's lifetime; runtime reconfiguration requires a
+    /// new instance.
+    fn fingerprint(&self) -> String {
+        format!(
+            "custom-embedder:type={}:dimensions={}",
+            std::any::type_name::<Self>(),
+            self.dimensions()
+        )
+    }
+
     /// Embed a batch of documents for indexing.
     async fn embed_documents(&self, texts: &[String]) -> Result<Vec<Embedding>>;
 
@@ -128,6 +142,10 @@ impl Default for HashEmbedder {
 impl Embedder for HashEmbedder {
     fn dimensions(&self) -> usize {
         self.dims
+    }
+
+    fn fingerprint(&self) -> String {
+        format!("hash-fnv1a-v1:{}d", self.dims)
     }
 
     async fn embed_documents(&self, texts: &[String]) -> Result<Vec<Embedding>> {

--- a/crates/openwave-retrieval/src/openai_embed.rs
+++ b/crates/openwave-retrieval/src/openai_embed.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 use crate::embed::{Embedder, Embedding};
 use crate::error::{Result, RetrievalError};
@@ -93,6 +94,16 @@ impl Embedder for OpenAiEmbedder {
         self.dimensions
     }
 
+    fn fingerprint(&self) -> String {
+        format!(
+            "openai-compatible-v1:endpoint={}:model={}:dimensions={}:projection={}",
+            endpoint_fingerprint(&self.base_url),
+            self.model,
+            self.dimensions,
+            self.project_dimensions
+        )
+    }
+
     async fn embed_documents(&self, texts: &[String]) -> Result<Vec<Embedding>> {
         // Don't make a request for nothing — the API rejects an empty input.
         if texts.is_empty() {
@@ -118,6 +129,33 @@ impl Embedder for OpenAiEmbedder {
         }
         parse_response(&bytes, texts.len(), self.dimensions)
     }
+}
+
+/// Collision-resistant identity of the endpoint's non-secret routing fields.
+fn endpoint_fingerprint(base_url: &str) -> String {
+    let canonical = reqwest::Url::parse(base_url).map_or_else(
+        |_| {
+            base_url
+                .split(['?', '#'])
+                .next()
+                .unwrap_or_default()
+                .to_string()
+        },
+        |mut url| {
+            let _ = url.set_username("");
+            let _ = url.set_password(None);
+            url.set_query(None);
+            url.set_fragment(None);
+            url.to_string()
+        },
+    );
+    let digest = Sha256::digest(canonical.trim_end_matches('/').as_bytes());
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    encoded
 }
 
 /// Build the JSON request body for an embeddings call. `dimensions` is included
@@ -300,5 +338,22 @@ mod tests {
         assert_eq!(embedder.dimensions(), 1536);
         // No network call for an empty batch, so this resolves without a server.
         assert!(embedder.embed_documents(&[]).await.unwrap().is_empty());
+    }
+
+    #[test]
+    fn fingerprint_tracks_endpoint_without_persisting_it() {
+        let default = OpenAiEmbedder::new("key", "model", 8).fingerprint();
+        let custom = OpenAiEmbedder::new("key", "model", 8)
+            .with_base_url("https://user:secret@example.test/v1?token=hidden")
+            .fingerprint();
+        let rotated_secret = OpenAiEmbedder::new("key", "model", 8)
+            .with_base_url("https://other:rotated@example.test/v1?token=changed")
+            .fingerprint();
+
+        assert_ne!(default, custom);
+        assert_eq!(custom, rotated_secret);
+        assert!(!custom.contains("secret"));
+        assert!(!custom.contains("hidden"));
+        assert!(!custom.contains("example.test"));
     }
 }

--- a/crates/openwave-retrieval/src/parse.rs
+++ b/crates/openwave-retrieval/src/parse.rs
@@ -33,6 +33,15 @@ impl ParsedDocument {
 /// Object-safe so parsers can be held as `Box<dyn DocumentParser>` and swapped by
 /// configuration (naive today, liteparse-backed later).
 pub trait DocumentParser: Send + Sync {
+    /// Stable identity for canonical-text behavior used in index watermarks.
+    ///
+    /// Custom parsers should override this whenever an implementation change can
+    /// alter canonical text. The value must remain stable for this parser
+    /// instance's lifetime; runtime reconfiguration requires a new instance.
+    fn fingerprint(&self) -> String {
+        format!("custom-parser:type={}", std::any::type_name::<Self>())
+    }
+
     /// Whether this parser can handle the given media (MIME) type.
     fn supports(&self, media_type: &str) -> bool;
 
@@ -58,6 +67,10 @@ impl PlainTextParser {
 }
 
 impl DocumentParser for PlainTextParser {
+    fn fingerprint(&self) -> String {
+        "plain-text-lossy-v1".to_string()
+    }
+
     fn supports(&self, media_type: &str) -> bool {
         // Match the top-level `text` type, ignoring any `; charset=...` suffix.
         // MIME types are case-insensitive (RFC 6838), so compare in lowercase.

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -56,41 +56,43 @@ impl Retriever {
         &self.store
     }
 
-    /// Ingest one document: parse its bytes, chunk, embed, and store.
+    /// Stable identity for the parser, chunker, and embedder configuration that
+    /// produced this retriever's index rows.
+    #[must_use]
+    pub fn index_fingerprint(&self) -> String {
+        format!(
+            "parser={};chunker={};embedder={}",
+            self.parser.fingerprint(),
+            self.chunker.fingerprint(),
+            self.embedder.fingerprint()
+        )
+    }
+
+    /// Parse source bytes into the canonical document persisted by callers.
     ///
-    /// A full, **atomic replace** for [`DocumentSource::Uri`] sources: the document
-    /// id is derived from the URI, so re-ingesting the same URI targets the same
-    /// document, and the store swaps its chunks in one operation (see
-    /// [`VectorStore::replace_document`]). Re-ingesting identical content is
-    /// idempotent; re-ingesting *changed* (even shorter, or now-empty) content
-    /// leaves no stale chunks behind; and two concurrent re-ingests of the same URI
-    /// resolve to one version rather than a mix. [`DocumentSource::Inline`] sources
-    /// get a fresh id every call, so they never collide with a prior ingest. A
-    /// document that chunks to nothing (empty or whitespace-only) stores nothing and
-    /// reports zero chunks — after clearing any prior version.
-    pub async fn ingest(
+    /// URI sources receive a stable derived id; inline sources receive a fresh
+    /// id for each parse.
+    pub fn parse_document(
         &self,
         source: DocumentSource,
         media_type: &str,
         raw: &[u8],
-    ) -> Result<IngestOutcome> {
+    ) -> Result<Document> {
         let parsed = self.parser.parse(raw, media_type)?;
-        // Stable id per URI so re-ingesting a file is idempotent; inline content
-        // has no external identity, so it gets a fresh id each time.
         let id = match &source {
             DocumentSource::Uri { uri } => DocumentId::derive(uri),
             _ => DocumentId::new(),
         };
-        let document = Document::with_id(id, source, media_type, parsed.text);
+        Ok(Document::with_id(id, source, media_type, parsed.text))
+    }
 
-        let chunks = self.chunker.chunk(&document)?;
+    /// Chunk, embed, and atomically replace one already-parsed document's index.
+    ///
+    /// Callers can persist `document` before awaiting external embedding I/O,
+    /// then record an index watermark only after this succeeds.
+    pub async fn index_document(&self, document: &Document) -> Result<usize> {
+        let chunks = self.chunker.chunk(document)?;
 
-        // Embed first (the slow, awaited step), then hand the store a single
-        // atomic replace. Doing the delete+insert as one store operation — rather
-        // than a separate prune then upsert with an embed await in between — is
-        // what keeps two concurrent re-ingests of the same document from
-        // interleaving and leaving a mix of versions. Empty content yields an
-        // empty record set, which clears any prior version of the document.
         let records: Vec<VectorRecord> = if chunks.is_empty() {
             Vec::new()
         } else {
@@ -112,6 +114,29 @@ impl Retriever {
 
         let count = records.len();
         self.store.replace_document(document.id, records).await?;
+        Ok(count)
+    }
+
+    /// Ingest one document: parse its bytes, chunk, embed, and store.
+    ///
+    /// A full, **atomic replace** for [`DocumentSource::Uri`] sources: the document
+    /// id is derived from the URI, so re-ingesting the same URI targets the same
+    /// document, and the store swaps its chunks in one operation (see
+    /// [`VectorStore::replace_document`]). Re-ingesting identical content is
+    /// idempotent; re-ingesting *changed* (even shorter, or now-empty) content
+    /// leaves no stale chunks behind; and two concurrent re-ingests of the same URI
+    /// resolve to one version rather than a mix. [`DocumentSource::Inline`] sources
+    /// get a fresh id every call, so they never collide with a prior ingest. A
+    /// document that chunks to nothing (empty or whitespace-only) stores nothing and
+    /// reports zero chunks — after clearing any prior version.
+    pub async fn ingest(
+        &self,
+        source: DocumentSource,
+        media_type: &str,
+        raw: &[u8],
+    ) -> Result<IngestOutcome> {
+        let document = self.parse_document(source, media_type, raw)?;
+        let count = self.index_document(&document).await?;
 
         Ok(IngestOutcome {
             document,
@@ -184,6 +209,33 @@ The Great Barrier Reef is the world's largest coral reef system.";
             Some(hits[0].snippet.as_str())
         );
         assert_eq!(hits[0].document_id, outcome.document.id);
+    }
+
+    #[tokio::test]
+    async fn parse_and_index_can_be_orchestrated_separately() {
+        let r = retriever();
+        let document = r
+            .parse_document(
+                DocumentSource::uri("file:///separate.txt"),
+                "text/plain",
+                b"persist this before embedding",
+            )
+            .unwrap();
+        assert_eq!(document.id, DocumentId::derive("file:///separate.txt"));
+        assert_eq!(document.text, "persist this before embedding");
+
+        assert_eq!(r.index_document(&document).await.unwrap(), 1);
+        let hits = r.search("persist embedding", 1).await.unwrap();
+        assert_eq!(hits[0].document_id, document.id);
+    }
+
+    #[test]
+    fn index_fingerprint_captures_the_pipeline_configuration() {
+        let r = retriever();
+        assert_eq!(
+            r.index_fingerprint(),
+            "parser=plain-text-lossy-v1;chunker=text-window-v1:max_chars=90:overlap=0;embedder=hash-fnv1a-v1:512d"
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -330,7 +330,9 @@ mod tests {
         ModelProvider, Project, ProjectId, ProviderEvent, ProviderId, SecretProvider,
         SequencedEvent, StopReason, Tool, ToolCtx, ToolOutput, ToolSpec, Usage,
     };
-    use openwave_retrieval::InMemoryVectorStore;
+    use openwave_retrieval::{
+        Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
+    };
     use resolver::ProviderResolver;
     use serde::de::DeserializeOwned;
     use tokio::sync::Notify;
@@ -404,6 +406,135 @@ mod tests {
         }
     }
 
+    /// An embedder that pauses its first document batch, exposing same-document
+    /// ingest interleavings to the route tests.
+    struct FirstBatchGatedEmbedder {
+        inner: HashEmbedder,
+        calls: AtomicUsize,
+        entered: Notify,
+        release: Notify,
+    }
+
+    #[async_trait]
+    impl Embedder for FirstBatchGatedEmbedder {
+        fn dimensions(&self) -> usize {
+            self.inner.dimensions()
+        }
+
+        fn fingerprint(&self) -> String {
+            "test-gated-hash-v1".into()
+        }
+
+        async fn embed_documents(
+            &self,
+            texts: &[String],
+        ) -> openwave_retrieval::Result<Vec<Embedding>> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                self.entered.notify_one();
+                self.release.notified().await;
+            }
+            self.inner.embed_documents(texts).await
+        }
+
+        async fn embed_query(&self, text: &str) -> openwave_retrieval::Result<Embedding> {
+            self.inner.embed_query(text).await
+        }
+    }
+
+    struct FailingEmbedder;
+
+    #[async_trait]
+    impl Embedder for FailingEmbedder {
+        fn dimensions(&self) -> usize {
+            8
+        }
+
+        async fn embed_documents(
+            &self,
+            _texts: &[String],
+        ) -> openwave_retrieval::Result<Vec<Embedding>> {
+            Err(RetrievalError::embed("injected embedding failure"))
+        }
+    }
+
+    struct FailAfterFirstBatchEmbedder {
+        inner: HashEmbedder,
+        calls: AtomicUsize,
+    }
+
+    struct FailNextDeleteVectorStore {
+        inner: InMemoryVectorStore,
+        fail_delete: std::sync::atomic::AtomicBool,
+    }
+
+    impl FailNextDeleteVectorStore {
+        fn new(dimensions: usize) -> Self {
+            Self {
+                inner: InMemoryVectorStore::new(dimensions),
+                fail_delete: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+
+        fn fail_next_delete(&self) {
+            self.fail_delete.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl VectorStore for FailNextDeleteVectorStore {
+        async fn upsert(&self, records: Vec<VectorRecord>) -> openwave_retrieval::Result<()> {
+            self.inner.upsert(records).await
+        }
+
+        async fn query(
+            &self,
+            query: &Embedding,
+            k: usize,
+        ) -> openwave_retrieval::Result<Vec<ScoredChunk>> {
+            self.inner.query(query, k).await
+        }
+
+        async fn replace_document(
+            &self,
+            document_id: openwave_core::DocumentId,
+            records: Vec<VectorRecord>,
+        ) -> openwave_retrieval::Result<()> {
+            if records.is_empty() && self.fail_delete.swap(false, Ordering::SeqCst) {
+                return Err(RetrievalError::vector_store("injected delete failure"));
+            }
+            self.inner.replace_document(document_id, records).await
+        }
+
+        async fn len(&self) -> openwave_retrieval::Result<usize> {
+            self.inner.len().await
+        }
+    }
+
+    #[async_trait]
+    impl Embedder for FailAfterFirstBatchEmbedder {
+        fn dimensions(&self) -> usize {
+            self.inner.dimensions()
+        }
+
+        fn fingerprint(&self) -> String {
+            "test-fail-after-first-v1".into()
+        }
+
+        async fn embed_documents(
+            &self,
+            texts: &[String],
+        ) -> openwave_retrieval::Result<Vec<Embedding>> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) > 0 {
+                return Err(RetrievalError::embed("injected update failure"));
+            }
+            self.inner.embed_documents(texts).await
+        }
+
+        async fn embed_query(&self, text: &str) -> openwave_retrieval::Result<Embedding> {
+            self.inner.embed_query(text).await
+        }
+    }
+
     /// A resolver that always hands back a fixed provider — lets a test inject a
     /// fake in place of the real credential-driven resolution.
     struct FixedResolver(Arc<dyn ModelProvider>);
@@ -444,6 +575,7 @@ mod tests {
         entered: Arc<Notify>,
         release: Arc<Notify>,
         blocked: std::sync::atomic::AtomicBool,
+        fail_document_delete: std::sync::atomic::AtomicBool,
     }
 
     impl PauseTerminalStore {
@@ -453,7 +585,12 @@ mod tests {
                 entered,
                 release,
                 blocked: std::sync::atomic::AtomicBool::new(false),
+                fail_document_delete: std::sync::atomic::AtomicBool::new(false),
             }
+        }
+
+        fn fail_next_document_delete(&self) {
+            self.fail_document_delete.store(true, Ordering::SeqCst);
         }
     }
 
@@ -484,6 +621,11 @@ mod tests {
             self.inner.list_documents(scope).await
         }
         async fn delete_document(&self, id: openwave_core::DocumentId) -> Result<()> {
+            if self.fail_document_delete.swap(false, Ordering::SeqCst) {
+                return Err(AgentError::Store(
+                    "injected document catalog delete failure".into(),
+                ));
+            }
             self.inner.delete_document(id).await
         }
         async fn upsert_document(
@@ -502,6 +644,16 @@ mod tests {
         ) -> Result<bool> {
             self.inner
                 .mark_document_indexed(id, revision, revision_token, fingerprint, indexed_at)
+                .await
+        }
+        async fn clear_document_index(
+            &self,
+            id: openwave_core::DocumentId,
+            revision: i64,
+            revision_token: uuid::Uuid,
+        ) -> Result<bool> {
+            self.inner
+                .clear_document_index(id, revision, revision_token)
                 .await
         }
         async fn create_chat(&self, chat: &Chat) -> Result<()> {
@@ -563,6 +715,17 @@ mod tests {
     async fn test_app_with(
         provider: Arc<dyn ModelProvider>,
     ) -> (Router, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
+        let (retrieval, _search) = build_retrieval(
+            Arc::new(HashEmbedder::default()),
+            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        );
+        test_app_with_retrieval(provider, retrieval).await
+    }
+
+    async fn test_app_with_retrieval(
+        provider: Arc<dyn ModelProvider>,
+        retrieval: Arc<Retriever>,
+    ) -> (Router, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -572,10 +735,15 @@ mod tests {
             .await
             .unwrap(),
         );
-        let (retrieval, _search) = build_retrieval(
-            Arc::new(HashEmbedder::default()),
-            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
-        );
+        test_app_from_parts(provider, retrieval, store, dir)
+    }
+
+    fn test_app_from_parts(
+        provider: Arc<dyn ModelProvider>,
+        retrieval: Arc<Retriever>,
+        store: Arc<dyn Store>,
+        dir: tempfile::TempDir,
+    ) -> (Router, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
         let state = AppState::new(
             Config::desktop(dir.path()),
             store.clone(),
@@ -890,7 +1058,7 @@ mod tests {
 
     #[tokio::test]
     async fn ingest_then_search_finds_the_passage() {
-        let (router, token, _store, _dir) = test_app().await;
+        let (router, token, store, _dir) = test_app().await;
         let bearer = format!("Bearer {token}");
 
         let ingest = post_json(
@@ -907,6 +1075,20 @@ mod tests {
         let ingest: serde_json::Value = json_body(ingest).await;
         assert!(ingest["chunks"].as_u64().unwrap() >= 1);
         assert!(ingest["document_id"].is_string());
+        let document_id = ingest["document_id"].as_str().unwrap().parse().unwrap();
+        let record = store
+            .get_document(document_id)
+            .await
+            .unwrap()
+            .expect("source record should be durable before the response");
+        assert_eq!(
+            record.canonical_text,
+            "Jupiter is the largest planet in the Solar System, a gas giant."
+        );
+        assert_eq!(record.content_revision, 1);
+        assert_eq!(record.indexed_revision, Some(1));
+        assert!(record.index_fingerprint.is_some());
+        assert!(record.indexed_at.is_some());
 
         // The ingested chunk is immediately searchable over the shared index.
         let search = post_json(
@@ -928,8 +1110,266 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn failed_indexing_leaves_authoritative_source_stale_for_retry() {
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            Arc::new(FailingEmbedder),
+            Arc::new(InMemoryVectorStore::new(8)),
+        ));
+        let (router, token, store, _dir) =
+            test_app_with_retrieval(Arc::new(FakeProvider), retrieval).await;
+        let bearer = format!("Bearer {token}");
+
+        let response = post_json(
+            &router,
+            &bearer,
+            "/documents",
+            serde_json::json!({
+                "uri": "file:///retry.txt",
+                "content": "authoritative even when embedding fails",
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let record = store
+            .get_document(openwave_core::DocumentId::derive("file:///retry.txt"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            record.canonical_text,
+            "authoritative even when embedding fails"
+        );
+        assert_eq!(record.content_revision, 1);
+        assert_eq!(record.indexed_revision, None);
+        assert_eq!(record.index_fingerprint, None);
+    }
+
+    #[tokio::test]
+    async fn failed_update_does_not_leave_the_prior_revision_searchable() {
+        let embedder = Arc::new(FailAfterFirstBatchEmbedder {
+            inner: HashEmbedder::default(),
+            calls: AtomicUsize::new(0),
+        });
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            embedder,
+            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        ));
+        let (router, token, store, _dir) =
+            test_app_with_retrieval(Arc::new(FakeProvider), retrieval).await;
+        let bearer = format!("Bearer {token}");
+        let uri = "file:///updated.txt";
+
+        assert_eq!(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({"uri": uri, "content": "obsolete searchable phrase"}),
+            )
+            .await
+            .status(),
+            StatusCode::CREATED
+        );
+        assert_eq!(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({"uri": uri, "content": "replacement failed to embed"}),
+            )
+            .await
+            .status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        let search: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/search",
+                serde_json::json!({"query": "obsolete searchable phrase"}),
+            )
+            .await,
+        )
+        .await;
+        assert!(search["citations"].as_array().unwrap().is_empty());
+        let record = store
+            .get_document(openwave_core::DocumentId::derive(uri))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.canonical_text, "replacement failed to embed");
+        assert_eq!(record.content_revision, 2);
+        assert_eq!(record.indexed_revision, None);
+    }
+
+    #[tokio::test]
+    async fn failed_vector_retirement_does_not_publish_the_new_source_revision() {
+        let vector_store = Arc::new(FailNextDeleteVectorStore::new(HashEmbedder::DEFAULT_DIMS));
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            Arc::new(HashEmbedder::default()),
+            vector_store.clone(),
+        ));
+        let (router, token, store, _dir) =
+            test_app_with_retrieval(Arc::new(FakeProvider), retrieval).await;
+        let bearer = format!("Bearer {token}");
+        let uri = "file:///retirement.txt";
+
+        assert_eq!(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({"uri": uri, "content": "still authoritative"}),
+            )
+            .await
+            .status(),
+            StatusCode::CREATED
+        );
+        vector_store.fail_next_delete();
+        assert_eq!(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({"uri": uri, "content": "must not publish"}),
+            )
+            .await
+            .status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+
+        let record = store
+            .get_document(openwave_core::DocumentId::derive(uri))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.canonical_text, "still authoritative");
+        assert_eq!(record.content_revision, 1);
+        assert_eq!(record.indexed_revision, None);
+        assert_eq!(record.index_fingerprint, None);
+        assert_eq!(record.indexed_at, None);
+    }
+
+    #[tokio::test]
+    async fn first_ingest_persists_source_without_attempting_vector_retirement() {
+        let vector_store = Arc::new(FailNextDeleteVectorStore::new(HashEmbedder::DEFAULT_DIMS));
+        vector_store.fail_next_delete();
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            Arc::new(HashEmbedder::default()),
+            vector_store,
+        ));
+        let (router, token, store, _dir) =
+            test_app_with_retrieval(Arc::new(FakeProvider), retrieval).await;
+        let bearer = format!("Bearer {token}");
+        let uri = "file:///first-source.txt";
+
+        assert_eq!(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({"uri": uri, "content": "source comes first"}),
+            )
+            .await
+            .status(),
+            StatusCode::CREATED
+        );
+        let record = store
+            .get_document(openwave_core::DocumentId::derive(uri))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.canonical_text, "source comes first");
+        assert_eq!(record.indexed_revision, Some(1));
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_document_ingests_publish_in_request_order() {
+        let embedder = Arc::new(FirstBatchGatedEmbedder {
+            inner: HashEmbedder::default(),
+            calls: AtomicUsize::new(0),
+            entered: Notify::new(),
+            release: Notify::new(),
+        });
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            embedder.clone(),
+            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        ));
+        let (router, token, store, _dir) =
+            test_app_with_retrieval(Arc::new(FakeProvider), retrieval).await;
+        let bearer = format!("Bearer {token}");
+
+        let first = tokio::spawn({
+            let router = router.clone();
+            let bearer = bearer.clone();
+            async move {
+                post_json(
+                    &router,
+                    &bearer,
+                    "/documents",
+                    serde_json::json!({
+                        "uri": "file:///concurrent.txt",
+                        "content": "first version",
+                    }),
+                )
+                .await
+            }
+        });
+        tokio::time::timeout(Duration::from_secs(1), embedder.entered.notified())
+            .await
+            .expect("first ingest did not reach embedding");
+
+        let second = tokio::spawn({
+            let router = router.clone();
+            let bearer = bearer.clone();
+            async move {
+                post_json(
+                    &router,
+                    &bearer,
+                    "/documents",
+                    serde_json::json!({
+                        "uri": "file:///concurrent.txt",
+                        "content": "second version",
+                    }),
+                )
+                .await
+            }
+        });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            embedder.calls.load(Ordering::SeqCst),
+            1,
+            "second request must wait before indexing the same document"
+        );
+        embedder.release.notify_one();
+
+        assert_eq!(first.await.unwrap().status(), StatusCode::CREATED);
+        assert_eq!(second.await.unwrap().status(), StatusCode::CREATED);
+        let record = store
+            .get_document(openwave_core::DocumentId::derive("file:///concurrent.txt"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.canonical_text, "second version");
+        assert_eq!(record.content_revision, 2);
+        assert_eq!(record.indexed_revision, Some(2));
+    }
+
+    #[tokio::test]
     async fn deleting_a_document_removes_it_from_the_index() {
-        let (router, token, _store, _dir) = test_app().await;
+        let (router, token, store, _dir) = test_app().await;
         let bearer = format!("Bearer {token}");
         let ingest: serde_json::Value = json_body(
             post_json(
@@ -976,7 +1416,8 @@ mod tests {
         .await;
         assert!(results["citations"].as_array().unwrap().is_empty());
         // Idempotent: deleting again is still 204.
-        assert_eq!(delete(id).await, StatusCode::NO_CONTENT);
+        assert_eq!(delete(id.clone()).await, StatusCode::NO_CONTENT);
+        assert_eq!(store.get_document(id.parse().unwrap()).await.unwrap(), None);
     }
 
     #[tokio::test]
@@ -1117,6 +1558,90 @@ mod tests {
             names.iter().any(|n| n == "read_file"),
             "file tools still present"
         );
+    }
+
+    #[tokio::test]
+    async fn catalog_delete_failure_leaves_source_stale_and_repairable() {
+        let dir = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("delete-failure.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let store = Arc::new(PauseTerminalStore::new(
+            inner,
+            Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
+        ));
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            Arc::new(HashEmbedder::default()),
+            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        ));
+        let (router, token, store_view, _dir) =
+            test_app_from_parts(Arc::new(FakeProvider), retrieval, store.clone(), dir);
+        let bearer = format!("Bearer {token}");
+        let uri = "file:///delete-failure.txt";
+        let ingested: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({"uri": uri, "content": "rebuildable source"}),
+            )
+            .await,
+        )
+        .await;
+        let id = ingested["document_id"].as_str().unwrap().to_string();
+
+        store.fail_next_document_delete();
+        let delete = |id: String| {
+            let router = router.clone();
+            let bearer = bearer.clone();
+            async move {
+                router
+                    .oneshot(
+                        Request::builder()
+                            .method("DELETE")
+                            .uri(format!("/documents/{id}"))
+                            .header(header::AUTHORIZATION, bearer)
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap()
+            }
+        };
+        assert_eq!(
+            delete(id.clone()).await.status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let record = store_view
+            .get_document(id.parse().unwrap())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(record.canonical_text, "rebuildable source");
+        assert_eq!(record.indexed_revision, None);
+        assert_eq!(record.index_fingerprint, None);
+        assert_eq!(record.indexed_at, None);
+
+        let search: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/search",
+                serde_json::json!({"query": "rebuildable source"}),
+            )
+            .await,
+        )
+        .await;
+        assert!(search["citations"].as_array().unwrap().is_empty());
+        assert_eq!(delete(id).await.status(), StatusCode::NO_CONTENT);
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{
-    Agent, ApprovalDecision, CallId, Chat, ChatId, Project, ProjectId, SecretProvider,
-    SequencedEvent, Store,
+    Agent, ApprovalDecision, CallId, Chat, ChatId, DocumentUpsert, Project, ProjectId,
+    SecretProvider, SequencedEvent, Store,
 };
 use openwave_retrieval::{Citation, DocumentId, DocumentSource, RetrievalError, SearchTool};
 
@@ -324,10 +324,11 @@ fn retrieval_error(err: RetrievalError) -> ServerError {
     }
 }
 
-/// `POST /documents` — ingest a document into the shared retrieval index
-/// (`201 Created`). The index is persisted to LanceDB under the data directory, so
-/// ingested documents survive a restart. The chunks are immediately searchable via
-/// `POST /search` and the agent's `search` tool.
+/// `POST /documents` — persist canonical source content, then ingest it into the
+/// shared retrieval index (`201 Created`). Source is committed before external
+/// embedding work; a failed index attempt remains cataloged without a watermark so
+/// it can be retried. Successful chunks are immediately searchable via `POST
+/// /search` and the agent's `search` tool.
 pub async fn ingest_document(
     State(state): State<AppState>,
     Json(body): Json<IngestDocument>,
@@ -342,28 +343,105 @@ pub async fn ingest_document(
         _ => DocumentSource::Inline,
     };
     let media_type = body.media_type.as_deref().unwrap_or("text/plain");
-    let outcome = state
+    // Pipeline components promise a stable fingerprint for their lifetime. Take
+    // one snapshot and use it for the exact parse/index operation below.
+    let index_fingerprint = state.retrieval.index_fingerprint();
+    let document = state
         .retrieval
-        .ingest(source, media_type, body.content.as_bytes())
+        .parse_document(source, media_type, body.content.as_bytes())
+        .map_err(retrieval_error)?;
+    let _write = state.document_writes.acquire(document.id).await;
+    let source_uri = match &document.source {
+        DocumentSource::Uri { uri } => Some(uri.clone()),
+        DocumentSource::Inline => None,
+        _ => None,
+    };
+    // Retire the prior revision before publishing a replacement. If either
+    // watermark clearing or vector deletion fails, the old source remains
+    // authoritative; after clearing, any interruption is visible to repair.
+    if let Some(current) = state.store.get_document(document.id).await? {
+        let cleared = state
+            .store
+            .clear_document_index(current.id, current.content_revision, current.revision_token)
+            .await?;
+        if !cleared {
+            return Err(ServerError::internal(format!(
+                "document {} changed while preparing its replacement",
+                document.id
+            )));
+        }
+        state
+            .retrieval
+            .delete(document.id)
+            .await
+            .map_err(retrieval_error)?;
+    }
+    let revision = state
+        .store
+        .upsert_document(&DocumentUpsert {
+            id: document.id,
+            project_id: None,
+            source_uri,
+            media_type: document.media_type.clone(),
+            title: None,
+            canonical_text: document.text.clone(),
+            updated_at: Utc::now(),
+        })
+        .await?;
+    let chunks = state
+        .retrieval
+        .index_document(&document)
         .await
         .map_err(retrieval_error)?;
+    let indexed = state
+        .store
+        .mark_document_indexed(
+            document.id,
+            revision.content_revision,
+            revision.revision_token,
+            &index_fingerprint,
+            Utc::now(),
+        )
+        .await?;
+    if !indexed {
+        return Err(ServerError::internal(format!(
+            "document {} changed while recording its index watermark",
+            document.id
+        )));
+    }
     Ok((
         StatusCode::CREATED,
         Json(IngestResult {
-            document_id: outcome.document.id,
-            chunks: outcome.chunks,
+            document_id: document.id,
+            chunks,
         }),
     ))
 }
 
-/// `DELETE /documents/{id}` — remove a document and its chunks from the index
-/// (`204 No Content`). Idempotent: deleting an unknown or already-removed document
-/// still returns `204`. `id` is the `document_id` returned by `POST /documents`.
+/// `DELETE /documents/{id}` — remove a document's index rows and authoritative
+/// catalog record (`204 No Content`). The catalog watermark is cleared first,
+/// then index deletion happens before source deletion. Any interrupted/failed
+/// request therefore retains rebuildable source in an explicitly stale state.
+/// Idempotent: deleting an unknown or already-removed document still returns
+/// `204`. `id` is the `document_id` returned by `POST /documents`.
 pub async fn delete_document(
     State(state): State<AppState>,
     Path(id): Path<DocumentId>,
 ) -> Result<StatusCode, ServerError> {
+    let _write = state.document_writes.acquire(id).await;
+    if let Some(document) = state.store.get_document(id).await? {
+        let cleared = state
+            .store
+            .clear_document_index(id, document.content_revision, document.revision_token)
+            .await?;
+        if !cleared {
+            return Err(ServerError::internal(format!(
+                "document {id} changed while preparing it for deletion"
+            )));
+        }
+    }
     state.retrieval.delete(id).await.map_err(retrieval_error)?;
+    state.store.delete_document(id).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -1,12 +1,14 @@
 //! Shared application state handed to every request handler.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 
 use openwave_core::{
-    AgentConfig, CancelToken, ChatId, Config, SecretProvider, SteerInbox, Store, ToolRegistry,
+    AgentConfig, CancelToken, ChatId, Config, DocumentId, SecretProvider, SteerInbox, Store,
+    ToolRegistry,
 };
 use openwave_retrieval::Retriever;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
 use uuid::Uuid;
 
 use crate::approvals::ApprovalBroker;
@@ -34,6 +36,9 @@ pub struct AppState {
     /// backs the agent's `search` tool. Its vector store is the same one the
     /// registered `SearchTool` queries, so an ingest is immediately searchable.
     pub retrieval: Arc<Retriever>,
+    /// Serializes source, index, and watermark writes for one document while
+    /// allowing unrelated documents to ingest concurrently.
+    pub document_writes: Arc<DocumentWriteGuard>,
     /// Per-turn agent tuning (model, limits, …).
     pub agent_config: AgentConfig,
     /// The secret every request must present as `Authorization: Bearer <token>`.
@@ -66,12 +71,41 @@ impl AppState {
             secrets,
             tools,
             retrieval,
+            document_writes: Arc::new(DocumentWriteGuard::default()),
             agent_config,
             token: Uuid::new_v4().to_string().into(),
             active_turns: Arc::new(TurnGuard::default()),
             events: Arc::new(EventBus::default()),
             approvals: Arc::new(ApprovalBroker::new()),
         }
+    }
+}
+
+/// Keyed asynchronous lock for document lifecycle writes.
+///
+/// Weak entries let locks disappear after the last holder/waiter finishes, so
+/// ingesting new document ids does not grow the map forever.
+#[derive(Default)]
+pub struct DocumentWriteGuard {
+    locks: Mutex<HashMap<DocumentId, Weak<AsyncMutex<()>>>>,
+}
+
+impl DocumentWriteGuard {
+    /// Wait for exclusive access to `document_id`.
+    pub async fn acquire(&self, document_id: DocumentId) -> OwnedMutexGuard<()> {
+        let lock = {
+            let mut locks = self.locks.lock().unwrap();
+            locks.retain(|_, lock| lock.strong_count() > 0);
+            match locks.get(&document_id).and_then(Weak::upgrade) {
+                Some(lock) => lock,
+                None => {
+                    let lock = Arc::new(AsyncMutex::new(()));
+                    locks.insert(document_id, Arc::downgrade(&lock));
+                    lock
+                }
+            }
+        };
+        lock.lock_owned().await
     }
 }
 


### PR DESCRIPTION
## Summary

- split retrieval parsing from indexing so canonical source can be committed before embedding or vector-store I/O
- fingerprint immutable parser, chunker, and embedder configuration and record the exact successful pipeline in the document watermark
- canonicalize custom embedding endpoints without credentials and hash their routing identity with SHA-256
- serialize ingest and delete per document while allowing unrelated documents to proceed concurrently
- persist source revisions before indexing, clear superseded vectors before awaited embedding work, leave failed attempts explicitly stale for retry, and mark only the exact revision token that reached Lance
- clear the catalog watermark before derived deletion, then remove index rows and source so every interrupted delete remains rebuildable and visibly stale
- cover failed initial and replacement embedding, deliberately interleaved same-URI ingests, catalog-delete failure recovery, catalog/index watermark persistence, and catalog-aware deletion

## Validation

- `bw --repo-root "$PWD" dev lint --rust`
- `cargo clippy -p openwave-retrieval -p openwave-server --all-targets -- -D warnings`
- `cargo test -p openwave-retrieval --features vec-lance`
- `cargo test -p openwave-core --no-default-features --features sqlite,tools`
- `cargo test -p openwave-server --lib`
