### PR TITLE
feat(agent): bind search to chat corpus

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -574,6 +574,7 @@ impl Agent {
         }
         let ctx = ToolCtx {
             chat_id: chat.id,
+            project_id: chat.project_id,
             workspace_dir: chat.workspace_dir.clone(),
         };
         let mut output = match tool.execute(&ctx, parse_args(&call.args)).await {
@@ -817,13 +818,38 @@ mod tests {
 
     use super::*;
     use crate::db::DbStore;
-    use crate::id::ChatId;
+    use crate::id::{ChatId, ProjectId};
+    use crate::model::Project;
     use crate::provider::ProviderId;
     use crate::tools::ReadFile;
 
     /// A scripted provider: step 0 calls `read_file`, step 1 gives a final answer.
     struct FakeProvider {
         calls: AtomicUsize,
+    }
+
+    struct ContextRecordingTool {
+        observed_project: Arc<Mutex<Option<Option<ProjectId>>>>,
+    }
+
+    #[async_trait]
+    impl Tool for ContextRecordingTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: "read_file".into(),
+                description: "record invocation context".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::ReadOnly
+        }
+
+        async fn execute(&self, ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+            *self.observed_project.lock().unwrap() = Some(ctx.project_id);
+            Ok(ToolOutput::text("recorded"))
+        }
     }
 
     #[async_trait]
