### PR TITLE
feat(server): audit document index generations

### DIFF
--- a/crates/openwave-core/src/db.rs
+++ b/crates/openwave-core/src/db.rs
@@ -26,7 +26,7 @@ use crate::model::{
     DocumentProcessingStatus, DocumentRecord, DocumentScope, DocumentSummaryRecord, DocumentUpsert,
     Message, Project, Role, ToolCallRecord,
 };
-use crate::storage::Store;
+use crate::storage::{DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, Store};
 
 /// Map any SeaORM failure into an [`AgentError::Store`].
 fn store_err(err: impl std::fmt::Display) -> AgentError {
@@ -540,6 +540,207 @@ impl Store for DbStore {
             .map_err(store_err)?
             .map(document_job_from_model)
             .transpose()
+    }
+
+    async fn ensure_document_index_job(
+        &self,
+        document_id: DocumentId,
+        expected_generation: DocumentGeneration,
+        pipeline_fingerprint: &str,
+        max_attempts: i32,
+        reason: DocumentIndexJobReason,
+    ) -> Result<EnsureDocumentIndexJobOutcome> {
+        if pipeline_fingerprint.is_empty()
+            || pipeline_fingerprint.chars().count() > DocumentJob::MAX_PIPELINE_FINGERPRINT_LEN
+        {
+            return Err(AgentError::Store(
+                "document job pipeline fingerprint must contain 1 to 512 characters".into(),
+            ));
+        }
+        if max_attempts < 1 {
+            return Err(AgentError::Store(
+                "document job max_attempts must be at least one".into(),
+            ));
+        }
+
+        loop {
+            let transaction = self.conn.begin().await.map_err(store_err)?;
+            acquire_document_write_lock(&transaction, document_id).await?;
+            let Some(document) = entities::document::Entity::find_by_id(document_id.0)
+                .one(&transaction)
+                .await
+                .map_err(store_err)?
+            else {
+                transaction.commit().await.map_err(store_err)?;
+                return Ok(EnsureDocumentIndexJobOutcome::MissingDocument);
+            };
+            ensure_live_document_generation_on(&transaction, &document).await?;
+            let current_generation = DocumentGeneration {
+                content_revision: document.content_revision,
+                revision_token: document.revision_token,
+            };
+
+            if current_generation != expected_generation {
+                if reason.advances_generation()
+                    && expected_generation
+                        .content_revision
+                        .checked_add(1)
+                        .is_some_and(|revision| revision == document.content_revision)
+                {
+                    if let Some(job) = find_exact_document_index_job_on(
+                        &transaction,
+                        document_id,
+                        current_generation,
+                        pipeline_fingerprint,
+                    )
+                    .await?
+                    {
+                        let job = document_job_from_model(job)?;
+                        transaction.commit().await.map_err(store_err)?;
+                        return Ok(if job.status == DocumentJobStatus::Failed {
+                            EnsureDocumentIndexJobOutcome::Failed(job)
+                        } else {
+                            EnsureDocumentIndexJobOutcome::Existing(job)
+                        });
+                    }
+                }
+                transaction.commit().await.map_err(store_err)?;
+                return Ok(EnsureDocumentIndexJobOutcome::GenerationChanged(
+                    current_generation,
+                ));
+            }
+
+            if let Some(candidate) = find_exact_document_index_job_on(
+                &transaction,
+                document_id,
+                current_generation,
+                pipeline_fingerprint,
+            )
+            .await?
+            {
+                let parsed = document_job_from_model(candidate.clone())?;
+                if matches!(
+                    parsed.status,
+                    DocumentJobStatus::Queued
+                        | DocumentJobStatus::Running
+                        | DocumentJobStatus::RetryWait
+                ) || (reason == DocumentIndexJobReason::PipelineChanged
+                    && parsed.status == DocumentJobStatus::Succeeded)
+                {
+                    transaction.commit().await.map_err(store_err)?;
+                    return Ok(EnsureDocumentIndexJobOutcome::Existing(parsed));
+                }
+                if parsed.status == DocumentJobStatus::Failed {
+                    transaction.commit().await.map_err(store_err)?;
+                    return Ok(EnsureDocumentIndexJobOutcome::Failed(parsed));
+                }
+                if reason == DocumentIndexJobReason::DerivedStateMissing {
+                    let now = Utc::now();
+                    reset_document_index_job_on(
+                        &transaction,
+                        candidate.id,
+                        &candidate.status,
+                        max_attempts,
+                        now,
+                    )
+                    .await?;
+                    clear_document_index_watermark_on(
+                        &transaction,
+                        document_id,
+                        current_generation,
+                    )
+                    .await?;
+                    let job = entities::document_job::Entity::find_by_id(candidate.id)
+                        .one(&transaction)
+                        .await
+                        .map_err(store_err)?
+                        .ok_or_else(|| {
+                            AgentError::Store("reset document job disappeared".into())
+                        })?;
+                    let job = document_job_from_model(job)?;
+                    transaction.commit().await.map_err(store_err)?;
+                    return Ok(EnsureDocumentIndexJobOutcome::Enqueued(job));
+                }
+            }
+
+            let target_generation = if reason.advances_generation() {
+                let Some(advanced) =
+                    try_advance_document_generation_on(&transaction, document_id, false).await?
+                else {
+                    transaction.rollback().await.map_err(store_err)?;
+                    continue;
+                };
+                if advanced.previous != Some(current_generation) {
+                    return Err(AgentError::Store(format!(
+                        "document {document_id} does not match its retained generation clock"
+                    )));
+                }
+                let updated = entities::document::Entity::update_many()
+                    .col_expr(
+                        entities::document::Column::ContentRevision,
+                        sea_orm::sea_query::Expr::value(advanced.current.content_revision),
+                    )
+                    .col_expr(
+                        entities::document::Column::RevisionToken,
+                        sea_orm::sea_query::Expr::value(advanced.current.revision_token),
+                    )
+                    .col_expr(
+                        entities::document::Column::ProcessingStatus,
+                        sea_orm::sea_query::Expr::value(DocumentProcessingStatus::Queued.as_str()),
+                    )
+                    .col_expr(
+                        entities::document::Column::IndexedRevision,
+                        sea_orm::sea_query::Expr::value(Option::<i64>::None),
+                    )
+                    .col_expr(
+                        entities::document::Column::IndexFingerprint,
+                        sea_orm::sea_query::Expr::value(Option::<String>::None),
+                    )
+                    .col_expr(
+                        entities::document::Column::IndexedAt,
+                        sea_orm::sea_query::Expr::value(
+                            Option::<chrono::DateTime<chrono::Utc>>::None,
+                        ),
+                    )
+                    .filter(entities::document::Column::Id.eq(document_id.0))
+                    .filter(
+                        entities::document::Column::ContentRevision
+                            .eq(current_generation.content_revision),
+                    )
+                    .filter(
+                        entities::document::Column::RevisionToken
+                            .eq(current_generation.revision_token),
+                    )
+                    .exec(&transaction)
+                    .await
+                    .map_err(store_err)?;
+                if updated.rows_affected != 1 {
+                    transaction.rollback().await.map_err(store_err)?;
+                    continue;
+                }
+                advanced.current
+            } else {
+                clear_document_index_watermark_on(&transaction, document_id, current_generation)
+                    .await?;
+                current_generation
+            };
+
+            let now = Utc::now();
+            cancel_live_document_jobs_on(&transaction, document_id, now).await?;
+            let job = new_document_index_job(
+                document_id,
+                target_generation,
+                pipeline_fingerprint,
+                max_attempts,
+                now,
+            );
+            document_job_active_model(&job)
+                .insert(&transaction)
+                .await
+                .map_err(store_err)?;
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(EnsureDocumentIndexJobOutcome::Enqueued(job));
+        }
     }
 
     async fn list_document_jobs(&self, document_id: DocumentId) -> Result<Vec<DocumentJob>> {
@@ -1554,6 +1755,203 @@ where
         .await
         .map_err(store_err)?;
     Ok(())
+}
+
+async fn find_exact_document_index_job_on<C>(
+    conn: &C,
+    document_id: DocumentId,
+    generation: DocumentGeneration,
+    pipeline_fingerprint: &str,
+) -> Result<Option<entities::document_job::Model>>
+where
+    C: ConnectionTrait,
+{
+    entities::document_job::Entity::find()
+        .filter(entities::document_job::Column::DocumentId.eq(document_id.0))
+        .filter(entities::document_job::Column::ContentRevision.eq(generation.content_revision))
+        .filter(entities::document_job::Column::RevisionToken.eq(generation.revision_token))
+        .filter(entities::document_job::Column::Kind.eq(DocumentJobKind::Index.as_str()))
+        .filter(entities::document_job::Column::PipelineFingerprint.eq(pipeline_fingerprint))
+        .one(conn)
+        .await
+        .map_err(store_err)
+}
+
+async fn clear_document_index_watermark_on<C>(
+    conn: &C,
+    document_id: DocumentId,
+    generation: DocumentGeneration,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let updated = entities::document::Entity::update_many()
+        .col_expr(
+            entities::document::Column::ProcessingStatus,
+            sea_orm::sea_query::Expr::value(DocumentProcessingStatus::Queued.as_str()),
+        )
+        .col_expr(
+            entities::document::Column::IndexedRevision,
+            sea_orm::sea_query::Expr::value(Option::<i64>::None),
+        )
+        .col_expr(
+            entities::document::Column::IndexFingerprint,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::document::Column::IndexedAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .filter(entities::document::Column::Id.eq(document_id.0))
+        .filter(entities::document::Column::ContentRevision.eq(generation.content_revision))
+        .filter(entities::document::Column::RevisionToken.eq(generation.revision_token))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "document {document_id} generation changed during index maintenance"
+        )));
+    }
+    Ok(())
+}
+
+async fn cancel_live_document_jobs_on<C>(
+    conn: &C,
+    document_id: DocumentId,
+    now: chrono::DateTime<Utc>,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    entities::document_job::Entity::update_many()
+        .col_expr(
+            entities::document_job::Column::Status,
+            sea_orm::sea_query::Expr::value(DocumentJobStatus::Cancelled.as_str()),
+        )
+        .col_expr(
+            entities::document_job::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            entities::document_job::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::document_job::Column::DocumentId.eq(document_id.0))
+        .filter(entities::document_job::Column::Status.is_in([
+            DocumentJobStatus::Queued.as_str(),
+            DocumentJobStatus::Running.as_str(),
+            DocumentJobStatus::RetryWait.as_str(),
+        ]))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+async fn reset_document_index_job_on<C>(
+    conn: &C,
+    id: uuid::Uuid,
+    expected_status: &str,
+    max_attempts: i32,
+    now: chrono::DateTime<Utc>,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let updated = entities::document_job::Entity::update_many()
+        .col_expr(
+            entities::document_job::Column::Status,
+            sea_orm::sea_query::Expr::value(DocumentJobStatus::Queued.as_str()),
+        )
+        .col_expr(
+            entities::document_job::Column::AttemptCount,
+            sea_orm::sea_query::Expr::value(0),
+        )
+        .col_expr(
+            entities::document_job::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(max_attempts),
+        )
+        .col_expr(
+            entities::document_job::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .col_expr(
+            entities::document_job::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::StartedAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::document_job::Column::Id.eq(id))
+        .filter(entities::document_job::Column::Status.eq(expected_status))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "document job {id} changed during index maintenance"
+        )));
+    }
+    Ok(())
+}
+
+fn new_document_index_job(
+    document_id: DocumentId,
+    generation: DocumentGeneration,
+    pipeline_fingerprint: &str,
+    max_attempts: i32,
+    now: chrono::DateTime<Utc>,
+) -> DocumentJob {
+    DocumentJob {
+        id: DocumentJobId::new(),
+        document_id,
+        content_revision: generation.content_revision,
+        revision_token: generation.revision_token,
+        kind: DocumentJobKind::Index,
+        status: DocumentJobStatus::Queued,
+        pipeline_fingerprint: pipeline_fingerprint.into(),
+        attempt_count: 0,
+        max_attempts,
+        available_at: now,
+        lease_token: None,
+        lease_expires_at: None,
+        started_at: None,
+        finished_at: None,
+        last_error_code: None,
+        last_error_detail: None,
+        created_at: now,
+        updated_at: now,
+    }
 }
 
 /// Start SQLite's write transaction before claim candidate reads.
