### PR TITLE
feat(core): journal turn cancellations atomically

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1416,10 +1416,13 @@ mod tests {
         assert_eq!(cancelled_claim.id, cancelled_turn_id);
         assert!(matches!(
             store
-                .request_turn_cancellation(cancelled_turn_id, Utc::now())
+                .request_turn_cancellation_and_append_event(cancelled_turn_id, Utc::now())
                 .await
                 .unwrap(),
-            Some(crate::RequestTurnCancellationOutcome::Requested(_))
+            Some(crate::JournaledTurnOutcome {
+                outcome: crate::RequestTurnCancellationOutcome::Requested(_),
+                terminal_event: None,
+            })
         ));
 
         let cancel = CancelToken::new();
@@ -1455,13 +1458,48 @@ mod tests {
                 | AgentEvent::TurnCancelled { .. }
                 | AgentEvent::TurnFailed { .. }
         )));
+        let cancellation = store
+            .finish_turn_cancellation_and_append_event(
+                cancelled_turn_id,
+                cancellation_token,
+                Utc::now(),
+                Usage::default(),
+            )
+            .await
+            .unwrap()
+            .expect("the exact worker acknowledgement must commit");
         assert!(matches!(
-            store
-                .finish_turn_cancellation(cancelled_turn_id, cancellation_token, Utc::now())
-                .await
-                .unwrap(),
-            Some(crate::FinishTurnCancellationOutcome::Cancelled(_))
+            cancellation.outcome,
+            crate::FinishTurnCancellationOutcome::Cancelled(_)
         ));
+        let terminal = cancellation
+            .terminal_event
+            .expect("terminal cancellation must return its committed event");
+        assert_eq!(
+            terminal.event,
+            AgentEvent::TurnCancelled {
+                usage: Usage::default()
+            }
+        );
+        assert_eq!(
+            store.list_events(chat.id, 0).await.unwrap().last(),
+            Some(&terminal)
+        );
+        let recovered = store
+            .finish_turn_cancellation_and_append_event(
+                cancelled_turn_id,
+                cancellation_token,
+                cancellation_claimed_at + chrono::Duration::hours(1),
+                Usage::default(),
+            )
+            .await
+            .unwrap()
+            .expect("an exact cancellation retry must remain recoverable");
+        assert!(matches!(
+            recovered.outcome,
+            crate::FinishTurnCancellationOutcome::Existing(_)
+        ));
+        assert_eq!(recovered.terminal_event, Some(terminal));
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1764,6 +1764,14 @@ impl Store for DbStore {
         ops::turn::request_turn_cancellation(self, id, now).await
     }
 
