### PR TITLE
feat(core): add atomic document parse workflow

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -27,8 +27,9 @@ use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId};
 use crate::model::Role;
 use crate::model::{
     Chat, DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
-    DocumentProcessingStatus, DocumentRecord, DocumentScope, DocumentSourceBlob,
-    DocumentSummaryRecord, DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord,
+    DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
+    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
+    Project, SourceRegion, ToolCallRecord,
 };
 use crate::storage::{DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, Store};
 
@@ -592,6 +593,42 @@ impl Store for DbStore {
         }
     }
 
+    async fn accept_document_source_and_enqueue_parse(
+        &self,
+        document: &DocumentSourceUpsert,
+        parser_fingerprint: &str,
+        max_attempts: i32,
+    ) -> Result<(DocumentRecord, DocumentJob)> {
+        ops::document::accept_source_and_enqueue_parse(
+            self,
+            document,
+            parser_fingerprint,
+            max_attempts,
+        )
+        .await
+    }
+
+    async fn complete_document_parse_job_and_enqueue_index(
+        &self,
+        id: DocumentJobId,
+        lease_token: uuid::Uuid,
+        completed_at: chrono::DateTime<Utc>,
+        output: &DocumentParseOutput,
+        index_fingerprint: &str,
+        index_max_attempts: i32,
+    ) -> Result<Option<(DocumentRecord, DocumentJob)>> {
+        ops::document::complete_parse_and_enqueue_index(
+            self,
+            id,
+            lease_token,
+            completed_at,
+            output,
+            index_fingerprint,
+            index_max_attempts,
+        )
+        .await
+    }
+
     async fn get_document_job(&self, id: DocumentJobId) -> Result<Option<DocumentJob>> {
         entities::document_job::Entity::find_by_id(id.0)
             .one(&self.conn)
@@ -667,6 +704,50 @@ impl Store for DbStore {
                 return Ok(EnsureDocumentIndexJobOutcome::GenerationChanged(
                     current_generation,
                 ));
+            }
+
+            if document.source_blob_id.is_some() && document.canonical_fingerprint.is_none() {
+                let parse_job = entities::document_job::Entity::find()
+                    .filter(entities::document_job::Column::DocumentId.eq(document_id.0))
+                    .filter(
+                        entities::document_job::Column::ContentRevision
+                            .eq(current_generation.content_revision),
+                    )
+                    .filter(
+                        entities::document_job::Column::RevisionToken
+                            .eq(current_generation.revision_token),
+                    )
+                    .filter(
+                        entities::document_job::Column::Kind.eq(DocumentJobKind::Parse.as_str()),
+                    )
+                    .order_by_desc(entities::document_job::Column::CreatedAt)
+                    .order_by_desc(entities::document_job::Column::Id)
+                    .one(&transaction)
+                    .await
+                    .map_err(store_err)?
+                    .ok_or_else(|| {
+                        AgentError::Store(format!(
+                            "unparsed document {document_id} has no current parse job"
+                        ))
+                    })?;
+                let parse_job = document_job_from_model(parse_job)?;
+                let outcome = if parse_job.status == DocumentJobStatus::Failed {
+                    EnsureDocumentIndexJobOutcome::Failed(parse_job)
+                } else if matches!(
+                    parse_job.status,
+                    DocumentJobStatus::Queued
+                        | DocumentJobStatus::Running
+                        | DocumentJobStatus::RetryWait
+                ) {
+                    EnsureDocumentIndexJobOutcome::Parsing(parse_job)
+                } else {
+                    return Err(AgentError::Store(format!(
+                        "unparsed document {document_id} has terminal parse state {}",
+                        parse_job.status.as_str()
+                    )));
+                };
+                transaction.commit().await.map_err(store_err)?;
+                return Ok(outcome);
             }
 
             if let Some(candidate) = find_exact_document_index_job_on(
@@ -1316,6 +1397,11 @@ impl Store for DbStore {
                 transaction.rollback().await.map_err(store_err)?;
                 return Ok(false);
             };
+            if candidate.kind != DocumentJobKind::Index.as_str() {
+                return Err(AgentError::Store(format!(
+                    "document job {id} is not an index job"
+                )));
+            }
             ensure_resolution_document_matches(&transaction, &candidate).await?;
 
             let resolved = entities::document_job::Entity::update_many()

--- a/crates/openwave-core/src/db/ops/document.rs
+++ b/crates/openwave-core/src/db/ops/document.rs
@@ -1,0 +1,365 @@
+use chrono::Utc;
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set, TransactionTrait};
+
+use crate::error::{AgentError, Result};
+use crate::id::{DocumentId, DocumentJobId};
+use crate::model::{
+    DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentParseOutput,
+    DocumentProcessingStatus, DocumentRecord, DocumentSourceUpsert,
+};
+
+use super::super::{
+    acquire_document_write_lock, cancel_live_document_jobs_on, document_from_model,
+    document_job_active_model, document_job_from_model, document_job_lease_is_live,
+    ensure_live_document_generation_on, ensure_resolution_document_matches, entities,
+    source_regions_to_db, store_err, try_advance_document_generation_on,
+    validate_document_source_regions, DbStore,
+};
+
+pub(in crate::db) async fn accept_source_and_enqueue_parse(
+    store: &DbStore,
+    source: &DocumentSourceUpsert,
+    parser_fingerprint: &str,
+    max_attempts: i32,
+) -> Result<(DocumentRecord, DocumentJob)> {
+    validate_source_input(source, parser_fingerprint, max_attempts)?;
+
+    loop {
+        let transaction = store.conn.begin().await.map_err(store_err)?;
+        acquire_document_write_lock(&transaction, source.id).await?;
+        let existing = entities::document::Entity::find_by_id(source.id.0)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+
+        if let Some(current) = existing.as_ref() {
+            if current.project_id != source.project_id.map(|id| id.0) {
+                return Err(AgentError::Store(format!(
+                    "document {} cannot move between project corpora",
+                    source.id
+                )));
+            }
+            ensure_live_document_generation_on(&transaction, current).await?;
+            if source_matches(current, source) {
+                if let Some(job) = entities::document_job::Entity::find()
+                    .filter(entities::document_job::Column::DocumentId.eq(current.id))
+                    .filter(
+                        entities::document_job::Column::ContentRevision
+                            .eq(current.content_revision),
+                    )
+                    .filter(
+                        entities::document_job::Column::RevisionToken.eq(current.revision_token),
+                    )
+                    .filter(
+                        entities::document_job::Column::Kind.eq(DocumentJobKind::Parse.as_str()),
+                    )
+                    .filter(
+                        entities::document_job::Column::PipelineFingerprint.eq(parser_fingerprint),
+                    )
+                    .one(&transaction)
+                    .await
+                    .map_err(store_err)?
+                {
+                    let record = document_from_model(current.clone())?;
+                    let job = document_job_from_model(job)?;
+                    transaction.commit().await.map_err(store_err)?;
+                    return Ok((record, job));
+                }
+            }
+        }
+
+        let Some(advanced) =
+            try_advance_document_generation_on(&transaction, source.id, false).await?
+        else {
+            transaction.rollback().await.map_err(store_err)?;
+            continue;
+        };
+        if let Some(current) = existing.as_ref() {
+            let current_generation = DocumentGeneration {
+                content_revision: current.content_revision,
+                revision_token: current.revision_token,
+            };
+            if advanced.previous != Some(current_generation) {
+                return Err(AgentError::Store(format!(
+                    "document {} does not match its retained generation clock",
+                    source.id
+                )));
+            }
+        }
+
+        let workflow_now = Utc::now();
+        let byte_len = i64::try_from(source.source_blob.byte_len)
+            .map_err(|_| AgentError::Store("document source is too large".into()))?;
+        let active = entities::document::ActiveModel {
+            id: Set(source.id.0),
+            project_id: Set(source.project_id.map(|id| id.0)),
+            source_uri: Set(source.source_uri.clone()),
+            media_type: Set(source.media_type.clone()),
+            title: Set(source.title.clone()),
+            source_blob_id: Set(Some(source.source_blob.id)),
+            source_sha256: Set(Some(source.source_blob.sha256.to_vec())),
+            source_byte_len: Set(Some(byte_len)),
+            canonical_text: Set(String::new()),
+            canonical_fingerprint: Set(None),
+            source_regions: Set(source_regions_to_db(&[])),
+            content_revision: Set(advanced.current.content_revision),
+            revision_token: Set(advanced.current.revision_token),
+            processing_status: Set(DocumentProcessingStatus::Queued.as_str().into()),
+            indexed_revision: Set(None),
+            index_fingerprint: Set(None),
+            created_at: Set(existing
+                .as_ref()
+                .map_or(source.updated_at, |current| current.created_at)),
+            updated_at: Set(source.updated_at),
+            indexed_at: Set(None),
+        };
+        if existing.is_some() {
+            active.update(&transaction).await.map_err(store_err)?;
+        } else {
+            active.insert(&transaction).await.map_err(store_err)?;
+        }
+
+        cancel_live_document_jobs_on(&transaction, source.id, workflow_now).await?;
+        let job = new_job(
+            source.id,
+            advanced.current,
+            DocumentJobKind::Parse,
+            parser_fingerprint,
+            max_attempts,
+            workflow_now,
+        );
+        document_job_active_model(&job)
+            .insert(&transaction)
+            .await
+            .map_err(store_err)?;
+        let record = entities::document::Entity::find_by_id(source.id.0)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| AgentError::Store("accepted source document disappeared".into()))?;
+        let record = document_from_model(record)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok((record, job));
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::db) async fn complete_parse_and_enqueue_index(
+    store: &DbStore,
+    id: DocumentJobId,
+    lease_token: uuid::Uuid,
+    completed_at: chrono::DateTime<Utc>,
+    output: &DocumentParseOutput,
+    index_fingerprint: &str,
+    index_max_attempts: i32,
+) -> Result<Option<(DocumentRecord, DocumentJob)>> {
+    validate_document_source_regions(&output.canonical_text, &output.source_regions)?;
+    validate_job_input(index_fingerprint, index_max_attempts)?;
+
+    let Some(candidate) = entities::document_job::Entity::find_by_id(id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    if candidate.kind != DocumentJobKind::Parse.as_str() {
+        return Err(AgentError::Store(format!(
+            "document job {id} is not a parse job"
+        )));
+    }
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_document_write_lock(&transaction, DocumentId(candidate.document_id)).await?;
+    let Some(job) = entities::document_job::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if job.kind != DocumentJobKind::Parse.as_str() {
+        return Err(AgentError::Store(format!(
+            "document job {id} changed semantic kind during parse completion"
+        )));
+    }
+    if !document_job_lease_is_live(&job, lease_token, completed_at) {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    ensure_resolution_document_matches(&transaction, &job).await?;
+
+    let completed = entities::document_job::Entity::update_many()
+        .col_expr(
+            entities::document_job::Column::Status,
+            sea_orm::sea_query::Expr::value(DocumentJobStatus::Succeeded.as_str()),
+        )
+        .col_expr(
+            entities::document_job::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(completed_at)),
+        )
+        .col_expr(
+            entities::document_job::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(completed_at),
+        )
+        .filter(entities::document_job::Column::Id.eq(id.0))
+        .filter(entities::document_job::Column::Status.eq(DocumentJobStatus::Running.as_str()))
+        .filter(entities::document_job::Column::LeaseToken.eq(lease_token))
+        .filter(entities::document_job::Column::LeaseExpiresAt.eq(job.lease_expires_at))
+        .filter(entities::document_job::Column::UpdatedAt.eq(job.updated_at))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if completed.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let published = entities::document::Entity::update_many()
+        .col_expr(
+            entities::document::Column::CanonicalText,
+            sea_orm::sea_query::Expr::value(output.canonical_text.clone()),
+        )
+        .col_expr(
+            entities::document::Column::CanonicalFingerprint,
+            sea_orm::sea_query::Expr::value(Some(job.pipeline_fingerprint.clone())),
+        )
+        .col_expr(
+            entities::document::Column::SourceRegions,
+            sea_orm::sea_query::Expr::value(source_regions_to_db(&output.source_regions)),
+        )
+        .col_expr(
+            entities::document::Column::ProcessingStatus,
+            sea_orm::sea_query::Expr::value(DocumentProcessingStatus::Queued.as_str()),
+        )
+        .col_expr(
+            entities::document::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(completed_at),
+        )
+        .filter(entities::document::Column::Id.eq(job.document_id))
+        .filter(entities::document::Column::ContentRevision.eq(job.content_revision))
+        .filter(entities::document::Column::RevisionToken.eq(job.revision_token))
+        .filter(entities::document::Column::SourceBlobId.is_not_null())
+        .filter(entities::document::Column::SourceSha256.is_not_null())
+        .filter(entities::document::Column::SourceByteLen.is_not_null())
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if published.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "parse job {id} lost its exact document generation"
+        )));
+    }
+
+    let generation = DocumentGeneration {
+        content_revision: job.content_revision,
+        revision_token: job.revision_token,
+    };
+    let index_job = new_job(
+        DocumentId(job.document_id),
+        generation,
+        DocumentJobKind::Index,
+        index_fingerprint,
+        index_max_attempts,
+        completed_at,
+    );
+    document_job_active_model(&index_job)
+        .insert(&transaction)
+        .await
+        .map_err(store_err)?;
+    let record = entities::document::Entity::find_by_id(job.document_id)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store("parsed source document disappeared".into()))?;
+    let record = document_from_model(record)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some((record, index_job)))
+}
+
+fn validate_source_input(
+    source: &DocumentSourceUpsert,
+    parser_fingerprint: &str,
+    max_attempts: i32,
+) -> Result<()> {
+    if source.media_type.is_empty() || source.source_uri.as_deref() == Some("") {
+        return Err(AgentError::Store("invalid document source metadata".into()));
+    }
+    i64::try_from(source.source_blob.byte_len)
+        .map_err(|_| AgentError::Store("document source is too large".into()))?;
+    validate_job_input(parser_fingerprint, max_attempts)
+}
+
+fn validate_job_input(fingerprint: &str, max_attempts: i32) -> Result<()> {
+    if fingerprint.is_empty()
+        || fingerprint.chars().count() > DocumentJob::MAX_PIPELINE_FINGERPRINT_LEN
+    {
+        return Err(AgentError::Store(
+            "document job pipeline fingerprint must contain 1 to 512 characters".into(),
+        ));
+    }
+    if max_attempts < 1 {
+        return Err(AgentError::Store(
+            "document job max_attempts must be at least one".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn source_matches(current: &entities::document::Model, source: &DocumentSourceUpsert) -> bool {
+    current.project_id == source.project_id.map(|id| id.0)
+        && current.source_uri == source.source_uri
+        && current.media_type == source.media_type
+        && current.title == source.title
+        && current.source_blob_id == Some(source.source_blob.id)
+        && current.source_sha256.as_deref() == Some(source.source_blob.sha256.as_slice())
+        && u64::try_from(current.source_byte_len.unwrap_or(-1)).ok()
+            == Some(source.source_blob.byte_len)
+}
+
+fn new_job(
+    document_id: DocumentId,
+    generation: DocumentGeneration,
+    kind: DocumentJobKind,
+    fingerprint: &str,
+    max_attempts: i32,
+    now: chrono::DateTime<Utc>,
+) -> DocumentJob {
+    DocumentJob {
+        id: DocumentJobId::new(),
+        document_id,
+        content_revision: generation.content_revision,
+        revision_token: generation.revision_token,
+        kind,
+        status: DocumentJobStatus::Queued,
+        pipeline_fingerprint: fingerprint.into(),
+        attempt_count: 0,
+        max_attempts,
+        available_at: now,
+        lease_token: None,
+        lease_expires_at: None,
+        started_at: None,
+        finished_at: None,
+        last_error_code: None,
+        last_error_detail: None,
+        created_at: now,
+        updated_at: now,
+    }
+}

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -1,1 +1,2 @@
 pub(in crate::db) mod conversation;
+pub(in crate::db) mod document;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::model::{ByteSpan, DocumentSourceBlob, SourceLocation};
+use crate::model::{
+    ByteSpan, DocumentParseOutput, DocumentSourceBlob, DocumentSourceUpsert, SourceLocation,
+};
 use chrono::{DateTime, Utc};
 
 async fn temp_store() -> (tempfile::TempDir, DbStore) {
@@ -496,6 +498,209 @@ async fn source_regions_roundtrip_and_provenance_changes_advance_revision() {
         .unwrap();
     assert_eq!(second.content_revision, 2);
     assert_eq!(second.source_regions, changed.source_regions);
+}
+
+#[tokio::test]
+async fn raw_source_parse_completion_atomically_enqueues_index() {
+    let (_dir, store) = temp_store().await;
+    let source = DocumentSourceUpsert {
+        id: DocumentId::new(),
+        project_id: None,
+        source_uri: Some("file:///report.pdf".into()),
+        media_type: "application/pdf".into(),
+        title: Some("Report".into()),
+        source_blob: DocumentSourceBlob {
+            id: uuid::Uuid::new_v4(),
+            sha256: [0x33; 32],
+            byte_len: 4_096,
+        },
+        updated_at: Utc::now(),
+    };
+
+    let (accepted, parse_job) = store
+        .accept_document_source_and_enqueue_parse(&source, "parser=pdf-v1", 3)
+        .await
+        .unwrap();
+    assert_eq!(accepted.source_blob.as_ref(), Some(&source.source_blob));
+    assert!(accepted.canonical_text.is_empty());
+    assert_eq!(accepted.canonical_fingerprint, None);
+    assert_eq!(parse_job.kind, DocumentJobKind::Parse);
+    assert_eq!(parse_job.status, DocumentJobStatus::Queued);
+
+    let repeated = store
+        .accept_document_source_and_enqueue_parse(&source, "parser=pdf-v1", 9)
+        .await
+        .unwrap();
+    assert_eq!(repeated, (accepted.clone(), parse_job.clone()));
+    assert_eq!(
+        store
+            .ensure_document_index_job(
+                source.id,
+                accepted.generation(),
+                "chunk=v1;embed=test",
+                5,
+                DocumentIndexJobReason::PipelineChanged,
+            )
+            .await
+            .unwrap(),
+        EnsureDocumentIndexJobOutcome::Parsing(parse_job.clone())
+    );
+    assert_eq!(store.list_document_jobs(source.id).await.unwrap().len(), 1);
+
+    let claim_at = Utc::now() + chrono::Duration::seconds(1);
+    let lease_expires_at = claim_at + chrono::Duration::minutes(1);
+    let claimed = store
+        .claim_document_job(claim_at, lease_expires_at)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.id, parse_job.id);
+    let lease_token = claimed.lease_token.unwrap();
+    assert!(store
+        .complete_document_index_job(
+            claimed.id,
+            lease_token,
+            claim_at + chrono::Duration::milliseconds(500),
+        )
+        .await
+        .is_err());
+    assert_eq!(
+        store
+            .get_document_job(claimed.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        DocumentJobStatus::Running
+    );
+    entities::document_job::Entity::update_many()
+        .col_expr(
+            entities::document_job::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Some("transient_parse".to_owned())),
+        )
+        .col_expr(
+            entities::document_job::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Some("prior attempt".to_owned())),
+        )
+        .filter(entities::document_job::Column::Id.eq(claimed.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let output = DocumentParseOutput {
+        canonical_text: "Page one".into(),
+        source_regions: vec![SourceRegion {
+            span: ByteSpan::new(0, 8),
+            location: SourceLocation::Page {
+                number: std::num::NonZeroU32::new(1).unwrap(),
+            },
+        }],
+    };
+    let completed_at = claim_at + chrono::Duration::seconds(1);
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_parse_index_insert
+             BEFORE INSERT ON document_job
+             WHEN NEW.kind = 'index'
+             BEGIN SELECT RAISE(FAIL, 'injected index insert failure'); END",
+        )
+        .await
+        .unwrap();
+    assert!(store
+        .complete_document_parse_job_and_enqueue_index(
+            claimed.id,
+            lease_token,
+            completed_at,
+            &output,
+            "chunk=v1;embed=test",
+            5,
+        )
+        .await
+        .is_err());
+    assert_eq!(
+        store
+            .get_document_job(claimed.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        DocumentJobStatus::Running
+    );
+    let still_processing = store.get_document(source.id).await.unwrap().unwrap();
+    assert_eq!(
+        still_processing.processing_status,
+        DocumentProcessingStatus::Processing
+    );
+    assert!(still_processing.canonical_text.is_empty());
+    assert_eq!(still_processing.canonical_fingerprint, None);
+    store
+        .conn
+        .execute_unprepared("DROP TRIGGER fail_parse_index_insert")
+        .await
+        .unwrap();
+
+    let (parsed, index_job) = store
+        .complete_document_parse_job_and_enqueue_index(
+            claimed.id,
+            lease_token,
+            completed_at,
+            &output,
+            "chunk=v1;embed=test",
+            5,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(parsed.generation(), accepted.generation());
+    assert_eq!(parsed.canonical_text, output.canonical_text);
+    assert_eq!(parsed.source_regions, output.source_regions);
+    assert_eq!(
+        parsed.canonical_fingerprint.as_deref(),
+        Some("parser=pdf-v1")
+    );
+    assert_eq!(parsed.processing_status, DocumentProcessingStatus::Queued);
+    assert_eq!(index_job.kind, DocumentJobKind::Index);
+    assert_eq!(index_job.status, DocumentJobStatus::Queued);
+    assert_eq!(index_job.document_id, source.id);
+    assert_eq!(index_job.content_revision, parsed.content_revision);
+    assert_eq!(index_job.revision_token, parsed.revision_token);
+    assert!(store
+        .complete_document_parse_job_and_enqueue_index(
+            claimed.id,
+            lease_token,
+            completed_at,
+            &output,
+            "chunk=v1;embed=test",
+            5,
+        )
+        .await
+        .unwrap()
+        .is_none());
+    let jobs = store.list_document_jobs(source.id).await.unwrap();
+    assert_eq!(jobs.len(), 2);
+    assert_eq!(jobs[0].status, DocumentJobStatus::Succeeded);
+    assert_eq!(jobs[0].last_error_code, None);
+    assert_eq!(jobs[0].last_error_detail, None);
+    assert_eq!(jobs[1], index_job);
+
+    let (reparse, reparse_job) = store
+        .accept_document_source_and_enqueue_parse(&source, "parser=pdf-v2", 3)
+        .await
+        .unwrap();
+    assert_eq!(reparse.content_revision, parsed.content_revision + 1);
+    assert_ne!(reparse.revision_token, parsed.revision_token);
+    assert!(reparse.canonical_text.is_empty());
+    assert_eq!(reparse.canonical_fingerprint, None);
+    assert_eq!(reparse_job.kind, DocumentJobKind::Parse);
+    assert_eq!(
+        store
+            .get_document_job(index_job.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        DocumentJobStatus::Cancelled
+    );
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -52,9 +52,9 @@ pub use id::{CallId, ChatId, DocumentId, DocumentJobId, MessageId, ProjectId, St
 pub use keychain::KeychainSecretProvider;
 pub use model::{
     validate_source_regions, ByteSpan, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
-    DocumentJobStatus, DocumentListCursor, DocumentProcessingStatus, DocumentRecord, DocumentScope,
-    DocumentSourceBlob, DocumentSummaryRecord, DocumentUpsert, Message, Project, Role,
-    SourceLocation, SourceRegion, ToolCallRecord,
+    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
+    DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
+    DocumentUpsert, Message, Project, Role, SourceLocation, SourceRegion, ToolCallRecord,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -171,6 +171,34 @@ pub struct DocumentSourceBlob {
     pub byte_len: u64,
 }
 
+/// Metadata and immutable bytes accepted for asynchronous document parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentSourceUpsert {
+    /// Stable document identifier.
+    pub id: DocumentId,
+    /// Owning project, or `None` for an explicitly unscoped document.
+    pub project_id: Option<ProjectId>,
+    /// Source path or URL, when known.
+    pub source_uri: Option<String>,
+    /// Media type used to select the parser.
+    pub media_type: String,
+    /// Optional human-facing title.
+    pub title: Option<String>,
+    /// Immutable source bytes already published to the blob store.
+    pub source_blob: DocumentSourceBlob,
+    /// Source metadata timestamp; workflow timestamps remain store-owned.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Canonical parser output published by a successfully leased parse job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocumentParseOutput {
+    /// Parsed text-of-record used by the indexing stage.
+    pub canonical_text: String,
+    /// Parser-produced mappings into the original source.
+    pub source_regions: Vec<SourceRegion>,
+}
+
 /// Durable delivery state of one document-processing job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -22,8 +22,9 @@ use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId};
 use crate::model::{
-    Chat, DocumentGeneration, DocumentJob, DocumentJobStatus, DocumentListCursor, DocumentRecord,
-    DocumentScope, DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
+    Chat, DocumentGeneration, DocumentJob, DocumentJobStatus, DocumentListCursor,
+    DocumentParseOutput, DocumentRecord, DocumentScope, DocumentSourceUpsert,
+    DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
 };
 
 /// Why maintenance determined that a document needs an index job.
@@ -55,6 +56,8 @@ pub enum EnsureDocumentIndexJobOutcome {
     Existing(DocumentJob),
     /// The desired current job failed and requires an explicit user retry.
     Failed(DocumentJob),
+    /// Canonical content is still owned by the current parse stage.
+    Parsing(DocumentJob),
     /// The source document no longer exists.
     MissingDocument,
     /// The caller inspected an obsolete source generation.
@@ -209,6 +212,38 @@ pub trait Store: Send + Sync {
         _pipeline_fingerprint: &str,
         _max_attempts: i32,
     ) -> Result<(DocumentRecord, DocumentJob)> {
+        document_storage_unavailable()
+    }
+
+    /// Atomically accept immutable raw source bytes and enqueue their parse job.
+    ///
+    /// The blob must already be durably published. Repeating an identical source
+    /// and parser fingerprint returns the exact existing generation and job.
+    /// Any source or parser change advances the generation, clears canonical and
+    /// index state, and cancels older nonterminal work in the same transaction.
+    async fn accept_document_source_and_enqueue_parse(
+        &self,
+        _document: &DocumentSourceUpsert,
+        _parser_fingerprint: &str,
+        _max_attempts: i32,
+    ) -> Result<(DocumentRecord, DocumentJob)> {
+        document_storage_unavailable()
+    }
+
+    /// Atomically publish canonical parser output and enqueue the index stage.
+    ///
+    /// The transition succeeds only for the exact live, unexpired parse lease.
+    /// On success the parse job becomes terminal, canonical state becomes
+    /// authoritative, and one index job is queued in the same transaction.
+    async fn complete_document_parse_job_and_enqueue_index(
+        &self,
+        _id: DocumentJobId,
+        _lease_token: uuid::Uuid,
+        _completed_at: chrono::DateTime<chrono::Utc>,
+        _output: &DocumentParseOutput,
+        _index_fingerprint: &str,
+        _index_max_attempts: i32,
+    ) -> Result<Option<(DocumentRecord, DocumentJob)>> {
         document_storage_unavailable()
     }
 
@@ -878,6 +913,39 @@ mod tests {
                 ));
             }
 
+            if document.source_blob.is_some() && document.canonical_fingerprint.is_none() {
+                let parse_job = state
+                    .jobs
+                    .values()
+                    .filter(|job| {
+                        job.document_id == document_id
+                            && job.generation() == document.generation()
+                            && job.kind == DocumentJobKind::Parse
+                    })
+                    .max_by_key(|job| (job.created_at, job.id.0))
+                    .cloned()
+                    .ok_or_else(|| {
+                        AgentError::Store(format!(
+                            "unparsed document {document_id} has no current parse job"
+                        ))
+                    })?;
+                return Ok(if parse_job.status == DocumentJobStatus::Failed {
+                    EnsureDocumentIndexJobOutcome::Failed(parse_job)
+                } else if matches!(
+                    parse_job.status,
+                    DocumentJobStatus::Queued
+                        | DocumentJobStatus::Running
+                        | DocumentJobStatus::RetryWait
+                ) {
+                    EnsureDocumentIndexJobOutcome::Parsing(parse_job)
+                } else {
+                    return Err(AgentError::Store(format!(
+                        "unparsed document {document_id} has terminal parse state {}",
+                        parse_job.status.as_str()
+                    )));
+                });
+            }
+
             let desired_job_id = state.jobs.values().find_map(|job| {
                 (job.document_id == document_id
                     && job.generation() == document.generation()
@@ -1224,6 +1292,11 @@ mod tests {
             let Some(candidate) = state.jobs.get(&id).cloned() else {
                 return Ok(false);
             };
+            if candidate.kind != DocumentJobKind::Index {
+                return Err(AgentError::Store(format!(
+                    "document job {id} is not an index job"
+                )));
+            }
             if candidate.status != DocumentJobStatus::Running
                 || candidate.lease_token != Some(lease_token)
                 || candidate

--- a/crates/openwave-server/src/document_auditor.rs
+++ b/crates/openwave-server/src/document_auditor.rs
@@ -241,6 +241,7 @@ impl DocumentAuditor {
             EnsureDocumentIndexJobOutcome::Enqueued(_) => report.enqueued += 1,
             EnsureDocumentIndexJobOutcome::Failed(_) => report.failed_jobs += 1,
             EnsureDocumentIndexJobOutcome::Existing(_)
+            | EnsureDocumentIndexJobOutcome::Parsing(_)
             | EnsureDocumentIndexJobOutcome::MissingDocument
             | EnsureDocumentIndexJobOutcome::GenerationChanged(_) => report.skipped += 1,
         }


### PR DESCRIPTION
## Summary

- atomically accept immutable raw document sources and enqueue exact-generation parse jobs
- publish canonical parser output and enqueue indexing under the same leased transaction
- fence wrong-stage completion, stale leases, parser changes, and unparsed index maintenance
- isolate the new workflow in `db/ops/document.rs`
- preserve idempotency for repeated source acceptance and roll back parse publication when index enqueue fails

## Validation

- `cargo test -p openwave-core --all-features`
- `cargo test -p openwave-server --no-run`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo check -p openwave-core --no-default-features`
- `cargo fmt --all -- --check`
- `bw dev lint --rust`
