### PR TITLE
Ingest raw document bytes

### DIFF
--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -43,6 +43,18 @@ impl ServerError {
         }
     }
 
+    /// A `413 Payload Too Large` for a request that exceeds an endpoint's
+    /// explicit body-size limit.
+    pub fn payload_too_large(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::PAYLOAD_TOO_LARGE,
+            info: AgentErrorInfo {
+                kind: "payload_too_large".to_string(),
+                message: message.into(),
+            },
+        }
+    }
+
     /// A `409 Conflict` for a request that clashes with current state (e.g. a
     /// turn is already running for the chat).
     pub fn conflict(message: impl Into<String>) -> Self {

--- a/crates/openwave-server/src/extract.rs
+++ b/crates/openwave-server/src/extract.rs
@@ -6,14 +6,39 @@
 //! unparseable body, wrong/absent `Content-Type` — answers with the same
 //! `{ kind, message }` JSON a client can always parse.
 
-use axum::extract::rejection::{JsonRejection, PathRejection, QueryRejection};
+use axum::body::Bytes;
+use axum::extract::rejection::{BytesRejection, JsonRejection, PathRejection, QueryRejection};
 use axum::extract::{FromRequest, FromRequestParts, Request};
-use axum::http::request::Parts;
+use axum::http::{request::Parts, StatusCode};
 use axum::response::{IntoResponse, Response};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::error::ServerError;
+
+/// Raw request bytes with Axum's body failures mapped into the API's stable
+/// JSON error envelope.
+pub struct RawBytes(pub Bytes);
+
+impl<S> FromRequest<S> for RawBytes
+where
+    S: Send + Sync,
+{
+    type Rejection = ServerError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let bytes =
+            Bytes::from_request(req, state)
+                .await
+                .map_err(|rejection: BytesRejection| match rejection.status() {
+                    StatusCode::PAYLOAD_TOO_LARGE => ServerError::payload_too_large(
+                        "request body exceeds the raw document upload limit",
+                    ),
+                    _ => ServerError::bad_request(rejection.body_text()),
+                })?;
+        Ok(Self(bytes))
+    }
+}
 
 /// Like [`axum::Json`], but a parse or content-type failure becomes a `400` with
 /// a JSON `{ kind, message }` body. Also serializes as a JSON response body, so

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -31,6 +31,7 @@ mod state;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
+use axum::extract::DefaultBodyLimit;
 use axum::http::{header, Method};
 use axum::routing::{get, post};
 use axum::Router;
@@ -51,6 +52,8 @@ use resolver::KeyedResolver;
 pub use error::ServerError;
 pub use state::AppState;
 
