### PR TITLE
Resolve blob retirement leases

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -310,6 +310,36 @@ impl Store for DbStore {
         ops::blob::heartbeat(self, blob_id, lease_token, now, lease_expires_at).await
     }
 
+    async fn complete_blob_retirement(
+        &self,
+        blob_id: uuid::Uuid,
+        lease_token: uuid::Uuid,
+        completed_at: chrono::DateTime<Utc>,
+    ) -> Result<bool> {
+        ops::blob::complete(self, blob_id, lease_token, completed_at).await
+    }
+
+    async fn record_blob_retirement_failure(
+        &self,
+        blob_id: uuid::Uuid,
+        lease_token: uuid::Uuid,
+        failed_at: chrono::DateTime<Utc>,
+        retry_at: Option<chrono::DateTime<Utc>>,
+        error_code: &str,
+        error_detail: Option<&str>,
+    ) -> Result<Option<BlobRetirementStatus>> {
+        ops::blob::record_failure(
+            self,
+            blob_id,
+            lease_token,
+            failed_at,
+            retry_at,
+            error_code,
+            error_detail,
+        )
+        .await
+    }
+
     async fn get_document_generation(&self, id: DocumentId) -> Result<Option<DocumentGeneration>> {
         Ok(entities::document_generation::Entity::find_by_id(id.0)
             .one(&self.conn)

--- a/crates/openwave-core/src/db/ops/blob.rs
+++ b/crates/openwave-core/src/db/ops/blob.rs
@@ -298,6 +298,150 @@ pub(in crate::db) async fn heartbeat(
     Ok(updated.rows_affected == 1)
 }
 
+pub(in crate::db) async fn complete(
+    store: &DbStore,
+    blob_id: uuid::Uuid,
+    lease_token: uuid::Uuid,
+    completed_at: chrono::DateTime<Utc>,
+) -> Result<bool> {
+    let completed = entities::blob_retirement::Entity::update_many()
+        .col_expr(
+            entities::blob_retirement::Column::Status,
+            sea_orm::sea_query::Expr::value(BlobRetirementStatus::Succeeded.as_str()),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(completed_at)),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::blob_retirement::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(completed_at),
+        )
+        .filter(entities::blob_retirement::Column::BlobId.eq(blob_id))
+        .filter(
+            entities::blob_retirement::Column::Status.eq(BlobRetirementStatus::Running.as_str()),
+        )
+        .filter(entities::blob_retirement::Column::LeaseToken.eq(lease_token))
+        .filter(entities::blob_retirement::Column::LeaseExpiresAt.gt(completed_at))
+        .filter(entities::blob_retirement::Column::UpdatedAt.lte(completed_at))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(completed.rows_affected == 1)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::db) async fn record_failure(
+    store: &DbStore,
+    blob_id: uuid::Uuid,
+    lease_token: uuid::Uuid,
+    failed_at: chrono::DateTime<Utc>,
+    retry_at: Option<chrono::DateTime<Utc>>,
+    error_code: &str,
+    error_detail: Option<&str>,
+) -> Result<Option<BlobRetirementStatus>> {
+    validate_error(error_code, error_detail)?;
+    if retry_at.is_some_and(|retry_at| retry_at <= failed_at) {
+        return Err(AgentError::Store(
+            "blob retirement retry time must be after failure time".into(),
+        ));
+    }
+
+    loop {
+        let transaction = store.conn.begin().await.map_err(store_err)?;
+        acquire_write_lock(&transaction).await?;
+        let candidate = entities::blob_retirement::Entity::find_by_id(blob_id)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        let Some(candidate) =
+            candidate.filter(|candidate| lease_is_live(candidate, lease_token, failed_at))
+        else {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(None);
+        };
+        let will_retry = retry_at.is_some() && candidate.attempt_count < candidate.max_attempts;
+        let next_status = if will_retry {
+            BlobRetirementStatus::RetryWait
+        } else {
+            BlobRetirementStatus::Failed
+        };
+        let update = entities::blob_retirement::Entity::update_many()
+            .col_expr(
+                entities::blob_retirement::Column::Status,
+                sea_orm::sea_query::Expr::value(next_status.as_str()),
+            )
+            .col_expr(
+                entities::blob_retirement::Column::LeaseToken,
+                sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+            )
+            .col_expr(
+                entities::blob_retirement::Column::LeaseExpiresAt,
+                sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+            )
+            .col_expr(
+                entities::blob_retirement::Column::LastErrorCode,
+                sea_orm::sea_query::Expr::value(Some(error_code.to_owned())),
+            )
+            .col_expr(
+                entities::blob_retirement::Column::LastErrorDetail,
+                sea_orm::sea_query::Expr::value(error_detail.map(str::to_owned)),
+            )
+            .col_expr(
+                entities::blob_retirement::Column::UpdatedAt,
+                sea_orm::sea_query::Expr::value(failed_at),
+            );
+        let update = if let Some(retry_at) = retry_at.filter(|_| will_retry) {
+            update.col_expr(
+                entities::blob_retirement::Column::AvailableAt,
+                sea_orm::sea_query::Expr::value(retry_at),
+            )
+        } else {
+            update.col_expr(
+                entities::blob_retirement::Column::FinishedAt,
+                sea_orm::sea_query::Expr::value(Some(failed_at)),
+            )
+        };
+        let resolved = update
+            .filter(entities::blob_retirement::Column::BlobId.eq(blob_id))
+            .filter(
+                entities::blob_retirement::Column::Status
+                    .eq(BlobRetirementStatus::Running.as_str()),
+            )
+            .filter(entities::blob_retirement::Column::AttemptCount.eq(candidate.attempt_count))
+            .filter(entities::blob_retirement::Column::LeaseToken.eq(lease_token))
+            .filter(
+                entities::blob_retirement::Column::LeaseExpiresAt.eq(candidate.lease_expires_at),
+            )
+            .filter(entities::blob_retirement::Column::UpdatedAt.eq(candidate.updated_at))
+            .exec(&transaction)
+            .await
+            .map_err(store_err)?;
+        if resolved.rows_affected != 1 {
+            transaction.rollback().await.map_err(store_err)?;
+            continue;
+        }
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(next_status));
+    }
+}
+
 async fn cancel_candidate_on<C>(
     conn: &C,
     candidate: &entities::blob_retirement::Model,
@@ -397,6 +541,36 @@ fn is_due(retirement: &entities::blob_retirement::Model, now: chrono::DateTime<U
             .is_some_and(|lease_expires_at| lease_expires_at <= now),
         _ => false,
     }
+}
+
+fn lease_is_live(
+    retirement: &entities::blob_retirement::Model,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+) -> bool {
+    retirement.status == BlobRetirementStatus::Running.as_str()
+        && retirement.lease_token == Some(lease_token)
+        && retirement
+            .lease_expires_at
+            .is_some_and(|lease_expires_at| lease_expires_at > now)
+        && retirement.updated_at <= now
+}
+
+fn validate_error(error_code: &str, error_detail: Option<&str>) -> Result<()> {
+    let code_len = error_code.chars().count();
+    if !(1..=BlobRetirement::MAX_ERROR_CODE_LEN).contains(&code_len) {
+        return Err(AgentError::Store(
+            "blob retirement error code must contain 1 to 128 characters".into(),
+        ));
+    }
+    if error_detail.is_some_and(|detail| {
+        !(1..=BlobRetirement::MAX_ERROR_DETAIL_LEN).contains(&detail.chars().count())
+    }) {
+        return Err(AgentError::Store(
+            "blob retirement error detail must contain 1 to 4096 characters".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Coalesce a dropped source reference into one fresh retirement episode.

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -1129,6 +1129,284 @@ async fn blob_retirement_claim_and_heartbeat_require_the_live_lease() {
 }
 
 #[tokio::test]
+async fn blob_retirement_completion_requires_the_exact_live_lease() {
+    let (_dir, store) = temp_store().await;
+    let source = sample_raw_source(
+        DocumentId::new(),
+        "file:///retire-complete.bin",
+        DocumentSourceBlob::from_digest([0x75; 32], 75),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+        .await
+        .unwrap();
+    store.delete_document(source.id).await.unwrap();
+    let queued = store
+        .get_blob_retirement(source.source_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let claimed_at = queued.available_at + chrono::Duration::seconds(1);
+    let lease_expires_at = claimed_at + chrono::Duration::minutes(5);
+    let claimed = store
+        .claim_blob_retirement(claimed_at, lease_expires_at)
+        .await
+        .unwrap()
+        .unwrap();
+    let lease_token = claimed.lease_token.unwrap();
+    assert!(!store
+        .complete_blob_retirement(
+            claimed.blob_id,
+            uuid::Uuid::new_v4(),
+            claimed_at + chrono::Duration::seconds(1),
+        )
+        .await
+        .unwrap());
+    assert!(!store
+        .complete_blob_retirement(
+            claimed.blob_id,
+            lease_token,
+            claimed_at - chrono::Duration::seconds(1),
+        )
+        .await
+        .unwrap());
+    assert!(!store
+        .complete_blob_retirement(claimed.blob_id, lease_token, lease_expires_at)
+        .await
+        .unwrap());
+
+    let completed_at = claimed_at + chrono::Duration::seconds(2);
+    assert!(store
+        .complete_blob_retirement(claimed.blob_id, lease_token, completed_at)
+        .await
+        .unwrap());
+    let succeeded = store
+        .get_blob_retirement(claimed.blob_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(succeeded.status, BlobRetirementStatus::Succeeded);
+    assert_eq!(succeeded.lease_token, None);
+    assert_eq!(succeeded.lease_expires_at, None);
+    assert_eq!(succeeded.finished_at, Some(completed_at));
+    assert_eq!(succeeded.last_error_code, None);
+    assert_eq!(succeeded.last_error_detail, None);
+    assert!(!store
+        .complete_blob_retirement(claimed.blob_id, lease_token, completed_at)
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
+async fn blob_retirement_failure_retries_then_exhausts_the_attempt_budget() {
+    let (_dir, store) = temp_store().await;
+    let source = sample_raw_source(
+        DocumentId::new(),
+        "file:///retire-failure.bin",
+        DocumentSourceBlob::from_digest([0x76; 32], 76),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+        .await
+        .unwrap();
+    store.delete_document(source.id).await.unwrap();
+    entities::blob_retirement::Entity::update_many()
+        .col_expr(
+            entities::blob_retirement::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(2_i32),
+        )
+        .filter(entities::blob_retirement::Column::BlobId.eq(source.source_blob.id))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let queued = store
+        .get_blob_retirement(source.source_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let first_at = queued.available_at + chrono::Duration::seconds(1);
+    let first = store
+        .claim_blob_retirement(first_at, first_at + chrono::Duration::minutes(5))
+        .await
+        .unwrap()
+        .unwrap();
+    let first_token = first.lease_token.unwrap();
+    let failed_at = first_at + chrono::Duration::seconds(1);
+    let retry_at = failed_at + chrono::Duration::minutes(1);
+    assert!(store
+        .record_blob_retirement_failure(
+            first.blob_id,
+            first_token,
+            failed_at,
+            Some(failed_at),
+            "delete_failed",
+            None,
+        )
+        .await
+        .is_err());
+    assert!(store
+        .record_blob_retirement_failure(
+            first.blob_id,
+            first_token,
+            failed_at,
+            Some(retry_at),
+            "",
+            None,
+        )
+        .await
+        .is_err());
+    assert_eq!(
+        store
+            .record_blob_retirement_failure(
+                first.blob_id,
+                uuid::Uuid::new_v4(),
+                failed_at,
+                Some(retry_at),
+                "delete_failed",
+                Some("temporary filesystem error"),
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        store
+            .record_blob_retirement_failure(
+                first.blob_id,
+                first_token,
+                failed_at,
+                Some(retry_at),
+                "delete_failed",
+                Some("temporary filesystem error"),
+            )
+            .await
+            .unwrap(),
+        Some(BlobRetirementStatus::RetryWait)
+    );
+    let waiting = store
+        .get_blob_retirement(first.blob_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(waiting.status, BlobRetirementStatus::RetryWait);
+    assert_eq!(waiting.available_at, retry_at);
+    assert_eq!(waiting.finished_at, None);
+    assert_eq!(waiting.last_error_code.as_deref(), Some("delete_failed"));
+    assert_eq!(
+        store
+            .claim_blob_retirement(failed_at, failed_at + chrono::Duration::minutes(5))
+            .await
+            .unwrap(),
+        None
+    );
+
+    let second = store
+        .claim_blob_retirement(retry_at, retry_at + chrono::Duration::minutes(5))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.blob_id, first.blob_id);
+    assert_eq!(second.attempt_count, 2);
+    assert_ne!(second.lease_token, first.lease_token);
+    assert_eq!(second.last_error_code.as_deref(), Some("delete_failed"));
+    let terminal_at = retry_at + chrono::Duration::seconds(1);
+    assert_eq!(
+        store
+            .record_blob_retirement_failure(
+                second.blob_id,
+                second.lease_token.unwrap(),
+                terminal_at,
+                Some(terminal_at + chrono::Duration::minutes(1)),
+                "delete_failed",
+                None,
+            )
+            .await
+            .unwrap(),
+        Some(BlobRetirementStatus::Failed)
+    );
+    let failed = store
+        .get_blob_retirement(second.blob_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(failed.status, BlobRetirementStatus::Failed);
+    assert_eq!(failed.attempt_count, 2);
+    assert_eq!(failed.finished_at, Some(terminal_at));
+    assert_eq!(failed.lease_token, None);
+    assert_eq!(failed.lease_expires_at, None);
+}
+
+#[tokio::test]
+async fn blob_retirement_claim_skips_an_exhausted_lease_and_returns_later_work() {
+    let (_dir, store) = temp_store().await;
+    let exhausted_source = sample_raw_source(
+        DocumentId::new(),
+        "file:///retire-exhausted-first.bin",
+        DocumentSourceBlob::from_digest([0x77; 32], 77),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&exhausted_source, "parser-v1", 3)
+        .await
+        .unwrap();
+    store.delete_document(exhausted_source.id).await.unwrap();
+    entities::blob_retirement::Entity::update_many()
+        .col_expr(
+            entities::blob_retirement::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(1_i32),
+        )
+        .filter(entities::blob_retirement::Column::BlobId.eq(exhausted_source.source_blob.id))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let exhausted_queued = store
+        .get_blob_retirement(exhausted_source.source_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let first_at = exhausted_queued.available_at + chrono::Duration::seconds(1);
+    let first_expiry = first_at + chrono::Duration::minutes(1);
+    store
+        .claim_blob_retirement(first_at, first_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let later_source = sample_raw_source(
+        DocumentId::new(),
+        "file:///retire-later-work.bin",
+        DocumentSourceBlob::from_digest([0x78; 32], 78),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&later_source, "parser-v1", 3)
+        .await
+        .unwrap();
+    store.delete_document(later_source.id).await.unwrap();
+    entities::blob_retirement::Entity::update_many()
+        .col_expr(
+            entities::blob_retirement::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(first_expiry + chrono::Duration::milliseconds(500)),
+        )
+        .filter(entities::blob_retirement::Column::BlobId.eq(later_source.source_blob.id))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let claim_at = first_expiry + chrono::Duration::seconds(1);
+    let claimed = store
+        .claim_blob_retirement(claim_at, claim_at + chrono::Duration::minutes(5))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.blob_id, later_source.source_blob.id);
+    let exhausted = store
+        .get_blob_retirement(exhausted_source.source_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(exhausted.status, BlobRetirementStatus::Failed);
+    assert_eq!(exhausted.last_error_code.as_deref(), Some("lease_expired"));
+}
+
+#[tokio::test]
 async fn expired_blob_retirement_leases_are_reclaimed_then_fail_at_the_attempt_limit() {
     let (_dir, store) = temp_store().await;
     let source = sample_raw_source(

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -22,9 +22,9 @@ use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId};
 use crate::model::{
-    BlobRetirement, Chat, DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus,
-    DocumentListCursor, DocumentParseOutput, DocumentRecord, DocumentScope, DocumentSourceUpsert,
-    DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
+    BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
+    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentRecord, DocumentScope,
+    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
 };
 
 /// Why maintenance determined that a document needs an index job.
@@ -180,6 +180,36 @@ pub trait Store: Send + Sync {
         _now: chrono::DateTime<chrono::Utc>,
         _lease_expires_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool> {
+        document_storage_unavailable()
+    }
+
+    /// Mark one exact live blob-retirement lease as successfully deleted.
+    ///
+    /// Returns `false` if the row is no longer running under the exact,
+    /// unexpired lease or `completed_at` would regress durable state.
+    async fn complete_blob_retirement(
+        &self,
+        _blob_id: uuid::Uuid,
+        _lease_token: uuid::Uuid,
+        _completed_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        document_storage_unavailable()
+    }
+
+    /// Record a deletion failure for one exact live blob-retirement lease.
+    ///
+    /// A future `retry_at` moves work with attempts remaining to `retry_wait`;
+    /// no retry time, or an exhausted attempt budget, moves it to `failed`.
+    /// Returns the resulting state, or `None` when the lease lost ownership.
+    async fn record_blob_retirement_failure(
+        &self,
+        _blob_id: uuid::Uuid,
+        _lease_token: uuid::Uuid,
+        _failed_at: chrono::DateTime<chrono::Utc>,
+        _retry_at: Option<chrono::DateTime<chrono::Utc>>,
+        _error_code: &str,
+        _error_detail: Option<&str>,
+    ) -> Result<Option<BlobRetirementStatus>> {
         document_storage_unavailable()
     }
 


### PR DESCRIPTION
## Summary

- complete blob retirement only under the exact live lease
- record validated retryable or terminal deletion failures atomically
- preserve attempt budgets and fence stale or expired workers
- cover retry scheduling, exhaustion, and scan continuation

## Validation

- `cargo test -p openwave-core`
- `cargo test -p openwave-core blob_retirement -- --nocapture`
- `cargo fmt --all -- --check`
- `bw dev lint --rust`
