### PR TITLE
Publish source blobs immutably

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5660,6 +5660,7 @@ dependencies = [
  "sea-orm-migration",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -27,6 +27,7 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["v5"] }
 chrono = { workspace = true }

--- a/crates/openwave-core/src/blob.rs
+++ b/crates/openwave-core/src/blob.rs
@@ -17,10 +17,11 @@ use crate::{AgentError, BlobStore, Result};
 /// Filesystem-backed opaque byte storage.
 ///
 /// Blob ids are UUIDs and become flat filenames under `root`; caller-controlled
-/// paths never participate in path resolution. Writes use an adjacent temporary
-/// file followed by rename, so readers see either the previous complete value or
-/// the replacement, never a partial write. Clones share an in-process lock; the
-/// server owns one instance per data directory.
+/// paths never participate in path resolution. Writes sync an adjacent temporary
+/// file before atomically publishing a new destination, so readers never observe
+/// partial bytes. Existing ids accept identical bytes idempotently and reject
+/// replacement. Clones share an in-process lock; atomic no-replace publication
+/// also coordinates independent instances using the same directory.
 #[derive(Clone)]
 pub struct FsBlobStore {
     root: Arc<PathBuf>,
@@ -78,12 +79,33 @@ impl BlobStore for FsBlobStore {
                 let _guard = access
                     .write()
                     .map_err(|_| AgentError::Store("blob store lock poisoned".into()))?;
-                replace_file(&temporary, &destination)?;
-                sync_directory(&root)?;
-                Ok(())
+                match publish_new_file(&temporary, &destination) {
+                    Ok(()) => {
+                        // The destination must be durable before best-effort
+                        // temporary-name cleanup can report or fail.
+                        sync_directory(&root)
+                    }
+                    Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                        let existing = fs::read(&destination)
+                            .map_err(|error| blob_error("read immutable file", error))?;
+                        if existing == bytes {
+                            // A retry may be observing a link published just
+                            // before a prior process crashed. Re-establish the
+                            // namespace durability barrier before acknowledging.
+                            sync_directory(&root)
+                        } else {
+                            Err(AgentError::Store(
+                                "immutable blob id already contains different bytes".into(),
+                            ))
+                        }
+                    }
+                    Err(error) => Err(blob_error("publish immutable file", error)),
+                }
             })();
-            if result.is_err() {
-                let _ = fs::remove_file(&temporary);
+            if fs::remove_file(&temporary).is_ok() {
+                // Publication is already durable. Failure to persist removal
+                // can only leave an unreferenced, hidden temporary file.
+                let _ = sync_directory(&root);
             }
             result
         })
@@ -128,16 +150,14 @@ impl BlobStore for FsBlobStore {
 }
 
 #[cfg(not(windows))]
