### PR TITLE
Execute blob retirements

### DIFF
--- a/crates/openwave-core/src/blob.rs
+++ b/crates/openwave-core/src/blob.rs
@@ -128,22 +128,18 @@ impl BlobStore for FsBlobStore {
         .map_err(|error| AgentError::Store(format!("blob read task failed: {error}")))?
     }
 
-    async fn delete(&self, id: Uuid) -> Result<()> {
+    fn delete(&self, id: Uuid) -> Result<()> {
         let path = self.blob_path(id);
         let root = Arc::clone(&self.root);
         let access = Arc::clone(&self.access);
-        tokio::task::spawn_blocking(move || {
-            let _guard = access
-                .write()
-                .map_err(|_| AgentError::Store("blob store lock poisoned".into()))?;
-            match fs::remove_file(path) {
-                Ok(()) => sync_directory(&root),
-                Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
-                Err(error) => Err(blob_error("delete file", error)),
-            }
-        })
-        .await
-        .map_err(|error| AgentError::Store(format!("blob delete task failed: {error}")))?
+        let _guard = access
+            .write()
+            .map_err(|_| AgentError::Store("blob store lock poisoned".into()))?;
+        match fs::remove_file(path) {
+            Ok(()) => sync_directory(&root),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(blob_error("delete file", error)),
+        }
     }
 }
 
@@ -228,8 +224,8 @@ mod tests {
             reopened.get(id).await.unwrap().as_deref(),
             Some(&b"first"[..])
         );
-        reopened.delete(id).await.unwrap();
-        reopened.delete(id).await.unwrap();
+        reopened.delete(id).unwrap();
+        reopened.delete(id).unwrap();
         assert_eq!(reopened.get(id).await.unwrap(), None);
     }
 

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -310,6 +310,15 @@ impl Store for DbStore {
         ops::blob::heartbeat(self, blob_id, lease_token, now, lease_expires_at).await
     }
 
