### PR TITLE
feat(core): journal successful turn resolution atomically

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1226,15 +1226,62 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].turn_id, turn_id);
 
+        for (index, event) in events.iter().enumerate() {
+            let ordinal = i32::try_from(index + 1).unwrap();
+            assert_eq!(
+                store
+                    .append_turn_event(chat.id, turn_id, lease_token, ordinal, Utc::now(), event,)
+                    .await
+                    .unwrap(),
+                Some(i64::from(ordinal))
+            );
+        }
+
         let completed = store
-            .complete_turn_run(turn_id, lease_token, Utc::now(), &output)
+            .complete_turn_run_and_append_event(
+                turn_id,
+                lease_token,
+                Utc::now(),
+                &output,
+                usage,
+                stop_reason,
+            )
             .await
             .unwrap()
             .expect("the live worker lease can publish its prepared output");
         assert!(matches!(
-            completed,
+            completed.outcome,
             crate::CompleteTurnRunOutcome::Completed(_)
         ));
+        let terminal = completed
+            .terminal_event
+            .expect("completion must return its committed terminal event");
+        assert_eq!(terminal.seq, i64::try_from(events.len() + 1).unwrap());
+        assert_eq!(
+            terminal.event,
+            AgentEvent::TurnCompleted { usage, stop_reason }
+        );
+        assert_eq!(
+            store.list_events(chat.id, 0).await.unwrap().last(),
+            Some(&terminal)
+        );
+        let recovered = store
+            .complete_turn_run_and_append_event(
+                turn_id,
+                lease_token,
+                claimed_at + chrono::Duration::hours(1),
+                &output,
+                usage,
+                stop_reason,
+            )
+            .await
+            .unwrap()
+            .expect("an exact completion retry must remain recoverable");
+        assert!(matches!(
+            recovered.outcome,
+            crate::CompleteTurnRunOutcome::Existing(_)
+        ));
+        assert_eq!(recovered.terminal_event, Some(terminal));
         let stored = store.list_messages(chat.id).await.unwrap();
         assert_eq!(stored.len(), 2);
         assert_eq!(stored[1].id, output.id);

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -32,10 +32,11 @@ use crate::model::{
     DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, TurnFailureRetry, TurnRun,
     TurnRunStatus,
 };
+use crate::provider::{StopReason, Usage};
 use crate::storage::{
     AcceptTurnOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
     EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
-    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, Store,
+    JournaledTurnOutcome, RecordTurnFailureOutcome, RequestTurnCancellationOutcome, Store,
 };
 
 mod ops;
@@ -1690,6 +1691,27 @@ impl Store for DbStore {
         output: &Message,
     ) -> Result<Option<CompleteTurnRunOutcome>> {
         ops::turn::complete_turn_run(self, id, lease_token, now, output).await
+    }
+
+    async fn complete_turn_run_and_append_event(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        output: &Message,
+        usage: Usage,
+        stop_reason: StopReason,
+    ) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
+        ops::turn::complete_turn_run_and_append_event(
+            self,
+            id,
+            lease_token,
+            now,
+            output,
+            usage,
+            stop_reason,
+        )
+        .await
     }
 
     async fn record_turn_run_failure(

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -185,9 +185,9 @@ pub(in crate::db) async fn append_turn_event(
             "event lease token must not be nil".into(),
         ));
     }
