### PR TITLE
feat: add read-only MCP CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5726,7 +5726,9 @@ name = "openwave-cli"
 version = "0.0.0"
 dependencies = [
  "openwave-core",
+ "openwave-mcp",
  "openwave-server",
+ "serde_json",
  "tempfile",
  "tokio",
 ]

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Most agentic tools are cloud services that hold your data and meter your usage.
 OpenWave is the opposite: a slim desktop app (plus a headless mode) that runs the
 agent loop **on your machine**, keeps your data local, and lets you bring your
 own model — hosted or fully offline. Its MCP server foundation can expose the
-same tool registry to external agents; CLI lifecycle wiring and the MCP client
-remain in development.
+same tool registry to external agents; `openwave mcp <workspace>` serves the
+built-in read-only file tools today, while indexed search wiring and the MCP
+client remain in development.
 
 ## Principles
 
@@ -73,8 +74,8 @@ Pre-alpha, built in the open. The current stack includes projects and chats,
 local file tools, multi-provider model routing, a turn engine with live journaled
 WebSocket events, a baseline desktop UI, and durable asynchronous document
 ingestion/retrieval with grounded citations — all behind `openwave serve`.
-Connectors, richer document parsers, and complete MCP lifecycle wiring remain in
-development. Expect rapid change and rough edges — and see
+Connectors, richer document parsers, indexed-search MCP wiring, and the MCP client
+remain in development. Expect rapid change and rough edges — and see
 [CONTRIBUTING](CONTRIBUTING.md) if you'd like to help.
 
 ## Building
@@ -99,6 +100,9 @@ Headless API without the UI:
 ANTHROPIC_API_KEY=sk-... cargo run -p openwave-cli -- serve
 # then: curl -s http://127.0.0.1:PORT/healthz
 #       curl -H "Authorization: Bearer TOKEN" http://127.0.0.1:PORT/chats
