### PR TITLE
feat(server): expose the document catalog

### DIFF
--- a/crates/openwave-core/src/db.rs
+++ b/crates/openwave-core/src/db.rs
@@ -13,7 +13,7 @@ use chrono::Utc;
 use sea_orm::sea_query::OnConflict;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, Database, DatabaseConnection, EntityTrait,
-    QueryFilter, QueryOrder, Set, TryInsertResult,
+    FromQueryResult, QueryFilter, QueryOrder, QuerySelect, Set, TryInsertResult,
 };
 use sea_orm_migration::MigratorTrait;
 use serde_json::Value;
@@ -22,7 +22,8 @@ use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{CallId, ChatId, DocumentId, MessageId, ProjectId, TurnId};
 use crate::model::{
-    Chat, DocumentRecord, DocumentScope, DocumentUpsert, Message, Project, Role, ToolCallRecord,
+    Chat, DocumentListCursor, DocumentRecord, DocumentScope, DocumentSummaryRecord, DocumentUpsert,
+    Message, Project, Role, ToolCallRecord,
 };
 use crate::storage::Store;
 
@@ -35,6 +36,24 @@ fn store_err(err: impl std::fmt::Display) -> AgentError {
 #[derive(Clone)]
 pub struct DbStore {
     conn: DatabaseConnection,
+}
+
+/// Projected row for metadata-only document listings. Keeping this distinct
+/// from the entity model makes it impossible for this query to select the
+/// canonical text or revision token by accident.
+#[derive(Debug, FromQueryResult)]
+struct DocumentSummaryRow {
+    id: uuid::Uuid,
+    project_id: Option<uuid::Uuid>,
+    source_uri: Option<String>,
+    media_type: String,
+    title: Option<String>,
+    content_revision: i64,
+    indexed_revision: Option<i64>,
+    index_fingerprint: Option<String>,
+    created_at: chrono::DateTime<Utc>,
+    updated_at: chrono::DateTime<Utc>,
+    indexed_at: Option<chrono::DateTime<Utc>>,
 }
 
 impl DbStore {
@@ -140,6 +159,61 @@ impl Store for DbStore {
             .map_err(store_err)?
             .into_iter()
             .map(document_from_model)
+            .collect())
+    }
+
+    async fn list_document_summaries(
+        &self,
+        scope: DocumentScope,
+        after: Option<DocumentListCursor>,
+        limit: u64,
+    ) -> Result<Vec<DocumentSummaryRecord>> {
+        let mut query = entities::document::Entity::find();
+        query = match scope {
+            DocumentScope::All => query,
+            DocumentScope::Unscoped => {
+                query.filter(entities::document::Column::ProjectId.is_null())
+            }
+            DocumentScope::Project(id) => {
+                query.filter(entities::document::Column::ProjectId.eq(id.0))
+            }
+        };
+        if let Some(cursor) = after {
+            query = query.filter(
+                sea_orm::Condition::any()
+                    .add(entities::document::Column::CreatedAt.lt(cursor.created_at))
+                    .add(
+                        sea_orm::Condition::all()
+                            .add(entities::document::Column::CreatedAt.eq(cursor.created_at))
+                            .add(entities::document::Column::Id.lt(cursor.id.0)),
+                    ),
+            );
+        }
+
+        Ok(query
+            .select_only()
+            .columns([
+                entities::document::Column::Id,
+                entities::document::Column::ProjectId,
+                entities::document::Column::SourceUri,
+                entities::document::Column::MediaType,
+                entities::document::Column::Title,
+                entities::document::Column::ContentRevision,
+                entities::document::Column::IndexedRevision,
+                entities::document::Column::IndexFingerprint,
+                entities::document::Column::CreatedAt,
+                entities::document::Column::UpdatedAt,
+                entities::document::Column::IndexedAt,
+            ])
+            .order_by_desc(entities::document::Column::CreatedAt)
+            .order_by_desc(entities::document::Column::Id)
+            .limit(limit)
+            .into_model::<DocumentSummaryRow>()
+            .all(&self.conn)
+            .await
+            .map_err(store_err)?
+            .into_iter()
+            .map(document_summary_from_row)
             .collect())
     }
 
@@ -530,6 +604,22 @@ fn document_from_model(model: entities::document::Model) -> DocumentRecord {
         created_at: model.created_at,
         updated_at: model.updated_at,
         indexed_at: model.indexed_at,
+    }
+}
+
+fn document_summary_from_row(row: DocumentSummaryRow) -> DocumentSummaryRecord {
+    DocumentSummaryRecord {
+        id: DocumentId(row.id),
+        project_id: row.project_id.map(ProjectId),
+        source_uri: row.source_uri,
+        media_type: row.media_type,
+        title: row.title,
+        content_revision: row.content_revision,
+        indexed_revision: row.indexed_revision,
+        index_fingerprint: row.index_fingerprint,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        indexed_at: row.indexed_at,
     }
 }
 
