### PR TITLE
feat(retrieval): add hybrid lexical and dense search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5696,6 +5696,7 @@ version = "0.0.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
+ "arrow-select",
  "async-trait",
  "futures",
  "lancedb",

--- a/crates/openwave-retrieval/Cargo.toml
+++ b/crates/openwave-retrieval/Cargo.toml
@@ -25,7 +25,7 @@ embed-openai = ["dep:reqwest", "dep:sha2"]
 # default feature for library consumers because it pulls a large dependency tree
 # and needs `protoc` at build time. OpenWave's workspace CI installs `protoc`, and
 # the server enables this feature explicitly.
-vec-lance = ["dep:lancedb", "dep:arrow-array", "dep:arrow-schema", "dep:futures", "dep:tokio"]
+vec-lance = ["dep:lancedb", "dep:arrow-array", "dep:arrow-schema", "dep:arrow-select", "dep:futures", "dep:tokio"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -47,6 +47,7 @@ sha2 = { workspace = true, optional = true }
 lancedb = { version = "0.31", optional = true }
 arrow-array = { version = "58", optional = true }
 arrow-schema = { version = "58", optional = true }
+arrow-select = { version = "58", optional = true }
 futures = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync"], optional = true }
 

--- a/crates/openwave-retrieval/src/document.rs
+++ b/crates/openwave-retrieval/src/document.rs
@@ -192,7 +192,7 @@ impl Chunk {
 pub struct ScoredChunk {
     /// The matched chunk.
     pub chunk: Chunk,
-    /// Similarity score; higher is more relevant. For cosine, in `[-1, 1]`.
+    /// Backend relevance score; higher is more relevant.
     pub score: f32,
 }
 

--- a/crates/openwave-retrieval/src/hybrid.rs
+++ b/crates/openwave-retrieval/src/hybrid.rs
@@ -1,0 +1,201 @@
+//! Dependency-free lexical ranking and reciprocal rank fusion.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use crate::{ChunkId, Embedding, ScoredChunk, VectorRecord};
+
+const BM25_K1: f32 = 1.2;
+const BM25_B: f32 = 0.75;
+const RRF_K: f32 = 60.0;
+
+pub(crate) fn rank(
+    records: &[&VectorRecord],
+    query_text: &str,
+    query_embedding: &Embedding,
+    k: usize,
+) -> Vec<ScoredChunk> {
+    let dense = dense(records, query_embedding, k);
+    let lexical = bm25(records, query_text, k);
+    let mut fused = HashMap::new();
+    for (position, hit) in dense.into_iter().enumerate() {
+        add_rank(&mut fused, &hit.chunk, position);
+    }
+    for (position, (record, _)) in lexical.into_iter().enumerate() {
+        add_rank(&mut fused, &record.chunk, position);
+    }
+
+    let mut hits = fused
+        .into_values()
+        .map(|(chunk, score)| ScoredChunk { chunk, score })
+        .collect::<Vec<_>>();
+    sort_hits(&mut hits);
+    hits.truncate(k);
+    hits
+}
+
+pub(crate) fn dense(
+    records: &[&VectorRecord],
+    query_embedding: &Embedding,
+    k: usize,
+) -> Vec<ScoredChunk> {
+    let mut hits = records
+        .iter()
+        .map(|record| ScoredChunk {
+            chunk: record.chunk.clone(),
+            score: query_embedding.cosine_similarity(&record.embedding),
+        })
+        .collect::<Vec<_>>();
+    sort_hits(&mut hits);
+    hits.truncate(k);
+    hits
+}
+
+fn add_rank(
+    fused: &mut HashMap<ChunkId, (crate::Chunk, f32)>,
+    chunk: &crate::Chunk,
+    position: usize,
+) {
+    let entry = fused
+        .entry(chunk.id)
+        .or_insert_with(|| (chunk.clone(), 0.0));
+    entry.1 += 1.0 / (RRF_K + position as f32 + 1.0);
+}
+
+fn bm25<'a>(records: &[&'a VectorRecord], query: &str, k: usize) -> Vec<(&'a VectorRecord, f32)> {
+    let query_terms = tokenize(query).into_iter().collect::<BTreeSet<_>>();
+    if query_terms.is_empty() || records.is_empty() {
+        return Vec::new();
+    }
+
+    let documents = records
+        .iter()
+        .map(|record| tokenize(&record.chunk.text))
+        .collect::<Vec<_>>();
+    let average_length =
+        documents.iter().map(Vec::len).sum::<usize>() as f32 / documents.len() as f32;
+    let mut document_frequency = BTreeMap::new();
+    for terms in &documents {
+        let matching = terms
+            .iter()
+            .filter(|term| query_terms.contains(*term))
+            .collect::<BTreeSet<_>>();
+        for term in matching {
+            *document_frequency.entry(term.clone()).or_insert(0usize) += 1;
+        }
+    }
+
+    let corpus_size = records.len() as f32;
+    let mut scored = records
+        .iter()
+        .zip(documents)
+        .filter_map(|(record, terms)| {
+            let length = terms.len() as f32;
+            let mut frequencies = BTreeMap::new();
+            for term in terms {
+                if query_terms.contains(&term) {
+                    *frequencies.entry(term).or_insert(0usize) += 1;
+                }
+            }
+            let score = frequencies
+                .into_iter()
+                .fold(0.0, |score, (term, frequency)| {
+                    let frequency = frequency as f32;
+                    let document_frequency = *document_frequency.get(&term).unwrap_or(&0) as f32;
+                    let inverse_document_frequency = (1.0
+                        + (corpus_size - document_frequency + 0.5) / (document_frequency + 0.5))
+                        .ln();
+                    let normalized_length = if average_length == 0.0 {
+                        1.0
+                    } else {
+                        length / average_length
+                    };
+                    score
+                        + inverse_document_frequency * frequency * (BM25_K1 + 1.0)
+                            / (frequency + BM25_K1 * (1.0 - BM25_B + BM25_B * normalized_length))
+                });
+            (score > 0.0).then_some((*record, score))
+        })
+        .collect::<Vec<_>>();
+    sort_ranked(&mut scored);
+    scored.truncate(k);
+    scored
+}
+
+fn sort_ranked(ranked: &mut [(&VectorRecord, f32)]) {
+    ranked.sort_by(|(left_record, left_score), (right_record, right_score)| {
+        right_score
+            .total_cmp(left_score)
+            .then_with(|| left_record.chunk.id.0.cmp(&right_record.chunk.id.0))
+    });
+}
+
+fn sort_hits(hits: &mut [ScoredChunk]) {
+    hits.sort_by(|left, right| {
+        right
+            .score
+            .total_cmp(&left.score)
+            .then_with(|| left.chunk.id.0.cmp(&right.chunk.id.0))
+    });
+}
+
+fn tokenize(text: &str) -> Vec<String> {
+    text.split(|character: char| !character.is_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .map(str::to_lowercase)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ByteSpan, Chunk, DocumentId};
+
+    fn record(text: &str, vector: Vec<f32>) -> VectorRecord {
+        let document_id = DocumentId::new();
+        VectorRecord {
+            project_id: None,
+            chunk: Chunk::new(document_id, 0, ByteSpan::new(0, text.len()), text),
+            embedding: Embedding(vector),
+        }
+    }
+
+    #[test]
+    fn lexical_and_dense_candidates_are_both_fused() {
+        let lexical = record("ZXQ-4412 repair bulletin", vec![0.0, 1.0]);
+        let dense = record("ordinary semantic match", vec![1.0, 0.0]);
+        let records = [&lexical, &dense];
+
+        let hits = rank(&records, "zxq 4412", &Embedding(vec![1.0, 0.0]), 2);
+
+        assert_eq!(hits.len(), 2);
+        assert!(hits.iter().any(|hit| hit.chunk.text == lexical.chunk.text));
+        assert!(hits.iter().any(|hit| hit.chunk.text == dense.chunk.text));
+    }
+
+    #[test]
+    fn equal_fused_scores_use_chunk_id_as_a_stable_tiebreaker() {
+        let first = record("first", vec![1.0, 0.0]);
+        let second = record("second", vec![0.0, 1.0]);
+        let records = [&first, &second];
+
+        let hits = rank(&records, "missing", &Embedding(vec![0.0, 0.0]), 2);
+
+        let mut expected = [first.chunk.id, second.chunk.id];
+        expected.sort_by_key(|id| id.0);
+        assert_eq!(hits[0].chunk.id, expected[0]);
+        assert_eq!(hits[1].chunk.id, expected[1]);
+    }
+
+    #[test]
+    fn equal_multi_term_bm25_scores_are_stable_and_use_chunk_id_tiebreaker() {
+        let first = record("alpha beta beta", vec![1.0, 0.0]);
+        let second = record("beta alpha beta", vec![0.0, 1.0]);
+        let records = [&first, &second];
+
+        let ranked = bm25(&records, "beta alpha", 2);
+
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].1, ranked[1].1);
+        assert!(ranked[0].0.chunk.id.0 < ranked[1].0.chunk.id.0);
+    }
+}

