### PR TITLE
feat(retrieval): add markdown heading context

### DIFF
--- a/crates/openwave-retrieval/src/chunk.rs
+++ b/crates/openwave-retrieval/src/chunk.rs
@@ -11,9 +11,8 @@
 //! at least one chunk, but that overlap never crosses a Markdown section.
 //!
 //! Every emitted [`Chunk`] records its exact [`ByteSpan`], which is what makes
-//! citations precise. Richer strategies — nested heading context, sentence
-//! shingles — can be layered behind the [`Chunker`] trait later; this remains the
-//! dependable single-strategy floor.
+//! citations precise. Markdown chunks also carry their containing ATX heading
+//! hierarchy as derived retrieval context without changing those source spans.
 
 use crate::document::{ByteSpan, Chunk, Document};
 use crate::error::Result;
@@ -76,7 +75,7 @@ impl Default for TextChunker {
 impl Chunker for TextChunker {
     fn fingerprint(&self) -> String {
         format!(
-            "text-window-v2:markdown=atx-sections:max_chars={}:overlap={}",
+            "text-window-v3:markdown=atx-heading-context:max_chars={}:overlap={}",
             self.max_chars, self.overlap
         )
     }
@@ -105,7 +104,7 @@ impl Chunker for TextChunker {
             return Ok(self.chunk_markdown(document, &chars, &byte_at));
         }
 
-        Ok(self.chunk_range(document, &chars, &byte_at, 0, n, false, 0))
+        Ok(self.chunk_range(document, &chars, &byte_at, 0, n, false, 0, &[]))
     }
 }
 
