### PR TITLE
Restrict MCP tools to read-only

### DIFF
--- a/crates/openwave-mcp/src/lib.rs
+++ b/crates/openwave-mcp/src/lib.rs
@@ -1,8 +1,9 @@
 //! OpenWave MCP — the Model Context Protocol server face.
 //!
-//! Exposes OpenWave's tools (the same `ToolRegistry` the agent uses) to an external
-//! MCP client, so any MCP-speaking host can drive OpenWave's capabilities — for
-//! example the `search` tool over a document index.
+//! Exposes OpenWave's read-only tools from the same `ToolRegistry` the agent uses
+//! to an external MCP client, so any MCP-speaking host can drive capabilities such
+//! as `search` over a document index. Workspace-mutating and sensitive tools stay
+//! hidden until an approval-aware MCP execution bridge exists.
 //!
 //! [`McpServer`] answers `initialize`, `tools/list`, and `tools/call` and is
 //! transport-agnostic; [`serve_stdio`] runs it over the standard newline-delimited

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -16,7 +16,7 @@ use std::sync::{
     Arc,
 };
 
-use openwave_core::{ChatId, ToolCtx, ToolRegistry};
+use openwave_core::{ApprovalClass, ChatId, ToolCtx, ToolRegistry};
 use serde_json::Value;
 
 use crate::protocol::{
@@ -30,6 +30,10 @@ const SESSION_AWAITING_INITIALIZED: u8 = 1;
 const SESSION_READY: u8 = 2;
 
 /// An MCP server exposing a tool registry over the Model Context Protocol.
+///
+/// Only [`ApprovalClass::ReadOnly`] tools cross this boundary. Workspace and
+/// sensitive tools require an approval-aware execution bridge and remain hidden
+/// until one is configured in a future slice.
 pub struct McpServer {
     tools: Arc<ToolRegistry>,
     ctx: ToolCtx,
@@ -39,7 +43,8 @@ pub struct McpServer {
 }
 
 impl McpServer {
-    /// Build a server exposing `tools`, whose calls run within `ctx`.
+    /// Build a server exposing the read-only entries in `tools`, whose calls run
+    /// within `ctx`.
     #[must_use]
     pub fn new(tools: Arc<ToolRegistry>, ctx: ToolCtx) -> Self {
         Self {
@@ -174,6 +179,11 @@ impl McpServer {
             .tools
             .specs()
             .into_iter()
+            .filter(|spec| {
+                self.tools
+                    .get(&spec.name)
+                    .is_some_and(|tool| tool.approval_class() == ApprovalClass::ReadOnly)
+            })
             .map(|spec| ToolDescriptor {
                 name: spec.name,
                 description: spec.description,
@@ -194,6 +204,7 @@ impl McpServer {
         let tool = self
             .tools
             .get(&params.name)
+            .filter(|tool| tool.approval_class() == ApprovalClass::ReadOnly)
             .ok_or_else(|| RpcError::invalid_params(format!("unknown tool: {}", params.name)))?;
 
         // A tool's own failure is a result with isError = true, not a protocol
@@ -275,14 +286,43 @@ mod tests {
         }
     }
 
+    struct ClassifiedTool {
+        name: &'static str,
+        class: ApprovalClass,
+        ran: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Tool for ClassifiedTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: self.name.to_string(),
+                description: format!("{} test tool", self.name),
+                input_schema: json!({"type": "object"}),
+            }
+        }
+
+        fn approval_class(&self) -> ApprovalClass {
+            self.class
+        }
+
+        async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> openwave_core::Result<ToolOutput> {
+            self.ran.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(ToolOutput::text(self.name))
+        }
+    }
+
     fn server() -> McpServer {
-        let tools = Arc::new(ToolRegistry::new().with(Box::new(EchoTool)));
+        server_with(ToolRegistry::new().with(Box::new(EchoTool)))
+    }
+
+    fn server_with(tools: ToolRegistry) -> McpServer {
         let ctx = ToolCtx {
             chat_id: ChatId::new(),
             project_id: None,
             workspace_dir: PathBuf::from("/tmp/ws"),
         };
-        McpServer::new(tools, ctx)
+        McpServer::new(Arc::new(tools), ctx)
     }
 
     fn request(id: i64, method: &str, params: Value) -> Request {
@@ -309,8 +349,7 @@ mod tests {
         .unwrap()
     }
 
-    async fn initialized_server() -> McpServer {
-        let server = server();
+    async fn initialize_session(server: &McpServer) {
         let response = server
             .handle(request(1, "initialize", initialize_params()))
             .await
@@ -320,6 +359,11 @@ mod tests {
             .handle(initialized_notification(Value::Null))
             .await
             .is_none());
+    }
+
+    async fn initialized_server() -> McpServer {
+        let server = server();
+        initialize_session(&server).await;
         server
     }
 
@@ -482,6 +526,70 @@ mod tests {
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0]["name"], "echo");
         assert!(tools[0]["inputSchema"]["properties"]["text"].is_object());
+    }
+
+    #[tokio::test]
+    async fn only_read_only_tools_are_advertised_or_executable() {
+        let read_ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let workspace_ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let sensitive_ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let tools = ToolRegistry::new()
+            .with(Box::new(ClassifiedTool {
+                name: "read",
+                class: ApprovalClass::ReadOnly,
+                ran: Arc::clone(&read_ran),
+            }))
+            .with(Box::new(ClassifiedTool {
+                name: "write",
+                class: ApprovalClass::Workspace,
+                ran: Arc::clone(&workspace_ran),
+            }))
+            .with(Box::new(ClassifiedTool {
+                name: "external",
+                class: ApprovalClass::Sensitive,
+                ran: Arc::clone(&sensitive_ran),
+            }));
+        let server = server_with(tools);
+        initialize_session(&server).await;
+
+        let listed = server
+            .handle(request(2, "tools/list", Value::Null))
+            .await
+            .unwrap()
+            .result
+            .unwrap();
+        let names: Vec<&str> = listed["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|tool| tool["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, ["read"]);
+
+        for (id, name) in [(3, "write"), (4, "external")] {
+            let response = server
+                .handle(request(
+                    id,
+                    "tools/call",
+                    json!({"name": name, "arguments": {}}),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.error.unwrap().code, error_code::INVALID_PARAMS);
+        }
+        assert!(!workspace_ran.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(!sensitive_ran.load(std::sync::atomic::Ordering::SeqCst));
+
+        let response = server
+            .handle(request(
+                5,
+                "tools/call",
+                json!({"name": "read", "arguments": {}}),
+            ))
+            .await
+            .unwrap();
+        assert!(response.error.is_none());
+        assert!(read_ran.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     #[tokio::test]

--- a/crates/openwave-retrieval/src/embed.rs
+++ b/crates/openwave-retrieval/src/embed.rs
@@ -60,6 +60,15 @@ pub trait Embedder: Send + Sync {
     /// The dimensionality every vector this embedder returns will have.
     fn dimensions(&self) -> usize;
 
+    /// Whether embedding is guaranteed to stay in-process without network or
+    /// external-service access.
+    ///
+    /// Defaults to `false` so new provider-backed implementations fail closed at
+    /// approval boundaries until they explicitly prove they are local.
+    fn is_local(&self) -> bool {
+        false
+    }
+
     /// Stable identity for document-vector behavior used in index watermarks.
     ///
     /// Custom embedders should override this when two configurations with the
@@ -142,6 +151,10 @@ impl Default for HashEmbedder {
 impl Embedder for HashEmbedder {
     fn dimensions(&self) -> usize {
         self.dims
+    }
+
+    fn is_local(&self) -> bool {
+        true
     }
 
     fn fingerprint(&self) -> String {

--- a/crates/openwave-retrieval/src/lance_store.rs
+++ b/crates/openwave-retrieval/src/lance_store.rs
@@ -824,6 +824,10 @@ fn newest_generation(
 
 #[async_trait]
 impl VectorStore for LanceVectorStore {
+    fn is_local(&self) -> bool {
+        true
+    }
+
     async fn upsert(&self, records: Vec<VectorRecord>) -> Result<()> {
         self.validate_upsert_records(&records)?;
         let records = dedupe_by_chunk_id(records);

--- a/crates/openwave-retrieval/src/openai_embed.rs
+++ b/crates/openwave-retrieval/src/openai_embed.rs
@@ -94,6 +94,10 @@ impl Embedder for OpenAiEmbedder {
         self.dimensions
     }
 
+    fn is_local(&self) -> bool {
+        false
+    }
+
     fn fingerprint(&self) -> String {
         format!(
             "openai-compatible-v1:endpoint={}:model={}:dimensions={}:projection={}",

--- a/crates/openwave-retrieval/src/rerank.rs
+++ b/crates/openwave-retrieval/src/rerank.rs
@@ -13,6 +13,15 @@ use crate::{Result, RetrievalError, ScoredChunk};
 /// reranker configurations.
 #[async_trait]
 pub trait Reranker: Send + Sync {
+    /// Whether reranking is guaranteed to stay in-process without network or
+    /// external-service access.
+    ///
+    /// Defaults to `false` so new provider-backed implementations fail closed at
+    /// approval boundaries until they explicitly prove they are local.
+    fn is_local(&self) -> bool {
+        false
+    }
+
     /// Score every candidate for `query`, preserving input alignment.
     /// Implementations must use [`crate::Chunk::retrieval_text`] as the
     /// candidate text so structural context matches embedding and lexical inputs.

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -7,10 +7,12 @@
 //! the *same* `Arc<dyn VectorStore>` the ingest side writes to and the agent
 //! searches a live index.
 //!
-//! It is `ReadOnly` (never mutates), so the agent may call it without an approval
-//! prompt. Recoverable problems (empty query, an embedder/store hiccup) come back
-//! as [`ToolOutput::error`] for the model to see and adapt to, per the tool
-//! convention; only genuinely unexpected faults would be an `Err`.
+//! It is `ReadOnly` when embedding and optional reranking are guaranteed local.
+//! A provider-backed query is `Sensitive` because query text crosses a network or
+//! external-service boundary. Recoverable problems (empty query, an
+//! embedder/store hiccup) come back as [`ToolOutput::error`] for the model to see
+//! and adapt to, per the tool convention; only genuinely unexpected faults would
+//! be an `Err`.
 //!
 //! Enabled by the `tool` feature.
 
@@ -148,7 +150,15 @@ impl Tool for SearchTool {
     }
 
     fn approval_class(&self) -> ApprovalClass {
-        ApprovalClass::ReadOnly
+        let reranker_is_local = self
+            .reranker
+            .as_ref()
+            .is_none_or(|reranker| reranker.is_local());
+        if self.embedder.is_local() && self.store.is_local() && reranker_is_local {
+            ApprovalClass::ReadOnly
+        } else {
+            ApprovalClass::Sensitive
+        }
     }
 
     async fn execute(&self, ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
@@ -267,6 +277,19 @@ mod tests {
 
     struct FixedReranker(Vec<f32>);
 
+    struct RemoteEmbedder(HashEmbedder);
+
+    #[async_trait]
+    impl Embedder for RemoteEmbedder {
+        fn dimensions(&self) -> usize {
+            self.0.dimensions()
+        }
+
+        async fn embed_documents(&self, texts: &[String]) -> crate::Result<Vec<crate::Embedding>> {
+            self.0.embed_documents(texts).await
+        }
+    }
+
     #[async_trait]
     impl Reranker for FailingReranker {
         async fn rerank(
@@ -333,16 +356,37 @@ mod tests {
     }
 
     #[test]
-    fn advertises_a_read_only_search_spec() {
+    fn search_approval_tracks_query_egress() {
         let store = Arc::new(InMemoryVectorStore::new(DIMS));
-        let tool = SearchTool::new(Arc::new(HashEmbedder::new(DIMS)), store);
-        assert_eq!(tool.spec().name, "search");
-        assert_eq!(tool.approval_class(), ApprovalClass::ReadOnly);
-        assert!(tool.spec().input_schema["required"]
+        let local = SearchTool::new(Arc::new(HashEmbedder::new(DIMS)), store.clone());
+        assert_eq!(local.spec().name, "search");
+        assert_eq!(local.approval_class(), ApprovalClass::ReadOnly);
+        assert!(local.spec().input_schema["required"]
             .as_array()
             .unwrap()
             .iter()
             .any(|v| v == "query"));
+
+        let remote = SearchTool::new(
+            Arc::new(RemoteEmbedder(HashEmbedder::new(DIMS))),
+            store.clone(),
+        );
+        assert_eq!(remote.approval_class(), ApprovalClass::Sensitive);
+
+        let remote_store = SearchTool::new(
+            Arc::new(HashEmbedder::new(DIMS)),
+            Arc::new(SpyVectorStore {
+                candidates: Vec::new(),
+                calls: Mutex::new(Vec::new()),
+            }),
+        );
+        assert_eq!(remote_store.approval_class(), ApprovalClass::Sensitive);
+
+        // Unknown/provider-backed rerankers also fail closed even with a local
+        // embedder because they receive the query and candidate text.
+        let reranked = SearchTool::new(Arc::new(HashEmbedder::new(DIMS)), store)
+            .with_reranker(Arc::new(FixedReranker(Vec::new())));
+        assert_eq!(reranked.approval_class(), ApprovalClass::Sensitive);
     }
 
     #[test]

--- a/crates/openwave-retrieval/src/vector.rs
+++ b/crates/openwave-retrieval/src/vector.rs
@@ -128,6 +128,15 @@ impl DocumentGenerationState {
 /// `Arc<dyn VectorStore>`.
 #[async_trait]
 pub trait VectorStore: Send + Sync {
+    /// Whether queries are guaranteed to stay in-process without network or
+    /// external-service access.
+    ///
+    /// Defaults to `false` so new remote-capable backends fail closed at
+    /// approval boundaries until they explicitly prove they are local.
+    fn is_local(&self) -> bool {
+        false
+    }
+
     /// Insert or replace records, keyed by chunk id.
     ///
     /// Re-upserting a chunk with the same id overwrites it, so re-ingesting a
@@ -362,6 +371,10 @@ impl InMemoryVectorStore {
 
 #[async_trait]
 impl VectorStore for InMemoryVectorStore {
+    fn is_local(&self) -> bool {
+        true
+    }
+
     async fn upsert(&self, records: Vec<VectorRecord>) -> Result<()> {
         let mut scopes = HashMap::new();
         for record in &records {


### PR DESCRIPTION
## Summary

- expose only read-only registry entries through MCP tool discovery
- enforce the same approval-class check immediately before tool execution
- keep workspace-mutating and sensitive tools indistinguishable from unknown tools
- classify search as sensitive unless its embedder, vector store, and reranker explicitly prove they are local
- cover listing, execution, and non-execution across every approval class

## Verification

- `cargo test -p openwave-mcp`
- `cargo test --workspace`
- `cargo fmt --all --check`
- `bw dev lint --rust`
