### PR TITLE
Enforce source blob content identity

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -124,6 +124,11 @@ impl Store for DbStore {
 
     async fn create_document(&self, document: &DocumentRecord) -> Result<()> {
         validate_document_source_regions(&document.canonical_text, &document.source_regions)?;
+        let source_byte_len = document
+            .source_blob
+            .as_ref()
+            .map(validate_document_source_blob)
+            .transpose()?;
         let transaction = self.conn.begin().await.map_err(store_err)?;
         acquire_document_write_lock(&transaction, document.id).await?;
         let revision_token = uuid::Uuid::new_v4();
@@ -150,12 +155,7 @@ impl Store for DbStore {
                 .source_blob
                 .as_ref()
                 .map(|blob| blob.sha256.to_vec())),
-            source_byte_len: Set(document
-                .source_blob
-                .as_ref()
-                .map(|blob| i64::try_from(blob.byte_len))
-                .transpose()
-                .map_err(|_| AgentError::Store("document source is too large".into()))?),
+            source_byte_len: Set(source_byte_len),
             canonical_text: Set(document.canonical_text.clone()),
             canonical_fingerprint: Set(document.canonical_fingerprint.clone()),
             source_regions: Set(source_regions_to_db(&document.source_regions)),
@@ -2295,6 +2295,16 @@ fn validate_document_source_regions(text: &str, regions: &[SourceRegion]) -> Res
         .map_err(|message| AgentError::Store(format!("invalid document source regions: {message}")))
 }
 
+fn validate_document_source_blob(blob: &DocumentSourceBlob) -> Result<i64> {
+    if !blob.has_content_addressed_id() {
+        return Err(AgentError::Store(
+            "document source blob id does not match its SHA-256 digest".into(),
+        ));
+    }
+    i64::try_from(blob.byte_len)
+        .map_err(|_| AgentError::Store("document source is too large".into()))
+}
+
 fn source_regions_to_db(regions: &[SourceRegion]) -> Value {
     serde_json::to_value(regions).expect("SourceRegion serialization is infallible")
 }
@@ -2319,11 +2329,17 @@ fn source_blob_from_model(
             let byte_len = u64::try_from(byte_len).map_err(|_| {
                 AgentError::Store("stored document source length must be nonnegative".into())
             })?;
-            Ok(Some(DocumentSourceBlob {
+            let blob = DocumentSourceBlob {
                 id,
                 sha256,
                 byte_len,
-            }))
+            };
+            if !blob.has_content_addressed_id() {
+                return Err(AgentError::Store(
+                    "stored document source blob id does not match its SHA-256 digest".into(),
+                ));
+            }
+            Ok(Some(blob))
         }
         _ => Err(AgentError::Store(
             "stored document source descriptor is incomplete".into(),

--- a/crates/openwave-core/src/db/ops/document.rs
+++ b/crates/openwave-core/src/db/ops/document.rs
@@ -14,7 +14,7 @@ use super::super::{
     document_job_active_model, document_job_from_model, document_job_lease_is_live,
     ensure_live_document_generation_on, ensure_resolution_document_matches, entities,
     source_regions_to_db, store_err, try_advance_document_generation_on,
-    validate_document_source_regions, DbStore,
+    validate_document_source_blob, validate_document_source_regions, DbStore,
 };
 
 pub(in crate::db) async fn accept_source_and_enqueue_parse(
@@ -684,8 +684,7 @@ fn validate_source_input(
     if source.media_type.is_empty() || source.source_uri.as_deref() == Some("") {
         return Err(AgentError::Store("invalid document source metadata".into()));
     }
-    i64::try_from(source.source_blob.byte_len)
-        .map_err(|_| AgentError::Store("document source is too large".into()))?;
+    validate_document_source_blob(&source.source_blob)?;
     validate_job_input(parser_fingerprint, max_attempts)
 }
 

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -157,11 +157,7 @@ async fn documents_roundtrip_and_list_by_corpus_scope() {
     in_a.indexed_at = Some(DateTime::<Utc>::from_timestamp(2_001, 0).unwrap());
     let mut in_b = sample_document(Some(project_b.id));
     in_b.created_at = DateTime::<Utc>::from_timestamp(3_000, 0).unwrap();
-    in_b.source_blob = Some(DocumentSourceBlob {
-        id: uuid::Uuid::new_v4(),
-        sha256: [0x5a; 32],
-        byte_len: 8_192,
-    });
+    in_b.source_blob = Some(DocumentSourceBlob::from_digest([0x5a; 32], 8_192));
     in_b.canonical_fingerprint = Some("parser=markdown-v1".into());
 
     for document in [&unscoped, &in_a, &in_b] {
@@ -417,12 +413,18 @@ async fn document_constraints_reject_invalid_catalog_state() {
     assert!(store.create_document(&invalid_regions).await.is_err());
 
     let mut oversized_source = sample_document(None);
-    oversized_source.source_blob = Some(DocumentSourceBlob {
-        id: uuid::Uuid::new_v4(),
-        sha256: [0; 32],
-        byte_len: u64::MAX,
-    });
+    oversized_source.source_blob = Some(DocumentSourceBlob::from_digest([0; 32], u64::MAX));
     assert!(store.create_document(&oversized_source).await.is_err());
+
+    let mut invalid_source_id = sample_document(None);
+    let mut invalid_blob = DocumentSourceBlob::from_digest([0x11; 32], 512);
+    invalid_blob.id = uuid::Uuid::new_v4();
+    invalid_source_id.source_blob = Some(invalid_blob);
+    assert!(store.create_document(&invalid_source_id).await.is_err());
+    assert_eq!(
+        store.get_document(invalid_source_id.id).await.unwrap(),
+        None
+    );
 
     let mut empty_parser_fingerprint = sample_document(None);
     empty_parser_fingerprint.canonical_fingerprint = Some(String::new());
@@ -432,11 +434,7 @@ async fn document_constraints_reject_invalid_catalog_state() {
         .is_err());
 
     let mut valid_source = sample_document(None);
-    valid_source.source_blob = Some(DocumentSourceBlob {
-        id: uuid::Uuid::new_v4(),
-        sha256: [0x22; 32],
-        byte_len: 512,
-    });
+    valid_source.source_blob = Some(DocumentSourceBlob::from_digest([0x22; 32], 512));
     store.create_document(&valid_source).await.unwrap();
     assert!(entities::document::Entity::update_many()
         .col_expr(
@@ -447,6 +445,16 @@ async fn document_constraints_reject_invalid_catalog_state() {
         .exec(&store.conn)
         .await
         .is_err());
+    entities::document::Entity::update_many()
+        .col_expr(
+            entities::document::Column::SourceBlobId,
+            sea_orm::sea_query::Expr::value(Some(uuid::Uuid::new_v4())),
+        )
+        .filter(entities::document::Column::Id.eq(valid_source.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert!(store.get_document(valid_source.id).await.is_err());
 }
 
 #[tokio::test]
@@ -509,13 +517,20 @@ async fn raw_source_parse_completion_atomically_enqueues_index() {
         source_uri: Some("file:///report.pdf".into()),
         media_type: "application/pdf".into(),
         title: Some("Report".into()),
-        source_blob: DocumentSourceBlob {
-            id: uuid::Uuid::new_v4(),
-            sha256: [0x33; 32],
-            byte_len: 4_096,
-        },
+        source_blob: DocumentSourceBlob::from_digest([0x33; 32], 4_096),
         updated_at: Utc::now(),
     };
+
+    let mut invalid = source.clone();
+    invalid.source_blob.id = uuid::Uuid::new_v4();
+    let error = store
+        .accept_document_source_and_enqueue_parse(&invalid, "parser=pdf-v1", 3)
+        .await
+        .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("blob id does not match its SHA-256 digest"));
+    assert_eq!(store.get_document(source.id).await.unwrap(), None);
 
     let (accepted, parse_job) = store
         .accept_document_source_and_enqueue_parse(&source, "parser=pdf-v1", 3)
@@ -712,11 +727,7 @@ async fn ensure_parse_job_advances_parser_changes_and_reuses_the_transition() {
         source_uri: Some("file:///parser-upgrade.txt".into()),
         media_type: "text/plain".into(),
         title: None,
-        source_blob: DocumentSourceBlob {
-            id: uuid::Uuid::new_v4(),
-            sha256: [0x22; 32],
-            byte_len: 128,
-        },
+        source_blob: DocumentSourceBlob::from_digest([0x22; 32], 128),
         updated_at: Utc::now(),
     };
     let (accepted, parse_job) = store
@@ -734,11 +745,7 @@ async fn ensure_parse_job_advances_parser_changes_and_reuses_the_transition() {
     let repair_source = DocumentSourceUpsert {
         id: DocumentId::new(),
         source_uri: Some("file:///repair-missing-parse.txt".into()),
-        source_blob: DocumentSourceBlob {
-            id: uuid::Uuid::new_v4(),
-            sha256: [0x33; 32],
-            byte_len: 64,
-        },
+        source_blob: DocumentSourceBlob::from_digest([0x33; 32], 64),
         ..source.clone()
     };
     let (pending, missing_parse_job) = store
@@ -910,11 +917,7 @@ async fn concurrent_ensure_parse_advances_once_and_fences_stale_callers() {
         source_uri: Some("file:///concurrent-parser-upgrade.txt".into()),
         media_type: "text/plain".into(),
         title: None,
-        source_blob: DocumentSourceBlob {
-            id: uuid::Uuid::new_v4(),
-            sha256: [0x44; 32],
-            byte_len: 96,
-        },
+        source_blob: DocumentSourceBlob::from_digest([0x44; 32], 96),
         updated_at: Utc::now(),
     };
     let (accepted, parse_job) = store
@@ -1034,11 +1037,7 @@ async fn document_job_schema_enforces_delivery_and_idempotency_invariants() {
         .unwrap();
 
     let mut parse_document = sample_document(None);
-    parse_document.source_blob = Some(DocumentSourceBlob {
-        id: uuid::Uuid::new_v4(),
-        sha256: [0x11; 32],
-        byte_len: 1_024,
-    });
+    parse_document.source_blob = Some(DocumentSourceBlob::from_digest([0x11; 32], 1_024));
     store.create_document(&parse_document).await.unwrap();
     let parse_document = store
         .get_document(parse_document.id)
@@ -2400,11 +2399,7 @@ async fn explicit_retry_revives_only_the_pending_parse_stage() {
         source_uri: Some("file:///retry-report.pdf".into()),
         media_type: "application/pdf".into(),
         title: Some("Retry report".into()),
-        source_blob: DocumentSourceBlob {
-            id: uuid::Uuid::new_v4(),
-            sha256: [0x44; 32],
-            byte_len: 4_096,
-        },
+        source_blob: DocumentSourceBlob::from_digest([0x44; 32], 4_096),
         updated_at: Utc::now(),
     };
     let (document, queued) = store

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -179,11 +179,26 @@ impl DocumentSourceBlob {
     #[must_use]
     pub fn from_bytes(bytes: &[u8]) -> Self {
         let sha256: [u8; 32] = Sha256::digest(bytes).into();
+        Self::from_digest(
+            sha256,
+            u64::try_from(bytes.len()).expect("source byte length exceeds u64"),
+        )
+    }
+
+    /// Describe retained source from its already-computed digest and byte length.
+    #[must_use]
+    pub fn from_digest(sha256: [u8; 32], byte_len: u64) -> Self {
         Self {
             id: Uuid::new_v5(&Self::CONTENT_NAMESPACE, &sha256),
             sha256,
-            byte_len: u64::try_from(bytes.len()).expect("source byte length exceeds u64"),
+            byte_len,
         }
+    }
+
+    /// Whether the blob key is the canonical content address for its digest.
+    #[must_use]
+    pub fn has_content_addressed_id(&self) -> bool {
+        self.id == Uuid::new_v5(&Self::CONTENT_NAMESPACE, &self.sha256)
     }
 }
 
@@ -596,6 +611,14 @@ mod tests {
             first.id,
             Uuid::parse_str("bb06b189-790a-5087-89fd-767534773c0f").unwrap()
         );
+        assert!(first.has_content_addressed_id());
+        assert_eq!(
+            first,
+            DocumentSourceBlob::from_digest(first.sha256, first.byte_len)
+        );
+        let mut invalid = first.clone();
+        invalid.id = Uuid::new_v4();
+        assert!(!invalid.has_content_addressed_id());
         assert_ne!(first.id, DocumentSourceBlob::from_bytes(b"other").id);
     }
 

--- a/crates/openwave-server/src/document_auditor.rs
+++ b/crates/openwave-server/src/document_auditor.rs
@@ -373,11 +373,7 @@ mod tests {
             source_uri: Some("file:///audited-source.txt".into()),
             media_type: "text/plain".into(),
             title: None,
-            source_blob: DocumentSourceBlob {
-                id: uuid::Uuid::new_v4(),
-                sha256: [0x55; 32],
-                byte_len: 128,
-            },
+            source_blob: DocumentSourceBlob::from_digest([0x55; 32], 128),
             updated_at: Utc::now(),
         }
     }

--- a/crates/openwave-server/src/document_worker.rs
+++ b/crates/openwave-server/src/document_worker.rs
@@ -922,7 +922,8 @@ mod tests {
     async fn parse_job_rejects_source_bytes_that_do_not_match_the_descriptor() {
         let (_dir, store, retrieval, _embedder, worker) = harness().await;
         let raw = b"tampered source bytes".to_vec();
-        let blob_id = uuid::Uuid::new_v4();
+        let source_blob = DocumentSourceBlob::from_digest([0x77; 32], raw.len() as u64);
+        let blob_id = source_blob.id;
         worker
             .blobs
             .put(&blob_id.to_string(), raw.clone())
@@ -934,11 +935,7 @@ mod tests {
             source_uri: Some("file:///tampered.txt".into()),
             media_type: "text/plain".into(),
             title: None,
-            source_blob: DocumentSourceBlob {
-                id: blob_id,
-                sha256: [0x77; 32],
-                byte_len: raw.len() as u64,
-            },
+            source_blob,
             updated_at: Utc::now(),
         };
         let (_, parse_job) = store

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1369,12 +1369,11 @@ async fn explicit_retry_revives_the_exact_terminal_job() {
 
 #[tokio::test]
 async fn explicit_retry_selects_the_failed_parse_stage() {
-    use sha2::{Digest, Sha256};
-
     let (router, token, store, dir, worker) = test_app_with_worker().await;
     let bearer = format!("Bearer {token}");
     let raw = b"parse retry succeeds through the durable worker".to_vec();
-    let blob_id = uuid::Uuid::new_v4();
+    let source_blob = openwave_core::DocumentSourceBlob::from_bytes(&raw);
+    let blob_id = source_blob.id;
     let blobs = openwave_core::FsBlobStore::new(dir.path().join("blobs"));
     openwave_core::BlobStore::put(&blobs, &blob_id.to_string(), raw.clone())
         .await
@@ -1385,11 +1384,7 @@ async fn explicit_retry_selects_the_failed_parse_stage() {
         source_uri: Some("file:///parse-retry.txt".into()),
         media_type: "text/plain".into(),
         title: None,
-        source_blob: openwave_core::DocumentSourceBlob {
-            id: blob_id,
-            sha256: Sha256::digest(&raw).into(),
-            byte_len: raw.len() as u64,
-        },
+        source_blob,
         updated_at: chrono::Utc::now(),
     };
     let (_, parse_job) = store


### PR DESCRIPTION
## Summary

- derive retained-source blob IDs from an already-computed SHA-256 through a single model constructor
- reject source acceptance when the declared blob UUID is not the canonical content address for its digest
- preserve worker byte-length and SHA-256 verification while making fixtures use valid content-addressed descriptors

## Validation

- `cargo test -p openwave-core --all-features`
- `cargo test -p openwave-server --all-features`
- `bw dev lint --rust`
