### PR TITLE
feat: track source blob retirements

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1,3 +1,31 @@
+pub mod blob_retirement {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "blob_retirement")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub blob_id: Uuid,
+        pub status: String,
+        pub attempt_count: i32,
+        pub max_attempts: i32,
+        pub available_at: DateTimeUtc,
+        pub lease_token: Option<Uuid>,
+        pub lease_expires_at: Option<DateTimeUtc>,
+        pub started_at: Option<DateTimeUtc>,
+        pub finished_at: Option<DateTimeUtc>,
+        pub last_error_code: Option<String>,
+        pub last_error_detail: Option<String>,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod document_generation {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -1,6 +1,6 @@
 use sea_orm_migration::prelude::*;
 
-use super::{DocumentJobKind, DocumentJobStatus, DocumentProcessingStatus};
+use super::{BlobRetirementStatus, DocumentJobKind, DocumentJobStatus, DocumentProcessingStatus};
 
 pub struct Migrator;
 
@@ -520,6 +520,195 @@ impl MigrationTrait for AddDocuments {
             )
             .await?;
 
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_document_source_blob")
+                    .table(Document::Table)
+                    .col(Document::SourceBlobId)
+                    .to_owned(),
+            )
+            .await?;
+
+        let valid_blob_status = Expr::col(BlobRetirement::Status).is_in([
+            BlobRetirementStatus::Queued.as_str(),
+            BlobRetirementStatus::Running.as_str(),
+            BlobRetirementStatus::RetryWait.as_str(),
+            BlobRetirementStatus::Succeeded.as_str(),
+            BlobRetirementStatus::Failed.as_str(),
+            BlobRetirementStatus::Cancelled.as_str(),
+        ]);
+        let blob_running_lease = Expr::col(BlobRetirement::Status)
+            .eq(BlobRetirementStatus::Running.as_str())
+            .and(Expr::col(BlobRetirement::LeaseToken).is_not_null())
+            .and(Expr::col(BlobRetirement::LeaseExpiresAt).is_not_null());
+        let blob_no_lease = Expr::col(BlobRetirement::Status)
+            .ne(BlobRetirementStatus::Running.as_str())
+            .and(Expr::col(BlobRetirement::LeaseToken).is_null())
+            .and(Expr::col(BlobRetirement::LeaseExpiresAt).is_null());
+        let blob_terminal_finished = Expr::col(BlobRetirement::Status)
+            .is_in([
+                BlobRetirementStatus::Succeeded.as_str(),
+                BlobRetirementStatus::Failed.as_str(),
+                BlobRetirementStatus::Cancelled.as_str(),
+            ])
+            .and(Expr::col(BlobRetirement::FinishedAt).is_not_null());
+        let blob_nonterminal_unfinished = Expr::col(BlobRetirement::Status)
+            .is_in([
+                BlobRetirementStatus::Queued.as_str(),
+                BlobRetirementStatus::Running.as_str(),
+                BlobRetirementStatus::RetryWait.as_str(),
+            ])
+            .and(Expr::col(BlobRetirement::FinishedAt).is_null());
+        let blob_queued_attempt = Expr::col(BlobRetirement::Status)
+            .eq(BlobRetirementStatus::Queued.as_str())
+            .and(Expr::col(BlobRetirement::AttemptCount).eq(0))
+            .and(Expr::col(BlobRetirement::StartedAt).is_null());
+        let blob_running_attempt = Expr::col(BlobRetirement::Status)
+            .eq(BlobRetirementStatus::Running.as_str())
+            .and(Expr::col(BlobRetirement::AttemptCount).gte(1))
+            .and(Expr::col(BlobRetirement::StartedAt).is_not_null());
+        let blob_retryable_attempt = Expr::col(BlobRetirement::Status)
+            .eq(BlobRetirementStatus::RetryWait.as_str())
+            .and(Expr::col(BlobRetirement::AttemptCount).gte(1))
+            .and(Expr::col(BlobRetirement::AttemptCount).lt(Expr::col(BlobRetirement::MaxAttempts)))
+            .and(Expr::col(BlobRetirement::StartedAt).is_not_null());
+        let blob_completed_attempt = Expr::col(BlobRetirement::Status)
+            .is_in([
+                BlobRetirementStatus::Succeeded.as_str(),
+                BlobRetirementStatus::Failed.as_str(),
+            ])
+            .and(Expr::col(BlobRetirement::AttemptCount).gte(1))
+            .and(Expr::col(BlobRetirement::StartedAt).is_not_null());
+        let blob_cancelled_attempt = Expr::col(BlobRetirement::Status)
+            .eq(BlobRetirementStatus::Cancelled.as_str())
+            .and(
+                Expr::col(BlobRetirement::AttemptCount)
+                    .eq(0)
+                    .and(Expr::col(BlobRetirement::StartedAt).is_null())
+                    .or(Expr::col(BlobRetirement::AttemptCount)
+                        .gte(1)
+                        .and(Expr::col(BlobRetirement::StartedAt).is_not_null())),
+            );
+        manager
+            .create_table(
+                Table::create()
+                    .table(BlobRetirement::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(BlobRetirement::BlobId)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(BlobRetirement::Status)
+                            .string_len(32)
+                            .not_null()
+                            .default(BlobRetirementStatus::Queued.as_str()),
+                    )
+                    .col(
+                        ColumnDef::new(BlobRetirement::AttemptCount)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(BlobRetirement::MaxAttempts)
+                            .integer()
+                            .not_null()
+                            .default(crate::model::BlobRetirement::DEFAULT_MAX_ATTEMPTS),
+                    )
+                    .col(
+                        ColumnDef::new(BlobRetirement::AvailableAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(BlobRetirement::LeaseToken).uuid())
+                    .col(ColumnDef::new(BlobRetirement::LeaseExpiresAt).timestamp_with_time_zone())
+                    .col(ColumnDef::new(BlobRetirement::StartedAt).timestamp_with_time_zone())
+                    .col(ColumnDef::new(BlobRetirement::FinishedAt).timestamp_with_time_zone())
+                    .col(
+                        ColumnDef::new(BlobRetirement::LastErrorCode)
+                            .string_len(crate::model::BlobRetirement::MAX_ERROR_CODE_LEN as u32),
+                    )
+                    .col(
+                        ColumnDef::new(BlobRetirement::LastErrorDetail)
+                            .string_len(crate::model::BlobRetirement::MAX_ERROR_DETAIL_LEN as u32),
+                    )
+                    .col(
+                        ColumnDef::new(BlobRetirement::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(BlobRetirement::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .check(valid_blob_status)
+                    .check(
+                        Expr::col(BlobRetirement::AttemptCount)
+                            .gte(0)
+                            .and(Expr::col(BlobRetirement::MaxAttempts).gte(1))
+                            .and(
+                                Expr::col(BlobRetirement::AttemptCount)
+                                    .lte(Expr::col(BlobRetirement::MaxAttempts)),
+                            ),
+                    )
+                    .check(blob_running_lease.or(blob_no_lease))
+                    .check(blob_terminal_finished.or(blob_nonterminal_unfinished))
+                    .check(
+                        blob_queued_attempt
+                            .or(blob_running_attempt)
+                            .or(blob_retryable_attempt)
+                            .or(blob_completed_attempt)
+                            .or(blob_cancelled_attempt),
+                    )
+                    .check(
+                        Expr::col(BlobRetirement::LastErrorCode)
+                            .is_null()
+                            .or(Func::char_length(Expr::col(BlobRetirement::LastErrorCode))
+                                .between(
+                                    1,
+                                    crate::model::BlobRetirement::MAX_ERROR_CODE_LEN as i32,
+                                )),
+                    )
+                    .check(
+                        Expr::col(BlobRetirement::LastErrorDetail)
+                            .is_null()
+                            .or(
+                                Func::char_length(Expr::col(BlobRetirement::LastErrorDetail))
+                                    .between(
+                                        1,
+                                        crate::model::BlobRetirement::MAX_ERROR_DETAIL_LEN as i32,
+                                    ),
+                            ),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_blob_retirement_due")
+                    .table(BlobRetirement::Table)
+                    .col(BlobRetirement::Status)
+                    .col(BlobRetirement::AvailableAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_blob_retirement_stale_lease")
+                    .table(BlobRetirement::Table)
+                    .col(BlobRetirement::Status)
+                    .col(BlobRetirement::LeaseExpiresAt)
+                    .to_owned(),
+            )
+            .await?;
+
         let valid_job_status = Expr::col(DocumentJob::Status).is_in([
             DocumentJobStatus::Queued.as_str(),
             DocumentJobStatus::Running.as_str(),
@@ -775,6 +964,9 @@ impl MigrationTrait for AddDocuments {
             .drop_table(Table::drop().table(DocumentJob::Table).to_owned())
             .await?;
         manager
+            .drop_table(Table::drop().table(BlobRetirement::Table).to_owned())
+            .await?;
+        manager
             .drop_table(Table::drop().table(Document::Table).to_owned())
             .await?;
         manager
@@ -827,6 +1019,24 @@ enum DocumentGeneration {
     RetirementPending,
     RetirementContentRevision,
     RetirementRevisionToken,
+}
+
+#[derive(DeriveIden)]
+enum BlobRetirement {
+    Table,
+    BlobId,
+    Status,
+    AttemptCount,
+    MaxAttempts,
+    AvailableAt,
+    LeaseToken,
+    LeaseExpiresAt,
+    StartedAt,
+    FinishedAt,
+    LastErrorCode,
+    LastErrorDetail,
+    CreatedAt,
+    UpdatedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -26,10 +26,10 @@ use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId};
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
-    Chat, DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
-    DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
-    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
-    Project, SourceRegion, ToolCallRecord,
+    BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
+    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
+    DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
+    DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord,
 };
 use crate::storage::{
     DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, Store,
@@ -171,6 +171,9 @@ impl Store for DbStore {
         .insert(&transaction)
         .await
         .map_err(store_err)?;
+        if let Some(source_blob) = document.source_blob.as_ref() {
+            ops::blob::cancel_on(&transaction, source_blob.id).await?;
+        }
         transaction.commit().await.map_err(store_err)?;
         Ok(())
     }
@@ -283,6 +286,10 @@ impl Store for DbStore {
             .into_iter()
             .map(DocumentId)
             .collect())
+    }
+
+    async fn get_blob_retirement(&self, blob_id: uuid::Uuid) -> Result<Option<BlobRetirement>> {
+        ops::blob::get(self, blob_id).await
     }
 
     async fn get_document_generation(&self, id: DocumentId) -> Result<Option<DocumentGeneration>> {
@@ -446,6 +453,9 @@ impl Store for DbStore {
                 if deleted.rows_affected != 1 {
                     transaction.rollback().await.map_err(store_err)?;
                     continue;
+                }
+                if let Some(blob_id) = document.source_blob_id {
+                    ops::blob::enqueue_on(&transaction, blob_id).await?;
                 }
             }
             transaction.commit().await.map_err(store_err)?;

--- a/crates/openwave-core/src/db/ops/blob.rs
+++ b/crates/openwave-core/src/db/ops/blob.rs
@@ -1,0 +1,170 @@
+use chrono::Utc;
+use sea_orm::sea_query::OnConflict;
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set};
+
+use crate::error::{AgentError, Result};
+use crate::model::{BlobRetirement, BlobRetirementStatus};
+
+use super::super::{entities, store_err, DbStore};
+
+pub(in crate::db) async fn get(
+    store: &DbStore,
+    blob_id: uuid::Uuid,
+) -> Result<Option<BlobRetirement>> {
+    entities::blob_retirement::Entity::find_by_id(blob_id)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(from_model)
+        .transpose()
+}
+
+/// Replace one document's blob reference using a global blob-id lock order.
+///
+/// PostgreSQL row locks acquired by the retirement upsert and cancellation can
+/// otherwise deadlock when two documents concurrently swap `A -> B` and
+/// `B -> A`. Applying the old/new mutations in ascending UUID order makes the
+/// lock graph acyclic. The caller owns the surrounding document transaction.
+pub(in crate::db) async fn replace_reference_on<C>(
+    conn: &C,
+    old_blob_id: Option<uuid::Uuid>,
+    new_blob_id: uuid::Uuid,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let Some(old_blob_id) = old_blob_id.filter(|old| *old != new_blob_id) else {
+        return cancel_on(conn, new_blob_id).await;
+    };
+    if old_blob_id < new_blob_id {
+        enqueue_on(conn, old_blob_id).await?;
+        cancel_on(conn, new_blob_id).await
+    } else {
+        cancel_on(conn, new_blob_id).await?;
+        enqueue_on(conn, old_blob_id).await
+    }
+}
+
+/// Coalesce a dropped source reference into one fresh retirement episode.
+///
+/// This runs inside the document mutation transaction. A unique blob key makes
+/// concurrent drops idempotent, and clearing any prior lease fences a worker
+/// from completing an earlier episode after this requeue.
+pub(in crate::db) async fn enqueue_on<C>(conn: &C, blob_id: uuid::Uuid) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let now = Utc::now();
+    entities::blob_retirement::Entity::insert(entities::blob_retirement::ActiveModel {
+        blob_id: Set(blob_id),
+        status: Set(BlobRetirementStatus::Queued.as_str().into()),
+        attempt_count: Set(0),
+        max_attempts: Set(BlobRetirement::DEFAULT_MAX_ATTEMPTS),
+        available_at: Set(now),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        started_at: Set(None),
+        finished_at: Set(None),
+        last_error_code: Set(None),
+        last_error_detail: Set(None),
+        created_at: Set(now),
+        updated_at: Set(now),
+    })
+    .on_conflict(
+        OnConflict::column(entities::blob_retirement::Column::BlobId)
+            .update_columns([
+                entities::blob_retirement::Column::Status,
+                entities::blob_retirement::Column::AttemptCount,
+                entities::blob_retirement::Column::MaxAttempts,
+                entities::blob_retirement::Column::AvailableAt,
+                entities::blob_retirement::Column::LeaseToken,
+                entities::blob_retirement::Column::LeaseExpiresAt,
+                entities::blob_retirement::Column::StartedAt,
+                entities::blob_retirement::Column::FinishedAt,
+                entities::blob_retirement::Column::LastErrorCode,
+                entities::blob_retirement::Column::LastErrorDetail,
+                entities::blob_retirement::Column::UpdatedAt,
+            ])
+            .to_owned(),
+    )
+    .exec_without_returning(conn)
+    .await
+    .map_err(store_err)?;
+    Ok(())
+}
+
+/// Cancel any retirement state when a transaction establishes a live reference.
+pub(in crate::db) async fn cancel_on<C>(conn: &C, blob_id: uuid::Uuid) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let now = Utc::now();
+    entities::blob_retirement::Entity::update_many()
+        .col_expr(
+            entities::blob_retirement::Column::Status,
+            sea_orm::sea_query::Expr::value(BlobRetirementStatus::Cancelled.as_str()),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::blob_retirement::Column::BlobId.eq(blob_id))
+        .filter(
+            entities::blob_retirement::Column::Status.ne(BlobRetirementStatus::Cancelled.as_str()),
+        )
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+pub(in crate::db) fn from_model(model: entities::blob_retirement::Model) -> Result<BlobRetirement> {
+    let status = match model.status.as_str() {
+        "queued" => BlobRetirementStatus::Queued,
+        "running" => BlobRetirementStatus::Running,
+        "retry_wait" => BlobRetirementStatus::RetryWait,
+        "succeeded" => BlobRetirementStatus::Succeeded,
+        "failed" => BlobRetirementStatus::Failed,
+        "cancelled" => BlobRetirementStatus::Cancelled,
+        other => {
+            return Err(AgentError::Store(format!(
+                "unknown blob retirement status: {other}"
+            )))
+        }
+    };
+    Ok(BlobRetirement {
+        blob_id: model.blob_id,
+        status,
+        attempt_count: model.attempt_count,
+        max_attempts: model.max_attempts,
+        available_at: model.available_at,
+        lease_token: model.lease_token,
+        lease_expires_at: model.lease_expires_at,
+        started_at: model.started_at,
+        finished_at: model.finished_at,
+        last_error_code: model.last_error_code,
+        last_error_detail: model.last_error_detail,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+    })
+}

--- a/crates/openwave-core/src/db/ops/document.rs
+++ b/crates/openwave-core/src/db/ops/document.rs
@@ -16,6 +16,7 @@ use super::super::{
     source_regions_to_db, store_err, try_advance_document_generation_on,
     validate_document_source_blob, validate_document_source_regions, DbStore,
 };
+use super::blob as blob_ops;
 
 pub(in crate::db) async fn accept_source_and_enqueue_parse(
     store: &DbStore,
@@ -63,6 +64,7 @@ pub(in crate::db) async fn accept_source_and_enqueue_parse(
                 {
                     let record = document_from_model(current.clone())?;
                     let job = document_job_from_model(job)?;
+                    blob_ops::cancel_on(&transaction, source.source_blob.id).await?;
                     transaction.commit().await.map_err(store_err)?;
                     return Ok((record, job));
                 }
@@ -119,6 +121,13 @@ pub(in crate::db) async fn accept_source_and_enqueue_parse(
         } else {
             active.insert(&transaction).await.map_err(store_err)?;
         }
+
+        blob_ops::replace_reference_on(
+            &transaction,
+            existing.as_ref().and_then(|current| current.source_blob_id),
+            source.source_blob.id,
+        )
+        .await?;
 
         cancel_live_document_jobs_on(&transaction, source.id, workflow_now).await?;
         let job = new_job(

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -1,2 +1,3 @@
+pub(in crate::db) mod blob;
 pub(in crate::db) mod conversation;
 pub(in crate::db) mod document;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -31,6 +31,22 @@ fn sample_project() -> Project {
     }
 }
 
+fn sample_raw_source(
+    id: DocumentId,
+    uri: &str,
+    source_blob: DocumentSourceBlob,
+) -> DocumentSourceUpsert {
+    DocumentSourceUpsert {
+        id,
+        project_id: None,
+        source_uri: Some(uri.into()),
+        media_type: "application/octet-stream".into(),
+        title: None,
+        source_blob,
+        updated_at: Utc::now(),
+    }
+}
+
 fn sample_document(project_id: Option<ProjectId>) -> DocumentRecord {
     let created_at = DateTime::<Utc>::from_timestamp(1_700_000_100, 0).unwrap();
     DocumentRecord {
@@ -716,6 +732,264 @@ async fn raw_source_parse_completion_atomically_enqueues_index() {
             .status,
         DocumentJobStatus::Cancelled
     );
+}
+
+#[tokio::test]
+async fn blob_retirement_coalesces_candidates_and_live_writes_cancel_episodes() {
+    let (_dir, store) = temp_store().await;
+    let shared_blob = DocumentSourceBlob::from_digest([0x51; 32], 51);
+    let source_a = sample_raw_source(
+        DocumentId::new(),
+        "file:///shared-a.bin",
+        shared_blob.clone(),
+    );
+    let source_b = sample_raw_source(
+        DocumentId::new(),
+        "file:///shared-b.bin",
+        shared_blob.clone(),
+    );
+    let (_, job_a) = store
+        .accept_document_source_and_enqueue_parse(&source_a, "parser-v1", 3)
+        .await
+        .unwrap();
+    store
+        .accept_document_source_and_enqueue_parse(&source_b, "parser-v1", 3)
+        .await
+        .unwrap();
+    assert_eq!(
+        store.get_blob_retirement(shared_blob.id).await.unwrap(),
+        None
+    );
+
+    let replacement_b = sample_raw_source(
+        source_b.id,
+        source_b.source_uri.as_deref().unwrap(),
+        DocumentSourceBlob::from_digest([0x52; 32], 52),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&replacement_b, "parser-v1", 3)
+        .await
+        .unwrap();
+    let queued = store
+        .get_blob_retirement(shared_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    // A dropped reference creates a candidate even while another document
+    // still shares the blob. Claim must perform the authoritative indexed
+    // reference check before this candidate can become running.
+    assert_eq!(queued.status, BlobRetirementStatus::Queued);
+    assert_eq!(queued.attempt_count, 0);
+    assert_eq!(queued.max_attempts, BlobRetirement::DEFAULT_MAX_ATTEMPTS);
+    assert_eq!(queued.lease_token, None);
+    assert_eq!(queued.finished_at, None);
+
+    let repeated = store
+        .accept_document_source_and_enqueue_parse(&source_a, "parser-v1", 9)
+        .await
+        .unwrap();
+    assert_eq!(repeated.1, job_a);
+    let cancelled = store
+        .get_blob_retirement(shared_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(cancelled.status, BlobRetirementStatus::Cancelled);
+    assert_eq!(cancelled.created_at, queued.created_at);
+    assert!(cancelled.finished_at.is_some());
+
+    let replacement_a = sample_raw_source(
+        source_a.id,
+        source_a.source_uri.as_deref().unwrap(),
+        DocumentSourceBlob::from_digest([0x53; 32], 53),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&replacement_a, "parser-v1", 3)
+        .await
+        .unwrap();
+    let requeued = store
+        .get_blob_retirement(shared_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(requeued.status, BlobRetirementStatus::Queued);
+    assert_eq!(requeued.created_at, queued.created_at);
+    assert_eq!(requeued.attempt_count, 0);
+    assert_eq!(requeued.started_at, None);
+    assert_eq!(requeued.finished_at, None);
+
+    store.delete_document(replacement_a.id).await.unwrap();
+    let replacement_retirement = store
+        .get_blob_retirement(replacement_a.source_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(replacement_retirement.status, BlobRetirementStatus::Queued);
+    let source_c = sample_raw_source(
+        DocumentId::new(),
+        "file:///shared-c.bin",
+        replacement_a.source_blob.clone(),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&source_c, "parser-v1", 3)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_blob_retirement(replacement_a.source_blob.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        BlobRetirementStatus::Cancelled
+    );
+}
+
+#[tokio::test]
+async fn source_replacement_rolls_back_blob_retirement_with_job_insert_failure() {
+    let (_dir, store) = temp_store().await;
+    let original = sample_raw_source(
+        DocumentId::new(),
+        "file:///rollback-source.bin",
+        DocumentSourceBlob::from_digest([0x61; 32], 61),
+    );
+    let (original_record, original_job) = store
+        .accept_document_source_and_enqueue_parse(&original, "parser-v1", 3)
+        .await
+        .unwrap();
+    let replacement = sample_raw_source(
+        original.id,
+        original.source_uri.as_deref().unwrap(),
+        DocumentSourceBlob::from_digest([0x62; 32], 62),
+    );
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_replacement_parse_insert
+             BEFORE INSERT ON document_job
+             WHEN NEW.kind = 'parse'
+             BEGIN SELECT RAISE(FAIL, 'injected replacement failure'); END",
+        )
+        .await
+        .unwrap();
+    assert!(store
+        .accept_document_source_and_enqueue_parse(&replacement, "parser-v1", 3)
+        .await
+        .is_err());
+    store
+        .conn
+        .execute_unprepared("DROP TRIGGER fail_replacement_parse_insert")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.get_document(original.id).await.unwrap(),
+        Some(original_record)
+    );
+    assert_eq!(
+        store.get_document_job(original_job.id).await.unwrap(),
+        Some(original_job)
+    );
+    assert_eq!(
+        store
+            .get_blob_retirement(original.source_blob.id)
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        store
+            .get_blob_retirement(replacement.source_blob.id)
+            .await
+            .unwrap(),
+        None
+    );
+}
+
+#[tokio::test]
+async fn document_delete_rolls_back_when_blob_retirement_cannot_be_enqueued() {
+    let (_dir, store) = temp_store().await;
+    let source = sample_raw_source(
+        DocumentId::new(),
+        "file:///rollback-delete.bin",
+        DocumentSourceBlob::from_digest([0x63; 32], 63),
+    );
+    let (record, _) = store
+        .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+        .await
+        .unwrap();
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_blob_retirement_insert
+             BEFORE INSERT ON blob_retirement
+             BEGIN SELECT RAISE(FAIL, 'injected retirement failure'); END",
+        )
+        .await
+        .unwrap();
+    assert!(store.delete_document(source.id).await.is_err());
+    assert_eq!(store.get_document(source.id).await.unwrap(), Some(record));
+    assert_eq!(
+        store
+            .get_blob_retirement(source.source_blob.id)
+            .await
+            .unwrap(),
+        None
+    );
+    store
+        .conn
+        .execute_unprepared("DROP TRIGGER fail_blob_retirement_insert")
+        .await
+        .unwrap();
+    store.delete_document(source.id).await.unwrap();
+    assert_eq!(
+        store
+            .get_blob_retirement(source.source_blob.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        BlobRetirementStatus::Queued
+    );
+}
+
+#[tokio::test]
+async fn blob_retirement_constraints_reject_impossible_delivery_state() {
+    let (_dir, store) = temp_store().await;
+    let now = Utc::now();
+    let invalid_queued_lease = entities::blob_retirement::ActiveModel {
+        blob_id: Set(uuid::Uuid::new_v4()),
+        status: Set(BlobRetirementStatus::Queued.as_str().into()),
+        attempt_count: Set(0),
+        max_attempts: Set(BlobRetirement::DEFAULT_MAX_ATTEMPTS),
+        available_at: Set(now),
+        lease_token: Set(Some(uuid::Uuid::new_v4())),
+        lease_expires_at: Set(Some(now + chrono::Duration::minutes(1))),
+        started_at: Set(None),
+        finished_at: Set(None),
+        last_error_code: Set(None),
+        last_error_detail: Set(None),
+        created_at: Set(now),
+        updated_at: Set(now),
+    };
+    assert!(invalid_queued_lease.insert(&store.conn).await.is_err());
+
+    let exhausted_retry = entities::blob_retirement::ActiveModel {
+        blob_id: Set(uuid::Uuid::new_v4()),
+        status: Set(BlobRetirementStatus::RetryWait.as_str().into()),
+        attempt_count: Set(BlobRetirement::DEFAULT_MAX_ATTEMPTS),
+        max_attempts: Set(BlobRetirement::DEFAULT_MAX_ATTEMPTS),
+        available_at: Set(now),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        started_at: Set(Some(now)),
+        finished_at: Set(None),
+        last_error_code: Set(Some("transient_delete".into())),
+        last_error_detail: Set(None),
+        created_at: Set(now),
+        updated_at: Set(now),
+    };
+    assert!(exhausted_retry.insert(&store.conn).await.is_err());
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -51,10 +51,11 @@ pub use id::{CallId, ChatId, DocumentId, DocumentJobId, MessageId, ProjectId, St
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
 pub use model::{
-    validate_source_regions, ByteSpan, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
-    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
-    DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
-    DocumentUpsert, Message, Project, Role, SourceLocation, SourceRegion, ToolCallRecord,
+    validate_source_regions, BlobRetirement, BlobRetirementStatus, ByteSpan, Chat,
+    DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
+    DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
+    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
+    Project, Role, SourceLocation, SourceRegion, ToolCallRecord,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -408,6 +408,96 @@ impl DocumentJob {
     pub const MAX_ERROR_DETAIL_LEN: usize = 4096;
 }
 
+/// Durable deletion state for one content-addressed source blob.
+///
+/// Rows are coalesced by `blob_id`: dropping another reference resets the row
+/// to queued, while establishing any live reference cancels it. Queued rows are
+/// candidates, not deletion authorization: claim must atomically recheck the
+/// indexed authoritative document references and cancel any referenced blob.
+/// Exact worker leases fence a previous retirement episode from completing
+/// after either transition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlobRetirement {
+    /// Globally content-addressed blob identity.
+    pub blob_id: Uuid,
+    /// Durable delivery state.
+    pub status: BlobRetirementStatus,
+    /// Claims already made, including the current claim when running.
+    pub attempt_count: i32,
+    /// Maximum claims before a retryable deletion failure becomes terminal.
+    pub max_attempts: i32,
+    /// Earliest time this retirement may be claimed.
+    pub available_at: DateTime<Utc>,
+    /// Exact claim identity required for heartbeat/completion writes.
+    pub lease_token: Option<Uuid>,
+    /// When the current claim becomes recoverably stale.
+    pub lease_expires_at: Option<DateTime<Utc>>,
+    /// When the current retirement episode was first claimed.
+    pub started_at: Option<DateTime<Utc>>,
+    /// When this retirement entered a terminal state.
+    pub finished_at: Option<DateTime<Utc>>,
+    /// Stable machine-readable failure category.
+    pub last_error_code: Option<String>,
+    /// Bounded diagnostic detail for local operators.
+    pub last_error_detail: Option<String>,
+    /// When this blob first became a retirement candidate.
+    pub created_at: DateTime<Utc>,
+    /// When its durable state last changed.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl BlobRetirement {
+    /// Default number of deletion claims before explicit intervention.
+    pub const DEFAULT_MAX_ATTEMPTS: i32 = 5;
+    /// Maximum persisted stable failure-code length.
+    pub const MAX_ERROR_CODE_LEN: usize = 128;
+    /// Maximum persisted local diagnostic-detail length.
+    pub const MAX_ERROR_DETAIL_LEN: usize = 4096;
+}
+
+/// Durable delivery state for one coalesced blob retirement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum BlobRetirementStatus {
+    /// Due for authoritative reference validation at `available_at`; only an
+    /// unreferenced candidate may become running.
+    Queued,
+    /// Currently owned by the exact lease token and expiry on the row.
+    Running,
+    /// Failed transiently and becomes claimable again at `available_at`.
+    RetryWait,
+    /// The unreferenced blob was deleted or was already absent.
+    Succeeded,
+    /// Deletion exhausted retries or failed permanently.
+    Failed,
+    /// A live-reference write or claim-time check cancelled this episode. This
+    /// does not assert that the blob remains referenced forever; a later final
+    /// reference drop may reset the coalesced row to queued.
+    Cancelled,
+}
+
+impl BlobRetirementStatus {
+    /// Stable database and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::RetryWait => "retry_wait",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// Whether no worker may claim this row without an explicit requeue.
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
+    }
+}
+
 /// Metadata returned by bounded document listings.
 ///
 /// This deliberately excludes canonical content and the revision token so list
@@ -594,8 +684,14 @@ mod tests {
             serde_json::to_string(&DocumentJobStatus::RetryWait).unwrap(),
             "\"retry_wait\""
         );
+        assert_eq!(
+            serde_json::to_string(&BlobRetirementStatus::RetryWait).unwrap(),
+            "\"retry_wait\""
+        );
         assert!(DocumentJobStatus::Succeeded.is_terminal());
         assert!(!DocumentJobStatus::Running.is_terminal());
+        assert!(BlobRetirementStatus::Cancelled.is_terminal());
+        assert!(!BlobRetirementStatus::Queued.is_terminal());
     }
 
     #[test]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -22,8 +22,8 @@ use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId};
 use crate::model::{
-    Chat, DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
-    DocumentParseOutput, DocumentRecord, DocumentScope, DocumentSourceUpsert,
+    BlobRetirement, Chat, DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus,
+    DocumentListCursor, DocumentParseOutput, DocumentRecord, DocumentScope, DocumentSourceUpsert,
     DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
 };
 
@@ -152,6 +152,11 @@ pub trait Store: Send + Sync {
             .into_iter()
             .map(|document| document.id)
             .collect())
+    }
+
+    /// Read the coalesced retirement state for one source blob.
+    async fn get_blob_retirement(&self, _blob_id: uuid::Uuid) -> Result<Option<BlobRetirement>> {
+        document_storage_unavailable()
     }
 
     /// Read the newest durable generation, including a hard-delete tombstone.


### PR DESCRIPTION
## Summary

- add a durable, coalesced retirement-candidate model for content-addressed source blobs
- enqueue dropped source references atomically with document replacement or deletion
- cancel retirement atomically whenever a document establishes the blob as live source
- index authoritative source references for the execution worker's final safety check

Queued rows are candidates rather than deletion authorization. The claim stage
must atomically reject any blob that still has an indexed live source reference.

## Validation

- `cargo test -p openwave-core --all-features`
- `cargo fmt --all --check`
- `bw dev lint --rust`
