### PR TITLE
feat(server): add project document APIs

### DIFF
--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -62,6 +62,22 @@ pub fn app(state: AppState) -> Router {
             post(routes::create_project).get(routes::list_projects),
         )
         .route("/projects/{id}", get(routes::get_project))
+        .route(
+            "/projects/{project_id}/documents",
+            post(routes::ingest_project_document).get(routes::list_project_documents),
+        )
+        .route(
+            "/projects/{project_id}/documents/{document_id}",
+            get(routes::get_project_document).delete(routes::delete_project_document),
+        )
+        .route(
+            "/projects/{project_id}/documents/{document_id}/retry",
+            post(routes::retry_project_document),
+        )
+        .route(
+            "/projects/{project_id}/search",
+            post(routes::search_project_documents),
+        )
         .route("/models", get(routes::list_models))
         .route("/providers", get(routes::list_providers))
         .route(
@@ -1369,6 +1385,202 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn project_document_routes_enforce_corpus_identity_and_ownership() {
+        let (router, token, store, _dir, worker) = test_app_with_worker().await;
+        let bearer = format!("Bearer {token}");
+        let project_a = make_project(&router, &bearer).await;
+        let project_b = make_project(&router, &bearer).await;
+        let uri = "file:///shared-source.txt";
+
+        let root: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/documents",
+                serde_json::json!({"uri": uri, "content": "loose corpus zephyr"}),
+            )
+            .await,
+        )
+        .await;
+        let a: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                &format!("/projects/{}/documents", project_a.id),
+                serde_json::json!({"uri": uri, "content": "project alpha aurora"}),
+            )
+            .await,
+        )
+        .await;
+        let b: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                &format!("/projects/{}/documents", project_b.id),
+                serde_json::json!({"uri": uri, "content": "project beta nebula"}),
+            )
+            .await,
+        )
+        .await;
+
+        assert_eq!(
+            root["document_id"],
+            openwave_core::DocumentId::derive(uri).to_string()
+        );
+        assert_eq!(
+            a["document_id"],
+            openwave_core::DocumentId::derive_for_project(project_a.id, uri).to_string()
+        );
+        assert_eq!(
+            b["document_id"],
+            openwave_core::DocumentId::derive_for_project(project_b.id, uri).to_string()
+        );
+        assert_ne!(root["document_id"], a["document_id"]);
+        assert_ne!(a["document_id"], b["document_id"]);
+
+        for _ in 0..3 {
+            assert!(matches!(
+                worker.run_once().await.unwrap(),
+                document_worker::WorkerOutcome::Completed(_)
+            ));
+        }
+
+        let request = |method: axum::http::Method, uri: String| {
+            let router = router.clone();
+            let bearer = bearer.clone();
+            async move {
+                router
+                    .oneshot(
+                        Request::builder()
+                            .method(method)
+                            .uri(uri)
+                            .header(header::AUTHORIZATION, bearer)
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap()
+            }
+        };
+
+        let a_id = a["document_id"].as_str().unwrap();
+        let b_id = b["document_id"].as_str().unwrap();
+        let listing: serde_json::Value = json_body(
+            request(
+                axum::http::Method::GET,
+                format!("/projects/{}/documents", project_a.id),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(listing["documents"].as_array().unwrap().len(), 1);
+        assert_eq!(listing["documents"][0]["document_id"], a["document_id"]);
+        assert_eq!(
+            listing["documents"][0]["project_id"],
+            project_a.id.to_string()
+        );
+
+        assert_eq!(
+            request(
+                axum::http::Method::GET,
+                format!("/projects/{}/documents/{b_id}", project_a.id),
+            )
+            .await
+            .status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            request(
+                axum::http::Method::DELETE,
+                format!("/projects/{}/documents/{a_id}", project_b.id),
+            )
+            .await
+            .status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            request(axum::http::Method::DELETE, format!("/documents/{a_id}"),)
+                .await
+                .status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            request(axum::http::Method::GET, format!("/documents/{a_id}"),)
+                .await
+                .status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            post_json(
+                &router,
+                &bearer,
+                &format!("/documents/{a_id}/retry"),
+                serde_json::Value::Null,
+            )
+            .await
+            .status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            store
+                .get_document(a_id.parse().unwrap())
+                .await
+                .unwrap()
+                .unwrap()
+                .project_id,
+            Some(project_a.id)
+        );
+
+        let root_search: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                "/search",
+                serde_json::json!({"query": "project beta nebula", "k": 1}),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(
+            root_search["citations"][0]["document_id"],
+            root["document_id"]
+        );
+        let a_search: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                &format!("/projects/{}/search", project_a.id),
+                serde_json::json!({"query": "project beta nebula", "k": 1}),
+            )
+            .await,
+        )
+        .await;
+        assert_eq!(a_search["citations"][0]["document_id"], a["document_id"]);
+
+        let unknown = ProjectId::new();
+        assert_eq!(
+            post_json(
+                &router,
+                &bearer,
+                &format!("/projects/{unknown}/documents"),
+                serde_json::json!({"uri": uri, "content": "orphan"}),
+            )
+            .await
+            .status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            request(
+                axum::http::Method::DELETE,
+                format!("/projects/{}/documents/{a_id}", project_a.id),
+            )
+            .await
+            .status(),
+            StatusCode::ACCEPTED
+        );
+    }
+
+    #[tokio::test]
     async fn failed_indexing_leaves_authoritative_source_stale_for_retry() {
         let retrieval = Arc::new(Retriever::new(
             Box::new(PlainTextParser::new()),
@@ -1469,6 +1681,100 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let retried = store.get_document_job(job_id).await.unwrap().unwrap();
+        assert_eq!(retried.status, openwave_core::DocumentJobStatus::Queued);
+        assert_eq!(retried.attempt_count, 0);
+        assert_eq!(retried.id, job_id);
+    }
+
+    #[tokio::test]
+    async fn project_retry_revives_only_the_owned_terminal_job() {
+        let (router, token, store, _dir) = test_app().await;
+        let bearer = format!("Bearer {token}");
+        let project_a = make_project(&router, &bearer).await;
+        let project_b = make_project(&router, &bearer).await;
+        let ingested: serde_json::Value = json_body(
+            post_json(
+                &router,
+                &bearer,
+                &format!("/projects/{}/documents", project_a.id),
+                serde_json::json!({
+                    "uri": "file:///project-manual-retry.txt",
+                    "content": "retry only within the owning project"
+                }),
+            )
+            .await,
+        )
+        .await;
+        let document_id: openwave_core::DocumentId =
+            ingested["document_id"].as_str().unwrap().parse().unwrap();
+        let job_id: openwave_core::DocumentJobId =
+            ingested["job_id"].as_str().unwrap().parse().unwrap();
+        let now = chrono::Utc::now();
+        let claimed = store
+            .claim_document_job(now, now + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(claimed.id, job_id);
+        assert_eq!(
+            store
+                .record_document_job_failure(
+                    job_id,
+                    claimed.lease_token.unwrap(),
+                    chrono::Utc::now(),
+                    None,
+                    "project_manual_test_failure",
+                    None,
+                )
+                .await
+                .unwrap(),
+            Some(openwave_core::DocumentJobStatus::Failed)
+        );
+
+        assert_eq!(
+            post_json(
+                &router,
+                &bearer,
+                &format!("/documents/{document_id}/retry"),
+                serde_json::Value::Null,
+            )
+            .await
+            .status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            post_json(
+                &router,
+                &bearer,
+                &format!("/projects/{}/documents/{document_id}/retry", project_b.id),
+                serde_json::Value::Null,
+            )
+            .await
+            .status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(
+            store
+                .get_document_job(job_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            openwave_core::DocumentJobStatus::Failed
+        );
+
+        let response = post_json(
+            &router,
+            &bearer,
+            &format!("/projects/{}/documents/{document_id}/retry", project_a.id),
+            serde_json::Value::Null,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let response: serde_json::Value = json_body(response).await;
+        assert_eq!(response["document_id"], document_id.to_string());
+        assert_eq!(response["job_id"], job_id.to_string());
         let retried = store.get_document_job(job_id).await.unwrap().unwrap();
         assert_eq!(retried.status, openwave_core::DocumentJobStatus::Queued);
         assert_eq!(retried.attempt_count, 0);

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -471,6 +471,24 @@ pub async fn ingest_document(
     State(state): State<AppState>,
     Json(body): Json<IngestDocument>,
 ) -> Result<impl IntoResponse, ServerError> {
+    ingest_document_in_scope(&state, None, body).await
+}
+
+/// `POST /projects/{project_id}/documents` — enqueue a document in one project corpus.
+pub async fn ingest_project_document(
+    State(state): State<AppState>,
+    Path(project_id): Path<ProjectId>,
+    Json(body): Json<IngestDocument>,
+) -> Result<impl IntoResponse, ServerError> {
+    require_project(&state, project_id).await?;
+    ingest_document_in_scope(&state, Some(project_id), body).await
+}
+
+async fn ingest_document_in_scope(
+    state: &AppState,
+    project_id: Option<ProjectId>,
+    body: IngestDocument,
+) -> Result<(StatusCode, Json<IngestResult>), ServerError> {
     if body.content.trim().is_empty() {
         return Err(ServerError::bad_request("content must not be empty"));
     }
@@ -484,7 +502,7 @@ pub async fn ingest_document(
     // Pipeline components promise a stable fingerprint for their lifetime. Take
     // one snapshot and use it for the exact parse/index operation below.
     let index_fingerprint = state.retrieval.index_fingerprint();
-    let document = state
+    let mut document = state
         .retrieval
         .parse_document(source, media_type, body.content.as_bytes())
         .map_err(retrieval_error)?;
@@ -493,13 +511,20 @@ pub async fn ingest_document(
         DocumentSource::Inline => None,
         _ => None,
     };
+    if let Some(project_id) = project_id {
+        document.id = source_uri
+            .as_deref()
+            .map(|uri| DocumentId::derive_for_project(project_id, uri))
+            .unwrap_or(document.id);
+        document.project_id = Some(project_id);
+    }
     let _document_write = state.document_writes.acquire(document.id).await;
     let (revision, job) = state
         .store
         .upsert_document_and_enqueue_index(
             &DocumentUpsert {
                 id: document.id,
-                project_id: None,
+                project_id,
                 source_uri,
                 media_type: document.media_type.clone(),
                 title: None,
@@ -528,8 +553,31 @@ pub async fn retry_document(
     State(state): State<AppState>,
     Path(id): Path<DocumentId>,
 ) -> Result<impl IntoResponse, ServerError> {
+    retry_document_in_scope(&state, id, None).await
+}
+
+/// `POST /projects/{project_id}/documents/{document_id}/retry` — revive an owned
+/// document's current exact failed index job.
+pub async fn retry_project_document(
+    State(state): State<AppState>,
+    Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
+) -> Result<impl IntoResponse, ServerError> {
+    require_project(&state, project_id).await?;
+    retry_document_in_scope(&state, document_id, Some(project_id)).await
+}
+
+async fn retry_document_in_scope(
+    state: &AppState,
+    id: DocumentId,
+    project_id: Option<ProjectId>,
+) -> Result<(StatusCode, Json<IngestResult>), ServerError> {
     let _document_write = state.document_writes.acquire(id).await;
-    if state.store.get_document(id).await?.is_none() {
+    if state
+        .store
+        .get_document(id)
+        .await?
+        .is_none_or(|document| document.project_id != project_id)
+    {
         return Err(ServerError::not_found(format!("document {id} not found")));
     }
     let fingerprint = state.retrieval.index_fingerprint();
@@ -546,7 +594,7 @@ pub async fn retry_document(
         .store
         .get_document(id)
         .await?
-        .filter(|record| record.generation() == job.generation())
+        .filter(|record| record.project_id == project_id && record.generation() == job.generation())
         .ok_or_else(|| {
             ServerError::internal(format!(
                 "retried job {} no longer matches document {id}",
@@ -572,6 +620,24 @@ pub async fn list_documents(
     State(state): State<AppState>,
     Query(query): Query<DocumentListQuery>,
 ) -> Result<Json<DocumentListPage>, ServerError> {
+    list_documents_in_scope(&state, DocumentScope::Unscoped, query).await
+}
+
+/// `GET /projects/{project_id}/documents` — list one project's document corpus.
+pub async fn list_project_documents(
+    State(state): State<AppState>,
+    Path(project_id): Path<ProjectId>,
+    Query(query): Query<DocumentListQuery>,
+) -> Result<Json<DocumentListPage>, ServerError> {
+    require_project(&state, project_id).await?;
+    list_documents_in_scope(&state, DocumentScope::Project(project_id), query).await
+}
+
+async fn list_documents_in_scope(
+    state: &AppState,
+    scope: DocumentScope,
+    query: DocumentListQuery,
+) -> Result<Json<DocumentListPage>, ServerError> {
     let limit = query.limit.unwrap_or(DEFAULT_DOCUMENT_PAGE_SIZE);
     if limit == 0 || limit > MAX_DOCUMENT_PAGE_SIZE {
         return Err(ServerError::bad_request(format!(
@@ -585,7 +651,7 @@ pub async fn list_documents(
         .transpose()?;
     let mut records = state
         .store
-        .list_document_summaries(DocumentScope::Unscoped, cursor, limit + 1)
+        .list_document_summaries(scope, cursor, limit + 1)
         .await?;
     let has_more = records.len() > limit as usize;
     records.truncate(limit as usize);
@@ -619,6 +685,22 @@ pub async fn get_document(
         .ok_or_else(|| ServerError::not_found(format!("document {id} not found")))
 }
 
+/// `GET /projects/{project_id}/documents/{document_id}` — fetch an owned document.
+pub async fn get_project_document(
+    State(state): State<AppState>,
+    Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
+) -> Result<Json<DocumentDetail>, ServerError> {
+    require_project(&state, project_id).await?;
+    state
+        .store
+        .get_document(document_id)
+        .await?
+        .filter(|document| document.project_id == Some(project_id))
+        .map(DocumentDetail::from)
+        .map(Json)
+        .ok_or_else(|| ServerError::not_found(format!("document {document_id} not found")))
+}
+
 /// `DELETE /documents/{id}` — atomically delete authoritative source/jobs and
 /// persist a pending empty tombstone. The durable worker publishes it.
 pub async fn delete_document(
@@ -626,7 +708,37 @@ pub async fn delete_document(
     Path(id): Path<DocumentId>,
 ) -> Result<StatusCode, ServerError> {
     let _document_write = state.document_writes.acquire(id).await;
+    if state
+        .store
+        .get_document(id)
+        .await?
+        .is_some_and(|document| document.project_id.is_some())
+    {
+        return Err(ServerError::not_found(format!("document {id} not found")));
+    }
     state.store.delete_document(id).await?;
+    state.document_job_wake.notify_one();
+    Ok(StatusCode::ACCEPTED)
+}
+
+/// `DELETE /projects/{project_id}/documents/{document_id}` — retire an owned document.
+pub async fn delete_project_document(
+    State(state): State<AppState>,
+    Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
+) -> Result<StatusCode, ServerError> {
+    require_project(&state, project_id).await?;
+    let _document_write = state.document_writes.acquire(document_id).await;
+    if state
+        .store
+        .get_document(document_id)
+        .await?
+        .is_none_or(|document| document.project_id != Some(project_id))
+    {
+        return Err(ServerError::not_found(format!(
+            "document {document_id} not found"
+        )));
+    }
+    state.store.delete_document(document_id).await?;
     state.document_job_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
 }
@@ -656,6 +768,24 @@ pub async fn search_documents(
     State(state): State<AppState>,
     Json(body): Json<SearchRequest>,
 ) -> Result<Json<SearchResults>, ServerError> {
+    search_documents_in_scope(&state, SearchScope::Unscoped, body).await
+}
+
+/// `POST /projects/{project_id}/search` — search exactly one project corpus.
+pub async fn search_project_documents(
+    State(state): State<AppState>,
+    Path(project_id): Path<ProjectId>,
+    Json(body): Json<SearchRequest>,
+) -> Result<Json<SearchResults>, ServerError> {
+    require_project(&state, project_id).await?;
+    search_documents_in_scope(&state, SearchScope::Project(project_id), body).await
+}
+
+async fn search_documents_in_scope(
+    state: &AppState,
+    scope: SearchScope,
+    body: SearchRequest,
+) -> Result<Json<SearchResults>, ServerError> {
     let query = body.query.trim();
     if query.is_empty() {
         return Err(ServerError::bad_request("query must not be empty"));
@@ -666,10 +796,19 @@ pub async fn search_documents(
         .clamp(1, SearchTool::MAX_K);
     let citations = state
         .retrieval
-        .search(SearchScope::Unscoped, query, k)
+        .search(scope, query, k)
         .await
         .map_err(retrieval_error)?;
     Ok(Json(SearchResults { citations }))
+}
+
+async fn require_project(state: &AppState, project_id: ProjectId) -> Result<(), ServerError> {
+    if state.store.get_project(project_id).await?.is_none() {
+        return Err(ServerError::not_found(format!(
+            "project {project_id} not found"
+        )));
+    }
+    Ok(())
 }
 
 /// Body of `POST /chats`.


### PR DESCRIPTION
## Summary

- add nested project routes for document ingestion, listing, detail, deletion, retry, and search
- derive URI-backed document IDs within the owning project namespace
- enforce project ownership at every nested boundary while keeping root document routes explicitly unscoped
- search project corpora with the project filter applied before top-k selection
- preserve exact-generation durable retry semantics for failed project documents

## Validation

- `cargo test -p openwave-server`
- `cargo test -p openwave-server project_document_routes_enforce_corpus_identity_and_ownership`
- `cargo test -p openwave-server project_document_retry_requires_ownership_and_requeues_exact_failure`
- `bw dev lint --rust`
