### PR TITLE
feat(core): accept turns atomically

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -186,6 +186,7 @@ pub mod turn_run {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
         pub chat_id: Uuid,
+        pub input_message_id: Uuid,
         pub model: String,
         pub status: String,
         pub attempt_count: i32,

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -49,6 +49,54 @@ impl MigrationTrait for Init {
             )
             .await?;
 
+        manager
+            .create_table(
+                Table::create()
+                    .table(Message::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Message::Id).uuid().not_null().primary_key())
+                    .col(ColumnDef::new(Message::ChatId).uuid().not_null())
+                    .col(ColumnDef::new(Message::TurnId).uuid().not_null())
+                    .col(ColumnDef::new(Message::Role).text().not_null())
+                    .col(ColumnDef::new(Message::Content).text().not_null())
+                    .col(
+                        ColumnDef::new(Message::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_message_chat")
+                            .from(Message::Table, Message::ChatId)
+                            .to(Chat::Table, Chat::Id),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_message_chat")
+                    .table(Message::Table)
+                    .col(Message::ChatId)
+                    .col(Message::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_message_turn_identity")
+                    .table(Message::Table)
+                    .col(Message::Id)
+                    .col(Message::ChatId)
+                    .col(Message::TurnId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
         let valid_turn_status = Expr::col(TurnRun::Status).is_in([
             TurnRunStatus::Queued.as_str(),
             TurnRunStatus::Running.as_str(),
@@ -132,6 +180,7 @@ impl MigrationTrait for Init {
                     .if_not_exists()
                     .col(ColumnDef::new(TurnRun::Id).uuid().not_null().primary_key())
                     .col(ColumnDef::new(TurnRun::ChatId).uuid().not_null())
+                    .col(ColumnDef::new(TurnRun::InputMessageId).uuid().not_null())
                     .col(
                         ColumnDef::new(TurnRun::Model)
                             .string_len(crate::model::TurnRun::MAX_MODEL_LEN as u32)
@@ -189,6 +238,19 @@ impl MigrationTrait for Init {
                             .to(Chat::Table, Chat::Id)
                             .on_delete(ForeignKeyAction::Cascade),
                     )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_run_input_message")
+                            .from_tbl(TurnRun::Table)
+                            .from_col(TurnRun::InputMessageId)
+                            .from_col(TurnRun::ChatId)
+                            .from_col(TurnRun::Id)
+                            .to_tbl(Message::Table)
+                            .to_col(Message::Id)
+                            .to_col(Message::ChatId)
+                            .to_col(Message::TurnId)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
                     .check(
                         Func::char_length(Expr::col(TurnRun::Model))
                             .between(1, crate::model::TurnRun::MAX_MODEL_LEN as i32),
@@ -229,6 +291,16 @@ impl MigrationTrait for Init {
             )
             .await?;
 
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_run_input_message")
+                    .table(TurnRun::Table)
+                    .col(TurnRun::InputMessageId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
         manager
             .create_index(
                 Index::create()
@@ -279,42 +351,6 @@ impl MigrationTrait for Init {
         manager
             .create_table(
                 Table::create()
-                    .table(Message::Table)
-                    .if_not_exists()
-                    .col(ColumnDef::new(Message::Id).uuid().not_null().primary_key())
-                    .col(ColumnDef::new(Message::ChatId).uuid().not_null())
-                    .col(ColumnDef::new(Message::TurnId).uuid().not_null())
-                    .col(ColumnDef::new(Message::Role).text().not_null())
-                    .col(ColumnDef::new(Message::Content).text().not_null())
-                    .col(
-                        ColumnDef::new(Message::CreatedAt)
-                            .timestamp_with_time_zone()
-                            .not_null(),
-                    )
-                    .foreign_key(
-                        ForeignKey::create()
-                            .name("fk_message_chat")
-                            .from(Message::Table, Message::ChatId)
-                            .to(Chat::Table, Chat::Id),
-                    )
-                    .to_owned(),
-            )
-            .await?;
-
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_message_chat")
-                    .table(Message::Table)
-                    .col(Message::ChatId)
-                    .col(Message::CreatedAt)
-                    .to_owned(),
-            )
-            .await?;
-
-        manager
-            .create_table(
-                Table::create()
                     .table(Setting::Table)
                     .if_not_exists()
                     .col(ColumnDef::new(Setting::Key).text().not_null().primary_key())
@@ -328,13 +364,13 @@ impl MigrationTrait for Init {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Message::Table).to_owned())
+            .drop_table(Table::drop().table(TurnRun::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(Setting::Table).to_owned())
             .await?;
         manager
-            .drop_table(Table::drop().table(TurnRun::Table).to_owned())
+            .drop_table(Table::drop().table(Message::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(Chat::Table).to_owned())
@@ -1322,6 +1358,7 @@ enum TurnRun {
     Table,
     Id,
     ChatId,
+    InputMessageId,
     Model,
     Status,
     AttemptCount,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -32,7 +32,8 @@ use crate::model::{
     DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, TurnRun, TurnRunStatus,
 };
 use crate::storage::{
-    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, Store,
+    AcceptTurnOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
+    EnsureDocumentParseJobOutcome, Store,
 };
 
 mod ops;
@@ -1648,6 +1649,16 @@ impl Store for DbStore {
 
     async fn list_turn_runs(&self, chat_id: ChatId) -> Result<Vec<TurnRun>> {
         ops::conversation::list_turn_runs(self, chat_id).await
+    }
+
+    async fn accept_turn(
+        &self,
+        id: TurnId,
+        chat_id: ChatId,
+        model: &str,
+        content: &str,
+    ) -> Result<AcceptTurnOutcome> {
+        ops::conversation::accept_turn(self, id, chat_id, model, content).await
     }
 
     async fn append_message(&self, message: &Message) -> Result<()> {

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -2,12 +2,16 @@ use std::path::PathBuf;
 
 use chrono::Utc;
 use sea_orm::sea_query::OnConflict;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait,
+};
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{CallId, ChatId, MessageId, ProjectId, TurnId};
 use crate::model::{Chat, Message, Role, ToolCallRecord, TurnRun, TurnRunStatus};
+use crate::storage::AcceptTurnOutcome;
 
 use super::super::{entities, store_err, DbStore};
 
@@ -85,6 +89,175 @@ pub(in crate::db) async fn list_turn_runs(
         .into_iter()
         .map(turn_run_from_model)
         .collect()
+}
+
+pub(in crate::db) async fn accept_turn(
+    store: &DbStore,
+    id: TurnId,
+    chat_id: ChatId,
+    model: &str,
+    content: &str,
+) -> Result<AcceptTurnOutcome> {
+    validate_turn_input(model, content)?;
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let chat_lock = entities::chat::Entity::update_many()
+        .col_expr(
+            entities::chat::Column::Title,
+            sea_orm::sea_query::Expr::col(entities::chat::Column::Title).into(),
+        )
+        .filter(entities::chat::Column::Id.eq(chat_id.0))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if chat_lock.rows_affected != 1 {
+        return Err(AgentError::Store(format!("chat {chat_id} does not exist")));
+    }
+
+    if let Some(existing) = entities::turn_run::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let existing =
+            exact_accepted_turn_on(&transaction, existing, chat_id, model, content).await?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(AcceptTurnOutcome::Existing(existing));
+    }
+
+    if let Some(active) = find_active_turn_on(&transaction, chat_id).await? {
+        let active = turn_run_from_model(active)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(AcceptTurnOutcome::ChatBusy(active));
+    }
+
+    let now = Utc::now();
+    let input_message_id = MessageId::new();
+    let message = entities::message::ActiveModel {
+        id: Set(input_message_id.0),
+        chat_id: Set(chat_id.0),
+        turn_id: Set(id.0),
+        role: Set(role_to_db(Role::User).into()),
+        content: Set(content.into()),
+        created_at: Set(now),
+    };
+    if let Err(error) = message.insert(&transaction).await {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(store_err(error));
+    }
+
+    let run = entities::turn_run::ActiveModel {
+        id: Set(id.0),
+        chat_id: Set(chat_id.0),
+        input_message_id: Set(input_message_id.0),
+        model: Set(model.into()),
+        status: Set(TurnRunStatus::Queued.as_str().into()),
+        attempt_count: Set(0),
+        max_attempts: Set(TurnRun::DEFAULT_MAX_ATTEMPTS),
+        available_at: Set(now),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        started_at: Set(None),
+        finished_at: Set(None),
+        last_error_code: Set(None),
+        last_error_detail: Set(None),
+        created_at: Set(now),
+        updated_at: Set(now),
+    };
+    let inserted = match run.insert(&transaction).await {
+        Ok(inserted) => inserted,
+        Err(error) => {
+            transaction.rollback().await.map_err(store_err)?;
+            if let Some(existing) = entities::turn_run::Entity::find_by_id(id.0)
+                .one(&store.conn)
+                .await
+                .map_err(store_err)?
+            {
+                let existing =
+                    exact_accepted_turn_on(&store.conn, existing, chat_id, model, content).await?;
+                return Ok(AcceptTurnOutcome::Existing(existing));
+            }
+            if let Some(active) = find_active_turn_on(&store.conn, chat_id).await? {
+                return Ok(AcceptTurnOutcome::ChatBusy(turn_run_from_model(active)?));
+            }
+            return Err(store_err(error));
+        }
+    };
+
+    transaction.commit().await.map_err(store_err)?;
+    Ok(AcceptTurnOutcome::Accepted(turn_run_from_model(inserted)?))
+}
+
+fn validate_turn_input(model: &str, content: &str) -> Result<()> {
+    if model.trim().is_empty()
+        || model.contains('\0')
+        || model.chars().count() > TurnRun::MAX_MODEL_LEN
+    {
+        return Err(AgentError::Store(format!(
+            "turn model must contain 1 to {} non-NUL characters",
+            TurnRun::MAX_MODEL_LEN
+        )));
+    }
+    if content.trim().is_empty() || content.contains('\0') {
+        return Err(AgentError::Store(
+            "turn content must be non-empty and contain no NUL characters".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn find_active_turn_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+) -> Result<Option<entities::turn_run::Model>>
+where
+    C: ConnectionTrait,
+{
+    entities::turn_run::Entity::find()
+        .filter(entities::turn_run::Column::ChatId.eq(chat_id.0))
+        .filter(entities::turn_run::Column::Status.is_in([
+            TurnRunStatus::Queued.as_str(),
+            TurnRunStatus::Running.as_str(),
+            TurnRunStatus::RetryWait.as_str(),
+        ]))
+        .one(conn)
+        .await
+        .map_err(store_err)
+}
+
+async fn exact_accepted_turn_on<C>(
+    conn: &C,
+    existing: entities::turn_run::Model,
+    chat_id: ChatId,
+    model: &str,
+    content: &str,
+) -> Result<TurnRun>
+where
+    C: ConnectionTrait,
+{
+    let message = entities::message::Entity::find_by_id(existing.input_message_id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "turn {} is missing its input message",
+                TurnId(existing.id)
+            ))
+        })?;
+    if existing.chat_id != chat_id.0
+        || existing.model != model
+        || message.chat_id != chat_id.0
+        || message.turn_id != existing.id
+        || message.role != role_to_db(Role::User)
+        || message.content != content
+    {
+        return Err(AgentError::Store(format!(
+            "turn {} was already accepted with different input",
+            TurnId(existing.id)
+        )));
+    }
+    turn_run_from_model(existing)
 }
 
 pub(in crate::db) async fn append_message(store: &DbStore, message: &Message) -> Result<()> {
@@ -238,6 +411,7 @@ fn turn_run_from_model(model: entities::turn_run::Model) -> Result<TurnRun> {
     Ok(TurnRun {
         id: TurnId(model.id),
         chat_id: ChatId(model.chat_id),
+        input_message_id: MessageId(model.input_message_id),
         model: model.model,
         status: turn_run_status_from_db(&model.status)?,
         attempt_count: model.attempt_count,

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4572,15 +4572,30 @@ async fn chats_and_messages_roundtrip() {
     assert_eq!(store.list_messages(chat.id).await.unwrap(), vec![msg]);
 }
 
-#[tokio::test]
-async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
-    let (_dir, store) = temp_store().await;
-    let chat = sample_chat();
-    store.create_chat(&chat).await.unwrap();
-    let now = DateTime::<Utc>::from_timestamp(1_752_408_000, 0).unwrap();
-    let make_turn = |chat_id: ChatId, model: &str| entities::turn_run::ActiveModel {
-        id: Set(TurnId::new().0),
+async fn make_queued_turn(
+    store: &DbStore,
+    chat_id: ChatId,
+    model: &str,
+    now: DateTime<Utc>,
+) -> entities::turn_run::ActiveModel {
+    let turn_id = TurnId::new();
+    let input_message_id = MessageId::new();
+    entities::message::ActiveModel {
+        id: Set(input_message_id.0),
         chat_id: Set(chat_id.0),
+        turn_id: Set(turn_id.0),
+        role: Set("user".into()),
+        content: Set("turn input".into()),
+        created_at: Set(now),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+
+    entities::turn_run::ActiveModel {
+        id: Set(turn_id.0),
+        chat_id: Set(chat_id.0),
+        input_message_id: Set(input_message_id.0),
         model: Set(model.into()),
         status: Set(TurnRunStatus::Queued.as_str().into()),
         attempt_count: Set(0),
@@ -4594,9 +4609,17 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         last_error_detail: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
-    };
+    }
+}
 
-    let first = make_turn(chat.id, "claude-sonnet-4-5")
+#[tokio::test]
+async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let now = DateTime::<Utc>::from_timestamp(1_752_408_000, 0).unwrap();
+    let first = make_queued_turn(&store, chat.id, "claude-sonnet-4-5", now)
+        .await
         .insert(&store.conn)
         .await
         .unwrap();
@@ -4608,7 +4631,8 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     assert_eq!(store.list_turn_runs(chat.id).await.unwrap(), vec![stored]);
 
     // The database, not a process-local map, owns the one-live-turn invariant.
-    assert!(make_turn(chat.id, "gpt-5")
+    assert!(make_queued_turn(&store, chat.id, "gpt-5", now)
+        .await
         .insert(&store.conn)
         .await
         .is_err());
@@ -4634,7 +4658,8 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         .exec(&store.conn)
         .await
         .unwrap();
-    make_turn(chat.id, "gpt-5")
+    make_queued_turn(&store, chat.id, "gpt-5", now)
+        .await
         .insert(&store.conn)
         .await
         .unwrap();
@@ -4642,42 +4667,46 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let invalid_chat = sample_chat();
     store.create_chat(&invalid_chat).await.unwrap();
 
-    let mut running_without_lease = make_turn(invalid_chat.id, "gpt-5");
+    let mut running_without_lease = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     running_without_lease.status = Set(TurnRunStatus::Running.as_str().into());
     running_without_lease.attempt_count = Set(1);
     running_without_lease.started_at = Set(Some(now));
     assert!(running_without_lease.insert(&store.conn).await.is_err());
 
-    let mut retry_without_error = make_turn(invalid_chat.id, "gpt-5");
+    let mut retry_without_error = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     retry_without_error.status = Set(TurnRunStatus::RetryWait.as_str().into());
     retry_without_error.attempt_count = Set(1);
     retry_without_error.max_attempts = Set(2);
     retry_without_error.started_at = Set(Some(now));
     assert!(retry_without_error.insert(&store.conn).await.is_err());
 
-    let mut failed_without_finish = make_turn(invalid_chat.id, "gpt-5");
+    let mut failed_without_finish = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     failed_without_finish.status = Set(TurnRunStatus::Failed.as_str().into());
     failed_without_finish.attempt_count = Set(1);
     failed_without_finish.started_at = Set(Some(now));
     failed_without_finish.last_error_code = Set(Some("provider_error".into()));
     assert!(failed_without_finish.insert(&store.conn).await.is_err());
 
-    let mut unknown_status = make_turn(invalid_chat.id, "gpt-5");
+    let mut unknown_status = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     unknown_status.status = Set("waiting_for_magic".into());
     assert!(unknown_status.insert(&store.conn).await.is_err());
-    assert!(make_turn(invalid_chat.id, "")
+    assert!(make_queued_turn(&store, invalid_chat.id, "", now)
+        .await
         .insert(&store.conn)
         .await
         .is_err());
-    assert!(make_turn(
+    assert!(make_queued_turn(
+        &store,
         invalid_chat.id,
         &"m".repeat(crate::model::TurnRun::MAX_MODEL_LEN + 1),
+        now,
     )
+    .await
     .insert(&store.conn)
     .await
     .is_err());
 
-    let mut oversized_error = make_turn(invalid_chat.id, "gpt-5");
+    let mut oversized_error = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     oversized_error.status = Set(TurnRunStatus::Failed.as_str().into());
     oversized_error.attempt_count = Set(1);
     oversized_error.started_at = Set(Some(now));
@@ -4690,7 +4719,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     // The turn identity is global and cannot be replayed against another chat.
     let other = sample_chat();
     store.create_chat(&other).await.unwrap();
-    let mut duplicate_identity = make_turn(other.id, "gpt-5");
+    let mut duplicate_identity = make_queued_turn(&store, other.id, "gpt-5", now).await;
     duplicate_identity.id = Set(first.id);
     assert!(duplicate_identity.insert(&store.conn).await.is_err());
 
@@ -4698,7 +4727,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     // must reach these shapes atomically under exact predicates.
     let running_chat = sample_chat();
     store.create_chat(&running_chat).await.unwrap();
-    let mut running = make_turn(running_chat.id, "gpt-5");
+    let mut running = make_queued_turn(&store, running_chat.id, "gpt-5", now).await;
     running.status = Set(TurnRunStatus::Running.as_str().into());
     running.attempt_count = Set(1);
     running.started_at = Set(Some(now));
@@ -4708,7 +4737,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
 
     let retry_chat = sample_chat();
     store.create_chat(&retry_chat).await.unwrap();
-    let mut retry_wait = make_turn(retry_chat.id, "gpt-5");
+    let mut retry_wait = make_queued_turn(&store, retry_chat.id, "gpt-5", now).await;
     retry_wait.status = Set(TurnRunStatus::RetryWait.as_str().into());
     retry_wait.attempt_count = Set(1);
     retry_wait.max_attempts = Set(2);
@@ -4718,7 +4747,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
 
     let failed_chat = sample_chat();
     store.create_chat(&failed_chat).await.unwrap();
-    let mut failed = make_turn(failed_chat.id, "gpt-5");
+    let mut failed = make_queued_turn(&store, failed_chat.id, "gpt-5", now).await;
     failed.status = Set(TurnRunStatus::Failed.as_str().into());
     failed.attempt_count = Set(1);
     failed.started_at = Set(Some(now));
@@ -4730,7 +4759,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     for started in [false, true] {
         let cancelled_chat = sample_chat();
         store.create_chat(&cancelled_chat).await.unwrap();
-        let mut cancelled = make_turn(cancelled_chat.id, "gpt-5");
+        let mut cancelled = make_queued_turn(&store, cancelled_chat.id, "gpt-5", now).await;
         cancelled.status = Set(TurnRunStatus::Cancelled.as_str().into());
         cancelled.finished_at = Set(Some(now));
         if started {
@@ -4739,6 +4768,298 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         }
         cancelled.insert(&store.conn).await.unwrap();
     }
+}
+
+#[tokio::test]
+async fn turn_run_input_message_must_match_its_chat_and_turn() {
+    let (_dir, store) = temp_store().await;
+    let first_chat = sample_chat();
+    let second_chat = sample_chat();
+    store.create_chat(&first_chat).await.unwrap();
+    store.create_chat(&second_chat).await.unwrap();
+    let now = DateTime::<Utc>::from_timestamp(1_752_408_000, 0).unwrap();
+
+    let mut missing = make_queued_turn(&store, first_chat.id, "gpt-5", now).await;
+    missing.input_message_id = Set(MessageId::new().0);
+    assert!(missing.insert(&store.conn).await.is_err());
+
+    let mut wrong_chat = make_queued_turn(&store, first_chat.id, "gpt-5", now).await;
+    wrong_chat.chat_id = Set(second_chat.id.0);
+    assert!(wrong_chat.insert(&store.conn).await.is_err());
+
+    let mut wrong_turn = make_queued_turn(&store, first_chat.id, "gpt-5", now).await;
+    wrong_turn.id = Set(TurnId::new().0);
+    assert!(wrong_turn.insert(&store.conn).await.is_err());
+}
+
+#[tokio::test]
+async fn turn_acceptance_is_atomic_idempotent_and_chat_scoped() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected first acceptance outcome: {outcome:?}"),
+    };
+    assert_eq!(accepted.id, turn_id);
+    assert_eq!(accepted.chat_id, chat.id);
+    assert_eq!(accepted.model, "gpt-5");
+    assert_eq!(accepted.status, TurnRunStatus::Queued);
+    assert_eq!(accepted.attempt_count, 0);
+    assert_eq!(accepted.max_attempts, 1);
+    assert_eq!(accepted.lease_token, None);
+
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].id, accepted.input_message_id);
+    assert_eq!(messages[0].turn_id, turn_id);
+    assert_eq!(messages[0].role, Role::User);
+    assert_eq!(messages[0].content, "hello");
+
+    let existing = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Existing(turn) => turn,
+        outcome => panic!("unexpected retry outcome: {outcome:?}"),
+    };
+    assert_eq!(existing, accepted);
+    assert_eq!(store.list_turn_runs(chat.id).await.unwrap().len(), 1);
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
+
+    assert!(store
+        .accept_turn(turn_id, chat.id, "gpt-5", "different")
+        .await
+        .is_err());
+    assert!(store
+        .accept_turn(turn_id, chat.id, "other-model", "hello")
+        .await
+        .is_err());
+
+    let busy = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "next")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::ChatBusy(turn) => turn,
+        outcome => panic!("unexpected busy outcome: {outcome:?}"),
+    };
+    assert_eq!(busy, accepted);
+
+    let other = sample_chat();
+    store.create_chat(&other).await.unwrap();
+    assert!(store
+        .accept_turn(turn_id, other.id, "gpt-5", "hello")
+        .await
+        .is_err());
+
+    let missing = ChatId::new();
+    assert!(store
+        .accept_turn(TurnId::new(), missing, "gpt-5", "hello")
+        .await
+        .is_err());
+    assert!(store
+        .accept_turn(TurnId::new(), other.id, "", "hello")
+        .await
+        .is_err());
+    assert!(store
+        .accept_turn(TurnId::new(), other.id, "gpt-5", " \n\t")
+        .await
+        .is_err());
+    assert!(store
+        .accept_turn(TurnId::new(), other.id, "gpt\0-5", "hello")
+        .await
+        .is_err());
+    assert!(store
+        .accept_turn(TurnId::new(), other.id, "gpt-5", "hello\0world")
+        .await
+        .is_err());
+    assert!(store.list_turn_runs(other.id).await.unwrap().is_empty());
+    assert!(store.list_messages(other.id).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn concurrent_turn_acceptance_commits_one_request_and_one_message() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let store = std::sync::Arc::new(store);
+    let turn_id = TurnId::new();
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .accept_turn(turn_id, chat.id, "gpt-5", "same input")
+                .await
+                .unwrap()
+        }));
+    }
+
+    let mut accepted = 0;
+    let mut existing = 0;
+    for task in tasks {
+        match task.await.unwrap() {
+            AcceptTurnOutcome::Accepted(_) => accepted += 1,
+            AcceptTurnOutcome::Existing(_) => existing += 1,
+            outcome => panic!("unexpected concurrent outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!(accepted, 1);
+    assert_eq!(existing, 7);
+    assert_eq!(store.list_turn_runs(chat.id).await.unwrap().len(), 1);
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
+
+    let competing_chat = sample_chat();
+    store.create_chat(&competing_chat).await.unwrap();
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for index in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .accept_turn(
+                    TurnId::new(),
+                    competing_chat.id,
+                    "gpt-5",
+                    &format!("input {index}"),
+                )
+                .await
+                .unwrap()
+        }));
+    }
+    let mut accepted = 0;
+    let mut busy = 0;
+    for task in tasks {
+        match task.await.unwrap() {
+            AcceptTurnOutcome::Accepted(_) => accepted += 1,
+            AcceptTurnOutcome::ChatBusy(_) => busy += 1,
+            outcome => panic!("unexpected competing outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!(accepted, 1);
+    assert_eq!(busy, 7);
+    assert_eq!(
+        store.list_turn_runs(competing_chat.id).await.unwrap().len(),
+        1
+    );
+    assert_eq!(
+        store.list_messages(competing_chat.id).await.unwrap().len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn concurrent_cross_chat_reuse_of_a_turn_id_commits_once() {
+    let (_dir, store) = temp_store().await;
+    let first_chat = sample_chat();
+    let second_chat = sample_chat();
+    store.create_chat(&first_chat).await.unwrap();
+    store.create_chat(&second_chat).await.unwrap();
+    let store = std::sync::Arc::new(store);
+    let turn_id = TurnId::new();
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+
+    let mut tasks = Vec::new();
+    for chat_id in [first_chat.id, second_chat.id] {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .accept_turn(turn_id, chat_id, "gpt-5", "same input")
+                .await
+        }));
+    }
+
+    let mut accepted = 0;
+    let mut rejected = 0;
+    for task in tasks {
+        match task.await.unwrap() {
+            Ok(AcceptTurnOutcome::Accepted(_)) => accepted += 1,
+            Err(_) => rejected += 1,
+            outcome => panic!("unexpected cross-chat outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!(accepted, 1);
+    assert_eq!(rejected, 1);
+    assert_eq!(
+        store.get_turn_run(turn_id).await.unwrap().unwrap().id,
+        turn_id
+    );
+    assert_eq!(
+        store.list_messages(first_chat.id).await.unwrap().len()
+            + store.list_messages(second_chat.id).await.unwrap().len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn turn_acceptance_rolls_back_when_input_message_insert_fails() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_turn_input
+             BEFORE INSERT ON message
+             WHEN NEW.content = 'force failure'
+             BEGIN
+               SELECT RAISE(ABORT, 'forced input failure');
+             END;",
+        )
+        .await
+        .unwrap();
+
+    let turn_id = TurnId::new();
+    assert!(store
+        .accept_turn(turn_id, chat.id, "gpt-5", "force failure")
+        .await
+        .is_err());
+    assert_eq!(store.get_turn_run(turn_id).await.unwrap(), None);
+    assert!(store.list_turn_runs(chat.id).await.unwrap().is_empty());
+    assert!(store.list_messages(chat.id).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn turn_acceptance_rolls_back_message_when_turn_insert_fails() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_turn_run
+             BEFORE INSERT ON turn_run
+             WHEN NEW.model = 'force-run-failure'
+             BEGIN
+               SELECT RAISE(ABORT, 'forced turn failure');
+             END;",
+        )
+        .await
+        .unwrap();
+
+    let turn_id = TurnId::new();
+    assert!(store
+        .accept_turn(turn_id, chat.id, "force-run-failure", "input was inserted")
+        .await
+        .is_err());
+    assert_eq!(store.get_turn_run(turn_id).await.unwrap(), None);
+    assert!(store.list_turn_runs(chat.id).await.unwrap().is_empty());
+    assert!(store.list_messages(chat.id).await.unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -63,7 +63,7 @@ pub use provider::{
 };
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
-    BlobStore, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
+    AcceptTurnOutcome, BlobStore, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
     EnsureDocumentParseJobOutcome, SecretProvider, Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -621,6 +621,8 @@ pub struct TurnRun {
     pub id: TurnId,
     /// Conversation this turn belongs to.
     pub chat_id: ChatId,
+    /// Exact persisted user message that supplied this turn's initial input.
+    pub input_message_id: MessageId,
     /// Model selected when the turn was accepted.
     pub model: String,
     /// Durable delivery state.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -84,6 +84,17 @@ pub enum EnsureDocumentParseJobOutcome {
     GenerationChanged(DocumentGeneration),
 }
 
+/// Result of atomically accepting one exact client turn request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AcceptTurnOutcome {
+    /// The input message and queued turn were committed by this call.
+    Accepted(TurnRun),
+    /// This exact turn identity and request were already committed.
+    Existing(TurnRun),
+    /// Another nonterminal turn already owns the chat's single live slot.
+    ChatBusy(TurnRun),
+}
+
 fn document_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "document storage is not implemented by this Store".into(),
@@ -539,6 +550,22 @@ pub trait Store: Send + Sync {
 
     /// List a chat's durable turn history in deterministic creation-time order.
     async fn list_turn_runs(&self, _chat_id: ChatId) -> Result<Vec<TurnRun>> {
+        turn_storage_unavailable()
+    }
+
+    /// Atomically persist a user's initial message and queue its exact turn.
+    ///
+    /// `id` is the caller-visible idempotency identity. Repeating the same id,
+    /// chat, model, and byte-exact content returns [`AcceptTurnOutcome::Existing`]
+    /// without another message or turn. Reusing an id for different input is an
+    /// error. A different live turn for the chat returns `ChatBusy`.
+    async fn accept_turn(
+        &self,
+        _id: TurnId,
+        _chat_id: ChatId,
+        _model: &str,
+        _content: &str,
+    ) -> Result<AcceptTurnOutcome> {
         turn_storage_unavailable()
     }
 


### PR DESCRIPTION
## Summary

- atomically persist an exact user input message and its queued durable turn
- bind the run to that same message, chat, and turn with a composite foreign key
- use caller-supplied turn IDs as the idempotency boundary for ambiguous retries
- return the committed turn on exact retry and the current live turn when a chat is busy
- reject reused identities with different chat, model, or byte-exact input

## Concurrency

The transaction acquires the chat row as a writer before its first read, then inserts the input message and turn together. SQLite's writer lock and PostgreSQL's row lock serialize same-chat acceptance, while the turn primary key fences cross-chat identity collisions. Store-owned timestamps and a database-bound input-message identity make retries exact.

This slice does not activate the worker or change the HTTP route. Claim, heartbeat, resolution, and runtime wiring remain separate changes.

## Validation

- full workspace tests
- 173 all-feature core tests
- eight-way exact-retry and competing-turn concurrency coverage plus a simultaneous cross-chat identity race
- direct missing, wrong-chat, and wrong-turn input-reference rejection
- injected message and turn insertion failures prove rollback in both write orders
- Rust lint
- formatting and diff checks
