### PR TITLE
refactor: type blob store identifiers

### DIFF
--- a/crates/openwave-core/src/blob.rs
+++ b/crates/openwave-core/src/blob.rs
@@ -44,17 +44,15 @@ impl FsBlobStore {
         &self.root
     }
 
-    fn blob_path(&self, id: &str) -> Result<PathBuf> {
-        let id =
-            Uuid::parse_str(id).map_err(|_| AgentError::Store("blob id must be a UUID".into()))?;
-        Ok(self.root.join(format!("{id}.blob")))
+    fn blob_path(&self, id: Uuid) -> PathBuf {
+        self.root.join(format!("{id}.blob"))
     }
 }
 
 #[async_trait]
 impl BlobStore for FsBlobStore {
-    async fn put(&self, id: &str, bytes: Vec<u8>) -> Result<()> {
-        let destination = self.blob_path(id)?;
+    async fn put(&self, id: Uuid, bytes: Vec<u8>) -> Result<()> {
+        let destination = self.blob_path(id);
         let root = Arc::clone(&self.root);
         let access = Arc::clone(&self.access);
         tokio::task::spawn_blocking(move || {
@@ -113,8 +111,8 @@ impl BlobStore for FsBlobStore {
         .map_err(|error| AgentError::Store(format!("blob write task failed: {error}")))?
     }
 
-    async fn get(&self, id: &str) -> Result<Option<Vec<u8>>> {
-        let path = self.blob_path(id)?;
+    async fn get(&self, id: Uuid) -> Result<Option<Vec<u8>>> {
+        let path = self.blob_path(id);
         let access = Arc::clone(&self.access);
         tokio::task::spawn_blocking(move || {
             let _guard = access
@@ -130,8 +128,8 @@ impl BlobStore for FsBlobStore {
         .map_err(|error| AgentError::Store(format!("blob read task failed: {error}")))?
     }
 
-    async fn delete(&self, id: &str) -> Result<()> {
-        let path = self.blob_path(id)?;
+    async fn delete(&self, id: Uuid) -> Result<()> {
+        let path = self.blob_path(id);
         let root = Arc::clone(&self.root);
         let access = Arc::clone(&self.access);
         tokio::task::spawn_blocking(move || {
@@ -208,47 +206,44 @@ mod tests {
     #[tokio::test]
     async fn roundtrips_reopens_and_deletes_idempotently() {
         let directory = tempfile::tempdir().unwrap();
-        let id = Uuid::new_v4().to_string();
+        let id = Uuid::new_v4();
         let store = FsBlobStore::new(directory.path());
 
-        assert_eq!(store.get(&id).await.unwrap(), None);
-        store.put(&id, b"first".to_vec()).await.unwrap();
-        assert_eq!(
-            store.get(&id).await.unwrap().as_deref(),
-            Some(&b"first"[..])
-        );
+        assert_eq!(store.get(id).await.unwrap(), None);
+        store.put(id, b"first".to_vec()).await.unwrap();
+        assert_eq!(store.get(id).await.unwrap().as_deref(), Some(&b"first"[..]));
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let mode = fs::metadata(store.blob_path(&id).unwrap())
+            let mode = fs::metadata(store.blob_path(id))
                 .unwrap()
                 .permissions()
                 .mode();
             assert_eq!(mode & 0o777, 0o600);
         }
-        store.put(&id, b"first".to_vec()).await.unwrap();
+        store.put(id, b"first".to_vec()).await.unwrap();
 
         let reopened = FsBlobStore::new(directory.path());
         assert_eq!(
-            reopened.get(&id).await.unwrap().as_deref(),
+            reopened.get(id).await.unwrap().as_deref(),
             Some(&b"first"[..])
         );
-        reopened.delete(&id).await.unwrap();
-        reopened.delete(&id).await.unwrap();
-        assert_eq!(reopened.get(&id).await.unwrap(), None);
+        reopened.delete(id).await.unwrap();
+        reopened.delete(id).await.unwrap();
+        assert_eq!(reopened.get(id).await.unwrap(), None);
     }
 
     #[tokio::test]
     async fn immutable_publication_is_idempotent_and_rejects_replacement() {
         let directory = tempfile::tempdir().unwrap();
-        let id = Uuid::new_v4().to_string();
+        let id = Uuid::new_v4();
         let store = FsBlobStore::new(directory.path());
 
-        store.put(&id, b"retained source".to_vec()).await.unwrap();
-        store.put(&id, b"retained source".to_vec()).await.unwrap();
-        assert!(store.put(&id, b"different source".to_vec()).await.is_err());
+        store.put(id, b"retained source".to_vec()).await.unwrap();
+        store.put(id, b"retained source".to_vec()).await.unwrap();
+        assert!(store.put(id, b"different source".to_vec()).await.is_err());
         assert_eq!(
-            store.get(&id).await.unwrap().as_deref(),
+            store.get(id).await.unwrap().as_deref(),
             Some(&b"retained source"[..])
         );
     }
@@ -256,29 +251,18 @@ mod tests {
     #[tokio::test]
     async fn independent_stores_choose_one_complete_immutable_value() {
         let directory = tempfile::tempdir().unwrap();
-        let id = Uuid::new_v4().to_string();
+        let id = Uuid::new_v4();
         let left_store = FsBlobStore::new(directory.path());
         let right_store = FsBlobStore::new(directory.path());
         let first = vec![b'a'; 128 * 1024];
         let second = vec![b'b'; 128 * 1024];
 
         let (left, right) = tokio::join!(
-            left_store.put(&id, first.clone()),
-            right_store.put(&id, second.clone())
+            left_store.put(id, first.clone()),
+            right_store.put(id, second.clone())
         );
         assert_ne!(left.is_ok(), right.is_ok());
-        let stored = left_store.get(&id).await.unwrap().unwrap();
+        let stored = left_store.get(id).await.unwrap().unwrap();
         assert!(stored == first || stored == second);
-    }
-
-    #[tokio::test]
-    async fn rejects_non_uuid_ids_without_touching_the_filesystem() {
-        let directory = tempfile::tempdir().unwrap();
-        let root = directory.path().join("blobs");
-        let store = FsBlobStore::new(&root);
-
-        assert!(store.put("../escape", vec![1]).await.is_err());
-        assert!(store.get("").await.is_err());
-        assert!(!root.exists());
     }
 }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -494,13 +494,13 @@ pub trait BlobStore: Send + Sync {
     /// Repeating the same publication is a no-op; publishing different bytes
     /// under an existing id fails without changing the stored value. Callers
     /// allocate a new id when content changes.
-    async fn put(&self, id: &str, bytes: Vec<u8>) -> Result<()>;
+    async fn put(&self, id: uuid::Uuid, bytes: Vec<u8>) -> Result<()>;
 
     /// Fetch bytes by `id`, or `None` if absent.
-    async fn get(&self, id: &str) -> Result<Option<Vec<u8>>>;
+    async fn get(&self, id: uuid::Uuid) -> Result<Option<Vec<u8>>>;
 
     /// Delete a blob; a no-op if it doesn't exist.
-    async fn delete(&self, id: &str) -> Result<()>;
+    async fn delete(&self, id: uuid::Uuid) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/document_worker.rs
+++ b/crates/openwave-server/src/document_worker.rs
@@ -316,9 +316,9 @@ impl DocumentWorker {
                 )
                 .await;
         };
-        let blob_id = descriptor.id.to_string();
+        let blob_id = descriptor.id;
         let bytes = match self
-            .supervise(&job, lease_token, self.blobs.get(&blob_id))
+            .supervise(&job, lease_token, self.blobs.get(blob_id))
             .await
         {
             Supervised::LeaseLost => return Ok(WorkerOutcome::LeaseLost(job.id)),
@@ -924,11 +924,7 @@ mod tests {
         let raw = b"tampered source bytes".to_vec();
         let source_blob = DocumentSourceBlob::from_digest([0x77; 32], raw.len() as u64);
         let blob_id = source_blob.id;
-        worker
-            .blobs
-            .put(&blob_id.to_string(), raw.clone())
-            .await
-            .unwrap();
+        worker.blobs.put(blob_id, raw.clone()).await.unwrap();
         let source = DocumentSourceUpsert {
             id: DocumentId::new(),
             project_id: None,

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -241,10 +241,7 @@ async fn ingest_document_in_scope(
     // failure may leave an unreferenced content-addressed blob; it must be
     // reclaimed by a grace-period sweep, not eagerly deleted, because another
     // document may already share the same blob id.
-    state
-        .blobs
-        .put(&source_blob.id.to_string(), source_bytes)
-        .await?;
+    state.blobs.put(source_blob.id, source_bytes).await?;
 
     let (revision, job) = state
         .store

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -100,7 +100,7 @@ struct FirstPutGatedBlobStore {
 
 #[async_trait]
 impl BlobStore for FirstPutGatedBlobStore {
-    async fn put(&self, id: &str, bytes: Vec<u8>) -> Result<()> {
+    async fn put(&self, id: uuid::Uuid, bytes: Vec<u8>) -> Result<()> {
         if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
             self.entered.notify_one();
             self.release.notified().await;
@@ -108,11 +108,11 @@ impl BlobStore for FirstPutGatedBlobStore {
         self.inner.put(id, bytes).await
     }
 
-    async fn get(&self, id: &str) -> Result<Option<Vec<u8>>> {
+    async fn get(&self, id: uuid::Uuid) -> Result<Option<Vec<u8>>> {
         self.inner.get(id).await
     }
 
-    async fn delete(&self, id: &str) -> Result<()> {
+    async fn delete(&self, id: uuid::Uuid) -> Result<()> {
         self.inner.delete(id).await
     }
 }
@@ -699,16 +699,12 @@ async fn app_state_roots_blob_storage_under_the_data_directory() {
         retrieval,
         AgentConfig::default(),
     );
-    let id = uuid::Uuid::new_v4().to_string();
+    let id = uuid::Uuid::new_v4();
 
-    state
-        .blobs
-        .put(&id, b"source bytes".to_vec())
-        .await
-        .unwrap();
+    state.blobs.put(id, b"source bytes".to_vec()).await.unwrap();
 
     assert_eq!(
-        state.blobs.get(&id).await.unwrap().as_deref(),
+        state.blobs.get(id).await.unwrap().as_deref(),
         Some(&b"source bytes"[..])
     );
     assert!(dir
@@ -1375,7 +1371,7 @@ async fn explicit_retry_selects_the_failed_parse_stage() {
     let source_blob = openwave_core::DocumentSourceBlob::from_bytes(&raw);
     let blob_id = source_blob.id;
     let blobs = openwave_core::FsBlobStore::new(dir.path().join("blobs"));
-    openwave_core::BlobStore::put(&blobs, &blob_id.to_string(), raw.clone())
+    openwave_core::BlobStore::put(&blobs, blob_id, raw.clone())
         .await
         .unwrap();
     let source = openwave_core::DocumentSourceUpsert {


### PR DESCRIPTION
## Summary

- make `BlobStore` accept UUID identifiers instead of opaque strings
- remove redundant UUID parsing from the filesystem backend
- update source publication and parse-worker call sites to use descriptor IDs directly

## Validation

- `bw dev lint --rust`
- `cargo fmt --all --check`
- `cargo test -p openwave-core --features blob-fs blob::tests`
- focused server blob storage and parse-worker tests
