### PR TITLE
ci: exercise turn state on postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,10 +196,58 @@ jobs:
       - name: test
         run: cargo test --workspace --locked
 
+  postgres:
+    name: postgres state machine
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: openwave_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d openwave_test"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 15
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+      OPENWAVE_POSTGRES_TEST_URL: postgres://postgres:postgres@localhost:5432/openwave_test
+      OPENWAVE_REQUIRE_POSTGRES_TEST: "true"
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}
+      RUSTC_WRAPPER: sccache
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install toolchain (honors rust-toolchain.toml)
+        run: rustup show
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@v0.0.10
+        with:
+          version: v0.16.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cargo-registry
+          add-job-id-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Exercise durable turn state on PostgreSQL
+        run: >-
+          cargo test -p openwave-core --no-default-features --features postgres
+          --test postgres_turn_state --locked
+
   rust:
     name: fmt · clippy · build · test
     if: ${{ always() }}
-    needs: [changes, fmt, lint, build, test]
+    needs: [changes, fmt, lint, build, test, postgres]
     runs-on: ubuntu-latest
     steps:
       - name: Require every Rust lane
@@ -208,6 +256,7 @@ jobs:
           LINT_RESULT: ${{ needs.lint.result }}
           BUILD_RESULT: ${{ needs.build.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          POSTGRES_RESULT: ${{ needs.postgres.result }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           RUST_CHANGED: ${{ needs.changes.outputs.rust }}
         run: |
@@ -218,12 +267,14 @@ jobs:
               test "$LINT_RESULT" = success
               test "$BUILD_RESULT" = success
               test "$TEST_RESULT" = success
+              test "$POSTGRES_RESULT" = success
               ;;
             false)
               test "$FMT_RESULT" = skipped
               test "$LINT_RESULT" = skipped
               test "$BUILD_RESULT" = skipped
               test "$TEST_RESULT" = skipped
+              test "$POSTGRES_RESULT" = skipped
               ;;
             *)
               echo "invalid Rust change detector output: $RUST_CHANGED" >&2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ futures = "0.3"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
-sea-orm = { version = "1", default-features = false, features = ["macros", "runtime-tokio-rustls", "sqlx-sqlite", "with-uuid", "with-chrono", "with-json"] }
-sea-orm-migration = { version = "1", default-features = false, features = ["runtime-tokio-rustls", "sqlx-sqlite"] }
+sea-orm = { version = "1", default-features = false, features = ["macros", "runtime-tokio-rustls", "with-uuid", "with-chrono", "with-json"] }
+sea-orm-migration = { version = "1", default-features = false, features = ["runtime-tokio-rustls"] }
 tokio = { version = "1", features = ["rt", "macros", "fs"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 sha2 = "0.10"

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -14,7 +14,19 @@ workspace = true
 default = ["sqlite", "keychain", "tools", "blob-fs"]
 # The default SeaORM-backed Store with the SQLite driver. Turn off
 # (`default-features = false`) to depend on just the trait contracts.
-sqlite = ["dep:sea-orm", "dep:sea-orm-migration"]
+sqlite = [
+    "dep:sea-orm",
+    "dep:sea-orm-migration",
+    "sea-orm/sqlx-sqlite",
+    "sea-orm-migration/sqlx-sqlite",
+]
+# PostgreSQL-backed Store for self-hosted deployments and cross-backend tests.
+postgres = [
+    "dep:sea-orm",
+    "dep:sea-orm-migration",
+    "sea-orm/sqlx-postgres",
+    "sea-orm-migration/sqlx-postgres",
+]
 # The OS-keychain-backed SecretProvider.
 keychain = ["dep:keyring", "dep:tokio"]
 # The built-in filesystem tools (read_file / list_dir / write_file).

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -455,7 +455,9 @@ async fn document_constraints_reject_invalid_catalog_state() {
     assert!(entities::document::Entity::update_many()
         .col_expr(
             entities::document::Column::SourceSha256,
-            sea_orm::sea_query::Expr::value(Some(vec![0x22; 31])),
+            sea_orm::sea_query::Expr::value(sea_orm::sea_query::Value::Bytes(Some(Box::new(
+                vec![0x22; 31],
+            )))),
         )
         .filter(entities::document::Column::Id.eq(valid_source.id.0))
         .exec(&store.conn)

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod blob;
 pub mod cancel;
 pub mod config;
 pub mod context;
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub mod db;
 pub mod error;
 pub mod event;
@@ -43,7 +43,7 @@ pub use approval::{
 pub use blob::FsBlobStore;
 pub use cancel::{CancelToken, Cancelled};
 pub use config::{Config, Profile};
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub use db::DbStore;
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -1,0 +1,134 @@
+#![cfg(feature = "postgres")]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::{Duration, Utc};
+use openwave_core::{AcceptTurnOutcome, Chat, ChatId, DbStore, Store, TurnId, TurnRunStatus};
+
+fn sample_chat() -> Chat {
+    Chat {
+        id: ChatId::new(),
+        project_id: None,
+        title: None,
+        model: None,
+        workspace_dir: PathBuf::from("/tmp/openwave-postgres-test"),
+        created_at: Utc::now(),
+    }
+}
+
+#[tokio::test]
+async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = Arc::new(DbStore::connect(&url).await.unwrap());
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "postgres input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    assert!(matches!(
+        store
+            .accept_turn(turn_id, chat.id, "gpt-5", "postgres input")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::Existing(_)
+    ));
+
+    let claim_at = accepted.available_at + Duration::seconds(1);
+    let lease_expires_at = claim_at + Duration::minutes(1);
+    let barrier = Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        let token = uuid::Uuid::new_v4();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            (
+                token,
+                store
+                    .claim_turn_run(token, claim_at, lease_expires_at)
+                    .await,
+            )
+        }));
+    }
+
+    let mut winner = None;
+    let mut empty = 0;
+    for task in tasks {
+        let (token, outcome) = task.await.unwrap();
+        match outcome.unwrap() {
+            Some(turn) => {
+                assert!(winner.replace((token, turn)).is_none());
+            }
+            None => empty += 1,
+        }
+    }
+    assert_eq!(empty, 7);
+    let (token, claimed) = winner.unwrap();
+    assert_eq!(claimed.id, turn_id);
+    assert_eq!(claimed.status, TurnRunStatus::Running);
+    assert_eq!(claimed.lease_token, Some(token));
+    assert_eq!(
+        store
+            .claim_turn_run(token, claim_at, lease_expires_at)
+            .await
+            .unwrap(),
+        Some(claimed)
+    );
+
+    assert_eq!(
+        store
+            .claim_turn_run(
+                uuid::Uuid::new_v4(),
+                lease_expires_at,
+                lease_expires_at + Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        store.get_turn_run(turn_id).await.unwrap().unwrap().status,
+        TurnRunStatus::Failed
+    );
+
+    let next_chat = sample_chat();
+    store.create_chat(&next_chat).await.unwrap();
+    let next = match store
+        .accept_turn(TurnId::new(), next_chat.id, "gpt-5", "later input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let delayed_retry_at = next.available_at + Duration::seconds(1);
+    assert_eq!(
+        store
+            .claim_turn_run(
+                token,
+                delayed_retry_at,
+                delayed_retry_at + Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        store.get_turn_run(next.id).await.unwrap().unwrap().status,
+        TurnRunStatus::Queued
+    );
+}


### PR DESCRIPTION
## Summary

- make the SeaORM SQLite and PostgreSQL driver features explicit
- exercise durable turn acceptance and claiming against PostgreSQL 17
- add the focused PostgreSQL test as a required, parallel CI lane

## CI

- reuses the existing registry and sccache configuration
- avoids the Tauri system dependencies required by the desktop lanes
- participates in the aggregate required check

## Validation

- passed against a disposable local PostgreSQL 17 container
- `cargo test -p openwave-core --all-features --locked`
- `bw dev lint --rust`
- workflow YAML parse and `git diff --check`
