### PR TITLE
feat(core): cancel turns durably

### DIFF
--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -152,17 +152,22 @@ impl MigrationTrait for Init {
         let valid_turn_status = Expr::col(TurnRun::Status).is_in([
             TurnRunStatus::Queued.as_str(),
             TurnRunStatus::Running.as_str(),
+            TurnRunStatus::Cancelling.as_str(),
             TurnRunStatus::RetryWait.as_str(),
             TurnRunStatus::Completed.as_str(),
             TurnRunStatus::Failed.as_str(),
             TurnRunStatus::Cancelled.as_str(),
         ]);
-        let running_lease = Expr::col(TurnRun::Status)
-            .eq(TurnRunStatus::Running.as_str())
+        let active_lease = Expr::col(TurnRun::Status)
+            .is_in([
+                TurnRunStatus::Running.as_str(),
+                TurnRunStatus::Cancelling.as_str(),
+            ])
             .and(Expr::col(TurnRun::LeaseToken).is_not_null())
             .and(Expr::col(TurnRun::LeaseExpiresAt).is_not_null());
         let no_lease = Expr::col(TurnRun::Status)
             .ne(TurnRunStatus::Running.as_str())
+            .and(Expr::col(TurnRun::Status).ne(TurnRunStatus::Cancelling.as_str()))
             .and(Expr::col(TurnRun::LeaseToken).is_null())
             .and(Expr::col(TurnRun::LeaseExpiresAt).is_null());
         let completed_output = Expr::col(TurnRun::Status)
@@ -182,6 +187,7 @@ impl MigrationTrait for Init {
             .is_in([
                 TurnRunStatus::Queued.as_str(),
                 TurnRunStatus::Running.as_str(),
+                TurnRunStatus::Cancelling.as_str(),
                 TurnRunStatus::RetryWait.as_str(),
             ])
             .and(Expr::col(TurnRun::FinishedAt).is_null());
@@ -189,8 +195,11 @@ impl MigrationTrait for Init {
             .eq(TurnRunStatus::Queued.as_str())
             .and(Expr::col(TurnRun::AttemptCount).eq(0))
             .and(Expr::col(TurnRun::StartedAt).is_null());
-        let running_attempt = Expr::col(TurnRun::Status)
-            .eq(TurnRunStatus::Running.as_str())
+        let leased_attempt = Expr::col(TurnRun::Status)
+            .is_in([
+                TurnRunStatus::Running.as_str(),
+                TurnRunStatus::Cancelling.as_str(),
+            ])
             .and(Expr::col(TurnRun::AttemptCount).gte(1))
             .and(Expr::col(TurnRun::StartedAt).is_not_null());
         let retryable_attempt = Expr::col(TurnRun::Status)
@@ -225,6 +234,7 @@ impl MigrationTrait for Init {
             .is_in([
                 TurnRunStatus::Queued.as_str(),
                 TurnRunStatus::Running.as_str(),
+                TurnRunStatus::Cancelling.as_str(),
                 TurnRunStatus::Completed.as_str(),
                 TurnRunStatus::Cancelled.as_str(),
             ])
@@ -350,12 +360,12 @@ impl MigrationTrait for Init {
                                     .lte(Expr::col(TurnRun::MaxAttempts)),
                             ),
                     )
-                    .check(running_lease.or(no_lease))
+                    .check(active_lease.or(no_lease))
                     .check(completed_output.or(no_output))
                     .check(terminal_finished.or(nonterminal_unfinished))
                     .check(
                         queued_attempt
-                            .or(running_attempt)
+                            .or(leased_attempt)
                             .or(retryable_attempt)
                             .or(resolved_attempt)
                             .or(cancelled_attempt),
@@ -397,6 +407,7 @@ impl MigrationTrait for Init {
                     .and_where(Expr::col(TurnRun::Status).is_in([
                         TurnRunStatus::Queued.as_str(),
                         TurnRunStatus::Running.as_str(),
+                        TurnRunStatus::Cancelling.as_str(),
                         TurnRunStatus::RetryWait.as_str(),
                     ]))
                     .to_owned(),

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -34,7 +34,8 @@ use crate::model::{
 };
 use crate::storage::{
     AcceptTurnOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
-    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, RecordTurnFailureOutcome, Store,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, Store,
 };
 
 mod ops;
@@ -1710,6 +1711,23 @@ impl Store for DbStore {
             error_detail,
         )
         .await
+    }
+
+    async fn request_turn_cancellation(
+        &self,
+        id: TurnId,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<Option<RequestTurnCancellationOutcome>> {
+        ops::turn::request_turn_cancellation(self, id, now).await
+    }
+
+    async fn finish_turn_cancellation(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<Option<FinishTurnCancellationOutcome>> {
+        ops::turn::finish_turn_cancellation(self, id, lease_token, now).await
     }
 
     async fn append_message(&self, message: &Message) -> Result<()> {

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -7,7 +7,10 @@ use sea_orm::{
 use crate::error::{AgentError, Result};
 use crate::id::{ChatId, MessageId, TurnId};
 use crate::model::{Message, Role, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus};
-use crate::storage::{AcceptTurnOutcome, CompleteTurnRunOutcome, RecordTurnFailureOutcome};
+use crate::storage::{
+    AcceptTurnOutcome, CompleteTurnRunOutcome, FinishTurnCancellationOutcome,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome,
+};
 
 use super::super::{entities, store_err, DbStore};
 
@@ -195,7 +198,10 @@ pub(in crate::db) async fn claim_turn_run(
             .await
             .map_err(store_err)?;
         let expired = entities::turn_run::Entity::find()
-            .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
+            .filter(entities::turn_run::Column::Status.is_in([
+                TurnRunStatus::Running.as_str(),
+                TurnRunStatus::Cancelling.as_str(),
+            ]))
             .filter(entities::turn_run::Column::LeaseExpiresAt.lte(now))
             .filter(entities::turn_run::Column::UpdatedAt.lte(now))
             .order_by_asc(entities::turn_run::Column::LeaseExpiresAt)
@@ -219,6 +225,47 @@ pub(in crate::db) async fn claim_turn_run(
             transaction.commit().await.map_err(store_err)?;
             return Ok(None);
         };
+
+        if candidate.status == TurnRunStatus::Cancelling.as_str() {
+            let cancelled = entities::turn_run::Entity::update_many()
+                .col_expr(
+                    entities::turn_run::Column::Status,
+                    sea_orm::sea_query::Expr::value(TurnRunStatus::Cancelled.as_str()),
+                )
+                .col_expr(
+                    entities::turn_run::Column::LeaseToken,
+                    sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+                )
+                .col_expr(
+                    entities::turn_run::Column::LeaseExpiresAt,
+                    sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+                )
+                .col_expr(
+                    entities::turn_run::Column::FinishedAt,
+                    sea_orm::sea_query::Expr::value(Some(now)),
+                )
+                .col_expr(
+                    entities::turn_run::Column::UpdatedAt,
+                    sea_orm::sea_query::Expr::value(now),
+                )
+                .filter(entities::turn_run::Column::Id.eq(candidate.id))
+                .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Cancelling.as_str()))
+                .filter(entities::turn_run::Column::AttemptCount.eq(candidate.attempt_count))
+                .filter(entities::turn_run::Column::LeaseToken.eq(candidate.lease_token))
+                .filter(entities::turn_run::Column::LeaseExpiresAt.eq(candidate.lease_expires_at))
+                .filter(entities::turn_run::Column::LeaseExpiresAt.lte(now))
+                .filter(entities::turn_run::Column::UpdatedAt.eq(candidate.updated_at))
+                .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+                .exec(&transaction)
+                .await
+                .map_err(store_err)?;
+            if cancelled.rows_affected != 1 {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+            transaction.commit().await.map_err(store_err)?;
+            continue;
+        }
 
         let reclaiming = candidate.status == TurnRunStatus::Running.as_str();
         if reclaiming && candidate.attempt_count >= candidate.max_attempts {
@@ -714,6 +761,199 @@ pub(in crate::db) async fn record_turn_run_failure(
     Ok(Some(RecordTurnFailureOutcome::Recorded(receipt)))
 }
 
+pub(in crate::db) async fn request_turn_cancellation(
+    store: &DbStore,
+    id: TurnId,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<RequestTurnCancellationOutcome>> {
+    let now = canonical_db_timestamp(now)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_exact_turn_write_lock(&transaction, id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let Some(turn) = entities::turn_run::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let status = turn_run_status_from_db(&turn.status)?;
+    match status {
+        TurnRunStatus::Cancelling | TurnRunStatus::Cancelled => {
+            let turn = turn_run_from_model(turn)?;
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(RequestTurnCancellationOutcome::Existing(turn)));
+        }
+        TurnRunStatus::Completed | TurnRunStatus::Failed => {
+            let turn = turn_run_from_model(turn)?;
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(RequestTurnCancellationOutcome::AlreadyTerminal(turn)));
+        }
+        TurnRunStatus::Queued | TurnRunStatus::Running | TurnRunStatus::RetryWait => {}
+    }
+    if turn.updated_at > now {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let next_status = if status == TurnRunStatus::Running {
+        TurnRunStatus::Cancelling
+    } else {
+        TurnRunStatus::Cancelled
+    };
+    let update = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(next_status.as_str()),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        );
+    let update = if next_status == TurnRunStatus::Cancelled {
+        update
+            .col_expr(
+                entities::turn_run::Column::FinishedAt,
+                sea_orm::sea_query::Expr::value(Some(now)),
+            )
+            .col_expr(
+                entities::turn_run::Column::LastErrorCode,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entities::turn_run::Column::LastErrorDetail,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+    } else {
+        update
+    };
+    let update = update
+        .filter(entities::turn_run::Column::Id.eq(id.0))
+        .filter(entities::turn_run::Column::Status.eq(&turn.status))
+        .filter(entities::turn_run::Column::AttemptCount.eq(turn.attempt_count))
+        .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at))
+        .filter(entities::turn_run::Column::UpdatedAt.lte(now));
+    let update = if status == TurnRunStatus::Running {
+        update
+            .filter(entities::turn_run::Column::LeaseToken.eq(turn.lease_token))
+            .filter(entities::turn_run::Column::LeaseExpiresAt.eq(turn.lease_expires_at))
+    } else {
+        update
+    };
+    let cancelled = update.exec(&transaction).await.map_err(store_err)?;
+    if cancelled.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let updated = entities::turn_run::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("cancelled turn {id} disappeared")))
+        .and_then(turn_run_from_model)?;
+    transaction.commit().await.map_err(store_err)?;
+    if next_status == TurnRunStatus::Cancelling {
+        Ok(Some(RequestTurnCancellationOutcome::Requested(updated)))
+    } else {
+        Ok(Some(RequestTurnCancellationOutcome::Cancelled(updated)))
+    }
+}
+
+pub(in crate::db) async fn finish_turn_cancellation(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<FinishTurnCancellationOutcome>> {
+    if lease_token.is_nil() {
+        return Err(AgentError::Store("turn lease token must not be nil".into()));
+    }
+    let now = canonical_db_timestamp(now)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_exact_turn_write_lock(&transaction, id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let Some(claim) = entities::turn_claim::Entity::find_by_id(lease_token)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .filter(|claim| claim.turn_id == id.0)
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let Some(turn) = entities::turn_run::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if turn.status == TurnRunStatus::Cancelled.as_str() && turn.attempt_count == claim.attempt_count
+    {
+        let turn = turn_run_from_model(turn)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(FinishTurnCancellationOutcome::Existing(turn)));
+    }
+    if turn.status != TurnRunStatus::Cancelling.as_str()
+        || turn.attempt_count != claim.attempt_count
+        || turn.lease_token != Some(lease_token)
+        || turn.updated_at > now
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let cancelled = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnRunStatus::Cancelled.as_str()),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::turn_run::Column::Id.eq(id.0))
+        .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Cancelling.as_str()))
+        .filter(entities::turn_run::Column::AttemptCount.eq(claim.attempt_count))
+        .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.eq(turn.lease_expires_at))
+        .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at))
+        .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if cancelled.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let cancelled = entities::turn_run::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("cancelled turn {id} disappeared")))
+        .and_then(turn_run_from_model)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(FinishTurnCancellationOutcome::Cancelled(cancelled)))
+}
+
 async fn acquire_exact_turn_write_lock<C>(conn: &C, id: TurnId) -> Result<bool>
 where
     C: ConnectionTrait,