-fn replace_file(temporary: &Path, destination: &Path) -> Result<()> {
-    fs::rename(temporary, destination).map_err(|error| blob_error("publish file", error))
+fn publish_new_file(temporary: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::hard_link(temporary, destination)
 }
 
 #[cfg(windows)]
-fn replace_file(temporary: &Path, destination: &Path) -> Result<()> {
+fn publish_new_file(temporary: &Path, destination: &Path) -> std::io::Result<()> {
     use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::{
-        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
-    };
+    use windows_sys::Win32::Storage::FileSystem::{MoveFileExW, MOVEFILE_WRITE_THROUGH};
 
     let temporary: Vec<u16> = temporary
         .as_os_str()
@@ -155,11 +175,11 @@ fn replace_file(temporary: &Path, destination: &Path) -> Result<()> {
         MoveFileExW(
             temporary.as_ptr(),
             destination.as_ptr(),
-            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            MOVEFILE_WRITE_THROUGH,
         )
     };
     if published == 0 {
-        Err(blob_error("publish file", std::io::Error::last_os_error()))
+        Err(std::io::Error::last_os_error())
     } else {
         Ok(())
     }
@@ -186,7 +206,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn roundtrips_overwrites_reopens_and_deletes_idempotently() {
+    async fn roundtrips_reopens_and_deletes_idempotently() {
         let directory = tempfile::tempdir().unwrap();
         let id = Uuid::new_v4().to_string();
         let store = FsBlobStore::new(directory.path());
@@ -206,12 +226,12 @@ mod tests {
                 .mode();
             assert_eq!(mode & 0o777, 0o600);
         }
-        store.put(&id, b"second".to_vec()).await.unwrap();
+        store.put(&id, b"first".to_vec()).await.unwrap();
 
         let reopened = FsBlobStore::new(directory.path());
         assert_eq!(
             reopened.get(&id).await.unwrap().as_deref(),
-            Some(&b"second"[..])
+            Some(&b"first"[..])
         );
         reopened.delete(&id).await.unwrap();
         reopened.delete(&id).await.unwrap();
@@ -219,20 +239,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn concurrent_overwrites_leave_one_complete_value() {
+    async fn immutable_publication_is_idempotent_and_rejects_replacement() {
         let directory = tempfile::tempdir().unwrap();
         let id = Uuid::new_v4().to_string();
         let store = FsBlobStore::new(directory.path());
+
+        store.put(&id, b"retained source".to_vec()).await.unwrap();
+        store.put(&id, b"retained source".to_vec()).await.unwrap();
+        assert!(store.put(&id, b"different source".to_vec()).await.is_err());
+        assert_eq!(
+            store.get(&id).await.unwrap().as_deref(),
+            Some(&b"retained source"[..])
+        );
+    }
+
+    #[tokio::test]
+    async fn independent_stores_choose_one_complete_immutable_value() {
+        let directory = tempfile::tempdir().unwrap();
+        let id = Uuid::new_v4().to_string();
+        let left_store = FsBlobStore::new(directory.path());
+        let right_store = FsBlobStore::new(directory.path());
         let first = vec![b'a'; 128 * 1024];
         let second = vec![b'b'; 128 * 1024];
 
         let (left, right) = tokio::join!(
-            store.put(&id, first.clone()),
-            store.put(&id, second.clone())
+            left_store.put(&id, first.clone()),
+            right_store.put(&id, second.clone())
         );
-        left.unwrap();
-        right.unwrap();
-        let stored = store.get(&id).await.unwrap().unwrap();
+        assert_ne!(left.is_ok(), right.is_ok());
+        let stored = left_store.get(&id).await.unwrap().unwrap();
         assert!(stored == first || stored == second);
     }
 

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -31,7 +31,9 @@ use crate::model::{
     DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
     Project, SourceRegion, ToolCallRecord,
 };
-use crate::storage::{DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, Store};
+use crate::storage::{
+    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, Store,
+};
 
 mod ops;
 
@@ -881,6 +883,23 @@ impl Store for DbStore {
             transaction.commit().await.map_err(store_err)?;
             return Ok(EnsureDocumentIndexJobOutcome::Enqueued(job));
         }
+    }
+
+    async fn ensure_document_parse_job(
+        &self,
+        document_id: DocumentId,
+        expected_generation: DocumentGeneration,
+        pipeline_fingerprint: &str,
+        max_attempts: i32,
+    ) -> Result<EnsureDocumentParseJobOutcome> {
+        ops::document::ensure_parse_job(
+            self,
+            document_id,
+            expected_generation,
+            pipeline_fingerprint,
+            max_attempts,
+        )
+        .await
     }
 
     async fn list_document_jobs(&self, document_id: DocumentId) -> Result<Vec<DocumentJob>> {

--- a/crates/openwave-core/src/db/ops/document.rs
+++ b/crates/openwave-core/src/db/ops/document.rs
@@ -7,6 +7,7 @@ use crate::model::{
     DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentParseOutput,
     DocumentProcessingStatus, DocumentRecord, DocumentSourceUpsert,
 };
+use crate::storage::EnsureDocumentParseJobOutcome;
 
 use super::super::{
     acquire_document_write_lock, cancel_live_document_jobs_on, document_from_model,
@@ -292,6 +293,201 @@ pub(in crate::db) async fn complete_parse_and_enqueue_index(
     let record = document_from_model(record)?;
     transaction.commit().await.map_err(store_err)?;
     Ok(Some((record, index_job)))
+}
+
+pub(in crate::db) async fn ensure_parse_job(
+    store: &DbStore,
+    document_id: DocumentId,
+    expected_generation: DocumentGeneration,
+    pipeline_fingerprint: &str,
+    max_attempts: i32,
+) -> Result<EnsureDocumentParseJobOutcome> {
+    validate_job_input(pipeline_fingerprint, max_attempts)?;
+
+    loop {
+        let transaction = store.conn.begin().await.map_err(store_err)?;
+        acquire_document_write_lock(&transaction, document_id).await?;
+        let Some(document) = entities::document::Entity::find_by_id(document_id.0)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+        else {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(EnsureDocumentParseJobOutcome::MissingDocument);
+        };
+        ensure_live_document_generation_on(&transaction, &document).await?;
+        let current_generation = DocumentGeneration {
+            content_revision: document.content_revision,
+            revision_token: document.revision_token,
+        };
+
+        if current_generation != expected_generation {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(EnsureDocumentParseJobOutcome::GenerationChanged(
+                current_generation,
+            ));
+        }
+        if document.canonical_fingerprint.as_deref() == Some(pipeline_fingerprint) {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(EnsureDocumentParseJobOutcome::CanonicalCurrent);
+        }
+        if document.source_blob_id.is_none() {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(EnsureDocumentParseJobOutcome::SourceUnavailable);
+        }
+        if let Some(candidate) = find_exact_parse_job_on(
+            &transaction,
+            document_id,
+            current_generation,
+            pipeline_fingerprint,
+        )
+        .await?
+        {
+            let job = document_job_from_model(candidate)?;
+            let outcome = if job.status == DocumentJobStatus::Failed {
+                EnsureDocumentParseJobOutcome::Failed(job)
+            } else if matches!(
+                job.status,
+                DocumentJobStatus::Queued
+                    | DocumentJobStatus::Running
+                    | DocumentJobStatus::RetryWait
+            ) {
+                EnsureDocumentParseJobOutcome::Existing(job)
+            } else {
+                return Err(AgentError::Store(format!(
+                    "document {document_id} has desired parse job {} in terminal state {} without matching canonical output",
+                    job.id,
+                    job.status.as_str()
+                )));
+            };
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(outcome);
+        }
+
+        let has_current_parse_job = entities::document_job::Entity::find()
+            .filter(entities::document_job::Column::DocumentId.eq(document_id.0))
+            .filter(
+                entities::document_job::Column::ContentRevision
+                    .eq(current_generation.content_revision),
+            )
+            .filter(
+                entities::document_job::Column::RevisionToken.eq(current_generation.revision_token),
+            )
+            .filter(entities::document_job::Column::Kind.eq(DocumentJobKind::Parse.as_str()))
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .is_some();
+        let advances_generation = document.canonical_fingerprint.is_some() || has_current_parse_job;
+        let target_generation = if advances_generation {
+            let Some(advanced) =
+                try_advance_document_generation_on(&transaction, document_id, false).await?
+            else {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            };
+            if advanced.previous != Some(current_generation) {
+                return Err(AgentError::Store(format!(
+                    "document {document_id} does not match its retained generation clock"
+                )));
+            }
+            advanced.current
+        } else {
+            current_generation
+        };
+
+        let mut update = entities::document::Entity::update_many()
+            .col_expr(
+                entities::document::Column::CanonicalText,
+                sea_orm::sea_query::Expr::value(String::new()),
+            )
+            .col_expr(
+                entities::document::Column::CanonicalFingerprint,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entities::document::Column::SourceRegions,
+                sea_orm::sea_query::Expr::value(source_regions_to_db(&[])),
+            )
+            .col_expr(
+                entities::document::Column::ProcessingStatus,
+                sea_orm::sea_query::Expr::value(DocumentProcessingStatus::Queued.as_str()),
+            )
+            .col_expr(
+                entities::document::Column::IndexedRevision,
+                sea_orm::sea_query::Expr::value(Option::<i64>::None),
+            )
+            .col_expr(
+                entities::document::Column::IndexFingerprint,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entities::document::Column::IndexedAt,
+                sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+            );
+        if advances_generation {
+            update = update
+                .col_expr(
+                    entities::document::Column::ContentRevision,
+                    sea_orm::sea_query::Expr::value(target_generation.content_revision),
+                )
+                .col_expr(
+                    entities::document::Column::RevisionToken,
+                    sea_orm::sea_query::Expr::value(target_generation.revision_token),
+                );
+        }
+        let updated = update
+            .filter(entities::document::Column::Id.eq(document_id.0))
+            .filter(
+                entities::document::Column::ContentRevision.eq(current_generation.content_revision),
+            )
+            .filter(entities::document::Column::RevisionToken.eq(current_generation.revision_token))
+            .filter(entities::document::Column::SourceBlobId.is_not_null())
+            .exec(&transaction)
+            .await
+            .map_err(store_err)?;
+        if updated.rows_affected != 1 {
+            transaction.rollback().await.map_err(store_err)?;
+            continue;
+        }
+
+        let now = Utc::now();
+        cancel_live_document_jobs_on(&transaction, document_id, now).await?;
+        let job = new_job(
+            document_id,
+            target_generation,
+            DocumentJobKind::Parse,
+            pipeline_fingerprint,
+            max_attempts,
+            now,
+        );
+        document_job_active_model(&job)
+            .insert(&transaction)
+            .await
+            .map_err(store_err)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(EnsureDocumentParseJobOutcome::Enqueued(job));
+    }
+}
+
+async fn find_exact_parse_job_on<C>(
+    connection: &C,
+    document_id: DocumentId,
+    generation: DocumentGeneration,
+    pipeline_fingerprint: &str,
+) -> Result<Option<entities::document_job::Model>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    entities::document_job::Entity::find()
+        .filter(entities::document_job::Column::DocumentId.eq(document_id.0))
+        .filter(entities::document_job::Column::ContentRevision.eq(generation.content_revision))
+        .filter(entities::document_job::Column::RevisionToken.eq(generation.revision_token))
+        .filter(entities::document_job::Column::Kind.eq(DocumentJobKind::Parse.as_str()))
+        .filter(entities::document_job::Column::PipelineFingerprint.eq(pipeline_fingerprint))
+        .one(connection)
+        .await
+        .map_err(store_err)
 }
 
 pub(in crate::db) async fn retry_document_job(

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -704,6 +704,303 @@ async fn raw_source_parse_completion_atomically_enqueues_index() {
 }
 
 #[tokio::test]
+async fn ensure_parse_job_advances_parser_changes_and_reuses_the_transition() {
+    let (_dir, store) = temp_store().await;
+    let source = DocumentSourceUpsert {
+        id: DocumentId::new(),
+        project_id: None,
+        source_uri: Some("file:///parser-upgrade.txt".into()),
+        media_type: "text/plain".into(),
+        title: None,
+        source_blob: DocumentSourceBlob {
+            id: uuid::Uuid::new_v4(),
+            sha256: [0x22; 32],
+            byte_len: 128,
+        },
+        updated_at: Utc::now(),
+    };
+    let (accepted, parse_job) = store
+        .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .ensure_document_parse_job(source.id, accepted.generation(), "parser-v1", 9)
+            .await
+            .unwrap(),
+        EnsureDocumentParseJobOutcome::Existing(parse_job.clone())
+    );
+
+    let repair_source = DocumentSourceUpsert {
+        id: DocumentId::new(),
+        source_uri: Some("file:///repair-missing-parse.txt".into()),
+        source_blob: DocumentSourceBlob {
+            id: uuid::Uuid::new_v4(),
+            sha256: [0x33; 32],
+            byte_len: 64,
+        },
+        ..source.clone()
+    };
+    let (pending, missing_parse_job) = store
+        .accept_document_source_and_enqueue_parse(&repair_source, "parser-v1", 3)
+        .await
+        .unwrap();
+    assert_eq!(pending.canonical_fingerprint, None);
+    assert_eq!(
+        entities::document_job::Entity::delete_by_id(missing_parse_job.id.0)
+            .exec(&store.conn)
+            .await
+            .unwrap()
+            .rows_affected,
+        1
+    );
+    let repaired = store
+        .ensure_document_parse_job(repair_source.id, pending.generation(), "parser-v1", 7)
+        .await
+        .unwrap();
+    let EnsureDocumentParseJobOutcome::Enqueued(repaired) = repaired else {
+        panic!("expected missing Parse work to be repaired, got {repaired:?}");
+    };
+    assert_eq!(repaired.generation(), pending.generation());
+    assert_eq!(repaired.pipeline_fingerprint, "parser-v1");
+    assert_eq!(repaired.max_attempts, 7);
+
+    let claim_at = parse_job.available_at + chrono::Duration::seconds(1);
+    let running = store
+        .claim_document_job(claim_at, claim_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .unwrap();
+    let (parsed, index_job) = store
+        .complete_document_parse_job_and_enqueue_index(
+            running.id,
+            running.lease_token.unwrap(),
+            claim_at + chrono::Duration::seconds(1),
+            &DocumentParseOutput {
+                canonical_text: "canonical v1".into(),
+                source_regions: Vec::new(),
+            },
+            "index-v1",
+            5,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        store
+            .ensure_document_parse_job(source.id, parsed.generation(), "parser-v1", 3)
+            .await
+            .unwrap(),
+        EnsureDocumentParseJobOutcome::CanonicalCurrent
+    );
+
+    let outcome = store
+        .ensure_document_parse_job(source.id, parsed.generation(), "parser-v2", 4)
+        .await
+        .unwrap();
+    let EnsureDocumentParseJobOutcome::Enqueued(reparse_job) = outcome else {
+        panic!("expected a parser-change reparse job, got {outcome:?}");
+    };
+    assert_eq!(reparse_job.kind, DocumentJobKind::Parse);
+    assert_eq!(reparse_job.pipeline_fingerprint, "parser-v2");
+    assert_eq!(reparse_job.max_attempts, 4);
+    assert_eq!(reparse_job.content_revision, parsed.content_revision + 1);
+    assert_ne!(reparse_job.revision_token, parsed.revision_token);
+    let reparsing = store.get_document(source.id).await.unwrap().unwrap();
+    assert_eq!(reparsing.generation(), reparse_job.generation());
+    assert_eq!(reparsing.source_blob, parsed.source_blob);
+    assert!(reparsing.canonical_text.is_empty());
+    assert_eq!(reparsing.canonical_fingerprint, None);
+    assert!(reparsing.source_regions.is_empty());
+    assert_eq!(
+        reparsing.processing_status,
+        DocumentProcessingStatus::Queued
+    );
+    assert_eq!(reparsing.indexed_revision, None);
+    assert_eq!(reparsing.index_fingerprint, None);
+    assert_eq!(reparsing.indexed_at, None);
+    assert_eq!(
+        store
+            .get_document_job(index_job.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        DocumentJobStatus::Cancelled
+    );
+    assert_eq!(
+        store
+            .ensure_document_parse_job(source.id, parsed.generation(), "parser-v2", 8)
+            .await
+            .unwrap(),
+        EnsureDocumentParseJobOutcome::GenerationChanged(reparse_job.generation())
+    );
+    assert_eq!(
+        store
+            .ensure_document_parse_job(source.id, reparse_job.generation(), "parser-v2", 8)
+            .await
+            .unwrap(),
+        EnsureDocumentParseJobOutcome::Existing(reparse_job)
+    );
+
+    let canonical = DocumentUpsert {
+        id: DocumentId::new(),
+        project_id: None,
+        source_uri: None,
+        media_type: "text/plain".into(),
+        title: None,
+        canonical_text: "inline canonical".into(),
+        source_regions: Vec::new(),
+        updated_at: Utc::now(),
+    };
+    let (canonical, _) = store
+        .upsert_document_and_enqueue_index(&canonical, "index-v1", 3)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .ensure_document_parse_job(canonical.id, canonical.generation(), "parser-v2", 3)
+            .await
+            .unwrap(),
+        EnsureDocumentParseJobOutcome::SourceUnavailable
+    );
+
+    let before_failure = store.get_document(source.id).await.unwrap().unwrap();
+    let jobs_before_failure = store.list_document_jobs(source.id).await.unwrap();
+    let clock_before_failure = store
+        .get_document_generation(source.id)
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_ensure_parse_job_insert
+                 BEFORE INSERT ON document_job
+                 BEGIN
+                     SELECT RAISE(FAIL, 'injected ensure Parse job failure');
+                 END;",
+        )
+        .await
+        .unwrap();
+    assert!(store
+        .ensure_document_parse_job(source.id, before_failure.generation(), "parser-v3", 3)
+        .await
+        .is_err());
+    assert_eq!(
+        store.get_document(source.id).await.unwrap(),
+        Some(before_failure)
+    );
+    assert_eq!(
+        store.list_document_jobs(source.id).await.unwrap(),
+        jobs_before_failure
+    );
+    assert_eq!(
+        store.get_document_generation(source.id).await.unwrap(),
+        Some(clock_before_failure)
+    );
+}
+
+#[tokio::test]
+async fn concurrent_ensure_parse_advances_once_and_fences_stale_callers() {
+    let (_dir, store) = temp_store().await;
+    let source = DocumentSourceUpsert {
+        id: DocumentId::new(),
+        project_id: None,
+        source_uri: Some("file:///concurrent-parser-upgrade.txt".into()),
+        media_type: "text/plain".into(),
+        title: None,
+        source_blob: DocumentSourceBlob {
+            id: uuid::Uuid::new_v4(),
+            sha256: [0x44; 32],
+            byte_len: 96,
+        },
+        updated_at: Utc::now(),
+    };
+    let (accepted, parse_job) = store
+        .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+        .await
+        .unwrap();
+    let claim_at = parse_job.available_at + chrono::Duration::seconds(1);
+    let running = store
+        .claim_document_job(claim_at, claim_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .unwrap();
+    let (parsed, _) = store
+        .complete_document_parse_job_and_enqueue_index(
+            running.id,
+            running.lease_token.unwrap(),
+            claim_at + chrono::Duration::seconds(1),
+            &DocumentParseOutput {
+                canonical_text: "canonical v1".into(),
+                source_regions: Vec::new(),
+            },
+            "index-v1",
+            3,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(parsed.generation(), accepted.generation());
+
+    let document_id = source.id;
+    let observed_generation = parsed.generation();
+    let store = std::sync::Arc::new(store);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .ensure_document_parse_job(document_id, observed_generation, "parser-v2", 5)
+                .await
+                .unwrap()
+        }));
+    }
+
+    let mut enqueued = None;
+    let mut fenced = 0;
+    for task in tasks {
+        match task.await.unwrap() {
+            EnsureDocumentParseJobOutcome::Enqueued(job) => {
+                assert!(enqueued.replace(job).is_none());
+            }
+            EnsureDocumentParseJobOutcome::GenerationChanged(generation) => {
+                assert_eq!(
+                    generation.content_revision,
+                    observed_generation.content_revision + 1
+                );
+                fenced += 1;
+            }
+            outcome => panic!("unexpected concurrent ensure outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!(fenced, 7);
+    let enqueued = enqueued.expect("one caller must enqueue the parser upgrade");
+    let current = store.get_document(document_id).await.unwrap().unwrap();
+    assert_eq!(current.generation(), enqueued.generation());
+    assert_eq!(
+        current.content_revision,
+        observed_generation.content_revision + 1
+    );
+    let jobs = store.list_document_jobs(document_id).await.unwrap();
+    assert_eq!(jobs.len(), 3);
+    assert_eq!(
+        jobs.iter()
+            .filter(|job| {
+                job.generation() == current.generation()
+                    && job.kind == DocumentJobKind::Parse
+                    && job.pipeline_fingerprint == "parser-v2"
+            })
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn document_job_schema_enforces_delivery_and_idempotency_invariants() {
     let (_dir, store) = temp_store().await;
     let document = sample_document(None);
@@ -2133,6 +2430,15 @@ async fn explicit_retry_revives_only_the_pending_parse_stage() {
             .await
             .unwrap(),
         Some(DocumentJobStatus::Failed)
+    );
+    assert_eq!(
+        store
+            .ensure_document_parse_job(source.id, document.generation(), "parser=pdf-v1", 5,)
+            .await
+            .unwrap(),
+        EnsureDocumentParseJobOutcome::Failed(
+            store.get_document_job(queued.id).await.unwrap().unwrap()
+        )
     );
 
     assert_eq!(

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -62,7 +62,8 @@ pub use provider::{
 };
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
-    BlobStore, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, SecretProvider, Store,
+    BlobStore, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
+    EnsureDocumentParseJobOutcome, SecretProvider, Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::num::NonZeroU32;
 use uuid::Uuid;
 
@@ -169,6 +170,21 @@ pub struct DocumentSourceBlob {
     pub sha256: [u8; 32],
     /// Exact source byte length.
     pub byte_len: u64,
+}
+
+impl DocumentSourceBlob {
+    const CONTENT_NAMESPACE: Uuid = Uuid::from_u128(0xd262_91eb_f9f7_5b4d_a65d_4a44_70f8_081f);
+
+    /// Describe source bytes using a deterministic content-addressed UUID.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        let sha256: [u8; 32] = Sha256::digest(bytes).into();
+        Self {
+            id: Uuid::new_v5(&Self::CONTENT_NAMESPACE, &sha256),
+            sha256,
+            byte_len: u64::try_from(bytes.len()).expect("source byte length exceeds u64"),
+        }
+    }
 }
 
 /// Metadata and immutable bytes accepted for asynchronous document parsing.
@@ -565,6 +581,22 @@ mod tests {
         );
         assert!(DocumentJobStatus::Succeeded.is_terminal());
         assert!(!DocumentJobStatus::Running.is_terminal());
+    }
+
+    #[test]
+    fn source_blob_identity_is_deterministic_and_content_addressed() {
+        let first = DocumentSourceBlob::from_bytes(b"same source bytes");
+        assert_eq!(first, DocumentSourceBlob::from_bytes(b"same source bytes"));
+        assert_eq!(first.byte_len, 17);
+        assert_eq!(
+            first.sha256,
+            <[u8; 32]>::from(Sha256::digest(b"same source bytes"))
+        );
+        assert_eq!(
+            first.id,
+            Uuid::parse_str("bb06b189-790a-5087-89fd-767534773c0f").unwrap()
+        );
+        assert_ne!(first.id, DocumentSourceBlob::from_bytes(b"other").id);
     }
 
     fn page_region(start: usize, end: usize, page: u32) -> SourceRegion {

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -489,7 +489,11 @@ pub trait SecretProvider: Send + Sync {
 /// Opaque byte storage for documents, images, and exports.
 #[async_trait]
 pub trait BlobStore: Send + Sync {
-    /// Store bytes under `id`, overwriting any existing blob.
+    /// Publish immutable bytes under `id`.
+    ///
+    /// Repeating the same publication is a no-op; publishing different bytes
+    /// under an existing id fails without changing the stored value. Callers
+    /// allocate a new id when content changes.
     async fn put(&self, id: &str, bytes: Vec<u8>) -> Result<()>;
 
     /// Fetch bytes by `id`, or `None` if absent.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -64,6 +64,25 @@ pub enum EnsureDocumentIndexJobOutcome {
     GenerationChanged(DocumentGeneration),
 }
 
+/// Result of atomically ensuring canonical output from one parser pipeline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EnsureDocumentParseJobOutcome {
+    /// A new Parse job was inserted for the desired generation.
+    Enqueued(DocumentJob),
+    /// The desired current Parse job already exists and remains live.
+    Existing(DocumentJob),
+    /// The desired current Parse job exhausted its attempts.
+    Failed(DocumentJob),
+    /// Canonical output already came from the desired parser.
+    CanonicalCurrent,
+    /// Reparse was requested for a document without retained source bytes.
+    SourceUnavailable,
+    /// The source document no longer exists.
+    MissingDocument,
+    /// The caller inspected an obsolete source generation.
+    GenerationChanged(DocumentGeneration),
+}
+
 fn document_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "document storage is not implemented by this Store".into(),
@@ -262,6 +281,23 @@ pub trait Store: Send + Sync {
         _max_attempts: i32,
         _reason: DocumentIndexJobReason,
     ) -> Result<EnsureDocumentIndexJobOutcome> {
+        document_storage_unavailable()
+    }
+
+    /// Atomically establish the desired Parse job for retained source bytes.
+    ///
+    /// The caller's observed generation is a compare-and-swap fence. Missing
+    /// work for pending canonical output is repaired in that generation; a
+    /// parser change advances the generation once, clears derived canonical and
+    /// index state, and enqueues Parse without changing retained source fields.
+    /// Failed work remains failed until an explicit retry.
+    async fn ensure_document_parse_job(
+        &self,
+        _document_id: DocumentId,
+        _expected_generation: DocumentGeneration,
+        _pipeline_fingerprint: &str,
+        _max_attempts: i32,
+    ) -> Result<EnsureDocumentParseJobOutcome> {
         document_storage_unavailable()
     }
 
@@ -1034,6 +1070,119 @@ mod tests {
             };
             state.jobs.insert(job.id, job.clone());
             Ok(EnsureDocumentIndexJobOutcome::Enqueued(job))
+        }
+        async fn ensure_document_parse_job(
+            &self,
+            document_id: DocumentId,
+            expected_generation: DocumentGeneration,
+            pipeline_fingerprint: &str,
+            max_attempts: i32,
+        ) -> Result<EnsureDocumentParseJobOutcome> {
+            if pipeline_fingerprint.is_empty()
+                || pipeline_fingerprint.chars().count() > DocumentJob::MAX_PIPELINE_FINGERPRINT_LEN
+                || max_attempts < 1
+            {
+                return Err(AgentError::Store(
+                    "invalid document parse-job maintenance request".into(),
+                ));
+            }
+
+            let mut state = self.document_state.lock().unwrap();
+            let Some(mut document) = state.documents.get(&document_id).cloned() else {
+                return Ok(EnsureDocumentParseJobOutcome::MissingDocument);
+            };
+            if document.generation() != expected_generation {
+                return Ok(EnsureDocumentParseJobOutcome::GenerationChanged(
+                    document.generation(),
+                ));
+            }
+            if document.canonical_fingerprint.as_deref() == Some(pipeline_fingerprint) {
+                return Ok(EnsureDocumentParseJobOutcome::CanonicalCurrent);
+            }
+            if document.source_blob.is_none() {
+                return Ok(EnsureDocumentParseJobOutcome::SourceUnavailable);
+            }
+            if let Some(job) = state.jobs.values().find(|job| {
+                job.document_id == document_id
+                    && job.generation() == document.generation()
+                    && job.kind == DocumentJobKind::Parse
+                    && job.pipeline_fingerprint == pipeline_fingerprint
+            }) {
+                return Ok(if job.status == DocumentJobStatus::Failed {
+                    EnsureDocumentParseJobOutcome::Failed(job.clone())
+                } else if matches!(
+                    job.status,
+                    DocumentJobStatus::Queued
+                        | DocumentJobStatus::Running
+                        | DocumentJobStatus::RetryWait
+                ) {
+                    EnsureDocumentParseJobOutcome::Existing(job.clone())
+                } else {
+                    return Err(AgentError::Store(format!(
+                        "document {document_id} has desired parse job {} in terminal state {} without matching canonical output",
+                        job.id,
+                        job.status.as_str()
+                    )));
+                });
+            }
+
+            let has_current_parse_job = state.jobs.values().any(|job| {
+                job.document_id == document_id
+                    && job.generation() == document.generation()
+                    && job.kind == DocumentJobKind::Parse
+            });
+            if document.canonical_fingerprint.is_some() || has_current_parse_job {
+                let generation = allocate_mem_generation(&mut state, document_id)?;
+                document.content_revision = generation.content_revision;
+                document.revision_token = generation.revision_token;
+            }
+            document.canonical_text.clear();
+            document.canonical_fingerprint = None;
+            document.source_regions.clear();
+            document.processing_status = DocumentProcessingStatus::Queued;
+            document.indexed_revision = None;
+            document.index_fingerprint = None;
+            document.indexed_at = None;
+            state.documents.insert(document_id, document.clone());
+
+            let now = chrono::Utc::now();
+            for job in state.jobs.values_mut().filter(|job| {
+                job.document_id == document_id
+                    && matches!(
+                        job.status,
+                        DocumentJobStatus::Queued
+                            | DocumentJobStatus::Running
+                            | DocumentJobStatus::RetryWait
+                    )
+            }) {
+                job.status = DocumentJobStatus::Cancelled;
+                job.lease_token = None;
+                job.lease_expires_at = None;
+                job.finished_at = Some(now);
+                job.updated_at = now;
+            }
+            let job = DocumentJob {
+                id: DocumentJobId::new(),
+                document_id,
+                content_revision: document.content_revision,
+                revision_token: document.revision_token,
+                kind: DocumentJobKind::Parse,
+                status: DocumentJobStatus::Queued,
+                pipeline_fingerprint: pipeline_fingerprint.into(),
+                attempt_count: 0,
+                max_attempts,
+                available_at: now,
+                lease_token: None,
+                lease_expires_at: None,
+                started_at: None,
+                finished_at: None,
+                last_error_code: None,
+                last_error_detail: None,
+                created_at: now,
+                updated_at: now,
+            };
+            state.jobs.insert(job.id, job.clone());
+            Ok(EnsureDocumentParseJobOutcome::Enqueued(job))
         }
         async fn get_document_job(&self, id: DocumentJobId) -> Result<Option<DocumentJob>> {
             Ok(self.document_state.lock().unwrap().jobs.get(&id).cloned())
@@ -2028,6 +2177,107 @@ mod tests {
     }
 
     #[test]
+    fn mem_store_ensure_parse_job_advances_parser_changes_once() {
+        let store = MemStore::default();
+        let now = chrono::Utc::now();
+        let document_id = DocumentId::new();
+        let generation = DocumentGeneration {
+            content_revision: 1,
+            revision_token: uuid::Uuid::new_v4(),
+        };
+        let index_job = DocumentJob {
+            id: DocumentJobId::new(),
+            document_id,
+            content_revision: generation.content_revision,
+            revision_token: generation.revision_token,
+            kind: DocumentJobKind::Index,
+            status: DocumentJobStatus::Queued,
+            pipeline_fingerprint: "index-v1".into(),
+            attempt_count: 0,
+            max_attempts: 3,
+            available_at: now,
+            lease_token: None,
+            lease_expires_at: None,
+            started_at: None,
+            finished_at: None,
+            last_error_code: None,
+            last_error_detail: None,
+            created_at: now,
+            updated_at: now,
+        };
+        {
+            let mut state = store.document_state.lock().unwrap();
+            state.generations.insert(document_id, generation);
+            state.documents.insert(
+                document_id,
+                DocumentRecord {
+                    id: document_id,
+                    project_id: None,
+                    source_uri: Some("file:///parser-upgrade.txt".into()),
+                    media_type: "text/plain".into(),
+                    title: None,
+                    source_blob: Some(crate::model::DocumentSourceBlob {
+                        id: uuid::Uuid::new_v4(),
+                        sha256: [0x22; 32],
+                        byte_len: 128,
+                    }),
+                    canonical_text: "canonical v1".into(),
+                    canonical_fingerprint: Some("parser-v1".into()),
+                    source_regions: Vec::new(),
+                    content_revision: generation.content_revision,
+                    revision_token: generation.revision_token,
+                    processing_status: DocumentProcessingStatus::Queued,
+                    indexed_revision: None,
+                    index_fingerprint: None,
+                    created_at: now,
+                    updated_at: now,
+                    indexed_at: None,
+                },
+            );
+            state.jobs.insert(index_job.id, index_job.clone());
+        }
+
+        let outcome =
+            block_on(store.ensure_document_parse_job(document_id, generation, "parser-v2", 4))
+                .unwrap();
+        let EnsureDocumentParseJobOutcome::Enqueued(reparse_job) = outcome else {
+            panic!("expected a parser-change reparse job, got {outcome:?}");
+        };
+        assert_eq!(reparse_job.content_revision, 2);
+        assert_eq!(reparse_job.kind, DocumentJobKind::Parse);
+        assert_eq!(
+            block_on(store.get_document_job(index_job.id))
+                .unwrap()
+                .unwrap()
+                .status,
+            DocumentJobStatus::Cancelled
+        );
+        let reparsing = block_on(store.get_document(document_id)).unwrap().unwrap();
+        assert_eq!(reparsing.generation(), reparse_job.generation());
+        assert!(reparsing.canonical_text.is_empty());
+        assert_eq!(reparsing.canonical_fingerprint, None);
+        assert_eq!(
+            reparsing.processing_status,
+            DocumentProcessingStatus::Queued
+        );
+        assert_eq!(
+            block_on(store.ensure_document_parse_job(document_id, generation, "parser-v2", 8,))
+                .unwrap(),
+            EnsureDocumentParseJobOutcome::GenerationChanged(reparse_job.generation())
+        );
+        assert_eq!(
+            block_on(store.ensure_document_parse_job(
+                document_id,
+                reparse_job.generation(),
+                "parser-v2",
+                8,
+            ))
+            .unwrap(),
+            EnsureDocumentParseJobOutcome::Existing(reparse_job)
+        );
+    }
+
+    #[test]
     fn mem_store_explicit_retry_only_revives_current_failed_index_job() {
         let store = MemStore::default();
         let source = DocumentUpsert {
@@ -2279,6 +2529,12 @@ mod tests {
             );
             state.jobs.insert(job.id, job.clone());
         }
+
+        assert_eq!(
+            block_on(store.ensure_document_parse_job(document_id, generation, "parser=pdf-v1", 5,))
+                .unwrap(),
+            EnsureDocumentParseJobOutcome::Failed(job.clone())
+        );
 
         assert_eq!(
             block_on(store.retry_document_job(

--- a/crates/openwave-server/src/document_auditor.rs
+++ b/crates/openwave-server/src/document_auditor.rs
@@ -4,12 +4,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use openwave_core::{
-    DocumentId, DocumentIndexJobReason, DocumentJobStatus, DocumentProcessingStatus, DocumentScope,
-    EnsureDocumentIndexJobOutcome, Result, Store,
+    DocumentId, DocumentIndexJobReason, DocumentJobKind, DocumentJobStatus,
+    DocumentProcessingStatus, DocumentScope, EnsureDocumentIndexJobOutcome,
+    EnsureDocumentParseJobOutcome, Result, Store,
 };
 use openwave_retrieval::{Document, DocumentGenerationState, DocumentSource, Retriever};
 use tokio::sync::Notify;
 
+use crate::document_stage::MAX_PARSE_ATTEMPTS;
 use crate::document_worker::MAX_INDEX_ATTEMPTS;
 use crate::state::DocumentWriteGuard;
 
@@ -142,15 +144,58 @@ impl DocumentAuditor {
             report.skipped += 1;
             return Ok(());
         };
+
+        if document.source_blob.is_some() {
+            let parser_fingerprint = self
+                .retrieval
+                .canonical_fingerprint_for(&document.media_type);
+            let parser_fingerprint = match parser_fingerprint {
+                Ok(fingerprint) => Some(fingerprint),
+                Err(_) if document.canonical_fingerprint.is_some() => None,
+                Err(_) => {
+                    report.skipped += 1;
+                    return Ok(());
+                }
+            };
+            if let Some(parser_fingerprint) = parser_fingerprint {
+                match self
+                    .store
+                    .ensure_document_parse_job(
+                        document_id,
+                        document.generation(),
+                        &parser_fingerprint,
+                        MAX_PARSE_ATTEMPTS,
+                    )
+                    .await?
+                {
+                    EnsureDocumentParseJobOutcome::Enqueued(_) => {
+                        report.enqueued += 1;
+                        return Ok(());
+                    }
+                    EnsureDocumentParseJobOutcome::Failed(_) => {
+                        report.failed_jobs += 1;
+                        return Ok(());
+                    }
+                    EnsureDocumentParseJobOutcome::Existing(_)
+                    | EnsureDocumentParseJobOutcome::SourceUnavailable
+                    | EnsureDocumentParseJobOutcome::MissingDocument
+                    | EnsureDocumentParseJobOutcome::GenerationChanged(_) => {
+                        report.skipped += 1;
+                        return Ok(());
+                    }
+                    EnsureDocumentParseJobOutcome::CanonicalCurrent => {}
+                }
+            }
+        }
+
         let jobs = self.store.list_document_jobs(document_id).await?;
         let current_jobs: Vec<_> = jobs
             .iter()
             .filter(|job| job.generation() == document.generation())
             .collect();
-        let desired_job = current_jobs
-            .iter()
-            .copied()
-            .find(|job| job.pipeline_fingerprint == fingerprint);
+        let desired_job = current_jobs.iter().copied().find(|job| {
+            job.kind == DocumentJobKind::Index && job.pipeline_fingerprint == fingerprint
+        });
 
         if desired_job.is_some_and(|job| {
             matches!(
@@ -172,9 +217,12 @@ impl DocumentAuditor {
             .index_fingerprint
             .as_deref()
             .is_some_and(|indexed| indexed != fingerprint)
-            || (!current_jobs.is_empty()
+            || (current_jobs
+                .iter()
+                .any(|job| job.kind == DocumentJobKind::Index)
                 && current_jobs
                     .iter()
+                    .filter(|job| job.kind == DocumentJobKind::Index)
                     .all(|job| job.pipeline_fingerprint != fingerprint));
         let reason = if known_pipeline_changed {
             DocumentIndexJobReason::PipelineChanged
@@ -276,7 +324,8 @@ fn canonical_document(record: &openwave_core::DocumentRecord) -> Document {
 mod tests {
     use chrono::Utc;
     use openwave_core::{
-        ByteSpan, DbStore, DocumentJobStatus, DocumentProcessingStatus, DocumentUpsert,
+        ByteSpan, DbStore, DocumentJobKind, DocumentJobStatus, DocumentParseOutput,
+        DocumentProcessingStatus, DocumentSourceBlob, DocumentSourceUpsert, DocumentUpsert,
         SourceLocation, SourceRegion,
     };
     use openwave_retrieval::{
@@ -313,6 +362,22 @@ mod tests {
             title: None,
             canonical_text: text.into(),
             source_regions: Vec::new(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn raw_source(id: DocumentId) -> DocumentSourceUpsert {
+        DocumentSourceUpsert {
+            id,
+            project_id: None,
+            source_uri: Some("file:///audited-source.txt".into()),
+            media_type: "text/plain".into(),
+            title: None,
+            source_blob: DocumentSourceBlob {
+                id: uuid::Uuid::new_v4(),
+                sha256: [0x55; 32],
+                byte_len: 128,
+            },
             updated_at: Utc::now(),
         }
     }
@@ -423,6 +488,212 @@ mod tests {
         assert_eq!(
             store.get_document(id).await.unwrap().unwrap().generation(),
             advanced.generation()
+        );
+    }
+
+    #[tokio::test]
+    async fn parser_change_advances_once_and_enqueues_parse_before_index_audit() {
+        let (_dir, store, retrieval) = harness().await;
+        let id = DocumentId::new();
+        let source = raw_source(id);
+        let (accepted, parse_job) = store
+            .accept_document_source_and_enqueue_parse(&source, "old-parser", 3)
+            .await
+            .unwrap();
+        let claim_at = parse_job.available_at + chrono::Duration::seconds(1);
+        let running = store
+            .claim_document_job(claim_at, claim_at + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .unwrap();
+        let (parsed, old_index_job) = store
+            .complete_document_parse_job_and_enqueue_index(
+                running.id,
+                running.lease_token.unwrap(),
+                claim_at + chrono::Duration::seconds(1),
+                &DocumentParseOutput {
+                    canonical_text: "old canonical output".into(),
+                    source_regions: Vec::new(),
+                },
+                &retrieval.index_fingerprint(),
+                3,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(parsed.generation(), accepted.generation());
+
+        let auditor = auditor(store.clone(), retrieval.clone());
+        let first = auditor.audit_once().await.unwrap();
+        assert_eq!(first.enqueued, 1);
+        assert_eq!(first.failed_jobs, 0);
+        let reparsing = store.get_document(id).await.unwrap().unwrap();
+        assert_eq!(reparsing.content_revision, parsed.content_revision + 1);
+        assert!(reparsing.canonical_text.is_empty());
+        assert_eq!(reparsing.canonical_fingerprint, None);
+        assert_eq!(
+            store
+                .get_document_job(old_index_job.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            DocumentJobStatus::Cancelled
+        );
+        let desired_parser = retrieval
+            .canonical_fingerprint_for(&source.media_type)
+            .unwrap();
+        let jobs = store.list_document_jobs(id).await.unwrap();
+        assert!(jobs.iter().any(|job| {
+            job.generation() == reparsing.generation()
+                && job.kind == DocumentJobKind::Parse
+                && job.pipeline_fingerprint == desired_parser
+                && job.status == DocumentJobStatus::Queued
+        }));
+
+        let second = auditor.audit_once().await.unwrap();
+        assert_eq!(second.enqueued, 0);
+        assert_eq!(second.skipped, 1);
+        assert_eq!(
+            store.get_document(id).await.unwrap().unwrap().generation(),
+            reparsing.generation()
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_parse_remains_behind_explicit_retry() {
+        let (_dir, store, retrieval) = harness().await;
+        let source = raw_source(DocumentId::new());
+        let parser_fingerprint = retrieval
+            .canonical_fingerprint_for(&source.media_type)
+            .unwrap();
+        let (_, parse_job) = store
+            .accept_document_source_and_enqueue_parse(&source, &parser_fingerprint, 1)
+            .await
+            .unwrap();
+        let claim_at = parse_job.available_at + chrono::Duration::seconds(1);
+        let running = store
+            .claim_document_job(claim_at, claim_at + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            store
+                .record_document_job_failure(
+                    running.id,
+                    running.lease_token.unwrap(),
+                    claim_at + chrono::Duration::seconds(1),
+                    None,
+                    "parse_failed",
+                    None,
+                )
+                .await
+                .unwrap(),
+            Some(DocumentJobStatus::Failed)
+        );
+
+        let report = auditor(store.clone(), retrieval)
+            .audit_once()
+            .await
+            .unwrap();
+        assert_eq!(report.enqueued, 0);
+        assert_eq!(report.failed_jobs, 1);
+        assert_eq!(
+            store
+                .get_document_job(parse_job.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            DocumentJobStatus::Failed
+        );
+    }
+
+    #[tokio::test]
+    async fn unsupported_retained_media_is_stable_and_does_not_block_canonical_index_repair() {
+        let (_dir, store, retrieval) = harness().await;
+        let canonical_id = DocumentId::new();
+        let mut canonical_source = raw_source(canonical_id);
+        canonical_source.media_type = "application/pdf".into();
+        let (_, parse_job) = store
+            .accept_document_source_and_enqueue_parse(&canonical_source, "removed-pdf-parser", 3)
+            .await
+            .unwrap();
+        let claim_at = parse_job.available_at + chrono::Duration::seconds(1);
+        let running = store
+            .claim_document_job(claim_at, claim_at + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .unwrap();
+        let (canonical, old_index_job) = store
+            .complete_document_parse_job_and_enqueue_index(
+                running.id,
+                running.lease_token.unwrap(),
+                claim_at + chrono::Duration::seconds(1),
+                &DocumentParseOutput {
+                    canonical_text: "usable canonical PDF text".into(),
+                    source_regions: Vec::new(),
+                },
+                "old-index",
+                3,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let pending_id = DocumentId::new();
+        let mut pending_source = raw_source(pending_id);
+        pending_source.media_type = "application/pdf".into();
+        let (pending, pending_parse_job) = store
+            .accept_document_source_and_enqueue_parse(&pending_source, "removed-pdf-parser", 3)
+            .await
+            .unwrap();
+
+        let report = auditor(store.clone(), retrieval.clone())
+            .audit_once()
+            .await
+            .unwrap();
+        assert_eq!(report.scanned, 2);
+        assert_eq!(report.enqueued, 1);
+        assert_eq!(report.skipped, 1);
+        assert!(report.failures.is_empty());
+
+        let repaired = store.get_document(canonical_id).await.unwrap().unwrap();
+        assert_eq!(repaired.content_revision, canonical.content_revision + 1);
+        assert_eq!(repaired.canonical_text, canonical.canonical_text);
+        assert_eq!(
+            store
+                .get_document_job(old_index_job.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            DocumentJobStatus::Cancelled
+        );
+        assert!(store
+            .list_document_jobs(canonical_id)
+            .await
+            .unwrap()
+            .iter()
+            .any(|job| {
+                job.generation() == repaired.generation()
+                    && job.kind == DocumentJobKind::Index
+                    && job.pipeline_fingerprint == retrieval.index_fingerprint()
+                    && job.status == DocumentJobStatus::Queued
+            }));
+
+        assert_eq!(
+            store.get_document(pending_id).await.unwrap().unwrap(),
+            pending
+        );
+        assert_eq!(
+            store
+                .get_document_job(pending_parse_job.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            DocumentJobStatus::Queued
         );
     }
 


### PR DESCRIPTION
## Summary

- derive retained source-blob UUIDs deterministically from the full SHA-256 digest
- make blob publication immutable and idempotent: identical repeats succeed and mismatched replacements fail
- publish complete synced files with atomic no-replace semantics across independent store instances
- preserve crash durability with directory sync on Unix and no-replace `MOVEFILE_WRITE_THROUGH` on Windows

## Validation

- `cargo test -p openwave-core --no-default-features`
- `cargo test -p openwave-core --all-features`
- `bw dev lint --rust`
- golden content-ID, idempotence, mismatch, reopen, and independent-store contention coverage

Stacked after #95; this branch will be rebased onto `main` as its parents land independently.
