### PR TITLE
feat(core): bind journal events to durable turns

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -310,6 +310,10 @@ pub mod event {
         pub chat_id: Uuid,
         #[sea_orm(primary_key, auto_increment = false)]
         pub seq: i64,
+        pub turn_id: Option<Uuid>,
+        pub lease_token: Option<Uuid>,
+        pub attempt_event_ordinal: Option<i32>,
+        pub terminal: bool,
         #[sea_orm(column_type = "JsonBinary")]
         pub payload: Json,
         pub created_at: DateTimeUtc,

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -148,6 +148,17 @@ impl MigrationTrait for Init {
                     .to_owned(),
             )
             .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_claim_turn_token")
+                    .table(TurnClaim::Table)
+                    .col(TurnClaim::TurnId)
+                    .col(TurnClaim::Token)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
 
         let valid_turn_status = Expr::col(TurnRun::Status).is_in([
             TurnRunStatus::Queued.as_str(),
@@ -390,6 +401,17 @@ impl MigrationTrait for Init {
         manager
             .create_index(
                 Index::create()
+                    .name("idx_turn_run_chat_identity")
+                    .table(TurnRun::Table)
+                    .col(TurnRun::ChatId)
+                    .col(TurnRun::Id)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
                     .name("idx_turn_run_input_message")
                     .table(TurnRun::Table)
                     .col(TurnRun::InputMessageId)
@@ -591,6 +613,15 @@ impl MigrationTrait for AddEventJournal {
                     .if_not_exists()
                     .col(ColumnDef::new(Event::ChatId).uuid().not_null())
                     .col(ColumnDef::new(Event::Seq).big_integer().not_null())
+                    .col(ColumnDef::new(Event::TurnId).uuid())
+                    .col(ColumnDef::new(Event::LeaseToken).uuid())
+                    .col(ColumnDef::new(Event::AttemptEventOrdinal).integer())
+                    .col(
+                        ColumnDef::new(Event::Terminal)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
                     .col(ColumnDef::new(Event::Payload).json_binary().not_null())
                     .col(
                         ColumnDef::new(Event::CreatedAt)
@@ -604,6 +635,76 @@ impl MigrationTrait for AddEventJournal {
                             .from(Event::Table, Event::ChatId)
                             .to(Chat::Table, Chat::Id),
                     )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_event_turn")
+                            .from_tbl(Event::Table)
+                            .from_col(Event::ChatId)
+                            .from_col(Event::TurnId)
+                            .to_tbl(TurnRun::Table)
+                            .to_col(TurnRun::ChatId)
+                            .to_col(TurnRun::Id)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_event_turn_claim")
+                            .from_tbl(Event::Table)
+                            .from_col(Event::TurnId)
+                            .from_col(Event::LeaseToken)
+                            .to_tbl(TurnClaim::Table)
+                            .to_col(TurnClaim::TurnId)
+                            .to_col(TurnClaim::Token)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .check(
+                        Expr::col(Event::Terminal)
+                            .eq(false)
+                            .or(Expr::col(Event::TurnId).is_not_null()),
+                    )
+                    .check(
+                        Expr::col(Event::LeaseToken)
+                            .is_null()
+                            .and(Expr::col(Event::AttemptEventOrdinal).is_null())
+                            .or(Expr::col(Event::LeaseToken).is_not_null().and(
+                                Expr::col(Event::AttemptEventOrdinal)
+                                    .is_not_null()
+                                    .and(Expr::col(Event::TurnId).is_not_null()),
+                            )),
+                    )
+                    .check(
+                        Expr::col(Event::AttemptEventOrdinal)
+                            .is_null()
+                            .or(Expr::col(Event::AttemptEventOrdinal).gte(1)),
+                    )
+                    .check(
+                        Expr::col(Event::TurnId)
+                            .is_null()
+                            .or(Expr::col(Event::Terminal).eq(true))
+                            .or(Expr::col(Event::LeaseToken).is_not_null()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_event_attempt_ordinal")
+                    .table(Event::Table)
+                    .col(Event::LeaseToken)
+                    .col(Event::AttemptEventOrdinal)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_event_one_terminal_per_turn")
+                    .table(Event::Table)
+                    .col(Event::TurnId)
+                    .unique()
+                    .and_where(Expr::col(Event::Terminal).eq(true))
                     .to_owned(),
             )
             .await?;
@@ -1618,6 +1719,10 @@ enum Event {
     Table,
     ChatId,
     Seq,
+    TurnId,
+    LeaseToken,
+    AttemptEventOrdinal,
+    Terminal,
     Payload,
     CreatedAt,
 }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1775,6 +1775,27 @@ impl Store for DbStore {
         ops::conversation::append_event(self, chat_id, event).await
     }
 
+    async fn append_turn_event(
+        &self,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        attempt_event_ordinal: i32,
+        now: chrono::DateTime<Utc>,
+        event: &AgentEvent,
+    ) -> Result<Option<i64>> {
+        ops::conversation::append_turn_event(
+            self,
+            chat_id,
+            turn_id,
+            lease_token,
+            attempt_event_ordinal,
+            now,
+            event,
+        )
+        .await
+    }
+
     async fn list_events(&self, chat_id: ChatId, after: i64) -> Result<Vec<SequencedEvent>> {
         ops::conversation::list_events(self, chat_id, after).await
     }

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -3,16 +3,18 @@ use std::path::PathBuf;
 use chrono::Utc;
 use sea_orm::sea_query::OnConflict;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait,
 };
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{CallId, ChatId, MessageId, ProjectId, TurnId};
-use crate::model::{Chat, Message, Role, ToolCallRecord};
+use crate::model::{Chat, Message, Role, ToolCallRecord, TurnRunStatus};
 
 use super::super::{entities, store_err, DbStore};
-use super::acquire_chat_write_lock;
+use super::turn::canonical_db_timestamp;
+use super::{acquire_chat_write_lock, acquire_turn_write_lock};
 
 pub(in crate::db) async fn create_chat(store: &DbStore, chat: &Chat) -> Result<()> {
     entities::chat::ActiveModel {
@@ -149,28 +151,190 @@ pub(in crate::db) async fn append_event(
     if !acquire_chat_write_lock(&transaction, chat_id).await? {
         return Err(AgentError::Store(format!("chat {chat_id} does not exist")));
     }
+    if entities::turn_run::Entity::find()
+        .filter(entities::turn_run::Column::ChatId.eq(chat_id.0))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .is_some()
+    {
+        return Err(AgentError::Store(format!(
+            "chat {chat_id} uses durable turns; append through an exact claim"
+        )));
+    }
 
+    let seq = append_event_on(&transaction, chat_id, None, None, None, event).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(seq)
+}
+
+pub(in crate::db) async fn append_turn_event(
+    store: &DbStore,
+    chat_id: ChatId,
+    turn_id: TurnId,
+    lease_token: uuid::Uuid,
+    attempt_event_ordinal: i32,
+    now: chrono::DateTime<Utc>,
+    event: &AgentEvent,
+) -> Result<Option<i64>> {
+    if turn_id.0.is_nil() {
+        return Err(AgentError::Store("event turn id must not be nil".into()));
+    }
+    if lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "event lease token must not be nil".into(),
+        ));
+    }
+    if attempt_event_ordinal < 1 {
+        return Err(AgentError::Store(
+            "attempt event ordinal must be positive".into(),
+        ));
+    }
+    if matches!(
+        event,
+        AgentEvent::TurnCompleted { .. }
+            | AgentEvent::TurnFailed { .. }
+            | AgentEvent::TurnCancelled { .. }
+    ) {
+        return Err(AgentError::Store(
+            "terminal turn events must be committed by turn resolution".into(),
+        ));
+    }
+    if let AgentEvent::TurnStarted {
+        turn_id: payload_turn_id,
+    } = event
+    {
+        if *payload_turn_id != turn_id {
+            return Err(AgentError::Store(format!(
+                "turn-started event names {payload_turn_id}, not authoritative turn {turn_id}"
+            )));
+        }
+    }
+    let now = canonical_db_timestamp(now)?;
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, chat_id).await? {
+        return Err(AgentError::Store(format!("chat {chat_id} does not exist")));
+    }
+    if !acquire_turn_write_lock(&transaction, turn_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    if let Some(existing) = entities::event::Entity::find()
+        .filter(entities::event::Column::LeaseToken.eq(lease_token))
+        .filter(entities::event::Column::AttemptEventOrdinal.eq(attempt_event_ordinal))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let payload = serde_json::from_value::<AgentEvent>(existing.payload.clone())?;
+        if existing.chat_id != chat_id.0
+            || existing.turn_id != Some(turn_id.0)
+            || existing.lease_token != Some(lease_token)
+            || existing.attempt_event_ordinal != Some(attempt_event_ordinal)
+            || existing.terminal
+            || payload != *event
+        {
+            return Err(AgentError::Store(format!(
+                "turn event identity ({lease_token}, {attempt_event_ordinal}) was reused with different data"
+            )));
+        }
+        let seq = existing.seq;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(seq));
+    }
+
+    let Some(claim) = entities::turn_claim::Entity::find_by_id(lease_token)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .filter(|claim| claim.turn_id == turn_id.0)
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let Some(turn) = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if turn.chat_id != chat_id.0 {
+        return Err(AgentError::Store(format!(
+            "turn {turn_id} does not belong to chat {chat_id}"
+        )));
+    }
+    if turn.status != TurnRunStatus::Running.as_str()
+        || turn.attempt_count != claim.attempt_count
+        || turn.lease_token != Some(lease_token)
+        || turn
+            .lease_expires_at
+            .is_none_or(|lease_expires_at| lease_expires_at <= now)
+        || turn.updated_at > now
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let seq = append_event_on(
+        &transaction,
+        chat_id,
+        Some(turn_id),
+        Some(lease_token),
+        Some(attempt_event_ordinal),
+        event,
+    )
+    .await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(seq))
+}
+
+pub(in crate::db::ops) async fn append_event_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+    turn_id: Option<TurnId>,
+    lease_token: Option<uuid::Uuid>,
+    attempt_event_ordinal: Option<i32>,
+    event: &AgentEvent,
+) -> Result<i64>
+where
+    C: ConnectionTrait,
+{
     let last = entities::event::Entity::find()
         .filter(entities::event::Column::ChatId.eq(chat_id.0))
         .order_by_desc(entities::event::Column::Seq)
-        .one(&transaction)
+        .one(conn)
         .await
         .map_err(store_err)?;
     let seq = last
         .map_or(Some(1), |model| model.seq.checked_add(1))
         .ok_or_else(|| AgentError::Store(format!("event sequence exhausted for chat {chat_id}")))?;
-
     entities::event::ActiveModel {
         chat_id: Set(chat_id.0),
         seq: Set(seq),
+        turn_id: Set(turn_id.map(|id| id.0)),
+        lease_token: Set(lease_token),
+        attempt_event_ordinal: Set(attempt_event_ordinal),
+        terminal: Set(turn_id.is_some() && is_terminal_event(event)),
         payload: Set(serde_json::to_value(event)?),
         created_at: Set(Utc::now()),
     }
-    .insert(&transaction)
+    .insert(conn)
     .await
     .map_err(store_err)?;
-    transaction.commit().await.map_err(store_err)?;
     Ok(seq)
+}
+
+fn is_terminal_event(event: &AgentEvent) -> bool {
+    matches!(
+        event,
+        AgentEvent::TurnCompleted { .. }
+            | AgentEvent::TurnFailed { .. }
+            | AgentEvent::TurnCancelled { .. }
+    )
 }
 
 pub(in crate::db) async fn list_events(

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -1,7 +1,7 @@
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 
 use crate::error::Result;
-use crate::id::ChatId;
+use crate::id::{ChatId, TurnId};
 
 use super::{entities, store_err};
 
@@ -24,6 +24,23 @@ where
             sea_orm::sea_query::Expr::col(entities::chat::Column::Title).into(),
         )
         .filter(entities::chat::Column::Id.eq(chat_id.0))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(locked.rows_affected == 1)
+}
+
+/// Acquire the shared cross-backend write lock for one durable turn row.
+pub(in crate::db) async fn acquire_turn_write_lock<C>(conn: &C, turn_id: TurnId) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let locked = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::col(entities::turn_run::Column::UpdatedAt).into(),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
         .exec(conn)
         .await
         .map_err(store_err)?;

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -459,7 +459,9 @@ pub(in crate::db) async fn heartbeat_turn_run(
     Ok(heartbeat.rows_affected == 1)
 }
 
-fn canonical_db_timestamp(timestamp: chrono::DateTime<Utc>) -> Result<chrono::DateTime<Utc>> {
+pub(in crate::db) fn canonical_db_timestamp(
+    timestamp: chrono::DateTime<Utc>,
+) -> Result<chrono::DateTime<Utc>> {
     chrono::DateTime::from_timestamp_micros(timestamp.timestamp_micros()).ok_or_else(|| {
         AgentError::Store("turn output timestamp is outside the database range".into())
     })

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -12,6 +12,7 @@ use crate::storage::{
 };
 
 use super::super::super::{entities, store_err, DbStore};
+use super::super::acquire_turn_write_lock;
 use super::{canonical_db_timestamp, turn_run_from_model, turn_run_status_from_db};
 
 pub(in crate::db) async fn complete_turn_run(
@@ -31,7 +32,7 @@ pub(in crate::db) async fn complete_turn_run(
     }
 
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    if !acquire_exact_turn_write_lock(&transaction, id).await? {
+    if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
@@ -186,7 +187,7 @@ pub(in crate::db) async fn record_turn_run_failure(
     }
 
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    if !acquire_exact_turn_write_lock(&transaction, id).await? {
+    if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
@@ -318,7 +319,7 @@ pub(in crate::db) async fn request_turn_cancellation(
 ) -> Result<Option<RequestTurnCancellationOutcome>> {
     let now = canonical_db_timestamp(now)?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    if !acquire_exact_turn_write_lock(&transaction, id).await? {
+    if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
@@ -423,7 +424,7 @@ pub(in crate::db) async fn finish_turn_cancellation(
     }
     let now = canonical_db_timestamp(now)?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    if !acquire_exact_turn_write_lock(&transaction, id).await? {
+    if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
@@ -502,22 +503,6 @@ pub(in crate::db) async fn finish_turn_cancellation(
         .and_then(turn_run_from_model)?;
     transaction.commit().await.map_err(store_err)?;
     Ok(Some(FinishTurnCancellationOutcome::Cancelled(cancelled)))
-}
-
-async fn acquire_exact_turn_write_lock<C>(conn: &C, id: TurnId) -> Result<bool>
-where
-    C: ConnectionTrait,
-{
-    let locked = entities::turn_run::Entity::update_many()
-        .col_expr(
-            entities::turn_run::Column::UpdatedAt,
-            sea_orm::sea_query::Expr::col(entities::turn_run::Column::UpdatedAt).into(),
-        )
-        .filter(entities::turn_run::Column::Id.eq(id.0))
-        .exec(conn)
-        .await
-        .map_err(store_err)?;
-    Ok(locked.rows_affected == 1)
 }
 
 fn validate_turn_output(id: TurnId, lease_token: uuid::Uuid, output: &Message) -> Result<()> {

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -7029,6 +7029,176 @@ async fn event_journal_assigns_per_chat_seq_and_replays_after_cursor() {
 }
 
 #[tokio::test]
+async fn durable_turn_events_are_bound_and_reserve_one_terminal_slot() {
+    use crate::event::AgentEvent;
+    use crate::provider::{StopReason, Usage};
+
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = turn.available_at + chrono::Duration::seconds(1);
+    let lease_expires_at = claimed_at + chrono::Duration::minutes(1);
+    let lease_token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(lease_token, claimed_at, lease_expires_at)
+        .await
+        .unwrap()
+        .unwrap();
+    let started = AgentEvent::TurnStarted { turn_id: turn.id };
+    assert_eq!(
+        store
+            .append_turn_event(chat.id, turn.id, lease_token, 1, claimed_at, &started)
+            .await
+            .unwrap(),
+        Some(1)
+    );
+    assert_eq!(
+        store
+            .append_turn_event(
+                chat.id,
+                turn.id,
+                lease_token,
+                1,
+                lease_expires_at + chrono::Duration::seconds(1),
+                &started,
+            )
+            .await
+            .unwrap(),
+        Some(1),
+        "an exact ambiguous retry recovers its original sequence"
+    );
+    let stored = entities::event::Entity::find_by_id((chat.id.0, 1))
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.turn_id, Some(turn.id.0));
+    assert_eq!(stored.lease_token, Some(lease_token));
+    assert_eq!(stored.attempt_event_ordinal, Some(1));
+    assert!(!stored.terminal);
+    assert_eq!(
+        serde_json::from_value::<AgentEvent>(stored.payload).unwrap(),
+        started
+    );
+
+    let terminal = AgentEvent::TurnCompleted {
+        usage: Usage::default(),
+        stop_reason: StopReason::EndTurn,
+    };
+    assert!(store
+        .append_turn_event(chat.id, turn.id, lease_token, 2, claimed_at, &terminal)
+        .await
+        .is_err());
+    assert!(store
+        .append_turn_event(
+            chat.id,
+            turn.id,
+            lease_token,
+            1,
+            claimed_at,
+            &AgentEvent::ContextTruncated {
+                original_tokens: 20,
+                fitted_tokens: 10,
+            },
+        )
+        .await
+        .is_err());
+    assert!(store
+        .append_turn_event(
+            chat.id,
+            turn.id,
+            lease_token,
+            2,
+            claimed_at,
+            &AgentEvent::TurnStarted {
+                turn_id: TurnId::new(),
+            },
+        )
+        .await
+        .is_err());
+    assert_eq!(
+        store
+            .append_turn_event(
+                chat.id,
+                turn.id,
+                lease_token,
+                2,
+                lease_expires_at + chrono::Duration::seconds(1),
+                &AgentEvent::ContextTruncated {
+                    original_tokens: 20,
+                    fitted_tokens: 10,
+                },
+            )
+            .await
+            .unwrap(),
+        None,
+        "a stale lease cannot append a new event"
+    );
+    assert!(store.append_event(chat.id, &started).await.is_err());
+
+    entities::event::ActiveModel {
+        chat_id: Set(chat.id.0),
+        seq: Set(2),
+        turn_id: Set(Some(turn.id.0)),
+        lease_token: Set(Some(lease_token)),
+        attempt_event_ordinal: Set(Some(2)),
+        terminal: Set(true),
+        payload: Set(serde_json::to_value(&terminal).unwrap()),
+        created_at: Set(Utc::now()),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    assert!(entities::event::ActiveModel {
+        chat_id: Set(chat.id.0),
+        seq: Set(3),
+        turn_id: Set(Some(turn.id.0)),
+        lease_token: Set(Some(lease_token)),
+        attempt_event_ordinal: Set(Some(3)),
+        terminal: Set(true),
+        payload: Set(serde_json::to_value(&terminal).unwrap()),
+        created_at: Set(Utc::now()),
+    }
+    .insert(&store.conn)
+    .await
+    .is_err());
+    assert!(entities::event::ActiveModel {
+        chat_id: Set(chat.id.0),
+        seq: Set(4),
+        turn_id: Set(None),
+        lease_token: Set(None),
+        attempt_event_ordinal: Set(None),
+        terminal: Set(true),
+        payload: Set(serde_json::to_value(&terminal).unwrap()),
+        created_at: Set(Utc::now()),
+    }
+    .insert(&store.conn)
+    .await
+    .is_err());
+    assert!(entities::event::ActiveModel {
+        chat_id: Set(chat.id.0),
+        seq: Set(5),
+        turn_id: Set(Some(turn.id.0)),
+        lease_token: Set(None),
+        attempt_event_ordinal: Set(None),
+        terminal: Set(false),
+        payload: Set(serde_json::to_value(&started).unwrap()),
+        created_at: Set(Utc::now()),
+    }
+    .insert(&store.conn)
+    .await
+    .is_err());
+}
+
+#[tokio::test]
 async fn concurrent_event_writers_allocate_one_contiguous_chat_sequence() {
     use crate::event::AgentEvent;
 

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -730,10 +730,32 @@ pub trait Store: Send + Sync {
     /// Write a setting.
     async fn set_setting(&self, key: &str, value: &Value) -> Result<()>;
 
-    /// Append an event to a chat's journal, returning its assigned sequence
-    /// number. Sequence numbers are per-chat and monotonic (starting at 1),
-    /// so a client can replay the stream with [`list_events`](Self::list_events).
+    /// Append an event for the legacy direct-execution path.
+    ///
+    /// Sequence numbers are per-chat and monotonic (starting at 1). This method
+    /// rejects a chat once it has any durable turn history; durable workers must
+    /// use [`append_turn_event`](Self::append_turn_event) so stale attempts are
+    /// fenced and ambiguous retries recover the original sequence.
     async fn append_event(&self, chat_id: ChatId, event: &AgentEvent) -> Result<i64>;
+
+    /// Append a nonterminal event owned by an exact live turn attempt.
+    ///
+    /// `(lease_token, attempt_event_ordinal)` is the idempotency identity. An
+    /// exact retry returns the original sequence even after lease loss; reusing
+    /// it with different data is an error. A first append succeeds only while
+    /// the matching attempt still owns a live running lease. Completed, failed,
+    /// and cancelled events are reserved for atomic turn resolution.
+    async fn append_turn_event(
+        &self,
+        _chat_id: ChatId,
+        _turn_id: TurnId,
+        _lease_token: uuid::Uuid,
+        _attempt_event_ordinal: i32,
+        _now: chrono::DateTime<chrono::Utc>,
+        _event: &AgentEvent,
+    ) -> Result<Option<i64>> {
+        turn_storage_unavailable()
+    }
 
     /// List a chat's journaled events with `seq` greater than `after`, in
     /// sequence order. Pass `0` to replay from the start.

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -7,7 +7,8 @@ use chrono::{Duration, Utc};
 use openwave_core::{
     AcceptTurnOutcome, AgentEvent, Chat, ChatId, CompleteTurnRunOutcome, DbStore,
     FinishTurnCancellationOutcome, Message, MessageId, RecordTurnFailureOutcome,
-    RequestTurnCancellationOutcome, Role, Store, TurnFailureRetry, TurnId, TurnRunStatus,
+    RequestTurnCancellationOutcome, Role, StopReason, Store, TurnFailureRetry, TurnId,
+    TurnRunStatus, Usage,
 };
 
 fn sample_chat() -> Chat {
@@ -360,4 +361,122 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         events.iter().map(|event| event.seq).collect::<Vec<_>>(),
         (1..=16).collect::<Vec<_>>()
     );
+
+    let turn_event_chat = sample_chat();
+    store.create_chat(&turn_event_chat).await.unwrap();
+    let turn_event = match store
+        .accept_turn(TurnId::new(), turn_event_chat.id, "gpt-5", "event input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let event_claimed_at = turn_event.available_at + Duration::seconds(1);
+    let event_lease_token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(
+            event_lease_token,
+            event_claimed_at,
+            event_claimed_at + Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let started = AgentEvent::TurnStarted {
+        turn_id: turn_event.id,
+    };
+    assert_eq!(
+        store
+            .append_turn_event(
+                turn_event_chat.id,
+                turn_event.id,
+                event_lease_token,
+                1,
+                event_claimed_at,
+                &started,
+            )
+            .await
+            .unwrap(),
+        Some(1)
+    );
+    let turn_event_output = Message {
+        id: MessageId::new(),
+        chat_id: turn_event_chat.id,
+        turn_id: turn_event.id,
+        role: Role::Assistant,
+        content: "event turn complete".into(),
+        created_at: event_claimed_at + Duration::seconds(1),
+    };
+    store
+        .complete_turn_run(
+            turn_event.id,
+            event_lease_token,
+            turn_event_output.created_at,
+            &turn_event_output,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        store
+            .append_turn_event(
+                turn_event_chat.id,
+                turn_event.id,
+                event_lease_token,
+                1,
+                event_claimed_at + Duration::hours(1),
+                &started,
+            )
+            .await
+            .unwrap(),
+        Some(1),
+        "postgres exact retries recover the original sequence after terminal state"
+    );
+    assert_eq!(
+        store
+            .append_turn_event(
+                turn_event_chat.id,
+                turn_event.id,
+                event_lease_token,
+                2,
+                event_claimed_at + Duration::seconds(2),
+                &AgentEvent::TextDelta {
+                    text: "late".into(),
+                },
+            )
+            .await
+            .unwrap(),
+        None,
+        "postgres terminal state fences a new stale event"
+    );
+    assert!(store
+        .append_event(turn_event_chat.id, &started)
+        .await
+        .is_err());
+    assert!(store
+        .append_turn_event(
+            event_chat.id,
+            turn_event.id,
+            event_lease_token,
+            2,
+            event_claimed_at,
+            &started,
+        )
+        .await
+        .is_err());
+    assert!(store
+        .append_turn_event(
+            turn_event_chat.id,
+            turn_event.id,
+            event_lease_token,
+            2,
+            event_claimed_at,
+            &AgentEvent::TurnCompleted {
+                usage: Usage::default(),
+                stop_reason: StopReason::EndTurn,
+            },
+        )
+        .await
+        .is_err());
 }


### PR DESCRIPTION
## Summary

- bind durable-worker journal events to an exact claim and attempt-local ordinal
- fence first appends on the live lease while recovering exact ambiguous retries
- reserve terminal publication for atomic turn resolution and reject legacy appends on durable-turn chats
- enforce claim/turn/chat identity and one terminal journal row per turn in SQLite and PostgreSQL

## Testing

- `cargo test --workspace --locked`
- `cargo test -p openwave-core --all-features durable_turn_events_are_bound_and_reserve_one_terminal_slot`
- PostgreSQL 17 `postgres_turn_acceptance_claims_and_receipts_are_atomic`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `bw dev lint --rust`
- `cargo fmt --all --check`