-    if attempt_event_ordinal < 1 {
+    if !(1..i32::MAX).contains(&attempt_event_ordinal) {
         return Err(AgentError::Store(
-            "attempt event ordinal must be positive".into(),
+            "attempt event ordinal must be positive and below the terminal slot".into(),
         ));
     }
     if matches!(

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -15,7 +15,8 @@ use super::acquire_chat_write_lock;
 mod resolution;
 
 pub(in crate::db) use resolution::{
-    complete_turn_run, finish_turn_cancellation, record_turn_run_failure, request_turn_cancellation,
+    complete_turn_run, complete_turn_run_and_append_event, finish_turn_cancellation,
+    record_turn_run_failure, request_turn_cancellation,
 };
 
 pub(in crate::db) async fn get_turn_run(store: &DbStore, id: TurnId) -> Result<Option<TurnRun>> {

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -4,15 +4,19 @@ use sea_orm::{
 };
 
 use crate::error::{AgentError, Result};
-use crate::id::TurnId;
+use crate::event::{AgentEvent, SequencedEvent};
+use crate::id::{ChatId, TurnId};
 use crate::model::{Message, Role, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus};
+use crate::provider::{StopReason, Usage};
 use crate::storage::{
-    CompleteTurnRunOutcome, FinishTurnCancellationOutcome, RecordTurnFailureOutcome,
-    RequestTurnCancellationOutcome,
+    CompleteTurnRunOutcome, FinishTurnCancellationOutcome, JournaledTurnOutcome,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome,
 };
 
 use super::super::super::{entities, store_err, DbStore};
-use super::super::acquire_turn_write_lock;
+use super::super::{
+    acquire_chat_write_lock, acquire_turn_write_lock, conversation::append_event_on,
+};
 use super::{canonical_db_timestamp, turn_run_from_model, turn_run_status_from_db};
 
 pub(in crate::db) async fn complete_turn_run(
@@ -22,6 +26,35 @@ pub(in crate::db) async fn complete_turn_run(
     now: chrono::DateTime<Utc>,
     output: &Message,
 ) -> Result<Option<CompleteTurnRunOutcome>> {
+    Ok(
+        complete_turn_run_inner(store, id, lease_token, now, output, None)
+            .await?
+            .map(|resolution| resolution.outcome),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::db) async fn complete_turn_run_and_append_event(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    output: &Message,
+    usage: Usage,
+    stop_reason: StopReason,
+) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
+    let event = AgentEvent::TurnCompleted { usage, stop_reason };
+    complete_turn_run_inner(store, id, lease_token, now, output, Some(&event)).await
+}
+
+async fn complete_turn_run_inner(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    output: &Message,
+    terminal_event: Option<&AgentEvent>,
+) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
     validate_turn_output(id, lease_token, output)?;
     let now = canonical_db_timestamp(now)?;
     let output_created_at = canonical_db_timestamp(output.created_at)?;
@@ -31,7 +64,18 @@ pub(in crate::db) async fn complete_turn_run(
         ));
     }
 
+    let journal_chat_id = journal_chat_id(store, id, terminal_event.is_some()).await?;
+    if terminal_event.is_some() && journal_chat_id.is_none() {
+        return Ok(None);
+    }
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    if let Some(chat_id) = journal_chat_id {
+        if !acquire_chat_write_lock(&transaction, chat_id).await? {
+            return Err(AgentError::Store(format!(
+                "turn {id} references missing chat {chat_id}"
+            )));
+        }
+    }
     if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
@@ -69,9 +113,14 @@ pub(in crate::db) async fn complete_turn_run(
                 "turn {id} was already completed with different output"
             )));
         }
+        let sequenced_event =
+            exact_terminal_event_on(&transaction, id, lease_token, terminal_event).await?;
         let existing = turn_run_from_model(existing)?;
         transaction.commit().await.map_err(store_err)?;
-        return Ok(Some(CompleteTurnRunOutcome::Existing(existing)));
+        return Ok(Some(JournaledTurnOutcome {
+            outcome: CompleteTurnRunOutcome::Existing(existing),
+            terminal_event: sequenced_event,
+        }));
     }
     if existing.status != TurnRunStatus::Running.as_str()
         || existing.attempt_count != receipt.attempt_count
@@ -96,7 +145,12 @@ pub(in crate::db) async fn complete_turn_run(
     if let Err(error) = message.insert(&transaction).await {
         transaction.rollback().await.map_err(store_err)?;
         if let Some(existing) = exact_completed_turn_on(store, id, lease_token, output).await? {
-            return Ok(Some(CompleteTurnRunOutcome::Existing(existing)));
+            let sequenced_event =
+                exact_terminal_event_on(&store.conn, id, lease_token, terminal_event).await?;
+            return Ok(Some(JournaledTurnOutcome {
+                outcome: CompleteTurnRunOutcome::Existing(existing),
+                terminal_event: sequenced_event,
+            }));
         }
         return Err(store_err(error));
     }
@@ -141,6 +195,14 @@ pub(in crate::db) async fn complete_turn_run(
         transaction.rollback().await.map_err(store_err)?;
         return Ok(None);
     }
+    let sequenced_event = append_terminal_event_on(
+        &transaction,
+        id,
+        ChatId(existing.chat_id),
+        lease_token,
+        terminal_event,
+    )
+    .await?;
     let completed = entities::turn_run::Entity::find_by_id(id.0)
         .one(&transaction)
         .await
@@ -148,7 +210,10 @@ pub(in crate::db) async fn complete_turn_run(
         .ok_or_else(|| AgentError::Store(format!("completed turn {id} disappeared")))
         .and_then(turn_run_from_model)?;
     transaction.commit().await.map_err(store_err)?;
-    Ok(Some(CompleteTurnRunOutcome::Completed(completed)))
+    Ok(Some(JournaledTurnOutcome {
+        outcome: CompleteTurnRunOutcome::Completed(completed),
+        terminal_event: sequenced_event,
+    }))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -639,6 +704,83 @@ async fn exact_completed_turn_on(
         )));
     }
     Ok(Some(turn_run_from_model(existing)?))