--- a/crates/openwave-retrieval/src/lance_store.rs
+++ b/crates/openwave-retrieval/src/lance_store.rs
@@ -18,19 +18,25 @@
 
 use std::fs::{File, OpenOptions};
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use arrow_array::types::Float32Type;
 use arrow_array::{
     Array, ArrayRef, FixedSizeListArray, Float32Array, Int64Array, RecordBatch,
-    RecordBatchIterator, StringArray, UInt64Array,
+    RecordBatchIterator, StringArray, UInt32Array, UInt64Array,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_select::take::take;
 use async_trait::async_trait;
 use futures::TryStreamExt;
+use lancedb::index::scalar::FullTextSearchQuery;
+use lancedb::index::{Index, IndexType};
 use lancedb::query::{ExecutableQuery, QueryBase, Select};
+use lancedb::rerankers::Reranker;
+use lancedb::table::{OptimizeAction, OptimizeOptions};
 use lancedb::{DistanceType, Table};
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
 use crate::document::{ByteSpan, Chunk, ScoredChunk};
 use crate::embed::Embedding;
@@ -47,6 +53,8 @@ const TABLE: &str = "chunks";
 const VECTOR_COL: &str = "vector";
 /// LanceDB's distance column on query results.
 const DISTANCE_COL: &str = "_distance";
+const RELEVANCE_COL: &str = "_relevance_score";
+const INDEX_MUTATION_THRESHOLD: usize = 20;
 const UNVERSIONED_CHUNK: &str = "unversioned_chunk";
 const STAGED_CHUNK: &str = "staged_chunk";
 const ACTIVE_CHUNK: &str = "active_chunk";
@@ -57,14 +65,95 @@ const VISIBLE_CHUNKS: &str = "row_kind IN ('unversioned_chunk', 'active_chunk')"
 /// A persistent [`VectorStore`] backed by a local LanceDB dataset.
 ///
 /// One instance serializes every mutation so marker reads and their following
-/// merge commit form one coordinator operation. An exclusive lock file enforces
-/// one writer instance per dataset across handles and processes.
+/// merge commit form one coordinator operation. Queries share a read guard so
+/// Lance's lexical and dense branches observe one publication snapshot while
+/// still running concurrently with other queries. An exclusive lock file
+/// enforces one writer instance per dataset across handles and processes.
 pub struct LanceVectorStore {
     table: Table,
     schema: SchemaRef,
     dims: usize,
-    write_lock: Mutex<()>,
+    publication_lock: RwLock<()>,
+    text_index_name: String,
+    index_mutations: AtomicUsize,
     _writer_lock: File,
+}
+
+/// Conventional RRF(k=60) with a stable chunk-id secondary order.
+#[derive(Debug)]
+struct DeterministicRrf;
+
+fn hybrid_row_ids(batch: &RecordBatch) -> lancedb::Result<&UInt64Array> {
+    batch
+        .column_by_name("_rowid")
+        .and_then(|column| column.as_any().downcast_ref::<UInt64Array>())
+        .ok_or_else(|| lancedb::Error::InvalidInput {
+            message: "hybrid candidate is missing _rowid".to_string(),
+        })
+}
+
+#[async_trait]
+impl Reranker for DeterministicRrf {
+    async fn rerank_hybrid(
+        &self,
+        _query: &str,
+        vector_results: RecordBatch,
+        fts_results: RecordBatch,
+    ) -> lancedb::Result<RecordBatch> {
+        let mut scores = std::collections::BTreeMap::new();
+        for (position, row_id) in hybrid_row_ids(&vector_results)?.values().iter().enumerate() {
+            *scores.entry(*row_id).or_insert(0.0) += 1.0 / (61.0 + position as f32);
+        }
+        for (position, row_id) in hybrid_row_ids(&fts_results)?.values().iter().enumerate() {
+            *scores.entry(*row_id).or_insert(0.0) += 1.0 / (61.0 + position as f32);
+        }
+
+        let combined = self.merge_results(vector_results, fts_results)?;
+        let combined_row_ids = hybrid_row_ids(&combined)?;
+        let chunk_ids = combined
+            .column_by_name("chunk_id")
+            .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+            .ok_or_else(|| lancedb::Error::InvalidInput {
+                message: "hybrid candidate is missing chunk_id".to_string(),
+            })?;
+        let parsed_chunk_ids = (0..combined.num_rows())
+            .map(|index| {
+                chunk_ids.value(index).parse::<ChunkId>().map_err(|error| {
+                    lancedb::Error::InvalidInput {
+                        message: format!("hybrid candidate has invalid chunk_id: {error}"),
+                    }
+                })
+            })
+            .collect::<lancedb::Result<Vec<_>>>()?;
+        let relevance = Float32Array::from_iter_values(
+            combined_row_ids
+                .values()
+                .iter()
+                .map(|row_id| scores[row_id]),
+        );
+        let mut order = (0..combined.num_rows()).collect::<Vec<_>>();
+        order.sort_by(|left, right| {
+            relevance
+                .value(*right)
+                .total_cmp(&relevance.value(*left))
+                .then_with(|| parsed_chunk_ids[*left].0.cmp(&parsed_chunk_ids[*right].0))
+        });
+        let order = UInt32Array::from_iter_values(order.into_iter().map(|index| index as u32));
+
+        let mut fields = combined.schema().fields().to_vec();
+        fields.push(Arc::new(Field::new(
+            RELEVANCE_COL,
+            DataType::Float32,
+            false,
+        )));
+        let mut columns = combined.columns().to_vec();
+        columns.push(Arc::new(relevance));
+        let columns = columns
+            .iter()
+            .map(|column| take(column.as_ref(), &order, None))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).map_err(Into::into)
+    }
 }
 
 struct StoredRow {
@@ -129,11 +218,42 @@ impl LanceVectorStore {
                 .await
                 .map_err(lance_err)?,
         };
+        let text_index = table
+            .list_indices()
+            .await
+            .map_err(lance_err)?
+            .into_iter()
+            .find(|index| index.index_type == IndexType::FTS && index.columns == ["text"]);
+        let text_index_name = if let Some(index) = text_index {
+            index.name
+        } else {
+            table
+                .create_index(&["text"], Index::FTS(Default::default()))
+                .execute()
+                .await
+                .map_err(lance_err)?;
+            "text_idx".to_string()
+        };
+        if table
+            .index_stats(&text_index_name)
+            .await
+            .map_err(lance_err)?
+            .is_some_and(|stats| stats.num_unindexed_rows > 0)
+        {
+            let mut options = OptimizeOptions::default();
+            options.index_names = Some(vec![text_index_name.clone()]);
+            table
+                .optimize(OptimizeAction::Index(options))
+                .await
+                .map_err(lance_err)?;
+        }
         Ok(Self {
             table,
             schema,
             dims,
-            write_lock: Mutex::new(()),
+            publication_lock: RwLock::new(()),
+            text_index_name,
+            index_mutations: AtomicUsize::new(0),
             _writer_lock: writer_lock,
         })
     }
