### PR TITLE
feat(retrieval): diversify selected passages

### DIFF
--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -77,6 +77,7 @@ mod parse;
 mod retriever;
 #[cfg(feature = "tool")]
 mod search;
+mod selection;
 mod vector;
 
 pub use chunk::{Chunker, TextChunker};
@@ -93,6 +94,7 @@ pub use parse::{DocumentParser, ParsedDocument, PlainTextParser};
 pub use retriever::{GenerationIndexOutcome, IngestOutcome, Retriever};
 #[cfg(feature = "tool")]
 pub use search::SearchTool;
+pub use selection::MAX_SEARCH_RESULTS;
 pub use vector::{
     DocumentGenerationState, GenerationStageOutcome, InMemoryVectorStore, SearchOptions,
     SearchScope, VectorRecord, VectorStore, DEFAULT_MIN_DENSE_SIMILARITY,

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -13,6 +13,7 @@ use crate::embed::Embedder;
 use crate::error::{Result, RetrievalError};
 use crate::id::DocumentId;
 use crate::parse::DocumentParser;
+use crate::selection::{candidate_limit, result_limit, select};
 use crate::vector::{GenerationStageOutcome, SearchScope, VectorRecord, VectorStore};
 use openwave_core::DocumentGeneration;
 
@@ -250,8 +251,13 @@ impl Retriever {
 
     /// Search the index for the `k` chunks most relevant to `query`, as citations.
     pub async fn search(&self, scope: SearchScope, query: &str, k: usize) -> Result<Vec<Citation>> {
+        let k = result_limit(k);
         let embedding = self.embedder.embed_query(query).await?;
-        let hits = self.store.query(query, &embedding, k, scope).await?;
+        let candidates = self
+            .store
+            .query(query, &embedding, candidate_limit(k), scope)
+            .await?;
+        let hits = select(candidates, k);
         Ok(hits.into_iter().map(Citation::from).collect())
     }
 
@@ -265,17 +271,67 @@ impl Retriever {
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Mutex;
 
     use super::*;
     use crate::chunk::TextChunker;
+    use crate::document::{ByteSpan, Chunk, ScoredChunk};
     use crate::embed::HashEmbedder;
     use crate::parse::PlainTextParser;
-    use crate::vector::InMemoryVectorStore;
+    use crate::vector::{InMemoryVectorStore, SearchOptions};
 
     struct ControlledEmbedder {
         inner: HashEmbedder,
         calls: AtomicUsize,
         fail: AtomicBool,
+    }
+
+    struct QuerySpyVectorStore {
+        candidates: Vec<ScoredChunk>,
+        limits: Mutex<Vec<usize>>,
+    }
+
+    #[async_trait::async_trait]
+    impl VectorStore for QuerySpyVectorStore {
+        async fn upsert(&self, _records: Vec<VectorRecord>) -> Result<()> {
+            Ok(())
+        }
+
+        async fn query_with_options(
+            &self,
+            _query_text: &str,
+            _query: &crate::Embedding,
+            k: usize,
+            _options: SearchOptions,
+        ) -> Result<Vec<ScoredChunk>> {
+            self.limits.lock().unwrap().push(k);
+            Ok(self.candidates.iter().take(k).cloned().collect())
+        }
+
+        async fn replace_document(
+            &self,
+            _document_id: DocumentId,
+            _records: Vec<VectorRecord>,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn len(&self) -> Result<usize> {
+            Ok(self.candidates.len())
+        }
+    }
+
+    fn scored(
+        document_id: DocumentId,
+        ordinal: usize,
+        start: usize,
+        end: usize,
+        text: &str,
+    ) -> ScoredChunk {
+        ScoredChunk {
+            chunk: Chunk::new(document_id, ordinal, ByteSpan::new(start, end), text),
+            score: 1.0 - ordinal as f32 / 10.0,
+        }
     }
 
     #[async_trait::async_trait]
@@ -344,6 +400,74 @@ The Great Barrier Reef is the world's largest coral reef system.";
             Some(hits[0].snippet.as_str())
         );
         assert_eq!(hits[0].document_id, outcome.document.id);
+    }
+
+    #[tokio::test]
+    async fn search_requests_extra_candidates_and_backfills_after_suppression() {
+        let first = DocumentId::new();
+        let second = DocumentId::new();
+        let store = Arc::new(QuerySpyVectorStore {
+            candidates: vec![
+                scored(first, 0, 0, 100, "primary"),
+                scored(first, 1, 20, 80, "redundant"),
+                scored(second, 2, 0, 20, "backfill"),
+            ],
+            limits: Mutex::new(Vec::new()),
+        });
+        let retriever = Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::new(90, 0)),
+            Arc::new(HashEmbedder::new(512)),
+            store.clone(),
+        );
+
+        let citations = retriever
+            .search(SearchScope::Unscoped, "relevant material", 2)
+            .await
+            .unwrap();
+
+        assert_eq!(store.limits.lock().unwrap().as_slice(), &[8]);
+        assert_eq!(citations.len(), 2);
+        assert_eq!(citations[0].snippet, "primary");
+        assert_eq!(citations[1].snippet, "backfill");
+    }
+
+    #[tokio::test]
+    async fn search_caps_large_output_and_candidate_requests() {
+        let candidates: Vec<_> = (0..201)
+            .map(|ordinal| {
+                scored(
+                    DocumentId::new(),
+                    ordinal,
+                    ordinal * 20,
+                    ordinal * 20 + 10,
+                    "candidate",
+                )
+            })
+            .collect();
+        let store = Arc::new(QuerySpyVectorStore {
+            candidates,
+            limits: Mutex::new(Vec::new()),
+        });
+        let retriever = Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::new(90, 0)),
+            Arc::new(HashEmbedder::new(512)),
+            store.clone(),
+        );
+
+        let citations = retriever
+            .search(SearchScope::Unscoped, "relevant material", usize::MAX)
+            .await
+            .unwrap();
+        let empty = retriever
+            .search(SearchScope::Unscoped, "relevant material", 0)
+            .await
+            .unwrap();
+
+        assert_eq!(store.limits.lock().unwrap().as_slice(), &[200, 0]);
+        assert_eq!(citations.len(), crate::MAX_SEARCH_RESULTS);
+        assert!(empty.is_empty());
     }
 
     #[tokio::test]

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -23,6 +23,7 @@ use serde_json::{json, Value};
 
 use crate::document::Citation;
 use crate::embed::Embedder;
