### PR TITLE
feat(core): add durable turn run model

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -177,6 +177,36 @@ pub mod message {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod turn_run {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "turn_run")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub chat_id: Uuid,
+        pub model: String,
+        pub status: String,
+        pub attempt_count: i32,
+        pub max_attempts: i32,
+        pub available_at: DateTimeUtc,
+        pub lease_token: Option<Uuid>,
+        pub lease_expires_at: Option<DateTimeUtc>,
+        pub started_at: Option<DateTimeUtc>,
+        pub finished_at: Option<DateTimeUtc>,
+        pub last_error_code: Option<String>,
+        pub last_error_detail: Option<String>,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod tool_call {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -1,6 +1,9 @@
 use sea_orm_migration::prelude::*;
 
-use super::{BlobRetirementStatus, DocumentJobKind, DocumentJobStatus, DocumentProcessingStatus};
+use super::{
+    BlobRetirementStatus, DocumentJobKind, DocumentJobStatus, DocumentProcessingStatus,
+    TurnRunStatus,
+};
 
 pub struct Migrator;
 
@@ -42,6 +45,233 @@ impl MigrationTrait for Init {
                             .timestamp_with_time_zone()
                             .not_null(),
                     )
+                    .to_owned(),
+            )
+            .await?;
+
+        let valid_turn_status = Expr::col(TurnRun::Status).is_in([
+            TurnRunStatus::Queued.as_str(),
+            TurnRunStatus::Running.as_str(),
+            TurnRunStatus::RetryWait.as_str(),
+            TurnRunStatus::Completed.as_str(),
+            TurnRunStatus::Failed.as_str(),
+            TurnRunStatus::Cancelled.as_str(),
+        ]);
+        let running_lease = Expr::col(TurnRun::Status)
+            .eq(TurnRunStatus::Running.as_str())
+            .and(Expr::col(TurnRun::LeaseToken).is_not_null())
+            .and(Expr::col(TurnRun::LeaseExpiresAt).is_not_null());
+        let no_lease = Expr::col(TurnRun::Status)
+            .ne(TurnRunStatus::Running.as_str())
+            .and(Expr::col(TurnRun::LeaseToken).is_null())
+            .and(Expr::col(TurnRun::LeaseExpiresAt).is_null());
+        let terminal_finished = Expr::col(TurnRun::Status)
+            .is_in([
+                TurnRunStatus::Completed.as_str(),
+                TurnRunStatus::Failed.as_str(),
+                TurnRunStatus::Cancelled.as_str(),
+            ])
+            .and(Expr::col(TurnRun::FinishedAt).is_not_null());
+        let nonterminal_unfinished = Expr::col(TurnRun::Status)
+            .is_in([
+                TurnRunStatus::Queued.as_str(),
+                TurnRunStatus::Running.as_str(),
+                TurnRunStatus::RetryWait.as_str(),
+            ])
+            .and(Expr::col(TurnRun::FinishedAt).is_null());
+        let queued_attempt = Expr::col(TurnRun::Status)
+            .eq(TurnRunStatus::Queued.as_str())
+            .and(Expr::col(TurnRun::AttemptCount).eq(0))
+            .and(Expr::col(TurnRun::StartedAt).is_null());
+        let running_attempt = Expr::col(TurnRun::Status)
+            .eq(TurnRunStatus::Running.as_str())
+            .and(Expr::col(TurnRun::AttemptCount).gte(1))
+            .and(Expr::col(TurnRun::StartedAt).is_not_null());
+        let retryable_attempt = Expr::col(TurnRun::Status)
+            .eq(TurnRunStatus::RetryWait.as_str())
+            .and(Expr::col(TurnRun::AttemptCount).gte(1))
+            .and(Expr::col(TurnRun::AttemptCount).lt(Expr::col(TurnRun::MaxAttempts)))
+            .and(Expr::col(TurnRun::StartedAt).is_not_null());
+        let resolved_attempt = Expr::col(TurnRun::Status)
+            .is_in([
+                TurnRunStatus::Completed.as_str(),
+                TurnRunStatus::Failed.as_str(),
+            ])
+            .and(Expr::col(TurnRun::AttemptCount).gte(1))
+            .and(Expr::col(TurnRun::StartedAt).is_not_null());
+        let cancelled_attempt = Expr::col(TurnRun::Status)
+            .eq(TurnRunStatus::Cancelled.as_str())
+            .and(
+                Expr::col(TurnRun::AttemptCount)
+                    .eq(0)
+                    .and(Expr::col(TurnRun::StartedAt).is_null())
+                    .or(Expr::col(TurnRun::AttemptCount)
+                        .gte(1)
+                        .and(Expr::col(TurnRun::StartedAt).is_not_null())),
+            );
+        let failure_has_error = Expr::col(TurnRun::Status)
+            .is_in([
+                TurnRunStatus::RetryWait.as_str(),
+                TurnRunStatus::Failed.as_str(),
+            ])
+            .and(Expr::col(TurnRun::LastErrorCode).is_not_null());
+        let success_has_no_error = Expr::col(TurnRun::Status)
+            .is_in([
+                TurnRunStatus::Queued.as_str(),
+                TurnRunStatus::Running.as_str(),
+                TurnRunStatus::Completed.as_str(),
+                TurnRunStatus::Cancelled.as_str(),
+            ])
+            .and(Expr::col(TurnRun::LastErrorCode).is_null())
+            .and(Expr::col(TurnRun::LastErrorDetail).is_null());
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(TurnRun::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(TurnRun::Id).uuid().not_null().primary_key())
+                    .col(ColumnDef::new(TurnRun::ChatId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(TurnRun::Model)
+                            .string_len(crate::model::TurnRun::MAX_MODEL_LEN as u32)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnRun::Status)
+                            .string_len(32)
+                            .not_null()
+                            .default(TurnRunStatus::Queued.as_str()),
+                    )
+                    .col(
+                        ColumnDef::new(TurnRun::AttemptCount)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(TurnRun::MaxAttempts)
+                            .integer()
+                            .not_null()
+                            .default(crate::model::TurnRun::DEFAULT_MAX_ATTEMPTS),
+                    )
+                    .col(
+                        ColumnDef::new(TurnRun::AvailableAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(TurnRun::LeaseToken).uuid())
+                    .col(ColumnDef::new(TurnRun::LeaseExpiresAt).timestamp_with_time_zone())
+                    .col(ColumnDef::new(TurnRun::StartedAt).timestamp_with_time_zone())
+                    .col(ColumnDef::new(TurnRun::FinishedAt).timestamp_with_time_zone())
+                    .col(
+                        ColumnDef::new(TurnRun::LastErrorCode)
+                            .string_len(crate::model::TurnRun::MAX_ERROR_CODE_LEN as u32),
+                    )
+                    .col(
+                        ColumnDef::new(TurnRun::LastErrorDetail)
+                            .string_len(crate::model::TurnRun::MAX_ERROR_DETAIL_LEN as u32),
+                    )
+                    .col(
+                        ColumnDef::new(TurnRun::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnRun::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_run_chat")
+                            .from(TurnRun::Table, TurnRun::ChatId)
+                            .to(Chat::Table, Chat::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .check(
+                        Func::char_length(Expr::col(TurnRun::Model))
+                            .between(1, crate::model::TurnRun::MAX_MODEL_LEN as i32),
+                    )
+                    .check(valid_turn_status)
+                    .check(
+                        Expr::col(TurnRun::AttemptCount)
+                            .gte(0)
+                            .and(Expr::col(TurnRun::MaxAttempts).gte(1))
+                            .and(
+                                Expr::col(TurnRun::AttemptCount)
+                                    .lte(Expr::col(TurnRun::MaxAttempts)),
+                            ),
+                    )
+                    .check(running_lease.or(no_lease))
+                    .check(terminal_finished.or(nonterminal_unfinished))
+                    .check(
+                        queued_attempt
+                            .or(running_attempt)
+                            .or(retryable_attempt)
+                            .or(resolved_attempt)
+                            .or(cancelled_attempt),
+                    )
+                    .check(failure_has_error.or(success_has_no_error))
+                    .check(
+                        Expr::col(TurnRun::LastErrorCode)
+                            .is_null()
+                            .or(Func::char_length(Expr::col(TurnRun::LastErrorCode))
+                                .between(1, crate::model::TurnRun::MAX_ERROR_CODE_LEN as i32)),
+                    )
+                    .check(
+                        Expr::col(TurnRun::LastErrorDetail)
+                            .is_null()
+                            .or(Func::char_length(Expr::col(TurnRun::LastErrorDetail))
+                                .between(1, crate::model::TurnRun::MAX_ERROR_DETAIL_LEN as i32)),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_run_one_active")
+                    .table(TurnRun::Table)
+                    .col(TurnRun::ChatId)
+                    .unique()
+                    .and_where(Expr::col(TurnRun::Status).is_in([
+                        TurnRunStatus::Queued.as_str(),
+                        TurnRunStatus::Running.as_str(),
+                        TurnRunStatus::RetryWait.as_str(),
+                    ]))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_run_due")
+                    .table(TurnRun::Table)
+                    .col(TurnRun::Status)
+                    .col(TurnRun::AvailableAt)
+                    .col(TurnRun::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_run_stale_lease")
+                    .table(TurnRun::Table)
+                    .col(TurnRun::Status)
+                    .col(TurnRun::LeaseExpiresAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_run_history")
+                    .table(TurnRun::Table)
+                    .col(TurnRun::ChatId)
+                    .col(TurnRun::CreatedAt)
                     .to_owned(),
             )
             .await?;
@@ -102,6 +332,9 @@ impl MigrationTrait for Init {
             .await?;
         manager
             .drop_table(Table::drop().table(Setting::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(TurnRun::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(Chat::Table).to_owned())
@@ -1082,6 +1315,26 @@ enum Message {
     Role,
     Content,
     CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum TurnRun {
+    Table,
+    Id,
+    ChatId,
+    Model,
+    Status,
+    AttemptCount,
+    MaxAttempts,
+    AvailableAt,
+    LeaseToken,
+    LeaseExpiresAt,
+    StartedAt,
+    FinishedAt,
+    LastErrorCode,
+    LastErrorDetail,
+    CreatedAt,
+    UpdatedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -21,15 +21,15 @@ use serde_json::Value;
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 #[cfg(test)]
-use crate::id::{CallId, MessageId, TurnId};
-use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId};
+use crate::id::{CallId, MessageId};
+use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId, TurnId};
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
     BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
     DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
     DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
-    DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord,
+    DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, TurnRun, TurnRunStatus,
 };
 use crate::storage::{
     DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, Store,
@@ -1640,6 +1640,14 @@ impl Store for DbStore {
 
     async fn list_chats(&self) -> Result<Vec<Chat>> {
         ops::conversation::list_chats(self).await
+    }
+
+    async fn get_turn_run(&self, id: TurnId) -> Result<Option<TurnRun>> {
+        ops::conversation::get_turn_run(self, id).await
+    }
+
+    async fn list_turn_runs(&self, chat_id: ChatId) -> Result<Vec<TurnRun>> {
+        ops::conversation::list_turn_runs(self, chat_id).await
     }
 
     async fn append_message(&self, message: &Message) -> Result<()> {

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -7,7 +7,7 @@ use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrde
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{CallId, ChatId, MessageId, ProjectId, TurnId};
-use crate::model::{Chat, Message, Role, ToolCallRecord};
+use crate::model::{Chat, Message, Role, ToolCallRecord, TurnRun, TurnRunStatus};
 
 use super::super::{entities, store_err, DbStore};
 
@@ -60,6 +60,31 @@ pub(in crate::db) async fn list_chats(store: &DbStore) -> Result<Vec<Chat>> {
         .into_iter()
         .map(chat_from_model)
         .collect())
+}
+
+pub(in crate::db) async fn get_turn_run(store: &DbStore, id: TurnId) -> Result<Option<TurnRun>> {
+    entities::turn_run::Entity::find_by_id(id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(turn_run_from_model)
+        .transpose()
+}
+
+pub(in crate::db) async fn list_turn_runs(
+    store: &DbStore,
+    chat_id: ChatId,
+) -> Result<Vec<TurnRun>> {
+    entities::turn_run::Entity::find()
+        .filter(entities::turn_run::Column::ChatId.eq(chat_id.0))
+        .order_by_asc(entities::turn_run::Column::CreatedAt)
+        .order_by_asc(entities::turn_run::Column::Id)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(turn_run_from_model)
+        .collect()
 }
 
 pub(in crate::db) async fn append_message(store: &DbStore, message: &Message) -> Result<()> {
@@ -207,6 +232,40 @@ fn message_from_model(model: entities::message::Model) -> Result<Message> {
         content: model.content,
         created_at: model.created_at,
     })
+}
+
+fn turn_run_from_model(model: entities::turn_run::Model) -> Result<TurnRun> {
+    Ok(TurnRun {
+        id: TurnId(model.id),
+        chat_id: ChatId(model.chat_id),
+        model: model.model,
+        status: turn_run_status_from_db(&model.status)?,
+        attempt_count: model.attempt_count,
+        max_attempts: model.max_attempts,
+        available_at: model.available_at,
+        lease_token: model.lease_token,
+        lease_expires_at: model.lease_expires_at,
+        started_at: model.started_at,
+        finished_at: model.finished_at,
+        last_error_code: model.last_error_code,
+        last_error_detail: model.last_error_detail,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+    })
+}
+
+fn turn_run_status_from_db(text: &str) -> Result<TurnRunStatus> {
+    match text {
+        "queued" => Ok(TurnRunStatus::Queued),
+        "running" => Ok(TurnRunStatus::Running),
+        "retry_wait" => Ok(TurnRunStatus::RetryWait),
+        "completed" => Ok(TurnRunStatus::Completed),
+        "failed" => Ok(TurnRunStatus::Failed),
+        "cancelled" => Ok(TurnRunStatus::Cancelled),
+        other => Err(AgentError::Store(format!(
+            "unknown durable turn status: {other}"
+        ))),
+    }
 }
 
 fn tool_call_from_model(model: entities::tool_call::Model) -> ToolCallRecord {

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4573,6 +4573,175 @@ async fn chats_and_messages_roundtrip() {
 }
 
 #[tokio::test]
+async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let now = DateTime::<Utc>::from_timestamp(1_752_408_000, 0).unwrap();
+    let make_turn = |chat_id: ChatId, model: &str| entities::turn_run::ActiveModel {
+        id: Set(TurnId::new().0),
+        chat_id: Set(chat_id.0),
+        model: Set(model.into()),
+        status: Set(TurnRunStatus::Queued.as_str().into()),
+        attempt_count: Set(0),
+        max_attempts: Set(crate::model::TurnRun::DEFAULT_MAX_ATTEMPTS),
+        available_at: Set(now),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        started_at: Set(None),
+        finished_at: Set(None),
+        last_error_code: Set(None),
+        last_error_detail: Set(None),
+        created_at: Set(now),
+        updated_at: Set(now),
+    };
+
+    let first = make_turn(chat.id, "claude-sonnet-4-5")
+        .insert(&store.conn)
+        .await
+        .unwrap();
+    let stored = store.get_turn_run(TurnId(first.id)).await.unwrap().unwrap();
+    assert_eq!(stored.id, TurnId(first.id));
+    assert_eq!(stored.chat_id, chat.id);
+    assert_eq!(stored.model, "claude-sonnet-4-5");
+    assert_eq!(stored.status, TurnRunStatus::Queued);
+    assert_eq!(store.list_turn_runs(chat.id).await.unwrap(), vec![stored]);
+
+    // The database, not a process-local map, owns the one-live-turn invariant.
+    assert!(make_turn(chat.id, "gpt-5")
+        .insert(&store.conn)
+        .await
+        .is_err());
+
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnRunStatus::Completed.as_str()),
+        )
+        .col_expr(
+            entities::turn_run::Column::AttemptCount,
+            sea_orm::sea_query::Expr::value(1),
+        )
+        .col_expr(
+            entities::turn_run::Column::StartedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            entities::turn_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .filter(entities::turn_run::Column::Id.eq(first.id))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    make_turn(chat.id, "gpt-5")
+        .insert(&store.conn)
+        .await
+        .unwrap();
+
+    let invalid_chat = sample_chat();
+    store.create_chat(&invalid_chat).await.unwrap();
+
+    let mut running_without_lease = make_turn(invalid_chat.id, "gpt-5");
+    running_without_lease.status = Set(TurnRunStatus::Running.as_str().into());
+    running_without_lease.attempt_count = Set(1);
+    running_without_lease.started_at = Set(Some(now));
+    assert!(running_without_lease.insert(&store.conn).await.is_err());
+
+    let mut retry_without_error = make_turn(invalid_chat.id, "gpt-5");
+    retry_without_error.status = Set(TurnRunStatus::RetryWait.as_str().into());
+    retry_without_error.attempt_count = Set(1);
+    retry_without_error.max_attempts = Set(2);
+    retry_without_error.started_at = Set(Some(now));
+    assert!(retry_without_error.insert(&store.conn).await.is_err());
+
+    let mut failed_without_finish = make_turn(invalid_chat.id, "gpt-5");
+    failed_without_finish.status = Set(TurnRunStatus::Failed.as_str().into());
+    failed_without_finish.attempt_count = Set(1);
+    failed_without_finish.started_at = Set(Some(now));
+    failed_without_finish.last_error_code = Set(Some("provider_error".into()));
+    assert!(failed_without_finish.insert(&store.conn).await.is_err());
+
+    let mut unknown_status = make_turn(invalid_chat.id, "gpt-5");
+    unknown_status.status = Set("waiting_for_magic".into());
+    assert!(unknown_status.insert(&store.conn).await.is_err());
+    assert!(make_turn(invalid_chat.id, "")
+        .insert(&store.conn)
+        .await
+        .is_err());
+    assert!(make_turn(
+        invalid_chat.id,
+        &"m".repeat(crate::model::TurnRun::MAX_MODEL_LEN + 1),
+    )
+    .insert(&store.conn)
+    .await
+    .is_err());
+
+    let mut oversized_error = make_turn(invalid_chat.id, "gpt-5");
+    oversized_error.status = Set(TurnRunStatus::Failed.as_str().into());
+    oversized_error.attempt_count = Set(1);
+    oversized_error.started_at = Set(Some(now));
+    oversized_error.finished_at = Set(Some(now));
+    oversized_error.last_error_code = Set(Some(
+        "e".repeat(crate::model::TurnRun::MAX_ERROR_CODE_LEN + 1),
+    ));
+    assert!(oversized_error.insert(&store.conn).await.is_err());
+
+    // The turn identity is global and cannot be replayed against another chat.
+    let other = sample_chat();
+    store.create_chat(&other).await.unwrap();
+    let mut duplicate_identity = make_turn(other.id, "gpt-5");
+    duplicate_identity.id = Set(first.id);
+    assert!(duplicate_identity.insert(&store.conn).await.is_err());
+
+    // Every valid non-queued state is representable; later transition methods
+    // must reach these shapes atomically under exact predicates.
+    let running_chat = sample_chat();
+    store.create_chat(&running_chat).await.unwrap();
+    let mut running = make_turn(running_chat.id, "gpt-5");
+    running.status = Set(TurnRunStatus::Running.as_str().into());
+    running.attempt_count = Set(1);
+    running.started_at = Set(Some(now));
+    running.lease_token = Set(Some(uuid::Uuid::new_v4()));
+    running.lease_expires_at = Set(Some(now + chrono::Duration::minutes(1)));
+    running.insert(&store.conn).await.unwrap();
+
+    let retry_chat = sample_chat();
+    store.create_chat(&retry_chat).await.unwrap();
+    let mut retry_wait = make_turn(retry_chat.id, "gpt-5");
+    retry_wait.status = Set(TurnRunStatus::RetryWait.as_str().into());
+    retry_wait.attempt_count = Set(1);
+    retry_wait.max_attempts = Set(2);
+    retry_wait.started_at = Set(Some(now));
+    retry_wait.last_error_code = Set(Some("provider_unavailable".into()));
+    retry_wait.insert(&store.conn).await.unwrap();
+
+    let failed_chat = sample_chat();
+    store.create_chat(&failed_chat).await.unwrap();
+    let mut failed = make_turn(failed_chat.id, "gpt-5");
+    failed.status = Set(TurnRunStatus::Failed.as_str().into());
+    failed.attempt_count = Set(1);
+    failed.started_at = Set(Some(now));
+    failed.finished_at = Set(Some(now));
+    failed.last_error_code = Set(Some("unsafe_to_retry".into()));
+    failed.last_error_detail = Set(Some("tool outcome is ambiguous".into()));
+    failed.insert(&store.conn).await.unwrap();
+
+    for started in [false, true] {
+        let cancelled_chat = sample_chat();
+        store.create_chat(&cancelled_chat).await.unwrap();
+        let mut cancelled = make_turn(cancelled_chat.id, "gpt-5");
+        cancelled.status = Set(TurnRunStatus::Cancelled.as_str().into());
+        cancelled.finished_at = Set(Some(now));
+        if started {
+            cancelled.attempt_count = Set(1);
+            cancelled.started_at = Set(Some(now));
+        }
+        cancelled.insert(&store.conn).await.unwrap();
+    }
+}
+
+#[tokio::test]
 async fn settings_roundtrip_and_overwrite() {
     let (_dir, store) = temp_store().await;
     assert_eq!(store.get_setting("model").await.unwrap(), None);

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -55,7 +55,7 @@ pub use model::{
     DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
     DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
     DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
-    Project, Role, SourceLocation, SourceRegion, ToolCallRecord,
+    Project, Role, SourceLocation, SourceRegion, ToolCallRecord, TurnRun, TurnRunStatus,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1,12 +1,10 @@
 //! The persisted conversation model.
 //!
-//! Mirrors the `chat` and `message` tables of `Store` schema v1. A
+//! Mirrors the conversation tables of `Store` schema v1. A
 //! [`Chat`] is a durable conversation that owns a workspace directory; a
-//! [`Message`] is one user input or assistant answer within it.
-//!
-//! Turns and steps are runtime concepts of the agent loop (schema v1 has no
-//! table for them — they are referenced by `turn_id`), so they live with the
-//! loop, not here.
+//! [`TurnRun`] is one durably scheduled agent turn, and a [`Message`] is one
+//! user input or assistant answer within it. Steps remain runtime concepts of
+//! the agent loop.
 
 use std::path::PathBuf;
 
@@ -611,6 +609,98 @@ pub struct Chat {
     pub created_at: DateTime<Utc>,
 }
 
+/// Durable execution state of one user turn.
+///
+/// A turn is accepted once under its stable [`TurnId`], then claimed under an
+/// exact lease before model or tool work begins. Keeping this state separate
+/// from messages lets API acceptance, worker ownership, and terminal resolution
+/// be fenced without treating append-only conversation content as a job queue.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnRun {
+    /// Stable turn and idempotency identity.
+    pub id: TurnId,
+    /// Conversation this turn belongs to.
+    pub chat_id: ChatId,
+    /// Model selected when the turn was accepted.
+    pub model: String,
+    /// Durable delivery state.
+    pub status: TurnRunStatus,
+    /// Claims already made, including the current claim when running.
+    pub attempt_count: i32,
+    /// Maximum claims permitted for this turn.
+    pub max_attempts: i32,
+    /// Earliest time queued or retry-wait work may be claimed.
+    pub available_at: DateTime<Utc>,
+    /// Exact claim identity required for heartbeat and resolution writes.
+    pub lease_token: Option<Uuid>,
+    /// When the current claim becomes stale.
+    pub lease_expires_at: Option<DateTime<Utc>>,
+    /// When the first claim began.
+    pub started_at: Option<DateTime<Utc>>,
+    /// When this turn entered a terminal state.
+    pub finished_at: Option<DateTime<Utc>>,
+    /// Stable machine-readable failure category.
+    pub last_error_code: Option<String>,
+    /// Bounded diagnostic detail for local operators.
+    pub last_error_detail: Option<String>,
+    /// When this turn was accepted.
+    pub created_at: DateTime<Utc>,
+    /// When its durable state last changed.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl TurnRun {
+    /// New turns are not automatically replayed after an ambiguous side effect.
+    /// A later resumable-checkpoint slice may opt specific turns into more.
+    pub const DEFAULT_MAX_ATTEMPTS: i32 = 1;
+    /// Maximum persisted model identifier length.
+    pub const MAX_MODEL_LEN: usize = 512;
+    /// Maximum persisted machine-readable error code length.
+    pub const MAX_ERROR_CODE_LEN: usize = 128;
+    /// Maximum persisted diagnostic detail length.
+    pub const MAX_ERROR_DETAIL_LEN: usize = 4096;
+}
+
+/// Durable delivery state of a [`TurnRun`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TurnRunStatus {
+    /// Accepted durably and eligible to be claimed at `available_at`.
+    Queued,
+    /// Currently owned by the exact lease token and expiry on the turn.
+    Running,
+    /// Failed safely before an ambiguous side effect and awaits another claim.
+    RetryWait,
+    /// Produced a final answer successfully.
+    Completed,
+    /// Failed permanently or cannot be replayed safely.
+    Failed,
+    /// Cancelled before producing a final answer.
+    Cancelled,
+}
+
+impl TurnRunStatus {
+    /// Stable database and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::RetryWait => "retry_wait",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// Whether no worker may claim this turn without an explicit transition.
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
 /// One message in a chat: user input or assistant text.
 ///
 /// Tool calls are not messages; they persist separately (the `tool_call` table)
@@ -692,6 +782,12 @@ mod tests {
         assert!(!DocumentJobStatus::Running.is_terminal());
         assert!(BlobRetirementStatus::Cancelled.is_terminal());
         assert!(!BlobRetirementStatus::Queued.is_terminal());
+        assert_eq!(
+            serde_json::to_string(&TurnRunStatus::RetryWait).unwrap(),
+            "\"retry_wait\""
+        );
+        assert!(TurnRunStatus::Completed.is_terminal());
+        assert!(!TurnRunStatus::Running.is_terminal());
     }
 
     #[test]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -20,11 +20,12 @@ use serde_json::Value;
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId};
+use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId, TurnId};
 use crate::model::{
     BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
     DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentRecord, DocumentScope,
     DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
+    TurnRun,
 };
 
 /// Why maintenance determined that a document needs an index job.
@@ -86,6 +87,12 @@ pub enum EnsureDocumentParseJobOutcome {
 fn document_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "document storage is not implemented by this Store".into(),
+    ))
+}
+
+fn turn_storage_unavailable<T>() -> Result<T> {
+    Err(AgentError::Store(
+        "durable turn storage is not implemented by this Store".into(),
     ))
 }
 
@@ -524,6 +531,16 @@ pub trait Store: Send + Sync {
     /// Set (or clear, with `None`) a chat's model override. A no-op if the chat
     /// doesn't exist.
     async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()>;
+
+    /// Fetch one durable turn by its exact idempotency identity.
+    async fn get_turn_run(&self, _id: TurnId) -> Result<Option<TurnRun>> {
+        turn_storage_unavailable()
+    }
+
+    /// List a chat's durable turn history in deterministic creation-time order.
+    async fn list_turn_runs(&self, _chat_id: ChatId) -> Result<Vec<TurnRun>> {
+        turn_storage_unavailable()
+    }
 
     /// Append a message to its chat.
     async fn append_message(&self, message: &Message) -> Result<()>;


### PR DESCRIPTION
## Summary

- add a typed durable turn-run model with queued, leased, retry, and terminal states
- enforce one live turn per chat plus state-dependent lease, attempt, error, and timestamp invariants
- expose deterministic turn history reads through the Store seam and SQLite backend
- fold the table into the pre-v1 baseline migration rather than adding migration churn

## Design

Turn identities double as the idempotency boundary for the later acceptance API. The default attempt budget is intentionally one until a resumable checkpoint can prove that retrying a turn will not repeat an ambiguous side effect.

This is the state-model foundation only. Atomic message acceptance, claim and heartbeat transitions, worker activation, and durable cancel and steer commands remain separate slices. Existing development databases must be reset because the baseline migration changed.

## Validation

- full workspace tests
- 167 all-feature core tests
- focused valid and invalid state-matrix coverage
- Rust lint
- formatting and diff checks
