### PR TITLE
Lease blob retirement work

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -292,6 +292,24 @@ impl Store for DbStore {
         ops::blob::get(self, blob_id).await
     }
 
+    async fn claim_blob_retirement(
+        &self,
+        now: chrono::DateTime<Utc>,
+        lease_expires_at: chrono::DateTime<Utc>,
+    ) -> Result<Option<BlobRetirement>> {
+        ops::blob::claim(self, now, lease_expires_at).await
+    }
+
+    async fn heartbeat_blob_retirement(
+        &self,
+        blob_id: uuid::Uuid,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        lease_expires_at: chrono::DateTime<Utc>,
+    ) -> Result<bool> {
+        ops::blob::heartbeat(self, blob_id, lease_token, now, lease_expires_at).await
+    }
+
     async fn get_document_generation(&self, id: DocumentId) -> Result<Option<DocumentGeneration>> {
         Ok(entities::document_generation::Entity::find_by_id(id.0)
             .one(&self.conn)

--- a/crates/openwave-core/src/db/ops/blob.rs
+++ b/crates/openwave-core/src/db/ops/blob.rs
@@ -1,6 +1,9 @@
 use chrono::Utc;
 use sea_orm::sea_query::OnConflict;
-use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set};
+use sea_orm::{
+    ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set,
+    TransactionTrait,
+};
 
 use crate::error::{AgentError, Result};
 use crate::model::{BlobRetirement, BlobRetirementStatus};
@@ -42,6 +45,357 @@ where
     } else {
         cancel_on(conn, new_blob_id).await?;
         enqueue_on(conn, old_blob_id).await
+    }
+}
+
+pub(in crate::db) async fn claim(
+    store: &DbStore,
+    now: chrono::DateTime<Utc>,
+    lease_expires_at: chrono::DateTime<Utc>,
+) -> Result<Option<BlobRetirement>> {
+    if lease_expires_at <= now {
+        return Err(AgentError::Store(
+            "blob retirement lease expiry must be after claim time".into(),
+        ));
+    }
+    loop {
+        let transaction = store.conn.begin().await.map_err(store_err)?;
+        acquire_write_lock(&transaction).await?;
+        let due = entities::blob_retirement::Entity::find()
+            .filter(entities::blob_retirement::Column::Status.is_in([
+                BlobRetirementStatus::Queued.as_str(),
+                BlobRetirementStatus::RetryWait.as_str(),
+            ]))
+            .filter(entities::blob_retirement::Column::AvailableAt.lte(now))
+            .filter(
+                sea_orm::sea_query::Expr::col(entities::blob_retirement::Column::AttemptCount).lt(
+                    sea_orm::sea_query::Expr::col(entities::blob_retirement::Column::MaxAttempts),
+                ),
+            )
+            .order_by_asc(entities::blob_retirement::Column::AvailableAt)
+            .order_by_asc(entities::blob_retirement::Column::CreatedAt)
+            .order_by_asc(entities::blob_retirement::Column::BlobId)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        let expired = entities::blob_retirement::Entity::find()
+            .filter(
+                entities::blob_retirement::Column::Status
+                    .eq(BlobRetirementStatus::Running.as_str()),
+            )
+            .filter(entities::blob_retirement::Column::LeaseExpiresAt.lte(now))
+            .order_by_asc(entities::blob_retirement::Column::LeaseExpiresAt)
+            .order_by_asc(entities::blob_retirement::Column::CreatedAt)
+            .order_by_asc(entities::blob_retirement::Column::BlobId)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        let candidate = match (due, expired) {
+            (Some(due), Some(expired)) => {
+                if effective_due(&due)? <= effective_due(&expired)? {
+                    Some(due)
+                } else {
+                    Some(expired)
+                }
+            }
+            (candidate @ Some(_), None) | (None, candidate @ Some(_)) => candidate,
+            (None, None) => None,
+        };
+        let Some(candidate) = candidate else {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(None);
+        };
+        let candidate = entities::blob_retirement::Entity::find_by_id(candidate.blob_id)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        let Some(candidate) = candidate.filter(|candidate| is_due(candidate, now)) else {
+            transaction.rollback().await.map_err(store_err)?;
+            continue;
+        };
+        let referenced = entities::document::Entity::find()
+            .select_only()
+            .column(entities::document::Column::Id)
+            .filter(entities::document::Column::SourceBlobId.eq(candidate.blob_id))
+            .into_tuple::<uuid::Uuid>()
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .is_some();
+        if referenced {
+            if !cancel_candidate_on(&transaction, &candidate, now).await? {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+            transaction.commit().await.map_err(store_err)?;
+            continue;
+        }
+        let reclaiming = candidate.status == BlobRetirementStatus::Running.as_str();
+        if reclaiming && candidate.attempt_count >= candidate.max_attempts {
+            let failed = entities::blob_retirement::Entity::update_many()
+                .col_expr(
+                    entities::blob_retirement::Column::Status,
+                    sea_orm::sea_query::Expr::value(BlobRetirementStatus::Failed.as_str()),
+                )
+                .col_expr(
+                    entities::blob_retirement::Column::LeaseToken,
+                    sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+                )
+                .col_expr(
+                    entities::blob_retirement::Column::LeaseExpiresAt,
+                    sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+                )
+                .col_expr(
+                    entities::blob_retirement::Column::FinishedAt,
+                    sea_orm::sea_query::Expr::value(Some(now)),
+                )
+                .col_expr(
+                    entities::blob_retirement::Column::LastErrorCode,
+                    sea_orm::sea_query::Expr::value(Some("lease_expired".to_owned())),
+                )
+                .col_expr(
+                    entities::blob_retirement::Column::LastErrorDetail,
+                    sea_orm::sea_query::Expr::value(Some(
+                        "final blob retirement lease expired".to_owned(),
+                    )),
+                )
+                .col_expr(
+                    entities::blob_retirement::Column::UpdatedAt,
+                    sea_orm::sea_query::Expr::value(now),
+                )
+                .filter(entities::blob_retirement::Column::BlobId.eq(candidate.blob_id))
+                .filter(
+                    entities::blob_retirement::Column::Status
+                        .eq(BlobRetirementStatus::Running.as_str()),
+                )
+                .filter(entities::blob_retirement::Column::AttemptCount.eq(candidate.attempt_count))
+                .filter(entities::blob_retirement::Column::LeaseToken.eq(candidate.lease_token))
+                .filter(
+                    entities::blob_retirement::Column::LeaseExpiresAt
+                        .eq(candidate.lease_expires_at),
+                )
+                .filter(entities::blob_retirement::Column::UpdatedAt.eq(candidate.updated_at))
+                .exec(&transaction)
+                .await
+                .map_err(store_err)?;
+            if failed.rows_affected != 1 {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+            transaction.commit().await.map_err(store_err)?;
+            continue;
+        }
+
+        let next_attempt = candidate.attempt_count.checked_add(1).ok_or_else(|| {
+            AgentError::Store(format!(
+                "blob retirement {} attempt overflow",
+                candidate.blob_id
+            ))
+        })?;
+        let lease_token = uuid::Uuid::new_v4();
+        let claim = entities::blob_retirement::Entity::update_many()
+            .col_expr(
+                entities::blob_retirement::Column::Status,
+                sea_orm::sea_query::Expr::value(BlobRetirementStatus::Running.as_str()),
+            )
+            .col_expr(
+                entities::blob_retirement::Column::AttemptCount,
+                sea_orm::sea_query::Expr::value(next_attempt),
+            )
+            .col_expr(
+                entities::blob_retirement::Column::LeaseToken,
+                sea_orm::sea_query::Expr::value(Some(lease_token)),
+            )
+            .col_expr(
+                entities::blob_retirement::Column::LeaseExpiresAt,
+                sea_orm::sea_query::Expr::value(Some(lease_expires_at)),
+            )
+            .col_expr(
+                entities::blob_retirement::Column::StartedAt,
+                sea_orm::sea_query::Expr::value(Some(candidate.started_at.unwrap_or(now))),
+            )
+            .col_expr(
+                entities::blob_retirement::Column::UpdatedAt,
+                sea_orm::sea_query::Expr::value(now),
+            )
+            .filter(entities::blob_retirement::Column::BlobId.eq(candidate.blob_id))
+            .filter(entities::blob_retirement::Column::Status.eq(&candidate.status))
+            .filter(entities::blob_retirement::Column::AttemptCount.eq(candidate.attempt_count))
+            .filter(entities::blob_retirement::Column::UpdatedAt.eq(candidate.updated_at));
+        let claim = if reclaiming {
+            claim
+                .col_expr(
+                    entities::blob_retirement::Column::LastErrorCode,
+                    sea_orm::sea_query::Expr::value(Some("lease_expired".to_owned())),
+                )
+                .col_expr(
+                    entities::blob_retirement::Column::LastErrorDetail,
+                    sea_orm::sea_query::Expr::value(Some(
+                        "previous blob retirement lease expired".to_owned(),
+                    )),
+                )
+                .filter(entities::blob_retirement::Column::LeaseToken.eq(candidate.lease_token))
+                .filter(
+                    entities::blob_retirement::Column::LeaseExpiresAt
+                        .eq(candidate.lease_expires_at),
+                )
+        } else {
+            claim.filter(entities::blob_retirement::Column::AvailableAt.lte(now))
+        };
+        let claimed = claim.exec(&transaction).await.map_err(store_err)?;
+        if claimed.rows_affected != 1 {
+            transaction.rollback().await.map_err(store_err)?;
+            continue;
+        }
+        let claimed = entities::blob_retirement::Entity::find_by_id(candidate.blob_id)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| {
+                AgentError::Store(format!(
+                    "claimed blob retirement {} disappeared",
+                    candidate.blob_id
+                ))
+            })
+            .and_then(from_model)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(claimed));
+    }
+}
+
+pub(in crate::db) async fn heartbeat(
+    store: &DbStore,
+    blob_id: uuid::Uuid,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    lease_expires_at: chrono::DateTime<Utc>,
+) -> Result<bool> {
+    if lease_expires_at <= now {
+        return Err(AgentError::Store(
+            "blob retirement lease expiry must be after heartbeat time".into(),
+        ));
+    }
+    let updated = entities::blob_retirement::Entity::update_many()
+        .col_expr(
+            entities::blob_retirement::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Some(lease_expires_at)),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::blob_retirement::Column::BlobId.eq(blob_id))
+        .filter(
+            entities::blob_retirement::Column::Status.eq(BlobRetirementStatus::Running.as_str()),
+        )
+        .filter(entities::blob_retirement::Column::LeaseToken.eq(lease_token))
+        .filter(entities::blob_retirement::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::blob_retirement::Column::LeaseExpiresAt.lt(lease_expires_at))
+        .filter(entities::blob_retirement::Column::UpdatedAt.lte(now))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(updated.rows_affected == 1)
+}
+
+async fn cancel_candidate_on<C>(
+    conn: &C,
+    candidate: &entities::blob_retirement::Model,
+    now: chrono::DateTime<Utc>,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let cancelled = entities::blob_retirement::Entity::update_many()
+        .col_expr(
+            entities::blob_retirement::Column::Status,
+            sea_orm::sea_query::Expr::value(BlobRetirementStatus::Cancelled.as_str()),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::blob_retirement::Column::BlobId.eq(candidate.blob_id))
+        .filter(entities::blob_retirement::Column::Status.eq(&candidate.status))
+        .filter(entities::blob_retirement::Column::AttemptCount.eq(candidate.attempt_count))
+        .filter(entities::blob_retirement::Column::UpdatedAt.eq(candidate.updated_at))
+        .filter(match candidate.lease_token {
+            Some(lease_token) => entities::blob_retirement::Column::LeaseToken.eq(lease_token),
+            None => entities::blob_retirement::Column::LeaseToken.is_null(),
+        })
+        .filter(match candidate.lease_expires_at {
+            Some(lease_expires_at) => {
+                entities::blob_retirement::Column::LeaseExpiresAt.eq(lease_expires_at)
+            }
+            None => entities::blob_retirement::Column::LeaseExpiresAt.is_null(),
+        })
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(cancelled.rows_affected == 1)
+}
+
+async fn acquire_write_lock<C>(conn: &C) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    entities::blob_retirement::Entity::update_many()
+        .col_expr(
+            entities::blob_retirement::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::col(entities::blob_retirement::Column::UpdatedAt).into(),
+        )
+        .filter(entities::blob_retirement::Column::BlobId.is_null())
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+fn effective_due(retirement: &entities::blob_retirement::Model) -> Result<chrono::DateTime<Utc>> {
+    match retirement.status.as_str() {
+        "queued" | "retry_wait" => Ok(retirement.available_at),
+        "running" => retirement.lease_expires_at.ok_or_else(|| {
+            AgentError::Store(format!(
+                "running blob retirement {} has no lease expiry",
+                retirement.blob_id
+            ))
+        }),
+        other => Err(AgentError::Store(format!(
+            "non-claimable blob retirement {} has status {other}",
+            retirement.blob_id
+        ))),
+    }
+}
+
+fn is_due(retirement: &entities::blob_retirement::Model, now: chrono::DateTime<Utc>) -> bool {
+    match retirement.status.as_str() {
+        "queued" | "retry_wait" => {
+            retirement.available_at <= now && retirement.attempt_count < retirement.max_attempts
+        }
+        "running" => retirement
+            .lease_expires_at
+            .is_some_and(|lease_expires_at| lease_expires_at <= now),
+        _ => false,
     }
 }
 

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -993,6 +993,266 @@ async fn blob_retirement_constraints_reject_impossible_delivery_state() {
 }
 
 #[tokio::test]
