### PR TITLE
feat(server): repair stale document indexes on startup

### DIFF
--- a/crates/openwave-core/src/db.rs
+++ b/crates/openwave-core/src/db.rs
@@ -217,6 +217,30 @@ impl Store for DbStore {
             .collect())
     }
 
+    async fn list_document_ids(&self, scope: DocumentScope) -> Result<Vec<DocumentId>> {
+        let mut query = entities::document::Entity::find()
+            .select_only()
+            .column(entities::document::Column::Id);
+        query = match scope {
+            DocumentScope::All => query,
+            DocumentScope::Unscoped => {
+                query.filter(entities::document::Column::ProjectId.is_null())
+            }
+            DocumentScope::Project(id) => {
+                query.filter(entities::document::Column::ProjectId.eq(id.0))
+            }
+        };
+        Ok(query
+            .order_by_desc(entities::document::Column::CreatedAt)
+            .into_tuple::<uuid::Uuid>()
+            .all(&self.conn)
+            .await
+            .map_err(store_err)?
+            .into_iter()
+            .map(DocumentId)
+            .collect())
+    }
+
     async fn delete_document(&self, id: DocumentId) -> Result<()> {
         entities::document::Entity::delete_by_id(id.0)
             .exec(&self.conn)

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -59,7 +59,10 @@ pub struct DocumentRecord {
     pub revision_token: Uuid,
     /// Revision currently represented in the retrieval index, if any.
     pub indexed_revision: Option<i64>,
-    /// Canonical-text/chunker/embedder fingerprint for the indexed revision.
+    /// Chunker/embedder fingerprint for the indexed revision.
+    ///
+    /// Parser provenance is separate because reparsing requires original source
+    /// bytes; canonical text alone can only be rechunked and re-embedded.
     pub index_fingerprint: Option<String>,
     /// When this record was first created.
     pub created_at: DateTime<Utc>,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -81,6 +81,19 @@ pub trait Store: Send + Sync {
         document_storage_unavailable()
     }
 
+    /// List document ids in `scope` without requiring canonical content.
+    ///
+    /// The default preserves compatibility for external stores; database-backed
+    /// implementations should project only the id column for maintenance scans.
+    async fn list_document_ids(&self, scope: DocumentScope) -> Result<Vec<DocumentId>> {
+        Ok(self
+            .list_documents(scope)
+            .await?
+            .into_iter()
+            .map(|document| document.id)
+            .collect())
+    }
+
     /// Delete an authoritative document record. Idempotent for unknown ids.
     async fn delete_document(&self, _id: DocumentId) -> Result<()> {
         document_storage_unavailable()

--- a/crates/openwave-retrieval/src/lance_store.rs
+++ b/crates/openwave-retrieval/src/lance_store.rs
@@ -296,6 +296,14 @@ impl VectorStore for LanceVectorStore {
         Ok(())
     }
 
+    async fn document_len(&self, document_id: DocumentId) -> Result<Option<usize>> {
+        self.table
+            .count_rows(Some(format!("document_id = '{document_id}'")))
+            .await
+            .map(Some)
+            .map_err(lance_err)
+    }
+
     async fn len(&self) -> Result<usize> {
         self.table.count_rows(None).await.map_err(lance_err)
     }
@@ -433,6 +441,11 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(store.len().await.unwrap(), 2);
+            assert_eq!(store.document_len(doc).await.unwrap(), Some(2));
+            assert_eq!(
+                store.document_len(DocumentId::new()).await.unwrap(),
+                Some(0)
+            );
 
             // Nearest to "east" is the east vector, with its span/text intact.
             let hits = store.query(&Embedding(vec![1.0, 0.0]), 1).await.unwrap();

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -56,16 +56,31 @@ impl Retriever {
         &self.store
     }
 
-    /// Stable identity for the parser, chunker, and embedder configuration that
-    /// produced this retriever's index rows.
+    /// Stable identity for canonical parsing behavior.
+    ///
+    /// Canonical text cannot be regenerated from this identity alone; parser
+    /// upgrades require retained original bytes.
+    #[must_use]
+    pub fn canonical_fingerprint(&self) -> String {
+        self.parser.fingerprint()
+    }
+
+    /// Stable identity for the chunker and embedder configuration that produced
+    /// this retriever's derived index rows.
     #[must_use]
     pub fn index_fingerprint(&self) -> String {
         format!(
-            "parser={};chunker={};embedder={}",
-            self.parser.fingerprint(),
+            "chunker={};embedder={}",
             self.chunker.fingerprint(),
             self.embedder.fingerprint()
         )
+    }
+
+    /// Verify that the vector backend contains the expected number of chunks for
+    /// this canonical document under the active chunker.
+    pub async fn index_is_complete(&self, document: &Document) -> Result<bool> {
+        let expected = self.chunker.chunk(document)?.len();
+        Ok(self.store.document_len(document.id).await? == Some(expected))
     }
 
     /// Parse source bytes into the canonical document persisted by callers.
@@ -232,9 +247,10 @@ The Great Barrier Reef is the world's largest coral reef system.";
     #[test]
     fn index_fingerprint_captures_the_pipeline_configuration() {
         let r = retriever();
+        assert_eq!(r.canonical_fingerprint(), "plain-text-lossy-v1");
         assert_eq!(
             r.index_fingerprint(),
-            "parser=plain-text-lossy-v1;chunker=text-window-v1:max_chars=90:overlap=0;embedder=hash-fnv1a-v1:512d"
+            "chunker=text-window-v1:max_chars=90:overlap=0;embedder=hash-fnv1a-v1:512d"
         );
     }
 

--- a/crates/openwave-retrieval/src/vector.rs
+++ b/crates/openwave-retrieval/src/vector.rs
@@ -61,6 +61,16 @@ pub trait VectorStore: Send + Sync {
         records: Vec<VectorRecord>,
     ) -> Result<()>;
 
+    /// Count physically stored chunks for one document when the backend can do
+    /// so efficiently.
+    ///
+    /// `None` means coverage cannot be verified; repair callers should then act
+    /// conservatively rather than treating a catalog watermark as proof that
+    /// derived rows still exist.
+    async fn document_len(&self, _document_id: DocumentId) -> Result<Option<usize>> {
+        Ok(None)
+    }
+
     /// The number of records currently stored.
     async fn len(&self) -> Result<usize>;
 
@@ -187,6 +197,19 @@ impl VectorStore for InMemoryVectorStore {
         Ok(())
     }
 
+    async fn document_len(&self, document_id: DocumentId) -> Result<Option<usize>> {
+        let store = self
+            .records
+            .read()
+            .map_err(|_| RetrievalError::vector_store("in-memory store lock poisoned"))?;
+        Ok(Some(
+            store
+                .iter()
+                .filter(|record| record.chunk.document_id == document_id)
+                .count(),
+        ))
+    }
+
     async fn len(&self) -> Result<usize> {
         let store = self
             .records
@@ -279,6 +302,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(store.len().await.unwrap(), 1);
+        assert_eq!(store.document_len(doc).await.unwrap(), Some(1));
+        assert_eq!(
+            store.document_len(DocumentId::new()).await.unwrap(),
+            Some(0)
+        );
         // The second upsert's vector won.
         let hits = store.query(&Embedding(vec![0.0, 1.0]), 1).await.unwrap();
         assert!((hits[0].score - 1.0).abs() < 1e-6);

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -15,7 +15,7 @@ openwave-core = { path = "../openwave-core", default-features = false, features 
 openwave-router = { path = "../openwave-router" }
 openwave-retrieval = { path = "../openwave-retrieval", features = ["vec-lance"] }
 axum = { workspace = true }
-tokio = { workspace = true, features = ["net", "rt", "sync", "macros"] }
+tokio = { workspace = true, features = ["net", "rt", "sync", "macros", "time"] }
 tower-http = { version = "0.6", features = ["cors"] }
 futures = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/openwave-server/src/index_repair.rs
+++ b/crates/openwave-server/src/index_repair.rs
@@ -1,0 +1,274 @@
+//! Background repair of derived index rows from authoritative catalog content.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::Utc;
+use openwave_core::{DocumentId, DocumentRecord, DocumentScope, Result, Store};
+use openwave_retrieval::{Document, DocumentSource, Retriever};
+
+use crate::state::DocumentWriteGuard;
+
+/// Outcome of one best-effort catalog scan.
+#[derive(Debug, Default)]
+pub(crate) struct IndexRepairReport {
+    pub scanned: usize,
+    pub repaired: usize,
+    pub skipped: usize,
+    pub failures: Vec<IndexRepairFailure>,
+}
+
+/// A document left stale after a failed repair attempt.
+#[derive(Debug)]
+pub(crate) struct IndexRepairFailure {
+    pub document_id: DocumentId,
+    pub error: String,
+}
+
+#[derive(Debug, Clone)]
+struct PendingWatermark {
+    revision: i64,
+    revision_token: uuid::Uuid,
+    fingerprint: String,
+}
+
+/// Reconciliation state retained across background scans.
+#[derive(Debug, Default)]
+pub(crate) struct IndexRepairer {
+    pending_watermarks: HashMap<DocumentId, PendingWatermark>,
+}
+
+/// Rebuild stale or pipeline-mismatched document rows from canonical source.
+///
+/// The initial catalog scan is the only fatal operation. Individual documents
+/// are isolated: one provider/vector/store failure remains visible as a stale
+/// watermark but does not prevent other records from being repaired.
+#[cfg(test)]
+pub(crate) async fn repair_document_index(
+    store: Arc<dyn Store>,
+    retrieval: Arc<Retriever>,
+    writes: Arc<DocumentWriteGuard>,
+) -> Result<IndexRepairReport> {
+    IndexRepairer::default()
+        .repair(store, retrieval, writes)
+        .await
+}
+
+impl IndexRepairer {
+    /// Run one reconciliation while retaining successful-but-unmarked index
+    /// writes for cheap watermark-only retries on the next pass.
+    pub(crate) async fn repair(
+        &mut self,
+        store: Arc<dyn Store>,
+        retrieval: Arc<Retriever>,
+        writes: Arc<DocumentWriteGuard>,
+    ) -> Result<IndexRepairReport> {
+        let document_ids = store.list_document_ids(DocumentScope::All).await?;
+        let fingerprint = retrieval.index_fingerprint();
+        let mut report = IndexRepairReport {
+            scanned: document_ids.len(),
+            ..IndexRepairReport::default()
+        };
+        let mut candidates = Vec::new();
+
+        // First invalidate every stale or physically incomplete document. This pass
+        // is intentionally separate from embedding so later candidates cannot keep
+        // serving incompatible rows while earlier remote calls are in flight.
+        for document_id in document_ids {
+            let _write = writes.acquire(document_id).await;
+            let current = match store.get_document(document_id).await {
+                Ok(Some(document)) => document,
+                Ok(None) => {
+                    report.skipped += 1;
+                    continue;
+                }
+                Err(error) => {
+                    report.failures.push(IndexRepairFailure {
+                        document_id,
+                        error: error.to_string(),
+                    });
+                    continue;
+                }
+            };
+            if let Some(pending) = self.pending_watermarks.get(&current.id).cloned() {
+                if pending.revision == current.content_revision
+                    && pending.revision_token == current.revision_token
+                    && pending.fingerprint == fingerprint
+                {
+                    match store
+                        .mark_document_indexed(
+                            current.id,
+                            pending.revision,
+                            pending.revision_token,
+                            &pending.fingerprint,
+                            Utc::now(),
+                        )
+                        .await
+                    {
+                        Ok(true) => {
+                            self.pending_watermarks.remove(&current.id);
+                            report.repaired += 1;
+                            continue;
+                        }
+                        Ok(false) => {
+                            self.pending_watermarks.remove(&current.id);
+                        }
+                        Err(error) => {
+                            report.failures.push(IndexRepairFailure {
+                                document_id: current.id,
+                                error: error.to_string(),
+                            });
+                            continue;
+                        }
+                    }
+                } else {
+                    self.pending_watermarks.remove(&current.id);
+                }
+            }
+            let document = canonical_document(&current);
+            let watermark_matches = current.indexed_revision == Some(current.content_revision)
+                && current.index_fingerprint.as_deref() == Some(fingerprint.as_str());
+            if watermark_matches {
+                match retrieval.index_is_complete(&document).await {
+                    Ok(true) => {
+                        report.skipped += 1;
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        report.failures.push(IndexRepairFailure {
+                            document_id: current.id,
+                            error: error.to_string(),
+                        });
+                        continue;
+                    }
+                }
+            }
+            match store
+                .clear_document_index(current.id, current.content_revision, current.revision_token)
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    report.failures.push(IndexRepairFailure {
+                        document_id: current.id,
+                        error: "document changed before repair invalidation committed".into(),
+                    });
+                    continue;
+                }
+                Err(error) => {
+                    report.failures.push(IndexRepairFailure {
+                        document_id: current.id,
+                        error: error.to_string(),
+                    });
+                    continue;
+                }
+            }
+            if let Err(error) = retrieval.delete(current.id).await {
+                report.failures.push(IndexRepairFailure {
+                    document_id: current.id,
+                    error: error.to_string(),
+                });
+                continue;
+            }
+            candidates.push(current.id);
+        }
+
+        // Then rebuild invalidated candidates. Re-fetching under the keyed lock lets
+        // a live ingest/delete that won between passes supersede this snapshot.
+        for document_id in candidates {
+            let _write = writes.acquire(document_id).await;
+            let current = match store.get_document(document_id).await {
+                Ok(Some(document)) => document,
+                Ok(None) => {
+                    report.skipped += 1;
+                    continue;
+                }
+                Err(error) => {
+                    report.failures.push(IndexRepairFailure {
+                        document_id,
+                        error: error.to_string(),
+                    });
+                    continue;
+                }
+            };
+            let document = canonical_document(&current);
+            if current.indexed_revision == Some(current.content_revision)
+                && current.index_fingerprint.as_deref() == Some(fingerprint.as_str())
+            {
+                match retrieval.index_is_complete(&document).await {
+                    Ok(true) => {
+                        report.skipped += 1;
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        report.failures.push(IndexRepairFailure {
+                            document_id: current.id,
+                            error: error.to_string(),
+                        });
+                        continue;
+                    }
+                }
+            }
+            if let Err(error) = retrieval.index_document(&document).await {
+                report.failures.push(IndexRepairFailure {
+                    document_id: current.id,
+                    error: error.to_string(),
+                });
+                continue;
+            }
+
+            self.pending_watermarks.insert(
+                current.id,
+                PendingWatermark {
+                    revision: current.content_revision,
+                    revision_token: current.revision_token,
+                    fingerprint: fingerprint.clone(),
+                },
+            );
+
+            match store
+                .mark_document_indexed(
+                    current.id,
+                    current.content_revision,
+                    current.revision_token,
+                    &fingerprint,
+                    Utc::now(),
+                )
+                .await
+            {
+                Ok(true) => {
+                    self.pending_watermarks.remove(&current.id);
+                    report.repaired += 1;
+                }
+                Ok(false) => {
+                    self.pending_watermarks.remove(&current.id);
+                    report.failures.push(IndexRepairFailure {
+                        document_id: current.id,
+                        error: "document changed before its repair watermark committed".into(),
+                    });
+                }
+                Err(error) => report.failures.push(IndexRepairFailure {
+                    document_id: current.id,
+                    error: error.to_string(),
+                }),
+            }
+        }
+
+        Ok(report)
+    }
+}
+
+fn canonical_document(record: &DocumentRecord) -> Document {
+    let source = match record.source_uri.clone() {
+        Some(uri) => DocumentSource::uri(uri),
+        None => DocumentSource::Inline,
+    };
+    Document::with_id(
+        record.id,
+        source,
+        record.media_type.clone(),
+        record.canonical_text.clone(),
+    )
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -17,6 +17,7 @@ mod bus;
 mod error;
 mod extract;
 mod hub;
+mod index_repair;
 mod provider;
 mod providers;
 mod resolver;
@@ -25,6 +26,7 @@ mod state;
 
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::http::{header, Method};
 use axum::routing::{get, post};
@@ -135,6 +137,15 @@ pub struct Server {
     token: Arc<str>,
     listener: TcpListener,
     router: Router,
+    _index_repair: AbortTask,
+}
+
+struct AbortTask(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 impl Server {
@@ -181,6 +192,10 @@ pub async fn bind(config: Config) -> Result<Server> {
         agent_config,
     );
     let token = state.token.clone();
+    let repair_store = state.store.clone();
+    let repair_retrieval = state.retrieval.clone();
+    let repair_writes = state.document_writes.clone();
+    let repair_wake = state.index_repair_wake.clone();
     let router = app(state);
 
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
@@ -190,11 +205,68 @@ pub async fn bind(config: Config) -> Result<Server> {
         .local_addr()
         .map_err(|e| AgentError::config(format!("no local address: {e}")))?;
 
+    let index_repair = tokio::spawn(async move {
+        let mut repairer = index_repair::IndexRepairer::default();
+        let mut failure_delay = Duration::from_secs(60);
+        loop {
+            let retry_soon = match repairer
+                .repair(
+                    repair_store.clone(),
+                    repair_retrieval.clone(),
+                    repair_writes.clone(),
+                )
+                .await
+            {
+                Ok(report) => {
+                    let retry_soon = !report.failures.is_empty();
+                    if report.repaired > 0 || retry_soon {
+                        eprintln!(
+                            "openwave: document index repair scanned {}, repaired {}, skipped {}, failed {}",
+                            report.scanned,
+                            report.repaired,
+                            report.skipped,
+                            report.failures.len()
+                        );
+                        for failure in report.failures {
+                            eprintln!(
+                                "openwave: document index repair failed for {}: {}",
+                                failure.document_id, failure.error
+                            );
+                        }
+                    }
+                    retry_soon
+                }
+                Err(error) => {
+                    eprintln!("openwave: document index repair scan failed: {error}");
+                    true
+                }
+            };
+            let base_delay = if retry_soon {
+                let delay = failure_delay;
+                failure_delay = failure_delay
+                    .saturating_mul(5)
+                    .min(Duration::from_secs(6 * 60 * 60));
+                delay
+            } else {
+                failure_delay = Duration::from_secs(60);
+                Duration::from_secs(6 * 60 * 60)
+            };
+            let jitter_bound = (base_delay.as_secs() / 10).max(1);
+            let jitter = (uuid::Uuid::new_v4().as_u128() % u128::from(jitter_bound)) as u64;
+            let delay = base_delay.saturating_add(Duration::from_secs(jitter));
+            tokio::select! {
+                _ = tokio::time::sleep(delay) => {}
+                _ = repair_wake.notified() => {}
+            }
+        }
+    });
+
     Ok(Server {
         local_addr,
         token,
         listener,
         router,
+        _index_repair: AbortTask(index_repair),
     })
 }
 
@@ -579,6 +651,7 @@ mod tests {
         release: Arc<Notify>,
         blocked: std::sync::atomic::AtomicBool,
         fail_document_delete: std::sync::atomic::AtomicBool,
+        fail_document_mark: std::sync::atomic::AtomicBool,
     }
 
     impl PauseTerminalStore {
@@ -589,11 +662,16 @@ mod tests {
                 release,
                 blocked: std::sync::atomic::AtomicBool::new(false),
                 fail_document_delete: std::sync::atomic::AtomicBool::new(false),
+                fail_document_mark: std::sync::atomic::AtomicBool::new(false),
             }
         }
 
         fn fail_next_document_delete(&self) {
             self.fail_document_delete.store(true, Ordering::SeqCst);
+        }
+
+        fn fail_next_document_mark(&self) {
+            self.fail_document_mark.store(true, Ordering::SeqCst);
         }
     }
 
@@ -655,6 +733,11 @@ mod tests {
             fingerprint: &str,
             indexed_at: chrono::DateTime<chrono::Utc>,
         ) -> Result<bool> {
+            if self.fail_document_mark.swap(false, Ordering::SeqCst) {
+                return Err(AgentError::Store(
+                    "injected document watermark failure".into(),
+                ));
+            }
             self.inner
                 .mark_document_indexed(id, revision, revision_token, fingerprint, indexed_at)
                 .await
@@ -749,6 +832,42 @@ mod tests {
             .unwrap(),
         );
         test_app_from_parts(provider, retrieval, store, dir)
+    }
+
+    async fn test_app_with_retrieval_and_wake(
+        provider: Arc<dyn ModelProvider>,
+        retrieval: Arc<Retriever>,
+    ) -> (
+        Router,
+        Arc<str>,
+        Arc<dyn Store>,
+        tempfile::TempDir,
+        Arc<Notify>,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let state = AppState::new(
+            Config::desktop(dir.path()),
+            store.clone(),
+            Arc::new(FixedResolver(provider)),
+            Arc::new(MemSecrets::default()),
+            Arc::new(ToolRegistry::new()),
+            retrieval,
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        );
+        let token = state.token.clone();
+        let wake = state.index_repair_wake.clone();
+        (app(state), token, store, dir, wake)
     }
 
     fn test_app_from_parts(
@@ -1130,8 +1249,8 @@ mod tests {
             Arc::new(FailingEmbedder),
             Arc::new(InMemoryVectorStore::new(8)),
         ));
-        let (router, token, store, _dir) =
-            test_app_with_retrieval(Arc::new(FakeProvider), retrieval).await;
+        let (router, token, store, _dir, repair_wake) =
+            test_app_with_retrieval_and_wake(Arc::new(FakeProvider), retrieval).await;
         let bearer = format!("Bearer {token}");
 
         let response = post_json(
@@ -1158,6 +1277,9 @@ mod tests {
         assert_eq!(record.content_revision, 1);
         assert_eq!(record.indexed_revision, None);
         assert_eq!(record.index_fingerprint, None);
+        tokio::time::timeout(Duration::from_millis(100), repair_wake.notified())
+            .await
+            .expect("failed live ingest should wake index repair");
     }
 
     #[tokio::test]
@@ -1505,6 +1627,289 @@ mod tests {
         }
 
         assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn index_repair_rebuilds_missing_rows_despite_a_current_watermark() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("repair.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            Arc::new(HashEmbedder::default()),
+            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        ));
+        let writes = Arc::new(crate::state::DocumentWriteGuard::default());
+        let upsert = openwave_core::DocumentUpsert {
+            id: openwave_core::DocumentId::derive("file:///repair.txt"),
+            project_id: None,
+            source_uri: Some("file:///repair.txt".into()),
+            media_type: "text/plain".into(),
+            title: None,
+            canonical_text: "repair this durable source".into(),
+            updated_at: chrono::Utc::now(),
+        };
+        let revision = store.upsert_document(&upsert).await.unwrap();
+        let fingerprint = retrieval.index_fingerprint();
+        assert!(store
+            .mark_document_indexed(
+                revision.id,
+                revision.content_revision,
+                revision.revision_token,
+                &fingerprint,
+                chrono::Utc::now(),
+            )
+            .await
+            .unwrap());
+
+        let report =
+            index_repair::repair_document_index(store.clone(), retrieval.clone(), writes.clone())
+                .await
+                .unwrap();
+        assert_eq!(report.scanned, 1);
+        assert_eq!(report.repaired, 1);
+        assert_eq!(report.skipped, 0);
+        assert!(report.failures.is_empty());
+        let repaired = store.get_document(revision.id).await.unwrap().unwrap();
+        assert_eq!(repaired.indexed_revision, Some(1));
+        assert_eq!(
+            repaired.index_fingerprint.as_deref(),
+            Some(fingerprint.as_str())
+        );
+        let hits = retrieval.search("durable source", 1).await.unwrap();
+        assert_eq!(hits[0].document_id, revision.id);
+
+        let second = index_repair::repair_document_index(store, retrieval, writes)
+            .await
+            .unwrap();
+        assert_eq!(second.scanned, 1);
+        assert_eq!(second.repaired, 0);
+        assert_eq!(second.skipped, 1);
+        assert!(second.failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn index_repair_invalidates_all_stale_rows_before_embedding() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("repair-invalidation.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let vectors = Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS));
+        let seed_retrieval = Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            Arc::new(HashEmbedder::default()),
+            vectors.clone(),
+        );
+        let mut revisions = Vec::new();
+        for (id, text) in [
+            (openwave_core::DocumentId::new(), "first stale source"),
+            (openwave_core::DocumentId::new(), "second stale source"),
+        ] {
+            let revision = store
+                .upsert_document(&openwave_core::DocumentUpsert {
+                    id,
+                    project_id: None,
+                    source_uri: None,
+                    media_type: "text/plain".into(),
+                    title: None,
+                    canonical_text: text.into(),
+                    updated_at: chrono::Utc::now(),
+                })
+                .await
+                .unwrap();
+            let document = openwave_retrieval::Document::with_id(
+                id,
+                openwave_retrieval::DocumentSource::Inline,
+                "text/plain",
+                text,
+            );
+            seed_retrieval.index_document(&document).await.unwrap();
+            assert!(store
+                .mark_document_indexed(
+                    id,
+                    revision.content_revision,
+                    revision.revision_token,
+                    "obsolete-pipeline",
+                    chrono::Utc::now(),
+                )
+                .await
+                .unwrap());
+            revisions.push(revision);
+        }
+
+        let embedder = Arc::new(FirstBatchGatedEmbedder {
+            inner: HashEmbedder::default(),
+            calls: AtomicUsize::new(0),
+            entered: Notify::new(),
+            release: Notify::new(),
+        });
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            embedder.clone(),
+            vectors.clone(),
+        ));
+        let repair = tokio::spawn(index_repair::repair_document_index(
+            store,
+            retrieval,
+            Arc::new(crate::state::DocumentWriteGuard::default()),
+        ));
+        tokio::time::timeout(Duration::from_secs(1), embedder.entered.notified())
+            .await
+            .expect("repair did not reach embedding");
+
+        for revision in &revisions {
+            assert_eq!(vectors.document_len(revision.id).await.unwrap(), Some(0));
+        }
+        embedder.release.notify_one();
+        let report = repair.await.unwrap().unwrap();
+        assert_eq!(report.repaired, 2);
+        assert!(report.failures.is_empty());
+    }
+
+    #[tokio::test]
+    async fn index_repair_isolates_document_failures_and_keeps_them_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("repair-failure.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            Arc::new(FailingEmbedder),
+            Arc::new(InMemoryVectorStore::new(8)),
+        ));
+        let revision = store
+            .upsert_document(&openwave_core::DocumentUpsert {
+                id: openwave_core::DocumentId::new(),
+                project_id: None,
+                source_uri: None,
+                media_type: "text/plain".into(),
+                title: None,
+                canonical_text: "retry later".into(),
+                updated_at: chrono::Utc::now(),
+            })
+            .await
+            .unwrap();
+
+        let report = index_repair::repair_document_index(
+            store.clone(),
+            retrieval,
+            Arc::new(crate::state::DocumentWriteGuard::default()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(report.scanned, 1);
+        assert_eq!(report.repaired, 0);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].document_id, revision.id);
+        assert!(report.failures[0]
+            .error
+            .contains("injected embedding failure"));
+        assert_eq!(
+            store
+                .get_document(revision.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .indexed_revision,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn index_repair_retries_a_pending_watermark_without_reembedding() {
+        let dir = tempfile::tempdir().unwrap();
+        let inner: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("repair-watermark.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let store = Arc::new(PauseTerminalStore::new(
+            inner,
+            Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
+        ));
+        let embedder = Arc::new(FailAfterFirstBatchEmbedder {
+            inner: HashEmbedder::default(),
+            calls: AtomicUsize::new(0),
+        });
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::default()),
+            embedder.clone(),
+            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        ));
+        let revision = store
+            .upsert_document(&openwave_core::DocumentUpsert {
+                id: openwave_core::DocumentId::new(),
+                project_id: None,
+                source_uri: None,
+                media_type: "text/plain".into(),
+                title: None,
+                canonical_text: "embed exactly once".into(),
+                updated_at: chrono::Utc::now(),
+            })
+            .await
+            .unwrap();
+        store.fail_next_document_mark();
+        let writes = Arc::new(crate::state::DocumentWriteGuard::default());
+        let mut repairer = index_repair::IndexRepairer::default();
+
+        let first = repairer
+            .repair(store.clone(), retrieval.clone(), writes.clone())
+            .await
+            .unwrap();
+        assert_eq!(first.repaired, 0);
+        assert_eq!(first.failures.len(), 1);
+        assert_eq!(embedder.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            store
+                .get_document(revision.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .indexed_revision,
+            None
+        );
+
+        let second = repairer
+            .repair(store.clone(), retrieval, writes)
+            .await
+            .unwrap();
+        assert_eq!(second.repaired, 1);
+        assert!(second.failures.is_empty());
+        assert_eq!(embedder.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            store
+                .get_document(revision.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .indexed_revision,
+            Some(revision.content_revision)
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -4,6 +4,7 @@
 //! start a turn, and the WebSocket stream of a chat's turn events.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
@@ -28,6 +29,35 @@ use crate::state::AppState;
 
 /// The store-settings key for the selected model.
 const MODEL_SETTING: &str = "model";
+
+/// Notifies the reconciler if a source/index lifecycle exits before reaching a
+/// consistent terminal state. `Notify` retains a permit while the repair loop
+/// is busy, so failures cannot be lost between scans.
+struct RepairWake {
+    notify: Arc<tokio::sync::Notify>,
+    armed: bool,
+}
+
+impl RepairWake {
+    fn new(notify: Arc<tokio::sync::Notify>) -> Self {
+        Self {
+            notify,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for RepairWake {
+    fn drop(&mut self) {
+        if self.armed {
+            self.notify.notify_one();
+        }
+    }
+}
 
 /// Runtime settings a client can read. The API key itself is never returned —
 /// it lives in the `SecretProvider`, not the store — only whether one is set.
@@ -485,10 +515,12 @@ pub async fn ingest_document(
         DocumentSource::Inline => None,
         _ => None,
     };
+    let mut repair_wake = None;
     // Retire the prior revision before publishing a replacement. If either
     // watermark clearing or vector deletion fails, the old source remains
     // authoritative; after clearing, any interruption is visible to repair.
     if let Some(current) = state.store.get_document(document.id).await? {
+        repair_wake = Some(RepairWake::new(state.index_repair_wake.clone()));
         let cleared = state
             .store
             .clear_document_index(current.id, current.content_revision, current.revision_token)
@@ -517,6 +549,9 @@ pub async fn ingest_document(
             updated_at: Utc::now(),
         })
         .await?;
+    if repair_wake.is_none() {
+        repair_wake = Some(RepairWake::new(state.index_repair_wake.clone()));
+    }
     let chunks = state
         .retrieval
         .index_document(&document)
@@ -538,6 +573,10 @@ pub async fn ingest_document(
             document.id
         )));
     }
+    repair_wake
+        .as_mut()
+        .expect("a persisted document always arms repair")
+        .disarm();
     Ok((
         StatusCode::CREATED,
         Json(IngestResult {
@@ -612,7 +651,9 @@ pub async fn delete_document(
     Path(id): Path<DocumentId>,
 ) -> Result<StatusCode, ServerError> {
     let _write = state.document_writes.acquire(id).await;
+    let mut repair_wake = None;
     if let Some(document) = state.store.get_document(id).await? {
+        repair_wake = Some(RepairWake::new(state.index_repair_wake.clone()));
         let cleared = state
             .store
             .clear_document_index(id, document.content_revision, document.revision_token)
@@ -625,6 +666,9 @@ pub async fn delete_document(
     }
     state.retrieval.delete(id).await.map_err(retrieval_error)?;
     state.store.delete_document(id).await?;
+    if let Some(wake) = repair_wake.as_mut() {
+        wake.disarm();
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -8,7 +8,7 @@ use openwave_core::{
     ToolRegistry,
 };
 use openwave_retrieval::Retriever;
-use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use tokio::sync::{Mutex as AsyncMutex, Notify, OwnedMutexGuard};
 use uuid::Uuid;
 
 use crate::approvals::ApprovalBroker;
@@ -39,6 +39,9 @@ pub struct AppState {
     /// Serializes source, index, and watermark writes for one document while
     /// allowing unrelated documents to ingest concurrently.
     pub document_writes: Arc<DocumentWriteGuard>,
+    /// Wakes the background reconciler when a live document operation leaves
+    /// authoritative source in a stale, rebuildable state.
+    pub(crate) index_repair_wake: Arc<Notify>,
     /// Per-turn agent tuning (model, limits, …).
     pub agent_config: AgentConfig,
     /// The secret every request must present as `Authorization: Bearer <token>`.
@@ -72,6 +75,7 @@ impl AppState {
             tools,
             retrieval,
             document_writes: Arc::new(DocumentWriteGuard::default()),
+            index_repair_wake: Arc::new(Notify::new()),
             agent_config,
             token: Uuid::new_v4().to_string().into(),
             active_turns: Arc::new(TurnGuard::default()),


### PR DESCRIPTION
## Summary

- scan the authoritative document catalog when the server starts and periodically repair stale, pipeline-mismatched, or physically incomplete index rows in the background
- re-fetch each candidate under the same per-document lifecycle lock used by ingest and delete
- verify physical chunk coverage against the active chunker so recreated or partially lost vector indexes are rebuilt even when catalog watermarks look current
- keep canonical parser provenance separate from the chunker/embedder fingerprint because parser upgrades require original bytes, not canonical text alone
- invalidate every stale candidate before beginning embedding, then rebuild from canonical text and compare-and-set the exact revision/token watermark
- retain successful-but-unmarked writes so watermark retries never re-embed, and back off failed scans from one minute to six hours with jitter
- project only document ids for maintenance scans, reconcile healthy catalogs every six hours, and abort the task with the owning server
- cover physical row loss, fast multi-document invalidation, watermark-only retry, searchable rebuilt content, current-record skipping, idempotent follow-up scans, and per-document failure isolation

## Validation

- `bw --repo-root "$PWD" dev lint --rust`
- `cargo clippy -p openwave-server --all-targets -- -D warnings`
- `cargo test -p openwave-retrieval --features vec-lance`
- `cargo test -p openwave-server --lib`