@@ -371,6 +491,22 @@ impl LanceVectorStore {
             merge.when_not_matched_by_source_delete(Some(filter));
         }
         merge.execute(Box::new(reader)).await.map_err(lance_err)?;
+        let mutations = self.index_mutations.fetch_add(1, Ordering::Relaxed) + 1;
+        if mutations >= INDEX_MUTATION_THRESHOLD {
+            let mut options = OptimizeOptions::default();
+            options.index_names = Some(vec![self.text_index_name.clone()]);
+            if self
+                .table
+                .optimize(OptimizeAction::Index(options))
+                .await
+                .is_ok()
+            {
+                self.index_mutations.store(0, Ordering::Relaxed);
+            }
+            // Index maintenance is an optimization, not part of publication.
+            // On failure the committed mutation remains successful and the
+            // counter stays above threshold so the next mutation retries.
+        }
         Ok(())
     }
 
@@ -536,7 +672,7 @@ impl VectorStore for LanceVectorStore {
         if records.is_empty() {
             return Ok(());
         }
-        let _write = self.write_lock.lock().await;
+        let _write = self.publication_lock.write().await;
         let mut documents = std::collections::HashMap::new();
         for record in &records {
             documents
@@ -559,6 +695,7 @@ impl VectorStore for LanceVectorStore {
 
     async fn query(
         &self,
+        query_text: &str,
         query: &Embedding,
         k: usize,
         scope: SearchScope,
@@ -567,6 +704,7 @@ impl VectorStore for LanceVectorStore {
         if k == 0 {
             return Ok(Vec::new());
         }
+        let _snapshot = self.publication_lock.read().await;
         // Lance applies this predicate before the vector limit, so a closer row
         // in another corpus cannot consume one of this scope's top-k slots.
         // ProjectId is a parsed UUID newtype, not caller-provided query text.
@@ -574,7 +712,7 @@ impl VectorStore for LanceVectorStore {
             SearchScope::Unscoped => "project_id IS NULL".to_string(),
             SearchScope::Project(project_id) => format!("project_id = '{project_id}'"),
         };
-        let mut stream = self
+        let vector_query = self
             .table
             .query()
             .nearest_to(query.0.as_slice())
@@ -582,14 +720,26 @@ impl VectorStore for LanceVectorStore {
             .only_if(format!("({VISIBLE_CHUNKS}) AND ({scope_filter})"))
             .column(VECTOR_COL)
             .distance_type(DistanceType::Cosine)
-            .limit(k)
-            .execute()
-            .await
-            .map_err(lance_err)?;
+            .limit(k);
+        let hybrid = !query_text.trim().is_empty();
+        let mut stream = if hybrid {
+            vector_query
+                .full_text_search(FullTextSearchQuery::new(query_text.to_string()))
+                .rerank(Arc::new(DeterministicRrf))
+                .execute()
+                .await
+                .map_err(lance_err)?
+        } else {
+            vector_query.execute().await.map_err(lance_err)?
+        };
 
         let mut out = Vec::new();
         while let Some(batch) = stream.try_next().await.map_err(lance_err)? {
-            read_batch(&batch, &mut out)?;
+            if hybrid {
+                read_hybrid_batch(&batch, &mut out)?;
+            } else {
+                read_batch(&batch, &mut out)?;
+            }
         }
         Ok(out)
     }
@@ -601,7 +751,7 @@ impl VectorStore for LanceVectorStore {
     ) -> Result<()> {
         self.validate_document_records(document_id, &records)?;
         let records = dedupe_by_chunk_id(records);
-        let _write = self.write_lock.lock().await;
+        let _write = self.publication_lock.write().await;
         self.validate_live_document_scope(document_id, &records)
             .await?;
         if self.generation_rows_exist(document_id).await? {
@@ -627,7 +777,7 @@ impl VectorStore for LanceVectorStore {
         }
         self.validate_document_records(document_id, &records)?;
         let records = dedupe_by_chunk_id(records);
-        let _write = self.write_lock.lock().await;
+        let _write = self.publication_lock.write().await;
         if !records.is_empty() {
             self.validate_live_document_scope(document_id, &records)
                 .await?;
@@ -676,7 +826,7 @@ impl VectorStore for LanceVectorStore {
         document_id: DocumentId,
         generation: DocumentGeneration,
     ) -> Result<bool> {
-        let _write = self.write_lock.lock().await;
+        let _write = self.publication_lock.write().await;
         let staged = self.generation_marker(document_id, STAGED_MARKER).await?;
         if let Some(staged) = staged {
             if staged != generation {
@@ -722,7 +872,7 @@ impl VectorStore for LanceVectorStore {
         &self,
         document_id: DocumentId,
     ) -> Result<Option<DocumentGenerationState>> {
-        let _read = self.write_lock.lock().await;
+        let _read = self.publication_lock.read().await;
         let active = self.generation_marker(document_id, ACTIVE_MARKER).await?;
         let staged = self.generation_marker(document_id, STAGED_MARKER).await?;
         let newest = newest_generation(document_id, active, staged)?;
@@ -851,16 +1001,33 @@ fn read_vector_records(batch: &RecordBatch, out: &mut Vec<VectorRecord>) -> Resu
 /// Decode one result batch into [`ScoredChunk`]s, converting cosine distance to
 /// similarity (`1 - distance`) so scores match the crate's `[-1, 1]` convention.
 fn read_batch(batch: &RecordBatch, out: &mut Vec<ScoredChunk>) -> Result<()> {
+    read_scored_batch(batch, DISTANCE_COL, |distance| 1.0 - distance, out)
+}
+
+fn read_hybrid_batch(batch: &RecordBatch, out: &mut Vec<ScoredChunk>) -> Result<()> {
+    read_scored_batch(batch, RELEVANCE_COL, |score| score, out)
+}
+
+fn read_scored_batch(
+    batch: &RecordBatch,
+    score_column: &str,
+    convert_score: impl Fn(f32) -> f32,
+    out: &mut Vec<ScoredChunk>,
+) -> Result<()> {
     let chunk_ids = str_col(batch, "chunk_id")?;
     let doc_ids = str_col(batch, "document_id")?;
     let ordinals = u64_col(batch, "ordinal")?;
     let texts = str_col(batch, "text")?;
     let starts = u64_col(batch, "span_start")?;
     let ends = u64_col(batch, "span_end")?;
-    let distances = batch
-        .column_by_name(DISTANCE_COL)
+    let scores = batch
+        .column_by_name(score_column)
         .and_then(|c| c.as_any().downcast_ref::<Float32Array>())
-        .ok_or_else(|| RetrievalError::vector_store("query result missing _distance column"))?;
+        .ok_or_else(|| {
+            RetrievalError::vector_store(format!(
+                "query result missing or mistyped {score_column} column"
+            ))
+        })?;
 
     for i in 0..batch.num_rows() {
         let chunk_id: ChunkId = chunk_ids
@@ -880,7 +1047,7 @@ fn read_batch(batch: &RecordBatch, out: &mut Vec<ScoredChunk>) -> Result<()> {
                 text: texts.value(i).to_string(),
                 span,
             },
-            score: 1.0 - distances.value(i),
+            score: convert_score(scores.value(i)),
         });
     }
     Ok(())
@@ -985,13 +1152,13 @@ mod tests {
 
             // Nearest to "east" is the east vector, with its span/text intact.
             let hits = store
-                .query(&Embedding(vec![1.0, 0.0]), 1, SearchScope::Unscoped)
+                .query("", &Embedding(vec![1.0, 0.0]), 1, SearchScope::Unscoped)
                 .await
                 .unwrap();
             assert_eq!(hits.len(), 1);
             assert_eq!(hits[0].chunk.text, "east");
             assert_eq!(hits[0].chunk.document_id, doc);
-            assert!(hits[0].score > 0.9);
+            assert!((hits[0].score - 1.0).abs() < 1e-6);
 
             // A replacement is published as exactly one Lance dataset version.
             let version_before_replace = store.table.version().await.unwrap();
@@ -1005,7 +1172,7 @@ mod tests {
             );
             assert_eq!(store.len().await.unwrap(), 1);
             let hits = store
-                .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
+                .query("", &Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
                 .await
                 .unwrap();
             assert_eq!(hits[0].chunk.text, "south");
@@ -1015,7 +1182,7 @@ mod tests {
         let reopened = LanceVectorStore::connect(uri, 2).await.unwrap();
         assert_eq!(reopened.len().await.unwrap(), 1);
         let hits = reopened
-            .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits[0].chunk.text, "south");
@@ -1044,13 +1211,16 @@ mod tests {
                 .unwrap();
 
             let query = Embedding(vec![1.0, 0.0]);
-            let unscoped = store.query(&query, 1, SearchScope::Unscoped).await.unwrap();
+            let unscoped = store
+                .query("", &query, 1, SearchScope::Unscoped)
+                .await
+                .unwrap();
             let a = store
-                .query(&query, 1, SearchScope::Project(project_a))
+                .query("", &query, 1, SearchScope::Project(project_a))
                 .await
                 .unwrap();
             let b = store
-                .query(&query, 1, SearchScope::Project(project_b))
+                .query("", &query, 1, SearchScope::Project(project_b))
                 .await
                 .unwrap();
             assert_eq!(unscoped[0].chunk.text, "unscoped");
@@ -1062,7 +1232,7 @@ mod tests {
         let query = Embedding(vec![1.0, 0.0]);
         assert_eq!(
             reopened
-                .query(&query, 1, SearchScope::Unscoped)
+                .query("", &query, 1, SearchScope::Unscoped)
                 .await
                 .unwrap()[0]
                 .chunk
@@ -1071,7 +1241,7 @@ mod tests {
         );
         assert_eq!(
             reopened
-                .query(&query, 1, SearchScope::Project(project_a))
+                .query("", &query, 1, SearchScope::Project(project_a))
                 .await
                 .unwrap()[0]
                 .chunk
@@ -1080,13 +1250,217 @@ mod tests {
         );
         assert_eq!(
             reopened
-                .query(&query, 1, SearchScope::Project(project_b))
+                .query("", &query, 1, SearchScope::Project(project_b))
                 .await
                 .unwrap()[0]
                 .chunk
                 .text,
             "project-b"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_hybrid_search_sees_appends_but_not_staged_rows_and_prefilters_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
+            .await
+            .unwrap();
+        let project = ProjectId::new();
+
+        // The FTS index is created with the empty table. These rows are appended
+        // afterward and must still participate in native hybrid search.
+        store
+            .upsert(vec![
+                record(
+                    DocumentId::new(),
+                    0,
+                    "needleshard exact identifier",
+                    vec![0.0, 1.0],
+                ),
+                record(
+                    DocumentId::new(),
+                    0,
+                    "semantic dense candidate",
+                    vec![1.0, 0.0],
+                ),
+                project_record(
+                    project,
+                    DocumentId::new(),
+                    0,
+                    "needleshard wrong corpus",
+                    vec![1.0, 0.0],
+                ),
+            ])
+            .await
+            .unwrap();
+
+        let query = Embedding(vec![1.0, 0.0]);
+        let hits = store
+            .query("needleshard", &query, 2, SearchScope::Unscoped)
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].chunk.text, "needleshard exact identifier");
+        assert!(hits
+            .iter()
+            .any(|hit| hit.chunk.text == "semantic dense candidate"));
+        assert!(hits
+            .iter()
+            .all(|hit| hit.chunk.text != "needleshard wrong corpus"));
+
+        let staged_document = DocumentId::new();
+        let staged_generation = generation(1);
+        store
+            .stage_document_generation(
+                staged_document,
+                staged_generation,
+                vec![record(
+                    staged_document,
+                    0,
+                    "stagedneedle remains hidden",
+                    vec![1.0, 0.0],
+                )],
+            )
+            .await
+            .unwrap();
+        let before_activation = store
+            .query("stagedneedle", &query, 3, SearchScope::Unscoped)
+            .await
+            .unwrap();
+        assert!(before_activation
+            .iter()
+            .all(|hit| hit.chunk.text != "stagedneedle remains hidden"));
+
+        assert!(store
+            .activate_document_generation(staged_document, staged_generation)
+            .await
+            .unwrap());
+        let after_activation = store
+            .query("stagedneedle", &query, 3, SearchScope::Unscoped)
+            .await
+            .unwrap();
+        assert!(after_activation
+            .iter()
+            .any(|hit| hit.chunk.text == "stagedneedle remains hidden"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn native_hybrid_tie_at_k_boundary_matches_chunk_id_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
+            .await
+            .unwrap();
+        let dense = record(
+            DocumentId::derive("tie-dense"),
+            0,
+            "dense candidate",
+            vec![1.0, 0.0],
+        );
+        let lexical = record(
+            DocumentId::derive("tie-lexical"),
+            0,
+            "lexicalneedle candidate",
+            vec![0.0, 1.0],
+        );
+        let expected = dense.chunk.id.0.min(lexical.chunk.id.0);
+        store.upsert(vec![dense, lexical]).await.unwrap();
+
+        let hits = store
+            .query(
+                "lexicalneedle",
+                &Embedding(vec![1.0, 0.0]),
+                1,
+                SearchScope::Unscoped,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].chunk.id.0, expected);
+        assert!((hits[0].score - (1.0 / 61.0)).abs() < 1e-6);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reconnect_catches_up_fts_index_and_preserves_hybrid_search() {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+        {
+            let store = LanceVectorStore::connect(uri, 2).await.unwrap();
+            store
+                .upsert(vec![record(
+                    DocumentId::derive("reconnect-hybrid"),
+                    0,
+                    "reconnectneedle exact match",
+                    vec![0.0, 1.0],
+                )])
+                .await
+                .unwrap();
+            let stats = store
+                .table
+                .index_stats(&store.text_index_name)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(stats.num_unindexed_rows, 1);
+        }
+
+        let reopened = LanceVectorStore::connect(uri, 2).await.unwrap();
+        let stats = reopened
+            .table
+            .index_stats(&reopened.text_index_name)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stats.num_unindexed_rows, 0);
+        assert_eq!(stats.num_indexed_rows, 1);
+        let hits = reopened
+            .query(
+                "reconnectneedle",
+                &Embedding(vec![1.0, 0.0]),
+                1,
+                SearchScope::Unscoped,
+            )
+            .await
+            .unwrap();
+        assert_eq!(hits[0].chunk.text, "reconnectneedle exact match");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fts_index_is_optimized_after_bounded_mutations() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanceVectorStore::connect(dir.path().to_str().unwrap(), 2)
+            .await
+            .unwrap();
+
+        for index in 0..INDEX_MUTATION_THRESHOLD {
+            store
+                .upsert(vec![record(
+                    DocumentId::derive(&format!("index-maintenance-{index}")),
+                    0,
+                    &format!("maintenance row {index}"),
+                    vec![1.0, 0.0],
+                )])
+                .await
+                .unwrap();
+            if index + 1 == INDEX_MUTATION_THRESHOLD - 1 {
+                let stats = store
+                    .table
+                    .index_stats(&store.text_index_name)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(stats.num_unindexed_rows, INDEX_MUTATION_THRESHOLD - 1);
+            }
+        }
+
+        let stats = store
+            .table
+            .index_stats(&store.text_index_name)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stats.num_unindexed_rows, 0);
+        assert_eq!(stats.num_indexed_rows, INDEX_MUTATION_THRESHOLD);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1128,7 +1502,7 @@ mod tests {
 
         let query = Embedding(vec![1.0, 0.0]);
         assert!(store
-            .query(&query, 1, SearchScope::Project(project_a))
+            .query("", &query, 1, SearchScope::Project(project_a))
             .await
             .unwrap()
             .is_empty());
@@ -1138,7 +1512,7 @@ mod tests {
             .unwrap());
         assert_eq!(
             store
-                .query(&query, 1, SearchScope::Project(project_a))
+                .query("", &query, 1, SearchScope::Project(project_a))
                 .await
                 .unwrap()[0]
                 .chunk
@@ -1147,7 +1521,7 @@ mod tests {
         );
         assert_eq!(
             store
-                .query(&query, 1, SearchScope::Project(project_b))
+                .query("", &query, 1, SearchScope::Project(project_b))
                 .await
                 .unwrap()[0]
                 .chunk
@@ -1176,7 +1550,7 @@ mod tests {
         store.replace_document(doc, vec![a, b]).await.unwrap();
         assert_eq!(store.len().await.unwrap(), 1);
         let hits = store
-            .query(&Embedding(vec![0.0, 1.0]), 5, SearchScope::Unscoped)
+            .query("", &Embedding(vec![0.0, 1.0]), 5, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);
@@ -1235,7 +1609,7 @@ mod tests {
             .await
             .unwrap();
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
             .await
             .unwrap()
             .is_empty());
@@ -1244,7 +1618,7 @@ mod tests {
             .await
             .unwrap();
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 0, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 0, SearchScope::Unscoped)
             .await
             .unwrap()
             .is_empty());
@@ -1272,7 +1646,7 @@ mod tests {
         assert_eq!(store.table.version().await.unwrap(), version + 1);
         assert_eq!(store.len().await.unwrap(), 1);
         let hits = store
-            .query(&Embedding(vec![0.0, 1.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![0.0, 1.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);
@@ -1308,7 +1682,7 @@ mod tests {
         b.unwrap();
 
         let texts: std::collections::BTreeSet<_> = store
-            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap()
             .into_iter()
@@ -1341,7 +1715,7 @@ mod tests {
         assert!(err.to_string().contains("belongs to document"));
         assert_eq!(store.table.version().await.unwrap(), version);
         let hits = store
-            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);
@@ -1383,7 +1757,7 @@ mod tests {
             assert_eq!(store.table.version().await.unwrap(), version);
         }
         let hits = store
-            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);
@@ -1480,6 +1854,7 @@ mod tests {
         assert_eq!(
             store
                 .query(
+                    "",
                     &Embedding(vec![1.0, 0.0]),
                     10,
                     SearchScope::Project(project_a),
@@ -1492,6 +1867,7 @@ mod tests {
         );
         assert!(store
             .query(
+                "",
                 &Embedding(vec![1.0, 0.0]),
                 10,
                 SearchScope::Project(project_b),
@@ -1546,6 +1922,7 @@ mod tests {
         );
         let project_a_hits = store
             .query(
+                "",
                 &Embedding(vec![1.0, 0.0]),
                 10,
                 SearchScope::Project(project_a),
@@ -1557,6 +1934,7 @@ mod tests {
         }));
         assert!(store
             .query(
+                "",
                 &Embedding(vec![1.0, 0.0]),
                 10,
                 SearchScope::Project(project_b),
@@ -1676,7 +2054,7 @@ mod tests {
             Some(DocumentGenerationState::Staged(first))
         );
         let hits = store
-            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);
@@ -1699,7 +2077,7 @@ mod tests {
         );
         assert_eq!(reopened.len().await.unwrap(), 2);
         let hits = reopened
-            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert!(hits.iter().any(|hit| hit.chunk.text == "first"));
@@ -1853,6 +2231,7 @@ mod tests {
         assert_eq!(
             store
                 .query(
+                    "",
                     &Embedding(vec![0.0, 1.0]),
                     5,
                     SearchScope::Project(project_a)
@@ -1865,6 +2244,7 @@ mod tests {
         assert_eq!(
             store
                 .query(
+                    "",
                     &Embedding(vec![0.0, 1.0]),
                     5,
                     SearchScope::Project(project_b)
@@ -1912,7 +2292,7 @@ mod tests {
             .await
             .unwrap());
         let hits = store
-            .query(&Embedding(vec![0.0, 1.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![0.0, 1.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);

--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -12,9 +12,10 @@
 //! - [`Embedder`] — text → dense vectors, with separate document/query encodings.
 //!   Default: [`HashEmbedder`], a deterministic offline hashing encoder for tests
 //!   and local use; real providers (OpenAI/Cohere/ONNX) slot in behind the trait.
-//! - [`VectorStore`] — store embedded chunks, query by similarity. Default:
-//!   [`InMemoryVectorStore`], a brute-force cosine scan. Persistent, filtered, and
-//!   hybrid backends (sqlite-vec, pgvector, Qdrant) land later behind the trait.
+//! - [`VectorStore`] — store embedded chunks, query by lexical and dense relevance.
+//!   Default: [`InMemoryVectorStore`], dependency-free BM25 plus a brute-force
+//!   cosine scan, fused with reciprocal rank fusion. [`LanceVectorStore`] adds
+//!   the durable embedded implementation behind the `vec-lance` feature.
 //!
 //! [`Retriever`] wires all four into `ingest` and `search`. Everything a chunk or
 //! citation carries a [`ByteSpan`] — a precise byte range into the source text —
@@ -59,14 +60,14 @@
 //! an [`Embedder`] backed by the OpenAI-compatible `/embeddings` endpoint — a
 //! drop-in for [`HashEmbedder`] behind the same seam.
 //!
-//! Not yet wired: embedding reranking, hybrid retrieval, rich-format parsing,
-//! chat-to-project scope binding, and ANN index management. Each lands as its own
-//! slice behind these seams.
+//! Not yet wired: model reranking, rich-format parsing, and ANN index management.
+//! Each lands as its own slice behind these seams.
 
 mod chunk;
 mod document;
 mod embed;
 mod error;
+mod hybrid;
 mod id;
 #[cfg(feature = "vec-lance")]
 mod lance_store;

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -251,7 +251,7 @@ impl Retriever {
     /// Search the index for the `k` chunks most relevant to `query`, as citations.
     pub async fn search(&self, scope: SearchScope, query: &str, k: usize) -> Result<Vec<Citation>> {
         let embedding = self.embedder.embed_query(query).await?;
-        let hits = self.store.query(&embedding, k, scope).await?;
+        let hits = self.store.query(query, &embedding, k, scope).await?;
         Ok(hits.into_iter().map(Citation::from).collect())
     }
 

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -130,7 +130,7 @@ impl Tool for SearchTool {
             Some(project_id) => SearchScope::Project(project_id),
             None => SearchScope::Unscoped,
         };
-        let hits = match self.store.query(&embedding, k, scope).await {
+        let hits = match self.store.query(query, &embedding, k, scope).await {
             Ok(hits) => hits,
             Err(err) => return Ok(ToolOutput::error(format!("search failed: {err}"))),
         };

--- a/crates/openwave-retrieval/src/vector.rs
+++ b/crates/openwave-retrieval/src/vector.rs
@@ -1,11 +1,10 @@
-//! The vector-store seam: upsert embedded chunks, then query by nearest vector.
+//! The vector-store seam: upsert embedded chunks, then query by hybrid relevance.
 //!
 //! [`VectorStore`] is the interface every backend implements. [`InMemoryVectorStore`]
 //! is the reference backend — a brute-force cosine scan behind a lock. It has no
 //! persistence and is O(n) per query, which is exactly right for tests, small
 //! local corpora, and pinning down the semantics that persistent backends
-//! (sqlite-vec, pgvector, Qdrant) must reproduce. Those, plus hybrid dense+sparse
-//! search, arrive as feature-gated backends behind this trait later.
+//! (sqlite-vec, pgvector, Qdrant) must reproduce.
 
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -81,7 +80,7 @@ impl DocumentGenerationState {
     }
 }
 
-/// Stores embedded chunks and retrieves them by vector similarity.
+/// Stores embedded chunks and retrieves them by fused lexical and dense relevance.
 ///
 /// Object-safe and async so backends can do I/O. Implementations are held behind
 /// `Arc<dyn VectorStore>`.
@@ -97,12 +96,15 @@ pub trait VectorStore: Send + Sync {
     /// fence.
     async fn upsert(&self, records: Vec<VectorRecord>) -> Result<()>;
 
-    /// Return the `k` chunks most similar to `query`, highest score first.
+    /// Return the `k` chunks most relevant to the query text and embedding.
     ///
+    /// Non-empty text participates in lexical ranking; empty text requests the
+    /// dense-only fallback used by low-level callers and compatibility tests.
     /// Fewer than `k` come back when the store holds fewer records. `k == 0`
     /// yields an empty result.
     async fn query(
         &self,
+        query_text: &str,
         query: &Embedding,
         k: usize,
         scope: SearchScope,
@@ -198,7 +200,7 @@ pub trait VectorStore: Send + Sync {
     }
 }
 
-/// A brute-force, in-memory [`VectorStore`] using cosine similarity.
+/// An in-memory [`VectorStore`] using BM25, cosine similarity, and RRF.
 pub struct InMemoryVectorStore {
     dims: usize,
     state: RwLock<InMemoryVectorState>,
@@ -338,6 +340,7 @@ impl VectorStore for InMemoryVectorStore {
 
     async fn query(
         &self,
+        query_text: &str,
         query: &Embedding,
         k: usize,
         scope: SearchScope,
@@ -358,23 +361,14 @@ impl VectorStore for InMemoryVectorStore {
                 .filter_map(|publication| publication.active.as_ref())
                 .flat_map(|active| active.records.iter()),
         );
-        let mut scored: Vec<ScoredChunk> = visible
+        let visible = visible
             .filter(|record| scope.includes(record.project_id))
-            .map(|r| ScoredChunk {
-                chunk: r.chunk.clone(),
-                score: query.cosine_similarity(&r.embedding),
-            })
-            .collect();
-
-        // Highest score first. `total_cmp` gives a total order over f32 (no NaN
-        // surprises); ties fall back to chunk id for a stable, reproducible order.
-        scored.sort_by(|a, b| {
-            b.score
-                .total_cmp(&a.score)
-                .then_with(|| a.chunk.id.0.cmp(&b.chunk.id.0))
-        });
-        scored.truncate(k);
-        Ok(scored)
+            .collect::<Vec<_>>();
+        if query_text.trim().is_empty() {
+            Ok(crate::hybrid::dense(&visible, query, k))
+        } else {
+            Ok(crate::hybrid::rank(&visible, query_text, query, k))
+        }
     }
 
     async fn replace_document(
@@ -685,7 +679,7 @@ mod tests {
             }
         ));
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
             .await
             .is_err());
     }
@@ -705,7 +699,7 @@ mod tests {
 
         // A query pointing east should rank "east" first, then the diagonal.
         let hits = store
-            .query(&Embedding(vec![1.0, 0.0]), 2, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 2, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits.len(), 2);
@@ -747,6 +741,7 @@ mod tests {
 
         let project_hits = store
             .query(
+                "",
                 &Embedding(vec![1.0, 0.0]),
                 1,
                 SearchScope::Project(project_a),
@@ -757,11 +752,93 @@ mod tests {
         assert_eq!(project_hits[0].chunk.text, "weaker right-project hit");
 
         let unscoped_hits = store
-            .query(&Embedding(vec![1.0, 0.0]), 1, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 1, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(unscoped_hits.len(), 1);
         assert_eq!(unscoped_hits[0].chunk.text, "stronger unscoped hit");
+    }
+
+    #[tokio::test]
+    async fn hybrid_query_fuses_lexical_and_dense_candidates_within_scope() {
+        let store = InMemoryVectorStore::new(2);
+        let project = ProjectId::new();
+        store
+            .upsert(vec![
+                record(
+                    DocumentId::new(),
+                    0,
+                    "needleshard exact identifier",
+                    vec![0.0, 1.0],
+                ),
+                record(
+                    DocumentId::new(),
+                    0,
+                    "semantic dense candidate",
+                    vec![1.0, 0.0],
+                ),
+                scoped_record(
+                    DocumentId::new(),
+                    project,
+                    0,
+                    "needleshard wrong corpus",
+                    vec![1.0, 0.0],
+                ),
+            ])
+            .await
+            .unwrap();
+
+        let hits = store
+            .query(
+                "needleshard",
+                &Embedding(vec![1.0, 0.0]),
+                2,
+                SearchScope::Unscoped,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].chunk.text, "needleshard exact identifier");
+        assert!(hits
+            .iter()
+            .any(|hit| hit.chunk.text == "semantic dense candidate"));
+        assert!(hits
+            .iter()
+            .all(|hit| hit.chunk.text != "needleshard wrong corpus"));
+    }
+
+    #[tokio::test]
+    async fn hybrid_tie_at_k_boundary_uses_chunk_id() {
+        let store = InMemoryVectorStore::new(2);
+        let dense = record(
+            DocumentId::derive("tie-dense"),
+            0,
+            "dense candidate",
+            vec![1.0, 0.0],
+        );
+        let lexical = record(
+            DocumentId::derive("tie-lexical"),
+            0,
+            "lexicalneedle candidate",
+            vec![0.0, 1.0],
+        );
+        let expected = dense.chunk.id.0.min(lexical.chunk.id.0);
+        store.upsert(vec![dense, lexical]).await.unwrap();
+
+        let hits = store
+            .query(
+                "lexicalneedle",
+                &Embedding(vec![1.0, 0.0]),
+                1,
+                SearchScope::Unscoped,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].chunk.id.0, expected);
+        assert!((hits[0].score - (1.0 / 61.0)).abs() < 1e-6);
     }
 
     #[tokio::test]
@@ -831,6 +908,7 @@ mod tests {
         assert_eq!(store.len().await.unwrap(), 1);
         let hits = store
             .query(
+                "",
                 &Embedding(vec![1.0, 0.0]),
                 10,
                 SearchScope::Project(project_a),
@@ -841,6 +919,7 @@ mod tests {
         assert_eq!(hits[0].chunk.text, "original");
         assert!(store
             .query(
+                "",
                 &Embedding(vec![0.0, 1.0]),
                 10,
                 SearchScope::Project(project_b),
@@ -903,6 +982,7 @@ mod tests {
             .unwrap();
         assert!(store
             .query(
+                "",
                 &Embedding(vec![0.0, 1.0]),
                 1,
                 SearchScope::Project(project_b),
@@ -1004,6 +1084,7 @@ mod tests {
         assert_eq!(
             store
                 .query(
+                    "",
                     &Embedding(vec![0.0, 1.0]),
                     1,
                     SearchScope::Project(project_b),
@@ -1021,12 +1102,12 @@ mod tests {
         let store = InMemoryVectorStore::new(2);
         assert!(store.is_empty().await.unwrap());
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 0, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 0, SearchScope::Unscoped)
             .await
             .unwrap()
             .is_empty());
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
             .await
             .unwrap()
             .is_empty());
@@ -1053,7 +1134,7 @@ mod tests {
         );
         // The second upsert's vector won.
         let hits = store
-            .query(&Embedding(vec![0.0, 1.0]), 1, SearchScope::Unscoped)
+            .query("", &Embedding(vec![0.0, 1.0]), 1, SearchScope::Unscoped)
             .await
             .unwrap();
         assert!((hits[0].score - 1.0).abs() < 1e-6);
@@ -1080,7 +1161,7 @@ mod tests {
             .unwrap();
         assert_eq!(store.len().await.unwrap(), 2); // one a, one b
         let hits = store
-            .query(&Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 5, SearchScope::Unscoped)
             .await
             .unwrap();
         assert!(hits.iter().any(|h| h.chunk.text == "a-new"));
@@ -1108,7 +1189,7 @@ mod tests {
             .unwrap();
         assert_eq!(store.len().await.unwrap(), 1);
         let hits = store
-            .query(&Embedding(vec![0.0, 1.0]), 5, SearchScope::Unscoped)
+            .query("", &Embedding(vec![0.0, 1.0]), 5, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);
@@ -1161,7 +1242,7 @@ mod tests {
 
         assert!(err.to_string().contains("belongs to document"));
         let hits = store
-            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);
@@ -1191,7 +1272,7 @@ mod tests {
             Some(DocumentGenerationState::Staged(first))
         );
         assert!(store
-            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap()
             .is_empty());
@@ -1220,7 +1301,7 @@ mod tests {
             GenerationStageOutcome::Staged
         );
         let before_activation = store
-            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(before_activation.len(), 1);
@@ -1239,7 +1320,7 @@ mod tests {
             .unwrap());
 
         let after_activation = store
-            .query(&Embedding(vec![0.0, 1.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![0.0, 1.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(after_activation.len(), 1);
@@ -1382,6 +1463,7 @@ mod tests {
         assert_eq!(
             store
                 .query(
+                    "",
                     &Embedding(vec![0.0, 1.0]),
                     5,
                     SearchScope::Project(project_a)
@@ -1394,6 +1476,7 @@ mod tests {
         assert_eq!(
             store
                 .query(
+                    "",
                     &Embedding(vec![0.0, 1.0]),
                     5,
                     SearchScope::Project(project_b)
@@ -1466,7 +1549,7 @@ mod tests {
             .await
             .is_err());
         let hits = store
-            .query(&Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
+            .query("", &Embedding(vec![1.0, 0.0]), 10, SearchScope::Unscoped)
             .await
             .unwrap();
         assert_eq!(hits.len(), 1);

--- a/crates/openwave-server/src/document_worker.rs
+++ b/crates/openwave-server/src/document_worker.rs
@@ -536,11 +536,12 @@ mod tests {
 
         async fn query(
             &self,
+            query_text: &str,
             query: &Embedding,
             k: usize,
             scope: openwave_retrieval::SearchScope,
         ) -> openwave_retrieval::Result<Vec<ScoredChunk>> {
-            self.inner.query(query, k, scope).await
+            self.inner.query(query_text, query, k, scope).await
         }
 
         async fn replace_document(

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -539,11 +539,12 @@ mod tests {
 
         async fn query(
             &self,
+            query_text: &str,
             query: &Embedding,
             k: usize,
             scope: openwave_retrieval::SearchScope,
         ) -> openwave_retrieval::Result<Vec<ScoredChunk>> {
-            self.inner.query(query, k, scope).await
+            self.inner.query(query_text, query, k, scope).await
         }
 
         async fn replace_document(

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -76,8 +76,8 @@ list and fetch from sources like Drive and Box.
 
 ## `openwave-retrieval` — embeddings, vector search, citations ⚪
 
-Embeddings, chunking, ingestion, and grounded citations behind a `VectorStore`
-seam that runs embedded (sqlite-vec) or against pgvector / Qdrant.
+Embeddings, chunking, hybrid lexical+dense search, and grounded citations behind
+a `VectorStore` seam with in-memory and durable embedded LanceDB backends.
 
 **Depends on:** `openwave-core`.
 


### PR DESCRIPTION
## Summary

- make query text and its embedding one atomic vector-store search operation
- fuse dependency-free BM25 and dense cosine candidates with RRF in the in-memory backend
- use LanceDB's native FTS + vector hybrid query behind one publication snapshot
- apply deterministic chunk-id tie-breaking before the final hybrid limit
- preserve project and active-generation prefilters before candidate limits
- catch the Lance text index up on reconnect and after every 20 mutations while
  keeping appended rows immediately searchable through Lance's flat fallback

## Verification

- `cargo test -p openwave-retrieval`
- `cargo test -p openwave-retrieval --all-features`
- `cargo test -p openwave-server`
- `bw dev lint --rust`