+async fn blob_retirement_claim_cancels_referenced_candidates() {
+    let (_dir, store) = temp_store().await;
+    let shared_blob = DocumentSourceBlob::from_digest([0x71; 32], 71);
+    let source_a = sample_raw_source(
+        DocumentId::new(),
+        "file:///claim-shared-a.bin",
+        shared_blob.clone(),
+    );
+    let source_b = sample_raw_source(
+        DocumentId::new(),
+        "file:///claim-shared-b.bin",
+        shared_blob.clone(),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&source_a, "parser-v1", 3)
+        .await
+        .unwrap();
+    store
+        .accept_document_source_and_enqueue_parse(&source_b, "parser-v1", 3)
+        .await
+        .unwrap();
+    let replacement = sample_raw_source(
+        source_a.id,
+        source_a.source_uri.as_deref().unwrap(),
+        DocumentSourceBlob::from_digest([0x72; 32], 72),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&replacement, "parser-v1", 3)
+        .await
+        .unwrap();
+
+    let queued = store
+        .get_blob_retirement(shared_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let now = queued.available_at + chrono::Duration::seconds(1);
+    assert_eq!(
+        store
+            .claim_blob_retirement(now, now + chrono::Duration::minutes(5))
+            .await
+            .unwrap(),
+        None
+    );
+    let cancelled = store
+        .get_blob_retirement(shared_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(cancelled.status, BlobRetirementStatus::Cancelled);
+    assert_eq!(cancelled.attempt_count, 0);
+    assert_eq!(cancelled.lease_token, None);
+    assert_eq!(cancelled.finished_at, Some(now));
+}
+
+#[tokio::test]
+async fn blob_retirement_claim_and_heartbeat_require_the_live_lease() {
+    let (_dir, store) = temp_store().await;
+    let source = sample_raw_source(
+        DocumentId::new(),
+        "file:///retire-claim.bin",
+        DocumentSourceBlob::from_digest([0x73; 32], 73),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+        .await
+        .unwrap();
+    store.delete_document(source.id).await.unwrap();
+    let queued = store
+        .get_blob_retirement(source.source_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let now = queued.available_at + chrono::Duration::seconds(1);
+    assert!(store.claim_blob_retirement(now, now).await.is_err());
+
+    let first_expiry = now + chrono::Duration::minutes(5);
+    let claimed = store
+        .claim_blob_retirement(now, first_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.blob_id, source.source_blob.id);
+    assert_eq!(claimed.status, BlobRetirementStatus::Running);
+    assert_eq!(claimed.attempt_count, 1);
+    assert_eq!(claimed.started_at, Some(now));
+    assert_eq!(claimed.lease_expires_at, Some(first_expiry));
+    let lease_token = claimed.lease_token.unwrap();
+    assert!(!store
+        .heartbeat_blob_retirement(
+            claimed.blob_id,
+            uuid::Uuid::new_v4(),
+            now + chrono::Duration::minutes(1),
+            first_expiry + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap());
+    assert!(!store
+        .heartbeat_blob_retirement(
+            claimed.blob_id,
+            lease_token,
+            now + chrono::Duration::minutes(1),
+            first_expiry,
+        )
+        .await
+        .unwrap());
+    assert!(store
+        .heartbeat_blob_retirement(claimed.blob_id, lease_token, now, now)
+        .await
+        .is_err());
+
+    let heartbeat_at = now + chrono::Duration::minutes(1);
+    let extended = first_expiry + chrono::Duration::minutes(5);
+    assert!(store
+        .heartbeat_blob_retirement(claimed.blob_id, lease_token, heartbeat_at, extended)
+        .await
+        .unwrap());
+    let heartbeated = store
+        .get_blob_retirement(claimed.blob_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(heartbeated.lease_expires_at, Some(extended));
+    assert_eq!(heartbeated.updated_at, heartbeat_at);
+    assert!(!store
+        .heartbeat_blob_retirement(
+            claimed.blob_id,
+            lease_token,
+            extended,
+            extended + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn expired_blob_retirement_leases_are_reclaimed_then_fail_at_the_attempt_limit() {
+    let (_dir, store) = temp_store().await;
+    let source = sample_raw_source(
+        DocumentId::new(),
+        "file:///retire-reclaim.bin",
+        DocumentSourceBlob::from_digest([0x74; 32], 74),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+        .await
+        .unwrap();
+    store.delete_document(source.id).await.unwrap();
+    entities::blob_retirement::Entity::update_many()
+        .col_expr(
+            entities::blob_retirement::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(2_i32),
+        )
+        .filter(entities::blob_retirement::Column::BlobId.eq(source.source_blob.id))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let queued = store
+        .get_blob_retirement(source.source_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let first_at = queued.available_at + chrono::Duration::seconds(1);
+    let first_expiry = first_at + chrono::Duration::minutes(1);
+    let first = store
+        .claim_blob_retirement(first_at, first_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    let second_expiry = first_expiry + chrono::Duration::minutes(1);
+    let second = store
+        .claim_blob_retirement(first_expiry, second_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.blob_id, first.blob_id);
+    assert_eq!(second.attempt_count, 2);
+    assert_eq!(second.started_at, first.started_at);
+    assert_ne!(second.lease_token, first.lease_token);
+    assert_eq!(second.last_error_code.as_deref(), Some("lease_expired"));
+    assert!(!store
+        .heartbeat_blob_retirement(
+            first.blob_id,
+            first.lease_token.unwrap(),
+            first_expiry,
+            second_expiry + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap());
+
+    let final_at = second_expiry + chrono::Duration::seconds(1);
+    assert_eq!(
+        store
+            .claim_blob_retirement(final_at, final_at + chrono::Duration::minutes(1))
+            .await
+            .unwrap(),
+        None
+    );
+    let failed = store
+        .get_blob_retirement(first.blob_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(failed.status, BlobRetirementStatus::Failed);
+    assert_eq!(failed.attempt_count, 2);
+    assert_eq!(failed.lease_token, None);
+    assert_eq!(failed.lease_expires_at, None);
+    assert_eq!(failed.finished_at, Some(final_at));
+    assert_eq!(failed.last_error_code.as_deref(), Some("lease_expired"));
+}
+
+#[tokio::test]
+async fn concurrent_blob_retirement_claimers_never_share_a_blob() {
+    let (_dir, store) = temp_store().await;
+    let store = std::sync::Arc::new(store);
+    let mut latest_available_at = DateTime::<Utc>::from_timestamp(0, 0).unwrap();
+    for index in 0..6 {
+        let source = sample_raw_source(
+            DocumentId::new(),
+            &format!("file:///retire-concurrent-{index}.bin"),
+            DocumentSourceBlob::from_digest([0x80 + index as u8; 32], 80 + index),
+        );
+        store
+            .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+            .await
+            .unwrap();
+        store.delete_document(source.id).await.unwrap();
+        latest_available_at = latest_available_at.max(
+            store
+                .get_blob_retirement(source.source_blob.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .available_at,
+        );
+    }
+    let now = latest_available_at + chrono::Duration::seconds(1);
+    let claims = (0..12).map(|_| {
+        let store = store.clone();
+        tokio::spawn(async move {
+            store
+                .claim_blob_retirement(now, now + chrono::Duration::minutes(5))
+                .await
+        })
+    });
+
+    let mut claimed_ids = Vec::new();
+    for result in futures::future::join_all(claims).await {
+        if let Some(retirement) = result.unwrap().unwrap() {
+            claimed_ids.push(retirement.blob_id);
+        }
+    }
+    assert_eq!(claimed_ids.len(), 6);
+    claimed_ids.sort();
+    claimed_ids.dedup();
+    assert_eq!(claimed_ids.len(), 6);
+}
+
+#[tokio::test]
 async fn ensure_parse_job_advances_parser_changes_and_reuses_the_transition() {
     let (_dir, store) = temp_store().await;
     let source = DocumentSourceUpsert {

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -159,6 +159,30 @@ pub trait Store: Send + Sync {
         document_storage_unavailable()
     }
 
+    /// Claim the oldest effective-due blob retirement under a fresh lease.
+    ///
+    /// `lease_expires_at` must be after `now`. Expired running work is reclaimed
+    /// with a new token and attempt; an expired final attempt becomes failed and
+    /// the claim scan continues to the next candidate.
+    async fn claim_blob_retirement(
+        &self,
+        _now: chrono::DateTime<chrono::Utc>,
+        _lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<BlobRetirement>> {
+        document_storage_unavailable()
+    }
+
+    /// Extend one exact live blob-retirement lease monotonically.
+    async fn heartbeat_blob_retirement(
+        &self,
+        _blob_id: uuid::Uuid,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+        _lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        document_storage_unavailable()
+    }
+
     /// Read the newest durable generation, including a hard-delete tombstone.
     async fn get_document_generation(&self, _id: DocumentId) -> Result<Option<DocumentGeneration>> {
         document_storage_unavailable()


### PR DESCRIPTION
## Summary

- claim the oldest effective-due blob retirement with a fresh exact-token lease
- atomically cancel candidates that still have an authoritative document reference
- reclaim expired leases, fail exhausted work, and support monotonic heartbeats
- fence concurrent claimers and stale lease owners with exact compare-and-set writes

## Validation

- `cargo test -p openwave-core`
- `cargo test -p openwave-core blob_retirement -- --nocapture`
- `cargo fmt --all -- --check`
- `bw dev lint --rust`