@@ -3743,6 +4141,249 @@ mod tests {
         assert!(remaining.is_empty());
     }
 
+    async fn ready_document(store: &DbStore, source: &DocumentUpsert) -> DocumentRecord {
+        let (document, job) = store
+            .upsert_document_and_enqueue_index(source, "pipeline-v1", 3)
+            .await
+            .unwrap();
+        let claim_at = job.available_at + chrono::Duration::seconds(1);
+        let claimed = store
+            .claim_document_job(claim_at, claim_at + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(store
+            .complete_document_index_job(
+                claimed.id,
+                claimed.lease_token.unwrap(),
+                claim_at + chrono::Duration::seconds(1),
+            )
+            .await
+            .unwrap());
+        store.get_document(document.id).await.unwrap().unwrap()
+    }
+
+    #[tokio::test]
+    async fn missing_derived_state_requeues_succeeded_job_without_advancing_generation() {
+        let (_dir, store) = temp_store().await;
+        let source = DocumentUpsert {
+            id: DocumentId::new(),
+            project_id: None,
+            source_uri: Some("file:///missing-derived.txt".into()),
+            media_type: "text/plain".into(),
+            title: Some("missing derived".into()),
+            canonical_text: "same authoritative source".into(),
+            updated_at: DateTime::<Utc>::from_timestamp(9_000, 0).unwrap(),
+        };
+        let ready = ready_document(&store, &source).await;
+        let original_job = store.list_document_jobs(source.id).await.unwrap().remove(0);
+
+        let outcome = store
+            .ensure_document_index_job(
+                source.id,
+                ready.generation(),
+                "pipeline-v1",
+                7,
+                DocumentIndexJobReason::DerivedStateMissing,
+            )
+            .await
+            .unwrap();
+        let EnsureDocumentIndexJobOutcome::Enqueued(job) = outcome else {
+            panic!("expected requeued job")
+        };
+        assert_eq!(job.id, original_job.id);
+        assert_eq!(job.generation(), ready.generation());
+        assert_eq!(job.status, DocumentJobStatus::Queued);
+        assert_eq!(job.max_attempts, 7);
+        let current = store.get_document(source.id).await.unwrap().unwrap();
+        assert_eq!(current.generation(), ready.generation());
+        assert_eq!(current.processing_status, DocumentProcessingStatus::Queued);
+        assert_eq!(current.indexed_revision, None);
+        assert_eq!(current.index_fingerprint, None);
+    }
+
+    #[tokio::test]
+    async fn index_maintenance_does_not_implicitly_revive_failed_job() {
+        let (_dir, store) = temp_store().await;
+        let source = DocumentUpsert {
+            id: DocumentId::new(),
+            project_id: None,
+            source_uri: Some("file:///failed-maintenance.txt".into()),
+            media_type: "text/plain".into(),
+            title: None,
+            canonical_text: "requires an explicit retry".into(),
+            updated_at: DateTime::<Utc>::from_timestamp(9_050, 0).unwrap(),
+        };
+        let (document, job) = store
+            .upsert_document_and_enqueue_index(&source, "pipeline-v1", 1)
+            .await
+            .unwrap();
+        let claim_at = job.available_at + chrono::Duration::seconds(1);
+        let claimed = store
+            .claim_document_job(claim_at, claim_at + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            store
+                .record_document_job_failure(
+                    claimed.id,
+                    claimed.lease_token.unwrap(),
+                    claim_at + chrono::Duration::seconds(1),
+                    None,
+                    "embed_failed",
+                    None,
+                )
+                .await
+                .unwrap(),
+            Some(DocumentJobStatus::Failed)
+        );
+
+        let outcome = store
+            .ensure_document_index_job(
+                source.id,
+                document.generation(),
+                "pipeline-v1",
+                5,
+                DocumentIndexJobReason::DerivedStateMissing,
+            )
+            .await
+            .unwrap();
+        let EnsureDocumentIndexJobOutcome::Failed(failed) = outcome else {
+            panic!("failed maintenance job must remain a stable no-op")
+        };
+        assert_eq!(failed.id, job.id);
+        assert_eq!(failed.max_attempts, 1);
+        assert_eq!(
+            store
+                .get_document(source.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .processing_status,
+            DocumentProcessingStatus::Failed
+        );
+    }
+
+    #[tokio::test]
+    async fn incomplete_succeeded_generation_advances_once_and_reuses_the_new_job() {
+        let (_dir, store) = temp_store().await;
+        let source = DocumentUpsert {
+            id: DocumentId::new(),
+            project_id: None,
+            source_uri: Some("file:///incomplete-derived.txt".into()),
+            media_type: "text/plain".into(),
+            title: Some("incomplete derived".into()),
+            canonical_text: "source remains stable".into(),
+            updated_at: DateTime::<Utc>::from_timestamp(9_075, 0).unwrap(),
+        };
+        let ready = ready_document(&store, &source).await;
+        let succeeded = store.list_document_jobs(source.id).await.unwrap().remove(0);
+        assert_eq!(succeeded.status, DocumentJobStatus::Succeeded);
+
+        let first = store
+            .ensure_document_index_job(
+                source.id,
+                ready.generation(),
+                "pipeline-v1",
+                4,
+                DocumentIndexJobReason::DerivedStateIncomplete,
+            )
+            .await
+            .unwrap();
+        let EnsureDocumentIndexJobOutcome::Enqueued(job) = first else {
+            panic!("incomplete succeeded state must advance and enqueue")
+        };
+        assert_ne!(job.id, succeeded.id);
+        assert_eq!(job.content_revision, ready.content_revision + 1);
+
+        assert_eq!(
+            store
+                .ensure_document_index_job(
+                    source.id,
+                    ready.generation(),
+                    "pipeline-v1",
+                    4,
+                    DocumentIndexJobReason::DerivedStateIncomplete,
+                )
+                .await
+                .unwrap(),
+            EnsureDocumentIndexJobOutcome::Existing(job.clone())
+        );
+        let current = store.get_document(source.id).await.unwrap().unwrap();
+        assert_eq!(current.generation(), job.generation());
+        assert_eq!(current.canonical_text, ready.canonical_text);
+        assert_eq!(current.created_at, ready.created_at);
+        assert_eq!(current.updated_at, ready.updated_at);
+        assert_eq!(store.list_document_jobs(source.id).await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_pipeline_change_advances_once_and_preserves_source() {
+        let (_dir, store) = temp_store().await;
+        let source = DocumentUpsert {
+            id: DocumentId::new(),
+            project_id: None,
+            source_uri: Some("file:///pipeline-change.txt".into()),
+            media_type: "text/plain".into(),
+            title: Some("pipeline change".into()),
+            canonical_text: "same authoritative source".into(),
+            updated_at: DateTime::<Utc>::from_timestamp(9_100, 0).unwrap(),
+        };
+        let ready = ready_document(&store, &source).await;
+        let document_id = source.id;
+        let store = std::sync::Arc::new(store);
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let store = store.clone();
+            let barrier = barrier.clone();
+            let generation = ready.generation();
+            tasks.push(tokio::spawn(async move {
+                barrier.wait().await;
+                store
+                    .ensure_document_index_job(
+                        document_id,
+                        generation,
+                        "pipeline-v2",
+                        5,
+                        DocumentIndexJobReason::PipelineChanged,
+                    )
+                    .await
+                    .unwrap()
+            }));
+        }
+        let mut job_ids = std::collections::HashSet::new();
+        for task in tasks {
+            match task.await.unwrap() {
+                EnsureDocumentIndexJobOutcome::Enqueued(job)
+                | EnsureDocumentIndexJobOutcome::Existing(job) => {
+                    job_ids.insert(job.id);
+                }
+                outcome => panic!("unexpected outcome: {outcome:?}"),
+            }
+        }
+        assert_eq!(job_ids.len(), 1);
+
+        let current = store.get_document(document_id).await.unwrap().unwrap();
+        assert_eq!(current.content_revision, ready.content_revision + 1);
+        assert_ne!(current.revision_token, ready.revision_token);
+        assert_eq!(current.project_id, ready.project_id);
+        assert_eq!(current.source_uri, ready.source_uri);
+        assert_eq!(current.media_type, ready.media_type);
+        assert_eq!(current.title, ready.title);
+        assert_eq!(current.canonical_text, ready.canonical_text);
+        assert_eq!(current.created_at, ready.created_at);
+        assert_eq!(current.updated_at, ready.updated_at);
+        assert_eq!(current.processing_status, DocumentProcessingStatus::Queued);
+        assert_eq!(current.indexed_revision, None);
+        assert_eq!(current.index_fingerprint, None);
+        let jobs = store.list_document_jobs(document_id).await.unwrap();
+        assert_eq!(jobs.len(), 2);
+        assert_eq!(jobs[0].status, DocumentJobStatus::Succeeded);
+        assert_eq!(jobs[1].pipeline_fingerprint, "pipeline-v2");
+    }
+
     #[tokio::test]
     async fn source_revision_and_index_job_commit_and_supersede_together() {
         let (_dir, store) = temp_store().await;
@@ -5491,6 +6132,30 @@ mod tests {
             store.get_document_generation(source.id).await.unwrap(),
             Some(before.generation())
         );
+
+        assert!(store
+            .ensure_document_index_job(
+                source.id,
+                before.generation(),
+                "pipeline-v1",
+                3,
+                DocumentIndexJobReason::DerivedStateIncomplete,
+            )
+            .await
+            .is_err());
+        assert_eq!(
+            store.get_document(source.id).await.unwrap(),
+            Some(before.clone())
+        );
+        assert_eq!(
+            store.get_document_generation(source.id).await.unwrap(),
+            Some(before.generation())
+        );
+        assert!(store
+            .list_document_jobs(source.id)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -56,7 +56,9 @@ pub use provider::{
     Usage,
 };
 pub use steer::{SteerInbox, SteerMessage};
-pub use storage::{BlobStore, SecretProvider, Store};
+pub use storage::{
+    BlobStore, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, SecretProvider, Store,
+};
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]
 pub use tools::{ListDir, ReadFile, WriteFile};

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -26,6 +26,38 @@ use crate::model::{
     DocumentScope, DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
 };
 
+/// Why maintenance determined that a document needs an index job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DocumentIndexJobReason {
+    /// The operational watermark is current, but the derived generation is absent.
+    DerivedStateMissing,
+    /// The desired generation exists only partially and cannot be safely reused.
+    DerivedStateIncomplete,
+    /// The configured chunking/embedding pipeline differs from the indexed one.
+    PipelineChanged,
+}
+
+impl DocumentIndexJobReason {
+    pub(crate) const fn advances_generation(self) -> bool {
+        matches!(self, Self::DerivedStateIncomplete | Self::PipelineChanged)
+    }
+}
+
+/// Result of atomically ensuring one desired document index job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnsureDocumentIndexJobOutcome {
+    /// A new job was inserted or an exact terminal job was reset to queued.
+    Enqueued(DocumentJob),
+    /// The desired current job already exists and requires no state change.
+    Existing(DocumentJob),
+    /// The desired current job failed and requires an explicit user retry.
+    Failed(DocumentJob),
+    /// The source document no longer exists.
+    MissingDocument,
+    /// The caller inspected an obsolete source generation.
+    GenerationChanged(DocumentGeneration),
+}
+
 fn document_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "document storage is not implemented by this Store".into(),
@@ -159,6 +191,24 @@ pub trait Store: Send + Sync {
         _pipeline_fingerprint: &str,
         _max_attempts: i32,
     ) -> Result<(DocumentRecord, DocumentJob)> {
+        document_storage_unavailable()
+    }
+
+    /// Atomically establish the current index job requested by an auditor.
+    ///
+    /// `expected_generation` is a compare-and-swap fence around the auditor's
+    /// observation. Missing derived state requeues the exact current generation;
+    /// incomplete derived state and a changed pipeline advance the source
+    /// generation once without changing source fields. Failed jobs remain failed
+    /// until an explicit retry.
+    async fn ensure_document_index_job(
+        &self,
+        _document_id: DocumentId,
+        _expected_generation: DocumentGeneration,
+        _pipeline_fingerprint: &str,
+        _max_attempts: i32,
+        _reason: DocumentIndexJobReason,
+    ) -> Result<EnsureDocumentIndexJobOutcome> {
         document_storage_unavailable()
     }
 
@@ -408,6 +458,24 @@ mod tests {
         state.tombstones.remove(&id);
         state.pending_retirements.remove(&id);
         Ok(generation)
+    }
+
+    fn reset_mem_document_job(
+        job: &mut DocumentJob,
+        max_attempts: i32,
+        now: chrono::DateTime<chrono::Utc>,
+    ) {
+        job.status = DocumentJobStatus::Queued;
+        job.attempt_count = 0;
+        job.max_attempts = max_attempts;
+        job.available_at = now;
+        job.lease_token = None;
+        job.lease_expires_at = None;
+        job.started_at = None;
+        job.finished_at = None;
+        job.last_error_code = None;
+        job.last_error_detail = None;
+        job.updated_at = now;
     }
 
     #[async_trait]
@@ -693,6 +761,139 @@ mod tests {
             };
             state.jobs.insert(job.id, job.clone());
             Ok((record, job))
+        }
+        async fn ensure_document_index_job(
+            &self,
+            document_id: DocumentId,
+            expected_generation: DocumentGeneration,
+            pipeline_fingerprint: &str,
+            max_attempts: i32,
+            reason: DocumentIndexJobReason,
+        ) -> Result<EnsureDocumentIndexJobOutcome> {
+            if pipeline_fingerprint.is_empty()
+                || pipeline_fingerprint.chars().count() > DocumentJob::MAX_PIPELINE_FINGERPRINT_LEN
+                || max_attempts < 1
+            {
+                return Err(AgentError::Store(
+                    "invalid document index-job maintenance request".into(),
+                ));
+            }
+
+            let mut state = self.document_state.lock().unwrap();
+            let Some(mut document) = state.documents.get(&document_id).cloned() else {
+                return Ok(EnsureDocumentIndexJobOutcome::MissingDocument);
+            };
+
+            if document.generation() != expected_generation {
+                if reason.advances_generation()
+                    && expected_generation
+                        .content_revision
+                        .checked_add(1)
+                        .is_some_and(|revision| revision == document.content_revision)
+                {
+                    if let Some(job) = state.jobs.values().find(|job| {
+                        job.document_id == document_id
+                            && job.generation() == document.generation()
+                            && job.kind == DocumentJobKind::Index
+                            && job.pipeline_fingerprint == pipeline_fingerprint
+                    }) {
+                        return Ok(if job.status == DocumentJobStatus::Failed {
+                            EnsureDocumentIndexJobOutcome::Failed(job.clone())
+                        } else {
+                            EnsureDocumentIndexJobOutcome::Existing(job.clone())
+                        });
+                    }
+                }
+                return Ok(EnsureDocumentIndexJobOutcome::GenerationChanged(
+                    document.generation(),
+                ));
+            }
+
+            let desired_job_id = state.jobs.values().find_map(|job| {
+                (job.document_id == document_id
+                    && job.generation() == document.generation()
+                    && job.kind == DocumentJobKind::Index
+                    && job.pipeline_fingerprint == pipeline_fingerprint)
+                    .then_some(job.id)
+            });
+            if let Some(job_id) = desired_job_id {
+                let job = state.jobs.get(&job_id).unwrap().clone();
+                if matches!(
+                    job.status,
+                    DocumentJobStatus::Queued
+                        | DocumentJobStatus::Running
+                        | DocumentJobStatus::RetryWait
+                ) || (reason == DocumentIndexJobReason::PipelineChanged
+                    && job.status == DocumentJobStatus::Succeeded)
+                {
+                    return Ok(EnsureDocumentIndexJobOutcome::Existing(job));
+                }
+                if job.status == DocumentJobStatus::Failed {
+                    return Ok(EnsureDocumentIndexJobOutcome::Failed(job));
+                }
+                if reason == DocumentIndexJobReason::DerivedStateMissing {
+                    let now = chrono::Utc::now();
+                    let job = state.jobs.get_mut(&job_id).unwrap();
+                    reset_mem_document_job(job, max_attempts, now);
+                    let job = job.clone();
+                    document.processing_status = DocumentProcessingStatus::Queued;
+                    document.indexed_revision = None;
+                    document.index_fingerprint = None;
+                    document.indexed_at = None;
+                    state.documents.insert(document_id, document);
+                    return Ok(EnsureDocumentIndexJobOutcome::Enqueued(job));
+                }
+            }
+
+            if reason.advances_generation() {
+                let generation = allocate_mem_generation(&mut state, document_id)?;
+                document.content_revision = generation.content_revision;
+                document.revision_token = generation.revision_token;
+            }
+            document.processing_status = DocumentProcessingStatus::Queued;
+            document.indexed_revision = None;
+            document.index_fingerprint = None;
+            document.indexed_at = None;
+            state.documents.insert(document_id, document.clone());
+
+            let now = chrono::Utc::now();
+            for job in state.jobs.values_mut().filter(|job| {
+                job.document_id == document_id
+                    && matches!(
+                        job.status,
+                        DocumentJobStatus::Queued
+                            | DocumentJobStatus::Running
+                            | DocumentJobStatus::RetryWait
+                    )
+            }) {
+                job.status = DocumentJobStatus::Cancelled;
+                job.lease_token = None;
+                job.lease_expires_at = None;
+                job.finished_at = Some(now);
+                job.updated_at = now;
+            }
+            let job = DocumentJob {
+                id: DocumentJobId::new(),
+                document_id,
+                content_revision: document.content_revision,
+                revision_token: document.revision_token,
+                kind: DocumentJobKind::Index,
+                status: DocumentJobStatus::Queued,
+                pipeline_fingerprint: pipeline_fingerprint.into(),
+                attempt_count: 0,
+                max_attempts,
+                available_at: now,
+                lease_token: None,
+                lease_expires_at: None,
+                started_at: None,
+                finished_at: None,
+                last_error_code: None,
+                last_error_detail: None,
+                created_at: now,
+                updated_at: now,
+            };
+            state.jobs.insert(job.id, job.clone());
+            Ok(EnsureDocumentIndexJobOutcome::Enqueued(job))
         }
         async fn get_document_job(&self, id: DocumentJobId) -> Result<Option<DocumentJob>> {
             Ok(self.document_state.lock().unwrap().jobs.get(&id).cloned())
@@ -1324,7 +1525,111 @@ mod tests {
     }
 
     #[test]
-    fn mem_store_delete_overflow_leaves_source_job_and_clock_unchanged() {
+    fn mem_index_maintenance_requeues_or_advances_by_reason() {
+        let store = MemStore::default();
+        let source = DocumentUpsert {
+            id: DocumentId::new(),
+            project_id: None,
+            source_uri: Some("file:///maintenance.txt".into()),
+            media_type: "text/plain".into(),
+            title: Some("maintenance".into()),
+            canonical_text: "stable source".into(),
+            updated_at: chrono::DateTime::<chrono::Utc>::from_timestamp(100, 0).unwrap(),
+        };
+        let (first_document, first_job) =
+            block_on(store.upsert_document_and_enqueue_index(&source, "pipeline-v1", 3)).unwrap();
+        let claim_at = first_job.available_at + chrono::Duration::seconds(1);
+        let claimed =
+            block_on(store.claim_document_job(claim_at, claim_at + chrono::Duration::minutes(1)))
+                .unwrap()
+                .unwrap();
+        assert!(block_on(store.complete_document_index_job(
+            claimed.id,
+            claimed.lease_token.unwrap(),
+            claim_at + chrono::Duration::seconds(1),
+        ))
+        .unwrap());
+
+        let missing = block_on(store.ensure_document_index_job(
+            source.id,
+            first_document.generation(),
+            "pipeline-v1",
+            5,
+            DocumentIndexJobReason::DerivedStateMissing,
+        ))
+        .unwrap();
+        let EnsureDocumentIndexJobOutcome::Enqueued(requeued) = missing else {
+            panic!("missing state should requeue the exact succeeded job")
+        };
+        assert_eq!(requeued.id, first_job.id);
+        assert_eq!(requeued.generation(), first_document.generation());
+        assert_eq!(requeued.max_attempts, 5);
+
+        let changed = block_on(store.ensure_document_index_job(
+            source.id,
+            first_document.generation(),
+            "pipeline-v2",
+            4,
+            DocumentIndexJobReason::PipelineChanged,
+        ))
+        .unwrap();
+        let EnsureDocumentIndexJobOutcome::Enqueued(changed_job) = changed else {
+            panic!("pipeline change should enqueue an advanced generation")
+        };
+        assert_eq!(
+            changed_job.content_revision,
+            first_document.content_revision + 1
+        );
+        let repeated = block_on(store.ensure_document_index_job(
+            source.id,
+            first_document.generation(),
+            "pipeline-v2",
+            4,
+            DocumentIndexJobReason::PipelineChanged,
+        ))
+        .unwrap();
+        assert_eq!(
+            repeated,
+            EnsureDocumentIndexJobOutcome::Existing(changed_job.clone())
+        );
+        let changed_claim_at = changed_job.available_at + chrono::Duration::seconds(1);
+        let changed_claim = block_on(store.claim_document_job(
+            changed_claim_at,
+            changed_claim_at + chrono::Duration::minutes(1),
+        ))
+        .unwrap()
+        .unwrap();
+        assert_eq!(changed_claim.id, changed_job.id);
+        assert!(block_on(store.complete_document_index_job(
+            changed_claim.id,
+            changed_claim.lease_token.unwrap(),
+            changed_claim_at + chrono::Duration::seconds(1),
+        ))
+        .unwrap());
+        let incomplete = block_on(store.ensure_document_index_job(
+            source.id,
+            changed_job.generation(),
+            "pipeline-v2",
+            6,
+            DocumentIndexJobReason::DerivedStateIncomplete,
+        ))
+        .unwrap();
+        let EnsureDocumentIndexJobOutcome::Enqueued(incomplete_job) = incomplete else {
+            panic!("incomplete succeeded state should advance its generation")
+        };
+        assert_eq!(
+            incomplete_job.content_revision,
+            changed_job.content_revision + 1
+        );
+        let current = block_on(store.get_document(source.id)).unwrap().unwrap();
+        assert_eq!(current.generation(), incomplete_job.generation());
+        assert_eq!(current.canonical_text, source.canonical_text);
+        assert_eq!(current.created_at, first_document.created_at);
+        assert_eq!(current.updated_at, first_document.updated_at);
+    }
+
+    #[test]
+    fn mem_store_generation_overflow_leaves_source_job_and_clock_unchanged() {
         let store = MemStore::default();
         let source = DocumentUpsert {
             id: DocumentId::new(),
@@ -1358,7 +1663,45 @@ mod tests {
             block_on(store.get_document_generation(source.id)).unwrap(),
             Some(maximum)
         );
-        assert_eq!(block_on(store.get_document_job(job.id)).unwrap(), Some(job));
+        assert_eq!(
+            block_on(store.get_document_job(job.id)).unwrap(),
+            Some(job.clone())
+        );
+
+        let succeeded = {
+            let mut state = store.document_state.lock().unwrap();
+            let now = chrono::Utc::now();
+            let job = state.jobs.get_mut(&job.id).unwrap();
+            job.content_revision = i64::MAX;
+            job.status = DocumentJobStatus::Succeeded;
+            job.attempt_count = 1;
+            job.finished_at = Some(now);
+            job.updated_at = now;
+            job.clone()
+        };
+        assert!(block_on(store.ensure_document_index_job(
+            source.id,
+            maximum,
+            "pipeline-v1",
+            3,
+            DocumentIndexJobReason::DerivedStateIncomplete,
+        ))
+        .is_err());
+        assert_eq!(
+            block_on(store.get_document(source.id))
+                .unwrap()
+                .unwrap()
+                .generation(),
+            maximum
+        );
+        assert_eq!(
+            block_on(store.get_document_generation(source.id)).unwrap(),
+            Some(maximum)
+        );
+        assert_eq!(
+            block_on(store.get_document_job(succeeded.id)).unwrap(),
+            Some(succeeded)
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/document_auditor.rs
+++ b/crates/openwave-server/src/document_auditor.rs
@@ -1,0 +1,482 @@
+//! Reconcile operational document state with the current retrieval generation.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use openwave_core::{
+    DocumentId, DocumentIndexJobReason, DocumentJobStatus, DocumentProcessingStatus, DocumentScope,
+    EnsureDocumentIndexJobOutcome, Result, Store,
+};
+use openwave_retrieval::{Document, DocumentGenerationState, DocumentSource, Retriever};
+use tokio::sync::Notify;
+
+use crate::document_worker::MAX_INDEX_ATTEMPTS;
+use crate::state::DocumentWriteGuard;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DocumentAuditorConfig {
+    interval: Duration,
+    failure_delay: Duration,
+}
+
+impl Default for DocumentAuditorConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(6 * 60 * 60),
+            failure_delay: Duration::from_secs(60),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct DocumentAuditReport {
+    pub scanned: usize,
+    pub enqueued: usize,
+    pub skipped: usize,
+    pub failed_jobs: usize,
+    pub failures: Vec<DocumentAuditFailure>,
+}
+
+#[derive(Debug)]
+pub(crate) struct DocumentAuditFailure {
+    pub document_id: DocumentId,
+    pub error: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct DocumentAuditor {
+    store: Arc<dyn Store>,
+    retrieval: Arc<Retriever>,
+    document_writes: Arc<DocumentWriteGuard>,
+    wake: Arc<Notify>,
+    config: DocumentAuditorConfig,
+}
+
+impl DocumentAuditor {
+    pub(crate) fn new(
+        store: Arc<dyn Store>,
+        retrieval: Arc<Retriever>,
+        document_writes: Arc<DocumentWriteGuard>,
+        wake: Arc<Notify>,
+        config: DocumentAuditorConfig,
+    ) -> Self {
+        Self {
+            store,
+            retrieval,
+            document_writes,
+            wake,
+            config,
+        }
+    }
+
+    pub(crate) async fn run(self) {
+        loop {
+            let delay = match self.audit_once().await {
+                Ok(report) => {
+                    let retry_soon = !report.failures.is_empty();
+                    if report.enqueued > 0 || report.failed_jobs > 0 || !report.failures.is_empty()
+                    {
+                        eprintln!(
+                            "openwave: document audit scanned {}, enqueued {}, skipped {}, failed jobs {}, errors {}",
+                            report.scanned,
+                            report.enqueued,
+                            report.skipped,
+                            report.failed_jobs,
+                            report.failures.len()
+                        );
+                    }
+                    for failure in report.failures {
+                        eprintln!(
+                            "openwave: document {} audit failed: {}",
+                            failure.document_id, failure.error
+                        );
+                    }
+                    if retry_soon {
+                        self.config.failure_delay
+                    } else {
+                        self.config.interval
+                    }
+                }
+                Err(error) => {
+                    eprintln!("openwave: document audit scan failed: {error}");
+                    self.config.failure_delay
+                }
+            };
+            tokio::time::sleep(delay).await;
+        }
+    }
+
+    pub(crate) async fn audit_once(&self) -> Result<DocumentAuditReport> {
+        let document_ids = self.store.list_document_ids(DocumentScope::All).await?;
+        let fingerprint = self.retrieval.index_fingerprint();
+        let mut report = DocumentAuditReport {
+            scanned: document_ids.len(),
+            ..DocumentAuditReport::default()
+        };
+
+        for document_id in document_ids {
+            if let Err(error) = self
+                .audit_document(document_id, &fingerprint, &mut report)
+                .await
+            {
+                report.failures.push(DocumentAuditFailure {
+                    document_id,
+                    error: error.to_string(),
+                });
+            }
+        }
+        if report.enqueued > 0 {
+            self.wake.notify_one();
+        }
+        Ok(report)
+    }
+
+    async fn audit_document(
+        &self,
+        document_id: DocumentId,
+        fingerprint: &str,
+        report: &mut DocumentAuditReport,
+    ) -> Result<()> {
+        let _document_write = self.document_writes.acquire(document_id).await;
+        let Some(document) = self.store.get_document(document_id).await? else {
+            report.skipped += 1;
+            return Ok(());
+        };
+        let jobs = self.store.list_document_jobs(document_id).await?;
+        let current_jobs: Vec<_> = jobs
+            .iter()
+            .filter(|job| job.generation() == document.generation())
+            .collect();
+        let desired_job = current_jobs
+            .iter()
+            .copied()
+            .find(|job| job.pipeline_fingerprint == fingerprint);
+
+        if desired_job.is_some_and(|job| {
+            matches!(
+                job.status,
+                DocumentJobStatus::Queued
+                    | DocumentJobStatus::Running
+                    | DocumentJobStatus::RetryWait
+            )
+        }) {
+            report.skipped += 1;
+            return Ok(());
+        }
+        if desired_job.is_some_and(|job| job.status == DocumentJobStatus::Failed) {
+            report.failed_jobs += 1;
+            return Ok(());
+        }
+
+        let known_pipeline_changed = document
+            .index_fingerprint
+            .as_deref()
+            .is_some_and(|indexed| indexed != fingerprint)
+            || (!current_jobs.is_empty()
+                && current_jobs
+                    .iter()
+                    .all(|job| job.pipeline_fingerprint != fingerprint));
+        let reason = if known_pipeline_changed {
+            DocumentIndexJobReason::PipelineChanged
+        } else if document.processing_status == DocumentProcessingStatus::Ready
+            && document.indexed_revision == Some(document.content_revision)
+            && document.index_fingerprint.as_deref() == Some(fingerprint)
+        {
+            match self
+                .retrieval
+                .store()
+                .newest_document_generation(document_id)
+                .await
+                .map_err(|error| openwave_core::AgentError::msg(error.to_string()))?
+            {
+                Some(DocumentGenerationState::Active(generation))
+                    if generation == document.generation() =>
+                {
+                    if self
+                        .retrieval
+                        .index_is_complete(&canonical_document(&document))
+                        .await
+                        .map_err(|error| openwave_core::AgentError::msg(error.to_string()))?
+                    {
+                        report.skipped += 1;
+                        return Ok(());
+                    }
+                    DocumentIndexJobReason::DerivedStateIncomplete
+                }
+                Some(state)
+                    if state.generation().content_revision > document.content_revision
+                        || (state.generation().content_revision == document.content_revision
+                            && state.generation().revision_token != document.revision_token) =>
+                {
+                    return Err(openwave_core::AgentError::msg(format!(
+                        "vector generation {:?} is not covered by operational generation {:?}",
+                        state.generation(),
+                        document.generation()
+                    )));
+                }
+                Some(DocumentGenerationState::Staged(generation))
+                    if generation == document.generation() =>
+                {
+                    DocumentIndexJobReason::DerivedStateIncomplete
+                }
+                Some(DocumentGenerationState::Active(_))
+                | Some(DocumentGenerationState::Staged(_))
+                | None => DocumentIndexJobReason::DerivedStateMissing,
+            }
+        } else {
+            DocumentIndexJobReason::DerivedStateMissing
+        };
+
+        match self
+            .store
+            .ensure_document_index_job(
+                document_id,
+                document.generation(),
+                fingerprint,
+                MAX_INDEX_ATTEMPTS,
+                reason,
+            )
+            .await?
+        {
+            EnsureDocumentIndexJobOutcome::Enqueued(_) => report.enqueued += 1,
+            EnsureDocumentIndexJobOutcome::Failed(_) => report.failed_jobs += 1,
+            EnsureDocumentIndexJobOutcome::Existing(_)
+            | EnsureDocumentIndexJobOutcome::MissingDocument
+            | EnsureDocumentIndexJobOutcome::GenerationChanged(_) => report.skipped += 1,
+        }
+        Ok(())
+    }
+}
+
+fn canonical_document(record: &openwave_core::DocumentRecord) -> Document {
+    let source = match record.source_uri.clone() {
+        Some(uri) => DocumentSource::uri(uri),
+        None => DocumentSource::Inline,
+    };
+    Document::with_id(
+        record.id,
+        source,
+        record.media_type.clone(),
+        record.canonical_text.clone(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use openwave_core::{DbStore, DocumentJobStatus, DocumentProcessingStatus, DocumentUpsert};
+    use openwave_retrieval::{
+        Document, DocumentSource, HashEmbedder, InMemoryVectorStore, PlainTextParser, TextChunker,
+    };
+
+    use super::*;
+
+    async fn harness() -> (tempfile::TempDir, Arc<dyn Store>, Arc<Retriever>) {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("auditor.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let retrieval = Arc::new(Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::new(90, 0)),
+            Arc::new(HashEmbedder::new(32)),
+            Arc::new(InMemoryVectorStore::new(32)),
+        ));
+        (dir, store, retrieval)
+    }
+
+    fn source(id: DocumentId, text: &str) -> DocumentUpsert {
+        DocumentUpsert {
+            id,
+            project_id: None,
+            source_uri: None,
+            media_type: "text/plain".into(),
+            title: None,
+            canonical_text: text.into(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    async fn complete_operational_job(
+        store: &Arc<dyn Store>,
+        source: &DocumentUpsert,
+        fingerprint: &str,
+    ) -> (openwave_core::DocumentRecord, openwave_core::DocumentJob) {
+        let (record, job) = store
+            .upsert_document_and_enqueue_index(source, fingerprint, 3)
+            .await
+            .unwrap();
+        let now = Utc::now();
+        let claimed = store
+            .claim_document_job(now, now + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(claimed.id, job.id);
+        assert!(store
+            .complete_document_index_job(claimed.id, claimed.lease_token.unwrap(), Utc::now())
+            .await
+            .unwrap());
+        (record, job)
+    }
+
+    fn auditor(store: Arc<dyn Store>, retrieval: Arc<Retriever>) -> DocumentAuditor {
+        DocumentAuditor::new(
+            store,
+            retrieval,
+            Arc::new(DocumentWriteGuard::default()),
+            Arc::new(Notify::new()),
+            DocumentAuditorConfig {
+                interval: Duration::from_secs(60),
+                failure_delay: Duration::from_secs(1),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn missing_derived_generation_requeues_the_exact_succeeded_job() {
+        let (_dir, store, retrieval) = harness().await;
+        let id = DocumentId::new();
+        let (record, job) = complete_operational_job(
+            &store,
+            &source(id, "missing derived rows"),
+            &retrieval.index_fingerprint(),
+        )
+        .await;
+
+        let report = auditor(store.clone(), retrieval)
+            .audit_once()
+            .await
+            .unwrap();
+        assert_eq!(report.enqueued, 1);
+        let current = store.get_document(id).await.unwrap().unwrap();
+        assert_eq!(current.generation(), record.generation());
+        assert_eq!(current.processing_status, DocumentProcessingStatus::Queued);
+        let repaired = store.get_document_job(job.id).await.unwrap().unwrap();
+        assert_eq!(repaired.status, DocumentJobStatus::Queued);
+        assert_eq!(repaired.attempt_count, 0);
+    }
+
+    #[tokio::test]
+    async fn pipeline_change_advances_once_and_enqueues_the_desired_job() {
+        let (_dir, store, retrieval) = harness().await;
+        let id = DocumentId::new();
+        let (old, _) =
+            complete_operational_job(&store, &source(id, "same canonical source"), "old-pipeline")
+                .await;
+        let auditor = auditor(store.clone(), retrieval.clone());
+
+        let first = auditor.audit_once().await.unwrap();
+        assert_eq!(first.enqueued, 1);
+        let advanced = store.get_document(id).await.unwrap().unwrap();
+        assert_eq!(advanced.content_revision, old.content_revision + 1);
+        assert_eq!(advanced.canonical_text, old.canonical_text);
+        assert_eq!(advanced.processing_status, DocumentProcessingStatus::Queued);
+        let jobs = store.list_document_jobs(id).await.unwrap();
+        assert!(jobs.iter().any(|job| {
+            job.generation() == advanced.generation()
+                && job.pipeline_fingerprint == retrieval.index_fingerprint()
+                && job.status == DocumentJobStatus::Queued
+        }));
+
+        let second = auditor.audit_once().await.unwrap();
+        assert_eq!(second.enqueued, 0);
+        assert_eq!(
+            store.get_document(id).await.unwrap().unwrap().generation(),
+            advanced.generation()
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_active_ready_generation_is_left_untouched() {
+        let (_dir, store, retrieval) = harness().await;
+        let id = DocumentId::new();
+        let source = source(id, "healthy active generation");
+        let (record, _) =
+            complete_operational_job(&store, &source, &retrieval.index_fingerprint()).await;
+        let document = Document::with_id(
+            id,
+            DocumentSource::Inline,
+            source.media_type,
+            source.canonical_text,
+        );
+        retrieval
+            .stage_document_generation(&document, record.generation())
+            .await
+            .unwrap();
+        assert!(retrieval
+            .activate_document_generation(id, record.generation())
+            .await
+            .unwrap());
+
+        let report = auditor(store.clone(), retrieval)
+            .audit_once()
+            .await
+            .unwrap();
+        assert_eq!(report.enqueued, 0);
+        assert!(report.failures.is_empty());
+        assert_eq!(
+            store.get_document(id).await.unwrap().unwrap().generation(),
+            record.generation()
+        );
+    }
+
+    #[tokio::test]
+    async fn incomplete_exact_active_generation_advances_before_rebuild() {
+        let (_dir, store, retrieval) = harness().await;
+        let id = DocumentId::new();
+        let (record, _) = complete_operational_job(
+            &store,
+            &source(id, "this live document expects chunks"),
+            &retrieval.index_fingerprint(),
+        )
+        .await;
+        retrieval
+            .stage_document_tombstone(id, record.generation())
+            .await
+            .unwrap();
+        assert!(retrieval
+            .activate_document_generation(id, record.generation())
+            .await
+            .unwrap());
+
+        let report = auditor(store.clone(), retrieval)
+            .audit_once()
+            .await
+            .unwrap();
+        assert_eq!(report.enqueued, 1);
+        let advanced = store.get_document(id).await.unwrap().unwrap();
+        assert_eq!(advanced.content_revision, record.content_revision + 1);
+        assert_eq!(advanced.processing_status, DocumentProcessingStatus::Queued);
+    }
+
+    #[tokio::test]
+    async fn exact_staged_ready_generation_advances_instead_of_publishing_unknown_chunks() {
+        let (_dir, store, retrieval) = harness().await;
+        let id = DocumentId::new();
+        let (record, _) = complete_operational_job(
+            &store,
+            &source(id, "staged state is not proof of complete publication"),
+            &retrieval.index_fingerprint(),
+        )
+        .await;
+        retrieval
+            .stage_document_tombstone(id, record.generation())
+            .await
+            .unwrap();
+
+        let report = auditor(store.clone(), retrieval)
+            .audit_once()
+            .await
+            .unwrap();
+        assert_eq!(report.enqueued, 1);
+        let advanced = store.get_document(id).await.unwrap().unwrap();
+        assert_eq!(advanced.content_revision, record.content_revision + 1);
+        assert_eq!(advanced.processing_status, DocumentProcessingStatus::Queued);
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -14,6 +14,7 @@
 mod approvals;
 mod auth;
 mod bus;
+mod document_auditor;
 mod document_worker;
 mod error;
 mod extract;
@@ -137,6 +138,7 @@ pub struct Server {
     token: Arc<str>,
     listener: TcpListener,
     router: Router,
+    _document_auditor: AbortTask,
     _document_worker: AbortTask,
 }
 
@@ -199,6 +201,13 @@ pub async fn bind(config: Config) -> Result<Server> {
         state.document_writes.clone(),
         document_worker::DocumentWorkerConfig::default(),
     );
+    let document_auditor = document_auditor::DocumentAuditor::new(
+        state.store.clone(),
+        state.retrieval.clone(),
+        state.document_writes.clone(),
+        state.document_job_wake.clone(),
+        document_auditor::DocumentAuditorConfig::default(),
+    );
     let router = app(state);
 
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
@@ -208,6 +217,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         .local_addr()
         .map_err(|e| AgentError::config(format!("no local address: {e}")))?;
 
+    let document_auditor = tokio::spawn(document_auditor.run());
     let document_worker = tokio::spawn(document_worker.run());
 
     Ok(Server {
@@ -215,6 +225,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         token,
         listener,
         router,
+        _document_auditor: AbortTask(document_auditor),
         _document_worker: AbortTask(document_worker),
     })
 }


### PR DESCRIPTION
## Summary

- add an atomic maintenance transition that requeues an exact generation when derived state is missing and advances generation once when the retrieval pipeline changes
- run a startup and periodic document auditor that compares operational watermarks with staged/active vector state and only enqueues durable jobs
- preserve canonical source identity across pipeline changes, keep failed desired jobs behind explicit retry, and make repeated/concurrent audits idempotent
- restore automatic recovery after a Lance reset or pipeline change without reintroducing direct vector writes
- verify exact active generations are physically complete, advancing once before rebuilding an incomplete active generation
- retry per-document audit failures on the short failure interval instead of waiting for the normal six-hour scan

## Tests

- `cargo test -p openwave-core`
- `cargo test -p openwave-server`
- `bw dev lint --rust`
