### PR TITLE
feat(core): journal terminal turn failures atomically

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1343,7 +1343,7 @@ mod tests {
         )));
         let error_detail = error.to_string();
         let failure = store
-            .record_turn_run_failure(
+            .record_turn_run_failure_and_append_event(
                 failed_turn_id,
                 failure_token,
                 Utc::now(),
@@ -1355,9 +1355,42 @@ mod tests {
             .unwrap()
             .expect("the worker can record failure before publishing its event");
         assert!(matches!(
-            failure,
+            failure.outcome,
             crate::RecordTurnFailureOutcome::Recorded(_)
         ));
+        let terminal = failure
+            .terminal_event
+            .expect("terminal failure must return its committed event");
+        assert_eq!(
+            terminal.event,
+            AgentEvent::TurnFailed {
+                error: crate::AgentErrorInfo {
+                    kind: "agent_error".into(),
+                    message: error_detail.clone(),
+                }
+            }
+        );
+        assert_eq!(
+            store.list_events(chat.id, 0).await.unwrap().last(),
+            Some(&terminal)
+        );
+        let recovered = store
+            .record_turn_run_failure_and_append_event(
+                failed_turn_id,
+                failure_token,
+                failure_claimed_at + chrono::Duration::hours(1),
+                crate::TurnFailureRetry::Permanent,
+                "agent_error",
+                Some(&error_detail),
+            )
+            .await
+            .unwrap()
+            .expect("an exact terminal failure retry must remain recoverable");
+        assert!(matches!(
+            recovered.outcome,
+            crate::RecordTurnFailureOutcome::Existing(_)
+        ));
+        assert_eq!(recovered.terminal_event, Some(terminal));
 
         let cancelled_turn_id = TurnId::new();
         store

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1735,6 +1735,27 @@ impl Store for DbStore {
         .await
     }
 
+    async fn record_turn_run_failure_and_append_event(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        retry: TurnFailureRetry,
+        error_code: &str,
+        error_detail: Option<&str>,
+    ) -> Result<Option<JournaledTurnOutcome<RecordTurnFailureOutcome>>> {
+        ops::turn::record_turn_run_failure_and_append_event(
+            self,
+            id,
+            lease_token,
+            now,
+            retry,
+            error_code,
+            error_detail,
+        )
+        .await
+    }
+
     async fn request_turn_cancellation(
         &self,
         id: TurnId,

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -16,7 +16,7 @@ mod resolution;
 
 pub(in crate::db) use resolution::{
     complete_turn_run, complete_turn_run_and_append_event, finish_turn_cancellation,
-    record_turn_run_failure, request_turn_cancellation,
+    record_turn_run_failure, record_turn_run_failure_and_append_event, request_turn_cancellation,
 };
 
 pub(in crate::db) async fn get_turn_run(store: &DbStore, id: TurnId) -> Result<Option<TurnRun>> {

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -3,7 +3,7 @@ use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set, TransactionTrait,
 };
 
-use crate::error::{AgentError, Result};
+use crate::error::{AgentError, AgentErrorInfo, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, TurnId};
 use crate::model::{Message, Role, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus};
@@ -226,6 +226,60 @@ pub(in crate::db) async fn record_turn_run_failure(
     error_code: &str,
     error_detail: Option<&str>,
 ) -> Result<Option<RecordTurnFailureOutcome>> {
+    Ok(record_turn_run_failure_inner(
+        store,
+        id,
+        lease_token,
+        now,
+        retry,
+        error_code,
+        error_detail,
+        None,
+    )
+    .await?
+    .map(|resolution| resolution.outcome))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::db) async fn record_turn_run_failure_and_append_event(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    retry: TurnFailureRetry,
+    error_code: &str,
+    error_detail: Option<&str>,
+) -> Result<Option<JournaledTurnOutcome<RecordTurnFailureOutcome>>> {
+    let event = AgentEvent::TurnFailed {
+        error: AgentErrorInfo {
+            kind: error_code.to_owned(),
+            message: error_detail.unwrap_or(error_code).to_owned(),
+        },
+    };
+    record_turn_run_failure_inner(
+        store,
+        id,
+        lease_token,
+        now,
+        retry,
+        error_code,
+        error_detail,
+        Some(&event),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn record_turn_run_failure_inner(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    retry: TurnFailureRetry,
+    error_code: &str,
+    error_detail: Option<&str>,
+    terminal_event: Option<&AgentEvent>,
+) -> Result<Option<JournaledTurnOutcome<RecordTurnFailureOutcome>>> {
     validate_turn_failure(lease_token, error_code, error_detail)?;
     let now = canonical_db_timestamp(now)?;
     let requested_retry_at = match retry {
@@ -243,7 +297,18 @@ pub(in crate::db) async fn record_turn_run_failure(
     )
     .await?
     {
-        return Ok(Some(RecordTurnFailureOutcome::Existing(existing)));
+        let sequenced_event = exact_failure_terminal_event_on(
+            &store.conn,
+            id,
+            lease_token,
+            &existing,
+            terminal_event,
+        )
+        .await?;
+        return Ok(Some(JournaledTurnOutcome {
+            outcome: RecordTurnFailureOutcome::Existing(existing),
+            terminal_event: sequenced_event,
+        }));
     }
     if requested_retry_at.is_some_and(|retry_at| retry_at <= now) {
         return Err(AgentError::Store(
@@ -251,7 +316,18 @@ pub(in crate::db) async fn record_turn_run_failure(
         ));
     }
 
+    let journal_chat_id = journal_chat_id(store, id, terminal_event.is_some()).await?;
+    if terminal_event.is_some() && journal_chat_id.is_none() {
+        return Ok(None);
+    }
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    if let Some(chat_id) = journal_chat_id {
+        if !acquire_chat_write_lock(&transaction, chat_id).await? {
+            return Err(AgentError::Store(format!(
+                "turn {id} references missing chat {chat_id}"
+            )));
+        }
+    }
     if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
@@ -266,8 +342,19 @@ pub(in crate::db) async fn record_turn_run_failure(
     )
     .await?
     {
+        let sequenced_event = exact_failure_terminal_event_on(
+            &transaction,
+            id,
+            lease_token,
+            &existing,
+            terminal_event,
+        )
+        .await?;
         transaction.commit().await.map_err(store_err)?;
-        return Ok(Some(RecordTurnFailureOutcome::Existing(existing)));
+        return Ok(Some(JournaledTurnOutcome {
+            outcome: RecordTurnFailureOutcome::Existing(existing),
+            terminal_event: sequenced_event,
+        }));
     }
     let Some(claim) = entities::turn_claim::Entity::find_by_id(lease_token)
         .one(&transaction)
@@ -372,9 +459,24 @@ pub(in crate::db) async fn record_turn_run_failure(
         return Ok(None);
     }
 
+    let sequenced_event = if result_status == TurnRunStatus::Failed {
+        append_terminal_event_on(
+            &transaction,
+            id,
+            ChatId(turn.chat_id),
+            lease_token,
+            terminal_event,
+        )
+        .await?
+    } else {
+        None
+    };
     let receipt = turn_failure_from_model(receipt)?;
     transaction.commit().await.map_err(store_err)?;
-    Ok(Some(RecordTurnFailureOutcome::Recorded(receipt)))
+    Ok(Some(JournaledTurnOutcome {
+        outcome: RecordTurnFailureOutcome::Recorded(receipt),
+        terminal_event: sequenced_event,
+    }))
 }
 
 pub(in crate::db) async fn request_turn_cancellation(
@@ -767,20 +869,37 @@ where
         .one(conn)
         .await
         .map_err(store_err)?
-        .ok_or_else(|| AgentError::Store(format!("completed turn {id} is missing its event")))?;
+        .ok_or_else(|| AgentError::Store(format!("terminal turn {id} is missing its event")))?;
     let event = serde_json::from_value::<AgentEvent>(stored.payload)?;
     if stored.lease_token != Some(lease_token)
         || stored.attempt_event_ordinal != Some(i32::MAX)
         || event != *expected
     {
         return Err(AgentError::Store(format!(
-            "turn {id} was already completed with a different terminal event"
+            "turn {id} has a different terminal event"
         )));
     }
     Ok(Some(SequencedEvent {
         seq: stored.seq,
         event,
     }))
+}
+
+async fn exact_failure_terminal_event_on<C>(
+    conn: &C,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    receipt: &TurnFailureReceipt,
+    terminal_event: Option<&AgentEvent>,
+) -> Result<Option<SequencedEvent>>
+where
+    C: ConnectionTrait,
+{
+    if receipt.result_status == TurnRunStatus::Failed {
+        exact_terminal_event_on(conn, id, lease_token, terminal_event).await
+    } else {
+        Ok(None)
+    }
 }
 
 async fn exact_completed_output_on<C>(conn: &C, output: &Message) -> Result<bool>

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5560,8 +5560,8 @@ async fn turn_failure_receipt_recovers_exact_retries_after_the_turn_advances() {
         None
     );
 
-    let RecordTurnFailureOutcome::Recorded(receipt) = store
-        .record_turn_run_failure(
+    let journaled = store
+        .record_turn_run_failure_and_append_event(
             turn_id,
             token,
             resolved_at,
@@ -5571,10 +5571,12 @@ async fn turn_failure_receipt_recovers_exact_retries_after_the_turn_advances() {
         )
         .await
         .unwrap()
-        .unwrap()
-    else {
+        .unwrap();
+    let RecordTurnFailureOutcome::Recorded(receipt) = journaled.outcome else {
         panic!("first exact failure must commit")
     };
+    assert_eq!(journaled.terminal_event, None);
+    assert!(store.list_events(chat.id, 0).await.unwrap().is_empty());
     assert_eq!(receipt.lease_token, token);
     assert_eq!(receipt.turn_id, turn_id);
     assert_eq!(receipt.attempt_count, 1);
@@ -5608,7 +5610,7 @@ async fn turn_failure_receipt_recovers_exact_retries_after_the_turn_advances() {
         Some(RecordTurnFailureOutcome::Existing(receipt.clone()))
     );
     assert!(store
-        .record_turn_run_failure(
+        .record_turn_run_failure_and_append_event(
             turn_id,
             token,
             resolved_at,
@@ -5729,8 +5731,8 @@ async fn turn_failure_exhaustion_retains_retry_intent_and_rolls_back_atomically(
         .await
         .unwrap();
 
-    let RecordTurnFailureOutcome::Recorded(receipt) = store
-        .record_turn_run_failure(
+    let journaled = store
+        .record_turn_run_failure_and_append_event(
             turn_id,
             token,
             failed_at,
@@ -5740,8 +5742,8 @@ async fn turn_failure_exhaustion_retains_retry_intent_and_rolls_back_atomically(
         )
         .await
         .unwrap()
-        .unwrap()
-    else {
+        .unwrap();
+    let RecordTurnFailureOutcome::Recorded(receipt) = journaled.outcome else {
         panic!("failure after rollback must commit")
     };
     assert_eq!(receipt.result_status, TurnRunStatus::Failed);
@@ -5751,6 +5753,81 @@ async fn turn_failure_exhaustion_retains_retry_intent_and_rolls_back_atomically(
     assert_eq!(failed.finished_at, Some(failed_at));
     assert_eq!(failed.available_at, accepted.available_at);
     assert_eq!(failed.last_error_code.as_deref(), Some("provider_error"));
+    let terminal = journaled
+        .terminal_event
+        .expect("terminal failure must append an event");
+    assert_eq!(
+        terminal.event,
+        AgentEvent::TurnFailed {
+            error: crate::error::AgentErrorInfo {
+                kind: "provider_error".into(),
+                message: "provider_error".into(),
+            }
+        }
+    );
+    assert_eq!(store.list_events(chat.id, 0).await.unwrap(), vec![terminal]);
+}
+
+#[tokio::test]
+async fn turn_failure_rolls_back_receipt_and_state_when_terminal_event_fails() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(2))
+        .await
+        .unwrap()
+        .unwrap();
+    entities::event::ActiveModel {
+        chat_id: Set(chat.id.0),
+        seq: Set(1),
+        turn_id: Set(Some(turn_id.0)),
+        lease_token: Set(Some(token)),
+        attempt_event_ordinal: Set(Some(i32::MAX)),
+        terminal: Set(true),
+        payload: Set(serde_json::to_value(AgentEvent::TurnCompleted {
+            usage: Usage::default(),
+            stop_reason: StopReason::EndTurn,
+        })
+        .unwrap()),
+        created_at: Set(Utc::now()),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+
+    assert!(store
+        .record_turn_run_failure_and_append_event(
+            turn_id,
+            token,
+            claimed_at + chrono::Duration::seconds(1),
+            TurnFailureRetry::Permanent,
+            "provider_error",
+            Some("terminal insert must fail"),
+        )
+        .await
+        .is_err());
+    assert!(entities::turn_failure::Entity::find_by_id(token)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .is_none());
+    let still_running = store.get_turn_run(turn_id).await.unwrap().unwrap();
+    assert_eq!(still_running.status, TurnRunStatus::Running);
+    assert_eq!(still_running.finished_at, None);
+    assert_eq!(still_running.last_error_code, None);
+    assert_eq!(store.list_events(chat.id, 0).await.unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -710,6 +710,25 @@ pub trait Store: Send + Sync {
         turn_storage_unavailable()
     }
 
+    /// Resolve one claimed failure and append its terminal event atomically.
+    ///
+    /// Retry-wait outcomes do not publish a terminal event. Terminal failures
+    /// commit their receipt, turn transition, and `TurnFailed` journal row in
+    /// one transaction, and exact ambiguous retries recover the original
+    /// journal sequence.
+    #[allow(clippy::too_many_arguments)]
+    async fn record_turn_run_failure_and_append_event(
+        &self,
+        _id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+        _retry: TurnFailureRetry,
+        _error_code: &str,
+        _error_detail: Option<&str>,
+    ) -> Result<Option<JournaledTurnOutcome<RecordTurnFailureOutcome>>> {
+        turn_storage_unavailable()
+    }
+
     /// Durably request cancellation for one exact turn.
     ///
     /// Queued and retry-wait work becomes terminal immediately. Running work

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -221,7 +221,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         failures.push(tokio::spawn(async move {
             barrier.wait().await;
             store
-                .record_turn_run_failure(
+                .record_turn_run_failure_and_append_event(
                     failure_turn.id,
                     failure_token,
                     failure_at,
@@ -236,8 +236,10 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
     }
     let mut recorded = 0;
     let mut failure_existing = 0;
+    let mut failure_events = Vec::new();
     for failure in failures {
-        match failure.await.unwrap() {
+        let failure = failure.await.unwrap();
+        match failure.outcome {
             RecordTurnFailureOutcome::Recorded(receipt) => {
                 recorded += 1;
                 assert_eq!(receipt.result_status, TurnRunStatus::Failed);
@@ -249,8 +251,11 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
                 assert_eq!(receipt.requested_retry_at, Some(requested_retry_at));
             }
         }
+        failure_events.push(failure.terminal_event.unwrap());
     }
     assert_eq!((recorded, failure_existing), (1, 1));
+    assert_eq!(failure_events[0], failure_events[1]);
+    assert_eq!(failure_events[0].seq, 1);
     assert_eq!(
         store
             .get_turn_run(failure_turn.id)


### PR DESCRIPTION
## Summary

- commit terminal failure receipts, failed turn state, and `TurnFailed` journal rows in one transaction
- leave retry-wait attempts nonterminal while recovering exact terminal retries with their original sequence
- preserve chat-to-turn lock ordering and roll back receipt and state when terminal event insertion fails

## Testing

- `cargo test --workspace --all-features`
- `cargo test -p openwave-core --all-features`
- PostgreSQL 17 state-machine integration tests
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `bw dev lint --rust`
- `cargo fmt --all -- --check`