@@ -114,11 +113,15 @@ impl TextChunker {
         let mut chunks = Vec::new();
         let mut section_start = 0;
 
-        for heading_byte in markdown_heading_offsets(&document.text) {
+        let headings = markdown_headings(&document.text);
+        let mut heading_stack: Vec<(usize, String)> = Vec::new();
+        for heading_info in headings {
+            let heading_byte = heading_info.offset;
             let heading = byte_at
                 .binary_search(&heading_byte)
                 .expect("line starts are UTF-8 character boundaries");
             if heading > section_start {
+                let heading_path = visible_heading_path(&heading_stack);
                 chunks.extend(self.chunk_range(
                     document,
                     chars,
@@ -127,11 +130,20 @@ impl TextChunker {
                     heading,
                     true,
                     chunks.len(),
+                    &heading_path,
                 ));
             }
+            while heading_stack
+                .last()
+                .is_some_and(|(level, _)| *level >= heading_info.level)
+            {
+                heading_stack.pop();
+            }
+            heading_stack.push((heading_info.level, heading_info.title));
             section_start = heading;
         }
 
+        let heading_path = visible_heading_path(&heading_stack);
         chunks.extend(self.chunk_range(
             document,
             chars,
@@ -140,6 +152,7 @@ impl TextChunker {
             chars.len(),
             true,
             chunks.len(),
+            &heading_path,
         ));
         chunks
     }
@@ -154,6 +167,7 @@ impl TextChunker {
         range_end: usize,
         prefer_paragraphs: bool,
         first_ordinal: usize,
+        heading_path: &[String],
     ) -> Vec<Chunk> {
         let text = &document.text;
         let mut chunks = Vec::new();
@@ -173,11 +187,12 @@ impl TextChunker {
             // Slice on byte offsets we computed from the same char view.
             let piece = &text[span.start..span.end];
             if !piece.trim().is_empty() {
-                chunks.push(Chunk::new(
+                chunks.push(Chunk::with_heading_path(
                     document.id,
                     first_ordinal + ordinal,
                     span,
                     piece,
+                    heading_path.to_vec(),
                 ));
                 ordinal += 1;
             }
@@ -195,6 +210,18 @@ impl TextChunker {
     }
 }
 
+/// Derive the public breadcrumb without discarding empty structural frames.
+///
+/// A valid empty ATX heading still changes section boundaries and nesting, but
+/// contributes no user-visible context of its own.
+fn visible_heading_path(stack: &[(usize, String)]) -> Vec<String> {
+    stack
+        .iter()
+        .filter(|(_, title)| !title.is_empty())
+        .map(|(_, title)| title.clone())
+        .collect()
+}
+
 fn is_markdown(media_type: &str) -> bool {
     let base = media_type.split(';').next().unwrap_or(media_type).trim();
     matches!(
@@ -208,7 +235,14 @@ fn is_markdown(media_type: &str) -> bool {
 /// Fence recognition intentionally needs only line-local CommonMark syntax: a
 /// run of at least three backticks or tildes, indented by no more than three
 /// spaces. Heading-looking lines inside a fence remain ordinary section text.
-fn markdown_heading_offsets(text: &str) -> Vec<usize> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MarkdownHeading {
+    offset: usize,
+    level: usize,
+    title: String,
+}
+
+fn markdown_headings(text: &str) -> Vec<MarkdownHeading> {
     let mut headings = Vec::new();
     let mut offset = 0;
     let mut fence: Option<(u8, usize)> = None;
@@ -243,7 +277,43 @@ fn markdown_heading_offsets(text: &str) -> Vec<usize> {
                 if (1..=6).contains(&hashes)
                     && (body.len() == hashes || matches!(body[hashes], b' ' | b'\t'))
                 {
-                    headings.push(offset);
+                    let mut title = &body[hashes..];
+                    while title
+                        .first()
+                        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+                    {
+                        title = &title[1..];
+                    }
+                    while title
+                        .last()
+                        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+                    {
+                        title = &title[..title.len() - 1];
+                    }
+                    let closing_start = title
+                        .iter()
+                        .rposition(|byte| !matches!(byte, b'#'))
+                        .map_or(0, |index| index + 1);
+                    if closing_start < title.len()
+                        && (closing_start == 0 || matches!(title[closing_start - 1], b' ' | b'\t'))
+                    {
+                        title = if closing_start == 0 {
+                            &[]
+                        } else {
+                            &title[..closing_start - 1]
+                        };
+                        while title
+                            .last()
+                            .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+                        {
+                            title = &title[..title.len() - 1];
+                        }
+                    }
+                    headings.push(MarkdownHeading {
+                        offset,
+                        level: hashes,
+                        title: String::from_utf8_lossy(title).into_owned(),
+                    });
                 }
             }
         }
@@ -459,6 +529,91 @@ mod tests {
         assert_eq!(chunks.len(), 2);
         assert_eq!(chunks[0].span, ByteSpan::new(0, valid));
         assert_eq!(chunks[1].span, ByteSpan::new(valid, text.len()));
+        assert_eq!(chunks[0].heading_path, Vec::<String>::new());
+        assert_eq!(chunks[1].heading_path, ["valid"]);
+    }
+
+    #[test]
+    fn markdown_chunks_carry_normalized_nested_heading_paths() {
+        let text = concat!(
+            "preamble\n",
+            "#   Guide ###  \nroot\n",
+            "### Install ##\nchild\n",
+            "## Configure\nsibling\n",
+            "# API\nend",
+        );
+        let document = markdown("text/x-markdown; charset=utf-8", text);
+        let chunks = TextChunker::new(10_000, 0).chunk(&document).unwrap();
+
+        assert_eq!(chunks.len(), 5);
+        assert_eq!(chunks[0].heading_path, Vec::<String>::new());
+        assert_eq!(chunks[1].heading_path, ["Guide"]);
+        assert_eq!(chunks[2].heading_path, ["Guide", "Install"]);
+        assert_eq!(chunks[3].heading_path, ["Guide", "Configure"]);
+        assert_eq!(chunks[4].heading_path, ["API"]);
+        for chunk in &chunks {
+            assert_eq!(document.slice(chunk.span), Some(chunk.text.as_str()));
+        }
+    }
+
+    #[test]
+    fn markdown_heading_stack_uses_actual_levels_for_skipped_nesting() {
+        let text = concat!(
+            "### Initial\na\n",
+            "## Parent\nb\n",
+            "#### Deep\nc\n",
+            "### Sibling\nd",
+        );
+        let document = markdown("text/markdown", text);
+        let chunks = TextChunker::new(10_000, 0).chunk(&document).unwrap();
+
+        assert_eq!(chunks[0].heading_path, ["Initial"]);
+        assert_eq!(chunks[1].heading_path, ["Parent"]);
+        assert_eq!(chunks[2].heading_path, ["Parent", "Deep"]);
+        assert_eq!(chunks[3].heading_path, ["Parent", "Sibling"]);
+    }
+
+    #[test]
+    fn closing_only_hashes_are_structural_but_absent_from_breadcrumbs() {
+        let document = markdown("text/markdown", "# ###\none\n# #\ntwo\n## Child\nthree");
+        let chunks = TextChunker::new(10_000, 0).chunk(&document).unwrap();
+
+        assert_eq!(chunks.len(), 3);
+        assert!(chunks[0].heading_path.is_empty());
+        assert!(chunks[1].heading_path.is_empty());
+        assert_eq!(chunks[0].retrieval_text(), chunks[0].text);
+        assert_eq!(chunks[1].retrieval_text(), chunks[1].text);
+        assert_eq!(chunks[2].heading_path, ["Child"]);
+        assert!(chunks[2].retrieval_text().starts_with("Child\n\n## Child"));
+    }
+
+    #[test]
+    fn every_window_gets_uniform_context_including_the_heading_window() {
+        let document = markdown(
+            "text/markdown",
+            "# Guide\none two three four five six seven eight nine ten eleven twelve",
+        );
+        let chunks = TextChunker::new(20, 4).chunk(&document).unwrap();
+
+        assert!(chunks.len() > 2);
+        assert!(chunks.iter().all(|chunk| chunk.heading_path == ["Guide"]));
+        assert!(chunks[0].text.starts_with("# Guide"));
+        assert!(chunks[0].retrieval_text().starts_with("Guide\n\n# Guide"));
+        for chunk in &chunks {
+            assert!(chunk.retrieval_text().starts_with("Guide\n\n"));
+            assert_eq!(document.slice(chunk.span), Some(chunk.text.as_str()));
+        }
+    }
+
+    #[test]
+    fn heading_like_lines_in_fences_do_not_change_context() {
+        let text = "# Outer\n```md\n## Not a child\n```\nafter";
+        let document = markdown("text/markdown", text);
+        let chunks = TextChunker::new(10_000, 0).chunk(&document).unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].heading_path, ["Outer"]);
+        assert_eq!(chunks[0].text, text);
     }
 
     #[test]
@@ -561,10 +716,10 @@ mod tests {
     }
 
     #[test]
-    fn fingerprint_invalidates_v1_markdown_indexes() {
+    fn fingerprint_invalidates_v2_markdown_indexes() {
         assert_eq!(
             TextChunker::new(90, 10).fingerprint(),
-            "text-window-v2:markdown=atx-sections:max_chars=90:overlap=10"
+            "text-window-v3:markdown=atx-heading-context:max_chars=90:overlap=10"
         );
     }
 }

--- a/crates/openwave-retrieval/src/document.rs
+++ b/crates/openwave-retrieval/src/document.rs
@@ -8,6 +8,7 @@
 
 use openwave_core::ProjectId;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 use crate::id::{ChunkId, DocumentId};
 
@@ -164,6 +165,9 @@ pub struct Chunk {
     pub ordinal: usize,
     /// The chunk's text.
     pub text: String,
+    /// Markdown heading hierarchy that contains this chunk, outermost first.
+    /// Empty for non-Markdown documents and Markdown preambles.
+    pub heading_path: Vec<String>,
     /// The byte range this chunk occupies in the document text.
     pub span: ByteSpan,
 }
@@ -182,7 +186,42 @@ impl Chunk {
             document_id,
             ordinal,
             text: text.into(),
+            heading_path: Vec::new(),
             span,
+        }
+    }
+
+    /// Build a chunk with derived structural context while preserving source text.
+    #[must_use]
+    pub fn with_heading_path(
+        document_id: DocumentId,
+        ordinal: usize,
+        span: ByteSpan,
+        text: impl Into<String>,
+        heading_path: Vec<String>,
+    ) -> Self {
+        let mut chunk = Self::new(document_id, ordinal, span, text);
+        chunk.heading_path = heading_path;
+        chunk
+    }
+
+    /// Canonical text used for embedding, lexical ranking, and model reranking.
+    ///
+    /// Citation text remains the exact source slice in [`Self::text`].
+    /// Every chunk in a Markdown section receives the same breadcrumb prefix,
+    /// including the first chunk whose exact source text still contains the raw
+    /// heading line. This deliberate duplication keeps context uniform until a
+    /// richer parser separates heading blocks from body blocks.
+    #[must_use]
+    pub fn retrieval_text(&self) -> Cow<'_, str> {
+        if self.heading_path.is_empty() {
+            Cow::Borrowed(&self.text)
+        } else {
+            Cow::Owned(format!(
+                "{}\n\n{}",
+                self.heading_path.join(" > "),
+                self.text
+            ))
         }
     }
 }
@@ -213,6 +252,8 @@ pub struct Citation {
     pub span: ByteSpan,
     /// The cited text.
     pub snippet: String,
+    /// Markdown heading hierarchy containing the cited source span.
+    pub heading_path: Vec<String>,
     /// The final relevance score that surfaced this citation. When reranking is
     /// configured, this is the reranker score rather than the backend score.
     pub score: f32,
@@ -225,6 +266,7 @@ impl From<ScoredChunk> for Citation {
             chunk_id: scored.chunk.id,
             span: scored.chunk.span,
             snippet: scored.chunk.text,
+            heading_path: scored.chunk.heading_path,
             score: scored.score,
         }
     }
@@ -260,6 +302,23 @@ mod tests {
         let span = ByteSpan::new(3, 8);
         let chunk = Chunk::new(doc, 0, span, "abcde");
         assert_eq!(chunk.id, ChunkId::derive(doc, 3, 8));
+    }
+
+    #[test]
+    fn retrieval_text_adds_context_without_changing_source_text() {
+        let doc = DocumentId::new();
+        let plain = Chunk::new(doc, 0, ByteSpan::new(0, 4), "body");
+        assert!(matches!(plain.retrieval_text(), Cow::Borrowed("body")));
+
+        let contextual = Chunk::with_heading_path(
+            doc,
+            0,
+            ByteSpan::new(0, 4),
+            "body",
+            vec!["Guide".into(), "Setup".into()],
+        );
+        assert_eq!(contextual.text, "body");
+        assert_eq!(contextual.retrieval_text(), "Guide > Setup\n\nbody");
     }
 
     #[test]

--- a/crates/openwave-retrieval/src/hybrid.rs
+++ b/crates/openwave-retrieval/src/hybrid.rs
@@ -72,7 +72,7 @@ fn bm25<'a>(records: &[&'a VectorRecord], query: &str, k: usize) -> Vec<(&'a Vec
 
     let documents = records
         .iter()
-        .map(|record| tokenize(&record.chunk.text))
+        .map(|record| tokenize(&record.chunk.retrieval_text()))
         .collect::<Vec<_>>();
     let average_length =
         documents.iter().map(Vec::len).sum::<usize>() as f32 / documents.len() as f32;
@@ -206,5 +206,21 @@ mod tests {
         assert_eq!(ranked.len(), 2);
         assert_eq!(ranked[0].1, ranked[1].1);
         assert!(ranked[0].0.chunk.id.0 < ranked[1].0.chunk.id.0);
+    }
+
+    #[test]
+    fn lexical_ranking_matches_heading_context_but_returns_source_text() {
+        let mut contextual = record("installation details", vec![0.0, 1.0]);
+        contextual.chunk.heading_path = vec!["Operator Guide".into(), "Needleshard".into()];
+        let records = [&contextual];
+
+        let ranked = bm25(&records, "needleshard", 1);
+
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].0.chunk.text, "installation details");
+        assert_eq!(
+            ranked[0].0.chunk.retrieval_text(),
+            "Operator Guide > Needleshard\n\ninstallation details"
+        );
     }
 }

