### PR TITLE
feat(core): add durable local blob storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5664,6 +5664,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 workspace = true
 
 [features]
-default = ["sqlite", "keychain", "tools"]
+default = ["sqlite", "keychain", "tools", "blob-fs"]
 # The default SeaORM-backed Store with the SQLite driver. Turn off
 # (`default-features = false`) to depend on just the trait contracts.
 sqlite = ["dep:sea-orm", "dep:sea-orm-migration"]
@@ -19,6 +19,8 @@ sqlite = ["dep:sea-orm", "dep:sea-orm-migration"]
 keychain = ["dep:keyring", "dep:tokio"]
 # The built-in filesystem tools (read_file / list_dir / write_file).
 tools = ["dep:tokio"]
+# Durable local byte storage for desktop documents and artifacts.
+blob-fs = ["dep:tokio", "dep:windows-sys"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -40,6 +42,7 @@ tokio = { workspace = true, optional = true }
 keyring = { version = "3", features = ["apple-native"], optional = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { version = "3", features = ["windows-native"], optional = true }
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"], optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3", features = ["async-secret-service", "crypto-rust", "tokio"], optional = true }
 

--- a/crates/openwave-core/src/blob.rs
+++ b/crates/openwave-core/src/blob.rs
@@ -1,0 +1,249 @@
+//! Durable local [`BlobStore`](crate::BlobStore) implementation.
+
+#[cfg(unix)]
+use std::fs::File;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::{AgentError, BlobStore, Result};
+
+/// Filesystem-backed opaque byte storage.
+///
+/// Blob ids are UUIDs and become flat filenames under `root`; caller-controlled
+/// paths never participate in path resolution. Writes use an adjacent temporary
+/// file followed by rename, so readers see either the previous complete value or
+/// the replacement, never a partial write. Clones share an in-process lock; the
+/// server owns one instance per data directory.
+#[derive(Clone)]
+pub struct FsBlobStore {
+    root: Arc<PathBuf>,
+    access: Arc<RwLock<()>>,
+}
+
+impl FsBlobStore {
+    /// Create a store rooted at `root`. The directory is created on first write.
+    #[must_use]
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: Arc::new(root.into()),
+            access: Arc::new(RwLock::new(())),
+        }
+    }
+
+    /// Root directory containing blob files.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn blob_path(&self, id: &str) -> Result<PathBuf> {
+        let id =
+            Uuid::parse_str(id).map_err(|_| AgentError::Store("blob id must be a UUID".into()))?;
+        Ok(self.root.join(format!("{id}.blob")))
+    }
+}
+
+#[async_trait]
+impl BlobStore for FsBlobStore {
+    async fn put(&self, id: &str, bytes: Vec<u8>) -> Result<()> {
+        let destination = self.blob_path(id)?;
+        let root = Arc::clone(&self.root);
+        let access = Arc::clone(&self.access);
+        tokio::task::spawn_blocking(move || {
+            fs::create_dir_all(&*root).map_err(|error| blob_error("create directory", error))?;
+            if let Some(parent) = root.parent().filter(|path| !path.as_os_str().is_empty()) {
+                sync_directory(parent)?;
+            }
+            let temporary = root.join(format!(".{}.tmp", Uuid::new_v4()));
+            let result = (|| {
+                let mut options = OpenOptions::new();
+                options.write(true).create_new(true);
+                #[cfg(unix)]
+                options.mode(0o600);
+                let mut file = options
+                    .open(&temporary)
+                    .map_err(|error| blob_error("create temporary file", error))?;
+                file.write_all(&bytes)
+                    .map_err(|error| blob_error("write temporary file", error))?;
+                file.sync_all()
+                    .map_err(|error| blob_error("sync temporary file", error))?;
+
+                let _guard = access
+                    .write()
+                    .map_err(|_| AgentError::Store("blob store lock poisoned".into()))?;
+                replace_file(&temporary, &destination)?;
+                sync_directory(&root)?;
+                Ok(())
+            })();
+            if result.is_err() {
+                let _ = fs::remove_file(&temporary);
+            }
+            result
+        })
+        .await
+        .map_err(|error| AgentError::Store(format!("blob write task failed: {error}")))?
+    }
+
+    async fn get(&self, id: &str) -> Result<Option<Vec<u8>>> {
+        let path = self.blob_path(id)?;
+        let access = Arc::clone(&self.access);
+        tokio::task::spawn_blocking(move || {
+            let _guard = access
+                .read()
+                .map_err(|_| AgentError::Store("blob store lock poisoned".into()))?;
+            match fs::read(path) {
+                Ok(bytes) => Ok(Some(bytes)),
+                Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+                Err(error) => Err(blob_error("read file", error)),
+            }
+        })
+        .await
+        .map_err(|error| AgentError::Store(format!("blob read task failed: {error}")))?
+    }
+
+    async fn delete(&self, id: &str) -> Result<()> {
+        let path = self.blob_path(id)?;
+        let root = Arc::clone(&self.root);
+        let access = Arc::clone(&self.access);
+        tokio::task::spawn_blocking(move || {
+            let _guard = access
+                .write()
+                .map_err(|_| AgentError::Store("blob store lock poisoned".into()))?;
+            match fs::remove_file(path) {
+                Ok(()) => sync_directory(&root),
+                Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(blob_error("delete file", error)),
+            }
+        })
+        .await
+        .map_err(|error| AgentError::Store(format!("blob delete task failed: {error}")))?
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_file(temporary: &Path, destination: &Path) -> Result<()> {
+    fs::rename(temporary, destination).map_err(|error| blob_error("publish file", error))
+}
+
+#[cfg(windows)]
+fn replace_file(temporary: &Path, destination: &Path) -> Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let temporary: Vec<u16> = temporary
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let destination: Vec<u16> = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    // SAFETY: both pointers reference NUL-terminated UTF-16 buffers that remain
+    // alive for the duration of the call. The paths share one directory/volume.
+    let published = unsafe {
+        MoveFileExW(
+            temporary.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if published == 0 {
+        Err(blob_error("publish file", std::io::Error::last_os_error()))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> Result<()> {
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| blob_error("sync directory", error))
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn blob_error(action: &str, error: std::io::Error) -> AgentError {
+    AgentError::Store(format!("failed to {action} for blob: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn roundtrips_overwrites_reopens_and_deletes_idempotently() {
+        let directory = tempfile::tempdir().unwrap();
+        let id = Uuid::new_v4().to_string();
+        let store = FsBlobStore::new(directory.path());
+
+        assert_eq!(store.get(&id).await.unwrap(), None);
+        store.put(&id, b"first".to_vec()).await.unwrap();
+        assert_eq!(
+            store.get(&id).await.unwrap().as_deref(),
+            Some(&b"first"[..])
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(store.blob_path(&id).unwrap())
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+        store.put(&id, b"second".to_vec()).await.unwrap();
+
+        let reopened = FsBlobStore::new(directory.path());
+        assert_eq!(
+            reopened.get(&id).await.unwrap().as_deref(),
+            Some(&b"second"[..])
+        );
+        reopened.delete(&id).await.unwrap();
+        reopened.delete(&id).await.unwrap();
+        assert_eq!(reopened.get(&id).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn concurrent_overwrites_leave_one_complete_value() {
+        let directory = tempfile::tempdir().unwrap();
+        let id = Uuid::new_v4().to_string();
+        let store = FsBlobStore::new(directory.path());
+        let first = vec![b'a'; 128 * 1024];
+        let second = vec![b'b'; 128 * 1024];
+
+        let (left, right) = tokio::join!(
+            store.put(&id, first.clone()),
+            store.put(&id, second.clone())
+        );
+        left.unwrap();
+        right.unwrap();
+        let stored = store.get(&id).await.unwrap().unwrap();
+        assert!(stored == first || stored == second);
+    }
+
+    #[tokio::test]
+    async fn rejects_non_uuid_ids_without_touching_the_filesystem() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("blobs");
+        let store = FsBlobStore::new(&root);
+
+        assert!(store.put("../escape", vec![1]).await.is_err());
+        assert!(store.get("").await.is_err());
+        assert!(!root.exists());
+    }
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -15,6 +15,8 @@
 
 pub mod agent;
 pub mod approval;
+#[cfg(feature = "blob-fs")]
+pub mod blob;
 pub mod cancel;
 pub mod config;
 pub mod context;
@@ -37,6 +39,8 @@ pub use agent::{Agent, AgentConfig, ToolRegistry};
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalRequest, AutoApproveGate, RefuseGate,
 };
+#[cfg(feature = "blob-fs")]
+pub use blob::FsBlobStore;
 pub use cancel::{CancelToken, Cancelled};
 pub use config::{Config, Profile};
 #[cfg(feature = "sqlite")]

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
-openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools", "keychain"] }
+openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools", "keychain", "blob-fs"] }
 openwave-router = { path = "../openwave-router" }
 openwave-retrieval = { path = "../openwave-retrieval", features = ["vec-lance"] }
 axum = { workspace = true }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -1034,6 +1034,49 @@ mod tests {
         test_app_with(Arc::new(FakeProvider)).await
     }
 
+    #[tokio::test]
+    async fn app_state_roots_blob_storage_under_the_data_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let (retrieval, _search) = build_retrieval(
+            Arc::new(HashEmbedder::default()),
+            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        );
+        let state = AppState::new(
+            Config::desktop(dir.path()),
+            store,
+            Arc::new(FixedResolver(Arc::new(FakeProvider))),
+            Arc::new(MemSecrets::default()),
+            Arc::new(ToolRegistry::new()),
+            retrieval,
+            AgentConfig::default(),
+        );
+        let id = uuid::Uuid::new_v4().to_string();
+
+        state
+            .blobs
+            .put(&id, b"source bytes".to_vec())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            state.blobs.get(&id).await.unwrap().as_deref(),
+            Some(&b"source bytes"[..])
+        );
+        assert!(dir
+            .path()
+            .join("blobs")
+            .join(format!("{id}.blob"))
+            .is_file());
+    }
+
     async fn json_body<T: DeserializeOwned>(response: axum::response::Response) -> T {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         serde_json::from_slice(&bytes).unwrap()

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use openwave_core::{
-    AgentConfig, CancelToken, ChatId, Config, DocumentId, SecretProvider, SteerInbox, Store,
-    ToolRegistry,
+    AgentConfig, BlobStore, CancelToken, ChatId, Config, DocumentId, FsBlobStore, SecretProvider,
+    SteerInbox, Store, ToolRegistry,
 };
 use openwave_retrieval::Retriever;
 use tokio::sync::Notify;
@@ -26,6 +26,8 @@ pub struct AppState {
     pub config: Arc<Config>,
     /// Durable metadata, conversation state, and the event journal.
     pub store: Arc<dyn Store>,
+    /// Durable raw bytes and generated artifacts under the configured data directory.
+    pub blobs: Arc<dyn BlobStore>,
     /// Builds the model provider for each turn from the configured credentials.
     pub resolver: Arc<dyn ProviderResolver>,
     /// Credential custody — where the model API key is read from and written to.
@@ -64,9 +66,11 @@ impl AppState {
         retrieval: Arc<Retriever>,
         agent_config: AgentConfig,
     ) -> Self {
+        let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
         Self {
             config: Arc::new(config),
             store,
+            blobs,
             resolver,
             secrets,
             tools,


### PR DESCRIPTION
## Summary
- add an atomic filesystem-backed BlobStore for UUID-keyed bytes
- isolate blocking filesystem work and durably sync published files
- reject path-like identifiers and use owner-only file permissions on Unix
- wire blob storage under the server data directory

## Test plan
- `cargo test -p openwave-core`
- `cargo test -p openwave-server --lib`
- `cargo clippy -p openwave-core -p openwave-server --all-targets --all-features -- -D warnings`
- `cargo check -p openwave-core --no-default-features`