### PR TITLE
feat(core): lease durable turns

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -208,6 +208,26 @@ pub mod turn_run {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod turn_claim {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "turn_claim")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub token: Uuid,
+        pub turn_id: Uuid,
+        pub attempt_count: i32,
+        pub claimed_at: DateTimeUtc,
+        pub lease_expires_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod tool_call {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -97,6 +97,58 @@ impl MigrationTrait for Init {
             )
             .await?;
 
+        manager
+            .create_table(
+                Table::create()
+                    .table(TurnClaim::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(TurnClaim::Token)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(TurnClaim::TurnId).uuid().not_null())
+                    .col(ColumnDef::new(TurnClaim::AttemptCount).integer().not_null())
+                    .col(
+                        ColumnDef::new(TurnClaim::ClaimedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnClaim::LeaseExpiresAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .check(Expr::col(TurnClaim::AttemptCount).gte(1))
+                    .check(Expr::col(TurnClaim::LeaseExpiresAt).gt(Expr::col(TurnClaim::ClaimedAt)))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_claim_identity")
+                    .table(TurnClaim::Table)
+                    .col(TurnClaim::Token)
+                    .col(TurnClaim::TurnId)
+                    .col(TurnClaim::AttemptCount)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_claim_attempt")
+                    .table(TurnClaim::Table)
+                    .col(TurnClaim::TurnId)
+                    .col(TurnClaim::AttemptCount)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
         let valid_turn_status = Expr::col(TurnRun::Status).is_in([
             TurnRunStatus::Queued.as_str(),
             TurnRunStatus::Running.as_str(),
@@ -251,6 +303,19 @@ impl MigrationTrait for Init {
                             .to_col(Message::TurnId)
                             .on_delete(ForeignKeyAction::Restrict),
                     )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_run_live_claim")
+                            .from_tbl(TurnRun::Table)
+                            .from_col(TurnRun::LeaseToken)
+                            .from_col(TurnRun::Id)
+                            .from_col(TurnRun::AttemptCount)
+                            .to_tbl(TurnClaim::Table)
+                            .to_col(TurnClaim::Token)
+                            .to_col(TurnClaim::TurnId)
+                            .to_col(TurnClaim::AttemptCount)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
                     .check(
                         Func::char_length(Expr::col(TurnRun::Model))
                             .between(1, crate::model::TurnRun::MAX_MODEL_LEN as i32),
@@ -330,6 +395,16 @@ impl MigrationTrait for Init {
         manager
             .create_index(
                 Index::create()
+                    .name("idx_turn_run_lease_token")
+                    .table(TurnRun::Table)
+                    .col(TurnRun::LeaseToken)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
                     .name("idx_turn_run_stale_lease")
                     .table(TurnRun::Table)
                     .col(TurnRun::Status)
@@ -371,6 +446,9 @@ impl MigrationTrait for Init {
             .await?;
         manager
             .drop_table(Table::drop().table(Message::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(TurnClaim::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(Chat::Table).to_owned())
@@ -1372,6 +1450,16 @@ enum TurnRun {
     LastErrorDetail,
     CreatedAt,
     UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+enum TurnClaim {
+    Table,
+    Token,
+    TurnId,
+    AttemptCount,
+    ClaimedAt,
+    LeaseExpiresAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1661,6 +1661,25 @@ impl Store for DbStore {
         ops::conversation::accept_turn(self, id, chat_id, model, content).await
     }
 
+    async fn claim_turn_run(
+        &self,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        lease_expires_at: chrono::DateTime<Utc>,
+    ) -> Result<Option<TurnRun>> {
+        ops::conversation::claim_turn_run(self, lease_token, now, lease_expires_at).await
+    }
+
+    async fn heartbeat_turn_run(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        lease_expires_at: chrono::DateTime<Utc>,
+    ) -> Result<bool> {
+        ops::conversation::heartbeat_turn_run(self, id, lease_token, now, lease_expires_at).await
+    }
+
     async fn append_message(&self, message: &Message) -> Result<()> {
         ops::conversation::append_message(self, message).await
     }

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use sea_orm::sea_query::OnConflict;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set,
-    TransactionTrait,
+    TransactionTrait, TryInsertResult,
 };
 
 use crate::error::{AgentError, Result};
@@ -186,6 +186,285 @@ pub(in crate::db) async fn accept_turn(
 
     transaction.commit().await.map_err(store_err)?;
     Ok(AcceptTurnOutcome::Accepted(turn_run_from_model(inserted)?))
+}
+
+pub(in crate::db) async fn claim_turn_run(
+    store: &DbStore,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    lease_expires_at: chrono::DateTime<Utc>,
+) -> Result<Option<TurnRun>> {
+    if lease_token.is_nil() {
+        return Err(AgentError::Store("turn lease token must not be nil".into()));
+    }
+    if lease_expires_at <= now {
+        return Err(AgentError::Store(
+            "turn lease expiry must be after claim time".into(),
+        ));
+    }
+
+    loop {
+        let transaction = store.conn.begin().await.map_err(store_err)?;
+        acquire_turn_claim_write_lock(&transaction).await?;
+        if let Some(receipt) = entities::turn_claim::Entity::find_by_id(lease_token)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+        {
+            let existing = entities::turn_run::Entity::find_by_id(receipt.turn_id)
+                .one(&transaction)
+                .await
+                .map_err(store_err)?
+                .filter(|run| {
+                    run.status == TurnRunStatus::Running.as_str()
+                        && run.attempt_count == receipt.attempt_count
+                        && run.lease_token == Some(lease_token)
+                        && run
+                            .lease_expires_at
+                            .is_some_and(|lease_expires_at| lease_expires_at > now)
+                })
+                .map(turn_run_from_model)
+                .transpose()?;
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(existing);
+        }
+        let due = entities::turn_run::Entity::find()
+            .filter(entities::turn_run::Column::Status.is_in([
+                TurnRunStatus::Queued.as_str(),
+                TurnRunStatus::RetryWait.as_str(),
+            ]))
+            .filter(entities::turn_run::Column::AvailableAt.lte(now))
+            .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+            .filter(
+                sea_orm::sea_query::Expr::col(entities::turn_run::Column::AttemptCount).lt(
+                    sea_orm::sea_query::Expr::col(entities::turn_run::Column::MaxAttempts),
+                ),
+            )
+            .order_by_asc(entities::turn_run::Column::AvailableAt)
+            .order_by_asc(entities::turn_run::Column::CreatedAt)
+            .order_by_asc(entities::turn_run::Column::Id)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        let expired = entities::turn_run::Entity::find()
+            .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
+            .filter(entities::turn_run::Column::LeaseExpiresAt.lte(now))
+            .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+            .order_by_asc(entities::turn_run::Column::LeaseExpiresAt)
+            .order_by_asc(entities::turn_run::Column::CreatedAt)
+            .order_by_asc(entities::turn_run::Column::Id)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        let candidate = match (due, expired) {
+            (Some(due), Some(expired)) => {
+                if turn_run_due_order(&due, &expired).is_le() {
+                    Some(due)
+                } else {
+                    Some(expired)
+                }
+            }
+            (candidate @ Some(_), None) | (None, candidate @ Some(_)) => candidate,
+            (None, None) => None,
+        };
+        let Some(candidate) = candidate else {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(None);
+        };
+
+        let reclaiming = candidate.status == TurnRunStatus::Running.as_str();
+        if reclaiming && candidate.attempt_count >= candidate.max_attempts {
+            let failed = entities::turn_run::Entity::update_many()
+                .col_expr(
+                    entities::turn_run::Column::Status,
+                    sea_orm::sea_query::Expr::value(TurnRunStatus::Failed.as_str()),
+                )
+                .col_expr(
+                    entities::turn_run::Column::LeaseToken,
+                    sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+                )
+                .col_expr(
+                    entities::turn_run::Column::LeaseExpiresAt,
+                    sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+                )
+                .col_expr(
+                    entities::turn_run::Column::FinishedAt,
+                    sea_orm::sea_query::Expr::value(Some(now)),
+                )
+                .col_expr(
+                    entities::turn_run::Column::LastErrorCode,
+                    sea_orm::sea_query::Expr::value(Some("lease_expired".to_owned())),
+                )
+                .col_expr(
+                    entities::turn_run::Column::LastErrorDetail,
+                    sea_orm::sea_query::Expr::value(Some("final worker lease expired".to_owned())),
+                )
+                .col_expr(
+                    entities::turn_run::Column::UpdatedAt,
+                    sea_orm::sea_query::Expr::value(now),
+                )
+                .filter(entities::turn_run::Column::Id.eq(candidate.id))
+                .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
+                .filter(entities::turn_run::Column::AttemptCount.eq(candidate.attempt_count))
+                .filter(entities::turn_run::Column::LeaseToken.eq(candidate.lease_token))
+                .filter(entities::turn_run::Column::LeaseExpiresAt.eq(candidate.lease_expires_at))
+                .filter(entities::turn_run::Column::UpdatedAt.eq(candidate.updated_at))
+                .exec(&transaction)
+                .await
+                .map_err(store_err)?;
+            if failed.rows_affected != 1 {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+            transaction.commit().await.map_err(store_err)?;
+            continue;
+        }
+
+        let next_attempt = candidate.attempt_count.checked_add(1).ok_or_else(|| {
+            AgentError::Store(format!("turn {} attempt overflow", TurnId(candidate.id)))
+        })?;
+        let receipt = entities::turn_claim::Entity::insert(entities::turn_claim::ActiveModel {
+            token: Set(lease_token),
+            turn_id: Set(candidate.id),
+            attempt_count: Set(next_attempt),
+            claimed_at: Set(now),
+            lease_expires_at: Set(lease_expires_at),
+        })
+        .on_conflict_do_nothing()
+        .exec_without_returning(&transaction)
+        .await
+        .map_err(store_err)?;
+        if !matches!(receipt, TryInsertResult::Inserted(1)) {
+            transaction.rollback().await.map_err(store_err)?;
+            continue;
+        }
+        let claim = entities::turn_run::Entity::update_many()
+            .col_expr(
+                entities::turn_run::Column::Status,
+                sea_orm::sea_query::Expr::value(TurnRunStatus::Running.as_str()),
+            )
+            .col_expr(
+                entities::turn_run::Column::AttemptCount,
+                sea_orm::sea_query::Expr::value(next_attempt),
+            )
+            .col_expr(
+                entities::turn_run::Column::LeaseToken,
+                sea_orm::sea_query::Expr::value(Some(lease_token)),
+            )
+            .col_expr(
+                entities::turn_run::Column::LeaseExpiresAt,
+                sea_orm::sea_query::Expr::value(Some(lease_expires_at)),
+            )
+            .col_expr(
+                entities::turn_run::Column::StartedAt,
+                sea_orm::sea_query::Expr::value(Some(candidate.started_at.unwrap_or(now))),
+            )
+            .col_expr(
+                entities::turn_run::Column::LastErrorCode,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entities::turn_run::Column::LastErrorDetail,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entities::turn_run::Column::UpdatedAt,
+                sea_orm::sea_query::Expr::value(now),
+            )
+            .filter(entities::turn_run::Column::Id.eq(candidate.id))
+            .filter(entities::turn_run::Column::Status.eq(&candidate.status))
+            .filter(entities::turn_run::Column::AttemptCount.eq(candidate.attempt_count))
+            .filter(entities::turn_run::Column::UpdatedAt.eq(candidate.updated_at));
+        let claim = if reclaiming {
+            claim
+                .filter(entities::turn_run::Column::LeaseToken.eq(candidate.lease_token))
+                .filter(entities::turn_run::Column::LeaseExpiresAt.eq(candidate.lease_expires_at))
+        } else {
+            claim.filter(entities::turn_run::Column::AvailableAt.lte(now))
+        };
+        let claimed = claim.exec(&transaction).await.map_err(store_err)?;
+        if claimed.rows_affected != 1 {
+            transaction.rollback().await.map_err(store_err)?;
+            continue;
+        }
+
+        let claimed = entities::turn_run::Entity::find_by_id(candidate.id)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| {
+                AgentError::Store(format!("claimed turn {} disappeared", TurnId(candidate.id)))
+            })
+            .and_then(turn_run_from_model)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(claimed));
+    }
+}
+
+pub(in crate::db) async fn heartbeat_turn_run(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    lease_expires_at: chrono::DateTime<Utc>,
+) -> Result<bool> {
+    if lease_expires_at <= now {
+        return Err(AgentError::Store(
+            "turn lease expiry must be after heartbeat time".into(),
+        ));
+    }
+    let heartbeat = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Some(lease_expires_at)),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::turn_run::Column::Id.eq(id.0))
+        .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
+        .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.lt(lease_expires_at))
+        .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(heartbeat.rows_affected == 1)
+}
+
+async fn acquire_turn_claim_write_lock<C>(conn: &C) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::col(entities::turn_run::Column::UpdatedAt).into(),
+        )
+        .filter(entities::turn_run::Column::Id.is_null())
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+fn turn_run_due_order(
+    left: &entities::turn_run::Model,
+    right: &entities::turn_run::Model,
+) -> std::cmp::Ordering {
+    let due_at = |run: &entities::turn_run::Model| {
+        if run.status == TurnRunStatus::Running.as_str() {
+            run.lease_expires_at.unwrap_or(run.available_at)
+        } else {
+            run.available_at
+        }
+    };
+    due_at(left)
+        .cmp(&due_at(right))
+        .then_with(|| left.created_at.cmp(&right.created_at))
+        .then_with(|| left.id.cmp(&right.id))
 }
 
 fn validate_turn_input(model: &str, content: &str) -> Result<()> {

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4728,12 +4728,67 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let running_chat = sample_chat();
     store.create_chat(&running_chat).await.unwrap();
     let mut running = make_queued_turn(&store, running_chat.id, "gpt-5", now).await;
+    let running_turn_id = running.id.clone().unwrap();
     running.status = Set(TurnRunStatus::Running.as_str().into());
     running.attempt_count = Set(1);
     running.started_at = Set(Some(now));
-    running.lease_token = Set(Some(uuid::Uuid::new_v4()));
+    let running_token = uuid::Uuid::new_v4();
+    running.lease_token = Set(Some(running_token));
     running.lease_expires_at = Set(Some(now + chrono::Duration::minutes(1)));
+    entities::turn_claim::ActiveModel {
+        token: Set(running_token),
+        turn_id: Set(running_turn_id),
+        attempt_count: Set(1),
+        claimed_at: Set(now),
+        lease_expires_at: Set(now + chrono::Duration::minutes(1)),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
     running.insert(&store.conn).await.unwrap();
+    assert!(entities::turn_claim::ActiveModel {
+        token: Set(uuid::Uuid::new_v4()),
+        turn_id: Set(running_turn_id),
+        attempt_count: Set(1),
+        claimed_at: Set(now),
+        lease_expires_at: Set(now + chrono::Duration::minutes(1)),
+    }
+    .insert(&store.conn)
+    .await
+    .is_err());
+
+    let duplicate_lease_chat = sample_chat();
+    store.create_chat(&duplicate_lease_chat).await.unwrap();
+    let mut duplicate_lease = make_queued_turn(&store, duplicate_lease_chat.id, "gpt-5", now).await;
+    duplicate_lease.status = Set(TurnRunStatus::Running.as_str().into());
+    duplicate_lease.attempt_count = Set(1);
+    duplicate_lease.started_at = Set(Some(now));
+    duplicate_lease.lease_token = Set(Some(running_token));
+    duplicate_lease.lease_expires_at = Set(Some(now + chrono::Duration::minutes(1)));
+    assert!(duplicate_lease.insert(&store.conn).await.is_err());
+
+    let mismatched_receipt_chat = sample_chat();
+    store.create_chat(&mismatched_receipt_chat).await.unwrap();
+    let mut mismatched_receipt =
+        make_queued_turn(&store, mismatched_receipt_chat.id, "gpt-5", now).await;
+    let mismatched_turn_id = mismatched_receipt.id.clone().unwrap();
+    let mismatched_token = uuid::Uuid::new_v4();
+    entities::turn_claim::ActiveModel {
+        token: Set(mismatched_token),
+        turn_id: Set(mismatched_turn_id),
+        attempt_count: Set(2),
+        claimed_at: Set(now),
+        lease_expires_at: Set(now + chrono::Duration::minutes(1)),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    mismatched_receipt.status = Set(TurnRunStatus::Running.as_str().into());
+    mismatched_receipt.attempt_count = Set(1);
+    mismatched_receipt.started_at = Set(Some(now));
+    mismatched_receipt.lease_token = Set(Some(mismatched_token));
+    mismatched_receipt.lease_expires_at = Set(Some(now + chrono::Duration::minutes(1)));
+    assert!(mismatched_receipt.insert(&store.conn).await.is_err());
 
     let retry_chat = sample_chat();
     store.create_chat(&retry_chat).await.unwrap();
@@ -5003,6 +5058,377 @@ async fn concurrent_cross_chat_reuse_of_a_turn_id_commits_once() {
         store.list_messages(first_chat.id).await.unwrap().len()
             + store.list_messages(second_chat.id).await.unwrap().len(),
         1
+    );
+}
+
+#[tokio::test]
+async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(2),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    assert!(store
+        .claim_turn_run(
+            uuid::Uuid::nil(),
+            claimed_at,
+            claimed_at + chrono::Duration::seconds(1)
+        )
+        .await
+        .is_err());
+    let first_token = uuid::Uuid::new_v4();
+    assert!(store
+        .claim_turn_run(first_token, claimed_at, claimed_at)
+        .await
+        .is_err());
+    let first_expiry = claimed_at + chrono::Duration::minutes(1);
+    let first = store
+        .claim_turn_run(first_token, claimed_at, first_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.lease_token, Some(first_token));
+    assert_eq!(
+        store
+            .claim_turn_run(first_token, claimed_at, first_expiry)
+            .await
+            .unwrap(),
+        Some(first.clone())
+    );
+    assert_eq!(first.status, TurnRunStatus::Running);
+    assert_eq!(first.attempt_count, 1);
+    assert_eq!(first.started_at, Some(claimed_at));
+    assert_eq!(first.lease_expires_at, Some(first_expiry));
+
+    let heartbeat_at = claimed_at + chrono::Duration::seconds(10);
+    assert!(!store
+        .heartbeat_turn_run(
+            turn_id,
+            uuid::Uuid::new_v4(),
+            heartbeat_at,
+            first_expiry + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap());
+    assert!(!store
+        .heartbeat_turn_run(turn_id, first_token, heartbeat_at, first_expiry)
+        .await
+        .unwrap());
+    assert!(store
+        .heartbeat_turn_run(turn_id, first_token, heartbeat_at, heartbeat_at)
+        .await
+        .is_err());
+
+    let extended = first_expiry + chrono::Duration::minutes(1);
+    assert!(store
+        .heartbeat_turn_run(turn_id, first_token, heartbeat_at, extended)
+        .await
+        .unwrap());
+    assert!(!store
+        .heartbeat_turn_run(
+            turn_id,
+            first_token,
+            heartbeat_at - chrono::Duration::seconds(1),
+            extended + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap());
+    assert_eq!(
+        store
+            .claim_turn_run(
+                first_token,
+                extended,
+                extended + chrono::Duration::minutes(1)
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    let second_expiry = extended + chrono::Duration::minutes(1);
+    let second_token = uuid::Uuid::new_v4();
+    let second = store
+        .claim_turn_run(second_token, extended, second_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.id, turn_id);
+    assert_eq!(second.status, TurnRunStatus::Running);
+    assert_eq!(second.attempt_count, 2);
+    assert_eq!(second.started_at, first.started_at);
+    assert_eq!(second.lease_token, Some(second_token));
+    assert_eq!(second.last_error_code, None);
+    assert!(!store
+        .heartbeat_turn_run(
+            turn_id,
+            first_token,
+            extended + chrono::Duration::seconds(1),
+            second_expiry + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap());
+
+    assert_eq!(
+        store
+            .claim_turn_run(
+                uuid::Uuid::new_v4(),
+                second_expiry,
+                second_expiry + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    let failed = store.get_turn_run(turn_id).await.unwrap().unwrap();
+    assert_eq!(failed.status, TurnRunStatus::Failed);
+    assert_eq!(failed.attempt_count, 2);
+    assert_eq!(failed.lease_token, None);
+    assert_eq!(failed.lease_expires_at, None);
+    assert_eq!(failed.finished_at, Some(second_expiry));
+    assert_eq!(failed.last_error_code.as_deref(), Some("lease_expired"));
+
+    let next_chat = sample_chat();
+    store.create_chat(&next_chat).await.unwrap();
+    let next = match store
+        .accept_turn(TurnId::new(), next_chat.id, "gpt-5", "next")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let delayed_retry_at = next.available_at + chrono::Duration::seconds(1);
+    assert_eq!(
+        store
+            .claim_turn_run(
+                first_token,
+                delayed_retry_at,
+                delayed_retry_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        store.get_turn_run(next.id).await.unwrap().unwrap().status,
+        TurnRunStatus::Queued
+    );
+}
+
+#[tokio::test]
+async fn concurrent_turn_claimers_never_share_a_lease() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let accepted = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let store = std::sync::Arc::new(store);
+    let claim_at = accepted.available_at + chrono::Duration::seconds(1);
+    let lease_expires_at = claim_at + chrono::Duration::minutes(1);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        let lease_token = uuid::Uuid::new_v4();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .claim_turn_run(lease_token, claim_at, lease_expires_at)
+                .await
+        }));
+    }
+
+    let mut claimed = Vec::new();
+    let mut empty = 0;
+    for task in tasks {
+        match task.await.unwrap().unwrap() {
+            Some(turn) => claimed.push(turn),
+            None => empty += 1,
+        }
+    }
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(empty, 7);
+    assert_eq!(claimed[0].id, accepted.id);
+    assert_eq!(claimed[0].attempt_count, 1);
+    assert!(claimed[0].lease_token.is_some());
+}
+
+#[tokio::test]
+async fn turn_claim_orders_queued_and_expired_work_by_effective_due_time() {
+    let (_dir, store) = temp_store().await;
+    let expired_chat = sample_chat();
+    store.create_chat(&expired_chat).await.unwrap();
+    let expired_turn = match store
+        .accept_turn(TurnId::new(), expired_chat.id, "gpt-5", "first")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(2),
+        )
+        .filter(entities::turn_run::Column::Id.eq(expired_turn.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let first_claim_at = expired_turn.available_at + chrono::Duration::seconds(1);
+    let first_expiry = first_claim_at + chrono::Duration::minutes(1);
+    store
+        .claim_turn_run(uuid::Uuid::new_v4(), first_claim_at, first_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let queued_chat = sample_chat();
+    store.create_chat(&queued_chat).await.unwrap();
+    let queued_turn = match store
+        .accept_turn(TurnId::new(), queued_chat.id, "gpt-5", "second")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let queued_due_at = first_expiry - chrono::Duration::seconds(1);
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(queued_due_at),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(queued_due_at),
+        )
+        .filter(entities::turn_run::Column::Id.eq(queued_turn.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let claimed_queued = store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            first_expiry,
+            first_expiry + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed_queued.id, queued_turn.id);
+    let reclaimed_expired = store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            first_expiry,
+            first_expiry + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reclaimed_expired.id, expired_turn.id);
+    assert_eq!(reclaimed_expired.attempt_count, 2);
+}
+
+#[tokio::test]
+async fn turn_claim_prefers_an_earlier_expired_lease_over_queued_work() {
+    let (_dir, store) = temp_store().await;
+    let expired_chat = sample_chat();
+    store.create_chat(&expired_chat).await.unwrap();
+    let expired_turn = match store
+        .accept_turn(TurnId::new(), expired_chat.id, "gpt-5", "first")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(2),
+        )
+        .filter(entities::turn_run::Column::Id.eq(expired_turn.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let first_claim_at = expired_turn.available_at + chrono::Duration::seconds(1);
+    let first_expiry = first_claim_at + chrono::Duration::minutes(1);
+    store
+        .claim_turn_run(uuid::Uuid::new_v4(), first_claim_at, first_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let queued_chat = sample_chat();
+    store.create_chat(&queued_chat).await.unwrap();
+    let queued_turn = match store
+        .accept_turn(TurnId::new(), queued_chat.id, "gpt-5", "second")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let queued_due_at = first_expiry + chrono::Duration::seconds(1);
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(queued_due_at),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(queued_due_at),
+        )
+        .filter(entities::turn_run::Column::Id.eq(queued_turn.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let reclaimed = store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            queued_due_at,
+            queued_due_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reclaimed.id, expired_turn.id);
+    assert_eq!(reclaimed.attempt_count, 2);
+    assert_eq!(
+        store
+            .get_turn_run(queued_turn.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        TurnRunStatus::Queued
     );
 }
 

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -569,6 +569,38 @@ pub trait Store: Send + Sync {
         turn_storage_unavailable()
     }
 
+    /// Claim the oldest due turn under a fresh exact lease.
+    ///
+    /// `lease_token` is the caller's idempotency identity: retrying it while its
+    /// lease remains live returns the same running turn. Callers must retain it
+    /// across an ambiguous commit and use a fresh token for a new claim attempt.
+    /// A successful claim increments `attempt_count` and moves the turn to
+    /// `running`. Expired work is reclaimed only while another attempt is
+    /// permitted; an expired final attempt becomes terminally failed and the
+    /// scan continues. `lease_expires_at` must be after `now`.
+    async fn claim_turn_run(
+        &self,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+        _lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<TurnRun>> {
+        turn_storage_unavailable()
+    }
+
+    /// Extend one exact live turn lease monotonically.
+    ///
+    /// Returns `false` if the turn is not running, the token differs, the lease
+    /// already expired, or the proposed expiry does not extend the current one.
+    async fn heartbeat_turn_run(
+        &self,
+        _id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+        _lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        turn_storage_unavailable()
+    }
+
     /// Append a message to its chat.
     async fn append_message(&self, message: &Message) -> Result<()>;
 


### PR DESCRIPTION
## Summary

- claim the oldest effective-due durable turn under a fresh exact lease
- persist every caller-supplied claim token so an ambiguous commit can be retried exactly
- extend only an unexpired, token-matched lease and only to a later expiry
- reclaim expired work only while its persisted attempt budget permits
- fail an expired final attempt without replaying ambiguous model or tool work

## Concurrency

Claims acquire the SQLite writer lock before reading and use exact compare-and-set predicates for every backend. Concurrent claimers can observe the same PostgreSQL candidate, but only one can persist the claim receipt and change its status, attempt, prior lease identity, and update timestamp. Losing claimers retry the scan. The caller owns the claim token and every consumed token remains in a durable receipt ledger, so retrying after an ambiguous commit recovers the exact running attempt while its lease remains live; an expired or superseded token permanently resolves to no work and cannot claim a later turn. A composite foreign key proves every live lease has its matching token, turn, and attempt receipt. Heartbeats require the running status, exact token, live current expiry, monotonic proposed expiry, and non-regressing update time.

Queued and retry-wait work is ordered against expired running work by effective due time, then creation time and identity. The default one-attempt budget means an expired first lease becomes failed rather than being replayed until persisted execution checkpoints can prove retry safety.

This slice does not execute turns or add terminal success/failure APIs. Worker supervision and atomic event/message resolution remain separate changes.

## Validation

- full workspace tests
- 177 all-feature core tests
- eight-way concurrent claimer coverage
- exact claim retry, permanently consumed tokens, receipt constraints, expiry, monotonic timestamp/heartbeat, reclaim, and final-exhaustion coverage
- both queued-versus-expired effective-due orderings
- Rust lint
- formatting and diff checks
