### PR TITLE
feat(core): record claimed turn failures atomically

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -229,6 +229,29 @@ pub mod turn_claim {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod turn_failure {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "turn_failure")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub lease_token: Uuid,
+        pub turn_id: Uuid,
+        pub attempt_count: i32,
+        pub requested_retry_at: Option<DateTimeUtc>,
+        pub error_code: String,
+        pub error_detail: Option<String>,
+        pub resolved_at: DateTimeUtc,
+        pub result_status: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod tool_call {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -447,6 +447,86 @@ impl MigrationTrait for Init {
         manager
             .create_table(
                 Table::create()
+                    .table(TurnFailure::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(TurnFailure::LeaseToken)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(TurnFailure::TurnId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(TurnFailure::AttemptCount)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(TurnFailure::RequestedRetryAt).timestamp_with_time_zone())
+                    .col(
+                        ColumnDef::new(TurnFailure::ErrorCode)
+                            .string_len(crate::model::TurnRun::MAX_ERROR_CODE_LEN as u32)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnFailure::ErrorDetail)
+                            .string_len(crate::model::TurnRun::MAX_ERROR_DETAIL_LEN as u32),
+                    )
+                    .col(
+                        ColumnDef::new(TurnFailure::ResolvedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnFailure::ResultStatus)
+                            .string_len(32)
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_failure_claim")
+                            .from_tbl(TurnFailure::Table)
+                            .from_col(TurnFailure::LeaseToken)
+                            .from_col(TurnFailure::TurnId)
+                            .from_col(TurnFailure::AttemptCount)
+                            .to_tbl(TurnClaim::Table)
+                            .to_col(TurnClaim::Token)
+                            .to_col(TurnClaim::TurnId)
+                            .to_col(TurnClaim::AttemptCount)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .check(Expr::col(TurnFailure::AttemptCount).gte(1))
+                    .check(Expr::col(TurnFailure::ResultStatus).is_in([
+                        TurnRunStatus::RetryWait.as_str(),
+                        TurnRunStatus::Failed.as_str(),
+                    ]))
+                    .check(
+                        Expr::col(TurnFailure::ResultStatus)
+                            .ne(TurnRunStatus::RetryWait.as_str())
+                            .or(Expr::col(TurnFailure::RequestedRetryAt).is_not_null()),
+                    )
+                    .check(
+                        Expr::col(TurnFailure::RequestedRetryAt)
+                            .is_null()
+                            .or(Expr::col(TurnFailure::RequestedRetryAt)
+                                .gt(Expr::col(TurnFailure::ResolvedAt))),
+                    )
+                    .check(
+                        Func::char_length(Expr::col(TurnFailure::ErrorCode))
+                            .between(1, crate::model::TurnRun::MAX_ERROR_CODE_LEN as i32),
+                    )
+                    .check(
+                        Expr::col(TurnFailure::ErrorDetail)
+                            .is_null()
+                            .or(Func::char_length(Expr::col(TurnFailure::ErrorDetail))
+                                .between(1, crate::model::TurnRun::MAX_ERROR_DETAIL_LEN as i32)),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
                     .table(Setting::Table)
                     .if_not_exists()
                     .col(ColumnDef::new(Setting::Key).text().not_null().primary_key())
@@ -459,6 +539,9 @@ impl MigrationTrait for Init {
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(TurnFailure::Table).to_owned())
+            .await?;
         manager
             .drop_table(Table::drop().table(TurnRun::Table).to_owned())
             .await?;
@@ -1482,6 +1565,19 @@ enum TurnClaim {
     AttemptCount,
     ClaimedAt,
     LeaseExpiresAt,
+}
+
+#[derive(DeriveIden)]
+enum TurnFailure {
+    Table,
+    LeaseToken,
+    TurnId,
+    AttemptCount,
+    RequestedRetryAt,
+    ErrorCode,
+    ErrorDetail,
+    ResolvedAt,
+    ResultStatus,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -29,11 +29,12 @@ use crate::model::{
     BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
     DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
     DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
-    DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, TurnRun, TurnRunStatus,
+    DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, TurnFailureRetry, TurnRun,
+    TurnRunStatus,
 };
 use crate::storage::{
     AcceptTurnOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
-    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, Store,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, RecordTurnFailureOutcome, Store,
 };
 
 mod ops;
@@ -1688,6 +1689,27 @@ impl Store for DbStore {
         output: &Message,
     ) -> Result<Option<CompleteTurnRunOutcome>> {
         ops::turn::complete_turn_run(self, id, lease_token, now, output).await
+    }
+
+    async fn record_turn_run_failure(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        retry: TurnFailureRetry,
+        error_code: &str,
+        error_detail: Option<&str>,
+    ) -> Result<Option<RecordTurnFailureOutcome>> {
+        ops::turn::record_turn_run_failure(
+            self,
+            id,
+            lease_token,
+            now,
+            retry,
+            error_code,
+            error_detail,
+        )
+        .await
     }
 
     async fn append_message(&self, message: &Message) -> Result<()> {

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -6,8 +6,8 @@ use sea_orm::{
 
 use crate::error::{AgentError, Result};
 use crate::id::{ChatId, MessageId, TurnId};
-use crate::model::{Message, Role, TurnRun, TurnRunStatus};
-use crate::storage::{AcceptTurnOutcome, CompleteTurnRunOutcome};
+use crate::model::{Message, Role, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus};
+use crate::storage::{AcceptTurnOutcome, CompleteTurnRunOutcome, RecordTurnFailureOutcome};
 
 use super::super::{entities, store_err, DbStore};
 
@@ -520,6 +520,167 @@ pub(in crate::db) async fn complete_turn_run(
     Ok(Some(CompleteTurnRunOutcome::Completed(completed)))
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(in crate::db) async fn record_turn_run_failure(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    retry: TurnFailureRetry,
+    error_code: &str,
+    error_detail: Option<&str>,
+) -> Result<Option<RecordTurnFailureOutcome>> {
+    validate_turn_failure(lease_token, error_code, error_detail)?;
+    let now = canonical_db_timestamp(now)?;
+    let requested_retry_at = match retry {
+        TurnFailureRetry::Permanent => None,
+        TurnFailureRetry::RetryAt(retry_at) => Some(canonical_db_timestamp(retry_at)?),
+    };
+
+    if let Some(existing) = exact_turn_failure_on(
+        &store.conn,
+        id,
+        lease_token,
+        requested_retry_at,
+        error_code,
+        error_detail,
+    )
+    .await?
+    {
+        return Ok(Some(RecordTurnFailureOutcome::Existing(existing)));
+    }
+    if requested_retry_at.is_some_and(|retry_at| retry_at <= now) {
+        return Err(AgentError::Store(
+            "turn retry time must be after failure resolution time".into(),
+        ));
+    }
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_exact_turn_write_lock(&transaction, id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    if let Some(existing) = exact_turn_failure_on(
+        &transaction,
+        id,
+        lease_token,
+        requested_retry_at,
+        error_code,
+        error_detail,
+    )
+    .await?
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(RecordTurnFailureOutcome::Existing(existing)));
+    }
+    let Some(claim) = entities::turn_claim::Entity::find_by_id(lease_token)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .filter(|claim| claim.turn_id == id.0)
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let Some(turn) = entities::turn_run::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if turn.status != TurnRunStatus::Running.as_str()
+        || turn.attempt_count != claim.attempt_count
+        || turn.lease_token != Some(lease_token)
+        || turn
+            .lease_expires_at
+            .is_none_or(|expires_at| expires_at <= now)
+        || turn.updated_at > now
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let result_status = if requested_retry_at.is_some() && turn.attempt_count < turn.max_attempts {
+        TurnRunStatus::RetryWait
+    } else {
+        TurnRunStatus::Failed
+    };
+    let receipt = entities::turn_failure::ActiveModel {
+        lease_token: Set(lease_token),
+        turn_id: Set(id.0),
+        attempt_count: Set(claim.attempt_count),
+        requested_retry_at: Set(requested_retry_at),
+        error_code: Set(error_code.to_owned()),
+        error_detail: Set(error_detail.map(str::to_owned)),
+        resolved_at: Set(now),
+        result_status: Set(result_status.as_str().into()),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+
+    let update = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(result_status.as_str()),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Some(error_code.to_owned())),
+        )
+        .col_expr(
+            entities::turn_run::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(error_detail.map(str::to_owned)),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        );
+    let update = match result_status {
+        TurnRunStatus::RetryWait => update.col_expr(
+            entities::turn_run::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(
+                requested_retry_at.expect("retry-wait failure has a retry time"),
+            ),
+        ),
+        TurnRunStatus::Failed => update.col_expr(
+            entities::turn_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        ),
+        _ => unreachable!("failure resolution has a constrained result status"),
+    };
+    let updated = update
+        .filter(entities::turn_run::Column::Id.eq(id.0))
+        .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
+        .filter(entities::turn_run::Column::AttemptCount.eq(claim.attempt_count))
+        .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.eq(turn.lease_expires_at))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at))
+        .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let receipt = turn_failure_from_model(receipt)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(RecordTurnFailureOutcome::Recorded(receipt)))
+}
+
 async fn acquire_exact_turn_write_lock<C>(conn: &C, id: TurnId) -> Result<bool>
 where
     C: ConnectionTrait,
@@ -562,6 +723,84 @@ fn validate_turn_output(id: TurnId, lease_token: uuid::Uuid, output: &Message) -
         ));
     }
     Ok(())
+}
+
+fn validate_turn_failure(
+    lease_token: uuid::Uuid,
+    error_code: &str,
+    error_detail: Option<&str>,
+) -> Result<()> {
+    if lease_token.is_nil() {
+        return Err(AgentError::Store("turn lease token must not be nil".into()));
+    }
+    let code_len = error_code.chars().count();
+    if error_code.contains('\0') || !(1..=TurnRun::MAX_ERROR_CODE_LEN).contains(&code_len) {
+        return Err(AgentError::Store(
+            "turn error code must contain 1 to 128 non-NUL characters".into(),
+        ));
+    }
+    if error_detail.is_some_and(|detail| {
+        detail.contains('\0')
+            || !(1..=TurnRun::MAX_ERROR_DETAIL_LEN).contains(&detail.chars().count())
+    }) {
+        return Err(AgentError::Store(
+            "turn error detail must contain 1 to 4096 non-NUL characters".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn exact_turn_failure_on<C>(
+    conn: &C,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    requested_retry_at: Option<chrono::DateTime<Utc>>,
+    error_code: &str,
+    error_detail: Option<&str>,
+) -> Result<Option<TurnFailureReceipt>>
+where
+    C: ConnectionTrait,
+{
+    let Some(existing) = entities::turn_failure::Entity::find_by_id(lease_token)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    if existing.turn_id != id.0
+        || existing.requested_retry_at != requested_retry_at
+        || existing.error_code != error_code
+        || existing.error_detail.as_deref() != error_detail
+    {
+        return Err(AgentError::Store(format!(
+            "turn failure token {lease_token} was already recorded with different data"
+        )));
+    }
+    Ok(Some(turn_failure_from_model(existing)?))
+}
+
+fn turn_failure_from_model(model: entities::turn_failure::Model) -> Result<TurnFailureReceipt> {
+    let result_status = turn_run_status_from_db(&model.result_status)?;
+    if !matches!(
+        result_status,
+        TurnRunStatus::RetryWait | TurnRunStatus::Failed
+    ) {
+        return Err(AgentError::Store(format!(
+            "invalid durable turn failure result: {}",
+            model.result_status
+        )));
+    }
+    Ok(TurnFailureReceipt {
+        lease_token: model.lease_token,
+        turn_id: TurnId(model.turn_id),
+        attempt_count: model.attempt_count,
+        requested_retry_at: model.requested_retry_at,
+        error_code: model.error_code,
+        error_detail: model.error_detail,
+        resolved_at: model.resolved_at,
+        result_status,
+    })
 }
 
 async fn exact_completed_turn_on(

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4789,6 +4789,31 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     .await
     .unwrap();
     running.insert(&store.conn).await.unwrap();
+
+    let valid_failure = entities::turn_failure::ActiveModel {
+        lease_token: Set(running_token),
+        turn_id: Set(running_turn_id),
+        attempt_count: Set(1),
+        requested_retry_at: Set(Some(now + chrono::Duration::minutes(2))),
+        error_code: Set("provider_unavailable".into()),
+        error_detail: Set(Some("temporary outage".into())),
+        resolved_at: Set(now + chrono::Duration::seconds(1)),
+        result_status: Set(TurnRunStatus::RetryWait.as_str().into()),
+    };
+    let mut retry_without_time = valid_failure.clone();
+    retry_without_time.requested_retry_at = Set(None);
+    assert!(retry_without_time.insert(&store.conn).await.is_err());
+    let mut nonfuture_retry = valid_failure.clone();
+    nonfuture_retry.requested_retry_at = Set(Some(now));
+    assert!(nonfuture_retry.insert(&store.conn).await.is_err());
+    let mut unknown_failure_status = valid_failure.clone();
+    unknown_failure_status.result_status = Set("lost".into());
+    assert!(unknown_failure_status.insert(&store.conn).await.is_err());
+    let mut mismatched_failure_claim = valid_failure.clone();
+    mismatched_failure_claim.attempt_count = Set(2);
+    assert!(mismatched_failure_claim.insert(&store.conn).await.is_err());
+    valid_failure.insert(&store.conn).await.unwrap();
+
     assert!(entities::turn_claim::ActiveModel {
         token: Set(uuid::Uuid::new_v4()),
         turn_id: Set(running_turn_id),
@@ -5396,6 +5421,455 @@ async fn turn_completion_atomically_persists_exact_output_and_recovers_retries()
         .await
         .is_err());
     assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn turn_failure_receipt_recovers_exact_retries_after_the_turn_advances() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(2),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let lease_expires_at = claimed_at + chrono::Duration::minutes(2);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, lease_expires_at)
+        .await
+        .unwrap()
+        .unwrap();
+    let resolved_at =
+        claimed_at + chrono::Duration::seconds(1) + chrono::Duration::nanoseconds(999);
+    let retry_at = resolved_at + chrono::Duration::minutes(1) + chrono::Duration::nanoseconds(777);
+    let canonical_resolved_at =
+        DateTime::<Utc>::from_timestamp_micros(resolved_at.timestamp_micros()).unwrap();
+    let canonical_retry_at =
+        DateTime::<Utc>::from_timestamp_micros(retry_at.timestamp_micros()).unwrap();
+
+    assert!(store
+        .record_turn_run_failure(
+            turn_id,
+            token,
+            resolved_at,
+            TurnFailureRetry::RetryAt(canonical_resolved_at + chrono::Duration::nanoseconds(999)),
+            "provider_unavailable",
+            None,
+        )
+        .await
+        .is_err());
+    assert_eq!(
+        store
+            .record_turn_run_failure(
+                turn_id,
+                uuid::Uuid::new_v4(),
+                resolved_at,
+                TurnFailureRetry::RetryAt(retry_at),
+                "provider_unavailable",
+                Some("temporary outage"),
+            )
+            .await
+            .unwrap(),
+        None
+    );
+
+    let RecordTurnFailureOutcome::Recorded(receipt) = store
+        .record_turn_run_failure(
+            turn_id,
+            token,
+            resolved_at,
+            TurnFailureRetry::RetryAt(retry_at),
+            "provider_unavailable",
+            Some("temporary outage"),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    else {
+        panic!("first exact failure must commit")
+    };
+    assert_eq!(receipt.lease_token, token);
+    assert_eq!(receipt.turn_id, turn_id);
+    assert_eq!(receipt.attempt_count, 1);
+    assert_eq!(receipt.requested_retry_at, Some(canonical_retry_at));
+    assert_eq!(receipt.resolved_at, canonical_resolved_at);
+    assert_eq!(receipt.result_status, TurnRunStatus::RetryWait);
+    assert_eq!(receipt.error_code, "provider_unavailable");
+    assert_eq!(receipt.error_detail.as_deref(), Some("temporary outage"));
+    let waiting = store.get_turn_run(turn_id).await.unwrap().unwrap();
+    assert_eq!(waiting.status, TurnRunStatus::RetryWait);
+    assert_eq!(waiting.available_at, canonical_retry_at);
+    assert_eq!(waiting.finished_at, None);
+    assert_eq!(waiting.lease_token, None);
+    assert_eq!(
+        waiting.last_error_code.as_deref(),
+        Some("provider_unavailable")
+    );
+
+    assert_eq!(
+        store
+            .record_turn_run_failure(
+                turn_id,
+                token,
+                canonical_retry_at + chrono::Duration::hours(1),
+                TurnFailureRetry::RetryAt(retry_at),
+                "provider_unavailable",
+                Some("temporary outage"),
+            )
+            .await
+            .unwrap(),
+        Some(RecordTurnFailureOutcome::Existing(receipt.clone()))
+    );
+    assert!(store
+        .record_turn_run_failure(
+            turn_id,
+            token,
+            resolved_at,
+            TurnFailureRetry::Permanent,
+            "provider_unavailable",
+            Some("temporary outage"),
+        )
+        .await
+        .is_err());
+    assert!(store
+        .record_turn_run_failure(
+            turn_id,
+            token,
+            resolved_at,
+            TurnFailureRetry::RetryAt(retry_at),
+            "provider_unavailable",
+            Some("different outage"),
+        )
+        .await
+        .is_err());
+
+    let second_token = uuid::Uuid::new_v4();
+    let second_expiry = canonical_retry_at + chrono::Duration::minutes(2);
+    let second = store
+        .claim_turn_run(second_token, canonical_retry_at, second_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.attempt_count, 2);
+    assert_eq!(second.last_error_code, None);
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "recovered".into(),
+        created_at: canonical_retry_at + chrono::Duration::seconds(1),
+    };
+    assert!(matches!(
+        store
+            .complete_turn_run(turn_id, second_token, output.created_at, &output)
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::Completed(_))
+    ));
+    assert_eq!(
+        store
+            .record_turn_run_failure(
+                turn_id,
+                token,
+                second_expiry + chrono::Duration::hours(1),
+                TurnFailureRetry::RetryAt(retry_at),
+                "provider_unavailable",
+                Some("temporary outage"),
+            )
+            .await
+            .unwrap(),
+        Some(RecordTurnFailureOutcome::Existing(receipt))
+    );
+}
+
+#[tokio::test]
+async fn turn_failure_exhaustion_retains_retry_intent_and_rolls_back_atomically() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(2))
+        .await
+        .unwrap()
+        .unwrap();
+    let failed_at = claimed_at + chrono::Duration::seconds(1);
+    let retry_at = failed_at + chrono::Duration::minutes(1);
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_turn_failure
+             BEFORE UPDATE OF status ON turn_run
+             WHEN NEW.status = 'failed'
+             BEGIN SELECT RAISE(FAIL, 'forced turn failure rollback'); END",
+        )
+        .await
+        .unwrap();
+    assert!(store
+        .record_turn_run_failure(
+            turn_id,
+            token,
+            failed_at,
+            TurnFailureRetry::RetryAt(retry_at),
+            "provider_error",
+            None,
+        )
+        .await
+        .is_err());
+    assert!(entities::turn_failure::Entity::find_by_id(token)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        store.get_turn_run(turn_id).await.unwrap().unwrap().status,
+        TurnRunStatus::Running
+    );
+    store
+        .conn
+        .execute_unprepared("DROP TRIGGER fail_turn_failure")
+        .await
+        .unwrap();
+
+    let RecordTurnFailureOutcome::Recorded(receipt) = store
+        .record_turn_run_failure(
+            turn_id,
+            token,
+            failed_at,
+            TurnFailureRetry::RetryAt(retry_at),
+            "provider_error",
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    else {
+        panic!("failure after rollback must commit")
+    };
+    assert_eq!(receipt.result_status, TurnRunStatus::Failed);
+    assert_eq!(receipt.requested_retry_at, Some(retry_at));
+    let failed = store.get_turn_run(turn_id).await.unwrap().unwrap();
+    assert_eq!(failed.status, TurnRunStatus::Failed);
+    assert_eq!(failed.finished_at, Some(failed_at));
+    assert_eq!(failed.available_at, accepted.available_at);
+    assert_eq!(failed.last_error_code.as_deref(), Some("provider_error"));
+}
+
+#[tokio::test]
+async fn permanent_turn_failure_uses_the_heartbeated_lease_and_rejects_expiry() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let original_expiry = claimed_at + chrono::Duration::minutes(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, original_expiry)
+        .await
+        .unwrap()
+        .unwrap();
+    let heartbeat_at = claimed_at + chrono::Duration::seconds(30);
+    let extended_expiry = original_expiry + chrono::Duration::minutes(1);
+    assert!(store
+        .heartbeat_turn_run(turn_id, token, heartbeat_at, extended_expiry)
+        .await
+        .unwrap());
+    let failed_at = original_expiry + chrono::Duration::seconds(1);
+    let RecordTurnFailureOutcome::Recorded(receipt) = store
+        .record_turn_run_failure(
+            turn_id,
+            token,
+            failed_at,
+            TurnFailureRetry::Permanent,
+            "unsafe_to_retry",
+            Some("tool outcome is ambiguous"),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    else {
+        panic!("live heartbeated failure must commit")
+    };
+    assert_eq!(receipt.requested_retry_at, None);
+    assert_eq!(receipt.resolved_at, failed_at);
+    assert_eq!(receipt.result_status, TurnRunStatus::Failed);
+    let failed = store.get_turn_run(turn_id).await.unwrap().unwrap();
+    assert_eq!(failed.status, TurnRunStatus::Failed);
+    assert_eq!(failed.finished_at, Some(failed_at));
+    assert_eq!(failed.last_error_code.as_deref(), Some("unsafe_to_retry"));
+
+    let expired_chat = sample_chat();
+    store.create_chat(&expired_chat).await.unwrap();
+    let expired_turn = match store
+        .accept_turn(TurnId::new(), expired_chat.id, "gpt-5", "expired")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let expired_claim_at = expired_turn.available_at + chrono::Duration::seconds(1);
+    let expired_at = expired_claim_at + chrono::Duration::minutes(1);
+    let expired_token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(expired_token, expired_claim_at, expired_at)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        store
+            .record_turn_run_failure(
+                expired_turn.id,
+                expired_token,
+                expired_at,
+                TurnFailureRetry::Permanent,
+                "too_late",
+                None,
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    assert!(entities::turn_failure::Entity::find_by_id(expired_token)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        store
+            .get_turn_run(expired_turn.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        TurnRunStatus::Running
+    );
+}
+
+#[tokio::test]
+async fn turn_completion_and_failure_serialize_to_one_terminal_decision() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(2),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(2))
+        .await
+        .unwrap()
+        .unwrap();
+    let resolved_at = claimed_at + chrono::Duration::seconds(1);
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "race winner".into(),
+        created_at: resolved_at,
+    };
+    let store = std::sync::Arc::new(store);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let completion = {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        let output = output.clone();
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .complete_turn_run(turn_id, token, resolved_at, &output)
+                .await
+        })
+    };
+    let failure = {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .record_turn_run_failure(
+                    turn_id,
+                    token,
+                    resolved_at,
+                    TurnFailureRetry::RetryAt(resolved_at + chrono::Duration::minutes(1)),
+                    "provider_error",
+                    None,
+                )
+                .await
+        })
+    };
+    let completion = completion.await.unwrap().unwrap();
+    let failure = failure.await.unwrap().unwrap();
+    let turn = store.get_turn_run(turn_id).await.unwrap().unwrap();
+    match (completion, failure) {
+        (Some(CompleteTurnRunOutcome::Completed(_)), None) => {
+            assert_eq!(turn.status, TurnRunStatus::Completed);
+            assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
+            assert!(entities::turn_failure::Entity::find_by_id(token)
+                .one(&store.conn)
+                .await
+                .unwrap()
+                .is_none());
+        }
+        (None, Some(RecordTurnFailureOutcome::Recorded(receipt))) => {
+            assert_eq!(receipt.result_status, TurnRunStatus::RetryWait);
+            assert_eq!(turn.status, TurnRunStatus::RetryWait);
+            assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
+        }
+        outcomes => panic!("unexpected completion/failure race: {outcomes:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -55,7 +55,8 @@ pub use model::{
     DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
     DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
     DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
-    Project, Role, SourceLocation, SourceRegion, ToolCallRecord, TurnRun, TurnRunStatus,
+    Project, Role, SourceLocation, SourceRegion, ToolCallRecord, TurnFailureReceipt,
+    TurnFailureRetry, TurnRun, TurnRunStatus,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
@@ -64,7 +65,8 @@ pub use provider::{
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
     AcceptTurnOutcome, BlobStore, CompleteTurnRunOutcome, DocumentIndexJobReason,
-    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, SecretProvider, Store,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, RecordTurnFailureOutcome,
+    SecretProvider, Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -709,6 +709,44 @@ impl TurnRunStatus {
     }
 }
 
+/// Retry intent attached to one exact turn-attempt failure.
+///
+/// Workers must retain this value across an ambiguous database commit. A new
+/// backoff timestamp is a different failure request and is rejected if the
+/// original request already committed under the same lease token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnFailureRetry {
+    /// Do not claim this turn again automatically.
+    Permanent,
+    /// Make the turn eligible for another claim at the exact requested time.
+    RetryAt(DateTime<Utc>),
+}
+
+/// Immutable proof that one exact claimed attempt recorded a failure.
+///
+/// The mutable turn can advance to a later attempt after a retryable failure,
+/// so this receipt is the durable idempotency record for ambiguous retries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnFailureReceipt {
+    /// Exact claim identity that submitted the failure.
+    pub lease_token: Uuid,
+    /// Turn resolved by the claim.
+    pub turn_id: TurnId,
+    /// Attempt number recorded in the immutable claim receipt.
+    pub attempt_count: i32,
+    /// Requested retry time, retained even when exhaustion made the failure
+    /// terminal. `None` represents an explicitly permanent failure.
+    pub requested_retry_at: Option<DateTime<Utc>>,
+    /// Stable machine-readable failure category.
+    pub error_code: String,
+    /// Bounded diagnostic detail for local operators.
+    pub error_detail: Option<String>,
+    /// Fresh operational time at which the first resolution committed.
+    pub resolved_at: DateTime<Utc>,
+    /// Historical result of this resolution (`retry_wait` or `failed`).
+    pub result_status: TurnRunStatus,
+}
+
 /// One message in a chat: user input or assistant text.
 ///
 /// Tool calls are not messages; they persist separately (the `tool_call` table)

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -25,7 +25,7 @@ use crate::model::{
     BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
     DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentRecord, DocumentScope,
     DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
-    TurnRun,
+    TurnFailureReceipt, TurnFailureRetry, TurnRun,
 };
 
 /// Why maintenance determined that a document needs an index job.
