### PR TITLE
Refresh project status documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,29 +50,32 @@ box, so it works on your machine from the first run.
 Most agentic tools are cloud services that hold your data and meter your usage.
 OpenWave is the opposite: a slim desktop app (plus a headless mode) that runs the
 agent loop **on your machine**, keeps your data local, and lets you bring your
-own model — hosted or fully offline. It speaks [MCP](https://modelcontextprotocol.io),
-so it works with the agents and tools you already use.
+own model — hosted or fully offline. Its MCP server foundation can expose the
+same tool registry to external agents; CLI lifecycle wiring and the MCP client
+remain in development.
 
 ## Principles
 
 - **Local-first & private.** Your files, keys, and history stay on your machine.
-- **Bring your own keys.** Configure the models (Anthropic, OpenAI, Google, or
-  anything OpenAI-compatible — vLLM, LM Studio, Ollama, OpenRouter), embedding
-  services, and document parsers you want — with local-friendly defaults. We
+- **Bring your own keys.** Configure Anthropic, OpenAI, or an OpenAI-compatible
+  endpoint (vLLM, LM Studio, Ollama, OpenRouter), along with the embedding
+  services and document parsers you want — with local-friendly defaults. We
   never meter tokens.
 - **Slim by default.** Small install; no bundled model weights or language
   runtimes — fetched on first use, cached locally.
-- **Works with any agent.** An MCP server _and_ a client — OpenWave both exposes
-  tools and consumes them.
+- **Composable tool surface.** The MCP server foundation exposes OpenWave's
+  tools; mounting external MCP servers as a client is planned.
 - **Open core.** The runtime is Apache-2.0 and complete on its own.
 
 ## Status
 
-Pre-alpha, built in the open. The walking skeleton runs today: projects and
-chats, local file tools, a turn engine, and live event streaming over WebSocket,
-all behind `openwave serve`. Desktop UI, connectors, and retrieval come next.
-Expect rapid change and rough edges — and see [CONTRIBUTING](CONTRIBUTING.md) if
-you'd like to help.
+Pre-alpha, built in the open. The current stack includes projects and chats,
+local file tools, multi-provider model routing, a turn engine with live journaled
+WebSocket events, a baseline desktop UI, and durable asynchronous document
+ingestion/retrieval with grounded citations — all behind `openwave serve`.
+Connectors, richer document parsers, and complete MCP lifecycle wiring remain in
+development. Expect rapid change and rough edges — and see
+[CONTRIBUTING](CONTRIBUTING.md) if you'd like to help.
 
 ## Building
 
@@ -107,15 +110,14 @@ walkthrough of each crate, see [`docs/crates.md`](docs/crates.md).
 | Crate | What it is |
 | --- | --- |
 | [`openwave-core`](crates/openwave-core) | agent loop, tools, event stream, storage traits |
+| [`openwave-router`](crates/openwave-router) | Anthropic and OpenAI-compatible providers + model routing |
+| [`openwave-server`](crates/openwave-server) | authenticated local HTTP/WebSocket API + durable workers |
 | [`openwave-connectors`](crates/openwave-connectors) | OAuth + source connectors |
-| [`openwave-retrieval`](crates/openwave-retrieval) | embeddings, vector search, citations |
-| [`openwave-mcp`](crates/openwave-mcp) | MCP server & client |
+| [`openwave-retrieval`](crates/openwave-retrieval) | parsing, embeddings, hybrid search, citations |
+| [`openwave-mcp`](crates/openwave-mcp) | partial MCP server surface (client planned) |
 | [`openwave-desktop`](crates/openwave-desktop) | desktop app (Tauri) |
-| [`openwave-cli`](crates/openwave-cli) | headless daemon + CLI |
+| [`openwave-cli`](crates/openwave-cli) | headless `openwave serve` command |
 | [`openwave-slack`](crates/openwave-slack) | Slack adapter |
-
-_Model-provider adapters and routing/failover live in a planned `openwave-router`
-crate — see [`docs/crates.md`](docs/crates.md)._
 
 ## License
 

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -7,15 +7,20 @@ one rule that keeps it clean: **dependencies only flow downward toward
 libraries.
 
 ```
-      client binaries        openwave-desktop   openwave-cli   openwave-slack
-                                     │               │              │
-                                     └───────────────┼──────────────┘
-      libraries                    openwave-mcp  openwave-connectors  openwave-retrieval  openwave-router
-                                     └───────────────┴──────────────┴──────────────┘
-      the seam                                     openwave-core
+      clients            openwave-desktop   openwave-cli   openwave-slack (stub)
+                               │                 │
+                               └────── openwave-server
+                                            │
+      libraries          openwave-mcp   openwave-retrieval   openwave-router
+                               │             │                   │
+                               └─────────────┴───────────────────┘
+                                            │
+      the seam                         openwave-core
+
+      scaffold                         openwave-connectors (stub)
 ```
 
-**Status legend:** 🟢 in progress · 🔵 planned · ⚪ stub (scaffold only).
+**Status legend:** 🟢 built/in active development · 🟡 partial baseline · ⚪ stub.
 
 ---
 
@@ -31,37 +36,38 @@ client renders from, and the trait **contracts** — `Tool`, `ModelProvider`,
 implementations (SQLite, the local filesystem, the OS keychain). Concrete
 model-provider adapters do **not** live here; they live in `openwave-router`.
 
-Present today:
+Major surfaces present today:
 
 | Module | What it is |
 | --- | --- |
 | `id` | Typed identifiers (`ChatId`, `TurnId`, `CallId`, …) — newtypes so the compiler stops you mixing them up. |
 | `error` | The crate-wide `AgentError` + `Result`. |
-| `model` | The persisted conversation model (`Chat`, `Message`, `Role`). |
+| `model` | Persisted chats, projects, documents, jobs, leases, and lifecycle state. |
 | `tool` | The tool contract (`Tool`, `ToolSpec`, `ToolOutput`, `ToolCtx`, `ApprovalClass`). |
 | `provider` | The model-provider contract (`ModelProvider`, `ChatRequest`, `ProviderEvent`, `Usage`). |
+| `agent` | The cancellable/steerable multi-step turn loop and durable event journal integration. |
+| `db` / `storage` | SQLite/PostgreSQL-capable state transitions plus in-memory implementations. |
+| `blob` / `keychain` | Immutable local blob storage and OS-backed secret storage. |
 
 **Depends on:** nothing in the workspace.
 
 ---
 
-## `openwave-router` — model providers & routing 🔵
+## `openwave-router` — model providers & routing 🟢
 
-Owns the concrete model-provider adapters (Anthropic, OpenAI, an
-OpenAI-compatible adapter that covers Fireworks / OpenRouter / vLLM / LM Studio,
-and more) plus a composite `Router`.
+Owns the concrete Anthropic and OpenAI-compatible provider adapters (including
+OpenAI, Fireworks, OpenRouter, vLLM, and LM Studio endpoints) plus a composite
+`Router`.
 
-The `Router` is itself a `ModelProvider`, so the agent loop just holds one
-provider and never knows whether it's a single backend, a failover pool, or a
-remote gateway. Two things define it:
+The `Router` is itself a `ModelProvider`, so the agent loop holds one provider
+contract and does not depend on a concrete backend. Two things define it:
 
-- **Two deployment modes, one crate.** It runs **embedded** (local-first, keys on
-  the device) or as a **central gateway service** (keys stay server-side; clients
-  and sandboxes call it over the network via a thin `RemoteProvider`).
+- **Embedded local routing.** Provider credentials remain on the device and the
+  selected model determines the adapter used for each request.
 - **No default provider = fail-closed egress.** It calls no model until one is
   explicitly configured *and* enabled — nothing leaves your machine by accident.
 
-Health-based failover (circuit breaker + retry) rounds it out.
+Health-based failover remains planned.
 
 **Depends on:** `openwave-core`.
 
@@ -69,23 +75,27 @@ Health-based failover (circuit breaker + retry) rounds it out.
 
 ## `openwave-connectors` — OAuth & source connectors ⚪
 
-Loopback OAuth (RFC 8252 + PKCE), token refresh, and the connector tools that
-list and fetch from sources like Drive and Box.
+Scaffold reserved for loopback OAuth (RFC 8252 + PKCE), token refresh, and
+connector tools that list and fetch from sources like Drive and Box.
+
+**Depends on:** nothing in the workspace yet.
+
+## `openwave-retrieval` — parsing, search, citations 🟢
+
+Asynchronous parsing, structural chunking, embeddings, scoped hybrid
+lexical+dense search, reranking, and grounded citations behind a `VectorStore`
+seam with in-memory and durable embedded LanceDB backends. Durable source
+revisions and Parse→Index jobs are coordinated by `openwave-core` and
+`openwave-server`.
 
 **Depends on:** `openwave-core`.
 
-## `openwave-retrieval` — embeddings, vector search, citations ⚪
+## `openwave-mcp` — the MCP face 🟡
 
-Embeddings, chunking, hybrid lexical+dense search, and grounded citations behind
-a `VectorStore` seam with in-memory and durable embedded LanceDB backends.
-
-**Depends on:** `openwave-core`.
-
-## `openwave-mcp` — the MCP face ⚪
-
-Both halves of [MCP](https://modelcontextprotocol.io): a **server** that exposes
-OpenWave's core tools to external agents (Claude Code, Codex, Cursor…), and a
-**client** that mounts external MCP tool servers into the agent, namespaced.
+The server half of [MCP](https://modelcontextprotocol.io): JSON-RPC
+`initialize`, `tools/list`, and `tools/call` over stdio, backed by OpenWave's
+tool registry. CLI/session lifecycle wiring and the client that mounts external
+MCP servers remain planned.
 
 **Depends on:** `openwave-core`.
 
@@ -101,16 +111,25 @@ local run instructions.
 
 **Depends on:** `openwave-core`, `openwave-server` (+ Tauri).
 
-## `openwave-cli` — headless daemon + CLI ⚪
+## `openwave-server` — local API and workers 🟢
 
-The headless daemon (`openwave serve`) and a command-line client, over the same
-HTTP surface the desktop uses. For servers, scripts, and power users.
+The authenticated loopback HTTP/WebSocket surface shared by desktop and
+headless clients. It owns route orchestration and the durable document,
+retirement, and audit workers while core state transitions remain in
+`openwave-core`.
 
-**Depends on:** `openwave-core`.
+**Depends on:** `openwave-core`, `openwave-router`, `openwave-retrieval`.
+
+## `openwave-cli` — headless daemon + CLI 🟡
+
+The working headless daemon (`openwave serve`) over the same HTTP surface the
+desktop uses. Additional command-line client workflows remain in development.
+
+**Depends on:** `openwave-core`, `openwave-server`.
 
 ## `openwave-slack` — the Slack adapter ⚪
 
-A Socket Mode adapter (outbound WebSocket, no inbound ports) that drives the
-agent from a Slack workspace.
+A scaffold for a Socket Mode adapter (outbound WebSocket, no inbound ports) that
+will drive the agent from a Slack workspace.
 
-**Depends on:** `openwave-core`.
+**Depends on:** nothing in the workspace yet.


### PR DESCRIPTION
## Summary

- update the pre-alpha status to match the working desktop, provider, and retrieval stack
- add the server and router crates to the public workspace map
- distinguish the partial MCP server from the still-planned MCP client
- mark connector and Slack crates as scaffolds and document current crate dependencies

## Validation

- `git diff --check`
- verified every linked local path exists
