### PR TITLE
fix(core): serialize chat event journal writes

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use chrono::Utc;
 use sea_orm::sea_query::OnConflict;
-use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
@@ -10,6 +12,7 @@ use crate::id::{CallId, ChatId, MessageId, ProjectId, TurnId};
 use crate::model::{Chat, Message, Role, ToolCallRecord};
 
 use super::super::{entities, store_err, DbStore};
+use super::acquire_chat_write_lock;
 
 pub(in crate::db) async fn create_chat(store: &DbStore, chat: &Chat) -> Result<()> {
     entities::chat::ActiveModel {
@@ -139,19 +142,23 @@ pub(in crate::db) async fn append_event(
     chat_id: ChatId,
     event: &AgentEvent,
 ) -> Result<i64> {
-    // Next seq for this chat. This assumes a single writer per chat —
-    // the server enforces it by allowing only one active turn per chat at
-    // a time (a concurrent message is refused, not queued behind a second
-    // writer). Under that invariant read-then-insert is race-free; the
-    // composite (chat_id, seq) primary key is the backstop that turns any
-    // concurrent double-write into an error, never a silent dup or lost seq.
+    // Serialize sequence allocation on the durable chat row. This is also the
+    // lock used by turn acceptance, so independently running servers cannot
+    // race a journal append with the next turn's admission.
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, chat_id).await? {
+        return Err(AgentError::Store(format!("chat {chat_id} does not exist")));
+    }
+
     let last = entities::event::Entity::find()
         .filter(entities::event::Column::ChatId.eq(chat_id.0))
         .order_by_desc(entities::event::Column::Seq)
-        .one(&store.conn)
+        .one(&transaction)
         .await
         .map_err(store_err)?;
-    let seq = last.map_or(0, |model| model.seq) + 1;
+    let seq = last
+        .map_or(Some(1), |model| model.seq.checked_add(1))
+        .ok_or_else(|| AgentError::Store(format!("event sequence exhausted for chat {chat_id}")))?;
 
     entities::event::ActiveModel {
         chat_id: Set(chat_id.0),
@@ -159,9 +166,10 @@ pub(in crate::db) async fn append_event(
         payload: Set(serde_json::to_value(event)?),
         created_at: Set(Utc::now()),
     }
-    .insert(&store.conn)
+    .insert(&transaction)
     .await
     .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
     Ok(seq)
 }
 

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -1,4 +1,31 @@
+use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
+
+use crate::error::Result;
+use crate::id::ChatId;
+
+use super::{entities, store_err};
+
 pub(in crate::db) mod blob;
 pub(in crate::db) mod conversation;
 pub(in crate::db) mod document;
 pub(in crate::db) mod turn;
+
+/// Acquire the shared cross-backend write lock for one chat row.
+///
+/// Turn admission and per-chat event sequence allocation use the same lock so
+/// their read-then-write decisions remain serialized across server processes.
+pub(in crate::db) async fn acquire_chat_write_lock<C>(conn: &C, chat_id: ChatId) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let locked = entities::chat::Entity::update_many()
+        .col_expr(
+            entities::chat::Column::Title,
+            sea_orm::sea_query::Expr::col(entities::chat::Column::Title).into(),
+        )
+        .filter(entities::chat::Column::Id.eq(chat_id.0))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(locked.rows_affected == 1)
+}

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -10,6 +10,7 @@ use crate::model::{TurnRun, TurnRunStatus};
 use crate::storage::AcceptTurnOutcome;
 
 use super::super::{entities, store_err, DbStore};
+use super::acquire_chat_write_lock;
 
 mod resolution;
 
@@ -52,16 +53,7 @@ pub(in crate::db) async fn accept_turn(
     validate_turn_input(model, content)?;
 
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    let chat_lock = entities::chat::Entity::update_many()
-        .col_expr(
-            entities::chat::Column::Title,
-            sea_orm::sea_query::Expr::col(entities::chat::Column::Title).into(),
-        )
-        .filter(entities::chat::Column::Id.eq(chat_id.0))
-        .exec(&transaction)
-        .await
-        .map_err(store_err)?;
-    if chat_lock.rows_affected != 1 {
+    if !acquire_chat_write_lock(&transaction, chat_id).await? {
         return Err(AgentError::Store(format!("chat {chat_id} does not exist")));
     }
 

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -7029,6 +7029,57 @@ async fn event_journal_assigns_per_chat_seq_and_replays_after_cursor() {
 }
 
 #[tokio::test]
+async fn concurrent_event_writers_allocate_one_contiguous_chat_sequence() {
+    use crate::event::AgentEvent;
+
+    const WRITERS: i64 = 16;
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let store = std::sync::Arc::new(store);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(WRITERS as usize));
+    let mut tasks = Vec::new();
+    for index in 0..WRITERS {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            let event = AgentEvent::TextDelta {
+                text: format!("delta {index}"),
+            };
+            (index, store.append_event(chat.id, &event).await.unwrap())
+        }));
+    }
+
+    let mut assigned = Vec::new();
+    for task in tasks {
+        assigned.push(task.await.unwrap().1);
+    }
+    assigned.sort_unstable();
+    assert_eq!(assigned, (1..=WRITERS).collect::<Vec<_>>());
+
+    let events = store.list_events(chat.id, 0).await.unwrap();
+    assert_eq!(events.len(), WRITERS as usize);
+    assert_eq!(
+        events.iter().map(|event| event.seq).collect::<Vec<_>>(),
+        (1..=WRITERS).collect::<Vec<_>>()
+    );
+    let mut payloads = events
+        .into_iter()
+        .map(|event| match event.event {
+            AgentEvent::TextDelta { text } => text,
+            event => panic!("unexpected event: {event:?}"),
+        })
+        .collect::<Vec<_>>();
+    payloads.sort();
+    let mut expected = (0..WRITERS)
+        .map(|index| format!("delta {index}"))
+        .collect::<Vec<_>>();
+    expected.sort();
+    assert_eq!(payloads, expected);
+}
+
+#[tokio::test]
 async fn event_for_unknown_chat_is_rejected() {
     use crate::event::AgentEvent;
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use chrono::{Duration, Utc};
 use openwave_core::{
-    AcceptTurnOutcome, Chat, ChatId, CompleteTurnRunOutcome, DbStore,
+    AcceptTurnOutcome, AgentEvent, Chat, ChatId, CompleteTurnRunOutcome, DbStore,
     FinishTurnCancellationOutcome, Message, MessageId, RecordTurnFailureOutcome,
     RequestTurnCancellationOutcome, Role, Store, TurnFailureRetry, TurnId, TurnRunStatus,
 };
@@ -326,5 +326,38 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
             .await
             .unwrap(),
         Some(FinishTurnCancellationOutcome::Existing(cancelled))
+    );
+
+    let event_chat = sample_chat();
+    store.create_chat(&event_chat).await.unwrap();
+    let barrier = Arc::new(tokio::sync::Barrier::new(16));
+    let mut writers = Vec::new();
+    for index in 0..16 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        writers.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .append_event(
+                    event_chat.id,
+                    &AgentEvent::TextDelta {
+                        text: format!("postgres delta {index}"),
+                    },
+                )
+                .await
+                .unwrap()
+        }));
+    }
+    let mut assigned = Vec::new();
+    for writer in writers {
+        assigned.push(writer.await.unwrap());
+    }
+    assigned.sort_unstable();
+    assert_eq!(assigned, (1..=16).collect::<Vec<_>>());
+    let events = store.list_events(event_chat.id, 0).await.unwrap();
+    assert_eq!(events.len(), 16);
+    assert_eq!(
+        events.iter().map(|event| event.seq).collect::<Vec<_>>(),
+        (1..=16).collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
## Summary

- serialize per-chat event sequence allocation on the durable chat row
- allocate and insert each journal event in one transaction across SQLite and PostgreSQL
- share the same chat write lock with turn admission so independent server processes use one ordering boundary
- reject sequence exhaustion without a partial journal write

## Verification

- `cargo test --workspace --all-features`
- live PostgreSQL 17 turn-state integration test with 16 concurrent journal writers
- `bw dev lint --rust`
- `cargo fmt --all --check`