--- a/crates/openwave-retrieval/src/lance_store.rs
+++ b/crates/openwave-retrieval/src/lance_store.rs
@@ -21,10 +21,11 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use arrow_array::builder::{ListBuilder, StringBuilder};
 use arrow_array::types::Float32Type;
 use arrow_array::{
-    Array, ArrayRef, BooleanArray, FixedSizeListArray, Float32Array, Int64Array, RecordBatch,
-    RecordBatchIterator, StringArray, UInt32Array, UInt64Array,
+    Array, ArrayRef, BooleanArray, FixedSizeListArray, Float32Array, Int64Array, ListArray,
+    RecordBatch, RecordBatchIterator, StringArray, UInt32Array, UInt64Array,
 };
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use arrow_select::filter::filter_record_batch;
@@ -328,16 +329,18 @@ impl LanceVectorStore {
             .await
             .map_err(lance_err)?
             .into_iter()
-            .find(|index| index.index_type == IndexType::FTS && index.columns == ["text"]);
+            .find(|index| {
+                index.index_type == IndexType::FTS && index.columns == ["retrieval_text"]
+            });
         let text_index_name = if let Some(index) = text_index {
             index.name
         } else {
             table
-                .create_index(&["text"], Index::FTS(Default::default()))
+                .create_index(&["retrieval_text"], Index::FTS(Default::default()))
                 .execute()
                 .await
                 .map_err(lance_err)?;
-            "text_idx".to_string()
+            "retrieval_text_idx".to_string()
         };
         if table
             .index_stats(&text_index_name)
@@ -530,6 +533,26 @@ impl LanceVectorStore {
                 .as_ref()
                 .map_or("", |record| record.chunk.text.as_str())
         }));