@@ -951,6 +977,55 @@ mod tests {
         assert_eq!(calls[0].result.as_deref(), Some("hello from disk"));
         assert!(!calls[0].is_error);
         assert!(calls[0].completed_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn tool_context_inherits_the_chats_project_scope() {
+        let workspace = tempfile::tempdir().unwrap();
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let project = Project {
+            id: ProjectId::new(),
+            title: None,
+            workspace_dir: workspace.path().to_path_buf(),
+            created_at: Utc::now(),
+        };
+        store.create_project(&project).await.unwrap();
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: Some(project.id),
+            title: None,
+            model: None,
+            workspace_dir: workspace.path().to_path_buf(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let observed_project = Arc::new(Mutex::new(None));
+        let tools = Arc::new(ToolRegistry::new().with(Box::new(ContextRecordingTool {
+            observed_project: observed_project.clone(),
+        })));
+        let agent = Agent::new(
+            Arc::new(FakeProvider {
+                calls: AtomicUsize::new(0),
+            }),
+            tools,
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        );
+
+        let (tx, _rx) = unbounded();
+        agent.run_turn(&chat, "inspect context", &tx).await.unwrap();
+        assert_eq!(*observed_project.lock().unwrap(), Some(Some(project.id)));
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::error::Result;
-use crate::id::ChatId;
+use crate::id::{ChatId, ProjectId};
 
 /// The approval policy class a tool declares for itself.
 ///
@@ -96,6 +96,8 @@ impl ToolOutput {
 pub struct ToolCtx {
     /// The chat this call belongs to.
     pub chat_id: ChatId,
+    /// Project corpus inherited from the chat, or `None` for a loose chat.
+    pub project_id: Option<ProjectId>,
     /// Absolute path to the chat's workspace directory. Workspace-class
     /// tools stay within it without prompting.
     pub workspace_dir: PathBuf,

--- a/crates/openwave-core/src/tools.rs
+++ b/crates/openwave-core/src/tools.rs
@@ -253,6 +253,7 @@ mod tests {
     fn ctx(dir: &std::path::Path) -> ToolCtx {
         ToolCtx {
             chat_id: ChatId::new(),
+            project_id: None,
             workspace_dir: dir.to_path_buf(),
         }
     }

--- a/crates/openwave-mcp/src/lib.rs
+++ b/crates/openwave-mcp/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! # fn demo() {
 //! let tools = Arc::new(ToolRegistry::new());
-//! let ctx = ToolCtx { chat_id: ChatId::new(), workspace_dir: "/work".into() };
+//! let ctx = ToolCtx { chat_id: ChatId::new(), project_id: None, workspace_dir: "/work".into() };
 //! let server = McpServer::new(tools, ctx);
 //! // then: `openwave_mcp::serve_stdio(server).await` inside an async runtime.
 //! # let _ = server;

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -193,6 +193,7 @@ mod tests {
         let tools = Arc::new(ToolRegistry::new().with(Box::new(EchoTool)));
         let ctx = ToolCtx {
             chat_id: ChatId::new(),
+            project_id: None,
             workspace_dir: PathBuf::from("/tmp/ws"),
         };
         McpServer::new(tools, ctx)

--- a/crates/openwave-mcp/src/stdio.rs
+++ b/crates/openwave-mcp/src/stdio.rs
@@ -79,6 +79,7 @@ mod tests {
     fn empty_server() -> McpServer {
         let ctx = ToolCtx {
             chat_id: ChatId::new(),
+            project_id: None,
             workspace_dir: PathBuf::from("/tmp/ws"),
         };
         McpServer::new(Arc::new(ToolRegistry::new()), ctx)

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -108,7 +108,7 @@ impl Tool for SearchTool {
         ApprovalClass::ReadOnly
     }
 
-    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+    async fn execute(&self, ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
         let args: SearchArgs = match parse_args(args) {
             Ok(args) => args,
             Err(output) => return Ok(output),
@@ -126,7 +126,11 @@ impl Tool for SearchTool {
             Ok(embedding) => embedding,
             Err(err) => return Ok(ToolOutput::error(format!("embedding failed: {err}"))),
         };
-        let hits = match self.store.query(&embedding, k, SearchScope::Unscoped).await {
+        let scope = match ctx.project_id {
+            Some(project_id) => SearchScope::Project(project_id),
+            None => SearchScope::Unscoped,
+        };
+        let hits = match self.store.query(&embedding, k, scope).await {
             Ok(hits) => hits,
             Err(err) => return Ok(ToolOutput::error(format!("search failed: {err}"))),
         };
@@ -146,7 +150,7 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    use openwave_core::ChatId;
+    use openwave_core::{ChatId, ProjectId};
 
     use crate::chunk::{Chunker, TextChunker};
     use crate::document::{Document, DocumentSource};
@@ -183,8 +187,13 @@ mod tests {
     }
 
     fn ctx() -> ToolCtx {
+        ctx_for(None)
+    }
+
+    fn ctx_for(project_id: Option<ProjectId>) -> ToolCtx {
         ToolCtx {
             chat_id: ChatId::new(),
+            project_id,
             workspace_dir: PathBuf::from("/tmp/unused"),
         }
     }
@@ -232,6 +241,72 @@ mod tests {
         assert!(arr[0]["snippet"].as_str().unwrap().contains("Jupiter"));
         assert!(arr[0]["document_id"].is_string());
         assert!(arr[0]["span"]["start"].is_number());
+    }
+
+    #[tokio::test]
+    async fn search_scope_is_inherited_from_tool_context_not_model_arguments() {
+        let embedder = Arc::new(HashEmbedder::new(DIMS));
+        let store = Arc::new(InMemoryVectorStore::new(DIMS));
+        let project_a = ProjectId::new();
+        let project_b = ProjectId::new();
+        let documents = [
+            Document::new(
+                DocumentSource::Inline,
+                "text/plain",
+                "unscoped lighthouse fact",
+            ),
+            Document::new_scoped(
+                project_a,
+                DocumentSource::Inline,
+                "text/plain",
+                "project alpha lighthouse fact",
+            ),
+            Document::new_scoped(
+                project_b,
+                DocumentSource::Inline,
+                "text/plain",
+                "project beta lighthouse fact",
+            ),
+        ];
+        for document in documents {
+            let chunks = TextChunker::new(90, 0).chunk(&document).unwrap();
+            let texts: Vec<_> = chunks.iter().map(|chunk| chunk.text.clone()).collect();
+            let embeddings = embedder.embed_documents(&texts).await.unwrap();
+            store
+                .upsert(
+                    chunks
+                        .into_iter()
+                        .zip(embeddings)
+                        .map(|(chunk, embedding)| VectorRecord {
+                            project_id: document.project_id,
+                            chunk,
+                            embedding,
+                        })
+                        .collect(),
+                )
+                .await
+                .unwrap();
+        }
+        let tool = SearchTool::new(embedder, store);
+
+        let loose = tool
+            .execute(&ctx_for(None), json!({"query": "lighthouse fact", "k": 10}))
+            .await
+            .unwrap();
+        assert!(loose.content.contains("unscoped lighthouse"));
+        assert!(!loose.content.contains("project alpha"));
+        assert!(!loose.content.contains("project beta"));
+
+        let alpha = tool
+            .execute(
+                &ctx_for(Some(project_a)),
+                json!({"query": "lighthouse fact", "k": 10}),
+            )
+            .await
+            .unwrap();
+        assert!(alpha.content.contains("project alpha"));
+        assert!(!alpha.content.contains("unscoped lighthouse"));
+        assert!(!alpha.content.contains("project beta"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- carry the chat's optional project through `ToolCtx` for every tool invocation
- make the agent search tool derive its corpus scope from trusted chat context instead of model-supplied arguments
- keep loose chats restricted to unscoped documents and project chats restricted to their exact project
- initialize standalone MCP tool contexts explicitly as unscoped

## Tests

- `cargo test -p openwave-core`
- `cargo test -p openwave-retrieval`
- `cargo test -p openwave-mcp`
- `bw dev lint --rust`
