### PR TITLE
ci: publish one complete cargo registry cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,16 +108,16 @@ jobs:
             protobuf-compiler
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: cargo-registry
+          shared-key: cargo-registry-v2
           add-job-id-key: "false"
           cache-bin: false
           # Keep Cargo downloads cached, but never restore the multi-gigabyte
           # target archive that previously exhausted a hosted runner. sccache
           # reuses individual compiler outputs without pre-filling target/.
           cache-targets: false
-          # PR-scoped registry caches cannot help later PRs. All compiler lanes
-          # restore the trusted main cache and only main refreshes it.
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Every lane restores the shared trusted-main registry cache; only the
+          # comprehensive build job below publishes a new immutable key.
+          save-if: false
       - name: clippy
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
@@ -155,11 +155,14 @@ jobs:
             protobuf-compiler
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: cargo-registry
+          shared-key: cargo-registry-v2
           add-job-id-key: "false"
           cache-bin: false
           cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Fetch the complete workspace lockfile
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: cargo fetch --locked
       - name: build
         run: cargo build --workspace --locked
 
@@ -197,11 +200,11 @@ jobs:
             protobuf-compiler
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: cargo-registry
+          shared-key: cargo-registry-v2
           add-job-id-key: "false"
           cache-bin: false
           cache-targets: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: false
       - name: test
         run: cargo test --workspace --locked
 
@@ -244,11 +247,11 @@ jobs:
           version: v0.16.0
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: cargo-registry
+          shared-key: cargo-registry-v2
           add-job-id-key: "false"
           cache-bin: false
           cache-targets: false
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: false
       - name: Exercise durable turn state on PostgreSQL
         run: >-
           cargo test -p openwave-core --no-default-features --features postgres


### PR DESCRIPTION
## Summary

- make the comprehensive build lane the only job that publishes the shared Cargo registry cache on trusted `main`
- keep clippy, tests, PostgreSQL, and all pull-request jobs restore-only
- fetch the complete locked workspace dependency set before the trusted writer publishes a new immutable cache key
- move every lane to a fresh `cargo-registry-v2` key because the existing immutable cache cannot be repaired in place

## Why

All compiler lanes shared one immutable registry-cache key and could write it concurrently on `main`. The first finisher could publish only its dependency subset, preventing later comprehensive jobs from filling in missing Tauri or LanceDB archives for that key. A single comprehensive writer makes cache contents deterministic and complete.

The existing clippy, build, test, and PostgreSQL jobs remain parallel. A measured package-level test-sharding experiment was slower than the monolithic workspace test because it introduced additional Cargo feature graphs and linking work, so it is intentionally not included.

## Testing

- workflow YAML parse validation
- `git diff --check`
- proving GitHub Actions runs