+        let retrieval_texts = rows
+            .iter()
+            .map(|row| {
+                row.record.as_ref().map_or_else(String::new, |record| {
+                    record.chunk.retrieval_text().into_owned()
+                })
+            })
+            .collect::<Vec<_>>();
+        let retrieval_texts =
+            StringArray::from_iter_values(retrieval_texts.iter().map(String::as_str));
+        let mut heading_paths = ListBuilder::new(StringBuilder::new());
+        for row in rows {
+            if let Some(record) = &row.record {
+                for heading in &record.chunk.heading_path {
+                    heading_paths.values().append_value(heading);
+                }
+            }
+            heading_paths.append(true);
+        }
+        let heading_paths = heading_paths.finish();
         let starts = UInt64Array::from_iter_values(rows.iter().map(|row| {
             row.record
                 .as_ref()
@@ -576,6 +599,8 @@ impl LanceVectorStore {
             Arc::new(project_ids),
             Arc::new(ordinals),
             Arc::new(texts),
+            Arc::new(heading_paths),
+            Arc::new(retrieval_texts),
             Arc::new(starts),
             Arc::new(ends),
             Arc::new(revisions),
@@ -680,6 +705,8 @@ impl LanceVectorStore {
                 "project_id",
                 "ordinal",
                 "text",
+                "heading_path",
+                "retrieval_text",
                 "span_start",
                 "span_end",
                 VECTOR_COL,
@@ -1050,6 +1077,12 @@ fn build_schema(dims: usize) -> SchemaRef {
         Field::new("project_id", DataType::Utf8, true),
         Field::new("ordinal", DataType::UInt64, false),
         Field::new("text", DataType::Utf8, false),
+        Field::new(
+            "heading_path",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            false,
+        ),
+        Field::new("retrieval_text", DataType::Utf8, false),
         Field::new("span_start", DataType::UInt64, false),
         Field::new("span_end", DataType::UInt64, false),
         Field::new("content_revision", DataType::Int64, false),
@@ -1071,6 +1104,7 @@ fn read_vector_records(batch: &RecordBatch, out: &mut Vec<VectorRecord>) -> Resu
     let project_ids = str_col(batch, "project_id")?;
     let ordinals = u64_col(batch, "ordinal")?;
     let texts = str_col(batch, "text")?;
+    let heading_paths = list_str_col(batch, "heading_path")?;
     let starts = u64_col(batch, "span_start")?;
     let ends = u64_col(batch, "span_end")?;
     let vectors = batch
@@ -1111,6 +1145,7 @@ fn read_vector_records(batch: &RecordBatch, out: &mut Vec<VectorRecord>) -> Resu
                 document_id,
                 ordinal: ordinals.value(index) as usize,
                 text: texts.value(index).to_string(),
+                heading_path: list_str_value(heading_paths, index)?,
                 span: ByteSpan::new(starts.value(index) as usize, ends.value(index) as usize),
             },
             embedding: Embedding(values.values().to_vec()),
@@ -1139,6 +1174,7 @@ fn read_scored_batch(
     let doc_ids = str_col(batch, "document_id")?;
     let ordinals = u64_col(batch, "ordinal")?;
     let texts = str_col(batch, "text")?;
+    let heading_paths = list_str_col(batch, "heading_path")?;
     let starts = u64_col(batch, "span_start")?;
     let ends = u64_col(batch, "span_end")?;
     let scores = batch
@@ -1166,6 +1202,7 @@ fn read_scored_batch(
                 document_id,
                 ordinal: ordinals.value(i) as usize,
                 text: texts.value(i).to_string(),
+                heading_path: list_str_value(heading_paths, i)?,
                 span,
             },
             score: convert_score(scores.value(i)),
@@ -1179,6 +1216,22 @@ fn str_col<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray> {
         .column_by_name(name)
         .and_then(|c| c.as_any().downcast_ref::<StringArray>())
         .ok_or_else(|| RetrievalError::vector_store(format!("missing/mistyped column `{name}`")))
+}
+
+fn list_str_col<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a ListArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<ListArray>())
+        .ok_or_else(|| RetrievalError::vector_store(format!("missing/mistyped column `{name}`")))
+}
+
+fn list_str_value(column: &ListArray, index: usize) -> Result<Vec<String>> {
+    let values = column.value(index);
+    let values = values
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| RetrievalError::vector_store("heading_path values are not utf8"))?;
+    Ok(values.iter().flatten().map(ToOwned::to_owned).collect())
 }
 
 fn u64_col<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a UInt64Array> {
@@ -1283,10 +1336,9 @@ mod tests {
 
             // A replacement is published as exactly one Lance dataset version.
             let version_before_replace = store.table.version().await.unwrap();
-            store
-                .replace_document(doc, vec![record(doc, 0, "south", vec![1.0, 0.0])])
-                .await
-                .unwrap();
+            let mut south = record(doc, 0, "south", vec![1.0, 0.0]);
+            south.chunk.heading_path = vec!["Compass".into(), "Needleshard".into()];
+            store.replace_document(doc, vec![south]).await.unwrap();
             assert_eq!(
                 store.table.version().await.unwrap(),
                 version_before_replace + 1
@@ -1297,6 +1349,21 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(hits[0].chunk.text, "south");
+            assert_eq!(hits[0].chunk.heading_path, ["Compass", "Needleshard"]);
+            let heading_hits = store
+                .query(
+                    "needleshard",
+                    &Embedding(vec![0.0, 1.0]),
+                    1,
+                    SearchScope::Unscoped,
+                )
+                .await
+                .unwrap();
+            assert_eq!(heading_hits[0].chunk.text, "south");
+            assert_eq!(
+                heading_hits[0].chunk.heading_path,
+                ["Compass", "Needleshard"]
+            );
         }
 
         // Reopen the same directory: the data is still there — that's durability.
@@ -1307,6 +1374,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(hits[0].chunk.text, "south");
+        assert_eq!(hits[0].chunk.heading_path, ["Compass", "Needleshard"]);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/openwave-retrieval/src/rerank.rs
+++ b/crates/openwave-retrieval/src/rerank.rs
@@ -14,6 +14,8 @@ use crate::{Result, RetrievalError, ScoredChunk};
 #[async_trait]
 pub trait Reranker: Send + Sync {
     /// Score every candidate for `query`, preserving input alignment.
+    /// Implementations must use [`crate::Chunk::retrieval_text`] as the
+    /// candidate text so structural context matches embedding and lexical inputs.
     async fn rerank(&self, query: &str, candidates: &[ScoredChunk]) -> Result<Vec<f32>>;
 }
 

--- a/crates/openwave-retrieval/src/retriever.rs
+++ b/crates/openwave-retrieval/src/retriever.rs
@@ -210,7 +210,10 @@ impl Retriever {
         let records: Vec<VectorRecord> = if chunks.is_empty() {
             Vec::new()
         } else {
-            let texts: Vec<String> = chunks.iter().map(|c| c.text.clone()).collect();
+            let texts: Vec<String> = chunks
+                .iter()
+                .map(|chunk| chunk.retrieval_text().into_owned())
+                .collect();
             let embeddings = self.embedder.embed_documents(&texts).await?;
             if embeddings.len() != chunks.len() {
                 return Err(RetrievalError::embed(format!(
@@ -297,6 +300,11 @@ mod tests {
         fail: AtomicBool,
     }
 
+    struct CapturingEmbedder {
+        inner: HashEmbedder,
+        documents: Mutex<Vec<Vec<String>>>,
+    }
+
     struct QuerySpyVectorStore {
         candidates: Vec<ScoredChunk>,
         limits: Mutex<Vec<usize>>,
@@ -307,11 +315,28 @@ mod tests {
         candidate_counts: Mutex<Vec<usize>>,
     }
 
+    struct ContextObservingReranker {
+        observed: Mutex<Vec<Vec<String>>>,
+    }
+
     #[async_trait::async_trait]
     impl Reranker for SpyReranker {
         async fn rerank(&self, _query: &str, candidates: &[ScoredChunk]) -> Result<Vec<f32>> {
             self.candidate_counts.lock().unwrap().push(candidates.len());
             Ok(self.scores.clone())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Reranker for ContextObservingReranker {
+        async fn rerank(&self, _query: &str, candidates: &[ScoredChunk]) -> Result<Vec<f32>> {
+            self.observed.lock().unwrap().push(
+                candidates
+                    .iter()
+                    .map(|candidate| candidate.chunk.retrieval_text().into_owned())
+                    .collect(),
+            );
+            Ok(vec![1.0; candidates.len()])
         }
     }
 
@@ -377,6 +402,22 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
+    impl Embedder for CapturingEmbedder {
+        fn dimensions(&self) -> usize {
+            self.inner.dimensions()
+        }
+
+        async fn embed_documents(&self, texts: &[String]) -> Result<Vec<crate::Embedding>> {
+            self.documents.lock().unwrap().push(texts.to_vec());
+            self.inner.embed_documents(texts).await
+        }
+
+        async fn embed_query(&self, text: &str) -> Result<crate::Embedding> {
+            self.inner.embed_query(text).await
+        }
+    }
+
     fn retriever() -> Retriever {
         let dims = 512;
         // A 90-char window with newline-preferring cuts keeps each one-per-line
@@ -424,6 +465,42 @@ The Great Barrier Reef is the world's largest coral reef system.";
             Some(hits[0].snippet.as_str())
         );
         assert_eq!(hits[0].document_id, outcome.document.id);
+    }
+
+    #[tokio::test]
+    async fn markdown_heading_context_is_embedded_but_citations_stay_exact() {
+        let embedder = Arc::new(CapturingEmbedder {
+            inner: HashEmbedder::new(512),
+            documents: Mutex::new(Vec::new()),
+        });
+        let retriever = Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::new(10_000, 0)),
+            embedder.clone(),
+            Arc::new(InMemoryVectorStore::new(512)),
+        );
+        let document = Document::new(
+            DocumentSource::Inline,
+            "text/markdown",
+            "# Operator Guide\n## Needleshard\ninstallation details",
+        );
+
+        retriever.index_document(&document).await.unwrap();
+        let embedded = embedder.documents.lock().unwrap().clone();
+        assert_eq!(embedded.len(), 1);
+        assert_eq!(embedded[0].len(), 2);
+        assert!(embedded[0][1].starts_with("Operator Guide > Needleshard\n\n"));
+
+        let citations = retriever
+            .search(SearchScope::Unscoped, "needleshard", 1)
+            .await
+            .unwrap();
+        assert_eq!(citations[0].heading_path, ["Operator Guide", "Needleshard"]);
+        assert_eq!(
+            document.slice(citations[0].span),
+            Some(citations[0].snippet.as_str())
+        );
+        assert!(!citations[0].snippet.starts_with("Operator Guide >"));
     }
 
     #[tokio::test]
@@ -496,6 +573,38 @@ The Great Barrier Reef is the world's largest coral reef system.";
         assert_eq!(citations[0].score, 7.0);
         assert_eq!(citations[1].snippet, "candidate 6");
         assert_eq!(citations[1].score, 6.0);
+    }
+
+    #[tokio::test]
+    async fn reranker_observes_the_exact_contextual_candidate_text() {
+        let mut candidate = scored(DocumentId::new(), 0, 0, 4, "body");
+        candidate.chunk.heading_path = vec!["Guide".into(), "Setup".into()];
+        let store = Arc::new(QuerySpyVectorStore {
+            candidates: vec![candidate],
+            limits: Mutex::new(Vec::new()),
+        });
+        let reranker = Arc::new(ContextObservingReranker {
+            observed: Mutex::new(Vec::new()),
+        });
+        let retriever = Retriever::new(
+            Box::new(PlainTextParser::new()),
+            Box::new(TextChunker::new(90, 0)),
+            Arc::new(HashEmbedder::new(512)),
+            store,
+        )
+        .with_reranker(reranker.clone());
+
+        let citations = retriever
+            .search(SearchScope::Unscoped, "query", 1)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            reranker.observed.lock().unwrap().as_slice(),
+            &[vec!["Guide > Setup\n\nbody".to_string()]]
+        );
+        assert_eq!(citations[0].snippet, "body");
+        assert_eq!(citations[0].heading_path, ["Guide", "Setup"]);
     }
 
     #[tokio::test]
@@ -746,7 +855,7 @@ The Great Barrier Reef is the world's largest coral reef system.";
         assert_eq!(r.canonical_fingerprint(), "plain-text-lossy-v1");
         assert_eq!(
             r.index_fingerprint(),
-            "chunker=text-window-v2:markdown=atx-sections:max_chars=90:overlap=0;embedder=hash-fnv1a-v1:512d"
+            "chunker=text-window-v3:markdown=atx-heading-context:max_chars=90:overlap=0;embedder=hash-fnv1a-v1:512d"
         );
     }
 

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -77,12 +77,17 @@ fn render(citations: &[Citation]) -> String {
     let mut out = format!("Found {} passage{plural}:", citations.len());
     for (i, c) in citations.iter().enumerate() {
         out.push_str(&format!(
-            "\n\n{}. [score {:.3}] document {} (bytes {}..{})\n{}",
+            "\n\n{}. [score {:.3}] document {} (bytes {}..{}){}\n{}",
             i + 1,
             c.score,
             c.document_id,
             c.span.start,
             c.span.end,
+            if c.heading_path.is_empty() {
+                String::new()
+            } else {
+                format!("\nSection: {}", c.heading_path.join(" > "))
+            },
             c.snippet.trim()
         ));
     }
@@ -310,6 +315,39 @@ mod tests {
             .unwrap()
             .iter()
             .any(|v| v == "query"));
+    }
+
+    #[test]
+    fn render_shows_section_context_without_changing_the_snippet() {
+        let document_id = DocumentId::new();
+        let chunk = Chunk::with_heading_path(
+            document_id,
+            0,
+            ByteSpan::new(10, 14),
+            "body",
+            vec!["Guide".into(), "Setup".into()],
+        );
+        let citation = Citation::from(ScoredChunk { chunk, score: 0.5 });
+
+        let output = render(std::slice::from_ref(&citation));
+
+        assert!(output.contains("Section: Guide > Setup"));
+        assert!(output.ends_with("body"));
+        assert_eq!(citation.snippet, "body");
+        assert_eq!(citation.heading_path, ["Guide", "Setup"]);
+    }
+
+    #[test]
+    fn render_omits_section_line_for_an_empty_breadcrumb() {
+        let citation = Citation::from(ScoredChunk {
+            chunk: Chunk::new(DocumentId::new(), 0, ByteSpan::new(0, 4), "body"),
+            score: 0.5,
+        });
+
+        let output = render(&[citation]);
+
+        assert!(!output.contains("Section:"));
+        assert!(output.ends_with("body"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- attach fence-aware Markdown heading ancestry to chunks while preserving exact source spans and citation snippets
- use one canonical contextual representation for embedding, lexical ranking, and Lance full-text search, and require reranker implementations to score that representation
- preserve empty headings as structural frames without exposing empty breadcrumb entries or synthetic prefixes
- persist heading paths and contextual search text in Lance, including generation staging and reopen paths
- expose heading ancestry in citations and render section breadcrumbs for the search tool

The first chunk in a Markdown section still contains its raw heading line and also receives the same normalized breadcrumb prefix as later windows. This is deliberate uniform context until parsed heading and body blocks are represented separately.

## Validation

- `cargo test -p openwave-retrieval --no-default-features`
- `cargo test -p openwave-retrieval --all-features`
- `cargo test -p openwave-server --all-features`
- `bw dev lint --rust`