### PR TITLE
fix(core): tolerate competing turn claim receipts

### DIFF
--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -278,13 +278,46 @@ pub(in crate::db) async fn claim_turn_run(
             claimed_at: Set(now),
             lease_expires_at: Set(lease_expires_at),
         })
-        .on_conflict_do_nothing()
+        .on_conflict(
+            sea_orm::sea_query::OnConflict::new()
+                .do_nothing()
+                .to_owned(),
+        )
+        .do_nothing()
         .exec_without_returning(&transaction)
         .await
         .map_err(store_err)?;
         if !matches!(receipt, TryInsertResult::Inserted(1)) {
             transaction.rollback().await.map_err(store_err)?;
-            continue;
+            if entities::turn_claim::Entity::find_by_id(lease_token)
+                .one(&store.conn)
+                .await
+                .map_err(store_err)?
+                .is_some()
+            {
+                continue;
+            }
+            let conflicting_attempt = entities::turn_claim::Entity::find()
+                .filter(entities::turn_claim::Column::TurnId.eq(candidate.id))
+                .filter(entities::turn_claim::Column::AttemptCount.eq(next_attempt))
+                .one(&store.conn)
+                .await
+                .map_err(store_err)?;
+            let current = entities::turn_run::Entity::find_by_id(candidate.id)
+                .one(&store.conn)
+                .await
+                .map_err(store_err)?;
+            if conflicting_attempt.is_some()
+                && current
+                    .as_ref()
+                    .is_some_and(|turn| turn.attempt_count >= next_attempt)
+            {
+                continue;
+            }
+            return Err(AgentError::Store(format!(
+                "turn {} claim receipt for attempt {next_attempt} exists before the turn advanced",
+                TurnId(candidate.id)
+            )));
         }
         let claim = entities::turn_run::Entity::update_many()
             .col_expr(

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5313,6 +5313,56 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
 }
 
 #[tokio::test]
+async fn turn_claim_rejects_a_receipt_for_an_attempt_that_never_advanced() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let accepted = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    entities::turn_claim::ActiveModel {
+        token: Set(uuid::Uuid::new_v4()),
+        turn_id: Set(accepted.id.0),
+        attempt_count: Set(1),
+        claimed_at: Set(claimed_at),
+        lease_expires_at: Set(claimed_at + chrono::Duration::minutes(1)),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        store.claim_turn_run(
+            uuid::Uuid::new_v4(),
+            claimed_at,
+            claimed_at + chrono::Duration::minutes(1),
+        ),
+    )
+    .await
+    .expect("claim must not spin on an inconsistent attempt receipt");
+    let AgentError::Store(message) = result.unwrap_err() else {
+        panic!("unexpected claim error")
+    };
+    assert!(message.contains("exists before the turn advanced"));
+    assert_eq!(
+        store
+            .get_turn_run(accepted.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        TurnRunStatus::Queued
+    );
+}
+
+#[tokio::test]
 async fn turn_completion_atomically_persists_exact_output_and_recovers_retries() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();


### PR DESCRIPTION
## Summary

- tolerate every unique-key collision while inserting immutable turn claim receipts
- rescan after a competing `(turn_id, attempt_count)` receipt wins
- preserve exact-token retry behavior

## Rationale

PostgreSQL claimers can select the same queued turn before either exact CAS commits. The receipt table uniquely constrains both the caller token and the turn attempt, but the prior helper generated conflict handling only for the token primary key. A losing attempt-key insert therefore surfaced a database error instead of following the existing rescan path.

Targetless `ON CONFLICT DO NOTHING` covers both immutable receipt identities. `TryInsertResult` still distinguishes the winner from a no-op so only the winner proceeds to the turn CAS.

After a suppressed conflict, the loser audits the committed receipt. A legitimate competing winner must have advanced the turn attempt; a prewritten receipt for an attempt that never advanced is reported as store corruption instead of being rescanned forever.

## Validation

- real PostgreSQL 17 concurrent-claimer integration test passed five consecutive runs
- 188 all-feature `openwave-core` tests, including bounded inconsistent-receipt coverage
- `bw dev lint --rust`
- `git diff --check`