+}
+
+async fn journal_chat_id(
+    store: &DbStore,
+    id: TurnId,
+    journal_terminal: bool,
+) -> Result<Option<ChatId>> {
+    if !journal_terminal {
+        return Ok(None);
+    }
+    Ok(entities::turn_run::Entity::find_by_id(id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(|turn| ChatId(turn.chat_id)))
+}
+
+async fn append_terminal_event_on<C>(
+    conn: &C,
+    id: TurnId,
+    chat_id: ChatId,
+    lease_token: uuid::Uuid,
+    terminal_event: Option<&AgentEvent>,
+) -> Result<Option<SequencedEvent>>
+where
+    C: ConnectionTrait,
+{
+    let Some(event) = terminal_event else {
+        return Ok(None);
+    };
+    let seq = append_event_on(
+        conn,
+        chat_id,
+        Some(id),
+        Some(lease_token),
+        Some(i32::MAX),
+        event,
+    )
+    .await?;
+    Ok(Some(SequencedEvent {
+        seq,
+        event: event.clone(),
+    }))
+}
+
+async fn exact_terminal_event_on<C>(
+    conn: &C,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    expected: Option<&AgentEvent>,
+) -> Result<Option<SequencedEvent>>
+where
+    C: ConnectionTrait,
+{
+    let Some(expected) = expected else {
+        return Ok(None);
+    };
+    let stored = entities::event::Entity::find()
+        .filter(entities::event::Column::TurnId.eq(id.0))
+        .filter(entities::event::Column::Terminal.eq(true))
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("completed turn {id} is missing its event")))?;
+    let event = serde_json::from_value::<AgentEvent>(stored.payload)?;
+    if stored.lease_token != Some(lease_token)
+        || stored.attempt_event_ordinal != Some(i32::MAX)
+        || event != *expected
+    {
+        return Err(AgentError::Store(format!(
+            "turn {id} was already completed with a different terminal event"
+        )));
+    }
+    Ok(Some(SequencedEvent {
+        seq: stored.seq,
+        event,
+    }))
 }
 
 async fn exact_completed_output_on<C>(conn: &C, output: &Message) -> Result<bool>

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -6681,6 +6681,77 @@ async fn turn_completion_rolls_back_output_when_state_update_fails() {
 }
 
 #[tokio::test]
