### PR TITLE
ci: bound Rust workspace disk usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
   rust:
     name: fmt · clippy · build · test
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
     steps:
       - uses: actions/checkout@v7
       - name: Install toolchain (honors rust-toolchain.toml)
@@ -45,6 +49,10 @@ jobs:
             patchelf \
             protobuf-compiler
       - uses: Swatinem/rust-cache@v2
+        with:
+          # The Lance/Arrow and Tauri artifacts can exhaust a hosted runner when
+          # a full target directory is restored before every workspace gate.
+          cache-targets: false
       - name: rustfmt
         run: cargo fmt --all --check
       - name: clippy


### PR DESCRIPTION
## Summary

- disable debug symbols for CI dev/test profiles
- cache the Cargo registry without restoring the large workspace target directory
- keep the existing fmt, clippy, build, and test gates intact

## Motivation

The unified Lance/Arrow and Tauri workspace repeatedly exhausted the hosted runner while producing the desktop archive, which also caused linker bus errors.

## Validation

- workflow YAML parses successfully
- `bw dev lint --rust`
