### PR TITLE
feat(retrieval): add reranking seam

### DIFF
--- a/crates/openwave-retrieval/src/document.rs
+++ b/crates/openwave-retrieval/src/document.rs
@@ -192,7 +192,10 @@ impl Chunk {
 pub struct ScoredChunk {
     /// The matched chunk.
     pub chunk: Chunk,
-    /// Backend relevance score; higher is more relevant.
+    /// Relevance score; initially assigned by the backend and overwritten by an
+    /// optional reranker before final selection. Higher is more relevant within
+    /// one result set; reranker scores are not comparable across queries or
+    /// configurations.
     pub score: f32,
 }
 
@@ -210,7 +213,8 @@ pub struct Citation {
     pub span: ByteSpan,
     /// The cited text.
     pub snippet: String,
-    /// The relevance score that surfaced this citation.
+    /// The final relevance score that surfaced this citation. When reranking is
+    /// configured, this is the reranker score rather than the backend score.
     pub score: f32,
 }
 

--- a/crates/openwave-retrieval/src/error.rs
+++ b/crates/openwave-retrieval/src/error.rs
@@ -23,6 +23,10 @@ pub enum RetrievalError {
     #[error("embedding error: {0}")]
     Embed(String),
 
+    /// A reranking provider failed or returned malformed scores.
+    #[error("reranking error: {0}")]
+    Rerank(String),
+
     /// A vector backend failed (I/O, query, or upsert).
     #[error("vector store error: {0}")]
     VectorStore(String),
@@ -55,6 +59,11 @@ impl RetrievalError {
     /// Build a [`RetrievalError::Embed`] from anything string-like.
     pub fn embed(message: impl Into<String>) -> Self {
         Self::Embed(message.into())
+    }
+
+    /// Build a [`RetrievalError::Rerank`] from anything string-like.
+    pub fn rerank(message: impl Into<String>) -> Self {
+        Self::Rerank(message.into())
     }
 
     /// Build a [`RetrievalError::VectorStore`] from anything string-like.

--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -1,7 +1,8 @@
 //! OpenWave retrieval — ingest documents, embed them, search by meaning, and get
 //! back grounded citations.
 //!
-//! The crate is built from four seams, each a trait with a working default:
+//! The crate is built from four required provider-neutral seams with working
+//! retrieval defaults, plus an optional fifth:
 //!
 //! - [`DocumentParser`] — raw bytes → plain text. Default: [`PlainTextParser`]
 //!   (zero-dependency `text/*`). Rich formats (PDF/office/images) land later as a
@@ -17,7 +18,10 @@
 //!   cosine scan, fused with reciprocal rank fusion. [`LanceVectorStore`] adds
 //!   the durable embedded implementation behind the `vec-lance` feature.
 //!
-//! [`Retriever`] wires all four into `ingest` and `search`. Everything a chunk or
+//! - [`Reranker`] — optional query/candidate scoring after broad retrieval and
+//!   before result selection. No reranker is configured by default.
+//!
+//! [`Retriever`] wires these into `ingest` and `search`. Everything a chunk or
 //! citation carries a [`ByteSpan`] — a precise byte range into the source text —
 //! so every answer points back to exactly where it came from.
 //!
@@ -60,8 +64,8 @@
 //! an [`Embedder`] backed by the OpenAI-compatible `/embeddings` endpoint — a
 //! drop-in for [`HashEmbedder`] behind the same seam.
 //!
-//! Not yet wired: model reranking, rich-format parsing, and ANN index management.
-//! Each lands as its own slice behind these seams.
+//! Not yet wired: a concrete reranking provider, rich-format parsing, and ANN
+//! index management. Each lands as its own slice behind these seams.
 
 mod chunk;
 mod document;
@@ -74,6 +78,7 @@ mod lance_store;
 #[cfg(feature = "embed-openai")]
 mod openai_embed;
 mod parse;
+mod rerank;
 mod retriever;
 #[cfg(feature = "tool")]
 mod search;
@@ -91,6 +96,7 @@ pub use lance_store::LanceVectorStore;
 pub use openai_embed::OpenAiEmbedder;
 pub use openwave_core::{DocumentGeneration, ProjectId};
 pub use parse::{DocumentParser, ParsedDocument, PlainTextParser};
+pub use rerank::Reranker;
 pub use retriever::{GenerationIndexOutcome, IngestOutcome, Retriever};
 #[cfg(feature = "tool")]
 pub use search::SearchTool;

--- a/crates/openwave-retrieval/src/rerank.rs
+++ b/crates/openwave-retrieval/src/rerank.rs
@@ -1,0 +1,193 @@
+//! Provider-neutral model reranking.
+
+use async_trait::async_trait;
+
+use crate::{Result, RetrievalError, ScoredChunk};
+
+/// Assigns query-specific relevance scores to an existing candidate set.
+///
+/// Implementations must return exactly one finite score for every input chunk,
+/// in the same order as `candidates`. The retrieval pipeline validates that
+/// contract before changing any candidate score or rank. Scores are
+/// provider-specific and must not be compared across queries, models, or
+/// reranker configurations.
+#[async_trait]
+pub trait Reranker: Send + Sync {
+    /// Score every candidate for `query`, preserving input alignment.
+    async fn rerank(&self, query: &str, candidates: &[ScoredChunk]) -> Result<Vec<f32>>;
+}
+
+/// Apply an optional reranker and stably order candidates by its scores.
+///
+/// Empty candidate sets bypass the provider. Validation happens before mutation
+/// so malformed provider output never leaves a partially reranked result set.
+pub(crate) async fn rerank_candidates(
+    reranker: Option<&dyn Reranker>,
+    query: &str,
+    mut candidates: Vec<ScoredChunk>,
+) -> Result<Vec<ScoredChunk>> {
+    let Some(reranker) = reranker else {
+        return Ok(candidates);
+    };
+    if candidates.is_empty() {
+        return Ok(candidates);
+    }
+
+    let scores = reranker
+        .rerank(query, &candidates)
+        .await
+        .map_err(|error| match error {
+            error @ RetrievalError::Rerank(_) => error,
+            error => RetrievalError::rerank(error.to_string()),
+        })?;
+    if scores.len() != candidates.len() {
+        return Err(RetrievalError::rerank(format!(
+            "reranker returned {} scores for {} candidates",
+            scores.len(),
+            candidates.len()
+        )));
+    }
+    if let Some((index, score)) = scores
+        .iter()
+        .copied()
+        .enumerate()
+        .find(|(_, score)| !score.is_finite())
+    {
+        return Err(RetrievalError::rerank(format!(
+            "reranker returned non-finite score {score} at index {index}"
+        )));
+    }
+
+    for (candidate, score) in candidates.iter_mut().zip(scores) {
+        candidate.score = score;
+    }
+    // Stable sorting preserves backend order for exact reranker ties.
+    candidates.sort_by(|left, right| right.score.total_cmp(&left.score));
+    Ok(candidates)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::{ByteSpan, Chunk, DocumentId};
+
+    struct FixedReranker {
+        scores: Vec<f32>,
+        calls: AtomicUsize,
+    }
+
+    struct RerankFailure;
+    struct EmbedFailure;
+
+    #[async_trait]
+    impl Reranker for FixedReranker {
+        async fn rerank(&self, _query: &str, _candidates: &[ScoredChunk]) -> Result<Vec<f32>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.scores.clone())
+        }
+    }
+
+    #[async_trait]
+    impl Reranker for RerankFailure {
+        async fn rerank(&self, _query: &str, _candidates: &[ScoredChunk]) -> Result<Vec<f32>> {
+            Err(RetrievalError::rerank("provider unavailable"))
+        }
+    }
+
+    #[async_trait]
+    impl Reranker for EmbedFailure {
+        async fn rerank(&self, _query: &str, _candidates: &[ScoredChunk]) -> Result<Vec<f32>> {
+            Err(RetrievalError::embed("provider returned secret details"))
+        }
+    }
+
+    fn candidates(count: usize) -> Vec<ScoredChunk> {
+        let document_id = DocumentId::new();
+        (0..count)
+            .map(|ordinal| ScoredChunk {
+                chunk: Chunk::new(
+                    document_id,
+                    ordinal,
+                    ByteSpan::new(ordinal * 10, ordinal * 10 + 5),
+                    ordinal.to_string(),
+                ),
+                score: 10.0 - ordinal as f32,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn replaces_scores_reorders_and_preserves_ties() {
+        let reranker = FixedReranker {
+            scores: vec![0.2, 0.9, 0.9, 0.1],
+            calls: AtomicUsize::new(0),
+        };
+        let hits = rerank_candidates(Some(&reranker), "query", candidates(4))
+            .await
+            .unwrap();
+        assert_eq!(
+            hits.iter().map(|hit| hit.chunk.ordinal).collect::<Vec<_>>(),
+            vec![1, 2, 0, 3]
+        );
+        assert_eq!(
+            hits.iter().map(|hit| hit.score).collect::<Vec<_>>(),
+            vec![0.9, 0.9, 0.2, 0.1]
+        );
+    }
+
+    #[tokio::test]
+    async fn bypasses_empty_but_reranks_a_singleton() {
+        let reranker = FixedReranker {
+            scores: vec![0.25],
+            calls: AtomicUsize::new(0),
+        };
+        assert!(rerank_candidates(Some(&reranker), "query", vec![])
+            .await
+            .unwrap()
+            .is_empty());
+        let singleton = rerank_candidates(Some(&reranker), "query", candidates(1))
+            .await
+            .unwrap();
+        assert_eq!(singleton[0].score, 0.25);
+        assert_eq!(reranker.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn rejects_bad_output_and_propagates_provider_failure() {
+        for scores in [vec![0.1], vec![0.1, f32::NAN], vec![0.1, f32::INFINITY]] {
+            let reranker = FixedReranker {
+                scores,
+                calls: AtomicUsize::new(0),
+            };
+            let error = rerank_candidates(Some(&reranker), "query", candidates(2))
+                .await
+                .unwrap_err();
+            assert!(matches!(error, RetrievalError::Rerank(_)));
+        }
+
+        let error = rerank_candidates(Some(&RerankFailure), "query", candidates(2))
+            .await
+            .unwrap_err();
+        assert_eq!(error.to_string(), "reranking error: provider unavailable");
+
+        let error = rerank_candidates(Some(&EmbedFailure), "query", candidates(2))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, RetrievalError::Rerank(_)));
+        assert_eq!(
+            error.to_string(),
+            "reranking error: embedding error: provider returned secret details"
+        );
+    }
+
+    #[test]
+    fn is_object_safe() {
+        fn accepts_arc(_: std::sync::Arc<dyn Reranker>) {}
+        accepts_arc(std::sync::Arc::new(FixedReranker {
+            scores: vec![],
+            calls: AtomicUsize::new(0),
+        }));
+    }
+}

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -1,9 +1,9 @@
 //! The end-to-end pipeline: parse → chunk → embed → store, and query → cite.
 //!
-//! [`Retriever`] wires the four seams together behind two methods, [`Retriever::ingest`]
-//! and [`Retriever::search`]. It owns a parser and chunker and shares an embedder
-//! and vector store (the store is typically shared with the rest of the process,
-//! so a future `search` tool can query the same index this ingests into).
+//! [`Retriever`] wires the retrieval seams together behind two methods,
+//! [`Retriever::ingest`] and [`Retriever::search`]. It owns a parser and chunker,
+//! shares an embedder and vector store, and can optionally rerank broad search
+//! candidates before final result selection.
 
 use std::sync::Arc;
 
@@ -13,6 +13,7 @@ use crate::embed::Embedder;
 use crate::error::{Result, RetrievalError};
 use crate::id::DocumentId;
 use crate::parse::DocumentParser;
+use crate::rerank::{rerank_candidates, Reranker};
 use crate::selection::{candidate_limit, result_limit, select};
 use crate::vector::{GenerationStageOutcome, SearchScope, VectorRecord, VectorStore};
 use openwave_core::DocumentGeneration;
@@ -42,6 +43,7 @@ pub struct Retriever {
     chunker: Box<dyn Chunker>,
     embedder: Arc<dyn Embedder>,
     store: Arc<dyn VectorStore>,
+    reranker: Option<Arc<dyn Reranker>>,
 }
 
 impl Retriever {
@@ -58,7 +60,15 @@ impl Retriever {
             chunker,
             embedder,
             store,
+            reranker: None,
         }
+    }
+
+    /// Configure an optional model reranker for broad retrieval candidates.
+    #[must_use]
+    pub fn with_reranker(mut self, reranker: Arc<dyn Reranker>) -> Self {
+        self.reranker = Some(reranker);
+        self
     }
 
     /// Borrow the shared vector store (e.g. to hand a search tool the same index).
@@ -257,6 +267,7 @@ impl Retriever {
             .store
             .query(query, &embedding, candidate_limit(k), scope)
             .await?;
+        let candidates = rerank_candidates(self.reranker.as_deref(), query, candidates).await?;
         let hits = select(candidates, k);
         Ok(hits.into_iter().map(Citation::from).collect())
     }
@@ -289,6 +300,19 @@ mod tests {
     struct QuerySpyVectorStore {
         candidates: Vec<ScoredChunk>,
         limits: Mutex<Vec<usize>>,
+    }
+
+    struct SpyReranker {
+        scores: Vec<f32>,
+        candidate_counts: Mutex<Vec<usize>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Reranker for SpyReranker {
+        async fn rerank(&self, _query: &str, candidates: &[ScoredChunk]) -> Result<Vec<f32>> {
+            self.candidate_counts.lock().unwrap().push(candidates.len());
+            Ok(self.scores.clone())
+        }
     }
 
     #[async_trait::async_trait]
@@ -430,6 +454,75 @@ The Great Barrier Reef is the world's largest coral reef system.";
         assert_eq!(citations.len(), 2);
         assert_eq!(citations[0].snippet, "primary");
         assert_eq!(citations[1].snippet, "backfill");
+    }
+
+    #[tokio::test]
+    async fn reranks_every_overfetched_candidate_before_selection() {
+        let candidates: Vec<_> = (0..8)
+            .map(|ordinal| {
+                scored(
+                    DocumentId::new(),
+                    ordinal,
+                    ordinal * 10,
+                    ordinal * 10 + 5,
+                    &format!("candidate {ordinal}"),
+                )
+            })
+            .collect();
+        let store = Arc::new(QuerySpyVectorStore {
+            candidates,
+            limits: Mutex::new(Vec::new()),
+        });
+        let reranker = Arc::new(SpyReranker {
+            scores: (0..8).map(|index| index as f32).collect(),
+            candidate_counts: Mutex::new(Vec::new()),
+        });
+        let retriever = Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::new(90, 0)),
+            Arc::new(HashEmbedder::new(512)),
+            store.clone(),
+        )
+        .with_reranker(reranker.clone());
+
+        let citations = retriever
+            .search(SearchScope::Unscoped, "query", 2)
+            .await
+            .unwrap();
+
+        assert_eq!(store.limits.lock().unwrap().as_slice(), &[8]);
+        assert_eq!(reranker.candidate_counts.lock().unwrap().as_slice(), &[8]);
+        assert_eq!(citations[0].snippet, "candidate 7");
+        assert_eq!(citations[0].score, 7.0);
+        assert_eq!(citations[1].snippet, "candidate 6");
+        assert_eq!(citations[1].score, 6.0);
+    }
+
+    #[tokio::test]
+    async fn malformed_reranker_output_fails_search() {
+        let store = Arc::new(QuerySpyVectorStore {
+            candidates: vec![
+                scored(DocumentId::new(), 0, 0, 5, "first"),
+                scored(DocumentId::new(), 1, 10, 15, "second"),
+            ],
+            limits: Mutex::new(Vec::new()),
+        });
+        let retriever = Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::new(90, 0)),
+            Arc::new(HashEmbedder::new(512)),
+            store,
+        )
+        .with_reranker(Arc::new(SpyReranker {
+            scores: vec![1.0],
+            candidate_counts: Mutex::new(Vec::new()),
+        }));
+
+        let error = retriever
+            .search(SearchScope::Unscoped, "query", 2)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, RetrievalError::Rerank(_)));
     }
 
     #[tokio::test]

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -2,10 +2,10 @@
 //!
 //! [`SearchTool`] adapts the retrieval pipeline to `openwave-core`'s [`Tool`]
 //! contract so the agent loop can call it like any other capability. It holds the
