### PR TITLE
feat(retrieval): enforce document corpus scope

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -123,6 +123,8 @@ impl Store for DbStore {
             revision_token: Set(revision_token),
             tombstone: Set(false),
             retirement_pending: Set(false),
+            retirement_content_revision: Set(None),
+            retirement_revision_token: Set(None),
         }
         .insert(&transaction)
         .await
@@ -282,9 +284,8 @@ impl Store for DbStore {
         let mut query = entities::document_generation::Entity::find()
             .select_only()
             .column(entities::document_generation::Column::DocumentId)
-            .column(entities::document_generation::Column::ContentRevision)
-            .column(entities::document_generation::Column::RevisionToken)
-            .filter(entities::document_generation::Column::Tombstone.eq(true))
+            .column(entities::document_generation::Column::RetirementContentRevision)
+            .column(entities::document_generation::Column::RetirementRevisionToken)
             .filter(entities::document_generation::Column::RetirementPending.eq(true));
         if let Some(after) = after {
             query = query.filter(entities::document_generation::Column::DocumentId.gt(after.0));
@@ -319,20 +320,56 @@ impl Store for DbStore {
                 entities::document_generation::Column::RetirementPending,
                 sea_orm::sea_query::Expr::value(false),
             )
+            .col_expr(
+                entities::document_generation::Column::RetirementContentRevision,
+                sea_orm::sea_query::Expr::value(Option::<i64>::None),
+            )
+            .col_expr(
+                entities::document_generation::Column::RetirementRevisionToken,
+                sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+            )
             .filter(entities::document_generation::Column::DocumentId.eq(id.0))
             .filter(
-                entities::document_generation::Column::ContentRevision
+                entities::document_generation::Column::RetirementContentRevision
                     .eq(generation.content_revision),
             )
             .filter(
-                entities::document_generation::Column::RevisionToken.eq(generation.revision_token),
+                entities::document_generation::Column::RetirementRevisionToken
+                    .eq(generation.revision_token),
             )
-            .filter(entities::document_generation::Column::Tombstone.eq(true))
             .filter(entities::document_generation::Column::RetirementPending.eq(true))
             .exec(&self.conn)
             .await
             .map_err(store_err)?;
         Ok(updated.rows_affected == 1)
+    }
+
+    async fn get_pending_document_retirement(
+        &self,
+        id: DocumentId,
+    ) -> Result<Option<DocumentGeneration>> {
+        let Some(generation) = entities::document_generation::Entity::find_by_id(id.0)
+            .one(&self.conn)
+            .await
+            .map_err(store_err)?
+        else {
+            return Ok(None);
+        };
+        if !generation.retirement_pending {
+            return Ok(None);
+        }
+        let (Some(content_revision), Some(revision_token)) = (
+            generation.retirement_content_revision,
+            generation.retirement_revision_token,
+        ) else {
+            return Err(AgentError::Store(format!(
+                "document {id} has an incomplete pending retirement watermark"
+            )));
+        };
+        Ok(Some(DocumentGeneration {
+            content_revision,
+            revision_token,
+        }))
     }
 
     async fn delete_document(&self, id: DocumentId) -> Result<DocumentGeneration> {
@@ -2118,7 +2155,7 @@ where
             .checked_add(1)
             .ok_or_else(|| AgentError::Store(format!("document {id} revision overflow")))?;
         let revision_token = uuid::Uuid::new_v4();
-        let updated = entities::document_generation::Entity::update_many()
+        let mut update = entities::document_generation::Entity::update_many()
             .col_expr(
                 entities::document_generation::Column::ContentRevision,
                 sea_orm::sea_query::Expr::value(next_revision),
@@ -2130,11 +2167,23 @@ where
             .col_expr(
                 entities::document_generation::Column::Tombstone,
                 sea_orm::sea_query::Expr::value(tombstone),
-            )
-            .col_expr(
-                entities::document_generation::Column::RetirementPending,
-                sea_orm::sea_query::Expr::value(tombstone),
-            )
+            );
+        if tombstone {
+            update = update
+                .col_expr(
+                    entities::document_generation::Column::RetirementPending,
+                    sea_orm::sea_query::Expr::value(true),
+                )
+                .col_expr(
+                    entities::document_generation::Column::RetirementContentRevision,
+                    sea_orm::sea_query::Expr::value(next_revision),
+                )
+                .col_expr(
+                    entities::document_generation::Column::RetirementRevisionToken,
+                    sea_orm::sea_query::Expr::value(revision_token),
+                );
+        }
+        let updated = update
             .filter(entities::document_generation::Column::DocumentId.eq(id.0))
             .filter(
                 entities::document_generation::Column::ContentRevision
@@ -2172,6 +2221,8 @@ where
             revision_token: Set(current.revision_token),
             tombstone: Set(tombstone),
             retirement_pending: Set(tombstone),
+            retirement_content_revision: Set(tombstone.then_some(current.content_revision)),
+            retirement_revision_token: Set(tombstone.then_some(current.revision_token)),
         })
         .on_conflict_do_nothing()
         .exec_without_returning(conn)
@@ -2200,6 +2251,12 @@ where
         .await
         .map_err(store_err)?;
     if let Some(existing) = existing.as_ref() {
+        if existing.project_id != document.project_id.map(|id| id.0) {
+            return Err(AgentError::Store(format!(
+                "document {} cannot move between project corpora",
+                document.id
+            )));
+        }
         ensure_live_document_generation_on(conn, existing).await?;
     }
     let Some(advanced) = try_advance_document_generation_on(conn, document.id, false).await? else {
@@ -2571,6 +2628,8 @@ mod entities {
             pub revision_token: Uuid,
             pub tombstone: bool,
             pub retirement_pending: bool,
+            pub retirement_content_revision: Option<i64>,
+            pub retirement_revision_token: Option<Uuid>,
         }
 
         #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -3169,11 +3228,37 @@ mod migration {
                                 .not_null()
                                 .default(false),
                         )
+                        .col(
+                            ColumnDef::new(DocumentGeneration::RetirementContentRevision)
+                                .big_integer(),
+                        )
+                        .col(ColumnDef::new(DocumentGeneration::RetirementRevisionToken).uuid())
                         .check(Expr::col(DocumentGeneration::ContentRevision).gte(1))
                         .check(
                             Expr::col(DocumentGeneration::RetirementPending)
                                 .eq(false)
-                                .or(Expr::col(DocumentGeneration::Tombstone).eq(true)),
+                                .and(
+                                    Expr::col(DocumentGeneration::RetirementContentRevision)
+                                        .is_null(),
+                                )
+                                .and(
+                                    Expr::col(DocumentGeneration::RetirementRevisionToken)
+                                        .is_null(),
+                                )
+                                .or(Expr::col(DocumentGeneration::RetirementPending)
+                                    .eq(true)
+                                    .and(
+                                        Expr::col(DocumentGeneration::RetirementContentRevision)
+                                            .is_not_null(),
+                                    )
+                                    .and(
+                                        Expr::col(DocumentGeneration::RetirementContentRevision)
+                                            .gte(1),
+                                    )
+                                    .and(
+                                        Expr::col(DocumentGeneration::RetirementRevisionToken)
+                                            .is_not_null(),
+                                    )),
                         )
                         .to_owned(),
                 )
@@ -3559,6 +3644,8 @@ mod migration {
         RevisionToken,
         Tombstone,
         RetirementPending,
+        RetirementContentRevision,
+        RetirementRevisionToken,
     }
 
     #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::model::DocumentJobKind;
 use chrono::{DateTime, Utc};
 
 async fn temp_store() -> (tempfile::TempDir, DbStore) {
@@ -299,6 +298,39 @@ async fn document_project_fk_rejects_orphans_and_direct_project_deletion() {
             .unwrap()
             .unwrap()
     );
+}
+
+#[tokio::test]
+async fn live_document_cannot_move_between_project_corpora() {
+    let (_dir, store) = temp_store().await;
+    let project_a = sample_project();
+    let mut project_b = sample_project();
+    project_b.id = ProjectId::new();
+    store.create_project(&project_a).await.unwrap();
+    store.create_project(&project_b).await.unwrap();
+    let source = DocumentUpsert {
+        id: DocumentId::new(),
+        project_id: Some(project_a.id),
+        source_uri: Some("file:///scoped.txt".into()),
+        media_type: "text/plain".into(),
+        title: None,
+        canonical_text: "project A source".into(),
+        updated_at: Utc::now(),
+    };
+    let first = store
+        .upsert_document_and_enqueue_index(&source, "pipeline-v1", 3)
+        .await
+        .unwrap();
+    let moved = DocumentUpsert {
+        project_id: Some(project_b.id),
+        canonical_text: "must not move".into(),
+        ..source
+    };
+    assert!(store
+        .upsert_document_and_enqueue_index(&moved, "pipeline-v1", 3)
+        .await
+        .is_err());
+    assert_eq!(store.get_document(moved.id).await.unwrap(), Some(first.0));
 }
 
 #[tokio::test]
@@ -2375,11 +2407,21 @@ async fn pending_document_retirement_survives_reopen_and_uses_exact_cas() {
         })
         .await
         .unwrap();
