### PR TITLE
feat(core): complete claimed turns atomically

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -187,6 +187,7 @@ pub mod turn_run {
         pub id: Uuid,
         pub chat_id: Uuid,
         pub input_message_id: Uuid,
+        pub output_message_id: Option<Uuid>,
         pub model: String,
         pub status: String,
         pub attempt_count: i32,

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -165,6 +165,12 @@ impl MigrationTrait for Init {
             .ne(TurnRunStatus::Running.as_str())
             .and(Expr::col(TurnRun::LeaseToken).is_null())
             .and(Expr::col(TurnRun::LeaseExpiresAt).is_null());
+        let completed_output = Expr::col(TurnRun::Status)
+            .eq(TurnRunStatus::Completed.as_str())
+            .and(Expr::col(TurnRun::OutputMessageId).is_not_null());
+        let no_output = Expr::col(TurnRun::Status)
+            .ne(TurnRunStatus::Completed.as_str())
+            .and(Expr::col(TurnRun::OutputMessageId).is_null());
         let terminal_finished = Expr::col(TurnRun::Status)
             .is_in([
                 TurnRunStatus::Completed.as_str(),
@@ -233,6 +239,7 @@ impl MigrationTrait for Init {
                     .col(ColumnDef::new(TurnRun::Id).uuid().not_null().primary_key())
                     .col(ColumnDef::new(TurnRun::ChatId).uuid().not_null())
                     .col(ColumnDef::new(TurnRun::InputMessageId).uuid().not_null())
+                    .col(ColumnDef::new(TurnRun::OutputMessageId).uuid())
                     .col(
                         ColumnDef::new(TurnRun::Model)
                             .string_len(crate::model::TurnRun::MAX_MODEL_LEN as u32)
@@ -305,6 +312,19 @@ impl MigrationTrait for Init {
                     )
                     .foreign_key(
                         ForeignKey::create()
+                            .name("fk_turn_run_output_message")
+                            .from_tbl(TurnRun::Table)
+                            .from_col(TurnRun::OutputMessageId)
+                            .from_col(TurnRun::ChatId)
+                            .from_col(TurnRun::Id)
+                            .to_tbl(Message::Table)
+                            .to_col(Message::Id)
+                            .to_col(Message::ChatId)
+                            .to_col(Message::TurnId)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
                             .name("fk_turn_run_live_claim")
                             .from_tbl(TurnRun::Table)
                             .from_col(TurnRun::LeaseToken)
@@ -331,6 +351,7 @@ impl MigrationTrait for Init {
                             ),
                     )
                     .check(running_lease.or(no_lease))
+                    .check(completed_output.or(no_output))
                     .check(terminal_finished.or(nonterminal_unfinished))
                     .check(
                         queued_attempt
@@ -1437,6 +1458,7 @@ enum TurnRun {
     Id,
     ChatId,
     InputMessageId,
+    OutputMessageId,
     Model,
     Status,
     AttemptCount,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -32,8 +32,8 @@ use crate::model::{
     DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, TurnRun, TurnRunStatus,
 };
 use crate::storage::{
-    AcceptTurnOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
-    EnsureDocumentParseJobOutcome, Store,
+    AcceptTurnOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, Store,
 };
 
 mod ops;
@@ -1678,6 +1678,16 @@ impl Store for DbStore {
         lease_expires_at: chrono::DateTime<Utc>,
     ) -> Result<bool> {
         ops::turn::heartbeat_turn_run(self, id, lease_token, now, lease_expires_at).await
+    }
+
+    async fn complete_turn_run(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        output: &Message,
+    ) -> Result<Option<CompleteTurnRunOutcome>> {
+        ops::turn::complete_turn_run(self, id, lease_token, now, output).await
     }
 
     async fn append_message(&self, message: &Message) -> Result<()> {

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -6,8 +6,8 @@ use sea_orm::{
 
 use crate::error::{AgentError, Result};
 use crate::id::{ChatId, MessageId, TurnId};
-use crate::model::{TurnRun, TurnRunStatus};
-use crate::storage::AcceptTurnOutcome;
+use crate::model::{Message, Role, TurnRun, TurnRunStatus};
+use crate::storage::{AcceptTurnOutcome, CompleteTurnRunOutcome};
 
 use super::super::{entities, store_err, DbStore};
 
@@ -76,7 +76,7 @@ pub(in crate::db) async fn accept_turn(
         return Ok(AcceptTurnOutcome::ChatBusy(active));
     }
 
-    let now = Utc::now();
+    let now = canonical_db_timestamp(Utc::now())?;
     let input_message_id = MessageId::new();
     let message = entities::message::ActiveModel {
         id: Set(input_message_id.0),
@@ -95,6 +95,7 @@ pub(in crate::db) async fn accept_turn(
         id: Set(id.0),
         chat_id: Set(chat_id.0),
         input_message_id: Set(input_message_id.0),
+        output_message_id: Set(None),
         model: Set(model.into()),
         status: Set(TurnRunStatus::Queued.as_str().into()),
         attempt_count: Set(0),
@@ -139,6 +140,8 @@ pub(in crate::db) async fn claim_turn_run(
     now: chrono::DateTime<Utc>,
     lease_expires_at: chrono::DateTime<Utc>,
 ) -> Result<Option<TurnRun>> {
+    let now = canonical_db_timestamp(now)?;
+    let lease_expires_at = canonical_db_timestamp(lease_expires_at)?;
     if lease_token.is_nil() {
         return Err(AgentError::Store("turn lease token must not be nil".into()));
     }
@@ -353,6 +356,8 @@ pub(in crate::db) async fn heartbeat_turn_run(
     now: chrono::DateTime<Utc>,
     lease_expires_at: chrono::DateTime<Utc>,
 ) -> Result<bool> {
+    let now = canonical_db_timestamp(now)?;
+    let lease_expires_at = canonical_db_timestamp(lease_expires_at)?;
     if lease_expires_at <= now {
         return Err(AgentError::Store(
             "turn lease expiry must be after heartbeat time".into(),
@@ -377,6 +382,240 @@ pub(in crate::db) async fn heartbeat_turn_run(
         .await
         .map_err(store_err)?;
     Ok(heartbeat.rows_affected == 1)
+}
+
+pub(in crate::db) async fn complete_turn_run(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    output: &Message,
+) -> Result<Option<CompleteTurnRunOutcome>> {
+    validate_turn_output(id, lease_token, output)?;
+    let now = canonical_db_timestamp(now)?;
+    let output_created_at = canonical_db_timestamp(output.created_at)?;
+    if output_created_at > now {
+        return Err(AgentError::Store(
+            "turn output timestamp must not be after completion time".into(),
+        ));
+    }
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_exact_turn_write_lock(&transaction, id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let Some(receipt) = entities::turn_claim::Entity::find_by_id(lease_token)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .filter(|receipt| receipt.turn_id == id.0)
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let Some(existing) = entities::turn_run::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if output.chat_id.0 != existing.chat_id {
+        return Err(AgentError::Store(format!(
+            "turn {id} output belongs to a different chat"
+        )));
+    }
+
+    if existing.status == TurnRunStatus::Completed.as_str()
+        && existing.attempt_count == receipt.attempt_count
+    {
+        if existing.output_message_id != Some(output.id.0)
+            || !exact_completed_output_on(&transaction, output).await?
+        {
+            return Err(AgentError::Store(format!(
+                "turn {id} was already completed with different output"
+            )));
+        }
+        let existing = turn_run_from_model(existing)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(CompleteTurnRunOutcome::Existing(existing)));
+    }
+    if existing.status != TurnRunStatus::Running.as_str()
+        || existing.attempt_count != receipt.attempt_count
+        || existing.lease_token != Some(lease_token)
+        || existing
+            .lease_expires_at
+            .is_none_or(|expires_at| expires_at <= now)
+        || existing.updated_at > now
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let message = entities::message::ActiveModel {
+        id: Set(output.id.0),
+        chat_id: Set(output.chat_id.0),
+        turn_id: Set(output.turn_id.0),
+        role: Set("assistant".into()),
+        content: Set(output.content.clone()),
+        created_at: Set(output_created_at),
+    };
+    if let Err(error) = message.insert(&transaction).await {
+        transaction.rollback().await.map_err(store_err)?;
+        if let Some(existing) = exact_completed_turn_on(store, id, lease_token, output).await? {
+            return Ok(Some(CompleteTurnRunOutcome::Existing(existing)));
+        }
+        return Err(store_err(error));
+    }
+
+    let completed = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnRunStatus::Completed.as_str()),
+        )
+        .col_expr(
+            entities::turn_run::Column::OutputMessageId,
+            sea_orm::sea_query::Expr::value(Some(output.id.0)),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::turn_run::Column::Id.eq(id.0))
+        .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
+        .filter(entities::turn_run::Column::AttemptCount.eq(receipt.attempt_count))
+        .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.eq(existing.lease_expires_at))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::turn_run::Column::UpdatedAt.eq(existing.updated_at))
+        .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if completed.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let completed = entities::turn_run::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("completed turn {id} disappeared")))
+        .and_then(turn_run_from_model)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(CompleteTurnRunOutcome::Completed(completed)))
+}
+
+async fn acquire_exact_turn_write_lock<C>(conn: &C, id: TurnId) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let locked = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::col(entities::turn_run::Column::UpdatedAt).into(),
+        )
+        .filter(entities::turn_run::Column::Id.eq(id.0))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(locked.rows_affected == 1)
+}
+
+fn canonical_db_timestamp(timestamp: chrono::DateTime<Utc>) -> Result<chrono::DateTime<Utc>> {
+    chrono::DateTime::from_timestamp_micros(timestamp.timestamp_micros()).ok_or_else(|| {
+        AgentError::Store("turn output timestamp is outside the database range".into())
+    })
+}
+
+fn validate_turn_output(id: TurnId, lease_token: uuid::Uuid, output: &Message) -> Result<()> {
+    if lease_token.is_nil() {
+        return Err(AgentError::Store("turn lease token must not be nil".into()));
+    }
+    if output.id.0.is_nil() {
+        return Err(AgentError::Store(
+            "turn output message id must not be nil".into(),
+        ));
+    }
+    if output.turn_id != id || output.role != Role::Assistant {
+        return Err(AgentError::Store(
+            "turn output must be an assistant message for the completed turn".into(),
+        ));
+    }
+    if output.content.contains('\0') {
+        return Err(AgentError::Store(
+            "turn output must contain no NUL characters".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn exact_completed_turn_on(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    output: &Message,
+) -> Result<Option<TurnRun>> {
+    let Some(receipt) = entities::turn_claim::Entity::find_by_id(lease_token)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .filter(|receipt| receipt.turn_id == id.0)
+    else {
+        return Ok(None);
+    };
+    let Some(existing) = entities::turn_run::Entity::find_by_id(id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    if existing.status != TurnRunStatus::Completed.as_str()
+        || existing.attempt_count != receipt.attempt_count
+    {
+        return Ok(None);
+    }
+    if existing.output_message_id != Some(output.id.0)
+        || !exact_completed_output_on(&store.conn, output).await?
+    {
+        return Err(AgentError::Store(format!(
+            "turn {id} was already completed with different output"
+        )));
+    }
+    Ok(Some(turn_run_from_model(existing)?))
+}
+
+async fn exact_completed_output_on<C>(conn: &C, output: &Message) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let created_at = canonical_db_timestamp(output.created_at)?;
+    Ok(entities::message::Entity::find_by_id(output.id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .is_some_and(|message| {
+            message.chat_id == output.chat_id.0
+                && message.turn_id == output.turn_id.0
+                && message.role == "assistant"
+                && message.content == output.content
+                && message.created_at == created_at
+        }))
 }
 
 async fn acquire_turn_claim_write_lock<C>(conn: &C) -> Result<()>
@@ -489,6 +728,7 @@ fn turn_run_from_model(model: entities::turn_run::Model) -> Result<TurnRun> {
         id: TurnId(model.id),
         chat_id: ChatId(model.chat_id),
         input_message_id: MessageId(model.input_message_id),
+        output_message_id: model.output_message_id.map(MessageId),
         model: model.model,
         status: turn_run_status_from_db(&model.status)?,
         attempt_count: model.attempt_count,

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4598,6 +4598,7 @@ async fn make_queued_turn(
         id: Set(turn_id.0),
         chat_id: Set(chat_id.0),
         input_message_id: Set(input_message_id.0),
+        output_message_id: Set(None),
         model: Set(model.into()),
         status: Set(TurnRunStatus::Queued.as_str().into()),
         attempt_count: Set(0),
@@ -4639,6 +4640,18 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         .await
         .is_err());
 
+    let first_output_id = MessageId::new();
+    entities::message::ActiveModel {
+        id: Set(first_output_id.0),
+        chat_id: Set(chat.id.0),
+        turn_id: Set(first.id),
+        role: Set("assistant".into()),
+        content: Set("done".into()),
+        created_at: Set(now),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
     entities::turn_run::Entity::update_many()
         .col_expr(
             entities::turn_run::Column::Status,
@@ -4647,6 +4660,10 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         .col_expr(
             entities::turn_run::Column::AttemptCount,
             sea_orm::sea_query::Expr::value(1),
+        )
+        .col_expr(
+            entities::turn_run::Column::OutputMessageId,
+            sea_orm::sea_query::Expr::value(Some(first_output_id.0)),
         )
         .col_expr(
             entities::turn_run::Column::StartedAt,
@@ -4688,6 +4705,30 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     failed_without_finish.started_at = Set(Some(now));
     failed_without_finish.last_error_code = Set(Some("provider_error".into()));
     assert!(failed_without_finish.insert(&store.conn).await.is_err());
+
+    let mut completed_without_output =
+        make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
+    completed_without_output.status = Set(TurnRunStatus::Completed.as_str().into());
+    completed_without_output.attempt_count = Set(1);
+    completed_without_output.started_at = Set(Some(now));
+    completed_without_output.finished_at = Set(Some(now));
+    assert!(completed_without_output.insert(&store.conn).await.is_err());
+
+    let mut queued_with_output = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
+    queued_with_output.output_message_id = Set(Some(first_output_id.0));
+    assert!(queued_with_output.insert(&store.conn).await.is_err());
+
+    let mut completed_with_wrong_output =
+        make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
+    completed_with_wrong_output.status = Set(TurnRunStatus::Completed.as_str().into());
+    completed_with_wrong_output.attempt_count = Set(1);
+    completed_with_wrong_output.started_at = Set(Some(now));
+    completed_with_wrong_output.finished_at = Set(Some(now));
+    completed_with_wrong_output.output_message_id = Set(Some(first_output_id.0));
+    assert!(completed_with_wrong_output
+        .insert(&store.conn)
+        .await
+        .is_err());
 
     let mut unknown_status = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     unknown_status.status = Set("waiting_for_magic".into());
@@ -5120,7 +5161,10 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
     assert_eq!(first.started_at, Some(claimed_at));
     assert_eq!(first.lease_expires_at, Some(first_expiry));
 
-    let heartbeat_at = claimed_at + chrono::Duration::seconds(10);
+    let heartbeat_at =
+        claimed_at + chrono::Duration::seconds(10) + chrono::Duration::nanoseconds(900);
+    let canonical_heartbeat_at =
+        DateTime::<Utc>::from_timestamp_micros(heartbeat_at.timestamp_micros()).unwrap();
     assert!(!store
         .heartbeat_turn_run(
             turn_id,
@@ -5144,6 +5188,15 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
         .heartbeat_turn_run(turn_id, first_token, heartbeat_at, extended)
         .await
         .unwrap());
+    assert_eq!(
+        store
+            .get_turn_run(turn_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .updated_at,
+        canonical_heartbeat_at
+    );
     assert!(!store
         .heartbeat_turn_run(
             turn_id,
@@ -5232,6 +5285,413 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
         store.get_turn_run(next.id).await.unwrap().unwrap().status,
         TurnRunStatus::Queued
     );
+}
+
+#[tokio::test]
+async fn turn_completion_atomically_persists_exact_output_and_recovers_retries() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let lease_expires_at = claimed_at + chrono::Duration::minutes(1);
+    let lease_token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(lease_token, claimed_at, lease_expires_at)
+        .await
+        .unwrap()
+        .unwrap();
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "final answer".into(),
+        created_at: claimed_at + chrono::Duration::nanoseconds(1_234_567),
+    };
+
+    assert_eq!(
+        store
+            .complete_turn_run(turn_id, uuid::Uuid::new_v4(), output.created_at, &output)
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
+
+    let mut invalid = output.clone();
+    invalid.role = Role::User;
+    assert!(store
+        .complete_turn_run(turn_id, lease_token, output.created_at, &invalid)
+        .await
+        .is_err());
+    invalid = output.clone();
+    invalid.turn_id = TurnId::new();
+    assert!(store
+        .complete_turn_run(turn_id, lease_token, output.created_at, &invalid)
+        .await
+        .is_err());
+    invalid = output.clone();
+    invalid.chat_id = ChatId::new();
+    assert!(store
+        .complete_turn_run(turn_id, lease_token, output.created_at, &invalid)
+        .await
+        .is_err());
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
+
+    let CompleteTurnRunOutcome::Completed(completed) = store
+        .complete_turn_run(turn_id, lease_token, output.created_at, &output)
+        .await
+        .unwrap()
+        .unwrap()
+    else {
+        panic!("first exact completion must commit")
+    };
+    let canonical_completed_at =
+        DateTime::<Utc>::from_timestamp_micros(output.created_at.timestamp_micros()).unwrap();
+    assert_eq!(completed.status, TurnRunStatus::Completed);
+    assert_eq!(completed.output_message_id, Some(output.id));
+    assert_eq!(completed.lease_token, None);
+    assert_eq!(completed.lease_expires_at, None);
+    assert_eq!(completed.finished_at, Some(canonical_completed_at));
+    assert_eq!(completed.updated_at, canonical_completed_at);
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[1].id, output.id);
+    assert_eq!(messages[1].content, output.content);
+    assert_eq!(messages[1].created_at, canonical_completed_at);
+
+    assert_eq!(
+        store
+            .complete_turn_run(
+                turn_id,
+                lease_token,
+                lease_expires_at + chrono::Duration::seconds(1),
+                &output,
+            )
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::Existing(completed.clone()))
+    );
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
+
+    let mut mismatched = output.clone();
+    mismatched.content = "different answer".into();
+    assert!(store
+        .complete_turn_run(turn_id, lease_token, lease_expires_at, &mismatched)
+        .await
+        .is_err());
+    mismatched = output.clone();
+    mismatched.id = MessageId::new();
+    assert!(store
+        .complete_turn_run(turn_id, lease_token, lease_expires_at, &mismatched)
+        .await
+        .is_err());
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn turn_completion_uses_the_heartbeated_lease_and_fences_operation_time() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let original_expiry = claimed_at + chrono::Duration::minutes(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, original_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    let heartbeat_at = claimed_at + chrono::Duration::seconds(30);
+    let extended_expiry = original_expiry + chrono::Duration::minutes(1);
+    assert!(store
+        .heartbeat_turn_run(turn_id, token, heartbeat_at, extended_expiry)
+        .await
+        .unwrap());
+
+    let prepared_output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "prepared before retry".into(),
+        created_at: heartbeat_at - chrono::Duration::microseconds(1),
+    };
+    let future_output = Message {
+        id: MessageId::new(),
+        content: "future output".into(),
+        created_at: heartbeat_at + chrono::Duration::seconds(2),
+        ..prepared_output.clone()
+    };
+    assert!(store
+        .complete_turn_run(
+            turn_id,
+            token,
+            heartbeat_at + chrono::Duration::seconds(1),
+            &future_output,
+        )
+        .await
+        .is_err());
+    let output = Message {
+        id: MessageId::new(),
+        content: "after the original lease".into(),
+        created_at: original_expiry + chrono::Duration::seconds(1),
+        ..prepared_output
+    };
+    assert!(matches!(
+        store
+            .complete_turn_run(turn_id, token, output.created_at, &output)
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::Completed(_))
+    ));
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn turn_completion_rejects_prepared_output_retried_after_expiry() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let lease_expires_at = claimed_at + chrono::Duration::minutes(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, lease_expires_at)
+        .await
+        .unwrap()
+        .unwrap();
+    let prepared_output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "prepared while live".into(),
+        created_at: lease_expires_at - chrono::Duration::seconds(1),
+    };
+
+    assert_eq!(
+        store
+            .complete_turn_run(turn_id, token, lease_expires_at, &prepared_output)
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
+    assert_eq!(
+        store.get_turn_run(turn_id).await.unwrap().unwrap().status,
+        TurnRunStatus::Running
+    );
+}
+
+#[tokio::test]
+async fn stale_turn_attempt_cannot_complete_a_reclaimed_turn() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(2),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let first_claim_at = accepted.available_at + chrono::Duration::seconds(1);
+    let first_expiry = first_claim_at + chrono::Duration::minutes(1);
+    let first_token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(first_token, first_claim_at, first_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    let second_token = uuid::Uuid::new_v4();
+    let second_expiry = first_expiry + chrono::Duration::minutes(1);
+    let reclaimed = store
+        .claim_turn_run(second_token, first_expiry, second_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reclaimed.attempt_count, 2);
+
+    let stale_output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "stale answer".into(),
+        created_at: first_expiry + chrono::Duration::seconds(1),
+    };
+    assert_eq!(
+        store
+            .complete_turn_run(turn_id, first_token, stale_output.created_at, &stale_output)
+            .await
+            .unwrap(),
+        None
+    );
+    let output = Message {
+        id: MessageId::new(),
+        content: "current answer".into(),
+        ..stale_output
+    };
+    assert!(matches!(
+        store
+            .complete_turn_run(turn_id, second_token, output.created_at, &output)
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::Completed(_))
+    ));
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn concurrent_different_turn_completions_commit_one_output_once() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .unwrap();
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "one answer".into(),
+        created_at: claimed_at + chrono::Duration::seconds(1),
+    };
+    let competing_output = Message {
+        id: MessageId::new(),
+        content: "different answer".into(),
+        ..output.clone()
+    };
+    let store = std::sync::Arc::new(store);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let mut tasks = Vec::new();
+    for output in [output, competing_output] {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .complete_turn_run(turn_id, token, output.created_at, &output)
+                .await
+        }));
+    }
+    let mut committed = 0;
+    let mut conflicted = 0;
+    for task in tasks {
+        match task.await.unwrap() {
+            Ok(Some(CompleteTurnRunOutcome::Completed(_))) => committed += 1,
+            Err(AgentError::Store(message))
+                if message.contains("already completed with different output") =>
+            {
+                conflicted += 1;
+            }
+            outcome => panic!("unexpected concurrent completion outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!((committed, conflicted), (1, 1));
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn turn_completion_rolls_back_output_when_state_update_fails() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_turn_completion
+             BEFORE UPDATE OF status ON turn_run
+             WHEN NEW.status = 'completed'
+             BEGIN SELECT RAISE(FAIL, 'forced turn completion failure'); END",
+        )
+        .await
+        .unwrap();
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "must roll back".into(),
+        created_at: claimed_at + chrono::Duration::seconds(1),
+    };
+    assert!(store
+        .complete_turn_run(turn_id, token, output.created_at, &output)
+        .await
+        .is_err());
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
+    let still_running = store.get_turn_run(turn_id).await.unwrap().unwrap();
+    assert_eq!(still_running.status, TurnRunStatus::Running);
+    assert_eq!(still_running.output_message_id, None);
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -63,8 +63,8 @@ pub use provider::{
 };
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
-    AcceptTurnOutcome, BlobStore, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
-    EnsureDocumentParseJobOutcome, SecretProvider, Store,
+    AcceptTurnOutcome, BlobStore, CompleteTurnRunOutcome, DocumentIndexJobReason,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, SecretProvider, Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -623,6 +623,12 @@ pub struct TurnRun {
     pub chat_id: ChatId,
     /// Exact persisted user message that supplied this turn's initial input.
     pub input_message_id: MessageId,
+    /// Exact designated terminal assistant message committed with successful
+    /// completion. The composite database FK enforces its message/chat/turn
+    /// identity; [`Store::complete_turn_run`](crate::storage::Store::complete_turn_run)
+    /// enforces the assistant role because a foreign key cannot bind a literal
+    /// role value.
+    pub output_message_id: Option<MessageId>,
     /// Model selected when the turn was accepted.
     pub model: String,
     /// Durable delivery state.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -95,6 +95,15 @@ pub enum AcceptTurnOutcome {
     ChatBusy(TurnRun),
 }
 
+/// Result of atomically completing one exact claimed turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompleteTurnRunOutcome {
+    /// This call committed the terminal message and state transition.
+    Completed(TurnRun),
+    /// This exact completion was already committed by an earlier call.
+    Existing(TurnRun),
+}
+
 fn document_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "document storage is not implemented by this Store".into(),
@@ -598,6 +607,25 @@ pub trait Store: Send + Sync {
         _now: chrono::DateTime<chrono::Utc>,
         _lease_expires_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool> {
+        turn_storage_unavailable()
+    }
+
+    /// Atomically persist the final assistant message and complete its turn.
+    ///
+    /// The exact claim must still be live at the fresh operational `now`, and
+    /// the output cannot be dated after it. Repeating the same token and
+    /// exact output identity, content, and database-normalized timestamp after
+    /// an ambiguous commit returns the completed turn even after lease expiry,
+    /// without inserting another message. Returns
+    /// `None` when the token never owned this turn, its lease was lost, or
+    /// another terminal outcome already won.
+    async fn complete_turn_run(
+        &self,
+        _id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+        _output: &Message,
+    ) -> Result<Option<CompleteTurnRunOutcome>> {
         turn_storage_unavailable()
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -4,7 +4,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::{Duration, Utc};
-use openwave_core::{AcceptTurnOutcome, Chat, ChatId, DbStore, Store, TurnId, TurnRunStatus};
+use openwave_core::{
+    AcceptTurnOutcome, Chat, ChatId, CompleteTurnRunOutcome, DbStore, Message, MessageId, Role,
+    Store, TurnId, TurnRunStatus,
+};
 
 fn sample_chat() -> Chat {
     Chat {
@@ -131,4 +134,45 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         store.get_turn_run(next.id).await.unwrap().unwrap().status,
         TurnRunStatus::Queued
     );
+
+    let completion_token = uuid::Uuid::new_v4();
+    let completion_expiry = delayed_retry_at + Duration::minutes(1);
+    store
+        .claim_turn_run(completion_token, delayed_retry_at, completion_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: next_chat.id,
+        turn_id: next.id,
+        role: Role::Assistant,
+        content: "postgres completion".into(),
+        created_at: delayed_retry_at + Duration::seconds(1),
+    };
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let mut completions = Vec::new();
+    for _ in 0..2 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        let output = output.clone();
+        completions.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .complete_turn_run(next.id, completion_token, output.created_at, &output)
+                .await
+                .unwrap()
+                .unwrap()
+        }));
+    }
+    let mut committed = 0;
+    let mut existing = 0;
+    for completion in completions {
+        match completion.await.unwrap() {
+            CompleteTurnRunOutcome::Completed(_) => committed += 1,
+            CompleteTurnRunOutcome::Existing(_) => existing += 1,
+        }
+    }
+    assert_eq!((committed, existing), (1, 1));
+    assert_eq!(store.list_messages(next_chat.id).await.unwrap().len(), 2);
 }


### PR DESCRIPTION
## Summary

- atomically persist a designated final assistant message and complete its exact claimed turn
- recover byte-exact retries after ambiguous commits without duplicating output
- fence stale attempts, expired leases, heartbeat races, and timestamp regression on SQLite and PostgreSQL
- enforce the terminal output relationship in the baseline schema

## Validation

- 183 all-feature core tests
- full workspace test suite
- PostgreSQL 17 acceptance, claim, and concurrent completion integration test
- `bw dev lint --rust`
- rustfmt and `git diff --check`