+    async fn validate_blob_retirement_lease(
+        &self,
+        blob_id: uuid::Uuid,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<bool> {
+        ops::blob::validate_lease(self, blob_id, lease_token, now).await
+    }
+
     async fn complete_blob_retirement(
         &self,
         blob_id: uuid::Uuid,

--- a/crates/openwave-core/src/db/ops/blob.rs
+++ b/crates/openwave-core/src/db/ops/blob.rs
@@ -298,6 +298,47 @@ pub(in crate::db) async fn heartbeat(
     Ok(updated.rows_affected == 1)
 }
 
+pub(in crate::db) async fn validate_lease(
+    store: &DbStore,
+    blob_id: uuid::Uuid,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+) -> Result<bool> {
+    loop {
+        let transaction = store.conn.begin().await.map_err(store_err)?;
+        acquire_write_lock(&transaction).await?;
+        let candidate = entities::blob_retirement::Entity::find_by_id(blob_id)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        let Some(candidate) =
+            candidate.filter(|candidate| lease_is_live(candidate, lease_token, now))
+        else {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(false);
+        };
+        let referenced = entities::document::Entity::find()
+            .select_only()
+            .column(entities::document::Column::Id)
+            .filter(entities::document::Column::SourceBlobId.eq(blob_id))
+            .into_tuple::<uuid::Uuid>()
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .is_some();
+        if referenced {
+            if !cancel_candidate_on(&transaction, &candidate, now).await? {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(false);
+        }
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(true);
+    }
+}
+
 pub(in crate::db) async fn complete(
     store: &DbStore,
     blob_id: uuid::Uuid,

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -1198,6 +1198,83 @@ async fn blob_retirement_completion_requires_the_exact_live_lease() {
 }
 
 #[tokio::test]
+async fn blob_retirement_final_validation_cancels_a_new_authoritative_reference() {
+    let (_dir, store) = temp_store().await;
+    let retired_source = sample_raw_source(
+        DocumentId::new(),
+        "file:///retire-final-check.bin",
+        DocumentSourceBlob::from_digest([0x79; 32], 79),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&retired_source, "parser-v1", 3)
+        .await
+        .unwrap();
+    store.delete_document(retired_source.id).await.unwrap();
+    let queued = store
+        .get_blob_retirement(retired_source.source_blob.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let claimed_at = queued.available_at + chrono::Duration::seconds(1);
+    let claimed = store
+        .claim_blob_retirement(claimed_at, claimed_at + chrono::Duration::minutes(5))
+        .await
+        .unwrap()
+        .unwrap();
+
+    let live_source = sample_raw_source(
+        DocumentId::new(),
+        "file:///retire-final-check-live.bin",
+        DocumentSourceBlob::from_digest([0x7a; 32], 80),
+    );
+    store
+        .accept_document_source_and_enqueue_parse(&live_source, "parser-v1", 3)
+        .await
+        .unwrap();
+    // Simulate an uncoordinated external catalog writer to exercise the final
+    // indexed reference check itself, rather than the normal write-time cancel.
+    entities::document::Entity::update_many()
+        .col_expr(
+            entities::document::Column::SourceBlobId,
+            sea_orm::sea_query::Expr::value(Some(retired_source.source_blob.id)),
+        )
+        .col_expr(
+            entities::document::Column::SourceSha256,
+            sea_orm::sea_query::Expr::value(Some(retired_source.source_blob.sha256.to_vec())),
+        )
+        .col_expr(
+            entities::document::Column::SourceByteLen,
+            sea_orm::sea_query::Expr::value(Some(
+                i64::try_from(retired_source.source_blob.byte_len).unwrap(),
+            )),
+        )
+        .filter(entities::document::Column::Id.eq(live_source.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let validated_at = claimed_at + chrono::Duration::seconds(1);
+    assert!(
+        !store
+            .validate_blob_retirement_lease(
+                claimed.blob_id,
+                claimed.lease_token.unwrap(),
+                validated_at,
+            )
+            .await
+            .unwrap()
+    );
+    let cancelled = store
+        .get_blob_retirement(claimed.blob_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(cancelled.status, BlobRetirementStatus::Cancelled);
+    assert_eq!(cancelled.finished_at, Some(validated_at));
+    assert_eq!(cancelled.lease_token, None);
+}
+
+#[tokio::test]
 async fn blob_retirement_failure_retries_then_exhausts_the_attempt_budget() {
     let (_dir, store) = temp_store().await;
     let source = sample_raw_source(

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -183,6 +183,20 @@ pub trait Store: Send + Sync {
         document_storage_unavailable()
     }
 
+    /// Revalidate one exact live retirement lease immediately before deletion.
+    ///
+    /// This atomically cancels the retirement if an authoritative document
+    /// reference exists. Callers must hold the same cross-process blob guard
+    /// used by source publishers until deletion and resolution finish.
+    async fn validate_blob_retirement_lease(
+        &self,
+        _blob_id: uuid::Uuid,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        document_storage_unavailable()
+    }
+
     /// Mark one exact live blob-retirement lease as successfully deleted.
     ///
     /// Returns `false` if the row is no longer running under the exact,
@@ -558,8 +572,12 @@ pub trait BlobStore: Send + Sync {
     /// Fetch bytes by `id`, or `None` if absent.
     async fn get(&self, id: uuid::Uuid) -> Result<Option<Vec<u8>>>;
 
-    /// Delete a blob; a no-op if it doesn't exist.
-    async fn delete(&self, id: uuid::Uuid) -> Result<()>;
+    /// Delete a blob synchronously; a no-op if it doesn't exist.
+    ///
+    /// Async callers must move this operation to a blocking executor. This
+    /// boundary lets a lifecycle guard remain owned by the blocking operation
+    /// even when its awaiting worker is cancelled.
+    fn delete(&self, id: uuid::Uuid) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/blob_retirement_worker.rs
+++ b/crates/openwave-server/src/blob_retirement_worker.rs
@@ -1,0 +1,651 @@
+//! Durable source-blob retirement execution.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use openwave_core::{AgentError, BlobRetirement, BlobRetirementStatus, BlobStore, Result, Store};
+use tokio::sync::Notify;
+use uuid::Uuid;
+
+use crate::state::BlobWriteGuard;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BlobRetirementWorkerConfig {
+    lease: Duration,
+    heartbeat: Duration,
+    retry_base: Duration,
+    retry_cap: Duration,
+    idle_min: Duration,
+    idle_cap: Duration,
+    failure_delay: Duration,
+}
+
+impl Default for BlobRetirementWorkerConfig {
+    fn default() -> Self {
+        Self {
+            lease: Duration::from_secs(60),
+            heartbeat: Duration::from_secs(15),
+            retry_base: Duration::from_secs(5),
+            retry_cap: Duration::from_secs(5 * 60),
+            idle_min: Duration::from_millis(250),
+            idle_cap: Duration::from_secs(5),
+            failure_delay: Duration::from_secs(1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BlobRetirementWorkerOutcome {
+    Idle,
+    Completed(Uuid),
+    RetryScheduled(Uuid),
+    Failed(Uuid),
+    LeaseLost(Uuid),
+}
+
+#[derive(Clone)]
+pub(crate) struct BlobRetirementWorker {
+    store: Arc<dyn Store>,
+    blobs: Arc<dyn BlobStore>,
+    wake: Arc<Notify>,
+    blob_writes: Arc<BlobWriteGuard>,
+    config: BlobRetirementWorkerConfig,
+}
+
+enum Supervised<T> {
+    Completed(T),
+    LeaseLost,
+}
+
+impl BlobRetirementWorker {
+    pub(crate) fn new(
+        store: Arc<dyn Store>,
+        blobs: Arc<dyn BlobStore>,
+        wake: Arc<Notify>,
+        blob_writes: Arc<BlobWriteGuard>,
+        config: BlobRetirementWorkerConfig,
+    ) -> Self {
+        assert!(!config.lease.is_zero());
+        assert!(!config.heartbeat.is_zero());
+        assert!(config.heartbeat < config.lease);
+        Self {
+            store,
+            blobs,
+            wake,
+            blob_writes,
+            config,
+        }
+    }
+
+    pub(crate) async fn run(self) {
+        let mut idle_delay = self.config.idle_min;
+        loop {
+            match self.run_once().await {
+                Ok(BlobRetirementWorkerOutcome::Idle) => {
+                    tokio::select! {
+                        _ = tokio::time::sleep(idle_delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
+                }
+                Ok(_) => idle_delay = self.config.idle_min,
+                Err(error) => {
+                    eprintln!("openwave: blob retirement worker iteration failed: {error}");
+                    tokio::select! {
+                        _ = tokio::time::sleep(self.config.failure_delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn run_once(&self) -> Result<BlobRetirementWorkerOutcome> {
+        let now = Utc::now();
+        let lease_expires_at = now + chrono_duration(self.config.lease)?;
+        let Some(retirement) = self
+            .store
+            .claim_blob_retirement(now, lease_expires_at)
+            .await?
+        else {
+            return Ok(BlobRetirementWorkerOutcome::Idle);
+        };
+        self.process(retirement).await
+    }
+
+    async fn process(&self, retirement: BlobRetirement) -> Result<BlobRetirementWorkerOutcome> {
+        if retirement.status != BlobRetirementStatus::Running {
+            return Err(AgentError::msg(format!(
+                "claimed blob retirement {} has an invalid execution state",
+                retirement.blob_id
+            )));
+        }
+        let lease_token = retirement.lease_token.ok_or_else(|| {
+            AgentError::msg(format!(
+                "claimed blob retirement {} has no lease token",
+                retirement.blob_id
+            ))
+        })?;
+
+        let permit = match self
+            .supervise(
+                &retirement,
+                lease_token,
+                self.blob_writes.acquire(retirement.blob_id),
+            )
+            .await
+        {
+            Supervised::LeaseLost => {
+                return Ok(BlobRetirementWorkerOutcome::LeaseLost(retirement.blob_id));
+            }
+            Supervised::Completed(Ok(permit)) => permit,
+            Supervised::Completed(Err(error)) => {
+                return self
+                    .record_failure(
+                        &retirement,
+                        lease_token,
+                        "blob_lock_failed",
+                        &error.to_string(),
+                    )
+                    .await;
+            }
+        };
+
+        // Source publication takes this same cross-process guard around both
+        // blob publication and catalog acceptance. Once the exact lease and
+        // authoritative references are revalidated here, no new reference can
+        // appear until deletion and lease-fenced completion have finished.
+        if !self
+            .store
+            .validate_blob_retirement_lease(retirement.blob_id, lease_token, Utc::now())
+            .await?
+        {
+            return Ok(BlobRetirementWorkerOutcome::LeaseLost(retirement.blob_id));
+        }
+
+        let blobs = Arc::clone(&self.blobs);
+        let blob_id = retirement.blob_id;
+        let deletion = self
+            .supervise(&retirement, lease_token, async move {
+                tokio::task::spawn_blocking(move || {
+                    let result = blobs.delete(blob_id);
+                    (permit, result)
+                })
+                .await
+                .map_err(|error| AgentError::Store(format!("blob delete task failed: {error}")))
+            })
+            .await;
+        match deletion {
+            Supervised::LeaseLost => {
+                // Dropping the join future detaches the blocking operation, but
+                // that operation owns the file-lock permit until it exits.
+                Ok(BlobRetirementWorkerOutcome::LeaseLost(retirement.blob_id))
+            }
+            Supervised::Completed(Err(error)) => {
+                self.record_failure(
+                    &retirement,
+                    lease_token,
+                    "blob_delete_failed",
+                    &error.to_string(),
+                )
+                .await
+            }
+            Supervised::Completed(Ok((permit, result))) => {
+                let outcome = match result {
+                    Err(error) => {
+                        self.record_failure(
+                            &retirement,
+                            lease_token,
+                            "blob_delete_failed",
+                            &error.to_string(),
+                        )
+                        .await?
+                    }
+                    Ok(()) => {
+                        if self
+                            .store
+                            .complete_blob_retirement(retirement.blob_id, lease_token, Utc::now())
+                            .await?
+                        {
+                            BlobRetirementWorkerOutcome::Completed(retirement.blob_id)
+                        } else {
+                            BlobRetirementWorkerOutcome::LeaseLost(retirement.blob_id)
+                        }
+                    }
+                };
+                drop(permit);
+                Ok(outcome)
+            }
+        }
+    }
+
+    async fn supervise<T>(
+        &self,
+        retirement: &BlobRetirement,
+        lease_token: Uuid,
+        future: impl Future<Output = T>,
+    ) -> Supervised<T> {
+        tokio::pin!(future);
+        let mut heartbeat = tokio::time::interval(self.config.heartbeat);
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        heartbeat.tick().await;
+        loop {
+            tokio::select! {
+                result = &mut future => return Supervised::Completed(result),
+                _ = heartbeat.tick() => {
+                    if !self.prove_lease(retirement, lease_token).await {
+                        return Supervised::LeaseLost;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn prove_lease(&self, retirement: &BlobRetirement, lease_token: Uuid) -> bool {
+        let now = Utc::now();
+        let Ok(lease) = chrono_duration(self.config.lease) else {
+            return false;
+        };
+        matches!(
+            self.store
+                .heartbeat_blob_retirement(retirement.blob_id, lease_token, now, now + lease,)
+                .await,
+            Ok(true)
+        )
+    }
+
+    async fn record_failure(
+        &self,
+        retirement: &BlobRetirement,
+        lease_token: Uuid,
+        code: &str,
+        detail: &str,
+    ) -> Result<BlobRetirementWorkerOutcome> {
+        let failed_at = Utc::now();
+        let retry_at = if retirement.attempt_count < retirement.max_attempts {
+            Some(failed_at + chrono_duration(self.retry_delay(retirement))?)
+        } else {
+            None
+        };
+        let detail = truncate_detail(detail);
+        let status = self
+            .store
+            .record_blob_retirement_failure(
+                retirement.blob_id,
+                lease_token,
+                failed_at,
+                retry_at,
+                code,
+                Some(&detail),
+            )
+            .await?;
+        Ok(match status {
+            Some(BlobRetirementStatus::RetryWait) => {
+                BlobRetirementWorkerOutcome::RetryScheduled(retirement.blob_id)
+            }
+            Some(BlobRetirementStatus::Failed) => {
+                BlobRetirementWorkerOutcome::Failed(retirement.blob_id)
+            }
+            Some(_) | None => BlobRetirementWorkerOutcome::LeaseLost(retirement.blob_id),
+        })
+    }
+
+    fn retry_delay(&self, retirement: &BlobRetirement) -> Duration {
+        let exponent = retirement.attempt_count.saturating_sub(1).clamp(0, 20) as u32;
+        self.config
+            .retry_base
+            .saturating_mul(2_u32.saturating_pow(exponent))
+            .min(self.config.retry_cap)
+    }
+}
+
+fn truncate_detail(detail: &str) -> String {
+    detail
+        .chars()
+        .take(BlobRetirement::MAX_ERROR_DETAIL_LEN)
+        .collect()
+}
+
+fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {
+    chrono::Duration::from_std(duration)
+        .map_err(|error| AgentError::msg(format!("invalid blob-worker duration: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Condvar, Mutex as StdMutex};
+
+    use async_trait::async_trait;
+    use openwave_core::{
+        DbStore, DocumentId, DocumentSourceBlob, DocumentSourceUpsert, FsBlobStore,
+    };
+
+    use super::*;
+
+    fn config() -> BlobRetirementWorkerConfig {
+        BlobRetirementWorkerConfig {
+            lease: Duration::from_millis(500),
+            heartbeat: Duration::from_millis(25),
+            retry_base: Duration::from_millis(5),
+            retry_cap: Duration::from_millis(20),
+            idle_min: Duration::from_millis(1),
+            idle_cap: Duration::from_millis(5),
+            failure_delay: Duration::from_millis(1),
+        }
+    }
+
+    async fn store(dir: &tempfile::TempDir) -> Arc<DbStore> {
+        Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("worker.db").display()
+            ))
+            .await
+            .unwrap(),
+        )
+    }
+
+    fn source(id: DocumentId, blob: DocumentSourceBlob) -> DocumentSourceUpsert {
+        DocumentSourceUpsert {
+            id,
+            project_id: None,
+            source_uri: Some(format!("file:///{id}.bin")),
+            media_type: "application/octet-stream".into(),
+            title: None,
+            source_blob: blob,
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn worker(
+        store: Arc<DbStore>,
+        blobs: Arc<dyn BlobStore>,
+        blob_writes: Arc<BlobWriteGuard>,
+    ) -> BlobRetirementWorker {
+        BlobRetirementWorker::new(store, blobs, Arc::new(Notify::new()), blob_writes, config())
+    }
+
+    #[tokio::test]
+    async fn worker_deletes_and_completes_an_unreferenced_blob() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir).await;
+        let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(dir.path().join("blobs")));
+        let blob_writes = Arc::new(BlobWriteGuard::new(dir.path().join("blob-locks")));
+        let worker = worker(store.clone(), blobs.clone(), blob_writes);
+        let bytes = b"retire this source".to_vec();
+        let descriptor = DocumentSourceBlob::from_bytes(&bytes);
+        blobs.put(descriptor.id, bytes).await.unwrap();
+        let source = source(DocumentId::new(), descriptor.clone());
+        store
+            .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+            .await
+            .unwrap();
+        store.delete_document(source.id).await.unwrap();
+
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            BlobRetirementWorkerOutcome::Completed(descriptor.id)
+        );
+        assert_eq!(blobs.get(descriptor.id).await.unwrap(), None);
+        assert_eq!(
+            store
+                .get_blob_retirement(descriptor.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            BlobRetirementStatus::Succeeded
+        );
+    }
+
+    #[tokio::test]
+    async fn source_publication_guard_fences_retirement_before_catalog_acceptance() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir).await;
+        let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(dir.path().join("blobs")));
+        let blob_writes = Arc::new(BlobWriteGuard::new(dir.path().join("blob-locks")));
+        let worker = worker(store.clone(), blobs.clone(), blob_writes.clone());
+        let bytes = b"shared source survives".to_vec();
+        let descriptor = DocumentSourceBlob::from_bytes(&bytes);
+        blobs.put(descriptor.id, bytes.clone()).await.unwrap();
+        let retired_source = source(DocumentId::new(), descriptor.clone());
+        store
+            .accept_document_source_and_enqueue_parse(&retired_source, "parser-v1", 3)
+            .await
+            .unwrap();
+        store.delete_document(retired_source.id).await.unwrap();
+
+        // A publisher holds this lock from immutable put through catalog
+        // acceptance. The worker may claim meanwhile, but cannot validate or
+        // delete until the publisher's reference write has cancelled its lease.
+        let publisher = blob_writes.acquire(descriptor.id).await.unwrap();
+        let task = tokio::spawn({
+            let worker = worker.clone();
+            async move { worker.run_once().await.unwrap() }
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if store
+                    .get_blob_retirement(descriptor.id)
+                    .await
+                    .unwrap()
+                    .is_some_and(|retirement| retirement.status == BlobRetirementStatus::Running)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("worker did not claim the retirement");
+        blobs.put(descriptor.id, bytes.clone()).await.unwrap();
+        let live_source = source(DocumentId::new(), descriptor.clone());
+        store
+            .accept_document_source_and_enqueue_parse(&live_source, "parser-v1", 3)
+            .await
+            .unwrap();
+        drop(publisher);
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), task)
+                .await
+                .unwrap()
+                .unwrap(),
+            BlobRetirementWorkerOutcome::LeaseLost(descriptor.id)
+        );
+        assert_eq!(blobs.get(descriptor.id).await.unwrap(), Some(bytes));
+        assert_eq!(
+            store
+                .get_blob_retirement(descriptor.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            BlobRetirementStatus::Cancelled
+        );
+    }
+
+    struct FailOnceBlobStore {
+        inner: FsBlobStore,
+        fail_delete: AtomicBool,
+    }
+
+    #[async_trait]
+    impl BlobStore for FailOnceBlobStore {
+        async fn put(&self, id: Uuid, bytes: Vec<u8>) -> Result<()> {
+            self.inner.put(id, bytes).await
+        }
+
+        async fn get(&self, id: Uuid) -> Result<Option<Vec<u8>>> {
+            self.inner.get(id).await
+        }
+
+        fn delete(&self, id: Uuid) -> Result<()> {
+            if self.fail_delete.swap(false, Ordering::SeqCst) {
+                Err(AgentError::Store("injected blob delete failure".into()))
+            } else {
+                self.inner.delete(id)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn worker_retries_a_transient_delete_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir).await;
+        let blobs: Arc<dyn BlobStore> = Arc::new(FailOnceBlobStore {
+            inner: FsBlobStore::new(dir.path().join("blobs")),
+            fail_delete: AtomicBool::new(true),
+        });
+        let blob_writes = Arc::new(BlobWriteGuard::new(dir.path().join("blob-locks")));
+        let worker = worker(store.clone(), blobs.clone(), blob_writes);
+        let bytes = b"retry deleting this source".to_vec();
+        let descriptor = DocumentSourceBlob::from_bytes(&bytes);
+        blobs.put(descriptor.id, bytes).await.unwrap();
+        let source = source(DocumentId::new(), descriptor.clone());
+        store
+            .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+            .await
+            .unwrap();
+        store.delete_document(source.id).await.unwrap();
+
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            BlobRetirementWorkerOutcome::RetryScheduled(descriptor.id)
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            BlobRetirementWorkerOutcome::Completed(descriptor.id)
+        );
+        assert_eq!(blobs.get(descriptor.id).await.unwrap(), None);
+    }
+
+    struct DeleteGate {
+        entered: Notify,
+        released: StdMutex<bool>,
+        release: Condvar,
+    }
+
+    struct BlockingDeleteBlobStore {
+        inner: FsBlobStore,
+        gate: Arc<DeleteGate>,
+    }
+
+    #[async_trait]
+    impl BlobStore for BlockingDeleteBlobStore {
+        async fn put(&self, id: Uuid, bytes: Vec<u8>) -> Result<()> {
+            self.inner.put(id, bytes).await
+        }
+
+        async fn get(&self, id: Uuid) -> Result<Option<Vec<u8>>> {
+            self.inner.get(id).await
+        }
+
+        fn delete(&self, id: Uuid) -> Result<()> {
+            self.gate.entered.notify_one();
+            let mut released = self.gate.released.lock().unwrap();
+            while !*released {
+                released = self.gate.release.wait(released).unwrap();
+            }
+            drop(released);
+            self.inner.delete(id)
+        }
+    }
+
+    #[tokio::test]
+    async fn lease_loss_cannot_release_the_guard_before_blocking_delete_exits() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(&dir).await;
+        let gate = Arc::new(DeleteGate {
+            entered: Notify::new(),
+            released: StdMutex::new(false),
+            release: Condvar::new(),
+        });
+        let blobs: Arc<dyn BlobStore> = Arc::new(BlockingDeleteBlobStore {
+            inner: FsBlobStore::new(dir.path().join("blobs")),
+            gate: gate.clone(),
+        });
+        let blob_writes = Arc::new(BlobWriteGuard::new(dir.path().join("blob-locks")));
+        let worker = worker(store.clone(), blobs.clone(), blob_writes.clone());
+        let bytes = b"blocking retirement".to_vec();
+        let descriptor = DocumentSourceBlob::from_bytes(&bytes);
+        blobs.put(descriptor.id, bytes).await.unwrap();
+        let source = source(DocumentId::new(), descriptor.clone());
+        store
+            .accept_document_source_and_enqueue_parse(&source, "parser-v1", 3)
+            .await
+            .unwrap();
+        store.delete_document(source.id).await.unwrap();
+
+        let task = tokio::spawn({
+            let worker = worker.clone();
+            async move { worker.run_once().await.unwrap() }
+        });
+        tokio::time::timeout(Duration::from_secs(1), gate.entered.notified())
+            .await
+            .expect("worker did not enter blocking delete");
+        let running = store
+            .get_blob_retirement(descriptor.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            store
+                .record_blob_retirement_failure(
+                    descriptor.id,
+                    running.lease_token.unwrap(),
+                    Utc::now(),
+                    None,
+                    "lease_revoked_for_test",
+                    None,
+                )
+                .await
+                .unwrap(),
+            Some(BlobRetirementStatus::Failed)
+        );
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), task)
+                .await
+                .expect("worker did not observe lease loss")
+                .unwrap(),
+            BlobRetirementWorkerOutcome::LeaseLost(descriptor.id)
+        );
+
+        let publisher = tokio::spawn({
+            let blob_writes = blob_writes.clone();
+            async move { blob_writes.acquire(descriptor.id).await.unwrap() }
+        });
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(!publisher.is_finished());
+        {
+            let mut released = gate.released.lock().unwrap();
+            *released = true;
+            gate.release.notify_all();
+        }
+        let _publisher = tokio::time::timeout(Duration::from_secs(1), publisher)
+            .await
+            .expect("publisher remained blocked after delete exited")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn independent_blob_guards_serialize_on_the_same_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_guard = Arc::new(BlobWriteGuard::new(dir.path()));
+        let second_guard = Arc::new(BlobWriteGuard::new(dir.path()));
+        let blob_id = Uuid::new_v4();
+        let first = first_guard.acquire(blob_id).await.unwrap();
+        let waiting = tokio::spawn(async move { second_guard.acquire(blob_id).await.unwrap() });
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(!waiting.is_finished());
+        drop(first);
+        let _second = tokio::time::timeout(Duration::from_secs(1), waiting)
+            .await
+            .expect("independent guard did not acquire after release")
+            .unwrap();
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -13,6 +13,7 @@
 
 mod approvals;
 mod auth;
+mod blob_retirement_worker;
 mod bus;
 mod document_auditor;
 mod document_stage;
@@ -157,6 +158,7 @@ pub struct Server {
     router: Router,
     _document_auditor: AbortTask,
     _document_worker: AbortTask,
+    _blob_retirement_worker: AbortTask,
 }
 
 struct AbortTask(tokio::task::JoinHandle<()>);
@@ -226,6 +228,13 @@ pub async fn bind(config: Config) -> Result<Server> {
         state.document_job_wake.clone(),
         document_auditor::DocumentAuditorConfig::default(),
     );
+    let blob_retirement_worker = blob_retirement_worker::BlobRetirementWorker::new(
+        state.store.clone(),
+        state.blobs.clone(),
+        state.blob_retirement_wake.clone(),
+        state.blob_writes.clone(),
+        blob_retirement_worker::BlobRetirementWorkerConfig::default(),
+    );
     let router = app(state);
 
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
@@ -237,6 +246,7 @@ pub async fn bind(config: Config) -> Result<Server> {
 
     let document_auditor = tokio::spawn(document_auditor.run());
     let document_worker = tokio::spawn(document_worker.run());
+    let blob_retirement_worker = tokio::spawn(blob_retirement_worker.run());
 
     Ok(Server {
         local_addr,
@@ -245,6 +255,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         router,
         _document_auditor: AbortTask(document_auditor),
         _document_worker: AbortTask(document_worker),
+        _blob_retirement_worker: AbortTask(blob_retirement_worker),
     })
 }
 

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -241,6 +241,7 @@ async fn ingest_document_in_scope(
     // failure may leave an unreferenced content-addressed blob; it must be
     // reclaimed by a grace-period sweep, not eagerly deleted, because another
     // document may already share the same blob id.
+    let _blob_write = state.blob_writes.acquire(source_blob.id).await?;
     state.blobs.put(source_blob.id, source_bytes).await?;
 
     let (revision, job) = state
@@ -260,6 +261,7 @@ async fn ingest_document_in_scope(
         )
         .await?;
     state.document_job_wake.notify_one();
+    state.blob_retirement_wake.notify_one();
     Ok((
         StatusCode::ACCEPTED,
         Json(IngestResult {
@@ -448,6 +450,7 @@ pub async fn delete_document(
     }
     state.store.delete_document(id).await?;
     state.document_job_wake.notify_one();
+    state.blob_retirement_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
 }
 
@@ -470,6 +473,7 @@ pub async fn delete_project_document(
     }
     state.store.delete_document(document_id).await?;
     state.document_job_wake.notify_one();
+    state.blob_retirement_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
 }
 

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -1,11 +1,15 @@
 //! Shared application state handed to every request handler.
 
 use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use openwave_core::{
-    AgentConfig, BlobStore, CancelToken, ChatId, Config, DocumentId, FsBlobStore, SecretProvider,
-    SteerInbox, Store, ToolRegistry,
+    AgentConfig, AgentError, BlobStore, CancelToken, ChatId, Config, DocumentId, FsBlobStore,
+    Result, SecretProvider, SteerInbox, Store, ToolRegistry,
 };
 use openwave_retrieval::Retriever;
 use tokio::sync::Notify;
@@ -39,8 +43,12 @@ pub struct AppState {
     pub retrieval: Arc<Retriever>,
     /// Wakes the durable document worker after an enqueue commits.
     pub(crate) document_job_wake: Arc<Notify>,
+    /// Wakes the source-blob retirement worker after a reference drop commits.
+    pub(crate) blob_retirement_wake: Arc<Notify>,
     /// Serializes the final publish transition with source replacement/deletion.
     pub(crate) document_writes: Arc<DocumentWriteGuard>,
+    /// Coordinates source publication and retirement across server processes.
+    pub(crate) blob_writes: Arc<BlobWriteGuard>,
     /// Per-turn agent tuning (model, limits, …).
     pub agent_config: AgentConfig,
     /// The secret every request must present as `Authorization: Bearer <token>`.
@@ -67,6 +75,7 @@ impl AppState {
         agent_config: AgentConfig,
     ) -> Self {
         let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
+        let blob_writes = Arc::new(BlobWriteGuard::new(config.data_dir.join("blob-locks")));
         Self {
             config: Arc::new(config),
             store,
@@ -76,7 +85,9 @@ impl AppState {
             tools,
             retrieval,
             document_job_wake: Arc::new(Notify::new()),
+            blob_retirement_wake: Arc::new(Notify::new()),
             document_writes: Arc::new(DocumentWriteGuard::default()),
+            blob_writes,
             agent_config,
             token: Uuid::new_v4().to_string().into(),
             active_turns: Arc::new(TurnGuard::default()),
@@ -84,6 +95,48 @@ impl AppState {
             approvals: Arc::new(ApprovalBroker::new()),
         }
     }
+}
+
+/// Cross-process exclusion for one content-addressed blob lifecycle.
+///
+/// Lock files are permanent stable rendezvous points. Removing one could split
+/// waiters across different inodes, so the grace-period auditor must ignore this
+/// dedicated directory.
+pub(crate) struct BlobWriteGuard {
+    root: Arc<PathBuf>,
+}
+
+pub(crate) struct BlobWritePermit {
+    _file: File,
+}
+
+impl BlobWriteGuard {
+    pub(crate) fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: Arc::new(root.into()),
+        }
+    }
+
+    pub(crate) async fn acquire(&self, blob_id: Uuid) -> Result<BlobWritePermit> {
+        let root = Arc::clone(&self.root);
+        tokio::task::spawn_blocking(move || {
+            fs::create_dir_all(&*root).map_err(blob_lock_error)?;
+            let path = root.join(format!("{blob_id}.lock"));
+            let mut options = OpenOptions::new();
+            options.read(true).write(true).create(true);
+            #[cfg(unix)]
+            options.mode(0o600);
+            let file = options.open(path).map_err(blob_lock_error)?;
+            file.lock().map_err(blob_lock_error)?;
+            Ok(BlobWritePermit { _file: file })
+        })
+        .await
+        .map_err(|error| AgentError::Store(format!("blob lock task failed: {error}")))?
+    }
+}
+
+fn blob_lock_error(error: std::io::Error) -> AgentError {
+    AgentError::Store(format!("failed to acquire blob lifecycle lock: {error}"))
 }
 
 /// A bounded keyed async lock for document lifecycle transitions.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -112,8 +112,8 @@ impl BlobStore for FirstPutGatedBlobStore {
         self.inner.get(id).await
     }
 
-    async fn delete(&self, id: uuid::Uuid) -> Result<()> {
-        self.inner.delete(id).await
+    fn delete(&self, id: uuid::Uuid) -> Result<()> {
+        self.inner.delete(id)
     }
 }
 


### PR DESCRIPTION
## Summary

- execute source-blob retirement with durable claims, heartbeats, retries, and exact completion
- revalidate authoritative references immediately before deletion
- coordinate publication and retirement with one cross-process per-blob file lock
- supervise lock waits and filesystem deletion without allowing stale workers to resolve

## Validation

- `cargo test -p openwave-core`
- `cargo test -p openwave-server`
- `cargo test -p openwave-core blob_retirement -- --nocapture`
- `cargo test -p openwave-server blob_retirement_worker -- --nocapture`
- `cargo fmt --all -- --check`
- `bw dev lint --rust`