+
+# MCP stdio server confined to an explicit workspace (read_file + list_dir):
+cargo run -p openwave-cli -- mcp /absolute/path/to/workspace
 ```
 
 ## Layout
@@ -114,9 +118,9 @@ walkthrough of each crate, see [`docs/crates.md`](docs/crates.md).
 | [`openwave-server`](crates/openwave-server) | authenticated local HTTP/WebSocket API + durable workers |
 | [`openwave-connectors`](crates/openwave-connectors) | OAuth + source connectors |
 | [`openwave-retrieval`](crates/openwave-retrieval) | parsing, embeddings, hybrid search, citations |
-| [`openwave-mcp`](crates/openwave-mcp) | partial MCP server surface (client planned) |
+| [`openwave-mcp`](crates/openwave-mcp) | lifecycle-gated read-only MCP server surface (client planned) |
 | [`openwave-desktop`](crates/openwave-desktop) | desktop app (Tauri) |
-| [`openwave-cli`](crates/openwave-cli) | headless `openwave serve` command |
+| [`openwave-cli`](crates/openwave-cli) | headless `openwave serve` + `openwave mcp` commands |
 | [`openwave-slack`](crates/openwave-slack) | Slack adapter |
 
 ## License

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -16,12 +16,14 @@ name = "openwave"
 path = "src/main.rs"
 
 [dependencies]
-# `default-features = false`: the CLI itself only needs `Config`/`Result`. The
-# store/tool features it runs on come from `openwave-server` and unify in; this
-# just avoids pulling core's other defaults (e.g. keychain) the CLI doesn't use.
-openwave-core = { path = "../openwave-core", default-features = false }
+# `default-features = false`: the CLI directly needs config/contracts plus the
+# built-in file tools for `openwave mcp`; server persistence features still come
+# through `openwave-server`. This avoids directly enabling unrelated defaults.
+openwave-core = { path = "../openwave-core", default-features = false, features = ["tools"] }
+openwave-mcp = { path = "../openwave-mcp" }
 openwave-server = { path = "../openwave-server" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
+serde_json = { workspace = true }
 tempfile = "3"

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -1,12 +1,21 @@
-//! OpenWave CLI — the headless daemon.
+//! OpenWave CLI — the headless daemon and MCP server.
 //!
 //! `openwave serve` boots the in-process HTTP/WebSocket surface on a loopback
 //! port and prints the address and per-launch bearer token it minted, so a local
 //! client (the desktop shell, or a script) can connect. Configuration comes from
 //! the environment via [`Config::from_env`] (`OPENWAVE_PROFILE`,
 //! `OPENWAVE_DATA_DIR`); the model API key comes from `ANTHROPIC_API_KEY`.
+//!
+//! `openwave mcp <workspace>` serves the built-in read-only filesystem tools over
+//! MCP stdio, confined to the explicit workspace directory.
 
-use openwave_core::{Config, Result};
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use openwave_core::{AgentError, ChatId, Config, ListDir, ReadFile, Result, ToolCtx, ToolRegistry};
+
+const USAGE: &str = "usage: openwave serve\n       openwave mcp <workspace>";
 
 #[tokio::main]
 async fn main() {
@@ -19,14 +28,34 @@ async fn main() {
 }
 
 async fn run() -> Result<()> {
-    match std::env::args().nth(1).as_deref() {
+    let mut args = std::env::args_os().skip(1);
+    match args.next().as_deref() {
         // Default to `serve` so a bare `openwave` runs the daemon.
-        Some("serve") | None => serve().await,
+        None => serve().await,
+        Some(command) if command == OsStr::new("serve") => {
+            if args.next().is_some() {
+                usage_error("serve does not accept arguments");
+            }
+            serve().await
+        }
+        Some(command) if command == OsStr::new("mcp") => {
+            let Some(workspace) = args.next() else {
+                usage_error("mcp requires a workspace path");
+            };
+            if args.next().is_some() {
+                usage_error("mcp accepts exactly one workspace path");
+            }
+            serve_mcp(workspace.into()).await
+        }
         Some(other) => {
-            eprintln!("openwave: unknown command {other:?}\n\nusage: openwave serve");
-            std::process::exit(2);
+            usage_error(&format!("unknown command {other:?}"));
         }
     }
+}
+
+fn usage_error(message: &str) -> ! {
+    eprintln!("openwave: {message}\n\n{USAGE}");
+    std::process::exit(2);
 }
 
 /// Bind the server and run its accept loop, announcing where to reach it.
@@ -40,4 +69,24 @@ async fn serve() -> Result<()> {
     println!("openwave: listening on http://{}", server.local_addr());
     println!("openwave: token {}", server.token());
     server.serve().await
+}
+
+/// Serve the built-in read-only filesystem tools over MCP stdio.
+async fn serve_mcp(workspace: PathBuf) -> Result<()> {
+    let ctx = ToolCtx::try_new(ChatId::new(), None, workspace.clone()).map_err(|error| {
+        AgentError::config(format!(
+            "could not open MCP workspace {}: {error}",
+            workspace.display()
+        ))
+    })?;
+
+    let tools = Arc::new(
+        ToolRegistry::new()
+            .with(Box::new(ReadFile))
+            .with(Box::new(ListDir)),
+    );
+    let server = openwave_mcp::McpServer::new(tools, ctx);
+    openwave_mcp::serve_stdio(server)
+        .await
+        .map_err(|error| AgentError::msg(format!("MCP stdio error: {error}")))
 }

--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -1,13 +1,42 @@
-//! End-to-end test of the `openwave serve` daemon: spawn the built binary, read
-//! the address it announces on stdout, and confirm the server actually answers.
+//! End-to-end tests of the `openwave` process surfaces.
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
 
 /// Kills the daemon on drop — including on an assertion panic, since
 /// `std::process::Child` does not reap on its own.
 struct Reaper(Child);
+
+impl Reaper {
+    fn wait_with_output(&mut self, timeout: Duration) -> Output {
+        let deadline = Instant::now() + timeout;
+        let status = loop {
+            if let Some(status) = self.0.try_wait().unwrap() {
+                break status;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "child did not exit within {timeout:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        if let Some(mut pipe) = self.0.stdout.take() {
+            pipe.read_to_end(&mut stdout).unwrap();
+        }
+        if let Some(mut pipe) = self.0.stderr.take() {
+            pipe.read_to_end(&mut stderr).unwrap();
+        }
+        Output {
+            status,
+            stdout,
+            stderr,
+        }
+    }
+}
 
 impl Drop for Reaper {
     fn drop(&mut self) {
@@ -56,4 +85,83 @@ fn serve_announces_its_address_and_answers_health() {
 
     assert!(response.contains("200 OK"), "response: {response}");
     assert!(response.trim_end().ends_with("ok"), "response: {response}");
+}
+
+#[test]
+fn mcp_serves_read_only_tools_with_protocol_pure_stdout() {
+    let workspace = tempfile::tempdir().unwrap();
+    std::fs::write(workspace.path().join("note.txt"), "workspace note").unwrap();
+    let child = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .arg("mcp")
+        .arg(workspace.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave mcp");
+
+    let input = concat!(
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#,
+        "\n",
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+        "\n",
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+        "\n",
+        r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"note.txt"}}}"#,
+        "\n",
+    );
+    let mut child = Reaper(child);
+    let mut stdin = child.0.stdin.take().unwrap();
+    stdin.write_all(input.as_bytes()).unwrap();
+    drop(stdin);
+
+    let output = child.wait_with_output(Duration::from_secs(5));
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8(output.stderr).unwrap(), "");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let responses: Vec<serde_json::Value> = stdout
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert_eq!(responses.len(), 3, "stdout: {stdout}");
+    let tool_names: Vec<&str> = responses[1]["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(tool_names, ["list_dir", "read_file"]);
+    assert_eq!(
+        responses[2]["result"]["content"][0]["text"],
+        "workspace note"
+    );
+}
+
+// Linux filesystems accept arbitrary non-NUL byte paths; macOS commonly rejects
+// ill-formed UTF-8 names before the CLI can observe them.
+#[cfg(target_os = "linux")]
+#[test]
+fn mcp_accepts_a_non_utf8_workspace_path() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let parent = tempfile::tempdir().unwrap();
+    let workspace = parent
+        .path()
+        .join(std::ffi::OsString::from_vec(b"workspace-\xff".to_vec()));
+    std::fs::create_dir(&workspace).unwrap();
+    let child = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .arg("mcp")
+        .arg(&workspace)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave mcp with non-UTF-8 workspace");
+    let mut child = Reaper(child);
+
+    let output = child.wait_with_output(Duration::from_secs(5));
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(output.stderr.is_empty());
 }

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -93,9 +93,10 @@ revisions and Parse→Index jobs are coordinated by `openwave-core` and
 ## `openwave-mcp` — the MCP face 🟡
 
 The server half of [MCP](https://modelcontextprotocol.io): JSON-RPC
-`initialize`, `tools/list`, and `tools/call` over stdio, backed by OpenWave's
-tool registry. CLI/session lifecycle wiring and the client that mounts external
-MCP servers remain planned.
+`initialize`, `ping`, `tools/list`, and `tools/call` over stdio, backed by
+OpenWave's tool registry. Its atomic session lifecycle gates normal operations,
+and its execution boundary exposes only tools classified read-only. The client
+that mounts external MCP servers remains planned.
 
 **Depends on:** `openwave-core`.
 
@@ -123,9 +124,11 @@ retirement, and audit workers while core state transitions remain in
 ## `openwave-cli` — headless daemon + CLI 🟡
 
 The working headless daemon (`openwave serve`) over the same HTTP surface the
-desktop uses. Additional command-line client workflows remain in development.
+desktop uses, plus `openwave mcp <workspace>` for a read-only MCP stdio server
+confined to one explicit workspace. Indexed-document MCP search and additional
+command-line client workflows remain in development.
 
-**Depends on:** `openwave-core`, `openwave-server`.
+**Depends on:** `openwave-core`, `openwave-mcp`, `openwave-server`.
 
 ## `openwave-slack` — the Slack adapter ⚪
 


### PR DESCRIPTION
## Summary
- add `openwave mcp <workspace>` as a stdio MCP server
- expose the built-in read-only file tools through a pinned explicit workspace
- preserve non-UTF-8 Unix paths and keep stdout protocol-pure
- cover the real subprocess protocol flow with bounded, reaped process tests
- update user-facing crate and command documentation

## Verification
- `cargo test --workspace`
- `cargo test -p openwave-cli`
- `bw dev lint --rust`
- `cargo fmt --all --check`
- `git diff --check`