+async fn turn_completion_rolls_back_state_and_output_when_terminal_event_fails() {
+    use crate::error::AgentErrorInfo;
+    use crate::event::AgentEvent;
+    use crate::provider::{StopReason, Usage};
+
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .unwrap();
+    entities::event::ActiveModel {
+        chat_id: Set(chat.id.0),
+        seq: Set(1),
+        turn_id: Set(Some(turn_id.0)),
+        lease_token: Set(Some(token)),
+        attempt_event_ordinal: Set(Some(i32::MAX)),
+        terminal: Set(true),
+        payload: Set(serde_json::to_value(AgentEvent::TurnFailed {
+            error: AgentErrorInfo {
+                kind: "forced".into(),
+                message: "occupy terminal slot".into(),
+            },
+        })
+        .unwrap()),
+        created_at: Set(Utc::now()),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "must roll back".into(),
+        created_at: claimed_at + chrono::Duration::seconds(1),
+    };
+
+    assert!(store
+        .complete_turn_run_and_append_event(
+            turn_id,
+            token,
+            output.created_at,
+            &output,
+            Usage::default(),
+            StopReason::EndTurn,
+        )
+        .await
+        .is_err());
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
+    let still_running = store.get_turn_run(turn_id).await.unwrap().unwrap();
+    assert_eq!(still_running.status, TurnRunStatus::Running);
+    assert_eq!(still_running.output_message_id, None);
+    assert_eq!(store.list_events(chat.id, 0).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
 async fn concurrent_turn_claimers_never_share_a_lease() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -66,7 +66,8 @@ pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
     AcceptTurnOutcome, BlobStore, CompleteTurnRunOutcome, DocumentIndexJobReason,
     EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
-    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, SecretProvider, Store,
+    JournaledTurnOutcome, RecordTurnFailureOutcome, RequestTurnCancellationOutcome, SecretProvider,
+    Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -27,6 +27,7 @@ use crate::model::{
     DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
     TurnFailureReceipt, TurnFailureRetry, TurnRun,
 };
+use crate::provider::{StopReason, Usage};
 
 /// Why maintenance determined that a document needs an index job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -133,6 +134,15 @@ pub enum FinishTurnCancellationOutcome {
     Cancelled(TurnRun),
     /// This exact claimed attempt already reached terminal cancellation.
     Existing(TurnRun),
+}
+
+/// A durable turn transition together with any terminal event committed by it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JournaledTurnOutcome<T> {
+    /// The state-machine result.
+    pub outcome: T,
+    /// The exact terminal journal row when this operation publishes one.
+    pub terminal_event: Option<SequencedEvent>,
 }
 
 fn document_storage_unavailable<T>() -> Result<T> {
@@ -657,6 +667,24 @@ pub trait Store: Send + Sync {
         _now: chrono::DateTime<chrono::Utc>,
         _output: &Message,
     ) -> Result<Option<CompleteTurnRunOutcome>> {
+        turn_storage_unavailable()
+    }
+
+    /// Complete one claimed turn and append its terminal event atomically.
+    ///
+    /// Exact ambiguous retries recover both the completed turn and the same
+    /// journal sequence. No terminal event is visible unless the output message
+    /// and terminal state transition commit with it.
+    #[allow(clippy::too_many_arguments)]
+    async fn complete_turn_run_and_append_event(
+        &self,
+        _id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+        _output: &Message,
+        _usage: Usage,
+        _stop_reason: StopReason,
+    ) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
         turn_storage_unavailable()
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -161,7 +161,14 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         completions.push(tokio::spawn(async move {
             barrier.wait().await;
             store
-                .complete_turn_run(next.id, completion_token, output.created_at, &output)
+                .complete_turn_run_and_append_event(
+                    next.id,
+                    completion_token,
+                    output.created_at,
+                    &output,
+                    Usage::default(),
+                    StopReason::EndTurn,
+                )
                 .await
                 .unwrap()
                 .unwrap()
@@ -169,13 +176,18 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
     }
     let mut committed = 0;
     let mut existing = 0;
+    let mut terminal_events = Vec::new();
     for completion in completions {
-        match completion.await.unwrap() {
+        let completion = completion.await.unwrap();
+        match completion.outcome {
             CompleteTurnRunOutcome::Completed(_) => committed += 1,
             CompleteTurnRunOutcome::Existing(_) => existing += 1,
         }
+        terminal_events.push(completion.terminal_event.unwrap());
     }
     assert_eq!((committed, existing), (1, 1));
+    assert_eq!(terminal_events[0], terminal_events[1]);
+    assert_eq!(terminal_events[0].seq, 1);
     assert_eq!(store.list_messages(next_chat.id).await.unwrap().len(), 2);
 
     let failure_chat = sample_chat();


### PR DESCRIPTION
## Summary

- commit assistant output, terminal turn state, and the `TurnCompleted` journal row in one transaction
- recover exact ambiguous retries with the original terminal event sequence
- preserve chat-to-turn lock ordering and roll back state and output if terminal event insertion fails

## Testing

- `cargo test --workspace --all-features`
- `cargo test -p openwave-core --all-features`
- PostgreSQL 17 state-machine integration tests
- CI-equivalent Clippy checks
- `bw dev lint --rust`
- `cargo fmt --all -- --check`
