### PR TITLE
feat(core): journal claim scan terminal events

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1164,6 +1164,7 @@ mod tests {
             )
             .await
             .unwrap()
+            .turn
             .expect("accepted turn is claimable");
         assert_eq!(claimed.id, turn_id);
 
@@ -1314,6 +1315,7 @@ mod tests {
             )
             .await
             .unwrap()
+            .turn
             .expect("second accepted turn is claimable");
         assert_eq!(failed_claim.id, failed_turn_id);
         let failing_agent = Agent::new(
@@ -1412,6 +1414,7 @@ mod tests {
             )
             .await
             .unwrap()
+            .turn
             .expect("third accepted turn is claimable");
         assert_eq!(cancelled_claim.id, cancelled_turn_id);
         assert!(matches!(

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -229,6 +229,22 @@ pub mod turn_claim {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod turn_claim_lock {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "turn_claim_lock")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: i32,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod turn_failure {
     use sea_orm::entity::prelude::*;
 
@@ -313,6 +329,7 @@ pub mod event {
         pub turn_id: Option<Uuid>,
         pub lease_token: Option<Uuid>,
         pub attempt_event_ordinal: Option<i32>,
+        pub scan_token: Option<Uuid>,
         pub terminal: bool,
         #[sea_orm(column_type = "JsonBinary")]
         pub payload: Json,

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -160,6 +160,26 @@ impl MigrationTrait for Init {
             )
             .await?;
 
+        manager
+            .create_table(
+                Table::create()
+                    .table(TurnClaimLock::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(TurnClaimLock::Id)
+                            .integer()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .check(Expr::col(TurnClaimLock::Id).eq(1))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .get_connection()
+            .execute_unprepared("INSERT INTO turn_claim_lock (id) VALUES (1)")
+            .await?;
+
         let valid_turn_status = Expr::col(TurnRun::Status).is_in([
             TurnRunStatus::Queued.as_str(),
             TurnRunStatus::Running.as_str(),
@@ -588,6 +608,9 @@ impl MigrationTrait for Init {
             .drop_table(Table::drop().table(TurnClaim::Table).to_owned())
             .await?;
         manager
+            .drop_table(Table::drop().table(TurnClaimLock::Table).to_owned())
+            .await?;
+        manager
             .drop_table(Table::drop().table(Chat::Table).to_owned())
             .await?;
         Ok(())
@@ -616,6 +639,7 @@ impl MigrationTrait for AddEventJournal {
                     .col(ColumnDef::new(Event::TurnId).uuid())
                     .col(ColumnDef::new(Event::LeaseToken).uuid())
                     .col(ColumnDef::new(Event::AttemptEventOrdinal).integer())
+                    .col(ColumnDef::new(Event::ScanToken).uuid())
                     .col(
                         ColumnDef::new(Event::Terminal)
                             .boolean()
@@ -683,6 +707,11 @@ impl MigrationTrait for AddEventJournal {
                             .or(Expr::col(Event::Terminal).eq(true))
                             .or(Expr::col(Event::LeaseToken).is_not_null()),
                     )
+                    .check(
+                        Expr::col(Event::ScanToken)
+                            .is_null()
+                            .or(Expr::col(Event::Terminal).eq(true)),
+                    )
                     .to_owned(),
             )
             .await?;
@@ -693,6 +722,16 @@ impl MigrationTrait for AddEventJournal {
                     .table(Event::Table)
                     .col(Event::LeaseToken)
                     .col(Event::AttemptEventOrdinal)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_event_scan_token")
+                    .table(Event::Table)
+                    .col(Event::ScanToken)
                     .unique()
                     .to_owned(),
             )
@@ -1680,6 +1719,12 @@ enum TurnClaim {
 }
 
 #[derive(DeriveIden)]
+enum TurnClaimLock {
+    Table,
+    Id,
+}
+
+#[derive(DeriveIden)]
 enum TurnFailure {
     Table,
     LeaseToken,
@@ -1722,6 +1767,7 @@ enum Event {
     TurnId,
     LeaseToken,
     AttemptEventOrdinal,
+    ScanToken,
     Terminal,
     Payload,
     CreatedAt,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -34,7 +34,7 @@ use crate::model::{
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
-    AcceptTurnOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
+    AcceptTurnOutcome, ClaimTurnRunOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
     EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
     JournaledTurnOutcome, RecordTurnFailureOutcome, RequestTurnCancellationOutcome, Store,
 };
@@ -1669,7 +1669,7 @@ impl Store for DbStore {
         lease_token: uuid::Uuid,
         now: chrono::DateTime<Utc>,
         lease_expires_at: chrono::DateTime<Utc>,
-    ) -> Result<Option<TurnRun>> {
+    ) -> Result<ClaimTurnRunOutcome> {
         ops::turn::claim_turn_run(self, lease_token, now, lease_expires_at).await
     }
 

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -163,7 +163,7 @@ pub(in crate::db) async fn append_event(
         )));
     }
 
-    let seq = append_event_on(&transaction, chat_id, None, None, None, event).await?;
+    let seq = append_event_on(&transaction, chat_id, None, None, None, None, event).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(seq)
 }
@@ -285,6 +285,7 @@ pub(in crate::db) async fn append_turn_event(
         Some(turn_id),
         Some(lease_token),
         Some(attempt_event_ordinal),
+        None,
         event,
     )
     .await?;
@@ -298,6 +299,7 @@ pub(in crate::db::ops) async fn append_event_on<C>(
     turn_id: Option<TurnId>,
     lease_token: Option<uuid::Uuid>,
     attempt_event_ordinal: Option<i32>,
+    scan_token: Option<uuid::Uuid>,
     event: &AgentEvent,
 ) -> Result<i64>
 where
@@ -318,6 +320,7 @@ where
         turn_id: Set(turn_id.map(|id| id.0)),
         lease_token: Set(lease_token),
         attempt_event_ordinal: Set(attempt_event_ordinal),
+        scan_token: Set(scan_token),
         terminal: Set(turn_id.is_some() && is_terminal_event(event)),
         payload: Set(serde_json::to_value(event)?),
         created_at: Set(Utc::now()),

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -4,13 +4,14 @@ use sea_orm::{
     TransactionTrait, TryInsertResult,
 };
 
-use crate::error::{AgentError, Result};
+use crate::error::{AgentError, AgentErrorInfo, Result};
+use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, MessageId, TurnId};
 use crate::model::{TurnRun, TurnRunStatus};
-use crate::storage::AcceptTurnOutcome;
+use crate::storage::{AcceptTurnOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome};
 
 use super::super::{entities, store_err, DbStore};
-use super::acquire_chat_write_lock;
+use super::{acquire_chat_write_lock, conversation::append_event_on};
 
 mod resolution;
 
@@ -140,7 +141,7 @@ pub(in crate::db) async fn claim_turn_run(
     lease_token: uuid::Uuid,
     now: chrono::DateTime<Utc>,
     lease_expires_at: chrono::DateTime<Utc>,
-) -> Result<Option<TurnRun>> {
+) -> Result<ClaimTurnRunOutcome> {
     let now = canonical_db_timestamp(now)?;
     let lease_expires_at = canonical_db_timestamp(lease_expires_at)?;
     if lease_token.is_nil() {
@@ -155,6 +156,19 @@ pub(in crate::db) async fn claim_turn_run(
     loop {
         let transaction = store.conn.begin().await.map_err(store_err)?;
         acquire_turn_claim_write_lock(&transaction).await?;
+        if let Some(existing) = entities::event::Entity::find()
+            .filter(entities::event::Column::ScanToken.eq(lease_token))
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+        {
+            let terminal_event = claim_scan_terminal_event_from_model(existing, lease_token)?;
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(ClaimTurnRunOutcome {
+                turn: None,
+                terminal_event: Some(terminal_event),
+            });
+        }
         if let Some(receipt) = entities::turn_claim::Entity::find_by_id(lease_token)
             .one(&transaction)
             .await
@@ -175,7 +189,10 @@ pub(in crate::db) async fn claim_turn_run(
                 .map(turn_run_from_model)
                 .transpose()?;
             transaction.commit().await.map_err(store_err)?;
-            return Ok(existing);
+            return Ok(ClaimTurnRunOutcome {
+                turn: existing,
+                terminal_event: None,
+            });
         }
         let due = entities::turn_run::Entity::find()
             .filter(entities::turn_run::Column::Status.is_in([
@@ -221,10 +238,20 @@ pub(in crate::db) async fn claim_turn_run(
         };
         let Some(candidate) = candidate else {
             transaction.commit().await.map_err(store_err)?;
-            return Ok(None);
+            return Ok(ClaimTurnRunOutcome {
+                turn: None,
+                terminal_event: None,
+            });
         };
 
         if candidate.status == TurnRunStatus::Cancelling.as_str() {
+            let chat_id = ChatId(candidate.chat_id);
+            if !acquire_chat_write_lock(&transaction, chat_id).await? {
+                return Err(AgentError::Store(format!(
+                    "turn {} references missing chat {chat_id}",
+                    TurnId(candidate.id)
+                )));
+            }
             let cancelled = entities::turn_run::Entity::update_many()
                 .col_expr(
                     entities::turn_run::Column::Status,
@@ -261,12 +288,37 @@ pub(in crate::db) async fn claim_turn_run(
                 transaction.rollback().await.map_err(store_err)?;
                 continue;
             }
+            let event = AgentEvent::TurnCancelled {
+                usage: crate::provider::Usage::default(),
+            };
+            let sequenced_event = append_claim_scan_terminal_event_on(
+                &transaction,
+                &candidate,
+                chat_id,
+                lease_token,
+                &event,
+            )
+            .await?;
             transaction.commit().await.map_err(store_err)?;
-            continue;
+            return Ok(ClaimTurnRunOutcome {
+                turn: None,
+                terminal_event: Some(ClaimScanTerminalEvent {
+                    chat_id,
+                    turn_id: TurnId(candidate.id),
+                    event: sequenced_event,
+                }),
+            });
         }
 
         let reclaiming = candidate.status == TurnRunStatus::Running.as_str();
         if reclaiming && candidate.attempt_count >= candidate.max_attempts {
+            let chat_id = ChatId(candidate.chat_id);
+            if !acquire_chat_write_lock(&transaction, chat_id).await? {
+                return Err(AgentError::Store(format!(
+                    "turn {} references missing chat {chat_id}",
+                    TurnId(candidate.id)
+                )));
+            }
             let failed = entities::turn_run::Entity::update_many()
                 .col_expr(
                     entities::turn_run::Column::Status,
@@ -309,8 +361,48 @@ pub(in crate::db) async fn claim_turn_run(
                 transaction.rollback().await.map_err(store_err)?;
                 continue;
             }
+            let event = AgentEvent::TurnFailed {
+                error: AgentErrorInfo {
+                    kind: "lease_expired".into(),
+                    message: "final worker lease expired".into(),
+                },
+            };
+            let claim_token = candidate.lease_token.ok_or_else(|| {
+                AgentError::Store(format!(
+                    "terminalized turn {} is missing its claim token",
+                    TurnId(candidate.id)
+                ))
+            })?;
+            entities::turn_failure::ActiveModel {
+                lease_token: Set(claim_token),
+                turn_id: Set(candidate.id),
+                attempt_count: Set(candidate.attempt_count),
+                requested_retry_at: Set(None),
+                error_code: Set("lease_expired".into()),
+                error_detail: Set(Some("final worker lease expired".into())),
+                resolved_at: Set(now),
+                result_status: Set(TurnRunStatus::Failed.as_str().into()),
+            }
+            .insert(&transaction)
+            .await
+            .map_err(store_err)?;
+            let sequenced_event = append_claim_scan_terminal_event_on(
+                &transaction,
+                &candidate,
+                chat_id,
+                lease_token,
+                &event,
+            )
+            .await?;
             transaction.commit().await.map_err(store_err)?;
-            continue;
+            return Ok(ClaimTurnRunOutcome {
+                turn: None,
+                terminal_event: Some(ClaimScanTerminalEvent {
+                    chat_id,
+                    turn_id: TurnId(candidate.id),
+                    event: sequenced_event,
+                }),
+            });
         }
 
         let next_attempt = candidate.attempt_count.checked_add(1).ok_or_else(|| {
@@ -423,7 +515,10 @@ pub(in crate::db) async fn claim_turn_run(
             })
             .and_then(turn_run_from_model)?;
         transaction.commit().await.map_err(store_err)?;
-        return Ok(Some(claimed));
+        return Ok(ClaimTurnRunOutcome {
+            turn: Some(claimed),
+            terminal_event: None,
+        });
     }
 }
 
@@ -474,16 +569,77 @@ async fn acquire_turn_claim_write_lock<C>(conn: &C) -> Result<()>
 where
     C: ConnectionTrait,
 {
-    entities::turn_run::Entity::update_many()
+    let locked = entities::turn_claim_lock::Entity::update_many()
         .col_expr(
-            entities::turn_run::Column::UpdatedAt,
-            sea_orm::sea_query::Expr::col(entities::turn_run::Column::UpdatedAt).into(),
+            entities::turn_claim_lock::Column::Id,
+            sea_orm::sea_query::Expr::col(entities::turn_claim_lock::Column::Id).into(),
         )
-        .filter(entities::turn_run::Column::Id.is_null())
+        .filter(entities::turn_claim_lock::Column::Id.eq(1))
         .exec(conn)
         .await
         .map_err(store_err)?;
+    if locked.rows_affected != 1 {
+        return Err(AgentError::Store(
+            "durable turn claim lock is missing".into(),
+        ));
+    }
     Ok(())
+}
+
+async fn append_claim_scan_terminal_event_on<C>(
+    conn: &C,
+    candidate: &entities::turn_run::Model,
+    chat_id: ChatId,
+    scan_token: uuid::Uuid,
+    event: &AgentEvent,
+) -> Result<SequencedEvent>
+where
+    C: ConnectionTrait,
+{
+    let lease_token = candidate.lease_token.ok_or_else(|| {
+        AgentError::Store(format!(
+            "terminalized turn {} is missing its claim token",
+            TurnId(candidate.id)
+        ))
+    })?;
+    let seq = append_event_on(
+        conn,
+        chat_id,
+        Some(TurnId(candidate.id)),
+        Some(lease_token),
+        Some(i32::MAX),
+        Some(scan_token),
+        event,
+    )
+    .await?;
+    Ok(SequencedEvent {
+        seq,
+        event: event.clone(),
+    })
+}
+
+fn claim_scan_terminal_event_from_model(
+    model: entities::event::Model,
+    scan_token: uuid::Uuid,
+) -> Result<ClaimScanTerminalEvent> {
+    if model.scan_token != Some(scan_token) || !model.terminal {
+        return Err(AgentError::Store(format!(
+            "claim scan token {scan_token} references an invalid journal receipt"
+        )));
+    }
+    let turn_id = model.turn_id.map(TurnId).ok_or_else(|| {
+        AgentError::Store(format!(
+            "claim scan token {scan_token} references an event without a turn"
+        ))
+    })?;
+    Ok(ClaimScanTerminalEvent {
+        chat_id: ChatId(model.chat_id),
+        turn_id,
+        event: SequencedEvent {
+            seq: model.seq,
+            event: serde_json::from_value(model.payload)?,
+        },
+    })
 }
 
 fn turn_run_due_order(

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -656,6 +656,7 @@ where
         Some(id),
         lease_token,
         lease_token.map(|_| i32::MAX),
+        None,
         event,
     )
     .await?;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5194,13 +5194,15 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
         .claim_turn_run(first_token, claimed_at, first_expiry)
         .await
         .unwrap()
+        .turn
         .unwrap();
     assert_eq!(first.lease_token, Some(first_token));
     assert_eq!(
         store
             .claim_turn_run(first_token, claimed_at, first_expiry)
             .await
-            .unwrap(),
+            .unwrap()
+            .turn,
         Some(first.clone())
     );
     assert_eq!(first.status, TurnRunStatus::Running);
@@ -5261,7 +5263,8 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
                 extended + chrono::Duration::minutes(1)
             )
             .await
-            .unwrap(),
+            .unwrap()
+            .turn,
         None
     );
     let second_expiry = extended + chrono::Duration::minutes(1);
@@ -5270,6 +5273,7 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
         .claim_turn_run(second_token, extended, second_expiry)
         .await
         .unwrap()
+        .turn
         .unwrap();
     assert_eq!(second.id, turn_id);
     assert_eq!(second.status, TurnRunStatus::Running);
@@ -5287,16 +5291,32 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
         .await
         .unwrap());
 
+    let exhausted = store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            second_expiry,
+            second_expiry + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap();
+    assert_eq!(exhausted.turn, None);
+    let terminal = exhausted
+        .terminal_event
+        .expect("exhausted attempt must publish a terminal event");
+    assert_eq!(terminal.chat_id, chat.id);
+    assert_eq!(terminal.turn_id, turn_id);
     assert_eq!(
-        store
-            .claim_turn_run(
-                uuid::Uuid::new_v4(),
-                second_expiry,
-                second_expiry + chrono::Duration::minutes(1),
-            )
-            .await
-            .unwrap(),
-        None
+        terminal.event.event,
+        AgentEvent::TurnFailed {
+            error: crate::error::AgentErrorInfo {
+                kind: "lease_expired".into(),
+                message: "final worker lease expired".into(),
+            }
+        }
+    );
+    assert_eq!(
+        store.list_events(chat.id, 0).await.unwrap(),
+        vec![terminal.event.clone()]
     );
     let failed = store.get_turn_run(turn_id).await.unwrap().unwrap();
     assert_eq!(failed.status, TurnRunStatus::Failed);
@@ -5305,6 +5325,23 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
     assert_eq!(failed.lease_expires_at, None);
     assert_eq!(failed.finished_at, Some(second_expiry));
     assert_eq!(failed.last_error_code.as_deref(), Some("lease_expired"));
+    let recovered = store
+        .record_turn_run_failure_and_append_event(
+            turn_id,
+            second_token,
+            second_expiry + chrono::Duration::hours(1),
+            TurnFailureRetry::Permanent,
+            "lease_expired",
+            Some("final worker lease expired"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        recovered.outcome,
+        RecordTurnFailureOutcome::Existing(_)
+    ));
+    assert_eq!(recovered.terminal_event, Some(terminal.event));
 
     let next_chat = sample_chat();
     store.create_chat(&next_chat).await.unwrap();
@@ -5325,7 +5362,8 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
                 delayed_retry_at + chrono::Duration::minutes(1),
             )
             .await
-            .unwrap(),
+            .unwrap()
+            .turn,
         None
     );
     assert_eq!(
@@ -5405,6 +5443,7 @@ async fn turn_completion_atomically_persists_exact_output_and_recovers_retries()
         .claim_turn_run(lease_token, claimed_at, lease_expires_at)
         .await
         .unwrap()
+        .turn
         .unwrap();
     let output = Message {
         id: MessageId::new(),
@@ -5525,6 +5564,7 @@ async fn turn_failure_receipt_recovers_exact_retries_after_the_turn_advances() {
         .claim_turn_run(token, claimed_at, lease_expires_at)
         .await
         .unwrap()
+        .turn
         .unwrap();
     let resolved_at =
         claimed_at + chrono::Duration::seconds(1) + chrono::Duration::nanoseconds(999);
@@ -5638,6 +5678,7 @@ async fn turn_failure_receipt_recovers_exact_retries_after_the_turn_advances() {
         .claim_turn_run(second_token, canonical_retry_at, second_expiry)
         .await
         .unwrap()
+        .turn
         .unwrap();
     assert_eq!(second.attempt_count, 2);
     assert_eq!(second.last_error_code, None);
@@ -5692,6 +5733,7 @@ async fn turn_failure_exhaustion_retains_retry_intent_and_rolls_back_atomically(
         .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(2))
         .await
         .unwrap()
+        .turn
         .unwrap();
     let failed_at = claimed_at + chrono::Duration::seconds(1);
     let retry_at = failed_at + chrono::Duration::minutes(1);
@@ -5788,6 +5830,7 @@ async fn turn_failure_rolls_back_receipt_and_state_when_terminal_event_fails() {
         .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(2))
         .await
         .unwrap()
+        .turn
         .unwrap();
     entities::event::ActiveModel {
         chat_id: Set(chat.id.0),
@@ -5795,6 +5838,7 @@ async fn turn_failure_rolls_back_receipt_and_state_when_terminal_event_fails() {
         turn_id: Set(Some(turn_id.0)),
         lease_token: Set(Some(token)),
         attempt_event_ordinal: Set(Some(i32::MAX)),
+        scan_token: Set(None),
         terminal: Set(true),
         payload: Set(serde_json::to_value(AgentEvent::TurnCompleted {
             usage: Usage::default(),
@@ -5827,6 +5871,11 @@ async fn turn_failure_rolls_back_receipt_and_state_when_terminal_event_fails() {
     assert_eq!(still_running.status, TurnRunStatus::Running);
     assert_eq!(still_running.finished_at, None);
     assert_eq!(still_running.last_error_code, None);
+    assert!(entities::turn_failure::Entity::find_by_id(token)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .is_none());
     assert_eq!(store.list_events(chat.id, 0).await.unwrap().len(), 1);
 }
 
@@ -5851,6 +5900,7 @@ async fn permanent_turn_failure_uses_the_heartbeated_lease_and_rejects_expiry() 
         .claim_turn_run(token, claimed_at, original_expiry)
         .await
         .unwrap()
+        .turn
         .unwrap();
     let heartbeat_at = claimed_at + chrono::Duration::seconds(30);
     let extended_expiry = original_expiry + chrono::Duration::minutes(1);
@@ -5899,6 +5949,7 @@ async fn permanent_turn_failure_uses_the_heartbeated_lease_and_rejects_expiry() 
         .claim_turn_run(expired_token, expired_claim_at, expired_at)
         .await
         .unwrap()
+        .turn
         .unwrap();
     assert_eq!(
         store
@@ -6028,6 +6079,7 @@ async fn queued_and_retry_wait_turns_cancel_immediately_and_idempotently() {
         .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(2))
         .await
         .unwrap()
+        .turn
         .unwrap();
     let failed_at = claimed_at + chrono::Duration::seconds(1);
     let retry_at = failed_at + chrono::Duration::minutes(1);
@@ -6101,6 +6153,7 @@ async fn immediate_cancellation_rolls_back_when_terminal_event_fails() {
         turn_id: Set(Some(turn.id.0)),
         lease_token: Set(None),
         attempt_event_ordinal: Set(None),
+        scan_token: Set(None),
         terminal: Set(true),
         payload: Set(serde_json::to_value(AgentEvent::TurnCompleted {
             usage: Usage::default(),
@@ -6146,6 +6199,7 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
         .claim_turn_run(token, claimed_at, expires_at)
         .await
         .unwrap()
+        .turn
         .unwrap();
     let requested_at = claimed_at + chrono::Duration::seconds(1);
     let requested = store
@@ -6301,6 +6355,7 @@ async fn claim_scan_terminalizes_an_expired_cancelling_lease() {
         .claim_turn_run(token, claimed_at, expires_at)
         .await
         .unwrap()
+        .turn
         .unwrap();
     assert!(matches!(
         store
@@ -6310,28 +6365,49 @@ async fn claim_scan_terminalizes_an_expired_cancelling_lease() {
         Some(RequestTurnCancellationOutcome::Requested(_))
     ));
 
+    let scan = store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            expires_at,
+            expires_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap();
+    assert_eq!(scan.turn, None);
+    let terminal = scan
+        .terminal_event
+        .expect("expired cancellation must publish a terminal event");
+    assert_eq!(terminal.chat_id, chat.id);
+    assert_eq!(terminal.turn_id, turn.id);
     assert_eq!(
-        store
-            .claim_turn_run(
-                uuid::Uuid::new_v4(),
-                expires_at,
-                expires_at + chrono::Duration::minutes(1),
-            )
-            .await
-            .unwrap(),
-        None
+        terminal.event.event,
+        AgentEvent::TurnCancelled {
+            usage: Usage::default()
+        }
+    );
+    assert_eq!(
+        store.list_events(chat.id, 0).await.unwrap(),
+        vec![terminal.event.clone()]
     );
     let cancelled = store.get_turn_run(turn.id).await.unwrap().unwrap();
     assert_eq!(cancelled.status, TurnRunStatus::Cancelled);
     assert_eq!(cancelled.finished_at, Some(expires_at));
     assert_eq!(cancelled.lease_token, None);
+    let recovered = store
+        .finish_turn_cancellation_and_append_event(
+            turn.id,
+            token,
+            expires_at + chrono::Duration::hours(1),
+            Usage::default(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
-        store
-            .finish_turn_cancellation(turn.id, token, expires_at + chrono::Duration::hours(1),)
-            .await
-            .unwrap(),
-        Some(FinishTurnCancellationOutcome::Existing(cancelled))
+        recovered.outcome,
+        FinishTurnCancellationOutcome::Existing(cancelled)
     );
+    assert_eq!(recovered.terminal_event, Some(terminal.event));
     assert!(matches!(
         store
             .accept_turn(TurnId::new(), chat.id, "gpt-5", "slot recovered")
@@ -6339,6 +6415,166 @@ async fn claim_scan_terminalizes_an_expired_cancelling_lease() {
             .unwrap(),
         AcceptTurnOutcome::Accepted(_)
     ));
+}
+
+#[tokio::test]
+async fn claim_scan_rolls_back_terminal_state_when_event_append_fails() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "expire and roll back")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = turn.available_at + chrono::Duration::seconds(1);
+    let expires_at = claimed_at + chrono::Duration::minutes(1);
+    let token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(token, claimed_at, expires_at)
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    entities::event::ActiveModel {
+        chat_id: Set(chat.id.0),
+        seq: Set(1),
+        turn_id: Set(Some(turn.id.0)),
+        lease_token: Set(Some(token)),
+        attempt_event_ordinal: Set(Some(i32::MAX)),
+        scan_token: Set(None),
+        terminal: Set(true),
+        payload: Set(serde_json::to_value(AgentEvent::TurnFailed {
+            error: crate::error::AgentErrorInfo {
+                kind: "forced".into(),
+                message: "occupy terminal slot".into(),
+            },
+        })
+        .unwrap()),
+        created_at: Set(Utc::now()),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+
+    assert!(store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            expires_at,
+            expires_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .is_err());
+    let still_running = store.get_turn_run(turn.id).await.unwrap().unwrap();
+    assert_eq!(still_running.status, TurnRunStatus::Running);
+    assert_eq!(still_running.lease_token, Some(token));
+    assert_eq!(still_running.lease_expires_at, Some(expires_at));
+    assert_eq!(still_running.finished_at, None);
+    assert_eq!(still_running.last_error_code, None);
+    assert_eq!(store.list_events(chat.id, 0).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn claim_scan_returns_one_routable_terminal_action_at_a_time() {
+    let (_dir, store) = temp_store().await;
+    let first_chat = sample_chat();
+    let second_chat = sample_chat();
+    store.create_chat(&first_chat).await.unwrap();
+    store.create_chat(&second_chat).await.unwrap();
+    let first_turn = match store
+        .accept_turn(TurnId::new(), first_chat.id, "gpt-5", "first expired turn")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let second_turn = match store
+        .accept_turn(
+            TurnId::new(),
+            second_chat.id,
+            "gpt-5",
+            "second expired turn",
+        )
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at =
+        first_turn.available_at.max(second_turn.available_at) + chrono::Duration::seconds(1);
+    let expires_at = claimed_at + chrono::Duration::minutes(1);
+    for _ in 0..2 {
+        store
+            .claim_turn_run(uuid::Uuid::new_v4(), claimed_at, expires_at)
+            .await
+            .unwrap()
+            .turn
+            .expect("both turns must be claimable");
+    }
+
+    let scan_token = uuid::Uuid::new_v4();
+    let first_action = store
+        .claim_turn_run(
+            scan_token,
+            expires_at,
+            expires_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first_action.turn, None);
+    assert_eq!(
+        store
+            .claim_turn_run(
+                scan_token,
+                expires_at + chrono::Duration::seconds(1),
+                expires_at + chrono::Duration::minutes(2),
+            )
+            .await
+            .unwrap(),
+        first_action,
+        "an ambiguous scan retry must recover the same routed event"
+    );
+    let second_action = store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            expires_at + chrono::Duration::seconds(1),
+            expires_at + chrono::Duration::minutes(2),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second_action.turn, None);
+    let routed = vec![
+        first_action
+            .terminal_event
+            .expect("first scan must return its committed action"),
+        second_action
+            .terminal_event
+            .expect("second scan must return its committed action"),
+    ];
+    assert_ne!(routed[0].turn_id, routed[1].turn_id);
+    for terminal in routed {
+        let expected_chat = if terminal.turn_id == first_turn.id {
+            first_chat.id
+        } else if terminal.turn_id == second_turn.id {
+            second_chat.id
+        } else {
+            panic!("scan returned an unknown turn")
+        };
+        assert_eq!(terminal.chat_id, expected_chat);
+        assert!(matches!(
+            terminal.event.event,
+            AgentEvent::TurnFailed { .. }
+        ));
+        assert_eq!(
+            store.list_events(expected_chat, 0).await.unwrap(),
+            vec![terminal.event]
+        );
+    }
 }
 
 #[tokio::test]
@@ -6360,6 +6596,7 @@ async fn concurrent_cancellation_requests_converge_on_one_running_turn() {
         .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(1))
         .await
         .unwrap()
+        .turn
         .unwrap();
     let store = std::sync::Arc::new(store);
     let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
@@ -6415,6 +6652,7 @@ async fn turn_completion_and_cancellation_serialize_to_one_decision() {
         .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(1))
         .await
         .unwrap()
+        .turn
         .unwrap();
     let decided_at = claimed_at + chrono::Duration::seconds(1);
     let output = Message {
@@ -6492,6 +6730,7 @@ async fn turn_completion_and_failure_serialize_to_one_terminal_decision() {
         .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(2))
         .await
         .unwrap()
+        .turn
         .unwrap();
     let resolved_at = claimed_at + chrono::Duration::seconds(1);
     let output = Message {
@@ -6575,6 +6814,7 @@ async fn turn_completion_uses_the_heartbeated_lease_and_fences_operation_time() 
         .claim_turn_run(token, claimed_at, original_expiry)
         .await
         .unwrap()
+        .turn
         .unwrap();
     let heartbeat_at = claimed_at + chrono::Duration::seconds(30);
     let extended_expiry = original_expiry + chrono::Duration::minutes(1);
@@ -6643,6 +6883,7 @@ async fn turn_completion_rejects_prepared_output_retried_after_expiry() {
         .claim_turn_run(token, claimed_at, lease_expires_at)
         .await
         .unwrap()
+        .turn
         .unwrap();
     let prepared_output = Message {
         id: MessageId::new(),
@@ -6697,6 +6938,7 @@ async fn stale_turn_attempt_cannot_complete_a_reclaimed_turn() {
         .claim_turn_run(first_token, first_claim_at, first_expiry)
         .await
         .unwrap()
+        .turn
         .unwrap();
     let second_token = uuid::Uuid::new_v4();
     let second_expiry = first_expiry + chrono::Duration::minutes(1);
@@ -6704,6 +6946,7 @@ async fn stale_turn_attempt_cannot_complete_a_reclaimed_turn() {
         .claim_turn_run(second_token, first_expiry, second_expiry)
         .await
         .unwrap()
+        .turn
         .unwrap();
     assert_eq!(reclaimed.attempt_count, 2);
 
@@ -6757,6 +7000,7 @@ async fn concurrent_different_turn_completions_commit_one_output_once() {
         .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(1))
         .await
         .unwrap()
+        .turn
         .unwrap();
     let output = Message {
         id: MessageId::new(),
@@ -6821,6 +7065,7 @@ async fn turn_completion_rolls_back_output_when_state_update_fails() {
         .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(1))
         .await
         .unwrap()
+        .turn
         .unwrap();
     store
         .conn
@@ -6874,6 +7119,7 @@ async fn turn_completion_rolls_back_state_and_output_when_terminal_event_fails()
         .claim_turn_run(token, claimed_at, claimed_at + chrono::Duration::minutes(1))
         .await
         .unwrap()
+        .turn
         .unwrap();
     entities::event::ActiveModel {
         chat_id: Set(chat.id.0),
@@ -6881,6 +7127,7 @@ async fn turn_completion_rolls_back_state_and_output_when_terminal_event_fails()
         turn_id: Set(Some(turn_id.0)),
         lease_token: Set(Some(token)),
         attempt_event_ordinal: Set(Some(i32::MAX)),
+        scan_token: Set(None),
         terminal: Set(true),
         payload: Set(serde_json::to_value(AgentEvent::TurnFailed {
             error: AgentErrorInfo {
@@ -6954,7 +7201,7 @@ async fn concurrent_turn_claimers_never_share_a_lease() {
     let mut claimed = Vec::new();
     let mut empty = 0;
     for task in tasks {
-        match task.await.unwrap().unwrap() {
+        match task.await.unwrap().unwrap().turn {
             Some(turn) => claimed.push(turn),
             None => empty += 1,
         }
@@ -6994,6 +7241,7 @@ async fn turn_claim_orders_queued_and_expired_work_by_effective_due_time() {
         .claim_turn_run(uuid::Uuid::new_v4(), first_claim_at, first_expiry)
         .await
         .unwrap()
+        .turn
         .unwrap();
 
     let queued_chat = sample_chat();
@@ -7029,6 +7277,7 @@ async fn turn_claim_orders_queued_and_expired_work_by_effective_due_time() {
         )
         .await
         .unwrap()
+        .turn
         .unwrap();
     assert_eq!(claimed_queued.id, queued_turn.id);
     let reclaimed_expired = store
@@ -7039,6 +7288,7 @@ async fn turn_claim_orders_queued_and_expired_work_by_effective_due_time() {
         )
         .await
         .unwrap()
+        .turn
         .unwrap();
     assert_eq!(reclaimed_expired.id, expired_turn.id);
     assert_eq!(reclaimed_expired.attempt_count, 2);
@@ -7072,6 +7322,7 @@ async fn turn_claim_prefers_an_earlier_expired_lease_over_queued_work() {
         .claim_turn_run(uuid::Uuid::new_v4(), first_claim_at, first_expiry)
         .await
         .unwrap()
+        .turn
         .unwrap();
 
     let queued_chat = sample_chat();
@@ -7107,6 +7358,7 @@ async fn turn_claim_prefers_an_earlier_expired_lease_over_queued_work() {
         )
         .await
         .unwrap()
+        .turn
         .unwrap();
     assert_eq!(reclaimed.id, expired_turn.id);
     assert_eq!(reclaimed.attempt_count, 2);
@@ -7292,6 +7544,7 @@ async fn durable_turn_events_are_bound_and_reserve_one_terminal_slot() {
         .claim_turn_run(lease_token, claimed_at, lease_expires_at)
         .await
         .unwrap()
+        .turn
         .unwrap();
     let started = AgentEvent::TurnStarted { turn_id: turn.id };
     assert_eq!(
@@ -7391,6 +7644,7 @@ async fn durable_turn_events_are_bound_and_reserve_one_terminal_slot() {
         turn_id: Set(Some(turn.id.0)),
         lease_token: Set(Some(lease_token)),
         attempt_event_ordinal: Set(Some(2)),
+        scan_token: Set(None),
         terminal: Set(true),
         payload: Set(serde_json::to_value(&terminal).unwrap()),
         created_at: Set(Utc::now()),
@@ -7404,6 +7658,7 @@ async fn durable_turn_events_are_bound_and_reserve_one_terminal_slot() {
         turn_id: Set(Some(turn.id.0)),
         lease_token: Set(Some(lease_token)),
         attempt_event_ordinal: Set(Some(3)),
+        scan_token: Set(None),
         terminal: Set(true),
         payload: Set(serde_json::to_value(&terminal).unwrap()),
         created_at: Set(Utc::now()),
@@ -7417,6 +7672,7 @@ async fn durable_turn_events_are_bound_and_reserve_one_terminal_slot() {
         turn_id: Set(None),
         lease_token: Set(None),
         attempt_event_ordinal: Set(None),
+        scan_token: Set(None),
         terminal: Set(true),
         payload: Set(serde_json::to_value(&terminal).unwrap()),
         created_at: Set(Utc::now()),
@@ -7430,6 +7686,7 @@ async fn durable_turn_events_are_bound_and_reserve_one_terminal_slot() {
         turn_id: Set(Some(turn.id.0)),
         lease_token: Set(None),
         attempt_event_ordinal: Set(None),
+        scan_token: Set(None),
         terminal: Set(false),
         payload: Set(serde_json::to_value(&started).unwrap()),
         created_at: Set(Utc::now()),

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -64,10 +64,10 @@ pub use provider::{
 };
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
-    AcceptTurnOutcome, BlobStore, CompleteTurnRunOutcome, DocumentIndexJobReason,
-    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
-    JournaledTurnOutcome, RecordTurnFailureOutcome, RequestTurnCancellationOutcome, SecretProvider,
-    Store,
+    AcceptTurnOutcome, BlobStore, ClaimScanTerminalEvent, ClaimTurnRunOutcome,
+    CompleteTurnRunOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
+    EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome, JournaledTurnOutcome,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, SecretProvider, Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -145,6 +145,31 @@ pub struct JournaledTurnOutcome<T> {
     pub terminal_event: Option<SequencedEvent>,
 }
 
+/// A terminal event committed while a claim scan cleans expired work.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClaimScanTerminalEvent {
+    /// Chat whose per-chat journal assigned the sequence.
+    pub chat_id: ChatId,
+    /// Turn terminalized by the scan.
+    pub turn_id: TurnId,
+    /// Exact committed journal event.
+    pub event: SequencedEvent,
+}
+
+/// Result of one durable claim action.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClaimTurnRunOutcome {
+    /// The due turn claimed for execution, if any.
+    pub turn: Option<TurnRun>,
+    /// One expired turn terminalized instead of claiming work, if any.
+    ///
+    /// Exactly one of `turn` and `terminal_event` is present, or both are absent
+    /// when no work is due. Returning after one committed action lets the worker
+    /// publish the event before scanning again without losing an earlier commit
+    /// behind a later scan error.
+    pub terminal_event: Option<ClaimScanTerminalEvent>,
+}
+
 fn document_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "document storage is not implemented by this Store".into(),
@@ -619,21 +644,23 @@ pub trait Store: Send + Sync {
         turn_storage_unavailable()
     }
 
-    /// Claim the oldest due turn under a fresh exact lease.
+    /// Perform one durable claim action under a fresh exact lease.
     ///
     /// `lease_token` is the caller's idempotency identity: retrying it while its
     /// lease remains live returns the same running turn. Callers must retain it
     /// across an ambiguous commit and use a fresh token for a new claim attempt.
     /// A successful claim increments `attempt_count` and moves the turn to
     /// `running`. Expired work is reclaimed only while another attempt is
-    /// permitted; an expired final attempt becomes terminally failed and the
-    /// scan continues. `lease_expires_at` must be after `now`.
+    /// permitted. An expired cancellation or final attempt is terminalized with
+    /// its exact routed journal event and returned instead of claiming another
+    /// turn; the caller publishes it before scanning again. `lease_expires_at`
+    /// must be after `now`.
     async fn claim_turn_run(
         &self,
         _lease_token: uuid::Uuid,
         _now: chrono::DateTime<chrono::Utc>,
         _lease_expires_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<Option<TurnRun>> {
+    ) -> Result<ClaimTurnRunOutcome> {
         turn_storage_unavailable()
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -74,7 +74,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
     let mut empty = 0;
     for task in tasks {
         let (token, outcome) = task.await.unwrap();
-        match outcome.unwrap() {
+        match outcome.unwrap().turn {
             Some(turn) => {
                 assert!(winner.replace((token, turn)).is_none());
             }
@@ -90,20 +90,34 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         store
             .claim_turn_run(token, claim_at, lease_expires_at)
             .await
-            .unwrap(),
+            .unwrap()
+            .turn,
         Some(claimed)
     );
 
+    let expired = store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            lease_expires_at,
+            lease_expires_at + Duration::minutes(1),
+        )
+        .await
+        .unwrap();
+    assert_eq!(expired.turn, None);
+    let terminal = expired
+        .terminal_event
+        .expect("expired attempt must publish a terminal event");
+    assert_eq!(terminal.chat_id, chat.id);
+    assert_eq!(terminal.turn_id, turn_id);
+    assert!(matches!(
+        &terminal.event.event,
+        AgentEvent::TurnFailed { error }
+            if error.kind == "lease_expired"
+                && error.message == "final worker lease expired"
+    ));
     assert_eq!(
-        store
-            .claim_turn_run(
-                uuid::Uuid::new_v4(),
-                lease_expires_at,
-                lease_expires_at + Duration::minutes(1),
-            )
-            .await
-            .unwrap(),
-        None
+        store.list_events(chat.id, 0).await.unwrap(),
+        vec![terminal.event]
     );
     assert_eq!(
         store.get_turn_run(turn_id).await.unwrap().unwrap().status,
@@ -129,7 +143,8 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
                 delayed_retry_at + Duration::minutes(1),
             )
             .await
-            .unwrap(),
+            .unwrap()
+            .turn,
         None
     );
     assert_eq!(
@@ -143,6 +158,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         .claim_turn_run(completion_token, delayed_retry_at, completion_expiry)
         .await
         .unwrap()
+        .turn
         .unwrap();
     let output = Message {
         id: MessageId::new(),
@@ -212,6 +228,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         )
         .await
         .unwrap()
+        .turn
         .unwrap();
     let barrier = Arc::new(tokio::sync::Barrier::new(2));
     let mut failures = Vec::new();
@@ -293,6 +310,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         )
         .await
         .unwrap()
+        .turn
         .unwrap();
     let barrier = Arc::new(tokio::sync::Barrier::new(2));
     let mut cancellations = Vec::new();
@@ -420,6 +438,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         )
         .await
         .unwrap()
+        .turn
         .unwrap();
     let started = AgentEvent::TurnStarted {
         turn_id: turn_event.id,


### PR DESCRIPTION
## Summary
- make each claim scan perform exactly one durable action and return a chat-addressed terminal event
- persist a unique scan-token receipt so ambiguous retries recover the same routed event
- append expiration failure receipts and terminal journal rows in the same transaction
- remove the lossy pre-v1 claim variant and prove routing, recovery, and rollback behavior

## Validation
- cargo test -p openwave-core --all-features --locked
- bw dev lint --rust
- PostgreSQL state-machine coverage included in CI