@@ -102,6 +102,15 @@ pub enum CompleteTurnRunOutcome {
     Completed(TurnRun),
     /// This exact completion was already committed by an earlier call.
     Existing(TurnRun),
+}
+
+/// Result of recording one exact claimed turn failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecordTurnFailureOutcome {
+    /// This call committed the receipt and state transition.
+    Recorded(TurnFailureReceipt),
+    /// This exact failure request was already committed by an earlier call.
+    Existing(TurnFailureReceipt),
 }
 
 fn document_storage_unavailable<T>() -> Result<T> {
@@ -626,6 +635,28 @@ pub trait Store: Send + Sync {
         _now: chrono::DateTime<chrono::Utc>,
         _output: &Message,
     ) -> Result<Option<CompleteTurnRunOutcome>> {
+        turn_storage_unavailable()
+    }
+
+    /// Atomically record a failure for one exact live claimed attempt.
+    ///
+    /// `now` is a fresh operational lease fence and is not part of the stable
+    /// request identity. An exact retry is identified by the turn, claim token,
+    /// retry intent, error code, and error detail; it returns `Existing` even if
+    /// a later attempt has already advanced the mutable turn. Reusing a token
+    /// with different request data is an error. A requested retry moves the turn
+    /// to `retry_wait` only while attempts remain; otherwise the result is
+    /// terminally `failed`. Returns `None` when this claim did not win the live
+    /// attempt or another resolution already did.
+    async fn record_turn_run_failure(
+        &self,
+        _id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+        _retry: TurnFailureRetry,
+        _error_code: &str,
+        _error_detail: Option<&str>,
+    ) -> Result<Option<RecordTurnFailureOutcome>> {
         turn_storage_unavailable()
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use chrono::{Duration, Utc};
 use openwave_core::{
-    AcceptTurnOutcome, Chat, ChatId, CompleteTurnRunOutcome, DbStore, Message, MessageId, Role,
-    Store, TurnId, TurnRunStatus,
+    AcceptTurnOutcome, Chat, ChatId, CompleteTurnRunOutcome, DbStore, Message, MessageId,
+    RecordTurnFailureOutcome, Role, Store, TurnFailureRetry, TurnId, TurnRunStatus,
 };
 
 fn sample_chat() -> Chat {
@@ -175,4 +175,75 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
     }
     assert_eq!((committed, existing), (1, 1));
     assert_eq!(store.list_messages(next_chat.id).await.unwrap().len(), 2);
+
+    let failure_chat = sample_chat();
+    store.create_chat(&failure_chat).await.unwrap();
+    let failure_turn = match store
+        .accept_turn(TurnId::new(), failure_chat.id, "gpt-5", "postgres failure")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let failure_token = uuid::Uuid::new_v4();
+    let failure_claimed_at = failure_turn.available_at + Duration::seconds(1);
+    let failure_at = failure_claimed_at + Duration::seconds(1);
+    let requested_retry_at = failure_at + Duration::minutes(1);
+    store
+        .claim_turn_run(
+            failure_token,
+            failure_claimed_at,
+            failure_claimed_at + Duration::minutes(2),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let mut failures = Vec::new();
+    for _ in 0..2 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        failures.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .record_turn_run_failure(
+                    failure_turn.id,
+                    failure_token,
+                    failure_at,
+                    TurnFailureRetry::RetryAt(requested_retry_at),
+                    "provider_unavailable",
+                    Some("temporary outage"),
+                )
+                .await
+                .unwrap()
+                .unwrap()
+        }));
+    }
+    let mut recorded = 0;
+    let mut failure_existing = 0;
+    for failure in failures {
+        match failure.await.unwrap() {
+            RecordTurnFailureOutcome::Recorded(receipt) => {
+                recorded += 1;
+                assert_eq!(receipt.result_status, TurnRunStatus::Failed);
+                assert_eq!(receipt.requested_retry_at, Some(requested_retry_at));
+            }
+            RecordTurnFailureOutcome::Existing(receipt) => {
+                failure_existing += 1;
+                assert_eq!(receipt.result_status, TurnRunStatus::Failed);
+                assert_eq!(receipt.requested_retry_at, Some(requested_retry_at));
+            }
+        }
+    }
+    assert_eq!((recorded, failure_existing), (1, 1));
+    assert_eq!(
+        store
+            .get_turn_run(failure_turn.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        TurnRunStatus::Failed
+    );
 }


### PR DESCRIPTION
## Summary

- add immutable receipts for exact claimed-turn failures
- atomically transition live attempts to retry wait or terminal failure
- recover exact ambiguous retries after the mutable turn has advanced

## Details

Failure receipts preserve the claim identity, requested retry time, bounded diagnostics, first resolution time, and historical result. A fresh operational timestamp fences the live lease without becoming part of the stable failure-request identity.

Retry requests schedule another attempt only while the attempt budget permits it. Exhausted or explicitly permanent failures become terminal while retaining the original retry intent for exact replay and audit.

Completion and failure resolution serialize on the exact turn lock. The winning transition commits its message or receipt with the state update; the losing first-time call has no partial side effect.

## Validation

- 187 all-feature `openwave-core` tests
- full workspace all-feature test suite
- `bw dev lint --rust`
- SQLite concurrency, schema, rollback, stale ownership, and historical replay coverage
- PostgreSQL concurrent identical failure coverage in the required integration lane