+use crate::selection::{candidate_limit, select};
 use crate::vector::{SearchScope, VectorStore};
 
 /// A `Tool` that searches an embedded index and returns grounded citations.
@@ -34,8 +35,6 @@ pub struct SearchTool {
 impl SearchTool {
     /// Passages returned when the caller doesn't specify `k`.
     pub const DEFAULT_K: usize = 5;
-    /// Ceiling on `k`, so a large request can't fan out unboundedly.
-    pub const MAX_K: usize = 50;
 
     /// Build a search tool over a shared embedder and vector store.
     #[must_use]
@@ -49,7 +48,7 @@ impl SearchTool {
 struct SearchArgs {
     /// The natural-language query to search for.
     query: String,
-    /// How many passages to return (optional; clamped to `[1, MAX_K]`).
+    /// How many passages to return (optional; clamped to the shared maximum).
     #[serde(default)]
     k: Option<usize>,
 }
@@ -95,7 +94,7 @@ impl Tool for SearchTool {
                     "k": {
                         "type": "integer",
                         "minimum": 1,
-                        "maximum": Self::MAX_K,
+                        "maximum": crate::MAX_SEARCH_RESULTS,
                         "description": "How many passages to return (default 5)."
                     }
                 },
@@ -120,7 +119,10 @@ impl Tool for SearchTool {
         if query.is_empty() {
             return Ok(ToolOutput::error("query must not be empty"));
         }
-        let k = args.k.unwrap_or(Self::DEFAULT_K).clamp(1, Self::MAX_K);
+        let k = args
+            .k
+            .unwrap_or(Self::DEFAULT_K)
+            .clamp(1, crate::MAX_SEARCH_RESULTS);
 
         let embedding = match self.embedder.embed_query(query).await {
             Ok(embedding) => embedding,
@@ -130,10 +132,15 @@ impl Tool for SearchTool {
             Some(project_id) => SearchScope::Project(project_id),
             None => SearchScope::Unscoped,
         };
-        let hits = match self.store.query(query, &embedding, k, scope).await {
+        let candidates = match self
+            .store
+            .query(query, &embedding, candidate_limit(k), scope)
+            .await
+        {
             Ok(hits) => hits,
             Err(err) => return Ok(ToolOutput::error(format!("search failed: {err}"))),
         };
+        let hits = select(candidates, k);
 
         let citations: Vec<Citation> = hits.into_iter().map(Citation::from).collect();
         if citations.is_empty() {
@@ -149,13 +156,15 @@ impl Tool for SearchTool {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::Mutex;
 
     use openwave_core::{ChatId, ProjectId};
 
     use crate::chunk::{Chunker, TextChunker};
-    use crate::document::{Document, DocumentSource};
+    use crate::document::{ByteSpan, Chunk, Document, DocumentSource, ScoredChunk};
     use crate::embed::HashEmbedder;
-    use crate::vector::{InMemoryVectorStore, VectorRecord};
+    use crate::id::DocumentId;
+    use crate::vector::{InMemoryVectorStore, SearchOptions, VectorRecord};
 
     const DIMS: usize = 512;
 
@@ -195,6 +204,54 @@ mod tests {
             chat_id: ChatId::new(),
             project_id,
             workspace_dir: PathBuf::from("/tmp/unused"),
+        }
+    }
+
+    struct SpyVectorStore {
+        candidates: Vec<ScoredChunk>,
+        calls: Mutex<Vec<(usize, SearchScope)>>,
+    }
+
+    #[async_trait]
+    impl VectorStore for SpyVectorStore {
+        async fn upsert(&self, _records: Vec<VectorRecord>) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn query_with_options(
+            &self,
+            _query_text: &str,
+            _query: &crate::Embedding,
+            k: usize,
+            options: SearchOptions,
+        ) -> crate::Result<Vec<ScoredChunk>> {
+            self.calls.lock().unwrap().push((k, options.scope));
+            Ok(self.candidates.iter().take(k).cloned().collect())
+        }
+
+        async fn replace_document(
+            &self,
+            _document_id: DocumentId,
+            _records: Vec<VectorRecord>,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn len(&self) -> crate::Result<usize> {
+            Ok(self.candidates.len())
+        }
+    }
+
+    fn scored(
+        document_id: DocumentId,
+        ordinal: usize,
+        start: usize,
+        end: usize,
+        text: &str,
+    ) -> ScoredChunk {
+        ScoredChunk {
+            chunk: Chunk::new(document_id, ordinal, ByteSpan::new(start, end), text),
+            score: 1.0 - ordinal as f32 / 10.0,
         }
     }
 
@@ -307,6 +364,44 @@ mod tests {
         assert!(alpha.content.contains("project alpha"));
         assert!(!alpha.content.contains("unscoped lighthouse"));
         assert!(!alpha.content.contains("project beta"));
+    }
+
+    #[tokio::test]
+    async fn requests_four_times_k_and_backfills_using_trusted_context_scope() {
+        let first = DocumentId::new();
+        let second = DocumentId::new();
+        let project_id = ProjectId::new();
+        let forged_project_id = ProjectId::new();
+        let store = Arc::new(SpyVectorStore {
+            candidates: vec![
+                scored(first, 0, 0, 100, "primary"),
+                scored(first, 1, 20, 80, "redundant"),
+                scored(second, 2, 0, 20, "backfill"),
+            ],
+            calls: Mutex::new(Vec::new()),
+        });
+        let tool = SearchTool::new(Arc::new(HashEmbedder::new(DIMS)), store.clone());
+
+        let output = tool
+            .execute(
+                &ctx_for(Some(project_id)),
+                json!({
+                    "query": "relevant material",
+                    "k": 2,
+                    "project_id": forged_project_id
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error);
+        assert!(output.content.contains("primary"));
+        assert!(!output.content.contains("redundant"));
+        assert!(output.content.contains("backfill"));
+        assert_eq!(
+            store.calls.lock().unwrap().as_slice(),
+            &[(8, SearchScope::Project(project_id))]
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-retrieval/src/selection.rs
+++ b/crates/openwave-retrieval/src/selection.rs
@@ -1,0 +1,249 @@
+//! Post-retrieval result selection shared by the HTTP and tool entry points.
+//!
+//! Vector backends remain responsible only for corpus filtering and relevance
+//! ranking. Their native choice among exact ties at the candidate boundary is
+//! backend-defined; this module applies deterministic policy to the ranked
+//! candidates it receives.
+
+use std::collections::HashSet;
+
+use crate::document::{ByteSpan, ScoredChunk};
+use crate::id::DocumentId;
+
+/// Maximum number of passages any public search surface returns.
+pub const MAX_SEARCH_RESULTS: usize = 50;
+
+const CANDIDATE_MULTIPLIER: usize = 4;
+const MAX_SEARCH_CANDIDATES: usize = MAX_SEARCH_RESULTS * CANDIDATE_MULTIPLIER;
+const DIVERSITY_LOOKAHEAD: usize = 3;
+
+/// Clamp a low-level retrieval request without changing `k == 0` semantics.
+pub(crate) fn result_limit(k: usize) -> usize {
+    k.min(MAX_SEARCH_RESULTS)
+}
+
+/// Candidate count requested from the backend to allow policy backfill.
+pub(crate) fn candidate_limit(k: usize) -> usize {
+    k.saturating_mul(CANDIDATE_MULTIPLIER)
+        .min(MAX_SEARCH_CANDIDATES)
+}
+
+/// Select up to `k` candidates while suppressing redundant same-document spans
+/// and gently preferring document diversity within a four-result rank window.
+///
+/// Diversity can skip over the baseline candidate, but skipped candidates stay
+/// available for later rounds. The final results are restored to backend rank
+/// order, so selection changes membership without inventing a new score order.
+pub(crate) fn select(candidates: Vec<ScoredChunk>, k: usize) -> Vec<ScoredChunk> {
+    if k == 0 || candidates.is_empty() {
+        return Vec::new();
+    }
+
+    let mut remaining: Vec<usize> = (0..candidates.len()).collect();
+    let mut selected = Vec::with_capacity(k.min(candidates.len()));
+    let mut seen_documents = HashSet::<DocumentId>::new();
+
+    while selected.len() < k {
+        remaining.retain(|&index| {
+            !selected.iter().any(|&selected_index| {
+                substantially_overlaps(&candidates[index], &candidates[selected_index])
+            })
+        });
+        if remaining.is_empty() {
+            break;
+        }
+
+        let window_end = remaining
+            .len()
+            .min(1usize.saturating_add(DIVERSITY_LOOKAHEAD));
+        let chosen_position = remaining[..window_end]
+            .iter()
+            .position(|&index| !seen_documents.contains(&candidates[index].chunk.document_id))
+            .unwrap_or(0);
+        let chosen_index = remaining.remove(chosen_position);
+        seen_documents.insert(candidates[chosen_index].chunk.document_id);
+        selected.push(chosen_index);
+    }
+
+    selected.sort_unstable();
+    selected
+        .into_iter()
+        .map(|index| candidates[index].clone())
+        .collect()
+}
+
+fn substantially_overlaps(left: &ScoredChunk, right: &ScoredChunk) -> bool {
+    left.chunk.document_id == right.chunk.document_id
+        && overlap_exceeds_three_tenths(left.chunk.span, right.chunk.span)
+}
+
+fn overlap_exceeds_three_tenths(left: ByteSpan, right: ByteSpan) -> bool {
+    let shorter = left.len().min(right.len());
+    if shorter == 0 {
+        return false;
+    }
+    let intersection = left
+        .end
+        .min(right.end)
+        .saturating_sub(left.start.max(right.start));
+    (intersection as u128) * 10 > (shorter as u128) * 3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::Chunk;
+    use crate::id::DocumentId;
+
+    fn scored(document_id: DocumentId, ordinal: usize, start: usize, end: usize) -> ScoredChunk {
+        ScoredChunk {
+            chunk: Chunk::new(
+                document_id,
+                ordinal,
+                ByteSpan::new(start, end),
+                format!("chunk {ordinal}"),
+            ),
+            score: 1.0 - ordinal as f32 / 100.0,
+        }
+    }
+
+    #[test]
+    fn candidate_limit_is_four_times_output_and_capped() {
+        assert_eq!(result_limit(0), 0);
+        assert_eq!(result_limit(1), 1);
+        assert_eq!(result_limit(usize::MAX), MAX_SEARCH_RESULTS);
+        assert_eq!(candidate_limit(0), 0);
+        assert_eq!(candidate_limit(1), 4);
+        assert_eq!(candidate_limit(17), 68);
+        assert_eq!(candidate_limit(MAX_SEARCH_RESULTS), 200);
+        assert_eq!(candidate_limit(usize::MAX), 200);
+    }
+
+    #[test]
+    fn overlap_uses_strict_three_tenths_of_the_shorter_span() {
+        assert!(!overlap_exceeds_three_tenths(
+            ByteSpan::new(0, 10),
+            ByteSpan::new(7, 17)
+        ));
+        assert!(overlap_exceeds_three_tenths(
+            ByteSpan::new(0, 10),
+            ByteSpan::new(6, 16)
+        ));
+        assert!(!overlap_exceeds_three_tenths(
+            ByteSpan::new(0, 0),
+            ByteSpan::new(0, 10)
+        ));
+        assert!(!overlap_exceeds_three_tenths(
+            ByteSpan::new(0, 10),
+            ByteSpan::new(10, 20)
+        ));
+    }
+
+    #[test]
+    fn overlap_suppression_is_limited_to_the_same_document() {
+        let first = DocumentId::new();
+        let second = DocumentId::new();
+        let selected = select(vec![scored(first, 0, 0, 10), scored(second, 1, 0, 10)], 2);
+        assert_eq!(selected.len(), 2);
+    }
+
+    #[test]
+    fn a_contained_same_document_span_is_suppressed() {
+        let document = DocumentId::new();
+        let selected = select(
+            vec![scored(document, 0, 0, 100), scored(document, 1, 30, 60)],
+            2,
+        );
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].chunk.ordinal, 0);
+    }
+
+    #[test]
+    fn diversity_prefers_first_unseen_document_in_rank_window() {
+        let first = DocumentId::new();
+        let second = DocumentId::new();
+        let candidates = vec![
+            scored(first, 0, 0, 10),
+            scored(first, 1, 20, 30),
+            scored(first, 2, 40, 50),
+            scored(second, 3, 0, 10),
+        ];
+        let selected = select(candidates, 2);
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected[0].chunk.document_id, first);
+        assert_eq!(selected[1].chunk.document_id, second);
+    }
+
+    #[test]
+    fn diversity_does_not_reach_beyond_three_lookahead_candidates() {
+        let first = DocumentId::new();
+        let second = DocumentId::new();
+        let candidates = vec![
+            scored(first, 0, 0, 10),
+            scored(first, 1, 20, 30),
+            scored(first, 2, 40, 50),
+            scored(first, 3, 60, 70),
+            scored(first, 4, 80, 90),
+            scored(second, 5, 0, 10),
+        ];
+        let selected = select(candidates, 2);
+        assert_eq!(selected[1].chunk.ordinal, 1);
+    }
+
+    #[test]
+    fn skipped_candidates_remain_and_membership_returns_in_original_order() {
+        let first = DocumentId::new();
+        let second = DocumentId::new();
+        let candidates = vec![
+            scored(first, 0, 0, 10),
+            scored(first, 1, 20, 30),
+            scored(second, 2, 0, 10),
+        ];
+        let selected = select(candidates, 3);
+        let ordinals: Vec<_> = selected
+            .into_iter()
+            .map(|candidate| candidate.chunk.ordinal)
+            .collect();
+        assert_eq!(ordinals, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn overlapping_candidates_are_suppressed_and_later_candidates_backfill() {
+        let first = DocumentId::new();
+        let second = DocumentId::new();
+        let candidates = vec![
+            scored(first, 0, 0, 100),
+            scored(first, 1, 20, 80),
+            scored(second, 2, 0, 10),
+        ];
+        let selected = select(candidates, 2);
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected[0].chunk.ordinal, 0);
+        assert_eq!(selected[1].chunk.ordinal, 2);
+    }
+
+    #[test]
+    fn scores_do_not_affect_selected_membership() {
+        let first = DocumentId::new();
+        let second = DocumentId::new();
+        let candidates = vec![
+            scored(first, 0, 0, 100),
+            scored(first, 1, 20, 80),
+            scored(second, 2, 0, 20),
+        ];
+        let mut rescored = candidates.clone();
+        rescored[0].score = -500.0;
+        rescored[1].score = 10_000.0;
+        rescored[2].score = f32::NAN;
+
+        let original_ids: Vec<_> = select(candidates, 2)
+            .into_iter()
+            .map(|candidate| candidate.chunk.id)
+            .collect();
+        let rescored_ids: Vec<_> = select(rescored, 2)
+            .into_iter()
+            .map(|candidate| candidate.chunk.id)
+            .collect();
+        assert_eq!(original_ids, rescored_ids);
+    }
+}

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -20,6 +20,7 @@ use openwave_core::{
 };
 use openwave_retrieval::{
     Citation, DocumentId, DocumentSource, RetrievalError, SearchScope, SearchTool,
+    MAX_SEARCH_RESULTS,
 };
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
@@ -748,7 +749,7 @@ pub async fn delete_project_document(
 pub struct SearchRequest {
     /// The natural-language query.
     pub query: String,
-    /// How many passages to return (optional; clamped to `[1, SearchTool::MAX_K]`).
+    /// How many passages to return (optional; clamped to `[1, MAX_SEARCH_RESULTS]`).
     #[serde(default)]
     pub k: Option<usize>,
 }
@@ -793,7 +794,7 @@ async fn search_documents_in_scope(
     let k = body
         .k
         .unwrap_or(SearchTool::DEFAULT_K)
-        .clamp(1, SearchTool::MAX_K);
+        .clamp(1, MAX_SEARCH_RESULTS);
     let citations = state
         .retrieval
         .search(scope, query, k)


### PR DESCRIPTION
## Summary

- fetch a bounded candidate pool before applying result policy
- suppress heavily overlapping passages from the same document
- prefer document diversity within a small rank window while preserving backend order
- share one public result ceiling across the HTTP and agent search surfaces

## Validation

- `cargo test -p openwave-retrieval --no-default-features`
- `cargo test -p openwave-retrieval --all-features`
- `cargo test -p openwave-server --all-features`
- `bw dev lint --rust`