+    async fn request_turn_cancellation_and_append_event(
+        &self,
+        id: TurnId,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<Option<JournaledTurnOutcome<RequestTurnCancellationOutcome>>> {
+        ops::turn::request_turn_cancellation_and_append_event(self, id, now).await
+    }
+
     async fn finish_turn_cancellation(
         &self,
         id: TurnId,
@@ -1771,6 +1779,17 @@ impl Store for DbStore {
         now: chrono::DateTime<Utc>,
     ) -> Result<Option<FinishTurnCancellationOutcome>> {
         ops::turn::finish_turn_cancellation(self, id, lease_token, now).await
+    }
+
+    async fn finish_turn_cancellation_and_append_event(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        usage: Usage,
+    ) -> Result<Option<JournaledTurnOutcome<FinishTurnCancellationOutcome>>> {
+        ops::turn::finish_turn_cancellation_and_append_event(self, id, lease_token, now, usage)
+            .await
     }
 
     async fn append_message(&self, message: &Message) -> Result<()> {

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -16,7 +16,9 @@ mod resolution;
 
 pub(in crate::db) use resolution::{
     complete_turn_run, complete_turn_run_and_append_event, finish_turn_cancellation,
-    record_turn_run_failure, record_turn_run_failure_and_append_event, request_turn_cancellation,
+    finish_turn_cancellation_and_append_event, record_turn_run_failure,
+    record_turn_run_failure_and_append_event, request_turn_cancellation,
+    request_turn_cancellation_and_append_event,
 };
 
 pub(in crate::db) async fn get_turn_run(store: &DbStore, id: TurnId) -> Result<Option<TurnRun>> {

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -114,7 +114,7 @@ async fn complete_turn_run_inner(
             )));
         }
         let sequenced_event =
-            exact_terminal_event_on(&transaction, id, lease_token, terminal_event).await?;
+            exact_terminal_event_on(&transaction, id, Some(lease_token), terminal_event).await?;
         let existing = turn_run_from_model(existing)?;
         transaction.commit().await.map_err(store_err)?;
         return Ok(Some(JournaledTurnOutcome {
@@ -146,7 +146,7 @@ async fn complete_turn_run_inner(
         transaction.rollback().await.map_err(store_err)?;
         if let Some(existing) = exact_completed_turn_on(store, id, lease_token, output).await? {
             let sequenced_event =
-                exact_terminal_event_on(&store.conn, id, lease_token, terminal_event).await?;
+                exact_terminal_event_on(&store.conn, id, Some(lease_token), terminal_event).await?;
             return Ok(Some(JournaledTurnOutcome {
                 outcome: CompleteTurnRunOutcome::Existing(existing),
                 terminal_event: sequenced_event,
@@ -199,7 +199,7 @@ async fn complete_turn_run_inner(
         &transaction,
         id,
         ChatId(existing.chat_id),
-        lease_token,
+        Some(lease_token),
         terminal_event,
     )
     .await?;
@@ -464,7 +464,7 @@ async fn record_turn_run_failure_inner(
             &transaction,
             id,
             ChatId(turn.chat_id),
-            lease_token,
+            Some(lease_token),
             terminal_event,
         )
         .await?
@@ -484,8 +484,41 @@ pub(in crate::db) async fn request_turn_cancellation(
     id: TurnId,
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<RequestTurnCancellationOutcome>> {
+    Ok(request_turn_cancellation_inner(store, id, now, None)
+        .await?
+        .map(|resolution| resolution.outcome))
+}
+
+pub(in crate::db) async fn request_turn_cancellation_and_append_event(
+    store: &DbStore,
+    id: TurnId,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<JournaledTurnOutcome<RequestTurnCancellationOutcome>>> {
+    let event = AgentEvent::TurnCancelled {
+        usage: Usage::default(),
+    };
+    request_turn_cancellation_inner(store, id, now, Some(&event)).await
+}
+
+async fn request_turn_cancellation_inner(
+    store: &DbStore,
+    id: TurnId,
+    now: chrono::DateTime<Utc>,
+    terminal_event: Option<&AgentEvent>,
+) -> Result<Option<JournaledTurnOutcome<RequestTurnCancellationOutcome>>> {
     let now = canonical_db_timestamp(now)?;
+    let journal_chat_id = journal_chat_id(store, id, terminal_event.is_some()).await?;
+    if terminal_event.is_some() && journal_chat_id.is_none() {
+        return Ok(None);
+    }
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    if let Some(chat_id) = journal_chat_id {
+        if !acquire_chat_write_lock(&transaction, chat_id).await? {
+            return Err(AgentError::Store(format!(
+                "turn {id} references missing chat {chat_id}"
+            )));
+        }
+    }
     if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
@@ -501,14 +534,25 @@ pub(in crate::db) async fn request_turn_cancellation(
     let status = turn_run_status_from_db(&turn.status)?;
     match status {
         TurnRunStatus::Cancelling | TurnRunStatus::Cancelled => {
+            let sequenced_event = if status == TurnRunStatus::Cancelled {
+                existing_cancellation_event_on(&transaction, id, terminal_event.is_some()).await?
+            } else {
+                None
+            };
             let turn = turn_run_from_model(turn)?;
             transaction.commit().await.map_err(store_err)?;
-            return Ok(Some(RequestTurnCancellationOutcome::Existing(turn)));
+            return Ok(Some(JournaledTurnOutcome {
+                outcome: RequestTurnCancellationOutcome::Existing(turn),
+                terminal_event: sequenced_event,
+            }));
         }
         TurnRunStatus::Completed | TurnRunStatus::Failed => {
             let turn = turn_run_from_model(turn)?;
             transaction.commit().await.map_err(store_err)?;
-            return Ok(Some(RequestTurnCancellationOutcome::AlreadyTerminal(turn)));
+            return Ok(Some(JournaledTurnOutcome {
+                outcome: RequestTurnCancellationOutcome::AlreadyTerminal(turn),
+                terminal_event: None,
+            }));
         }
         TurnRunStatus::Queued | TurnRunStatus::Running | TurnRunStatus::RetryWait => {}
     }
@@ -572,12 +616,22 @@ pub(in crate::db) async fn request_turn_cancellation(
         .map_err(store_err)?
         .ok_or_else(|| AgentError::Store(format!("cancelled turn {id} disappeared")))
         .and_then(turn_run_from_model)?;
-    transaction.commit().await.map_err(store_err)?;
-    if next_status == TurnRunStatus::Cancelling {
-        Ok(Some(RequestTurnCancellationOutcome::Requested(updated)))
+    let sequenced_event = if next_status == TurnRunStatus::Cancelled {
+        append_terminal_event_on(&transaction, id, ChatId(turn.chat_id), None, terminal_event)
+            .await?
     } else {
-        Ok(Some(RequestTurnCancellationOutcome::Cancelled(updated)))
-    }
+        None
+    };
+    transaction.commit().await.map_err(store_err)?;
+    let outcome = if next_status == TurnRunStatus::Cancelling {
+        RequestTurnCancellationOutcome::Requested(updated)
+    } else {
+        RequestTurnCancellationOutcome::Cancelled(updated)
+    };
+    Ok(Some(JournaledTurnOutcome {
+        outcome,
+        terminal_event: sequenced_event,
+    }))
 }
 
 pub(in crate::db) async fn finish_turn_cancellation(
@@ -586,11 +640,47 @@ pub(in crate::db) async fn finish_turn_cancellation(
     lease_token: uuid::Uuid,
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<FinishTurnCancellationOutcome>> {
+    Ok(
+        finish_turn_cancellation_inner(store, id, lease_token, now, None)
+            .await?
+            .map(|resolution| resolution.outcome),
+    )
+}
+
+pub(in crate::db) async fn finish_turn_cancellation_and_append_event(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    usage: Usage,
+) -> Result<Option<JournaledTurnOutcome<FinishTurnCancellationOutcome>>> {
+    let event = AgentEvent::TurnCancelled { usage };
+    finish_turn_cancellation_inner(store, id, lease_token, now, Some(&event)).await
+}
+
+async fn finish_turn_cancellation_inner(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+    terminal_event: Option<&AgentEvent>,
+) -> Result<Option<JournaledTurnOutcome<FinishTurnCancellationOutcome>>> {
     if lease_token.is_nil() {
         return Err(AgentError::Store("turn lease token must not be nil".into()));
     }
     let now = canonical_db_timestamp(now)?;
+    let journal_chat_id = journal_chat_id(store, id, terminal_event.is_some()).await?;
+    if terminal_event.is_some() && journal_chat_id.is_none() {
+        return Ok(None);
+    }
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    if let Some(chat_id) = journal_chat_id {
+        if !acquire_chat_write_lock(&transaction, chat_id).await? {
+            return Err(AgentError::Store(format!(
+                "turn {id} references missing chat {chat_id}"
+            )));
+        }
+    }
     if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
@@ -614,9 +704,14 @@ pub(in crate::db) async fn finish_turn_cancellation(
     };
     if turn.status == TurnRunStatus::Cancelled.as_str() && turn.attempt_count == claim.attempt_count
     {
+        let sequenced_event =
+            exact_terminal_event_on(&transaction, id, Some(lease_token), terminal_event).await?;
         let turn = turn_run_from_model(turn)?;
         transaction.commit().await.map_err(store_err)?;
-        return Ok(Some(FinishTurnCancellationOutcome::Existing(turn)));
+        return Ok(Some(JournaledTurnOutcome {
+            outcome: FinishTurnCancellationOutcome::Existing(turn),
+            terminal_event: sequenced_event,
+        }));
     }
     if turn.status != TurnRunStatus::Cancelling.as_str()
         || turn.attempt_count != claim.attempt_count
@@ -668,8 +763,19 @@ pub(in crate::db) async fn finish_turn_cancellation(
         .map_err(store_err)?
         .ok_or_else(|| AgentError::Store(format!("cancelled turn {id} disappeared")))
         .and_then(turn_run_from_model)?;
+    let sequenced_event = append_terminal_event_on(
+        &transaction,
+        id,
+        ChatId(turn.chat_id),
+        Some(lease_token),
+        terminal_event,
+    )
+    .await?;
     transaction.commit().await.map_err(store_err)?;
-    Ok(Some(FinishTurnCancellationOutcome::Cancelled(cancelled)))
+    Ok(Some(JournaledTurnOutcome {
+        outcome: FinishTurnCancellationOutcome::Cancelled(cancelled),
+        terminal_event: sequenced_event,
+    }))
 }
 
 fn validate_turn_output(id: TurnId, lease_token: uuid::Uuid, output: &Message) -> Result<()> {
@@ -827,7 +933,7 @@ async fn append_terminal_event_on<C>(
     conn: &C,
     id: TurnId,
     chat_id: ChatId,
-    lease_token: uuid::Uuid,
+    lease_token: Option<uuid::Uuid>,
     terminal_event: Option<&AgentEvent>,
 ) -> Result<Option<SequencedEvent>>
 where
@@ -840,8 +946,8 @@ where
         conn,
         chat_id,
         Some(id),
-        Some(lease_token),
-        Some(i32::MAX),
+        lease_token,
+        lease_token.map(|_| i32::MAX),
         event,
     )
     .await?;
@@ -854,7 +960,7 @@ where
 async fn exact_terminal_event_on<C>(
     conn: &C,
     id: TurnId,
-    lease_token: uuid::Uuid,
+    lease_token: Option<uuid::Uuid>,
     expected: Option<&AgentEvent>,
 ) -> Result<Option<SequencedEvent>>
 where
@@ -871,8 +977,8 @@ where
         .map_err(store_err)?
         .ok_or_else(|| AgentError::Store(format!("terminal turn {id} is missing its event")))?;
     let event = serde_json::from_value::<AgentEvent>(stored.payload)?;
-    if stored.lease_token != Some(lease_token)
-        || stored.attempt_event_ordinal != Some(i32::MAX)
+    if stored.lease_token != lease_token
+        || stored.attempt_event_ordinal != lease_token.map(|_| i32::MAX)
         || event != *expected
     {
         return Err(AgentError::Store(format!(
@@ -896,10 +1002,40 @@ where
     C: ConnectionTrait,
 {
     if receipt.result_status == TurnRunStatus::Failed {
-        exact_terminal_event_on(conn, id, lease_token, terminal_event).await
+        exact_terminal_event_on(conn, id, Some(lease_token), terminal_event).await
     } else {
         Ok(None)
     }
+}
+
+async fn existing_cancellation_event_on<C>(
+    conn: &C,
+    id: TurnId,
+    expected: bool,
+) -> Result<Option<SequencedEvent>>
+where
+    C: ConnectionTrait,
+{
+    if !expected {
+        return Ok(None);
+    }
+    let stored = entities::event::Entity::find()
+        .filter(entities::event::Column::TurnId.eq(id.0))
+        .filter(entities::event::Column::Terminal.eq(true))
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("cancelled turn {id} is missing its event")))?;
+    let event = serde_json::from_value::<AgentEvent>(stored.payload)?;
+    if !matches!(event, AgentEvent::TurnCancelled { .. }) {
+        return Err(AgentError::Store(format!(
+            "cancelled turn {id} has a different terminal event"
+        )));
+    }
+    Ok(Some(SequencedEvent {
+        seq: stored.seq,
+        event,
+    }))
 }
 
 async fn exact_completed_output_on<C>(conn: &C, output: &Message) -> Result<bool>

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5945,30 +5945,45 @@ async fn queued_and_retry_wait_turns_cancel_immediately_and_idempotently() {
     };
     assert_eq!(
         store
-            .request_turn_cancellation(queued.id, queued.updated_at - chrono::Duration::seconds(1))
+            .request_turn_cancellation_and_append_event(
+                queued.id,
+                queued.updated_at - chrono::Duration::seconds(1),
+            )
             .await
             .unwrap(),
         None
     );
     let cancelled_at = queued.updated_at + chrono::Duration::seconds(1);
-    let RequestTurnCancellationOutcome::Cancelled(cancelled) = store
-        .request_turn_cancellation(queued.id, cancelled_at)
+    let journaled = store
+        .request_turn_cancellation_and_append_event(queued.id, cancelled_at)
         .await
         .unwrap()
-        .unwrap()
-    else {
+        .unwrap();
+    let RequestTurnCancellationOutcome::Cancelled(cancelled) = journaled.outcome else {
         panic!("queued cancellation must be immediate")
     };
     assert_eq!(cancelled.status, TurnRunStatus::Cancelled);
     assert_eq!(cancelled.attempt_count, 0);
     assert_eq!(cancelled.finished_at, Some(cancelled_at));
+    let terminal = journaled
+        .terminal_event
+        .expect("queued cancellation must append a terminal event");
     assert_eq!(
-        store
-            .request_turn_cancellation(queued.id, queued.updated_at)
-            .await
-            .unwrap(),
-        Some(RequestTurnCancellationOutcome::Existing(cancelled))
+        terminal.event,
+        AgentEvent::TurnCancelled {
+            usage: Usage::default()
+        }
     );
+    let recovered = store
+        .request_turn_cancellation_and_append_event(queued.id, queued.updated_at)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        recovered.outcome,
+        RequestTurnCancellationOutcome::Existing(cancelled)
+    );
+    assert_eq!(recovered.terminal_event, Some(terminal));
     let after_cancel = match store
         .accept_turn(TurnId::new(), queued_chat.id, "gpt-5", "after cancel")
         .await
@@ -6032,14 +6047,21 @@ async fn queued_and_retry_wait_turns_cancel_immediately_and_idempotently() {
         panic!("retryable failure must commit")
     };
     let retry_cancelled_at = failed_at + chrono::Duration::seconds(1);
-    let RequestTurnCancellationOutcome::Cancelled(cancelled) = store
-        .request_turn_cancellation(retry_turn.id, retry_cancelled_at)
+    let journaled = store
+        .request_turn_cancellation_and_append_event(retry_turn.id, retry_cancelled_at)
         .await
         .unwrap()
-        .unwrap()
-    else {
+        .unwrap();
+    let RequestTurnCancellationOutcome::Cancelled(cancelled) = journaled.outcome else {
         panic!("retry-wait cancellation must be immediate")
     };
+    assert!(matches!(
+        journaled.terminal_event,
+        Some(SequencedEvent {
+            event: AgentEvent::TurnCancelled { .. },
+            ..
+        })
+    ));
     assert_eq!(cancelled.status, TurnRunStatus::Cancelled);
     assert_eq!(cancelled.finished_at, Some(retry_cancelled_at));
     assert_eq!(cancelled.last_error_code, None);
@@ -6058,6 +6080,50 @@ async fn queued_and_retry_wait_turns_cancel_immediately_and_idempotently() {
             .unwrap(),
         Some(RecordTurnFailureOutcome::Existing(receipt))
     );
+}
+
+#[tokio::test]
+async fn immediate_cancellation_rolls_back_when_terminal_event_fails() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "cancel before claim")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    entities::event::ActiveModel {
+        chat_id: Set(chat.id.0),
+        seq: Set(1),
+        turn_id: Set(Some(turn.id.0)),
+        lease_token: Set(None),
+        attempt_event_ordinal: Set(None),
+        terminal: Set(true),
+        payload: Set(serde_json::to_value(AgentEvent::TurnCompleted {
+            usage: Usage::default(),
+            stop_reason: StopReason::EndTurn,
+        })
+        .unwrap()),
+        created_at: Set(Utc::now()),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+
+    assert!(store
+        .request_turn_cancellation_and_append_event(
+            turn.id,
+            turn.updated_at + chrono::Duration::seconds(1),
+        )
+        .await
+        .is_err());
+    let still_queued = store.get_turn_run(turn.id).await.unwrap().unwrap();
+    assert_eq!(still_queued.status, TurnRunStatus::Queued);
+    assert_eq!(still_queued.finished_at, None);
+    assert_eq!(store.list_events(chat.id, 0).await.unwrap().len(), 1);
 }
 
 #[tokio::test]
@@ -6082,14 +6148,15 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
         .unwrap()
         .unwrap();
     let requested_at = claimed_at + chrono::Duration::seconds(1);
-    let RequestTurnCancellationOutcome::Requested(cancelling) = store
-        .request_turn_cancellation(turn.id, requested_at)
+    let requested = store
+        .request_turn_cancellation_and_append_event(turn.id, requested_at)
         .await
         .unwrap()
-        .unwrap()
-    else {
+        .unwrap();
+    let RequestTurnCancellationOutcome::Requested(cancelling) = requested.outcome else {
         panic!("running cancellation must await worker acknowledgement")
     };
+    assert_eq!(requested.terminal_event, None);
     assert_eq!(cancelling.status, TurnRunStatus::Cancelling);
     assert_eq!(cancelling.lease_token, Some(token));
     assert_eq!(cancelling.lease_expires_at, Some(expires_at));
@@ -6159,25 +6226,51 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
     );
 
     let acknowledged_at = expires_at + chrono::Duration::seconds(1);
-    let FinishTurnCancellationOutcome::Cancelled(cancelled) = store
-        .finish_turn_cancellation(turn.id, token, acknowledged_at)
+    let usage = Usage {
+        input_tokens: 13,
+        output_tokens: 8,
+        ..Usage::default()
+    };
+    let journaled = store
+        .finish_turn_cancellation_and_append_event(turn.id, token, acknowledged_at, usage)
         .await
         .unwrap()
-        .unwrap()
-    else {
+        .unwrap();
+    let FinishTurnCancellationOutcome::Cancelled(cancelled) = journaled.outcome else {
         panic!("exact worker acknowledgement must cancel")
     };
     assert_eq!(cancelled.status, TurnRunStatus::Cancelled);
     assert_eq!(cancelled.lease_token, None);
     assert_eq!(cancelled.lease_expires_at, None);
     assert_eq!(cancelled.finished_at, Some(acknowledged_at));
+    let terminal = journaled
+        .terminal_event
+        .expect("worker acknowledgement must append a terminal event");
+    assert_eq!(terminal.event, AgentEvent::TurnCancelled { usage });
+    let recovered = store
+        .finish_turn_cancellation_and_append_event(
+            turn.id,
+            token,
+            acknowledged_at + chrono::Duration::hours(1),
+            usage,
+        )
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
-        store
-            .finish_turn_cancellation(turn.id, token, acknowledged_at + chrono::Duration::hours(1),)
-            .await
-            .unwrap(),
-        Some(FinishTurnCancellationOutcome::Existing(cancelled))
+        recovered.outcome,
+        FinishTurnCancellationOutcome::Existing(cancelled)
     );
+    assert_eq!(recovered.terminal_event, Some(terminal));
+    assert!(store
+        .finish_turn_cancellation_and_append_event(
+            turn.id,
+            token,
+            acknowledged_at + chrono::Duration::hours(1),
+            Usage::default(),
+        )
+        .await
+        .is_err());
     assert!(matches!(
         store
             .accept_turn(TurnId::new(), chat.id, "gpt-5", "after acknowledgement")

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -744,6 +744,19 @@ pub trait Store: Send + Sync {
         turn_storage_unavailable()
     }
 
+    /// Request cancellation and publish an immediate terminal outcome atomically.
+    ///
+    /// Queued and retry-wait turns commit `TurnCancelled` with their terminal
+    /// transition. Running turns only enter `cancelling`; their worker publishes
+    /// the terminal event when it acknowledges quiescence.
+    async fn request_turn_cancellation_and_append_event(
+        &self,
+        _id: TurnId,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<JournaledTurnOutcome<RequestTurnCancellationOutcome>>> {
+        turn_storage_unavailable()
+    }
+
     /// Acknowledge that one exact cancelling worker has quiesced.
     ///
     /// The immutable claim receipt and terminal attempt make exact retries
@@ -756,6 +769,20 @@ pub trait Store: Send + Sync {
         _lease_token: uuid::Uuid,
         _now: chrono::DateTime<chrono::Utc>,
     ) -> Result<Option<FinishTurnCancellationOutcome>> {
+        turn_storage_unavailable()
+    }
+
+    /// Acknowledge cancellation and publish its terminal event atomically.
+    ///
+    /// Exact ambiguous retries recover both the cancelled turn and the same
+    /// journal sequence, including the usage recorded by the original worker.
+    async fn finish_turn_cancellation_and_append_event(
+        &self,
+        _id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+        _usage: Usage,
+    ) -> Result<Option<JournaledTurnOutcome<FinishTurnCancellationOutcome>>> {
         turn_storage_unavailable()
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -302,7 +302,10 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         cancellations.push(tokio::spawn(async move {
             barrier.wait().await;
             store
-                .request_turn_cancellation(cancellation_turn.id, cancellation_requested_at)
+                .request_turn_cancellation_and_append_event(
+                    cancellation_turn.id,
+                    cancellation_requested_at,
+                )
                 .await
                 .unwrap()
                 .unwrap()
@@ -311,7 +314,9 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
     let mut requested = 0;
     let mut cancellation_existing = 0;
     for cancellation in cancellations {
-        match cancellation.await.unwrap() {
+        let cancellation = cancellation.await.unwrap();
+        assert_eq!(cancellation.terminal_event, None);
+        match cancellation.outcome {
             RequestTurnCancellationOutcome::Requested(turn) => {
                 requested += 1;
                 assert_eq!(turn.status, TurnRunStatus::Cancelling);
@@ -325,26 +330,42 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
     }
     assert_eq!((requested, cancellation_existing), (1, 1));
     let acknowledged_at = cancellation_expiry + Duration::seconds(1);
-    let FinishTurnCancellationOutcome::Cancelled(cancelled) = store
-        .finish_turn_cancellation(cancellation_turn.id, cancellation_token, acknowledged_at)
+    let usage = Usage {
+        input_tokens: 3,
+        output_tokens: 2,
+        ..Usage::default()
+    };
+    let journaled = store
+        .finish_turn_cancellation_and_append_event(
+            cancellation_turn.id,
+            cancellation_token,
+            acknowledged_at,
+            usage,
+        )
         .await
         .unwrap()
-        .unwrap()
-    else {
+        .unwrap();
+    let FinishTurnCancellationOutcome::Cancelled(cancelled) = journaled.outcome else {
         panic!("exact PostgreSQL cancellation acknowledgement must commit")
     };
     assert_eq!(cancelled.status, TurnRunStatus::Cancelled);
+    let terminal = journaled.terminal_event.unwrap();
+    assert_eq!(terminal.event, AgentEvent::TurnCancelled { usage });
+    let recovered = store
+        .finish_turn_cancellation_and_append_event(
+            cancellation_turn.id,
+            cancellation_token,
+            acknowledged_at + Duration::hours(1),
+            usage,
+        )
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
-        store
-            .finish_turn_cancellation(
-                cancellation_turn.id,
-                cancellation_token,
-                acknowledged_at + Duration::hours(1),
-            )
-            .await
-            .unwrap(),
-        Some(FinishTurnCancellationOutcome::Existing(cancelled))
+        recovered.outcome,
+        FinishTurnCancellationOutcome::Existing(cancelled)
     );
+    assert_eq!(recovered.terminal_event, Some(terminal));
 
     let event_chat = sample_chat();
     store.create_chat(&event_chat).await.unwrap();


### PR DESCRIPTION
## Summary

- commit immediate queued or retry-wait cancellation and its `TurnCancelled` journal row atomically
- keep running cancellation nonterminal until the exact worker acknowledgement commits its terminal event
- recover cancellation retries with the original sequence and usage while preserving chat-to-turn lock ordering

## Testing

- `cargo test --workspace --all-features`
- `cargo test -p openwave-core --all-features`
- PostgreSQL 17 state-machine integration tests
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `bw dev lint --rust`
- `cargo fmt --all -- --check`
