### PR TITLE
Retry exact Parse and Index document jobs

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -897,180 +897,23 @@ impl Store for DbStore {
             .collect()
     }
 
-    async fn retry_document_index_job(
+    async fn retry_document_job(
         &self,
         document_id: DocumentId,
+        expected_generation: DocumentGeneration,
+        kind: DocumentJobKind,
         pipeline_fingerprint: &str,
         max_attempts: i32,
     ) -> Result<Option<DocumentJob>> {
-        if pipeline_fingerprint.is_empty()
-            || pipeline_fingerprint.chars().count() > DocumentJob::MAX_PIPELINE_FINGERPRINT_LEN
-        {
-            return Err(AgentError::Store(
-                "document job pipeline fingerprint must contain 1 to 512 characters".into(),
-            ));
-        }
-        if max_attempts < 1 {
-            return Err(AgentError::Store(
-                "document job max_attempts must be at least one".into(),
-            ));
-        }
-
-        let transaction = self.conn.begin().await.map_err(store_err)?;
-        acquire_document_write_lock(&transaction, document_id).await?;
-        let Some(document) = entities::document::Entity::find_by_id(document_id.0)
-            .one(&transaction)
-            .await
-            .map_err(store_err)?
-        else {
-            transaction.commit().await.map_err(store_err)?;
-            return Ok(None);
-        };
-        ensure_live_document_generation_on(&transaction, &document).await?;
-        let candidate = entities::document_job::Entity::find()
-            .filter(entities::document_job::Column::DocumentId.eq(document.id))
-            .filter(entities::document_job::Column::ContentRevision.eq(document.content_revision))
-            .filter(entities::document_job::Column::RevisionToken.eq(document.revision_token))
-            .filter(entities::document_job::Column::Kind.eq(DocumentJobKind::Index.as_str()))
-            .filter(entities::document_job::Column::PipelineFingerprint.eq(pipeline_fingerprint))
-            .one(&transaction)
-            .await
-            .map_err(store_err)?;
-        let Some(candidate) = candidate else {
-            transaction.commit().await.map_err(store_err)?;
-            return Ok(None);
-        };
-        let mut parsed = document_job_from_model(candidate.clone())?;
-        if matches!(
-            parsed.status,
-            DocumentJobStatus::Queued | DocumentJobStatus::Running | DocumentJobStatus::RetryWait
-        ) {
-            let expected = if parsed.status == DocumentJobStatus::Running {
-                DocumentProcessingStatus::Processing
-            } else {
-                DocumentProcessingStatus::Queued
-            };
-            if document.processing_status != expected.as_str() {
-                return Err(AgentError::Store(format!(
-                    "document job {} is {} but exact document {} is unexpectedly {}",
-                    parsed.id,
-                    parsed.status.as_str(),
-                    document_id,
-                    document.processing_status
-                )));
-            }
-            transaction.commit().await.map_err(store_err)?;
-            return Ok(Some(parsed));
-        }
-        if parsed.status != DocumentJobStatus::Failed {
-            transaction.commit().await.map_err(store_err)?;
-            return Ok(None);
-        }
-        if document.processing_status != DocumentProcessingStatus::Failed.as_str() {
-            return Err(AgentError::Store(format!(
-                "failed document job {} does not match failed document {}",
-                parsed.id, document_id
-            )));
-        }
-
-        let now = Utc::now();
-        let revived = entities::document_job::Entity::update_many()
-            .col_expr(
-                entities::document_job::Column::Status,
-                sea_orm::sea_query::Expr::value(DocumentJobStatus::Queued.as_str()),
-            )
-            .col_expr(
-                entities::document_job::Column::AttemptCount,
-                sea_orm::sea_query::Expr::value(0),
-            )
-            .col_expr(
-                entities::document_job::Column::MaxAttempts,
-                sea_orm::sea_query::Expr::value(max_attempts),
-            )
-            .col_expr(
-                entities::document_job::Column::AvailableAt,
-                sea_orm::sea_query::Expr::value(now),
-            )
-            .col_expr(
-                entities::document_job::Column::LeaseToken,
-                sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
-            )
-            .col_expr(
-                entities::document_job::Column::LeaseExpiresAt,
-                sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
-            )
-            .col_expr(
-                entities::document_job::Column::StartedAt,
-                sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
-            )
-            .col_expr(
-                entities::document_job::Column::FinishedAt,
-                sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
-            )
-            .col_expr(
-                entities::document_job::Column::LastErrorCode,
-                sea_orm::sea_query::Expr::value(Option::<String>::None),
-            )
-            .col_expr(
-                entities::document_job::Column::LastErrorDetail,
-                sea_orm::sea_query::Expr::value(Option::<String>::None),
-            )
-            .col_expr(
-                entities::document_job::Column::UpdatedAt,
-                sea_orm::sea_query::Expr::value(now),
-            )
-            .filter(entities::document_job::Column::Id.eq(candidate.id))
-            .filter(entities::document_job::Column::Status.eq(DocumentJobStatus::Failed.as_str()))
-            .filter(entities::document_job::Column::UpdatedAt.eq(candidate.updated_at))
-            .exec(&transaction)
-            .await
-            .map_err(store_err)?;
-        let document_queued = entities::document::Entity::update_many()
-            .col_expr(
-                entities::document::Column::ProcessingStatus,
-                sea_orm::sea_query::Expr::value(DocumentProcessingStatus::Queued.as_str()),
-            )
-            .col_expr(
-                entities::document::Column::IndexedRevision,
-                sea_orm::sea_query::Expr::value(Option::<i64>::None),
-            )
-            .col_expr(
-                entities::document::Column::IndexFingerprint,
-                sea_orm::sea_query::Expr::value(Option::<String>::None),
-            )
-            .col_expr(
-                entities::document::Column::IndexedAt,
-                sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
-            )
-            .filter(entities::document::Column::Id.eq(document.id))
-            .filter(entities::document::Column::ContentRevision.eq(document.content_revision))
-            .filter(entities::document::Column::RevisionToken.eq(document.revision_token))
-            .filter(
-                entities::document::Column::ProcessingStatus
-                    .eq(DocumentProcessingStatus::Failed.as_str()),
-            )
-            .exec(&transaction)
-            .await
-            .map_err(store_err)?;
-        if revived.rows_affected != 1 || document_queued.rows_affected != 1 {
-            return Err(AgentError::Store(format!(
-                "failed document job {} changed during explicit retry",
-                parsed.id
-            )));
-        }
-        transaction.commit().await.map_err(store_err)?;
-        parsed.status = DocumentJobStatus::Queued;
-        parsed.attempt_count = 0;
-        parsed.max_attempts = max_attempts;
-        parsed.available_at = now;
-        parsed.lease_token = None;
-        parsed.lease_expires_at = None;
-        parsed.started_at = None;
-        parsed.finished_at = None;
-        parsed.last_error_code = None;
-        parsed.last_error_detail = None;
-        parsed.updated_at = now;
-        Ok(Some(parsed))
+        ops::document::retry_document_job(
+            self,
+            document_id,
+            expected_generation,
+            kind,
+            pipeline_fingerprint,
+            max_attempts,
+        )
+        .await
     }
 
     async fn claim_document_job(

--- a/crates/openwave-core/src/db/ops/document.rs
+++ b/crates/openwave-core/src/db/ops/document.rs
@@ -294,6 +294,192 @@ pub(in crate::db) async fn complete_parse_and_enqueue_index(
     Ok(Some((record, index_job)))
 }
 
+pub(in crate::db) async fn retry_document_job(
+    store: &DbStore,
+    document_id: DocumentId,
+    expected_generation: DocumentGeneration,
+    kind: DocumentJobKind,
+    pipeline_fingerprint: &str,
+    max_attempts: i32,
+) -> Result<Option<DocumentJob>> {
+    validate_job_input(pipeline_fingerprint, max_attempts)?;
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_document_write_lock(&transaction, document_id).await?;
+    let Some(document) = entities::document::Entity::find_by_id(document_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    ensure_live_document_generation_on(&transaction, &document).await?;
+    let current_generation = DocumentGeneration {
+        content_revision: document.content_revision,
+        revision_token: document.revision_token,
+    };
+    if current_generation != expected_generation {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let awaiting_parse =
+        document.source_blob_id.is_some() && document.canonical_fingerprint.is_none();
+    let stage_matches = match kind {
+        DocumentJobKind::Parse => awaiting_parse,
+        DocumentJobKind::Index => !awaiting_parse,
+    };
+    if !stage_matches {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let candidate = entities::document_job::Entity::find()
+        .filter(entities::document_job::Column::DocumentId.eq(document.id))
+        .filter(entities::document_job::Column::ContentRevision.eq(document.content_revision))
+        .filter(entities::document_job::Column::RevisionToken.eq(document.revision_token))
+        .filter(entities::document_job::Column::Kind.eq(kind.as_str()))
+        .filter(entities::document_job::Column::PipelineFingerprint.eq(pipeline_fingerprint))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?;
+    let Some(candidate) = candidate else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let mut job = document_job_from_model(candidate.clone())?;
+    if matches!(
+        job.status,
+        DocumentJobStatus::Queued | DocumentJobStatus::Running | DocumentJobStatus::RetryWait
+    ) {
+        let expected = if job.status == DocumentJobStatus::Running {
+            DocumentProcessingStatus::Processing
+        } else {
+            DocumentProcessingStatus::Queued
+        };
+        if document.processing_status != expected.as_str() {
+            return Err(AgentError::Store(format!(
+                "document job {} is {} but exact document {} is unexpectedly {}",
+                job.id,
+                job.status.as_str(),
+                document_id,
+                document.processing_status
+            )));
+        }
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(job));
+    }
+    if job.status != DocumentJobStatus::Failed {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    if document.processing_status != DocumentProcessingStatus::Failed.as_str() {
+        return Err(AgentError::Store(format!(
+            "failed document job {} does not match failed document {}",
+            job.id, document_id
+        )));
+    }
+
+    let now = Utc::now();
+    let revived = entities::document_job::Entity::update_many()
+        .col_expr(
+            entities::document_job::Column::Status,
+            sea_orm::sea_query::Expr::value(DocumentJobStatus::Queued.as_str()),
+        )
+        .col_expr(
+            entities::document_job::Column::AttemptCount,
+            sea_orm::sea_query::Expr::value(0),
+        )
+        .col_expr(
+            entities::document_job::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(max_attempts),
+        )
+        .col_expr(
+            entities::document_job::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .col_expr(
+            entities::document_job::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::StartedAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::document_job::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::document_job::Column::Id.eq(candidate.id))
+        .filter(entities::document_job::Column::Status.eq(DocumentJobStatus::Failed.as_str()))
+        .filter(entities::document_job::Column::UpdatedAt.eq(candidate.updated_at))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    let document_queued = entities::document::Entity::update_many()
+        .col_expr(
+            entities::document::Column::ProcessingStatus,
+            sea_orm::sea_query::Expr::value(DocumentProcessingStatus::Queued.as_str()),
+        )
+        .col_expr(
+            entities::document::Column::IndexedRevision,
+            sea_orm::sea_query::Expr::value(Option::<i64>::None),
+        )
+        .col_expr(
+            entities::document::Column::IndexFingerprint,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::document::Column::IndexedAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .filter(entities::document::Column::Id.eq(document.id))
+        .filter(entities::document::Column::ContentRevision.eq(document.content_revision))
+        .filter(entities::document::Column::RevisionToken.eq(document.revision_token))
+        .filter(
+            entities::document::Column::ProcessingStatus
+                .eq(DocumentProcessingStatus::Failed.as_str()),
+        )
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if revived.rows_affected != 1 || document_queued.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "failed document job {} changed during explicit retry",
+            job.id
+        )));
+    }
+    transaction.commit().await.map_err(store_err)?;
+    job.status = DocumentJobStatus::Queued;
+    job.attempt_count = 0;
+    job.max_attempts = max_attempts;
+    job.available_at = now;
+    job.lease_token = None;
+    job.lease_expires_at = None;
+    job.started_at = None;
+    job.finished_at = None;
+    job.last_error_code = None;
+    job.last_error_detail = None;
+    job.updated_at = now;
+    Ok(Some(job))
+}
+
 fn validate_source_input(
     source: &DocumentSourceUpsert,
     parser_fingerprint: &str,

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -1898,13 +1898,19 @@ async fn explicit_retry_only_revives_current_failed_index_job() {
         source_regions: Vec::new(),
         updated_at: DateTime::<Utc>::from_timestamp(1, 0).unwrap(),
     };
-    let (_, queued) = store
+    let (document, queued) = store
         .upsert_document_and_enqueue_index(&source, "pipeline-v1", 2)
         .await
         .unwrap();
     assert_eq!(
         store
-            .retry_document_index_job(source.id, "pipeline-v1", 9)
+            .retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                9,
+            )
             .await
             .unwrap(),
         Some(queued.clone())
@@ -1918,7 +1924,13 @@ async fn explicit_retry_only_revives_current_failed_index_job() {
         .unwrap();
     assert_eq!(
         store
-            .retry_document_index_job(source.id, "pipeline-v1", 9)
+            .retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                9,
+            )
             .await
             .unwrap(),
         Some(running.clone())
@@ -1939,14 +1951,26 @@ async fn explicit_retry_only_revives_current_failed_index_job() {
     );
     assert_eq!(
         store
-            .retry_document_index_job(source.id, "other-pipeline", 4)
+            .retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "other-pipeline",
+                4,
+            )
             .await
             .unwrap(),
         None
     );
 
     let retried = store
-        .retry_document_index_job(source.id, "pipeline-v1", 4)
+        .retry_document_job(
+            source.id,
+            document.generation(),
+            DocumentJobKind::Index,
+            "pipeline-v1",
+            4,
+        )
         .await
         .unwrap()
         .unwrap();
@@ -1967,7 +1991,13 @@ async fn explicit_retry_only_revives_current_failed_index_job() {
     assert_eq!(document.indexed_at, None);
     assert_eq!(
         store
-            .retry_document_index_job(source.id, "pipeline-v1", 8)
+            .retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                8,
+            )
             .await
             .unwrap(),
         Some(retried.clone())
@@ -1992,7 +2022,13 @@ async fn explicit_retry_only_revives_current_failed_index_job() {
         .unwrap());
     assert_eq!(
         store
-            .retry_document_index_job(source.id, "pipeline-v1", 4)
+            .retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                4,
+            )
             .await
             .unwrap(),
         None
@@ -2004,18 +2040,24 @@ async fn explicit_retry_only_revives_current_failed_index_job() {
         updated_at: source.updated_at + chrono::Duration::seconds(1),
         ..source.clone()
     };
-    let (_, cancelled) = store
+    let (replacement_document, cancelled) = store
         .upsert_document_and_enqueue_index(&replacement, "pipeline-v2", 2)
         .await
         .unwrap();
     assert_eq!(
         store
-            .retry_document_index_job(replacement.id, "pipeline-v1", 4)
+            .retry_document_job(
+                replacement.id,
+                replacement_document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                4,
+            )
             .await
             .unwrap(),
         None
     );
-    store
+    let (newer_document, _) = store
         .upsert_document_and_enqueue_index(
             &DocumentUpsert {
                 canonical_text: "newer replacement".into(),
@@ -2039,10 +2081,117 @@ async fn explicit_retry_only_revives_current_failed_index_job() {
     );
     assert_eq!(
         store
-            .retry_document_index_job(source.id, "pipeline-v2", 4)
+            .retry_document_job(
+                source.id,
+                newer_document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v2",
+                4,
+            )
             .await
             .unwrap(),
         None
+    );
+}
+
+#[tokio::test]
+async fn explicit_retry_revives_only_the_pending_parse_stage() {
+    let (_dir, store) = temp_store().await;
+    let source = DocumentSourceUpsert {
+        id: DocumentId::new(),
+        project_id: None,
+        source_uri: Some("file:///retry-report.pdf".into()),
+        media_type: "application/pdf".into(),
+        title: Some("Retry report".into()),
+        source_blob: DocumentSourceBlob {
+            id: uuid::Uuid::new_v4(),
+            sha256: [0x44; 32],
+            byte_len: 4_096,
+        },
+        updated_at: Utc::now(),
+    };
+    let (document, queued) = store
+        .accept_document_source_and_enqueue_parse(&source, "parser=pdf-v1", 1)
+        .await
+        .unwrap();
+    let claim_at = queued.available_at + chrono::Duration::seconds(1);
+    let running = store
+        .claim_document_job(claim_at, claim_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        store
+            .record_document_job_failure(
+                running.id,
+                running.lease_token.unwrap(),
+                claim_at + chrono::Duration::seconds(1),
+                None,
+                "parse_failed",
+                Some("malformed page"),
+            )
+            .await
+            .unwrap(),
+        Some(DocumentJobStatus::Failed)
+    );
+
+    assert_eq!(
+        store
+            .retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "parser=pdf-v1",
+                5,
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        store
+            .retry_document_job(
+                source.id,
+                DocumentGeneration {
+                    content_revision: document.content_revision + 1,
+                    revision_token: document.revision_token,
+                },
+                DocumentJobKind::Parse,
+                "parser=pdf-v1",
+                5,
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    let retried = store
+        .retry_document_job(
+            source.id,
+            document.generation(),
+            DocumentJobKind::Parse,
+            "parser=pdf-v1",
+            5,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(retried.id, queued.id);
+    assert_eq!(retried.kind, DocumentJobKind::Parse);
+    assert_eq!(retried.status, DocumentJobStatus::Queued);
+    assert_eq!(retried.attempt_count, 0);
+    assert_eq!(retried.max_attempts, 5);
+    assert_eq!(retried.started_at, None);
+    assert_eq!(retried.finished_at, None);
+    assert_eq!(retried.last_error_code, None);
+    assert_eq!(retried.last_error_detail, None);
+    assert_eq!(
+        store
+            .get_document(source.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .processing_status,
+        DocumentProcessingStatus::Queued
     );
 }
 

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -22,7 +22,7 @@ use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId};
 use crate::model::{
-    Chat, DocumentGeneration, DocumentJob, DocumentJobStatus, DocumentListCursor,
+    Chat, DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
     DocumentParseOutput, DocumentRecord, DocumentScope, DocumentSourceUpsert,
     DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
 };
@@ -275,16 +275,19 @@ pub trait Store: Send + Sync {
         document_storage_unavailable()
     }
 
-    /// Explicitly retry the current exact-generation failed index job.
+    /// Explicitly retry one exact-generation failed semantic job.
     ///
     /// A matching failed job is reset to a fresh queued delivery using a
     /// store-owned timestamp and `max_attempts`. Repeating the request while that
-    /// exact job is already nonterminal returns it unchanged. Succeeded,
-    /// cancelled, superseded, missing, or differently fingerprinted jobs are not
-    /// revived and return `None`.
-    async fn retry_document_index_job(
+    /// exact job is already nonterminal returns it unchanged. The observed
+    /// generation, semantic kind, fingerprint, and document stage must all still
+    /// agree. Succeeded, cancelled, superseded, missing, or mismatched jobs are
+    /// not revived and return `None`.
+    async fn retry_document_job(
         &self,
         _document_id: DocumentId,
+        _expected_generation: DocumentGeneration,
+        _kind: DocumentJobKind,
         _pipeline_fingerprint: &str,
         _max_attempts: i32,
     ) -> Result<Option<DocumentJob>> {
@@ -1053,9 +1056,11 @@ mod tests {
             });
             Ok(jobs)
         }
-        async fn retry_document_index_job(
+        async fn retry_document_job(
             &self,
             document_id: DocumentId,
+            expected_generation: DocumentGeneration,
+            kind: DocumentJobKind,
             pipeline_fingerprint: &str,
             max_attempts: i32,
         ) -> Result<Option<DocumentJob>> {
@@ -1069,6 +1074,18 @@ mod tests {
             let Some(document) = state.documents.get(&document_id).cloned() else {
                 return Ok(None);
             };
+            if document.generation() != expected_generation {
+                return Ok(None);
+            }
+            let awaiting_parse =
+                document.source_blob.is_some() && document.canonical_fingerprint.is_none();
+            let stage_matches = match kind {
+                DocumentJobKind::Parse => awaiting_parse,
+                DocumentJobKind::Index => !awaiting_parse,
+            };
+            if !stage_matches {
+                return Ok(None);
+            }
             let candidate_id = state
                 .jobs
                 .values()
@@ -1076,7 +1093,7 @@ mod tests {
                     job.document_id == document_id
                         && job.content_revision == document.content_revision
                         && job.revision_token == document.revision_token
-                        && job.kind == DocumentJobKind::Index
+                        && job.kind == kind
                         && job.pipeline_fingerprint == pipeline_fingerprint
                 })
                 .map(|job| job.id);
@@ -2023,10 +2040,17 @@ mod tests {
             source_regions: Vec::new(),
             updated_at: chrono::DateTime::<chrono::Utc>::from_timestamp(1, 0).unwrap(),
         };
-        let (_, queued) =
+        let (document, queued) =
             block_on(store.upsert_document_and_enqueue_index(&source, "pipeline-v1", 2)).unwrap();
         assert_eq!(
-            block_on(store.retry_document_index_job(source.id, "pipeline-v1", 9)).unwrap(),
+            block_on(store.retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                9,
+            ))
+            .unwrap(),
             Some(queued.clone())
         );
 
@@ -2036,7 +2060,14 @@ mod tests {
                 .unwrap()
                 .unwrap();
         assert_eq!(
-            block_on(store.retry_document_index_job(source.id, "pipeline-v1", 9)).unwrap(),
+            block_on(store.retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                9,
+            ))
+            .unwrap(),
             Some(running.clone())
         );
         assert_eq!(
@@ -2052,13 +2083,40 @@ mod tests {
             Some(DocumentJobStatus::Failed)
         );
         assert_eq!(
-            block_on(store.retry_document_index_job(source.id, "other-pipeline", 4)).unwrap(),
+            block_on(store.retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "other-pipeline",
+                4,
+            ))
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            block_on(store.retry_document_job(
+                source.id,
+                DocumentGeneration {
+                    content_revision: document.content_revision + 1,
+                    revision_token: document.revision_token,
+                },
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                4,
+            ))
+            .unwrap(),
             None
         );
 
-        let retried = block_on(store.retry_document_index_job(source.id, "pipeline-v1", 4))
-            .unwrap()
-            .unwrap();
+        let retried = block_on(store.retry_document_job(
+            source.id,
+            document.generation(),
+            DocumentJobKind::Index,
+            "pipeline-v1",
+            4,
+        ))
+        .unwrap()
+        .unwrap();
         assert_eq!(retried.id, queued.id);
         assert_eq!(retried.status, DocumentJobStatus::Queued);
         assert_eq!(retried.attempt_count, 0);
@@ -2075,7 +2133,14 @@ mod tests {
         assert_eq!(document.index_fingerprint, None);
         assert_eq!(document.indexed_at, None);
         assert_eq!(
-            block_on(store.retry_document_index_job(source.id, "pipeline-v1", 8)).unwrap(),
+            block_on(store.retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                8,
+            ))
+            .unwrap(),
             Some(retried.clone())
         );
 
@@ -2093,7 +2158,14 @@ mod tests {
         ))
         .unwrap());
         assert_eq!(
-            block_on(store.retry_document_index_job(source.id, "pipeline-v1", 4)).unwrap(),
+            block_on(store.retry_document_job(
+                source.id,
+                document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                4,
+            ))
+            .unwrap(),
             None
         );
 
@@ -2103,14 +2175,21 @@ mod tests {
             updated_at: source.updated_at + chrono::Duration::seconds(1),
             ..source.clone()
         };
-        let (_, cancelled) =
+        let (replacement_document, cancelled) =
             block_on(store.upsert_document_and_enqueue_index(&replacement, "pipeline-v2", 2))
                 .unwrap();
         assert_eq!(
-            block_on(store.retry_document_index_job(replacement.id, "pipeline-v1", 4)).unwrap(),
+            block_on(store.retry_document_job(
+                replacement.id,
+                replacement_document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v1",
+                4,
+            ))
+            .unwrap(),
             None
         );
-        block_on(store.upsert_document_and_enqueue_index(
+        let (newer_document, _) = block_on(store.upsert_document_and_enqueue_index(
             &DocumentUpsert {
                 canonical_text: "newer replacement".into(),
                 source_regions: Vec::new(),
@@ -2129,8 +2208,113 @@ mod tests {
             DocumentJobStatus::Cancelled
         );
         assert_eq!(
-            block_on(store.retry_document_index_job(source.id, "pipeline-v2", 4)).unwrap(),
+            block_on(store.retry_document_job(
+                source.id,
+                newer_document.generation(),
+                DocumentJobKind::Index,
+                "pipeline-v2",
+                4,
+            ))
+            .unwrap(),
             None
+        );
+    }
+
+    #[test]
+    fn mem_store_explicit_retry_revives_only_pending_parse_stage() {
+        let store = MemStore::default();
+        let now = chrono::Utc::now();
+        let document_id = DocumentId::new();
+        let generation = DocumentGeneration {
+            content_revision: 1,
+            revision_token: uuid::Uuid::new_v4(),
+        };
+        let job = DocumentJob {
+            id: DocumentJobId::new(),
+            document_id,
+            content_revision: generation.content_revision,
+            revision_token: generation.revision_token,
+            kind: DocumentJobKind::Parse,
+            status: DocumentJobStatus::Failed,
+            pipeline_fingerprint: "parser=pdf-v1".into(),
+            attempt_count: 3,
+            max_attempts: 3,
+            available_at: now,
+            lease_token: None,
+            lease_expires_at: None,
+            started_at: Some(now),
+            finished_at: Some(now),
+            last_error_code: Some("parse_failed".into()),
+            last_error_detail: Some("malformed page".into()),
+            created_at: now,
+            updated_at: now,
+        };
+        {
+            let mut state = store.document_state.lock().unwrap();
+            state.documents.insert(
+                document_id,
+                DocumentRecord {
+                    id: document_id,
+                    project_id: None,
+                    source_uri: Some("file:///report.pdf".into()),
+                    media_type: "application/pdf".into(),
+                    title: None,
+                    source_blob: Some(crate::model::DocumentSourceBlob {
+                        id: uuid::Uuid::new_v4(),
+                        sha256: [0x33; 32],
+                        byte_len: 4_096,
+                    }),
+                    canonical_text: String::new(),
+                    canonical_fingerprint: None,
+                    source_regions: Vec::new(),
+                    content_revision: generation.content_revision,
+                    revision_token: generation.revision_token,
+                    processing_status: DocumentProcessingStatus::Failed,
+                    indexed_revision: None,
+                    index_fingerprint: None,
+                    created_at: now,
+                    updated_at: now,
+                    indexed_at: None,
+                },
+            );
+            state.jobs.insert(job.id, job.clone());
+        }
+
+        assert_eq!(
+            block_on(store.retry_document_job(
+                document_id,
+                generation,
+                DocumentJobKind::Index,
+                "parser=pdf-v1",
+                5,
+            ))
+            .unwrap(),
+            None
+        );
+        let retried = block_on(store.retry_document_job(
+            document_id,
+            generation,
+            DocumentJobKind::Parse,
+            "parser=pdf-v1",
+            5,
+        ))
+        .unwrap()
+        .unwrap();
+        assert_eq!(retried.id, job.id);
+        assert_eq!(retried.kind, DocumentJobKind::Parse);
+        assert_eq!(retried.status, DocumentJobStatus::Queued);
+        assert_eq!(retried.attempt_count, 0);
+        assert_eq!(retried.max_attempts, 5);
+        assert_eq!(retried.started_at, None);
+        assert_eq!(retried.finished_at, None);
+        assert_eq!(retried.last_error_code, None);
+        assert_eq!(retried.last_error_detail, None);
+        assert_eq!(
+            block_on(store.get_document(document_id))
+                .unwrap()
+                .unwrap()
+                .processing_status,
+            DocumentProcessingStatus::Queued
         );
     }
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -575,18 +575,24 @@ async fn retry_document_in_scope(
     project_id: Option<ProjectId>,
 ) -> Result<(StatusCode, Json<IngestResult>), ServerError> {
     let _document_write = state.document_writes.acquire(id).await;
-    if state
+    let Some(document) = state
         .store
         .get_document(id)
         .await?
-        .is_none_or(|document| document.project_id != project_id)
-    {
+        .filter(|document| document.project_id == project_id)
+    else {
         return Err(ServerError::not_found(format!("document {id} not found")));
-    }
+    };
     let fingerprint = state.retrieval.index_fingerprint();
     let Some(job) = state
         .store
-        .retry_document_index_job(id, &fingerprint, MAX_INDEX_ATTEMPTS)
+        .retry_document_job(
+            id,
+            document.generation(),
+            openwave_core::DocumentJobKind::Index,
+            &fingerprint,
+            MAX_INDEX_ATTEMPTS,
+        )
         .await?
     else {
         return Err(ServerError::conflict(format!(


### PR DESCRIPTION
## Summary

- replace the Index-only retry API with an exact generation- and kind-aware transition
- preserve job identity while resetting failed delivery state and reject stale, terminal, wrong-stage, or wrong-fingerprint work
- keep SQLite retry logic in the document operations module and pass the caller-observed generation from the HTTP route
- cover Parse and Index behavior across the in-memory and SQLite stores

## Validation

- `cargo test --workspace --all-features`
- `cargo test -p openwave-core explicit_retry -- --nocapture`
- `bw dev lint --rust`
- `cargo fmt --all --check`