+    assert_eq!(
+        store
+            .list_pending_document_retirements(None, 10)
+            .await
+            .unwrap(),
+        vec![(id, tombstone)]
+    );
+    assert_eq!(
+        store.get_pending_document_retirement(id).await.unwrap(),
+        Some(tombstone)
+    );
     assert!(store
-        .list_pending_document_retirements(None, 10)
+        .complete_document_retirement(id, tombstone)
         .await
-        .unwrap()
-        .is_empty());
+        .unwrap());
     assert!(!store
         .complete_document_retirement(id, tombstone)
         .await

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -38,6 +38,9 @@ pub enum DocumentIndexJobReason {
 }
 
 impl DocumentIndexJobReason {
+    /// Whether this repair must publish under a fresh generation fence.
+    #[must_use]
+    #[allow(dead_code)]
     pub(crate) const fn advances_generation(self) -> bool {
         matches!(self, Self::DerivedStateIncomplete | Self::PipelineChanged)
     }
@@ -85,7 +88,9 @@ pub trait Store: Send + Sync {
     /// database store enforces this with a restricting foreign key, so projects
     /// cannot be deleted while they still own documents. The store replaces the
     /// supplied `revision_token` with a fresh token so a deleted document
-    /// lifecycle cannot be recreated with stale identity.
+    /// lifecycle cannot be recreated with stale identity. A live document's
+    /// ownership is immutable: callers must delete it before recreating the same
+    /// id in another corpus.
     async fn create_document(&self, _document: &DocumentRecord) -> Result<()> {
         document_storage_unavailable()
     }
@@ -132,7 +137,7 @@ pub trait Store: Send + Sync {
         document_storage_unavailable()
     }
 
-    /// List durable source-free tombstones whose retrieval retirement is unfinished.
+    /// List durable tombstone watermarks whose retrieval retirement is unfinished.
     ///
     /// Results are ordered by document id, strictly after `after` when present,
     /// and bounded by `limit`. A worker can advance past a poison entry and wrap
@@ -145,10 +150,18 @@ pub trait Store: Send + Sync {
         document_storage_unavailable()
     }
 
+    /// Read the exact retirement watermark currently pending for one document.
+    async fn get_pending_document_retirement(
+        &self,
+        _id: DocumentId,
+    ) -> Result<Option<DocumentGeneration>> {
+        document_storage_unavailable()
+    }
+
     /// Mark one exact tombstone generation's retrieval retirement complete.
     ///
-    /// Returns `false` when the generation is no longer pending, including when
-    /// the document was recreated or advanced since the caller observed it.
+    /// Returns `false` when that exact generation is no longer pending. A live
+    /// recreation may coexist with an older pending retirement watermark.
     async fn complete_document_retirement(
         &self,
         _id: DocumentId,
@@ -169,7 +182,10 @@ pub trait Store: Send + Sync {
     ///
     /// A never-seen id starts at revision one. Replacing or recreating an id
     /// increments its retained generation atomically, preserves `created_at` only
-    /// for a live replacement, and clears the index watermark.
+    /// for a live replacement, and clears the index watermark. `project_id`, when
+    /// present, must identify an existing project. A live document cannot move
+    /// between the unscoped and project corpora, or between projects; direct
+    /// upserts enforce the same ownership rules as the enqueueing write path.
     async fn upsert_document(&self, _document: &DocumentUpsert) -> Result<DocumentRecord> {
         document_storage_unavailable()
     }
@@ -184,7 +200,9 @@ pub trait Store: Send + Sync {
     /// status. Intentional reprocessing/retry is an explicit job-state transition,
     /// not another source write. `DocumentUpsert::updated_at` is source metadata
     /// and is deliberately excluded from retry identity. Workflow timestamps are
-    /// owned by the store rather than copied from source metadata.
+    /// owned by the store rather than copied from source metadata. `project_id`
+    /// must identify an existing project when present, and ownership of a live
+    /// document is immutable until that document is deleted.
     async fn upsert_document_and_enqueue_index(
         &self,
         _document: &DocumentUpsert,
@@ -425,7 +443,7 @@ mod tests {
         documents: HashMap<DocumentId, DocumentRecord>,
         generations: HashMap<DocumentId, DocumentGeneration>,
         tombstones: HashSet<DocumentId>,
-        pending_retirements: HashSet<DocumentId>,
+        pending_retirements: HashMap<DocumentId, DocumentGeneration>,
         jobs: HashMap<DocumentJobId, DocumentJob>,
     }
 
@@ -456,7 +474,6 @@ mod tests {
         };
         state.generations.insert(id, generation);
         state.tombstones.remove(&id);
-        state.pending_retirements.remove(&id);
         Ok(generation)
     }
 
@@ -494,6 +511,14 @@ mod tests {
             Ok(self.projects.lock().unwrap().values().cloned().collect())
         }
         async fn create_document(&self, document: &DocumentRecord) -> Result<()> {
+            if document
+                .project_id
+                .is_some_and(|id| !self.projects.lock().unwrap().contains_key(&id))
+            {
+                return Err(AgentError::Store(
+                    "document references an unknown project".into(),
+                ));
+            }
             let mut state = self.document_state.lock().unwrap();
             if state.generations.contains_key(&document.id) {
                 return Err(AgentError::Store("document already exists".into()));
@@ -502,7 +527,6 @@ mod tests {
             document.revision_token = uuid::Uuid::new_v4();
             state.generations.insert(document.id, document.generation());
             state.tombstones.remove(&document.id);
-            state.pending_retirements.remove(&document.id);
             state.documents.insert(document.id, document);
             Ok(())
         }
@@ -584,7 +608,7 @@ mod tests {
                 let generation = allocate_mem_generation(&mut state, id)?;
                 state.documents.remove(&id);
                 state.tombstones.insert(id);
-                state.pending_retirements.insert(id);
+                state.pending_retirements.insert(id, generation);
                 generation
             } else if let Some(generation) = state.generations.get(&id) {
                 *generation
@@ -604,13 +628,25 @@ mod tests {
             let mut retirements: Vec<_> = state
                 .pending_retirements
                 .iter()
-                .filter(|id| after.is_none_or(|after| id.0 > after.0))
-                .filter(|id| !state.documents.contains_key(id) && state.tombstones.contains(id))
-                .map(|id| (*id, state.generations[id]))
+                .filter(|(id, _)| after.is_none_or(|after| id.0 > after.0))
+                .map(|(id, generation)| (*id, *generation))
                 .collect();
             retirements.sort_unstable_by_key(|(id, _)| id.0);
             retirements.truncate(limit.try_into().unwrap_or(usize::MAX));
             Ok(retirements)
+        }
+
+        async fn get_pending_document_retirement(
+            &self,
+            id: DocumentId,
+        ) -> Result<Option<DocumentGeneration>> {
+            Ok(self
+                .document_state
+                .lock()
+                .unwrap()
+                .pending_retirements
+                .get(&id)
+                .copied())
         }
 
         async fn complete_document_retirement(
@@ -619,11 +655,7 @@ mod tests {
             generation: DocumentGeneration,
         ) -> Result<bool> {
             let mut state = self.document_state.lock().unwrap();
-            if !state.pending_retirements.contains(&id)
-                || !state.tombstones.contains(&id)
-                || state.documents.contains_key(&id)
-                || state.generations.get(&id) != Some(&generation)
-            {
+            if state.pending_retirements.get(&id) != Some(&generation) {
                 return Ok(false);
             }
             state.pending_retirements.remove(&id);
@@ -639,6 +671,16 @@ mod tests {
                 return Err(AgentError::Store("invalid document upsert".into()));
             }
             let mut state = self.document_state.lock().unwrap();
+            if state
+                .documents
+                .get(&document.id)
+                .is_some_and(|existing| existing.project_id != document.project_id)
+            {
+                return Err(AgentError::Store(format!(
+                    "document {} cannot move between project corpora",
+                    document.id
+                )));
+            }
             let created_at = state
                 .documents
                 .get(&document.id)
@@ -682,6 +724,16 @@ mod tests {
             }
 
             let mut state = self.document_state.lock().unwrap();
+            if state
+                .documents
+                .get(&document.id)
+                .is_some_and(|existing| existing.project_id != document.project_id)
+            {
+                return Err(AgentError::Store(format!(
+                    "document {} cannot move between project corpora",
+                    document.id
+                )));
+            }
             if let Some(existing) = state.documents.get(&document.id).filter(|existing| {
                 existing.project_id == document.project_id
                     && existing.source_uri == document.source_uri
@@ -1417,6 +1469,35 @@ mod tests {
     }
 
     #[test]
+    fn mem_store_create_document_rejects_an_unknown_project() {
+        let store = MemStore::default();
+        let now = chrono::Utc::now();
+        let document = DocumentRecord {
+            id: DocumentId::new(),
+            project_id: Some(ProjectId::new()),
+            source_uri: None,
+            media_type: "text/plain".into(),
+            title: None,
+            canonical_text: "orphan".into(),
+            content_revision: 1,
+            revision_token: uuid::Uuid::new_v4(),
+            processing_status: DocumentProcessingStatus::Queued,
+            indexed_revision: None,
+            index_fingerprint: None,
+            created_at: now,
+            updated_at: now,
+            indexed_at: None,
+        };
+
+        assert!(block_on(store.create_document(&document)).is_err());
+        assert_eq!(block_on(store.get_document(document.id)).unwrap(), None);
+        assert_eq!(
+            block_on(store.get_document_generation(document.id)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
     fn store_is_object_safe_and_roundtrips() {
         let store: Arc<dyn Store> = Arc::new(MemStore::default());
         let chat = Chat {
@@ -1521,6 +1602,47 @@ mod tests {
             ))
             .unwrap(),
             Some(DocumentJobStatus::RetryWait)
+        );
+    }
+
+    #[test]
+    fn mem_store_rejects_moving_a_live_document_between_corpora() {
+        let store: Arc<dyn Store> = Arc::new(MemStore::default());
+        let project_a = Project {
+            id: ProjectId::new(),
+            title: None,
+            workspace_dir: "/tmp/a".into(),
+            created_at: chrono::Utc::now(),
+        };
+        let project_b = Project {
+            id: ProjectId::new(),
+            workspace_dir: "/tmp/b".into(),
+            ..project_a.clone()
+        };
+        block_on(store.create_project(&project_a)).unwrap();
+        block_on(store.create_project(&project_b)).unwrap();
+        let source = DocumentUpsert {
+            id: DocumentId::new(),
+            project_id: Some(project_a.id),
+            source_uri: Some("file:///scoped.txt".into()),
+            media_type: "text/plain".into(),
+            title: None,
+            canonical_text: "project A source".into(),
+            updated_at: chrono::Utc::now(),
+        };
+        let first =
+            block_on(store.upsert_document_and_enqueue_index(&source, "pipeline-v1", 3)).unwrap();
+        let moved = DocumentUpsert {
+            project_id: Some(project_b.id),
+            canonical_text: "must not move".into(),
+            ..source
+        };
+        assert!(
+            block_on(store.upsert_document_and_enqueue_index(&moved, "pipeline-v1", 3)).is_err()
+        );
+        assert_eq!(
+            block_on(store.get_document(moved.id)).unwrap(),
+            Some(first.0)
         );
     }
 
@@ -1733,9 +1855,15 @@ mod tests {
             ..source.clone()
         }))
         .unwrap();
-        assert!(block_on(store.list_pending_document_retirements(None, 10))
-            .unwrap()
-            .is_empty());
+        assert_eq!(
+            block_on(store.list_pending_document_retirements(None, 10)).unwrap(),
+            vec![(source.id, tombstone)]
+        );
+        assert_eq!(
+            block_on(store.get_pending_document_retirement(source.id)).unwrap(),
+            Some(tombstone)
+        );
+        assert!(block_on(store.complete_document_retirement(source.id, tombstone)).unwrap());
         assert!(!block_on(store.complete_document_retirement(source.id, tombstone)).unwrap());
 
         let current_tombstone = block_on(store.delete_document(source.id)).unwrap();

--- a/crates/openwave-retrieval/src/document.rs
+++ b/crates/openwave-retrieval/src/document.rs
@@ -6,6 +6,7 @@
 //! from the vector index (offsets in the store, text rehydrated from the source),
 //! and it gives every answer a precise, verifiable pointer back into the source.
 
+use openwave_core::ProjectId;
 use serde::{Deserialize, Serialize};
 
 use crate::id::{ChunkId, DocumentId};
@@ -72,6 +73,8 @@ impl DocumentSource {
 pub struct Document {
     /// Stable identifier for this document.
     pub id: DocumentId,
+    /// Project corpus this document belongs to, or `None` for the unscoped corpus.
+    pub project_id: Option<ProjectId>,
     /// Where the document came from.
     pub source: DocumentSource,
     /// The document's media (MIME) type, e.g. `text/plain` or `text/markdown`.
@@ -104,6 +107,36 @@ impl Document {
     ) -> Self {
         Self {
             id,
+            project_id: None,
+            source,
+            media_type: media_type.into(),
+            text: text.into(),
+        }
+    }
+
+    /// Assemble a project-scoped document from freshly parsed text.
+    #[must_use]
+    pub fn new_scoped(
+        project_id: ProjectId,
+        source: DocumentSource,
+        media_type: impl Into<String>,
+        text: impl Into<String>,
+    ) -> Self {
+        Self::with_id_scoped(DocumentId::new(), project_id, source, media_type, text)
+    }
+
+    /// Assemble a project-scoped document with a caller-supplied id.
+    #[must_use]
+    pub fn with_id_scoped(
+        id: DocumentId,
+        project_id: ProjectId,
+        source: DocumentSource,
+        media_type: impl Into<String>,
+        text: impl Into<String>,
+    ) -> Self {
+        Self {
+            id,
+            project_id: Some(project_id),
             source,
             media_type: media_type.into(),
             text: text.into(),

--- a/crates/openwave-retrieval/src/lance_store.rs
+++ b/crates/openwave-retrieval/src/lance_store.rs
@@ -36,8 +36,10 @@ use crate::document::{ByteSpan, Chunk, ScoredChunk};
 use crate::embed::Embedding;
 use crate::error::{Result, RetrievalError};
 use crate::id::{ChunkId, DocumentId};
-use crate::vector::{DocumentGenerationState, GenerationStageOutcome, VectorRecord, VectorStore};
-use openwave_core::DocumentGeneration;
+use crate::vector::{
+    DocumentGenerationState, GenerationStageOutcome, SearchScope, VectorRecord, VectorStore,
+};
+use openwave_core::{DocumentGeneration, ProjectId};
 
 /// The single table all chunks and publication markers are stored in.
 const TABLE: &str = "chunks";
@@ -152,6 +154,114 @@ impl LanceVectorStore {
         Ok(())
     }
 
+    fn validate_document_records(
+        &self,
+        document_id: DocumentId,
+        records: &[VectorRecord],
+    ) -> Result<()> {
+        let project_id = records.first().map(|record| record.project_id);
+        for record in records {
+            self.check_dims(&record.embedding)?;
+            if record.chunk.document_id != document_id {
+                return Err(RetrievalError::vector_store(format!(
+                    "replacement record {} belongs to document {}, expected {document_id}",
+                    record.chunk.id, record.chunk.document_id
+                )));
+            }
+            if Some(record.project_id) != project_id {
+                return Err(RetrievalError::vector_store(format!(
+                    "records for document {document_id} span multiple project corpora"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_upsert_records(&self, records: &[VectorRecord]) -> Result<()> {
+        let mut projects = std::collections::HashMap::new();
+        for record in records {
+            self.check_dims(&record.embedding)?;
+            match projects.entry(record.chunk.document_id) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(record.project_id);
+                }
+                std::collections::hash_map::Entry::Occupied(entry)
+                    if *entry.get() != record.project_id =>
+                {
+                    return Err(RetrievalError::vector_store(format!(
+                        "records for document {} span multiple project corpora",
+                        record.chunk.document_id
+                    )));
+                }
+                std::collections::hash_map::Entry::Occupied(_) => {}
+            }
+        }
+        Ok(())
+    }
+
+    async fn live_document_project_id(
+        &self,
+        document_id: DocumentId,
+    ) -> Result<Option<Option<ProjectId>>> {
+        let mut stream = self
+            .table
+            .query()
+            .only_if(format!(
+                "document_id = '{document_id}' AND row_kind IN ('{UNVERSIONED_CHUNK}', '{ACTIVE_CHUNK}', '{STAGED_CHUNK}')"
+            ))
+            .select(Select::columns(&["project_id"]))
+            .execute()
+            .await
+            .map_err(lance_err)?;
+        let mut found = None;
+        while let Some(batch) = stream.try_next().await.map_err(lance_err)? {
+            let project_ids = str_col(&batch, "project_id")?;
+            for index in 0..batch.num_rows() {
+                let project_id = if project_ids.is_null(index) {
+                    None
+                } else {
+                    Some(
+                        project_ids
+                            .value(index)
+                            .parse::<ProjectId>()
+                            .map_err(|error| {
+                                RetrievalError::vector_store(format!(
+                                    "document {document_id} has an invalid project_id: {error}"
+                                ))
+                            })?,
+                    )
+                };
+                if found.is_some_and(|existing| existing != project_id) {
+                    return Err(RetrievalError::vector_store(format!(
+                        "stored records for document {document_id} span multiple project corpora"
+                    )));
+                }
+                found = Some(project_id);
+            }
+        }
+        Ok(found)
+    }
+
+    async fn validate_live_document_scope(
+        &self,
+        document_id: DocumentId,
+        records: &[VectorRecord],
+    ) -> Result<()> {
+        let Some(requested) = records.first().map(|record| record.project_id) else {
+            return Ok(());
+        };
+        if self
+            .live_document_project_id(document_id)
+            .await?
+            .is_some_and(|existing| existing != requested)
+        {
+            return Err(RetrievalError::vector_store(format!(
+                "document {document_id} cannot move between project corpora while it has live chunks"
+            )));
+        }
+        Ok(())
+    }
+
     fn rows_to_batch(&self, rows: &[StoredRow]) -> Result<RecordBatch> {
         let storage_ids =
             StringArray::from_iter_values(rows.iter().map(|row| row.storage_id.as_str()));
@@ -171,6 +281,20 @@ impl LanceVectorStore {
             .map(|row| row.document_id.to_string())
             .collect::<Vec<_>>();
         let doc_ids = StringArray::from_iter_values(doc_id_values.iter().map(String::as_str));
+        let project_id_values = rows
+            .iter()
+            .map(|row| {
+                row.record
+                    .as_ref()
+                    .and_then(|record| record.project_id)
+                    .map(|project_id| project_id.to_string())
+            })
+            .collect::<Vec<_>>();
+        let project_ids = StringArray::from_iter(
+            project_id_values
+                .iter()
+                .map(|project_id| project_id.as_deref()),
+        );
         let ordinals = UInt64Array::from_iter_values(rows.iter().map(|row| {
             row.record
                 .as_ref()
@@ -224,6 +348,7 @@ impl LanceVectorStore {
             Arc::new(row_kinds),
             Arc::new(chunk_ids),
             Arc::new(doc_ids),
+            Arc::new(project_ids),
             Arc::new(ordinals),
             Arc::new(texts),
             Arc::new(starts),
@@ -311,6 +436,7 @@ impl LanceVectorStore {
             .select(Select::columns(&[
                 "chunk_id",
                 "document_id",
+                "project_id",
                 "ordinal",
                 "text",
                 "span_start",
@@ -405,19 +531,22 @@ fn newest_generation(
 #[async_trait]
 impl VectorStore for LanceVectorStore {
     async fn upsert(&self, records: Vec<VectorRecord>) -> Result<()> {
-        for record in &records {
-            self.check_dims(&record.embedding)?;
-        }
+        self.validate_upsert_records(&records)?;
         let records = dedupe_by_chunk_id(records);
         if records.is_empty() {
             return Ok(());
         }
         let _write = self.write_lock.lock().await;
-        let documents = records
-            .iter()
-            .map(|record| record.chunk.document_id)
-            .collect::<std::collections::HashSet<_>>();
-        for document_id in documents {
+        let mut documents = std::collections::HashMap::new();
+        for record in &records {
+            documents
+                .entry(record.chunk.document_id)
+                .or_insert_with(Vec::new)
+                .push(record.clone());
+        }
+        for (document_id, document_records) in documents {
+            self.validate_live_document_scope(document_id, &document_records)
+                .await?;
             if self.generation_rows_exist(document_id).await? {
                 return Err(RetrievalError::vector_store(
                     "legacy upsert cannot modify a generation-managed document",
@@ -428,17 +557,29 @@ impl VectorStore for LanceVectorStore {
         self.merge_rows(&rows, None).await
     }
 
-    async fn query(&self, query: &Embedding, k: usize) -> Result<Vec<ScoredChunk>> {
+    async fn query(
+        &self,
+        query: &Embedding,
+        k: usize,
+        scope: SearchScope,
+    ) -> Result<Vec<ScoredChunk>> {
         self.check_dims(query)?;
         if k == 0 {
             return Ok(Vec::new());
         }
+        // Lance applies this predicate before the vector limit, so a closer row
+        // in another corpus cannot consume one of this scope's top-k slots.
+        // ProjectId is a parsed UUID newtype, not caller-provided query text.
+        let scope_filter = match scope {
+            SearchScope::Unscoped => "project_id IS NULL".to_string(),
+            SearchScope::Project(project_id) => format!("project_id = '{project_id}'"),
+        };
         let mut stream = self
             .table
             .query()
             .nearest_to(query.0.as_slice())
             .map_err(lance_err)?
-            .only_if(VISIBLE_CHUNKS)
+            .only_if(format!("({VISIBLE_CHUNKS}) AND ({scope_filter})"))
             .column(VECTOR_COL)
             .distance_type(DistanceType::Cosine)
             .limit(k)
@@ -458,17 +599,11 @@ impl VectorStore for LanceVectorStore {
         document_id: DocumentId,
         records: Vec<VectorRecord>,
     ) -> Result<()> {
-        for record in &records {
-            self.check_dims(&record.embedding)?;
-            if record.chunk.document_id != document_id {
-                return Err(RetrievalError::vector_store(format!(
-                    "replacement record {} belongs to document {}, expected {document_id}",
-                    record.chunk.id, record.chunk.document_id
-                )));
-            }
-        }
+        self.validate_document_records(document_id, &records)?;
         let records = dedupe_by_chunk_id(records);
         let _write = self.write_lock.lock().await;
+        self.validate_live_document_scope(document_id, &records)
+            .await?;
         if self.generation_rows_exist(document_id).await? {
             return Err(RetrievalError::vector_store(
                 "legacy replacement cannot modify a generation-managed document",
@@ -490,17 +625,13 @@ impl VectorStore for LanceVectorStore {
                 "document generation revision must be at least one",
             ));
         }
-        for record in &records {
-            self.check_dims(&record.embedding)?;
-            if record.chunk.document_id != document_id {
-                return Err(RetrievalError::vector_store(format!(
-                    "staged record {} belongs to document {}, expected {document_id}",
-                    record.chunk.id, record.chunk.document_id
-                )));
-            }
-        }
+        self.validate_document_records(document_id, &records)?;
         let records = dedupe_by_chunk_id(records);
         let _write = self.write_lock.lock().await;
+        if !records.is_empty() {
+            self.validate_live_document_scope(document_id, &records)
+                .await?;
+        }
         let active = self.generation_marker(document_id, ACTIVE_MARKER).await?;
         let staged = self.generation_marker(document_id, STAGED_MARKER).await?;
         if let Some(current) = newest_generation(document_id, active, staged)? {
@@ -645,6 +776,7 @@ fn build_schema(dims: usize) -> SchemaRef {
         Field::new("row_kind", DataType::Utf8, false),
         Field::new("chunk_id", DataType::Utf8, false),
         Field::new("document_id", DataType::Utf8, false),
+        Field::new("project_id", DataType::Utf8, true),
         Field::new("ordinal", DataType::UInt64, false),
         Field::new("text", DataType::Utf8, false),
         Field::new("span_start", DataType::UInt64, false),
@@ -665,6 +797,7 @@ fn build_schema(dims: usize) -> SchemaRef {
 fn read_vector_records(batch: &RecordBatch, out: &mut Vec<VectorRecord>) -> Result<()> {
     let chunk_ids = str_col(batch, "chunk_id")?;
     let doc_ids = str_col(batch, "document_id")?;
+    let project_ids = str_col(batch, "project_id")?;
     let ordinals = u64_col(batch, "ordinal")?;
     let texts = str_col(batch, "text")?;
     let starts = u64_col(batch, "span_start")?;
@@ -683,12 +816,25 @@ fn read_vector_records(batch: &RecordBatch, out: &mut Vec<VectorRecord>) -> Resu
             .value(index)
             .parse()
             .map_err(|error| RetrievalError::vector_store(format!("bad document_id: {error}")))?;
+        let project_id = if project_ids.is_null(index) {
+            None
+        } else {
+            Some(
+                project_ids
+                    .value(index)
+                    .parse::<ProjectId>()
+                    .map_err(|error| {
+                        RetrievalError::vector_store(format!("bad project_id: {error}"))
+                    })?,
+            )
+        };
         let values = vectors.value(index);
         let values = values
             .as_any()
             .downcast_ref::<Float32Array>()
             .ok_or_else(|| RetrievalError::vector_store("vector values are not float32"))?;
         out.push(VectorRecord {
+            project_id,
             chunk: Chunk {
                 id: chunk_id,
                 document_id,
@@ -772,8 +918,22 @@ mod tests {
     fn record(doc: DocumentId, ordinal: usize, text: &str, vector: Vec<f32>) -> VectorRecord {
         let span = ByteSpan::new(ordinal * 100, ordinal * 100 + text.len());
         VectorRecord {
+            project_id: None,
             chunk: Chunk::new(doc, ordinal, span, text),
             embedding: Embedding(vector),
+        }
+    }
+
+    fn project_record(
+        project_id: ProjectId,
+        doc: DocumentId,
+        ordinal: usize,
+        text: &str,
+        vector: Vec<f32>,
+    ) -> VectorRecord {
+        VectorRecord {
+            project_id: Some(project_id),
+            ..record(doc, ordinal, text, vector)
         }
     }
 
@@ -824,7 +984,10 @@ mod tests {
             );
 
             // Nearest to "east" is the east vector, with its span/text intact.
-            let hits = store.query(&Embedding(vec![1.0, 0.0]), 1).await.unwrap();
+            let hits = store
+                .query(&Embedding(vec![1.0, 0.0]), 1, SearchScope::Unscoped)
+                .await
+                .unwrap();
             assert_eq!(hits.len(), 1);
             assert_eq!(hits[0].chunk.text, "east");
             assert_eq!(hits[0].chunk.document_id, doc);
@@ -841,15 +1004,156 @@ mod tests {
                 version_before_replace + 1
             );
             assert_eq!(store.len().await.unwrap(), 1);
-            let hits = store.query(&Embedding(vec![1.0, 0.0]), 5).await.unwrap();
+            let hits = store
+                .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
+                .await
+                .unwrap();
             assert_eq!(hits[0].chunk.text, "south");
         }
 
         // Reopen the same directory: the data is still there — that's durability.
         let reopened = LanceVectorStore::connect(uri, 2).await.unwrap();
         assert_eq!(reopened.len().await.unwrap(), 1);
-        let hits = reopened.query(&Embedding(vec![1.0, 0.0]), 5).await.unwrap();
+        let hits = reopened
+            .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(hits[0].chunk.text, "south");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn query_filters_corpus_before_top_k_and_scope_persists_on_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        let unscoped_doc = DocumentId::new();
+        let a_doc = DocumentId::new();
+        let b_doc = DocumentId::new();
+
+        {
+            let store = LanceVectorStore::connect(uri, 2).await.unwrap();
+            store
+                .upsert(vec![
+                    record(unscoped_doc, 0, "unscoped", vec![0.8, 0.2]),
+                    project_record(project_a, a_doc, 0, "project-a", vec![0.9, 0.1]),
+                    // Globally closest, but it must not consume project A's k=1.
+                    project_record(project_b, b_doc, 0, "project-b", vec![1.0, 0.0]),
+                ])
+                .await
+                .unwrap();
+
+            let query = Embedding(vec![1.0, 0.0]);
+            let unscoped = store.query(&query, 1, SearchScope::Unscoped).await.unwrap();
+            let a = store
+                .query(&query, 1, SearchScope::Project(project_a))
+                .await
+                .unwrap();
+            let b = store
+                .query(&query, 1, SearchScope::Project(project_b))
+                .await
+                .unwrap();
+            assert_eq!(unscoped[0].chunk.text, "unscoped");
+            assert_eq!(a[0].chunk.text, "project-a");
+            assert_eq!(b[0].chunk.text, "project-b");
+        }
+
+        let reopened = LanceVectorStore::connect(uri, 2).await.unwrap();
+        let query = Embedding(vec![1.0, 0.0]);
+        assert_eq!(
+            reopened
+                .query(&query, 1, SearchScope::Unscoped)
+                .await
+                .unwrap()[0]
+                .chunk
+                .text,
+            "unscoped"
+        );
+        assert_eq!(
+            reopened
+                .query(&query, 1, SearchScope::Project(project_a))
+                .await
+                .unwrap()[0]
+                .chunk
+                .text,
+            "project-a"
+        );
+        assert_eq!(
+            reopened
+                .query(&query, 1, SearchScope::Project(project_b))
+                .await
+                .unwrap()[0]
+                .chunk
+                .text,
+            "project-b"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn generation_activation_preserves_project_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
+            .await
+            .unwrap();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        let a_doc = DocumentId::new();
+        let b_doc = DocumentId::new();
+        let first = generation(1);
+
+        store
+            .upsert(vec![project_record(
+                project_b,
+                b_doc,
+                0,
+                "project-b",
+                vec![1.0, 0.0],
+            )])
+            .await
+            .unwrap();
+        store
+            .stage_document_generation(
+                a_doc,
+                first,
+                vec![project_record(
+                    project_a,
+                    a_doc,
+                    0,
+                    "project-a-active",
+                    vec![0.9, 0.1],
+                )],
+            )
+            .await
+            .unwrap();
+
+        let query = Embedding(vec![1.0, 0.0]);
+        assert!(store
+            .query(&query, 1, SearchScope::Project(project_a))
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(store
+            .activate_document_generation(a_doc, first)
+            .await
+            .unwrap());
+        assert_eq!(
+            store
+                .query(&query, 1, SearchScope::Project(project_a))
+                .await
+                .unwrap()[0]
+                .chunk
+                .text,
+            "project-a-active"
+        );
+        assert_eq!(
+            store
+                .query(&query, 1, SearchScope::Project(project_b))
+                .await
+                .unwrap()[0]
+                .chunk
+                .text,
+            "project-b"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -871,7 +1175,10 @@ mod tests {
 
         store.replace_document(doc, vec![a, b]).await.unwrap();
         assert_eq!(store.len().await.unwrap(), 1);
-        let hits = store.query(&Embedding(vec![0.0, 1.0]), 5).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![0.0, 1.0]), 5, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].chunk.text, "new");
     }
@@ -928,7 +1235,7 @@ mod tests {
             .await
             .unwrap();
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 5)
+            .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
             .await
             .unwrap()
             .is_empty());
@@ -937,7 +1244,7 @@ mod tests {
             .await
             .unwrap();
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 0)
+            .query(&Embedding(vec![1.0, 0.0]), 0, SearchScope::Unscoped)
             .await
             .unwrap()
             .is_empty());
@@ -964,7 +1271,10 @@ mod tests {
 
         assert_eq!(store.table.version().await.unwrap(), version + 1);
         assert_eq!(store.len().await.unwrap(), 1);
-        let hits = store.query(&Embedding(vec![0.0, 1.0]), 10).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![0.0, 1.0]), 10, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].chunk.document_id, kept);
     }
@@ -998,7 +1308,7 @@ mod tests {
         b.unwrap();
 
         let texts: std::collections::BTreeSet<_> = store
-            .query(&Embedding(vec![1.0, 0.0]), 10)
+            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap()
             .into_iter()
@@ -1030,9 +1340,259 @@ mod tests {
 
         assert!(err.to_string().contains("belongs to document"));
         assert_eq!(store.table.version().await.unwrap(), version);
-        let hits = store.query(&Embedding(vec![1.0, 0.0]), 10).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].chunk.text, "original");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn document_writes_reject_mixed_project_metadata_before_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
+            .await
+            .unwrap();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        let legacy_doc = DocumentId::new();
+        let generation_doc = DocumentId::new();
+        store
+            .upsert(vec![record(legacy_doc, 0, "original", vec![1.0, 0.0])])
+            .await
+            .unwrap();
+
+        let version = store.table.version().await.unwrap();
+        let mixed_legacy = [
+            vec![
+                record(legacy_doc, 1, "unscoped", vec![1.0, 0.0]),
+                project_record(project_a, legacy_doc, 2, "project-a", vec![1.0, 0.0]),
+            ],
+            vec![
+                project_record(project_a, legacy_doc, 1, "project-a", vec![1.0, 0.0]),
+                project_record(project_b, legacy_doc, 2, "project-b", vec![1.0, 0.0]),
+            ],
+        ];
+        for records in mixed_legacy {
+            let error = store
+                .replace_document(legacy_doc, records)
+                .await
+                .unwrap_err();
+            assert!(error.to_string().contains("multiple project corpora"));
+            assert_eq!(store.table.version().await.unwrap(), version);
+        }
+        let hits = store
+            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].chunk.text, "original");
+
+        let mixed_generation = [
+            vec![
+                record(generation_doc, 0, "unscoped", vec![1.0, 0.0]),
+                project_record(project_a, generation_doc, 1, "project-a", vec![1.0, 0.0]),
+            ],
+            vec![
+                project_record(project_a, generation_doc, 0, "project-a", vec![1.0, 0.0]),
+                project_record(project_b, generation_doc, 1, "project-b", vec![1.0, 0.0]),
+            ],
+        ];
+        for records in mixed_generation {
+            let error = store
+                .stage_document_generation(generation_doc, generation(1), records)
+                .await
+                .unwrap_err();
+            assert!(error.to_string().contains("multiple project corpora"));
+            assert_eq!(store.table.version().await.unwrap(), version);
+            assert_eq!(
+                store
+                    .newest_document_generation(generation_doc)
+                    .await
+                    .unwrap(),
+                None
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn live_documents_cannot_move_between_project_corpora() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
+            .await
+            .unwrap();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+
+        let batch_doc = DocumentId::new();
+        let empty_version = store.table.version().await.unwrap();
+        let error = store
+            .upsert(vec![
+                project_record(project_a, batch_doc, 0, "batch-a", vec![1.0, 0.0]),
+                project_record(project_b, batch_doc, 1, "batch-b", vec![1.0, 0.0]),
+            ])
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("multiple project corpora"));
+        assert_eq!(store.table.version().await.unwrap(), empty_version);
+        assert_eq!(store.document_len(batch_doc).await.unwrap(), Some(0));
+
+        let legacy_doc = DocumentId::new();
+        store
+            .upsert(vec![project_record(
+                project_a,
+                legacy_doc,
+                0,
+                "legacy-a",
+                vec![1.0, 0.0],
+            )])
+            .await
+            .unwrap();
+        let legacy_version = store.table.version().await.unwrap();
+        let error = store
+            .upsert(vec![project_record(
+                project_b,
+                legacy_doc,
+                1,
+                "sequential-b",
+                vec![1.0, 0.0],
+            )])
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("cannot move"));
+        assert_eq!(store.table.version().await.unwrap(), legacy_version);
+        let error = store
+            .replace_document(
+                legacy_doc,
+                vec![project_record(
+                    project_b,
+                    legacy_doc,
+                    0,
+                    "replacement-b",
+                    vec![1.0, 0.0],
+                )],
+            )
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("cannot move"));
+        assert_eq!(store.table.version().await.unwrap(), legacy_version);
+        assert_eq!(
+            store
+                .query(
+                    &Embedding(vec![1.0, 0.0]),
+                    10,
+                    SearchScope::Project(project_a),
+                )
+                .await
+                .unwrap()[0]
+                .chunk
+                .text,
+            "legacy-a"
+        );
+        assert!(store
+            .query(
+                &Embedding(vec![1.0, 0.0]),
+                10,
+                SearchScope::Project(project_b),
+            )
+            .await
+            .unwrap()
+            .is_empty());
+
+        let generation_doc = DocumentId::new();
+        let first = generation(1);
+        store
+            .stage_document_generation(
+                generation_doc,
+                first,
+                vec![project_record(
+                    project_a,
+                    generation_doc,
+                    0,
+                    "generation-a",
+                    vec![1.0, 0.0],
+                )],
+            )
+            .await
+            .unwrap();
+        assert!(store
+            .activate_document_generation(generation_doc, first)
+            .await
+            .unwrap());
+        let active_version = store.table.version().await.unwrap();
+        let error = store
+            .stage_document_generation(
+                generation_doc,
+                generation(2),
+                vec![project_record(
+                    project_b,
+                    generation_doc,
+                    0,
+                    "generation-b",
+                    vec![1.0, 0.0],
+                )],
+            )
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("cannot move"));
+        assert_eq!(store.table.version().await.unwrap(), active_version);
+        assert_eq!(
+            store
+                .newest_document_generation(generation_doc)
+                .await
+                .unwrap(),
+            Some(DocumentGenerationState::Active(first))
+        );
+        let project_a_hits = store
+            .query(
+                &Embedding(vec![1.0, 0.0]),
+                10,
+                SearchScope::Project(project_a),
+            )
+            .await
+            .unwrap();
+        assert!(project_a_hits.iter().any(|hit| {
+            hit.chunk.document_id == generation_doc && hit.chunk.text == "generation-a"
+        }));
+        assert!(store
+            .query(
+                &Embedding(vec![1.0, 0.0]),
+                10,
+                SearchScope::Project(project_b),
+            )
+            .await
+            .unwrap()
+            .is_empty());
+
+        // Once an empty generation removes all live chunks, a recreated
+        // document may choose a new corpus.
+        let tombstone = generation(2);
+        store
+            .stage_document_generation(generation_doc, tombstone, Vec::new())
+            .await
+            .unwrap();
+        assert!(store
+            .activate_document_generation(generation_doc, tombstone)
+            .await
+            .unwrap());
+        assert_eq!(
+            store
+                .stage_document_generation(
+                    generation_doc,
+                    generation(3),
+                    vec![project_record(
+                        project_b,
+                        generation_doc,
+                        0,
+                        "recreated-b",
+                        vec![1.0, 0.0],
+                    )],
+                )
+                .await
+                .unwrap(),
+            GenerationStageOutcome::Staged
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1115,7 +1675,10 @@ mod tests {
             store.newest_document_generation(doc).await.unwrap(),
             Some(DocumentGenerationState::Staged(first))
         );
-        let hits = store.query(&Embedding(vec![1.0, 0.0]), 10).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].chunk.text, "other");
         drop(store);
@@ -1136,7 +1699,7 @@ mod tests {
         );
         assert_eq!(reopened.len().await.unwrap(), 2);
         let hits = reopened
-            .query(&Embedding(vec![1.0, 0.0]), 10)
+            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert!(hits.iter().any(|hit| hit.chunk.text == "first"));
@@ -1244,6 +1807,76 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn tombstone_allows_a_later_generation_to_change_corpus() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
+            .await
+            .unwrap();
+        let doc = DocumentId::new();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        for (generation, records) in [
+            (
+                generation(1),
+                vec![project_record(
+                    project_a,
+                    doc,
+                    0,
+                    "old corpus",
+                    vec![1.0, 0.0],
+                )],
+            ),
+            (generation(2), Vec::new()),
+            (
+                generation(3),
+                vec![project_record(
+                    project_b,
+                    doc,
+                    0,
+                    "new corpus",
+                    vec![0.0, 1.0],
+                )],
+            ),
+        ] {
+            assert_eq!(
+                store
+                    .stage_document_generation(doc, generation, records)
+                    .await
+                    .unwrap(),
+                GenerationStageOutcome::Staged
+            );
+            assert!(store
+                .activate_document_generation(doc, generation)
+                .await
+                .unwrap());
+        }
+        assert_eq!(
+            store
+                .query(
+                    &Embedding(vec![0.0, 1.0]),
+                    5,
+                    SearchScope::Project(project_a)
+                )
+                .await
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            store
+                .query(
+                    &Embedding(vec![0.0, 1.0]),
+                    5,
+                    SearchScope::Project(project_b)
+                )
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn concurrent_stages_leave_only_the_highest_generation_activatable() {
         let dir = tempfile::tempdir().unwrap();
         let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
@@ -1278,7 +1911,10 @@ mod tests {
             .activate_document_generation(doc, third)
             .await
             .unwrap());
-        let hits = store.query(&Embedding(vec![0.0, 1.0]), 10).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![0.0, 1.0]), 10, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].chunk.text, "third");
     }

--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -24,7 +24,7 @@
 //! use std::sync::Arc;
 //! use openwave_retrieval::{
 //!     Retriever, PlainTextParser, TextChunker, HashEmbedder, InMemoryVectorStore,
-//!     DocumentSource,
+//!     DocumentSource, SearchScope,
 //! };
 //!
 //! # async fn demo() -> openwave_retrieval::Result<()> {
@@ -39,7 +39,9 @@
 //! retriever
 //!     .ingest(DocumentSource::uri("notes.txt"), "text/plain", b"Jupiter is a gas giant.")
 //!     .await?;
-//! let hits = retriever.search("largest planet", 3).await?;
+//! let hits = retriever
+//!     .search(SearchScope::Unscoped, "largest planet", 3)
+//!     .await?;
 //! for hit in hits {
 //!     println!("[{:.3}] {}", hit.score, hit.snippet);
 //! }
@@ -58,7 +60,7 @@
 //! drop-in for [`HashEmbedder`] behind the same seam.
 //!
 //! Not yet wired: embedding reranking, hybrid retrieval, rich-format parsing,
-//! per-chat/project index scoping, and ANN index management. Each lands as its own
+//! chat-to-project scope binding, and ANN index management. Each lands as its own
 //! slice behind these seams.
 
 mod chunk;
@@ -85,11 +87,12 @@ pub use id::{ChunkId, DocumentId};
 pub use lance_store::LanceVectorStore;
 #[cfg(feature = "embed-openai")]
 pub use openai_embed::OpenAiEmbedder;
-pub use openwave_core::DocumentGeneration;
+pub use openwave_core::{DocumentGeneration, ProjectId};
 pub use parse::{DocumentParser, ParsedDocument, PlainTextParser};
 pub use retriever::{GenerationIndexOutcome, IngestOutcome, Retriever};
 #[cfg(feature = "tool")]
 pub use search::SearchTool;
 pub use vector::{
-    DocumentGenerationState, GenerationStageOutcome, InMemoryVectorStore, VectorRecord, VectorStore,
+    DocumentGenerationState, GenerationStageOutcome, InMemoryVectorStore, SearchScope,
+    VectorRecord, VectorStore,
 };

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -13,7 +13,7 @@ use crate::embed::Embedder;
 use crate::error::{Result, RetrievalError};
 use crate::id::DocumentId;
 use crate::parse::DocumentParser;
-use crate::vector::{GenerationStageOutcome, VectorRecord, VectorStore};
+use crate::vector::{GenerationStageOutcome, SearchScope, VectorRecord, VectorStore};
 use openwave_core::DocumentGeneration;
 
 /// The outcome of ingesting one document.
@@ -211,7 +211,11 @@ impl Retriever {
             chunks
                 .into_iter()
                 .zip(embeddings)
-                .map(|(chunk, embedding)| VectorRecord { chunk, embedding })
+                .map(|(chunk, embedding)| VectorRecord {
+                    project_id: document.project_id,
+                    chunk,
+                    embedding,
+                })
                 .collect()
         };
         Ok(records)
@@ -245,9 +249,9 @@ impl Retriever {
     }
 
     /// Search the index for the `k` chunks most relevant to `query`, as citations.
-    pub async fn search(&self, query: &str, k: usize) -> Result<Vec<Citation>> {
+    pub async fn search(&self, scope: SearchScope, query: &str, k: usize) -> Result<Vec<Citation>> {
         let embedding = self.embedder.embed_query(query).await?;
-        let hits = self.store.query(&embedding, k).await?;
+        let hits = self.store.query(&embedding, k, scope).await?;
         Ok(hits.into_iter().map(Citation::from).collect())
     }
 
@@ -324,7 +328,11 @@ The Great Barrier Reef is the world's largest coral reef system.";
         assert!(outcome.chunks >= 3);
 
         let hits = r
-            .search("which planet is the largest gas giant", 1)
+            .search(
+                SearchScope::Unscoped,
+                "which planet is the largest gas giant",
+                1,
+            )
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);
@@ -352,7 +360,35 @@ The Great Barrier Reef is the world's largest coral reef system.";
         assert_eq!(document.text, "persist this before embedding");
 
         assert_eq!(r.index_document(&document).await.unwrap(), 1);
-        let hits = r.search("persist embedding", 1).await.unwrap();
+        let hits = r
+            .search(SearchScope::Unscoped, "persist embedding", 1)
+            .await
+            .unwrap();
+        assert_eq!(hits[0].document_id, document.id);
+    }
+
+    #[tokio::test]
+    async fn indexing_preserves_the_documents_project_scope() {
+        let r = retriever();
+        let project_id = openwave_core::ProjectId::new();
+        let document = Document::new_scoped(
+            project_id,
+            DocumentSource::Inline,
+            "text/plain",
+            "project-only retrieval content",
+        );
+        assert_eq!(r.index_document(&document).await.unwrap(), 1);
+
+        assert!(r
+            .search(SearchScope::Unscoped, "retrieval content", 1)
+            .await
+            .unwrap()
+            .is_empty());
+        let hits = r
+            .search(SearchScope::Project(project_id), "retrieval content", 1)
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].document_id, document.id);
     }
 
@@ -376,12 +412,22 @@ The Great Barrier Reef is the world's largest coral reef system.";
         let staged = r.stage_document_generation(&document, first).await.unwrap();
         assert_eq!(staged.chunks, Some(1));
         assert_eq!(staged.stage, GenerationStageOutcome::Staged);
-        assert!(r.search("indexing", 5).await.unwrap().is_empty());
+        assert!(r
+            .search(SearchScope::Unscoped, "indexing", 5)
+            .await
+            .unwrap()
+            .is_empty());
         assert!(r
             .activate_document_generation(document.id, first)
             .await
             .unwrap());
-        assert_eq!(r.search("indexing", 5).await.unwrap().len(), 1);
+        assert_eq!(
+            r.search(SearchScope::Unscoped, "indexing", 5)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
 
         assert_eq!(
             r.stage_document_tombstone(document.id, tombstone)
@@ -389,12 +435,22 @@ The Great Barrier Reef is the world's largest coral reef system.";
                 .unwrap(),
             GenerationStageOutcome::Staged
         );
-        assert_eq!(r.search("indexing", 5).await.unwrap().len(), 1);
+        assert_eq!(
+            r.search(SearchScope::Unscoped, "indexing", 5)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
         assert!(r
             .activate_document_generation(document.id, tombstone)
             .await
             .unwrap());
-        assert!(r.search("indexing", 5).await.unwrap().is_empty());
+        assert!(r
+            .search(SearchScope::Unscoped, "indexing", 5)
+            .await
+            .unwrap()
+            .is_empty());
         assert_eq!(
             r.stage_document_generation(&document, first)
                 .await
@@ -486,7 +542,11 @@ The Great Barrier Reef is the world's largest coral reef system.";
             .unwrap();
         assert_eq!(outcome.chunks, 0);
         assert!(r.store().is_empty().await.unwrap());
-        assert!(r.search("anything", 5).await.unwrap().is_empty());
+        assert!(r
+            .search(SearchScope::Unscoped, "anything", 5)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]
@@ -506,7 +566,11 @@ The Great Barrier Reef is the world's largest coral reef system.";
         let records: Vec<VectorRecord> = chunks
             .into_iter()
             .zip(embeddings)
-            .map(|(chunk, embedding)| VectorRecord { chunk, embedding })
+            .map(|(chunk, embedding)| VectorRecord {
+                project_id: None,
+                chunk,
+                embedding,
+            })
             .collect();
 
         // Upsert the same derived-id records twice; the store must not grow.
@@ -539,7 +603,10 @@ The Great Barrier Reef is the world's largest coral reef system.";
         assert_eq!(r.store().len().await.unwrap(), after_first);
 
         // And a single search returns each chunk once, not doubled.
-        let hits = r.search("three four five", 10).await.unwrap();
+        let hits = r
+            .search(SearchScope::Unscoped, "three four five", 10)
+            .await
+            .unwrap();
         let unique: std::collections::HashSet<_> = hits.iter().map(|h| h.chunk_id).collect();
         assert_eq!(unique.len(), hits.len());
     }
@@ -566,7 +633,7 @@ The Great Barrier Reef is the world's largest coral reef system.";
         assert_eq!(second.document.id, first.document.id);
         // The store holds only the new chunks — the old beta/gamma ones are pruned.
         assert_eq!(r.store().len().await.unwrap(), second.chunks);
-        let hits = r.search("gamma", 10).await.unwrap();
+        let hits = r.search(SearchScope::Unscoped, "gamma", 10).await.unwrap();
         assert!(
             hits.iter().all(|h| !h.snippet.contains("gamma")),
             "stale chunks from the longer version must be gone"

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -23,7 +23,7 @@ use serde_json::{json, Value};
 
 use crate::document::Citation;
 use crate::embed::Embedder;
-use crate::vector::VectorStore;
+use crate::vector::{SearchScope, VectorStore};
 
 /// A `Tool` that searches an embedded index and returns grounded citations.
 pub struct SearchTool {
@@ -126,7 +126,7 @@ impl Tool for SearchTool {
             Ok(embedding) => embedding,
             Err(err) => return Ok(ToolOutput::error(format!("embedding failed: {err}"))),
         };
-        let hits = match self.store.query(&embedding, k).await {
+        let hits = match self.store.query(&embedding, k, SearchScope::Unscoped).await {
             Ok(hits) => hits,
             Err(err) => return Ok(ToolOutput::error(format!("search failed: {err}"))),
         };
@@ -171,7 +171,11 @@ mod tests {
         let records: Vec<VectorRecord> = chunks
             .into_iter()
             .zip(embeddings)
-            .map(|(chunk, embedding)| VectorRecord { chunk, embedding })
+            .map(|(chunk, embedding)| VectorRecord {
+                project_id: None,
+                chunk,
+                embedding,
+            })
             .collect();
         store.upsert(records).await.unwrap();
 

--- a/crates/openwave-retrieval/src/vector.rs
+++ b/crates/openwave-retrieval/src/vector.rs
@@ -4,9 +4,8 @@
 //! is the reference backend — a brute-force cosine scan behind a lock. It has no
 //! persistence and is O(n) per query, which is exactly right for tests, small
 //! local corpora, and pinning down the semantics that persistent backends
-//! (sqlite-vec, pgvector, Qdrant) must reproduce. Those, plus metadata filtering
-//! and hybrid dense+sparse search, arrive as feature-gated backends behind this
-//! trait later.
+//! (sqlite-vec, pgvector, Qdrant) must reproduce. Those, plus hybrid dense+sparse
+//! search, arrive as feature-gated backends behind this trait later.
 
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -18,10 +17,31 @@ use crate::embed::Embedding;
 use crate::error::{Result, RetrievalError};
 use crate::id::DocumentId;
 use openwave_core::DocumentGeneration;
+use openwave_core::ProjectId;
+
+/// Corpus boundary applied to every retrieval query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchScope {
+    /// Only documents not assigned to a project.
+    Unscoped,
+    /// Only documents assigned to this project.
+    Project(ProjectId),
+}
+
+impl SearchScope {
+    fn includes(self, project_id: Option<ProjectId>) -> bool {
+        match self {
+            Self::Unscoped => project_id.is_none(),
+            Self::Project(expected) => project_id == Some(expected),
+        }
+    }
+}
 
 /// A chunk together with its embedding, ready to store.
 #[derive(Debug, Clone)]
 pub struct VectorRecord {
+    /// Project corpus this vector belongs to, or `None` for the unscoped corpus.
+    pub project_id: Option<ProjectId>,
     /// The chunk being indexed.
     pub chunk: Chunk,
     /// Its embedding. Must match the store's dimensionality.
@@ -81,7 +101,12 @@ pub trait VectorStore: Send + Sync {
     ///
     /// Fewer than `k` come back when the store holds fewer records. `k == 0`
     /// yields an empty result.
-    async fn query(&self, query: &Embedding, k: usize) -> Result<Vec<ScoredChunk>>;
+    async fn query(
+        &self,
+        query: &Embedding,
+        k: usize,
+        scope: SearchScope,
+    ) -> Result<Vec<ScoredChunk>>;
 
     /// Atomically replace every chunk of `document_id` with `records`: remove the
     /// document's existing chunks and store the new ones as one operation.
@@ -226,7 +251,8 @@ impl InMemoryVectorStore {
         &self,
         document_id: DocumentId,
         records: &[VectorRecord],
-    ) -> Result<()> {
+    ) -> Result<Option<Option<ProjectId>>> {
+        let project_id = records.first().map(|record| record.project_id);
         for record in records {
             self.check_dims(&record.embedding)?;
             if record.chunk.document_id != document_id {
@@ -235,6 +261,30 @@ impl InMemoryVectorStore {
                     record.chunk.id, record.chunk.document_id
                 )));
             }
+            if Some(record.project_id) != project_id {
+                return Err(RetrievalError::vector_store(format!(
+                    "records for document {document_id} span multiple project corpora"
+                )));
+            }
+        }
+        Ok(project_id)
+    }
+
+    fn ensure_scope_unchanged<'a>(
+        document_id: DocumentId,
+        requested: Option<Option<ProjectId>>,
+        existing: impl Iterator<Item = &'a VectorRecord>,
+    ) -> Result<()> {
+        let Some(requested) = requested else {
+            return Ok(());
+        };
+        if existing
+            .filter(|record| record.chunk.document_id == document_id)
+            .any(|record| record.project_id != requested)
+        {
+            return Err(RetrievalError::vector_store(format!(
+                "document {document_id} cannot move between project corpora while it has indexed records"
+            )));
         }
         Ok(())
     }
@@ -243,8 +293,23 @@ impl InMemoryVectorStore {
 #[async_trait]
 impl VectorStore for InMemoryVectorStore {
     async fn upsert(&self, records: Vec<VectorRecord>) -> Result<()> {
+        let mut scopes = HashMap::new();
         for record in &records {
             self.check_dims(&record.embedding)?;
+            match scopes.entry(record.chunk.document_id) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(record.project_id);
+                }
+                std::collections::hash_map::Entry::Occupied(entry)
+                    if *entry.get() != record.project_id =>
+                {
+                    return Err(RetrievalError::vector_store(format!(
+                        "records for document {} span multiple project corpora",
+                        record.chunk.document_id
+                    )));
+                }
+                std::collections::hash_map::Entry::Occupied(_) => {}
+            }
         }
         let mut store = self
             .state
@@ -258,13 +323,25 @@ impl VectorStore for InMemoryVectorStore {
                 "legacy upsert cannot modify a generation-managed document",
             ));
         }
+        for (document_id, project_id) in scopes {
+            Self::ensure_scope_unchanged(
+                document_id,
+                Some(project_id),
+                store.unversioned_records.iter(),
+            )?;
+        }
         for record in records {
             upsert_unversioned(&mut store.unversioned_records, record);
         }
         Ok(())
     }
 
-    async fn query(&self, query: &Embedding, k: usize) -> Result<Vec<ScoredChunk>> {
+    async fn query(
+        &self,
+        query: &Embedding,
+        k: usize,
+        scope: SearchScope,
+    ) -> Result<Vec<ScoredChunk>> {
         self.check_dims(query)?;
         if k == 0 {
             return Ok(Vec::new());
@@ -282,6 +359,7 @@ impl VectorStore for InMemoryVectorStore {
                 .flat_map(|active| active.records.iter()),
         );
         let mut scored: Vec<ScoredChunk> = visible
+            .filter(|record| scope.includes(record.project_id))
             .map(|r| ScoredChunk {
                 chunk: r.chunk.clone(),
                 score: query.cosine_similarity(&r.embedding),
@@ -304,7 +382,7 @@ impl VectorStore for InMemoryVectorStore {
         document_id: DocumentId,
         records: Vec<VectorRecord>,
     ) -> Result<()> {
-        self.validate_document_records(document_id, &records)?;
+        let project_id = self.validate_document_records(document_id, &records)?;
         // Delete + insert under a single write lock, so a concurrent ingest can't
         // observe or race a half-applied replacement.
         let mut store = self
@@ -316,6 +394,7 @@ impl VectorStore for InMemoryVectorStore {
                 "legacy replacement cannot modify a generation-managed document",
             ));
         }
+        Self::ensure_scope_unchanged(document_id, project_id, store.unversioned_records.iter())?;
         store
             .unversioned_records
             .retain(|r| r.chunk.document_id != document_id);
@@ -348,12 +427,36 @@ impl VectorStore for InMemoryVectorStore {
                 "document generation revision must be at least one",
             ));
         }
-        self.validate_document_records(document_id, &records)?;
+        let project_id = self.validate_document_records(document_id, &records)?;
         let records = dedupe_records(records);
         let mut state = self
             .state
             .write()
             .map_err(|_| RetrievalError::vector_store("in-memory store lock poisoned"))?;
+        if !records.is_empty() {
+            if let Some(publication) = state.publications.get(&document_id) {
+                let existing = publication
+                    .active
+                    .as_ref()
+                    .into_iter()
+                    .flat_map(|generation| generation.records.iter())
+                    .chain(
+                        publication
+                            .staged
+                            .as_ref()
+                            .into_iter()
+                            .flat_map(|generation| generation.records.iter()),
+                    );
+                Self::ensure_scope_unchanged(document_id, project_id, existing)?;
+            }
+        }
+        if !records.is_empty() {
+            Self::ensure_scope_unchanged(
+                document_id,
+                project_id,
+                state.unversioned_records.iter(),
+            )?;
+        }
         let publication = state.publications.entry(document_id).or_default();
         let newest = publication
             .active
@@ -540,8 +643,22 @@ mod tests {
     fn record(doc: DocumentId, ordinal: usize, text: &str, vector: Vec<f32>) -> VectorRecord {
         let span = ByteSpan::new(ordinal * 100, ordinal * 100 + text.len());
         VectorRecord {
+            project_id: None,
             chunk: Chunk::new(doc, ordinal, span, text),
             embedding: Embedding(vector),
+        }
+    }
+
+    fn scoped_record(
+        doc: DocumentId,
+        project_id: ProjectId,
+        ordinal: usize,
+        text: &str,
+        vector: Vec<f32>,
+    ) -> VectorRecord {
+        VectorRecord {
+            project_id: Some(project_id),
+            ..record(doc, ordinal, text, vector)
         }
     }
 
@@ -567,7 +684,10 @@ mod tests {
                 actual: 2
             }
         ));
-        assert!(store.query(&Embedding(vec![1.0, 0.0]), 5).await.is_err());
+        assert!(store
+            .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
+            .await
+            .is_err());
     }
 
     #[tokio::test]
@@ -584,7 +704,10 @@ mod tests {
             .unwrap();
 
         // A query pointing east should rank "east" first, then the diagonal.
-        let hits = store.query(&Embedding(vec![1.0, 0.0]), 2).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![1.0, 0.0]), 2, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].chunk.text, "east");
         assert_eq!(hits[1].chunk.text, "north-east");
@@ -592,16 +715,318 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn query_filters_by_corpus_before_scoring_and_top_k() {
+        let store = InMemoryVectorStore::new(2);
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        store
+            .upsert(vec![
+                scoped_record(
+                    DocumentId::new(),
+                    project_a,
+                    0,
+                    "weaker right-project hit",
+                    vec![0.8, 0.6],
+                ),
+                scoped_record(
+                    DocumentId::new(),
+                    project_b,
+                    0,
+                    "stronger wrong-project hit",
+                    vec![1.0, 0.0],
+                ),
+                record(
+                    DocumentId::new(),
+                    0,
+                    "stronger unscoped hit",
+                    vec![1.0, 0.0],
+                ),
+            ])
+            .await
+            .unwrap();
+
+        let project_hits = store
+            .query(
+                &Embedding(vec![1.0, 0.0]),
+                1,
+                SearchScope::Project(project_a),
+            )
+            .await
+            .unwrap();
+        assert_eq!(project_hits.len(), 1);
+        assert_eq!(project_hits[0].chunk.text, "weaker right-project hit");
+
+        let unscoped_hits = store
+            .query(&Embedding(vec![1.0, 0.0]), 1, SearchScope::Unscoped)
+            .await
+            .unwrap();
+        assert_eq!(unscoped_hits.len(), 1);
+        assert_eq!(unscoped_hits[0].chunk.text, "stronger unscoped hit");
+    }
+
+    #[tokio::test]
+    async fn document_writes_reject_mixed_project_metadata() {
+        let store = InMemoryVectorStore::new(2);
+        let doc = DocumentId::new();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        let records = vec![
+            scoped_record(doc, project_a, 0, "a", vec![1.0, 0.0]),
+            scoped_record(doc, project_b, 1, "b", vec![0.0, 1.0]),
+        ];
+
+        let replacement_error = store
+            .replace_document(doc, records.clone())
+            .await
+            .unwrap_err();
+        assert!(replacement_error
+            .to_string()
+            .contains("multiple project corpora"));
+        let stage_error = store
+            .stage_document_generation(doc, generation(1), records)
+            .await
+            .unwrap_err();
+        assert!(stage_error.to_string().contains("multiple project corpora"));
+        assert!(store.is_empty().await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn upsert_rejects_mixed_or_incrementally_changed_project_metadata_atomically() {
+        let store = InMemoryVectorStore::new(2);
+        let doc = DocumentId::new();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+
+        let mixed_error = store
+            .upsert(vec![
+                scoped_record(doc, project_a, 0, "a", vec![1.0, 0.0]),
+                scoped_record(doc, project_b, 1, "b", vec![0.0, 1.0]),
+            ])
+            .await
+            .unwrap_err();
+        assert!(mixed_error.to_string().contains("multiple project corpora"));
+        assert!(store.is_empty().await.unwrap());
+
+        store
+            .upsert(vec![scoped_record(
+                doc,
+                project_a,
+                0,
+                "original",
+                vec![1.0, 0.0],
+            )])
+            .await
+            .unwrap();
+        let move_error = store
+            .upsert(vec![scoped_record(
+                doc,
+                project_b,
+                1,
+                "must not land",
+                vec![0.0, 1.0],
+            )])
+            .await
+            .unwrap_err();
+        assert!(move_error.to_string().contains("cannot move"));
+        assert_eq!(store.len().await.unwrap(), 1);
+        let hits = store
+            .query(
+                &Embedding(vec![1.0, 0.0]),
+                10,
+                SearchScope::Project(project_a),
+            )
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].chunk.text, "original");
+        assert!(store
+            .query(
+                &Embedding(vec![0.0, 1.0]),
+                10,
+                SearchScope::Project(project_b),
+            )
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn replacement_allows_scope_change_only_after_clearing_live_records() {
+        let store = InMemoryVectorStore::new(2);
+        let doc = DocumentId::new();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        store
+            .replace_document(
+                doc,
+                vec![scoped_record(
+                    doc,
+                    project_a,
+                    0,
+                    "project a",
+                    vec![1.0, 0.0],
+                )],
+            )
+            .await
+            .unwrap();
+
+        assert!(store
+            .replace_document(
+                doc,
+                vec![scoped_record(
+                    doc,
+                    project_b,
+                    0,
+                    "blocked move",
+                    vec![0.0, 1.0],
+                )],
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("cannot move"));
+        assert_eq!(store.len().await.unwrap(), 1);
+
+        store.replace_document(doc, Vec::new()).await.unwrap();
+        store
+            .replace_document(
+                doc,
+                vec![scoped_record(
+                    doc,
+                    project_b,
+                    0,
+                    "project b",
+                    vec![0.0, 1.0],
+                )],
+            )
+            .await
+            .unwrap();
+        assert!(store
+            .query(
+                &Embedding(vec![0.0, 1.0]),
+                1,
+                SearchScope::Project(project_b),
+            )
+            .await
+            .unwrap()[0]
+            .chunk
+            .text
+            .contains("project b"));
+    }
+
+    #[tokio::test]
+    async fn staging_allows_scope_change_only_after_an_active_empty_tombstone() {
+        let store = InMemoryVectorStore::new(2);
+        let doc = DocumentId::new();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        let first = generation(1);
+        let tombstone = generation(2);
+        let recreated = generation(3);
+        store
+            .stage_document_generation(
+                doc,
+                first,
+                vec![scoped_record(
+                    doc,
+                    project_a,
+                    0,
+                    "project a",
+                    vec![1.0, 0.0],
+                )],
+            )
+            .await
+            .unwrap();
+
+        assert!(store
+            .stage_document_generation(
+                doc,
+                tombstone,
+                vec![scoped_record(
+                    doc,
+                    project_b,
+                    0,
+                    "blocked while staged",
+                    vec![0.0, 1.0],
+                )],
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("cannot move"));
+        assert!(store
+            .activate_document_generation(doc, first)
+            .await
+            .unwrap());
+        assert!(store
+            .stage_document_generation(
+                doc,
+                tombstone,
+                vec![scoped_record(
+                    doc,
+                    project_b,
+                    0,
+                    "blocked while active",
+                    vec![0.0, 1.0],
+                )],
+            )
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("cannot move"));
+
+        store
+            .stage_document_generation(doc, tombstone, Vec::new())
+            .await
+            .unwrap();
+        assert!(store
+            .activate_document_generation(doc, tombstone)
+            .await
+            .unwrap());
+        store
+            .stage_document_generation(
+                doc,
+                recreated,
+                vec![scoped_record(
+                    doc,
+                    project_b,
+                    0,
+                    "project b",
+                    vec![0.0, 1.0],
+                )],
+            )
+            .await
+            .unwrap();
+        assert!(store
+            .activate_document_generation(doc, recreated)
+            .await
+            .unwrap());
+        assert_eq!(
+            store
+                .query(
+                    &Embedding(vec![0.0, 1.0]),
+                    1,
+                    SearchScope::Project(project_b),
+                )
+                .await
+                .unwrap()[0]
+                .chunk
+                .text,
+            "project b"
+        );
+    }
+
+    #[tokio::test]
     async fn k_zero_and_empty_store_return_nothing() {
         let store = InMemoryVectorStore::new(2);
         assert!(store.is_empty().await.unwrap());
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 0)
+            .query(&Embedding(vec![1.0, 0.0]), 0, SearchScope::Unscoped)
             .await
             .unwrap()
             .is_empty());
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 5)
+            .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
             .await
             .unwrap()
             .is_empty());
@@ -627,7 +1052,10 @@ mod tests {
             Some(0)
         );
         // The second upsert's vector won.
-        let hits = store.query(&Embedding(vec![0.0, 1.0]), 1).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![0.0, 1.0]), 1, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert!((hits[0].score - 1.0).abs() < 1e-6);
     }
 
@@ -651,7 +1079,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(store.len().await.unwrap(), 2); // one a, one b
-        let hits = store.query(&Embedding(vec![1.0, 0.0]), 5).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert!(hits.iter().any(|h| h.chunk.text == "a-new"));
         assert!(
             !hits.iter().any(|h| h.chunk.text == "a1"),
@@ -676,7 +1107,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(store.len().await.unwrap(), 1);
-        let hits = store.query(&Embedding(vec![0.0, 1.0]), 5).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![0.0, 1.0]), 5, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].chunk.text, "new");
     }
@@ -726,7 +1160,10 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("belongs to document"));
-        let hits = store.query(&Embedding(vec![1.0, 0.0]), 10).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].chunk.text, "original");
     }
@@ -754,7 +1191,7 @@ mod tests {
             Some(DocumentGenerationState::Staged(first))
         );
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 10)
+            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap()
             .is_empty());
@@ -782,7 +1219,10 @@ mod tests {
                 .unwrap(),
             GenerationStageOutcome::Staged
         );
-        let before_activation = store.query(&Embedding(vec![1.0, 0.0]), 10).await.unwrap();
+        let before_activation = store
+            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(before_activation.len(), 1);
         assert_eq!(before_activation[0].chunk.text, "first");
         assert!(!store
@@ -798,7 +1238,10 @@ mod tests {
             .await
             .unwrap());
 
-        let after_activation = store.query(&Embedding(vec![0.0, 1.0]), 10).await.unwrap();
+        let after_activation = store
+            .query(&Embedding(vec![0.0, 1.0]), 10, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(after_activation.len(), 1);
         assert_eq!(after_activation[0].chunk.text, "third");
         assert_eq!(
@@ -896,6 +1339,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tombstone_allows_a_later_generation_to_change_corpus() {
+        let store = InMemoryVectorStore::new(2);
+        let doc = DocumentId::new();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        for (generation, records) in [
+            (
+                generation(1),
+                vec![scoped_record(
+                    doc,
+                    project_a,
+                    0,
+                    "old corpus",
+                    vec![1.0, 0.0],
+                )],
+            ),
+            (generation(2), Vec::new()),
+            (
+                generation(3),
+                vec![scoped_record(
+                    doc,
+                    project_b,
+                    0,
+                    "new corpus",
+                    vec![0.0, 1.0],
+                )],
+            ),
+        ] {
+            assert_eq!(
+                store
+                    .stage_document_generation(doc, generation, records)
+                    .await
+                    .unwrap(),
+                GenerationStageOutcome::Staged
+            );
+            assert!(store
+                .activate_document_generation(doc, generation)
+                .await
+                .unwrap());
+        }
+        assert_eq!(
+            store
+                .query(
+                    &Embedding(vec![0.0, 1.0]),
+                    5,
+                    SearchScope::Project(project_a)
+                )
+                .await
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            store
+                .query(
+                    &Embedding(vec![0.0, 1.0]),
+                    5,
+                    SearchScope::Project(project_b)
+                )
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn staging_validation_does_not_mutate_publication_state() {
         let store = InMemoryVectorStore::new(2);
         let doc = DocumentId::new();
@@ -955,7 +1465,10 @@ mod tests {
             .replace_document(doc, vec![record(doc, 0, "legacy", vec![1.0, 1.0])])
             .await
             .is_err());
-        let hits = store.query(&Embedding(vec![1.0, 0.0]), 10).await.unwrap();
+        let hits = store
+            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .await
+            .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].chunk.text, "active");
         assert!(store

--- a/crates/openwave-server/src/document_auditor.rs
+++ b/crates/openwave-server/src/document_auditor.rs
@@ -253,12 +253,21 @@ fn canonical_document(record: &openwave_core::DocumentRecord) -> Document {
         Some(uri) => DocumentSource::uri(uri),
         None => DocumentSource::Inline,
     };
-    Document::with_id(
-        record.id,
-        source,
-        record.media_type.clone(),
-        record.canonical_text.clone(),
-    )
+    match record.project_id {
+        Some(project_id) => Document::with_id_scoped(
+            record.id,
+            project_id,
+            source,
+            record.media_type.clone(),
+            record.canonical_text.clone(),
+        ),
+        None => Document::with_id(
+            record.id,
+            source,
+            record.media_type.clone(),
+            record.canonical_text.clone(),
+        ),
+    }
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/document_worker.rs
+++ b/crates/openwave-server/src/document_worker.rs
@@ -180,8 +180,11 @@ impl DocumentWorker {
         // operational tombstone cannot be replaced between vector activation
         // and the completion CAS below.
         let _document_write = self.document_writes.acquire(document_id).await;
-        if self.store.get_document(document_id).await?.is_some()
-            || self.store.get_document_generation(document_id).await? != Some(generation)
+        if self
+            .store
+            .get_pending_document_retirement(document_id)
+            .await?
+            != Some(generation)
         {
             return Ok(WorkerOutcome::Idle);
         }
@@ -234,6 +237,18 @@ impl DocumentWorker {
                 job.id
             ))
         })?;
+        // A recreated source can have a newer live generation while an older
+        // tombstone still has to retire the prior corpus publication. Retire
+        // that exact watermark before attempting to stage the recreated job;
+        // otherwise corpus validation correctly fences the new records behind
+        // the still-active old scope.
+        if let Some(retirement) = self
+            .store
+            .get_pending_document_retirement(job.document_id)
+            .await?
+        {
+            self.retire(job.document_id, retirement).await?;
+        }
         let Some(source) = self.store.get_document(job.document_id).await? else {
             return Ok(WorkerOutcome::Superseded(job.id));
         };
@@ -424,12 +439,21 @@ fn canonical_document(record: &openwave_core::DocumentRecord) -> Document {
         Some(uri) => DocumentSource::uri(uri),
         None => DocumentSource::Inline,
     };
-    Document::with_id(
-        record.id,
-        source,
-        record.media_type.clone(),
-        record.canonical_text.clone(),
-    )
+    match record.project_id {
+        Some(project_id) => Document::with_id_scoped(
+            record.id,
+            project_id,
+            source,
+            record.media_type.clone(),
+            record.canonical_text.clone(),
+        ),
+        None => Document::with_id(
+            record.id,
+            source,
+            record.media_type.clone(),
+            record.canonical_text.clone(),
+        ),
+    }
 }
 
 fn classify_retrieval_error(error: &RetrievalError) -> (bool, &'static str) {
@@ -462,7 +486,9 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use async_trait::async_trait;
-    use openwave_core::{DbStore, DocumentId, DocumentProcessingStatus, DocumentUpsert};
+    use openwave_core::{
+        DbStore, DocumentId, DocumentProcessingStatus, DocumentUpsert, Project, ProjectId,
+    };
     use openwave_retrieval::{
         Embedder, Embedding, HashEmbedder, InMemoryVectorStore, PlainTextParser, ScoredChunk,
         TextChunker, VectorRecord, VectorStore,
@@ -512,8 +538,9 @@ mod tests {
             &self,
             query: &Embedding,
             k: usize,
+            scope: openwave_retrieval::SearchScope,
         ) -> openwave_retrieval::Result<Vec<ScoredChunk>> {
-            self.inner.query(query, k).await
+            self.inner.query(query, k, scope).await
         }
 
         async fn replace_document(
@@ -730,7 +757,105 @@ mod tests {
             Some(document.generation())
         );
         assert_eq!(
-            retrieval.search("worker indexing", 5).await.unwrap().len(),
+            retrieval
+                .search(
+                    openwave_retrieval::SearchScope::Unscoped,
+                    "worker indexing",
+                    5,
+                )
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn recreation_in_a_new_corpus_retires_before_publishing() {
+        let (_dir, store, retrieval, _embedder, worker) = harness().await;
+        let id = DocumentId::new();
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        for project_id in [project_a, project_b] {
+            store
+                .create_project(&Project {
+                    id: project_id,
+                    title: None,
+                    workspace_dir: std::path::PathBuf::from(format!("/{project_id}")),
+                    created_at: Utc::now(),
+                })
+                .await
+                .unwrap();
+        }
+        let mut first = source(id, "first project corpus");
+        first.project_id = Some(project_a);
+        let (first_record, first_job) = store
+            .upsert_document_and_enqueue_index(&first, &retrieval.index_fingerprint(), 3)
+            .await
+            .unwrap();
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            WorkerOutcome::Completed(first_job.id)
+        );
+
+        let tombstone = store.delete_document(id).await.unwrap();
+        let mut recreated = source(id, "second project corpus");
+        recreated.project_id = Some(project_b);
+        let (recreated_record, recreated_job) = store
+            .upsert_document_and_enqueue_index(&recreated, &retrieval.index_fingerprint(), 3)
+            .await
+            .unwrap();
+        assert_eq!(
+            tombstone.content_revision,
+            first_record.content_revision + 1
+        );
+        assert_eq!(
+            recreated_record.content_revision,
+            tombstone.content_revision + 1
+        );
+        assert_eq!(
+            store.get_pending_document_retirement(id).await.unwrap(),
+            Some(tombstone)
+        );
+
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            WorkerOutcome::Completed(recreated_job.id)
+        );
+        assert_eq!(
+            store.get_pending_document_retirement(id).await.unwrap(),
+            None
+        );
+        assert_eq!(
+            retrieval
+                .store()
+                .active_document_generation(id)
+                .await
+                .unwrap(),
+            Some(recreated_record.generation())
+        );
+        assert_eq!(
+            retrieval
+                .search(
+                    openwave_retrieval::SearchScope::Project(project_a),
+                    "project corpus",
+                    5,
+                )
+                .await
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            retrieval
+                .search(
+                    openwave_retrieval::SearchScope::Project(project_b),
+                    "project corpus",
+                    5,
+                )
+                .await
+                .unwrap()
+                .len(),
             1
         );
     }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -525,8 +525,9 @@ mod tests {
             &self,
             query: &Embedding,
             k: usize,
+            scope: openwave_retrieval::SearchScope,
         ) -> openwave_retrieval::Result<Vec<ScoredChunk>> {
-            self.inner.query(query, k).await
+            self.inner.query(query, k, scope).await
         }
 
         async fn replace_document(
@@ -725,6 +726,12 @@ mod tests {
             self.inner
                 .list_pending_document_retirements(after, limit)
                 .await
+        }
+        async fn get_pending_document_retirement(
+            &self,
+            id: openwave_core::DocumentId,
+        ) -> Result<Option<openwave_core::DocumentGeneration>> {
+            self.inner.get_pending_document_retirement(id).await
         }
         async fn complete_document_retirement(
             &self,
@@ -2173,6 +2180,38 @@ mod tests {
         assert!(results["citations"].as_array().unwrap().is_empty());
     }
 
+    #[tokio::test]
+    async fn root_search_never_returns_project_owned_vectors() {
+        let vectors = Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS));
+        vectors
+            .upsert(vec![VectorRecord {
+                project_id: Some(ProjectId::new()),
+                chunk: openwave_retrieval::Chunk::new(
+                    openwave_core::DocumentId::new(),
+                    0,
+                    openwave_retrieval::ByteSpan::new(0, 14),
+                    "project secret",
+                ),
+                embedding: Embedding(vec![0.0; HashEmbedder::DEFAULT_DIMS]),
+            }])
+            .await
+            .unwrap();
+        let (retrieval, _search) = build_retrieval(Arc::new(HashEmbedder::default()), vectors);
+        let (router, token, _store, _dir) =
+            test_app_with_retrieval(Arc::new(FakeProvider), retrieval).await;
+        let results: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &format!("Bearer {token}"),
+                "/search",
+                serde_json::json!({"query": "project secret"}),
+            )
+            .await,
+        )
+        .await;
+        assert!(results["citations"].as_array().unwrap().is_empty());
+    }
+
     #[test]
     fn agent_deps_registers_the_search_tool_alongside_the_file_tools() {
         let (_retrieval, tools, _config) = agent_deps(
@@ -2346,6 +2385,7 @@ mod tests {
             );
             store
                 .upsert(vec![openwave_retrieval::VectorRecord {
+                    project_id: None,
                     chunk,
                     embedding: openwave_retrieval::Embedding(vec![1.0, 0.0]),
                 }])

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -18,7 +18,9 @@ use openwave_core::{
     DocumentRecord, DocumentScope, DocumentSummaryRecord, DocumentUpsert, Project, ProjectId,
     SecretProvider, SequencedEvent, Store,
 };
-use openwave_retrieval::{Citation, DocumentId, DocumentSource, RetrievalError, SearchTool};
+use openwave_retrieval::{
+    Citation, DocumentId, DocumentSource, RetrievalError, SearchScope, SearchTool,
+};
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::document_worker::MAX_INDEX_ATTEMPTS;
@@ -664,7 +666,7 @@ pub async fn search_documents(
         .clamp(1, SearchTool::MAX_K);
     let citations = state
         .retrieval
-        .search(query, k)
+        .search(SearchScope::Unscoped, query, k)
         .await
         .map_err(retrieval_error)?;
     Ok(Json(SearchResults { citations }))


### PR DESCRIPTION
## Summary

- require every vector query to choose an unscoped or exact-project corpus, with filtering applied before scoring and top-k
- persist optional project ownership on vector rows through InMemory and Lance generation staging/activation and schema reset
- propagate document project metadata through worker/auditor indexing while keeping existing HTTP and tool search explicitly unscoped
- reject mixed-corpus document publications and prevent a live document id from moving between project corpora
- retain an exact deletion watermark across immediate recreation so old-corpus vectors retire before the recreated generation publishes

## Tests

- `cargo test -p openwave-core`
- `cargo test -p openwave-retrieval --features vec-lance`
- `cargo test -p openwave-server`
- `bw dev lint --rust`