-//! two seams a query needs — an [`Embedder`] and a [`VectorStore`] — and nothing
-//! else, so it stays decoupled from ingestion (parser/chunker). Point it at the
-//! *same* `Arc<dyn VectorStore>` the ingest side writes to and the agent searches
-//! a live index.
+//! query-side seams — an [`Embedder`], a [`VectorStore`], and optionally a model
+//! reranker — so it stays decoupled from ingestion (parser/chunker). Point it at
+//! the *same* `Arc<dyn VectorStore>` the ingest side writes to and the agent
+//! searches a live index.
 //!
 //! It is `ReadOnly` (never mutates), so the agent may call it without an approval
 //! prompt. Recoverable problems (empty query, an embedder/store hiccup) come back
@@ -23,6 +23,7 @@ use serde_json::{json, Value};
 
 use crate::document::Citation;
 use crate::embed::Embedder;
+use crate::rerank::{rerank_candidates, Reranker};
 use crate::selection::{candidate_limit, select};
 use crate::vector::{SearchScope, VectorStore};
 
@@ -30,6 +31,7 @@ use crate::vector::{SearchScope, VectorStore};
 pub struct SearchTool {
     embedder: Arc<dyn Embedder>,
     store: Arc<dyn VectorStore>,
+    reranker: Option<Arc<dyn Reranker>>,
 }
 
 impl SearchTool {
@@ -39,7 +41,18 @@ impl SearchTool {
     /// Build a search tool over a shared embedder and vector store.
     #[must_use]
     pub fn new(embedder: Arc<dyn Embedder>, store: Arc<dyn VectorStore>) -> Self {
-        Self { embedder, store }
+        Self {
+            embedder,
+            store,
+            reranker: None,
+        }
+    }
+
+    /// Configure an optional model reranker for broad retrieval candidates.
+    #[must_use]
+    pub fn with_reranker(mut self, reranker: Arc<dyn Reranker>) -> Self {
+        self.reranker = Some(reranker);
+        self
     }
 }
 
@@ -140,6 +153,11 @@ impl Tool for SearchTool {
             Ok(hits) => hits,
             Err(err) => return Ok(ToolOutput::error(format!("search failed: {err}"))),
         };
+        let candidates = match rerank_candidates(self.reranker.as_deref(), query, candidates).await
+        {
+            Ok(candidates) => candidates,
+            Err(_) => return Ok(ToolOutput::error("reranking failed")),
+        };
         let hits = select(candidates, k);
 
         let citations: Vec<Citation> = hits.into_iter().map(Citation::from).collect();
@@ -210,6 +228,32 @@ mod tests {
     struct SpyVectorStore {
         candidates: Vec<ScoredChunk>,
         calls: Mutex<Vec<(usize, SearchScope)>>,
+    }
+
+    struct FailingReranker;
+
+    struct FixedReranker(Vec<f32>);
+
+    #[async_trait]
+    impl Reranker for FailingReranker {
+        async fn rerank(
+            &self,
+            _query: &str,
+            _candidates: &[ScoredChunk],
+        ) -> crate::Result<Vec<f32>> {
+            Err(crate::RetrievalError::rerank("provider unavailable"))
+        }
+    }
+
+    #[async_trait]
+    impl Reranker for FixedReranker {
+        async fn rerank(
+            &self,
+            _query: &str,
+            _candidates: &[ScoredChunk],
+        ) -> crate::Result<Vec<f32>> {
+            Ok(self.0.clone())
+        }
     }
 
     #[async_trait]
@@ -402,6 +446,53 @@ mod tests {
             store.calls.lock().unwrap().as_slice(),
             &[(8, SearchScope::Project(project_id))]
         );
+    }
+
+    #[tokio::test]
+    async fn reranker_failure_is_model_facing() {
+        let store = Arc::new(SpyVectorStore {
+            candidates: vec![
+                scored(DocumentId::new(), 0, 0, 5, "first"),
+                scored(DocumentId::new(), 1, 10, 15, "second"),
+            ],
+            calls: Mutex::new(Vec::new()),
+        });
+        let tool = SearchTool::new(Arc::new(HashEmbedder::new(DIMS)), store)
+            .with_reranker(Arc::new(FailingReranker));
+
+        let output = tool
+            .execute(&ctx(), json!({"query": "query", "k": 2}))
+            .await
+            .unwrap();
+
+        assert!(output.is_error);
+        assert_eq!(output.content, "reranking failed");
+        assert!(!output.content.contains("provider unavailable"));
+    }
+
+    #[tokio::test]
+    async fn reranker_reorders_results_and_replaces_tool_scores() {
+        let store = Arc::new(SpyVectorStore {
+            candidates: vec![
+                scored(DocumentId::new(), 0, 0, 5, "backend first"),
+                scored(DocumentId::new(), 1, 10, 15, "reranked first"),
+            ],
+            calls: Mutex::new(Vec::new()),
+        });
+        let tool = SearchTool::new(Arc::new(HashEmbedder::new(DIMS)), store)
+            .with_reranker(Arc::new(FixedReranker(vec![0.1, 0.9])));
+
+        let output = tool
+            .execute(&ctx(), json!({"query": "query", "k": 2}))
+            .await
+            .unwrap();
+
+        assert!(!output.is_error);
+        let citations: Vec<Citation> = serde_json::from_value(output.data.unwrap()).unwrap();
+        assert_eq!(citations[0].snippet, "reranked first");
+        assert_eq!(citations[0].score, 0.9);
+        assert_eq!(citations[1].snippet, "backend first");
+        assert_eq!(citations[1].score, 0.1);
     }
 
     #[tokio::test]

--- a/crates/openwave-retrieval/src/selection.rs
+++ b/crates/openwave-retrieval/src/selection.rs
@@ -32,8 +32,9 @@ pub(crate) fn candidate_limit(k: usize) -> usize {
 /// and gently preferring document diversity within a four-result rank window.
 ///
 /// Diversity can skip over the baseline candidate, but skipped candidates stay
-/// available for later rounds. The final results are restored to backend rank
-/// order, so selection changes membership without inventing a new score order.
+/// available for later rounds. The final results are restored to input rank
+/// order (backend rank, or reranker rank when configured), so selection changes
+/// membership without inventing a new score order.
 pub(crate) fn select(candidates: Vec<ScoredChunk>, k: usize) -> Vec<ScoredChunk> {
     if k == 0 || candidates.is_empty() {
         return Vec::new();


### PR DESCRIPTION
## Summary

- add a provider-neutral, async `Reranker` seam with optional builder wiring
- rerank the full bounded candidate pool before overlap and diversity selection
- validate score count and finiteness before replacing scores or changing rank
- preserve backend order for reranker ties and surface failures consistently

## Validation

- `cargo test -p openwave-retrieval --no-default-features`
- `cargo test -p openwave-retrieval --all-features`
- `cargo test -p openwave-server --all-features`
- `bw dev lint --rust`