@@ -1470,6 +1560,84 @@ mod tests {
         store.delete_document(unscoped.id).await.unwrap();
         store.delete_document(unscoped.id).await.unwrap();
         assert_eq!(store.get_document(unscoped.id).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn document_summaries_page_by_created_at_then_id_without_gaps() {
+        let (_dir, store) = temp_store().await;
+        // Keep both groups inside one microsecond so cursor implementations
+        // that truncate sub-microsecond precision would skip the older group.
+        let newer = DateTime::<Utc>::from_timestamp(2_000, 900).unwrap();
+        let older = DateTime::<Utc>::from_timestamp(2_000, 700).unwrap();
+        let fixtures = [
+            (3_u128, newer, "newest tie"),
+            (2, newer, "middle tie"),
+            (1, newer, "last tie"),
+            (5, older, "older high id"),
+            (4, older, "older low id"),
+        ];
+        for (raw_id, created_at, title) in fixtures {
+            let mut document = sample_document(None);
+            document.id = DocumentId(uuid::Uuid::from_u128(raw_id));
+            document.title = Some(title.into());
+            document.canonical_text = format!("content that listings must not load: {title}");
+            document.created_at = created_at;
+            document.updated_at = created_at;
+            store.create_document(&document).await.unwrap();
+        }
+
+        let first = store
+            .list_document_summaries(DocumentScope::All, None, 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            first
+                .iter()
+                .map(|document| document.id.0)
+                .collect::<Vec<_>>(),
+            vec![uuid::Uuid::from_u128(3), uuid::Uuid::from_u128(2)]
+        );
+        let second = store
+            .list_document_summaries(
+                DocumentScope::All,
+                Some(DocumentListCursor {
+                    created_at: first[1].created_at,
+                    id: first[1].id,
+                }),
+                2,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            second
+                .iter()
+                .map(|document| document.id.0)
+                .collect::<Vec<_>>(),
+            vec![uuid::Uuid::from_u128(1), uuid::Uuid::from_u128(5)]
+        );
+        let third = store
+            .list_document_summaries(
+                DocumentScope::All,
+                Some(DocumentListCursor {
+                    created_at: second[1].created_at,
+                    id: second[1].id,
+                }),
+                2,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            third
+                .iter()
+                .map(|document| document.id.0)
+                .collect::<Vec<_>>(),
+            vec![uuid::Uuid::from_u128(4)]
+        );
+        assert!(store
+            .list_document_summaries(DocumentScope::All, None, 0)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -47,7 +47,8 @@ pub use id::{CallId, ChatId, DocumentId, MessageId, ProjectId, StepId, TurnId};
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
 pub use model::{
-    Chat, DocumentRecord, DocumentScope, DocumentUpsert, Message, Project, Role, ToolCallRecord,
+    Chat, DocumentListCursor, DocumentRecord, DocumentScope, DocumentSummaryRecord, DocumentUpsert,
+    Message, Project, Role, ToolCallRecord,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -69,6 +69,50 @@ pub struct DocumentRecord {
     pub indexed_at: Option<DateTime<Utc>>,
 }
 
+/// Metadata returned by bounded document listings.
+///
+/// This deliberately excludes canonical content and the revision token so list
+/// callers cannot accidentally load either large source text or write-only
+/// concurrency credentials.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentSummaryRecord {
+    /// Stable identifier shared with the retrieval index.
+    pub id: DocumentId,
+    /// Owning project, or `None` for an explicitly unscoped document.
+    pub project_id: Option<ProjectId>,
+    /// Source path or URL, or `None` for content supplied inline.
+    pub source_uri: Option<String>,
+    /// Media type of the canonical content.
+    pub media_type: String,
+    /// Optional human-facing title.
+    pub title: Option<String>,
+    /// Current authoritative source revision.
+    pub content_revision: i64,
+    /// Revision currently represented in the retrieval index, if any.
+    pub indexed_revision: Option<i64>,
+    /// Chunker/embedder fingerprint for the indexed revision.
+    pub index_fingerprint: Option<String>,
+    /// When this record was first created.
+    pub created_at: DateTime<Utc>,
+    /// When authoritative content or metadata last changed.
+    pub updated_at: DateTime<Utc>,
+    /// When the current index watermark was recorded.
+    pub indexed_at: Option<DateTime<Utc>>,
+}
+
+/// Stable position in a newest-first document listing.
+///
+/// Cursors use both creation time and id because creation timestamps need not
+/// be unique. Records following this cursor compare strictly lower by the
+/// descending `(created_at, id)` display order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentListCursor {
+    /// Creation time of the final item in the preceding page.
+    pub created_at: DateTime<Utc>,
+    /// Id of the final item in the preceding page.
+    pub id: DocumentId,
+}
+
 /// Authoritative content to create or replace for a document.
 ///
 /// The store owns revision and index-watermark transitions: the first upsert is

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -22,7 +22,8 @@ use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, DocumentId, ProjectId};
 use crate::model::{
-    Chat, DocumentRecord, DocumentScope, DocumentUpsert, Message, Project, ToolCallRecord,
+    Chat, DocumentListCursor, DocumentRecord, DocumentScope, DocumentSummaryRecord, DocumentUpsert,
+    Message, Project, ToolCallRecord,
 };
 
 fn document_storage_unavailable<T>() -> Result<T> {
@@ -63,6 +64,20 @@ pub trait Store: Send + Sync {
 
     /// List documents in `scope`, most-recently-created first.
     async fn list_documents(&self, _scope: DocumentScope) -> Result<Vec<DocumentRecord>> {
+        document_storage_unavailable()
+    }
+
+    /// List document metadata in deterministic newest-first order.
+    ///
+    /// At most `limit` records are returned. When `after` is present, results
+    /// begin strictly after its `(created_at, id)` tuple in descending display
+    /// order. Implementations must not load canonical text or revision tokens.
+    async fn list_document_summaries(
+        &self,
+        _scope: DocumentScope,
+        _after: Option<DocumentListCursor>,
+        _limit: u64,
+    ) -> Result<Vec<DocumentSummaryRecord>> {
         document_storage_unavailable()
     }
 
@@ -243,6 +258,40 @@ mod tests {
                 .cloned()
                 .collect())
         }
+        async fn list_document_summaries(
+            &self,
+            scope: DocumentScope,
+            after: Option<DocumentListCursor>,
+            limit: u64,
+        ) -> Result<Vec<DocumentSummaryRecord>> {
+            let mut documents: Vec<_> = self
+                .documents
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|document| match scope {
+                    DocumentScope::All => true,
+                    DocumentScope::Unscoped => document.project_id.is_none(),
+                    DocumentScope::Project(id) => document.project_id == Some(id),
+                })
+                .filter(|document| {
+                    after.is_none_or(|cursor| {
+                        document.created_at < cursor.created_at
+                            || (document.created_at == cursor.created_at
+                                && document.id.0 < cursor.id.0)
+                    })
+                })
+                .map(document_summary)
+                .collect();
+            documents.sort_by(|left, right| {
+                right
+                    .created_at
+                    .cmp(&left.created_at)
+                    .then_with(|| right.id.0.cmp(&left.id.0))
+            });
+            documents.truncate(limit.try_into().unwrap_or(usize::MAX));
+            Ok(documents)
+        }
         async fn delete_document(&self, id: DocumentId) -> Result<()> {
             self.documents.lock().unwrap().remove(&id);
             Ok(())
@@ -413,6 +462,22 @@ mod tests {
                 .filter(|(id, e)| *id == chat_id && e.seq > after)
                 .map(|(_, e)| e.clone())
                 .collect())
+        }
+    }
+
+    fn document_summary(document: &DocumentRecord) -> DocumentSummaryRecord {
+        DocumentSummaryRecord {
+            id: document.id,
+            project_id: document.project_id,
+            source_uri: document.source_uri.clone(),
+            media_type: document.media_type.clone(),
+            title: document.title.clone(),
+            content_revision: document.content_revision,
+            indexed_revision: document.indexed_revision,
+            index_fingerprint: document.index_fingerprint.clone(),
+            created_at: document.created_at,
+            updated_at: document.updated_at,
+            indexed_at: document.indexed_at,
         }
     }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -70,10 +70,13 @@ pub fn app(state: AppState) -> Router {
             "/providers/{kind}/credential",
             axum::routing::delete(routes::delete_provider_credential),
         )
-        .route("/documents", post(routes::ingest_document))
+        .route(
+            "/documents",
+            post(routes::ingest_document).get(routes::list_documents),
+        )
         .route(
             "/documents/{id}",
-            axum::routing::delete(routes::delete_document),
+            get(routes::get_document).delete(routes::delete_document),
         )
         .route("/search", post(routes::search_documents))
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
@@ -619,6 +622,16 @@ mod tests {
             scope: openwave_core::DocumentScope,
         ) -> Result<Vec<openwave_core::DocumentRecord>> {
             self.inner.list_documents(scope).await
+        }
+        async fn list_document_summaries(
+            &self,
+            scope: openwave_core::DocumentScope,
+            after: Option<openwave_core::DocumentListCursor>,
+            limit: u64,
+        ) -> Result<Vec<openwave_core::DocumentSummaryRecord>> {
+            self.inner
+                .list_document_summaries(scope, after, limit)
+                .await
         }
         async fn delete_document(&self, id: openwave_core::DocumentId) -> Result<()> {
             if self.fail_document_delete.swap(false, Ordering::SeqCst) {
@@ -1291,6 +1304,207 @@ mod tests {
             .unwrap();
         assert_eq!(record.canonical_text, "source comes first");
         assert_eq!(record.indexed_revision, Some(1));
+    }
+
+    #[tokio::test]
+    async fn document_catalog_pages_metadata_and_keeps_project_content_private() {
+        let (router, token, store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let ingested: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({
+                    "uri": "file:///catalog.txt",
+                    "media_type": "text/markdown",
+                    "content": "# Catalog\n\nDurable source",
+                }),
+            )
+            .await,
+        )
+        .await;
+        let id = ingested["document_id"].as_str().unwrap().to_owned();
+
+        for suffix in ["second", "third"] {
+            assert_eq!(
+                post_json(
+                    &router,
+                    &bearer,
+                    "/documents",
+                    serde_json::json!({
+                        "uri": format!("file:///{suffix}.txt"),
+                        "content": format!("{suffix} document"),
+                    }),
+                )
+                .await
+                .status(),
+                StatusCode::CREATED
+            );
+        }
+
+        let project = make_project(&router, &bearer).await;
+        let project_document_id = openwave_core::DocumentId::new();
+        let now = chrono::Utc::now();
+        store
+            .create_document(&openwave_core::DocumentRecord {
+                id: project_document_id,
+                project_id: Some(project.id),
+                source_uri: Some("file:///project-secret.txt".into()),
+                media_type: "text/plain".into(),
+                title: None,
+                canonical_text: "project-only source".into(),
+                content_revision: 1,
+                revision_token: uuid::Uuid::new_v4(),
+                indexed_revision: None,
+                index_fingerprint: None,
+                created_at: now,
+                updated_at: now,
+                indexed_at: None,
+            })
+            .await
+            .unwrap();
+
+        let get = |uri: String| {
+            let router = router.clone();
+            let bearer = bearer.clone();
+            async move {
+                router
+                    .oneshot(
+                        Request::builder()
+                            .uri(uri)
+                            .header(header::AUTHORIZATION, bearer)
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap()
+            }
+        };
+
+        let first = get("/documents?limit=2".into()).await;
+        assert_eq!(first.status(), StatusCode::OK);
+        let first: serde_json::Value = json_body(first).await;
+        let first_documents = first["documents"].as_array().unwrap();
+        assert_eq!(first_documents.len(), 2);
+        let cursor = first["next_cursor"].as_str().expect("a second page");
+        assert!(first_documents.iter().all(|summary| {
+            summary.get("content").is_none() && summary.get("revision_token").is_none()
+        }));
+
+        let second = get(format!("/documents?limit=2&cursor={cursor}")).await;
+        assert_eq!(second.status(), StatusCode::OK);
+        let second: serde_json::Value = json_body(second).await;
+        let second_documents = second["documents"].as_array().unwrap();
+        assert_eq!(second_documents.len(), 1);
+        assert!(second["next_cursor"].is_null());
+
+        let listed_ids: std::collections::HashSet<_> = first_documents
+            .iter()
+            .chain(second_documents)
+            .map(|summary| summary["document_id"].as_str().unwrap())
+            .collect();
+        assert_eq!(listed_ids.len(), 3);
+        assert!(listed_ids.contains(id.as_str()));
+        assert!(!listed_ids.contains(project_document_id.to_string().as_str()));
+
+        let catalog_summary = first_documents
+            .iter()
+            .chain(second_documents)
+            .find(|summary| summary["document_id"] == id)
+            .unwrap();
+        assert_eq!(catalog_summary["uri"], "file:///catalog.txt");
+        assert_eq!(catalog_summary["media_type"], "text/markdown");
+        assert_eq!(catalog_summary["content_revision"], 1);
+        assert_eq!(catalog_summary["indexed_revision"], 1);
+
+        let detail = get(format!("/documents/{id}")).await;
+        assert_eq!(detail.status(), StatusCode::OK);
+        let detail: serde_json::Value = json_body(detail).await;
+        assert_eq!(detail["content"], "# Catalog\n\nDurable source");
+        assert_eq!(detail["document_id"], id);
+        assert!(detail.get("revision_token").is_none());
+
+        assert_eq!(
+            get(format!("/documents/{project_document_id}"))
+                .await
+                .status(),
+            StatusCode::NOT_FOUND
+        );
+
+        assert_eq!(
+            get("/documents?limit=0".into()).await.status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            get("/documents?cursor=garbage".into()).await.status(),
+            StatusCode::BAD_REQUEST
+        );
+
+        assert_eq!(
+            get(format!("/documents/{}", openwave_core::DocumentId::new()))
+                .await
+                .status(),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[tokio::test]
+    async fn document_catalog_cursor_preserves_nanosecond_ordering() {
+        let (router, token, store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let mut expected = Vec::new();
+
+        for nanos in [900, 800, 700] {
+            let id = openwave_core::DocumentId::new();
+            let created_at = chrono::DateTime::from_timestamp(1_700_000_000, nanos).unwrap();
+            store
+                .create_document(&openwave_core::DocumentRecord {
+                    id,
+                    project_id: None,
+                    source_uri: Some(format!("file:///{nanos}.txt")),
+                    media_type: "text/plain".into(),
+                    title: None,
+                    canonical_text: nanos.to_string(),
+                    content_revision: 1,
+                    revision_token: uuid::Uuid::new_v4(),
+                    indexed_revision: None,
+                    index_fingerprint: None,
+                    created_at,
+                    updated_at: created_at,
+                    indexed_at: None,
+                })
+                .await
+                .unwrap();
+            expected.push(id.to_string());
+        }
+
+        let mut uri = "/documents?limit=1".to_owned();
+        let mut actual = Vec::new();
+        loop {
+            let response = router
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(&uri)
+                        .header(header::AUTHORIZATION, &bearer)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let page: serde_json::Value = json_body(response).await;
+            let documents = page["documents"].as_array().unwrap();
+            assert_eq!(documents.len(), 1);
+            actual.push(documents[0]["document_id"].as_str().unwrap().to_owned());
+            let Some(cursor) = page["next_cursor"].as_str() else {
+                break;
+            };
+            uri = format!("/documents?limit=1&cursor={cursor}");
+        }
+
+        assert_eq!(actual, expected);
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -14,8 +14,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{
-    Agent, ApprovalDecision, CallId, Chat, ChatId, DocumentUpsert, Project, ProjectId,
-    SecretProvider, SequencedEvent, Store,
+    Agent, ApprovalDecision, CallId, Chat, ChatId, DocumentListCursor, DocumentRecord,
+    DocumentScope, DocumentSummaryRecord, DocumentUpsert, Project, ProjectId, SecretProvider,
+    SequencedEvent, Store,
 };
 use openwave_retrieval::{Citation, DocumentId, DocumentSource, RetrievalError, SearchTool};
 
@@ -315,6 +316,134 @@ pub struct IngestResult {
     pub chunks: usize,
 }
 
+/// Catalog metadata returned by document listings.
+#[derive(Debug, Serialize)]
+pub struct DocumentSummary {
+    /// Stable identifier shared with citations and delete/get routes.
+    pub document_id: DocumentId,
+    /// Owning project, or `None` for the unscoped corpus.
+    pub project_id: Option<ProjectId>,
+    /// Source path or URL, or `None` for inline content.
+    pub uri: Option<String>,
+    /// Media type of the canonical content.
+    pub media_type: String,
+    /// Optional human-facing title.
+    pub title: Option<String>,
+    /// Current authoritative source revision.
+    pub content_revision: i64,
+    /// Source revision currently represented in the index.
+    pub indexed_revision: Option<i64>,
+    /// Parser/chunker/embedder identity for the current indexed revision.
+    pub index_fingerprint: Option<String>,
+    /// When this document was first created.
+    pub created_at: chrono::DateTime<Utc>,
+    /// When its authoritative source last changed.
+    pub updated_at: chrono::DateTime<Utc>,
+    /// When the current index watermark was recorded.
+    pub indexed_at: Option<chrono::DateTime<Utc>>,
+}
+
+impl From<DocumentSummaryRecord> for DocumentSummary {
+    fn from(document: DocumentSummaryRecord) -> Self {
+        Self {
+            document_id: document.id,
+            project_id: document.project_id,
+            uri: document.source_uri,
+            media_type: document.media_type,
+            title: document.title,
+            content_revision: document.content_revision,
+            indexed_revision: document.indexed_revision,
+            index_fingerprint: document.index_fingerprint,
+            created_at: document.created_at,
+            updated_at: document.updated_at,
+            indexed_at: document.indexed_at,
+        }
+    }
+}
+
+impl From<&DocumentRecord> for DocumentSummary {
+    fn from(document: &DocumentRecord) -> Self {
+        Self {
+            document_id: document.id,
+            project_id: document.project_id,
+            uri: document.source_uri.clone(),
+            media_type: document.media_type.clone(),
+            title: document.title.clone(),
+            content_revision: document.content_revision,
+            indexed_revision: document.indexed_revision,
+            index_fingerprint: document.index_fingerprint.clone(),
+            created_at: document.created_at,
+            updated_at: document.updated_at,
+            indexed_at: document.indexed_at,
+        }
+    }
+}
+
+/// Query parameters for bounded document catalog pagination.
+#[derive(Debug, Default, Deserialize)]
+pub struct DocumentListQuery {
+    /// Maximum number of documents to return (defaults to 50, maximum 200).
+    pub limit: Option<u64>,
+    /// Opaque cursor returned by the previous page.
+    pub cursor: Option<String>,
+}
+
+/// One bounded page of catalog metadata.
+#[derive(Debug, Serialize)]
+pub struct DocumentListPage {
+    /// Documents in newest-first order.
+    pub documents: Vec<DocumentSummary>,
+    /// Cursor for the next page, or `None` when this is the final page.
+    pub next_cursor: Option<String>,
+}
+
+const DEFAULT_DOCUMENT_PAGE_SIZE: u64 = 50;
+const MAX_DOCUMENT_PAGE_SIZE: u64 = 200;
+
+fn encode_document_cursor(cursor: DocumentListCursor) -> String {
+    format!(
+        "{}:{:09}:{}",
+        cursor.created_at.timestamp(),
+        cursor.created_at.timestamp_subsec_nanos(),
+        cursor.id
+    )
+}
+
+fn decode_document_cursor(raw: &str) -> Result<DocumentListCursor, ServerError> {
+    let mut parts = raw.splitn(3, ':');
+    let seconds = parts.next().and_then(|part| part.parse::<i64>().ok());
+    let nanos = parts.next().and_then(|part| part.parse::<u32>().ok());
+    let id = parts.next();
+    let created_at = seconds
+        .zip(nanos)
+        .and_then(|(seconds, nanos)| chrono::DateTime::<Utc>::from_timestamp(seconds, nanos))
+        .ok_or_else(|| ServerError::bad_request("invalid document cursor"))?;
+    let id = id
+        .ok_or_else(|| ServerError::bad_request("invalid document cursor"))?
+        .parse()
+        .map_err(|_| ServerError::bad_request("invalid document cursor"))?;
+    Ok(DocumentListCursor { created_at, id })
+}
+
+/// Full document response, including the canonical text used for reindexing.
+#[derive(Debug, Serialize)]
+pub struct DocumentDetail {
+    /// Catalog metadata.
+    #[serde(flatten)]
+    pub summary: DocumentSummary,
+    /// Parsed text-of-record. Citation spans index into this string.
+    pub content: String,
+}
+
+impl From<DocumentRecord> for DocumentDetail {
+    fn from(document: DocumentRecord) -> Self {
+        Self {
+            summary: DocumentSummary::from(&document),
+            content: document.canonical_text,
+        }
+    }
+}
+
 /// Map a retrieval failure to an HTTP error: a parse problem is the caller's
 /// (unsupported media type / bad content), everything else is server-side.
 fn retrieval_error(err: RetrievalError) -> ServerError {
@@ -416,6 +545,60 @@ pub async fn ingest_document(
             chunks,
         }),
     ))
+}
+
+/// `GET /documents` — list the explicitly unscoped corpus without returning each
+/// document's potentially large canonical text. Project-scoped listing lands with
+/// corpus scoping; this endpoint never widens to every project's documents.
+pub async fn list_documents(
+    State(state): State<AppState>,
+    Query(query): Query<DocumentListQuery>,
+) -> Result<Json<DocumentListPage>, ServerError> {
+    let limit = query.limit.unwrap_or(DEFAULT_DOCUMENT_PAGE_SIZE);
+    if limit == 0 || limit > MAX_DOCUMENT_PAGE_SIZE {
+        return Err(ServerError::bad_request(format!(
+            "document limit must be between 1 and {MAX_DOCUMENT_PAGE_SIZE}"
+        )));
+    }
+    let cursor = query
+        .cursor
+        .as_deref()
+        .map(decode_document_cursor)
+        .transpose()?;
+    let mut records = state
+        .store
+        .list_document_summaries(DocumentScope::Unscoped, cursor, limit + 1)
+        .await?;
+    let has_more = records.len() > limit as usize;
+    records.truncate(limit as usize);
+    let next_cursor = has_more.then(|| {
+        let last = records
+            .last()
+            .expect("a page with another row has at least one returned row");
+        encode_document_cursor(DocumentListCursor {
+            created_at: last.created_at,
+            id: last.id,
+        })
+    });
+    Ok(Json(DocumentListPage {
+        documents: records.into_iter().map(DocumentSummary::from).collect(),
+        next_cursor,
+    }))
+}
+
+/// `GET /documents/{id}` — fetch canonical source and catalog metadata, or `404`.
+pub async fn get_document(
+    State(state): State<AppState>,
+    Path(id): Path<DocumentId>,
+) -> Result<Json<DocumentDetail>, ServerError> {
+    state
+        .store
+        .get_document(id)
+        .await?
+        .filter(|document| document.project_id.is_none())
+        .map(DocumentDetail::from)
+        .map(Json)
+        .ok_or_else(|| ServerError::not_found(format!("document {id} not found")))
 }
 
 /// `DELETE /documents/{id}` — remove a document's index rows and authoritative


### PR DESCRIPTION
## Summary

- add authenticated `GET /documents` over the explicitly unscoped catalog
- add authenticated `GET /documents/{id}` with canonical source content for inspection and recovery
- keep large canonical text out of list responses and keep internal revision identity tokens out of both response shapes
- return revision, index watermark, provenance, media, and timestamp metadata for operational visibility
- cover list/detail response shape, canonical content, watermark metadata, and unknown-document handling

## Validation

- `bw --repo-root "$PWD" dev lint --rust`
- `cargo clippy -p openwave-server --all-targets -- -D warnings`
- `cargo test -p openwave-server --lib`
