### PR TITLE
Execute durable Parse document jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5740,6 +5740,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-tungstenite",

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }

--- a/crates/openwave-server/src/document_stage.rs
+++ b/crates/openwave-server/src/document_stage.rs
@@ -1,0 +1,126 @@
+//! Select the semantic pipeline stage currently owning one document generation.
+
+use openwave_core::{DocumentJobKind, DocumentRecord};
+use openwave_retrieval::{Result, Retriever};
+
+/// Maximum attempts assigned to newly queued or explicitly retried parse jobs.
+pub(crate) const MAX_PARSE_ATTEMPTS: i32 = 3;
+
+/// The exact semantic job configuration eligible for explicit retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DocumentJobSpec {
+    pub kind: DocumentJobKind,
+    pub pipeline_fingerprint: String,
+    pub max_attempts: i32,
+}
+
+/// Select Parse only while retained bytes are still awaiting canonical output;
+/// otherwise select Index. Parser upgrades require a separate atomic reparse
+/// transition rather than reviving a failed job in the current generation.
+pub(crate) fn retry_document_job_spec(
+    document: &DocumentRecord,
+    retrieval: &Retriever,
+) -> Result<DocumentJobSpec> {
+    if document.source_blob.is_some() && document.canonical_fingerprint.is_none() {
+        let fingerprint = retrieval.canonical_fingerprint_for(&document.media_type)?;
+        return Ok(DocumentJobSpec {
+            kind: DocumentJobKind::Parse,
+            pipeline_fingerprint: fingerprint,
+            max_attempts: MAX_PARSE_ATTEMPTS,
+        });
+    }
+
+    Ok(DocumentJobSpec {
+        kind: DocumentJobKind::Index,
+        pipeline_fingerprint: retrieval.index_fingerprint(),
+        max_attempts: crate::document_worker::MAX_INDEX_ATTEMPTS,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use openwave_core::{DocumentId, DocumentProcessingStatus, DocumentSourceBlob};
+    use openwave_retrieval::{HashEmbedder, InMemoryVectorStore, PlainTextParser, TextChunker};
+
+    use super::*;
+
+    fn retrieval() -> Retriever {
+        Retriever::new(
+            Box::new(PlainTextParser),
+            Box::new(TextChunker::default()),
+            Arc::new(HashEmbedder::default()),
+            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        )
+    }
+
+    fn record(
+        source_blob: Option<DocumentSourceBlob>,
+        canonical_fingerprint: Option<&str>,
+    ) -> DocumentRecord {
+        let now = chrono::Utc::now();
+        DocumentRecord {
+            id: DocumentId::new(),
+            project_id: None,
+            source_uri: None,
+            media_type: "text/plain".into(),
+            title: None,
+            source_blob,
+            canonical_text: "canonical".into(),
+            canonical_fingerprint: canonical_fingerprint.map(str::to_string),
+            source_regions: Vec::new(),
+            content_revision: 1,
+            revision_token: uuid::Uuid::new_v4(),
+            processing_status: DocumentProcessingStatus::Failed,
+            indexed_revision: None,
+            index_fingerprint: None,
+            created_at: now,
+            updated_at: now,
+            indexed_at: None,
+        }
+    }
+
+    fn blob() -> DocumentSourceBlob {
+        DocumentSourceBlob {
+            id: uuid::Uuid::new_v4(),
+            sha256: [0x66; 32],
+            byte_len: 128,
+        }
+    }
+
+    #[test]
+    fn retained_source_selects_parse_only_while_canonical_output_is_pending() {
+        let retrieval = retrieval();
+        let desired = retry_document_job_spec(&record(Some(blob()), None), &retrieval).unwrap();
+        assert_eq!(desired.kind, DocumentJobKind::Parse);
+        assert_eq!(desired.pipeline_fingerprint, "plain-text-lossy-v1");
+        assert_eq!(desired.max_attempts, MAX_PARSE_ATTEMPTS);
+
+        for canonical_fingerprint in ["plain-text-lossy-v1", "older-parser"] {
+            let desired = retry_document_job_spec(
+                &record(Some(blob()), Some(canonical_fingerprint)),
+                &retrieval,
+            )
+            .unwrap();
+            assert_eq!(desired.kind, DocumentJobKind::Index);
+            assert_eq!(
+                desired.max_attempts,
+                crate::document_worker::MAX_INDEX_ATTEMPTS
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_only_document_selects_index_without_parser_provenance() {
+        let desired = retry_document_job_spec(&record(None, None), &retrieval()).unwrap();
+        assert_eq!(desired.kind, DocumentJobKind::Index);
+    }
+
+    #[test]
+    fn retained_source_requires_a_parser_for_its_media_type() {
+        let mut document = record(Some(blob()), None);
+        document.media_type = "application/pdf".into();
+        assert!(retry_document_job_spec(&document, &retrieval()).is_err());
+    }
+}

--- a/crates/openwave-server/src/document_worker.rs
+++ b/crates/openwave-server/src/document_worker.rs
@@ -1,4 +1,4 @@
-//! Durable document-index job execution.
+//! Durable Parse and Index document-job execution.
 
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -7,12 +7,13 @@ use std::time::Duration;
 
 use chrono::Utc;
 use openwave_core::{
-    AgentError, DocumentId, DocumentJob, DocumentJobId, DocumentJobKind, DocumentJobStatus, Result,
-    Store,
+    AgentError, BlobStore, DocumentId, DocumentJob, DocumentJobId, DocumentJobKind,
+    DocumentJobStatus, DocumentParseOutput, Result, Store,
 };
 use openwave_retrieval::{
     Document, DocumentSource, GenerationStageOutcome, RetrievalError, Retriever,
 };
+use sha2::{Digest, Sha256};
 use tokio::sync::Notify;
 
 use crate::state::DocumentWriteGuard;
@@ -59,6 +60,7 @@ pub(crate) enum WorkerOutcome {
 #[derive(Clone)]
 pub(crate) struct DocumentWorker {
     store: Arc<dyn Store>,
+    blobs: Arc<dyn BlobStore>,
     retrieval: Arc<Retriever>,
     wake: Arc<Notify>,
     document_writes: Arc<DocumentWriteGuard>,
@@ -75,6 +77,7 @@ enum Supervised<T> {
 impl DocumentWorker {
     pub(crate) fn new(
         store: Arc<dyn Store>,
+        blobs: Arc<dyn BlobStore>,
         retrieval: Arc<Retriever>,
         wake: Arc<Notify>,
         document_writes: Arc<DocumentWriteGuard>,
@@ -85,6 +88,7 @@ impl DocumentWorker {
         assert!(config.heartbeat < config.lease);
         Self {
             store,
+            blobs,
             retrieval,
             wake,
             document_writes,
@@ -225,7 +229,7 @@ impl DocumentWorker {
     }
 
     async fn process(&self, job: DocumentJob) -> Result<WorkerOutcome> {
-        if job.kind != DocumentJobKind::Index || job.status != DocumentJobStatus::Running {
+        if job.status != DocumentJobStatus::Running {
             return Err(AgentError::msg(format!(
                 "claimed document job {} has an invalid execution state",
                 job.id
@@ -237,6 +241,194 @@ impl DocumentWorker {
                 job.id
             ))
         })?;
+        let Some(source) = self.store.get_document(job.document_id).await? else {
+            return Ok(WorkerOutcome::Superseded(job.id));
+        };
+        if source.generation() != job.generation() {
+            return Ok(WorkerOutcome::Superseded(job.id));
+        }
+        match job.kind {
+            DocumentJobKind::Parse => self.process_parse(job, lease_token, source).await,
+            DocumentJobKind::Index => self.process_index(job, lease_token, source).await,
+            _ => {
+                self.record_failure(
+                    &job,
+                    lease_token,
+                    false,
+                    "unsupported_job_kind",
+                    "document worker does not support this semantic job kind",
+                )
+                .await
+            }
+        }
+    }
+
+    async fn process_parse(
+        &self,
+        job: DocumentJob,
+        lease_token: uuid::Uuid,
+        source: openwave_core::DocumentRecord,
+    ) -> Result<WorkerOutcome> {
+        if source.canonical_fingerprint.is_some() {
+            return self
+                .record_failure(
+                    &job,
+                    lease_token,
+                    false,
+                    "invalid_document_stage",
+                    "parse job does not own a document with published canonical output",
+                )
+                .await;
+        }
+        let fingerprint = match self.retrieval.canonical_fingerprint_for(&source.media_type) {
+            Ok(fingerprint) => fingerprint,
+            Err(error) => {
+                return self
+                    .record_failure(
+                        &job,
+                        lease_token,
+                        false,
+                        "parser_unavailable",
+                        &error.to_string(),
+                    )
+                    .await;
+            }
+        };
+        if job.pipeline_fingerprint != fingerprint {
+            return self
+                .record_failure(
+                    &job,
+                    lease_token,
+                    false,
+                    "pipeline_changed",
+                    "job parser fingerprint does not match the active parser",
+                )
+                .await;
+        }
+        let Some(descriptor) = source.source_blob.as_ref() else {
+            return self
+                .record_failure(
+                    &job,
+                    lease_token,
+                    false,
+                    "source_blob_missing",
+                    "parse job has no retained source descriptor",
+                )
+                .await;
+        };
+        let blob_id = descriptor.id.to_string();
+        let bytes = match self
+            .supervise(&job, lease_token, self.blobs.get(&blob_id))
+            .await
+        {
+            Supervised::LeaseLost => return Ok(WorkerOutcome::LeaseLost(job.id)),
+            Supervised::Completed(Ok(Some(bytes))) => bytes,
+            Supervised::Completed(Ok(None)) => {
+                return self
+                    .record_failure(
+                        &job,
+                        lease_token,
+                        false,
+                        "source_blob_missing",
+                        "retained source blob does not exist",
+                    )
+                    .await;
+            }
+            Supervised::Completed(Err(error)) => {
+                return self
+                    .record_failure(
+                        &job,
+                        lease_token,
+                        true,
+                        "source_blob_read_failed",
+                        &error.to_string(),
+                    )
+                    .await;
+            }
+        };
+        if usize::try_from(descriptor.byte_len).ok() != Some(bytes.len()) {
+            return self
+                .record_failure(
+                    &job,
+                    lease_token,
+                    false,
+                    "source_blob_length_mismatch",
+                    "retained source byte length does not match its descriptor",
+                )
+                .await;
+        }
+        let digest: [u8; 32] = Sha256::digest(&bytes).into();
+        if digest != descriptor.sha256 {
+            return self
+                .record_failure(
+                    &job,
+                    lease_token,
+                    false,
+                    "source_blob_digest_mismatch",
+                    "retained source digest does not match its descriptor",
+                )
+                .await;
+        }
+        let document_source = match source.source_uri.clone() {
+            Some(uri) => DocumentSource::uri(uri),
+            None => DocumentSource::Inline,
+        };
+        let parsed = match self
+            .supervise(
+                &job,
+                lease_token,
+                self.retrieval
+                    .parse_document(document_source, &source.media_type, &bytes),
+            )
+            .await
+        {
+            Supervised::LeaseLost => return Ok(WorkerOutcome::LeaseLost(job.id)),
+            Supervised::Completed(Ok(parsed)) => parsed,
+            Supervised::Completed(Err(error)) => {
+                let (retryable, code) = classify_retrieval_error(&error);
+                return self
+                    .record_failure(&job, lease_token, retryable, code, &error.to_string())
+                    .await;
+            }
+        };
+        let completed = self
+            .store
+            .complete_document_parse_job_and_enqueue_index(
+                job.id,
+                lease_token,
+                Utc::now(),
+                &DocumentParseOutput {
+                    canonical_text: parsed.text,
+                    source_regions: parsed.source_regions,
+                },
+                &self.retrieval.index_fingerprint(),
+                MAX_INDEX_ATTEMPTS,
+            )
+            .await?;
+        Ok(if completed.is_some() {
+            WorkerOutcome::Completed(job.id)
+        } else {
+            WorkerOutcome::LeaseLost(job.id)
+        })
+    }
+
+    async fn process_index(
+        &self,
+        job: DocumentJob,
+        lease_token: uuid::Uuid,
+        source: openwave_core::DocumentRecord,
+    ) -> Result<WorkerOutcome> {
+        if source.source_blob.is_some() && source.canonical_fingerprint.is_none() {
+            return self
+                .record_failure(
+                    &job,
+                    lease_token,
+                    false,
+                    "invalid_document_stage",
+                    "index job cannot consume canonical output that is still pending",
+                )
+                .await;
+        }
         // A recreated source can have a newer live generation while an older
         // tombstone still has to retire the prior corpus publication. Retire
         // that exact watermark before attempting to stage the recreated job;
@@ -248,12 +440,6 @@ impl DocumentWorker {
             .await?
         {
             self.retire(job.document_id, retirement).await?;
-        }
-        let Some(source) = self.store.get_document(job.document_id).await? else {
-            return Ok(WorkerOutcome::Superseded(job.id));
-        };
-        if source.generation() != job.generation() {
-            return Ok(WorkerOutcome::Superseded(job.id));
         }
         let fingerprint = self.retrieval.index_fingerprint();
         if job.pipeline_fingerprint != fingerprint {
@@ -488,8 +674,8 @@ mod tests {
 
     use async_trait::async_trait;
     use openwave_core::{
-        ByteSpan, DbStore, DocumentId, DocumentProcessingStatus, DocumentUpsert, Project,
-        ProjectId, SourceLocation, SourceRegion,
+        ByteSpan, DbStore, DocumentId, DocumentProcessingStatus, DocumentSourceBlob,
+        DocumentSourceUpsert, DocumentUpsert, Project, ProjectId, SourceLocation, SourceRegion,
     };
     use openwave_retrieval::{
         Embedder, Embedding, HashEmbedder, InMemoryVectorStore, PlainTextParser, ScoredChunk,
@@ -698,6 +884,7 @@ mod tests {
         ));
         let worker = DocumentWorker::new(
             store.clone(),
+            Arc::new(openwave_core::FsBlobStore::new(dir.path().join("blobs"))),
             retrieval.clone(),
             Arc::new(Notify::new()),
             Arc::new(DocumentWriteGuard::default()),
@@ -729,6 +916,55 @@ mod tests {
             source_regions: Vec::new(),
             updated_at: Utc::now(),
         }
+    }
+
+    #[tokio::test]
+    async fn parse_job_rejects_source_bytes_that_do_not_match_the_descriptor() {
+        let (_dir, store, retrieval, _embedder, worker) = harness().await;
+        let raw = b"tampered source bytes".to_vec();
+        let blob_id = uuid::Uuid::new_v4();
+        worker
+            .blobs
+            .put(&blob_id.to_string(), raw.clone())
+            .await
+            .unwrap();
+        let source = DocumentSourceUpsert {
+            id: DocumentId::new(),
+            project_id: None,
+            source_uri: Some("file:///tampered.txt".into()),
+            media_type: "text/plain".into(),
+            title: None,
+            source_blob: DocumentSourceBlob {
+                id: blob_id,
+                sha256: [0x77; 32],
+                byte_len: raw.len() as u64,
+            },
+            updated_at: Utc::now(),
+        };
+        let (_, parse_job) = store
+            .accept_document_source_and_enqueue_parse(
+                &source,
+                &retrieval
+                    .canonical_fingerprint_for(&source.media_type)
+                    .unwrap(),
+                3,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            WorkerOutcome::Failed(parse_job.id)
+        );
+        let failed = store.get_document_job(parse_job.id).await.unwrap().unwrap();
+        assert_eq!(failed.status, DocumentJobStatus::Failed);
+        assert_eq!(
+            failed.last_error_code.as_deref(),
+            Some("source_blob_digest_mismatch")
+        );
+        let document = store.get_document(source.id).await.unwrap().unwrap();
+        assert_eq!(document.processing_status, DocumentProcessingStatus::Failed);
+        assert_eq!(document.canonical_fingerprint, None);
     }
 
     #[tokio::test]
@@ -1027,6 +1263,7 @@ mod tests {
         ));
         let worker = DocumentWorker::new(
             store.clone(),
+            Arc::new(openwave_core::FsBlobStore::new(dir.path().join("blobs"))),
             retrieval.clone(),
             Arc::new(Notify::new()),
             Arc::new(DocumentWriteGuard::default()),
@@ -1114,6 +1351,7 @@ mod tests {
         let document_writes = Arc::new(DocumentWriteGuard::default());
         let worker = DocumentWorker::new(
             store.clone(),
+            Arc::new(openwave_core::FsBlobStore::new(dir.path().join("blobs"))),
             retrieval.clone(),
             Arc::new(Notify::new()),
             document_writes.clone(),
@@ -1191,6 +1429,7 @@ mod tests {
         ));
         let worker = DocumentWorker::new(
             store.clone(),
+            Arc::new(openwave_core::FsBlobStore::new(dir.path().join("blobs"))),
             retrieval,
             Arc::new(Notify::new()),
             Arc::new(DocumentWriteGuard::default()),

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -15,6 +15,7 @@ mod approvals;
 mod auth;
 mod bus;
 mod document_auditor;
+mod document_stage;
 mod document_worker;
 mod error;
 mod extract;
@@ -212,6 +213,7 @@ pub async fn bind(config: Config) -> Result<Server> {
     let token = state.token.clone();
     let document_worker = document_worker::DocumentWorker::new(
         state.store.clone(),
+        state.blobs.clone(),
         state.retrieval.clone(),
         state.document_job_wake.clone(),
         state.document_writes.clone(),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -24,6 +24,7 @@ use openwave_retrieval::{
 };
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
+use crate::document_stage::retry_document_job_spec;
 use crate::document_worker::MAX_INDEX_ATTEMPTS;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
@@ -551,7 +552,7 @@ async fn ingest_document_in_scope(
 }
 
 /// `POST /documents/{id}/retry` — explicitly revive the current exact failed
-/// index job without mutating canonical source content or its generation.
+/// semantic job without mutating source content or its generation.
 pub async fn retry_document(
     State(state): State<AppState>,
     Path(id): Path<DocumentId>,
@@ -560,7 +561,7 @@ pub async fn retry_document(
 }
 
 /// `POST /projects/{project_id}/documents/{document_id}/retry` — revive an owned
-/// document's current exact failed index job.
+/// document's current exact failed semantic job.
 pub async fn retry_project_document(
     State(state): State<AppState>,
     Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
@@ -583,15 +584,15 @@ async fn retry_document_in_scope(
     else {
         return Err(ServerError::not_found(format!("document {id} not found")));
     };
-    let fingerprint = state.retrieval.index_fingerprint();
+    let desired = retry_document_job_spec(&document, &state.retrieval).map_err(retrieval_error)?;
     let Some(job) = state
         .store
         .retry_document_job(
             id,
             document.generation(),
-            openwave_core::DocumentJobKind::Index,
-            &fingerprint,
-            MAX_INDEX_ATTEMPTS,
+            desired.kind,
+            &desired.pipeline_fingerprint,
+            desired.max_attempts,
         )
         .await?
     else {

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -628,6 +628,7 @@ async fn test_app_with_retrieval_and_worker(
     let token = state.token.clone();
     let worker = document_worker::DocumentWorker::new(
         store.clone(),
+        state.blobs.clone(),
         retrieval,
         state.document_job_wake.clone(),
         state.document_writes.clone(),
@@ -1353,6 +1354,97 @@ async fn explicit_retry_revives_the_exact_terminal_job() {
     assert_eq!(retried.status, openwave_core::DocumentJobStatus::Queued);
     assert_eq!(retried.attempt_count, 0);
     assert_eq!(retried.id, job_id);
+}
+
+#[tokio::test]
+async fn explicit_retry_selects_the_failed_parse_stage() {
+    use sha2::{Digest, Sha256};
+
+    let (router, token, store, dir, worker) = test_app_with_worker().await;
+    let bearer = format!("Bearer {token}");
+    let raw = b"parse retry succeeds through the durable worker".to_vec();
+    let blob_id = uuid::Uuid::new_v4();
+    let blobs = openwave_core::FsBlobStore::new(dir.path().join("blobs"));
+    openwave_core::BlobStore::put(&blobs, &blob_id.to_string(), raw.clone())
+        .await
+        .unwrap();
+    let source = openwave_core::DocumentSourceUpsert {
+        id: openwave_core::DocumentId::new(),
+        project_id: None,
+        source_uri: Some("file:///parse-retry.txt".into()),
+        media_type: "text/plain".into(),
+        title: None,
+        source_blob: openwave_core::DocumentSourceBlob {
+            id: blob_id,
+            sha256: Sha256::digest(&raw).into(),
+            byte_len: raw.len() as u64,
+        },
+        updated_at: chrono::Utc::now(),
+    };
+    let (_, parse_job) = store
+        .accept_document_source_and_enqueue_parse(&source, "plain-text-lossy-v1", 1)
+        .await
+        .unwrap();
+    let claim_at = parse_job.available_at + chrono::Duration::seconds(1);
+    let claimed = store
+        .claim_document_job(claim_at, claim_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.id, parse_job.id);
+    assert_eq!(
+        store
+            .record_document_job_failure(
+                claimed.id,
+                claimed.lease_token.unwrap(),
+                claim_at + chrono::Duration::seconds(1),
+                None,
+                "parse_failed",
+                None,
+            )
+            .await
+            .unwrap(),
+        Some(openwave_core::DocumentJobStatus::Failed)
+    );
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/documents/{}/retry", source.id))
+                .header(header::AUTHORIZATION, bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let retried = store.get_document_job(parse_job.id).await.unwrap().unwrap();
+    assert_eq!(retried.id, parse_job.id);
+    assert_eq!(retried.kind, openwave_core::DocumentJobKind::Parse);
+    assert_eq!(retried.status, openwave_core::DocumentJobStatus::Queued);
+    assert_eq!(retried.attempt_count, 0);
+    assert_eq!(retried.max_attempts, document_stage::MAX_PARSE_ATTEMPTS);
+
+    assert_eq!(
+        worker.run_once().await.unwrap(),
+        document_worker::WorkerOutcome::Completed(parse_job.id)
+    );
+    let jobs = store.list_document_jobs(source.id).await.unwrap();
+    assert_eq!(jobs.len(), 2);
+    assert_eq!(jobs[0].status, openwave_core::DocumentJobStatus::Succeeded);
+    assert_eq!(jobs[1].kind, openwave_core::DocumentJobKind::Index);
+    assert_eq!(jobs[1].status, openwave_core::DocumentJobStatus::Queued);
+    assert_eq!(
+        worker.run_once().await.unwrap(),
+        document_worker::WorkerOutcome::Completed(jobs[1].id)
+    );
+    let document = store.get_document(source.id).await.unwrap().unwrap();
+    assert_eq!(document.canonical_text.as_bytes(), raw);
+    assert_eq!(
+        document.processing_status,
+        openwave_core::DocumentProcessingStatus::Ready
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- select the current Parse or Index stage for exact explicit retries
- execute Parse jobs under the durable worker's existing lease and heartbeat supervision
- verify retained source length and SHA-256 before parsing
- publish canonical parser output and enqueue Index atomically, with end-to-end Parse retry coverage

## Validation

- `cargo test -p openwave-server`
- `cargo test -p openwave-server explicit_retry_selects_the_failed_parse_stage -- --nocapture`
- `cargo test --workspace --all-features`
- `bw dev lint --rust`
- `cargo fmt --all --check`