@@ -911,7 +1151,9 @@ fn turn_run_due_order(
     right: &entities::turn_run::Model,
 ) -> std::cmp::Ordering {
     let due_at = |run: &entities::turn_run::Model| {
-        if run.status == TurnRunStatus::Running.as_str() {
+        if run.status == TurnRunStatus::Running.as_str()
+            || run.status == TurnRunStatus::Cancelling.as_str()
+        {
             run.lease_expires_at.unwrap_or(run.available_at)
         } else {
             run.available_at
@@ -953,6 +1195,7 @@ where
         .filter(entities::turn_run::Column::Status.is_in([
             TurnRunStatus::Queued.as_str(),
             TurnRunStatus::Running.as_str(),
+            TurnRunStatus::Cancelling.as_str(),
             TurnRunStatus::RetryWait.as_str(),
         ]))
         .one(conn)
@@ -1021,6 +1264,7 @@ fn turn_run_status_from_db(text: &str) -> Result<TurnRunStatus> {
     match text {
         "queued" => Ok(TurnRunStatus::Queued),
         "running" => Ok(TurnRunStatus::Running),
+        "cancelling" => Ok(TurnRunStatus::Cancelling),
         "retry_wait" => Ok(TurnRunStatus::RetryWait),
         "completed" => Ok(TurnRunStatus::Completed),
         "failed" => Ok(TurnRunStatus::Failed),

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -2067,6 +2067,7 @@ async fn document_job_schema_enforces_delivery_and_idempotency_invariants() {
     running_without_lease.attempt_count = Set(1);
     running_without_lease.started_at = Set(Some(now));
     assert!(running_without_lease.insert(&store.conn).await.is_err());
+
     let mut running_without_attempt = make_job(&another_document, "pipeline-v1");
     running_without_attempt.status = Set(DocumentJobStatus::Running.as_str().into());
     running_without_attempt.lease_token = Set(Some(uuid::Uuid::new_v4()));
@@ -4692,6 +4693,13 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     running_without_lease.started_at = Set(Some(now));
     assert!(running_without_lease.insert(&store.conn).await.is_err());
 
+    let mut cancelling_without_lease =
+        make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
+    cancelling_without_lease.status = Set(TurnRunStatus::Cancelling.as_str().into());
+    cancelling_without_lease.attempt_count = Set(1);
+    cancelling_without_lease.started_at = Set(Some(now));
+    assert!(cancelling_without_lease.insert(&store.conn).await.is_err());
+
     let mut retry_without_error = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     retry_without_error.status = Set(TurnRunStatus::RetryWait.as_str().into());
     retry_without_error.attempt_count = Set(1);
@@ -4789,6 +4797,20 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     .await
     .unwrap();
     running.insert(&store.conn).await.unwrap();
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnRunStatus::Cancelling.as_str()),
+        )
+        .filter(entities::turn_run::Column::Id.eq(running_turn_id))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert!(make_queued_turn(&store, running_chat.id, "gpt-5", now)
+        .await
+        .insert(&store.conn)
+        .await
+        .is_err());
 
     let valid_failure = entities::turn_failure::ActiveModel {
         lease_token: Set(running_token),
@@ -5829,6 +5851,446 @@ async fn permanent_turn_failure_uses_the_heartbeated_lease_and_rejects_expiry() 
             .status,
         TurnRunStatus::Running
     );
+}
+
+#[tokio::test]
+async fn queued_and_retry_wait_turns_cancel_immediately_and_idempotently() {
+    let (_dir, store) = temp_store().await;
+    let queued_chat = sample_chat();
+    store.create_chat(&queued_chat).await.unwrap();
+    let queued = match store
+        .accept_turn(TurnId::new(), queued_chat.id, "gpt-5", "queued")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    assert_eq!(
+        store
+            .request_turn_cancellation(queued.id, queued.updated_at - chrono::Duration::seconds(1))
+            .await
+            .unwrap(),
+        None
+    );
+    let cancelled_at = queued.updated_at + chrono::Duration::seconds(1);
+    let RequestTurnCancellationOutcome::Cancelled(cancelled) = store
+        .request_turn_cancellation(queued.id, cancelled_at)
+        .await
+        .unwrap()
+        .unwrap()
+    else {
+        panic!("queued cancellation must be immediate")
+    };
+    assert_eq!(cancelled.status, TurnRunStatus::Cancelled);
+    assert_eq!(cancelled.attempt_count, 0);
+    assert_eq!(cancelled.finished_at, Some(cancelled_at));
+    assert_eq!(
+        store
+            .request_turn_cancellation(queued.id, queued.updated_at)
+            .await
+            .unwrap(),
+        Some(RequestTurnCancellationOutcome::Existing(cancelled))
+    );
+    let after_cancel = match store
+        .accept_turn(TurnId::new(), queued_chat.id, "gpt-5", "after cancel")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    assert!(matches!(
+        store
+            .request_turn_cancellation(
+                after_cancel.id,
+                after_cancel.updated_at + chrono::Duration::seconds(1),
+            )
+            .await
+            .unwrap(),
+        Some(RequestTurnCancellationOutcome::Cancelled(_))
+    ));
+
+    let retry_chat = sample_chat();
+    store.create_chat(&retry_chat).await.unwrap();
+    let retry_turn = match store
+        .accept_turn(TurnId::new(), retry_chat.id, "gpt-5", "retry")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(2),
+        )
+        .filter(entities::turn_run::Column::Id.eq(retry_turn.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let claimed_at = retry_turn.available_at + chrono::Duration::seconds(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(2))
+        .await
+        .unwrap()
+        .unwrap();
+    let failed_at = claimed_at + chrono::Duration::seconds(1);
+    let retry_at = failed_at + chrono::Duration::minutes(1);
+    let RecordTurnFailureOutcome::Recorded(receipt) = store
+        .record_turn_run_failure(
+            retry_turn.id,
+            token,
+            failed_at,
+            TurnFailureRetry::RetryAt(retry_at),
+            "provider_unavailable",
+            Some("temporary outage"),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    else {
+        panic!("retryable failure must commit")
+    };
+    let retry_cancelled_at = failed_at + chrono::Duration::seconds(1);
+    let RequestTurnCancellationOutcome::Cancelled(cancelled) = store
+        .request_turn_cancellation(retry_turn.id, retry_cancelled_at)
+        .await
+        .unwrap()
+        .unwrap()
+    else {
+        panic!("retry-wait cancellation must be immediate")
+    };
+    assert_eq!(cancelled.status, TurnRunStatus::Cancelled);
+    assert_eq!(cancelled.finished_at, Some(retry_cancelled_at));
+    assert_eq!(cancelled.last_error_code, None);
+    assert_eq!(cancelled.last_error_detail, None);
+    assert_eq!(
+        store
+            .record_turn_run_failure(
+                retry_turn.id,
+                token,
+                retry_cancelled_at,
+                TurnFailureRetry::RetryAt(retry_at),
+                "provider_unavailable",
+                Some("temporary outage"),
+            )
+            .await
+            .unwrap(),
+        Some(RecordTurnFailureOutcome::Existing(receipt))
+    );
+}
+
+#[tokio::test]
+async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledgement() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "running")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = turn.available_at + chrono::Duration::seconds(1);
+    let expires_at = claimed_at + chrono::Duration::minutes(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, expires_at)
+        .await
+        .unwrap()
+        .unwrap();
+    let requested_at = claimed_at + chrono::Duration::seconds(1);
+    let RequestTurnCancellationOutcome::Requested(cancelling) = store
+        .request_turn_cancellation(turn.id, requested_at)
+        .await
+        .unwrap()
+        .unwrap()
+    else {
+        panic!("running cancellation must await worker acknowledgement")
+    };
+    assert_eq!(cancelling.status, TurnRunStatus::Cancelling);
+    assert_eq!(cancelling.lease_token, Some(token));
+    assert_eq!(cancelling.lease_expires_at, Some(expires_at));
+    assert_eq!(cancelling.finished_at, None);
+    assert!(!store
+        .heartbeat_turn_run(
+            turn.id,
+            token,
+            requested_at + chrono::Duration::seconds(1),
+            expires_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap());
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: turn.id,
+        role: Role::Assistant,
+        content: "too late".into(),
+        created_at: requested_at + chrono::Duration::seconds(1),
+    };
+    assert_eq!(
+        store
+            .complete_turn_run(turn.id, token, output.created_at, &output)
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        store
+            .record_turn_run_failure(
+                turn.id,
+                token,
+                output.created_at,
+                TurnFailureRetry::Permanent,
+                "too_late",
+                None,
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    assert!(matches!(
+        store
+            .accept_turn(TurnId::new(), chat.id, "gpt-5", "must remain busy")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::ChatBusy(active) if active.status == TurnRunStatus::Cancelling
+    ));
+    assert_eq!(
+        store
+            .request_turn_cancellation(turn.id, claimed_at)
+            .await
+            .unwrap(),
+        Some(RequestTurnCancellationOutcome::Existing(cancelling))
+    );
+    assert!(store
+        .finish_turn_cancellation(turn.id, uuid::Uuid::nil(), requested_at)
+        .await
+        .is_err());
+    assert_eq!(
+        store
+            .finish_turn_cancellation(turn.id, uuid::Uuid::new_v4(), requested_at)
+            .await
+            .unwrap(),
+        None
+    );
+
+    let acknowledged_at = expires_at + chrono::Duration::seconds(1);
+    let FinishTurnCancellationOutcome::Cancelled(cancelled) = store
+        .finish_turn_cancellation(turn.id, token, acknowledged_at)
+        .await
+        .unwrap()
+        .unwrap()
+    else {
+        panic!("exact worker acknowledgement must cancel")
+    };
+    assert_eq!(cancelled.status, TurnRunStatus::Cancelled);
+    assert_eq!(cancelled.lease_token, None);
+    assert_eq!(cancelled.lease_expires_at, None);
+    assert_eq!(cancelled.finished_at, Some(acknowledged_at));
+    assert_eq!(
+        store
+            .finish_turn_cancellation(turn.id, token, acknowledged_at + chrono::Duration::hours(1),)
+            .await
+            .unwrap(),
+        Some(FinishTurnCancellationOutcome::Existing(cancelled))
+    );
+    assert!(matches!(
+        store
+            .accept_turn(TurnId::new(), chat.id, "gpt-5", "after acknowledgement")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::Accepted(_)
+    ));
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn claim_scan_terminalizes_an_expired_cancelling_lease() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "cancel and crash")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = turn.available_at + chrono::Duration::seconds(1);
+    let expires_at = claimed_at + chrono::Duration::minutes(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, expires_at)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        store
+            .request_turn_cancellation(turn.id, claimed_at + chrono::Duration::seconds(1))
+            .await
+            .unwrap(),
+        Some(RequestTurnCancellationOutcome::Requested(_))
+    ));
+
+    assert_eq!(
+        store
+            .claim_turn_run(
+                uuid::Uuid::new_v4(),
+                expires_at,
+                expires_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        None
+    );
+    let cancelled = store.get_turn_run(turn.id).await.unwrap().unwrap();
+    assert_eq!(cancelled.status, TurnRunStatus::Cancelled);
+    assert_eq!(cancelled.finished_at, Some(expires_at));
+    assert_eq!(cancelled.lease_token, None);
+    assert_eq!(
+        store
+            .finish_turn_cancellation(turn.id, token, expires_at + chrono::Duration::hours(1),)
+            .await
+            .unwrap(),
+        Some(FinishTurnCancellationOutcome::Existing(cancelled))
+    );
+    assert!(matches!(
+        store
+            .accept_turn(TurnId::new(), chat.id, "gpt-5", "slot recovered")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::Accepted(_)
+    ));
+}
+
+#[tokio::test]
+async fn concurrent_cancellation_requests_converge_on_one_running_turn() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "cancel concurrently")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = turn.available_at + chrono::Duration::seconds(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .unwrap();
+    let store = std::sync::Arc::new(store);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
+    let requested_at = claimed_at + chrono::Duration::seconds(1);
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store.request_turn_cancellation(turn.id, requested_at).await
+        }));
+    }
+    let mut requested = 0;
+    let mut existing = 0;
+    for task in tasks {
+        match task.await.unwrap().unwrap().unwrap() {
+            RequestTurnCancellationOutcome::Requested(cancelling) => {
+                requested += 1;
+                assert_eq!(cancelling.lease_token, Some(token));
+            }
+            RequestTurnCancellationOutcome::Existing(cancelling) => {
+                existing += 1;
+                assert_eq!(cancelling.status, TurnRunStatus::Cancelling);
+                assert_eq!(cancelling.lease_token, Some(token));
+            }
+            outcome => panic!("unexpected concurrent cancellation outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!((requested, existing), (1, 7));
+    assert_eq!(
+        store.get_turn_run(turn.id).await.unwrap().unwrap().status,
+        TurnRunStatus::Cancelling
+    );
+}
+
+#[tokio::test]
+async fn turn_completion_and_cancellation_serialize_to_one_decision() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "race cancellation")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = turn.available_at + chrono::Duration::seconds(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .unwrap();
+    let decided_at = claimed_at + chrono::Duration::seconds(1);
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: turn.id,
+        role: Role::Assistant,
+        content: "race answer".into(),
+        created_at: decided_at,
+    };
+    let store = std::sync::Arc::new(store);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let completion = {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .complete_turn_run(turn.id, token, decided_at, &output)
+                .await
+        })
+    };
+    let cancellation = {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store.request_turn_cancellation(turn.id, decided_at).await
+        })
+    };
+    let completion = completion.await.unwrap().unwrap();
+    let cancellation = cancellation.await.unwrap().unwrap().unwrap();
+    match (completion, cancellation) {
+        (
+            Some(CompleteTurnRunOutcome::Completed(completed)),
+            RequestTurnCancellationOutcome::AlreadyTerminal(observed),
+        ) => {
+            assert_eq!(observed, completed);
+            assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
+        }
+        (None, RequestTurnCancellationOutcome::Requested(cancelling)) => {
+            assert_eq!(cancelling.status, TurnRunStatus::Cancelling);
+            assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
+        }
+        outcomes => panic!("unexpected completion/cancellation race: {outcomes:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -65,8 +65,8 @@ pub use provider::{
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
     AcceptTurnOutcome, BlobStore, CompleteTurnRunOutcome, DocumentIndexJobReason,
-    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, RecordTurnFailureOutcome,
-    SecretProvider, Store,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, SecretProvider, Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -678,6 +678,10 @@ pub enum TurnRunStatus {
     Queued,
     /// Currently owned by the exact lease token and expiry on the turn.
     Running,
+    /// Cancellation was requested while a worker still owns the exact lease.
+    /// The chat remains occupied until that worker acknowledges quiescence or
+    /// the expired lease is cleaned up.
+    Cancelling,
     /// Failed safely before an ambiguous side effect and awaits another claim.
     RetryWait,
     /// Produced a final answer successfully.
@@ -695,6 +699,7 @@ impl TurnRunStatus {
         match self {
             Self::Queued => "queued",
             Self::Running => "running",
+            Self::Cancelling => "cancelling",
             Self::RetryWait => "retry_wait",
             Self::Completed => "completed",
             Self::Failed => "failed",

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -113,6 +113,28 @@ pub enum RecordTurnFailureOutcome {
     Existing(TurnFailureReceipt),
 }
 
+/// Result of requesting durable cancellation for one exact turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestTurnCancellationOutcome {
+    /// Queued or retry-wait work was cancelled before a worker owned it.
+    Cancelled(TurnRun),
+    /// Running work entered the durable `cancelling` phase.
+    Requested(TurnRun),
+    /// This turn was already cancelling or cancelled.
+    Existing(TurnRun),
+    /// Successful completion or terminal failure won before cancellation.
+    AlreadyTerminal(TurnRun),
+}
+
+/// Result of a worker acknowledging that cancellation has quiesced execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FinishTurnCancellationOutcome {
+    /// This call committed the terminal cancellation transition.
+    Cancelled(TurnRun),
+    /// This exact claimed attempt already reached terminal cancellation.
+    Existing(TurnRun),
+}
+
 fn document_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "document storage is not implemented by this Store".into(),
@@ -657,6 +679,36 @@ pub trait Store: Send + Sync {
         _error_code: &str,
         _error_detail: Option<&str>,
     ) -> Result<Option<RecordTurnFailureOutcome>> {
+        turn_storage_unavailable()
+    }
+
+    /// Durably request cancellation for one exact turn.
+    ///
+    /// Queued and retry-wait work becomes terminal immediately. Running work
+    /// enters `cancelling` while retaining its exact lease, so the database's
+    /// one-live-turn-per-chat invariant remains held until the cooperative
+    /// worker actually stops. The empty-payload request converges on the exact
+    /// turn identity, so cancelling/cancelled retries return `Existing`.
+    async fn request_turn_cancellation(
+        &self,
+        _id: TurnId,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<RequestTurnCancellationOutcome>> {
+        turn_storage_unavailable()
+    }
+
+    /// Acknowledge that one exact cancelling worker has quiesced.
+    ///
+    /// The immutable claim receipt and terminal attempt make exact retries
+    /// recoverable after lease expiry. Returns `None` for a stale token, a turn
+    /// that is not cancelling, or a first-time acknowledgement with regressing
+    /// operational time.
+    async fn finish_turn_cancellation(
+        &self,
+        _id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<FinishTurnCancellationOutcome>> {
         turn_storage_unavailable()
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -5,8 +5,9 @@ use std::sync::Arc;
 
 use chrono::{Duration, Utc};
 use openwave_core::{
-    AcceptTurnOutcome, Chat, ChatId, CompleteTurnRunOutcome, DbStore, Message, MessageId,
-    RecordTurnFailureOutcome, Role, Store, TurnFailureRetry, TurnId, TurnRunStatus,
+    AcceptTurnOutcome, Chat, ChatId, CompleteTurnRunOutcome, DbStore,
+    FinishTurnCancellationOutcome, Message, MessageId, RecordTurnFailureOutcome,
+    RequestTurnCancellationOutcome, Role, Store, TurnFailureRetry, TurnId, TurnRunStatus,
 };
 
 fn sample_chat() -> Chat {
@@ -245,5 +246,85 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
             .unwrap()
             .status,
         TurnRunStatus::Failed
+    );
+
+    let cancellation_chat = sample_chat();
+    store.create_chat(&cancellation_chat).await.unwrap();
+    let cancellation_turn = match store
+        .accept_turn(
+            TurnId::new(),
+            cancellation_chat.id,
+            "gpt-5",
+            "postgres cancellation",
+        )
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let cancellation_token = uuid::Uuid::new_v4();
+    let cancellation_claimed_at = cancellation_turn.available_at + Duration::seconds(1);
+    let cancellation_expiry = cancellation_claimed_at + Duration::minutes(1);
+    let cancellation_requested_at = cancellation_claimed_at + Duration::seconds(1);
+    store
+        .claim_turn_run(
+            cancellation_token,
+            cancellation_claimed_at,
+            cancellation_expiry,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let mut cancellations = Vec::new();
+    for _ in 0..2 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        cancellations.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .request_turn_cancellation(cancellation_turn.id, cancellation_requested_at)
+                .await
+                .unwrap()
+                .unwrap()
+        }));
+    }
+    let mut requested = 0;
+    let mut cancellation_existing = 0;
+    for cancellation in cancellations {
+        match cancellation.await.unwrap() {
+            RequestTurnCancellationOutcome::Requested(turn) => {
+                requested += 1;
+                assert_eq!(turn.status, TurnRunStatus::Cancelling);
+            }
+            RequestTurnCancellationOutcome::Existing(turn) => {
+                cancellation_existing += 1;
+                assert_eq!(turn.status, TurnRunStatus::Cancelling);
+            }
+            outcome => panic!("unexpected cancellation outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!((requested, cancellation_existing), (1, 1));
+    let acknowledged_at = cancellation_expiry + Duration::seconds(1);
+    let FinishTurnCancellationOutcome::Cancelled(cancelled) = store
+        .finish_turn_cancellation(cancellation_turn.id, cancellation_token, acknowledged_at)
+        .await
+        .unwrap()
+        .unwrap()
+    else {
+        panic!("exact PostgreSQL cancellation acknowledgement must commit")
+    };
+    assert_eq!(cancelled.status, TurnRunStatus::Cancelled);
+    assert_eq!(
+        store
+            .finish_turn_cancellation(
+                cancellation_turn.id,
+                cancellation_token,
+                acknowledged_at + Duration::hours(1),
+            )
+            .await
+            .unwrap(),
+        Some(FinishTurnCancellationOutcome::Existing(cancelled))
     );
 }


### PR DESCRIPTION
## Summary

- add a durable `cancelling` state that retains the live turn lease until the worker has quiesced
- cancel queued and retry-wait turns immediately while preserving one-active-turn-per-chat invariants
- make cancellation requests and worker acknowledgements atomic, fenced, and idempotent across SQLite and PostgreSQL
- terminalize expired cancellation leases during claim scans so abandoned cancellations cannot wedge a chat

## Testing

- `cargo test -p openwave-core --all-features`
- `cargo test --workspace --all-features`
- PostgreSQL 17 `postgres_turn_state` integration test with `OPENWAVE_REQUIRE_POSTGRES_TEST=1`
- `bw dev lint --rust`
- `cargo fmt --all --check`