+const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
+
 /// Build the router: unauthenticated health check plus the token-guarded API.
 pub fn app(state: AppState) -> Router {
     // `route_layer` applies the token check to matched API routes only, so an
@@ -68,6 +71,11 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/projects/{project_id}/documents",
             post(routes::ingest_project_document).get(routes::list_project_documents),
+        )
+        .route(
+            "/projects/{project_id}/documents/raw",
+            post(routes::ingest_raw_project_document)
+                .layer(DefaultBodyLimit::max(MAX_RAW_DOCUMENT_BYTES)),
         )
         .route(
             "/projects/{project_id}/documents/{document_id}",
@@ -94,6 +102,10 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/documents",
             post(routes::ingest_document).get(routes::list_documents),
+        )
+        .route(
+            "/documents/raw",
+            post(routes::ingest_raw_document).layer(DefaultBodyLimit::max(MAX_RAW_DOCUMENT_BYTES)),
         )
         .route(
             "/documents/{id}",

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -1,7 +1,7 @@
 //! Document ingestion, catalog, lifecycle, and search HTTP handlers.
 
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,7 @@ use openwave_retrieval::{
 
 use crate::document_stage::{retry_document_job_spec, MAX_PARSE_ATTEMPTS};
 use crate::error::ServerError;
-use crate::extract::{Json, Path, Query};
+use crate::extract::{Json, Path, Query, RawBytes};
 use crate::state::AppState;
 
 /// Body of `POST /documents`.
@@ -31,6 +31,13 @@ pub struct IngestDocument {
     /// Media (MIME) type; defaults to `text/plain` when omitted.
     #[serde(default)]
     pub media_type: Option<String>,
+}
+
+/// Query parameters for raw-byte document ingestion.
+#[derive(Debug, Default, Deserialize)]
+pub struct RawDocumentQuery {
+    /// Optional source URI used for provenance and idempotent document identity.
+    pub uri: Option<String>,
 }
 
 /// Result of `POST /documents`.
@@ -214,23 +221,93 @@ async fn ingest_document_in_scope(
     if body.content.trim().is_empty() {
         return Err(ServerError::bad_request("content must not be empty"));
     }
-    let source_uri = match body.uri.as_deref().map(str::trim) {
+    publish_document_source(
+        state,
+        project_id,
+        body.uri,
+        body.media_type.unwrap_or_else(|| "text/plain".to_owned()),
+        body.content.into_bytes(),
+    )
+    .await
+}
+
+/// `POST /documents/raw` — retain the exact request body under its required
+/// `Content-Type` and enqueue asynchronous parsing.
+pub async fn ingest_raw_document(
+    State(state): State<AppState>,
+    Query(query): Query<RawDocumentQuery>,
+    headers: HeaderMap,
+    RawBytes(bytes): RawBytes,
+) -> Result<impl IntoResponse, ServerError> {
+    ingest_raw_document_in_scope(&state, None, query, &headers, bytes.to_vec()).await
+}
+
+/// `POST /projects/{project_id}/documents/raw` — retain exact bytes in one
+/// project corpus and enqueue asynchronous parsing.
+pub async fn ingest_raw_project_document(
+    State(state): State<AppState>,
+    Path(project_id): Path<ProjectId>,
+    Query(query): Query<RawDocumentQuery>,
+    headers: HeaderMap,
+    RawBytes(bytes): RawBytes,
+) -> Result<impl IntoResponse, ServerError> {
+    require_project(&state, project_id).await?;
+    ingest_raw_document_in_scope(&state, Some(project_id), query, &headers, bytes.to_vec()).await
+}
+
+async fn ingest_raw_document_in_scope(
+    state: &AppState,
+    project_id: Option<ProjectId>,
+    query: RawDocumentQuery,
+    headers: &HeaderMap,
+    source_bytes: Vec<u8>,
+) -> Result<(StatusCode, Json<IngestResult>), ServerError> {
+    if source_bytes.is_empty() {
+        return Err(ServerError::bad_request("content must not be empty"));
+    }
+    let media_type = headers
+        .get(header::CONTENT_TYPE)
+        .ok_or_else(|| ServerError::bad_request("Content-Type header is required"))?
+        .to_str()
+        .map_err(|_| ServerError::bad_request("Content-Type header is not valid text"))?
+        .trim();
+    if media_type.is_empty() {
+        return Err(ServerError::bad_request(
+            "Content-Type header must not be empty",
+        ));
+    }
+    publish_document_source(
+        state,
+        project_id,
+        query.uri,
+        media_type.to_owned(),
+        source_bytes,
+    )
+    .await
+}
+
+async fn publish_document_source(
+    state: &AppState,
+    project_id: Option<ProjectId>,
+    source_uri: Option<String>,
+    media_type: String,
+    source_bytes: Vec<u8>,
+) -> Result<(StatusCode, Json<IngestResult>), ServerError> {
+    let source_uri = match source_uri.as_deref().map(str::trim) {
         // Trim before deriving the document id: a padded URI must resolve to the
         // same document as its unpadded form, or idempotent re-ingest breaks.
         Some(uri) if !uri.is_empty() => Some(uri.to_owned()),
         _ => None,
     };
-    let media_type = body.media_type.as_deref().unwrap_or("text/plain");
     let parser_fingerprint = state
         .retrieval
-        .canonical_fingerprint_for(media_type)
+        .canonical_fingerprint_for(&media_type)
         .map_err(retrieval_error)?;
     let document_id = match (project_id, source_uri.as_deref()) {
         (Some(project_id), Some(uri)) => DocumentId::derive_for_project(project_id, uri),
         (None, Some(uri)) => DocumentId::derive(uri),
         (_, None) => DocumentId::new(),
     };
-    let source_bytes = body.content.into_bytes();
     let source_blob = DocumentSourceBlob::from_bytes(&source_bytes);
     // Serialize the entire source publication boundary for one document. If
     // the first accepted request blocks on blob I/O, a later request cannot
@@ -251,7 +328,7 @@ async fn ingest_document_in_scope(
                 id: document_id,
                 project_id,
                 source_uri,
-                media_type: media_type.to_owned(),
+                media_type,
                 title: None,
                 source_blob,
                 updated_at: Utc::now(),

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1001,6 +1001,145 @@ async fn post_json(
         .unwrap()
 }
 
+/// POST exact bytes to a raw document route.
+async fn post_raw(
+    router: &Router,
+    bearer: &str,
+    uri: &str,
+    content_type: Option<&str>,
+    body: Vec<u8>,
+) -> axum::response::Response {
+    let mut request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header(header::AUTHORIZATION, bearer);
+    if let Some(content_type) = content_type {
+        request = request.header(header::CONTENT_TYPE, content_type);
+    }
+    router
+        .clone()
+        .oneshot(request.body(Body::from(body)).unwrap())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn raw_ingest_retains_exact_bytes_and_runs_the_async_pipeline() {
+    let (router, token, store, dir, worker) = test_app_with_worker().await;
+    let bearer = format!("Bearer {token}");
+    let raw = b"raw \xff source\n".to_vec();
+    let response = post_raw(
+        &router,
+        &bearer,
+        "/documents/raw?uri=file%3A%2F%2F%2Fraw.txt",
+        Some("text/plain; charset=utf-8"),
+        raw.clone(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let accepted: serde_json::Value = json_body(response).await;
+    let document_id: openwave_core::DocumentId =
+        accepted["document_id"].as_str().unwrap().parse().unwrap();
+    assert_eq!(
+        document_id,
+        openwave_core::DocumentId::derive("file:///raw.txt")
+    );
+
+    let pending = store.get_document(document_id).await.unwrap().unwrap();
+    assert_eq!(pending.media_type, "text/plain; charset=utf-8");
+    let source_blob = pending.source_blob.unwrap();
+    let blobs = openwave_core::FsBlobStore::new(dir.path().join("blobs"));
+    assert_eq!(blobs.get(source_blob.id).await.unwrap().unwrap(), raw);
+
+    run_parse_and_index(&worker).await;
+    let ready = store.get_document(document_id).await.unwrap().unwrap();
+    assert_eq!(ready.canonical_text, String::from_utf8_lossy(&raw));
+    assert_eq!(
+        ready.processing_status,
+        openwave_core::DocumentProcessingStatus::Ready
+    );
+}
+
+#[tokio::test]
+async fn raw_ingest_enforces_media_type_body_and_project_scope() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    let missing_type = post_raw(&router, &bearer, "/documents/raw", None, b"body".to_vec()).await;
+    assert_eq!(missing_type.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(missing_type).await;
+    assert_eq!(error.kind, "bad_request");
+
+    let empty = post_raw(
+        &router,
+        &bearer,
+        "/documents/raw",
+        Some("text/plain"),
+        Vec::new(),
+    )
+    .await;
+    assert_eq!(empty.status(), StatusCode::BAD_REQUEST);
+
+    let unsupported = post_raw(
+        &router,
+        &bearer,
+        "/documents/raw",
+        Some("application/octet-stream"),
+        b"binary".to_vec(),
+    )
+    .await;
+    assert_eq!(unsupported.status(), StatusCode::BAD_REQUEST);
+
+    let project = make_project(&router, &bearer).await;
+    let response = post_raw(
+        &router,
+        &bearer,
+        &format!("/projects/{}/documents/raw", project.id),
+        Some("text/markdown"),
+        b"# scoped".to_vec(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let accepted: serde_json::Value = json_body(response).await;
+    let document_id = accepted["document_id"].as_str().unwrap().parse().unwrap();
+    assert_eq!(
+        store
+            .get_document(document_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .project_id,
+        Some(project.id)
+    );
+}
+
+#[tokio::test]
+async fn raw_ingest_has_an_explicit_limit_and_preserves_payload_too_large() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let boundary = post_raw(
+        &router,
+        &bearer,
+        "/documents/raw",
+        Some("text/plain"),
+        vec![b'x'; MAX_RAW_DOCUMENT_BYTES],
+    )
+    .await;
+    assert_eq!(boundary.status(), StatusCode::ACCEPTED);
+
+    let too_large = post_raw(
+        &router,
+        &bearer,
+        "/documents/raw",
+        Some("text/plain"),
+        vec![b'x'; MAX_RAW_DOCUMENT_BYTES + 1],
+    )
+    .await;
+    assert_eq!(too_large.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    let error: AgentErrorInfo = json_body(too_large).await;
+    assert_eq!(error.kind, "payload_too_large");
+}
+
 #[tokio::test]
 async fn ingest_then_search_finds_the_passage() {
     let (router, token, store, _dir, worker) = test_app_with_worker().await;


### PR DESCRIPTION
## Summary

- add authenticated raw-byte ingestion for unscoped and project document corpora
- retain exact request bytes with required media type and optional idempotent source URI
- reuse the guarded durable Parse state-machine publication path used by JSON ingestion
- enforce an explicit 16 MiB upload limit with the standard JSON `413` error envelope

## Validation

- `cargo test -p openwave-server`
- `cargo test -p openwave-server raw_ingest -- --nocapture`
- `cargo fmt --all -- --check`
- `bw dev lint --rust`
