### PR TITLE
feat(core): surface turn identity conflicts

### DIFF
--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -69,7 +69,7 @@ pub(in crate::db) async fn accept_turn(
         let existing =
             exact_accepted_turn_on(&transaction, existing, chat_id, model, content).await?;
         transaction.commit().await.map_err(store_err)?;
-        return Ok(AcceptTurnOutcome::Existing(existing));
+        return Ok(existing);
     }
 
     if let Some(active) = find_active_turn_on(&transaction, chat_id).await? {
@@ -121,9 +121,8 @@ pub(in crate::db) async fn accept_turn(
                 .await
                 .map_err(store_err)?
             {
-                let existing =
-                    exact_accepted_turn_on(&store.conn, existing, chat_id, model, content).await?;
-                return Ok(AcceptTurnOutcome::Existing(existing));
+                return exact_accepted_turn_on(&store.conn, existing, chat_id, model, content)
+                    .await;
             }
             if let Some(active) = find_active_turn_on(&store.conn, chat_id).await? {
                 return Ok(AcceptTurnOutcome::ChatBusy(turn_run_from_model(active)?));
@@ -705,7 +704,7 @@ async fn exact_accepted_turn_on<C>(
     chat_id: ChatId,
     model: &str,
     content: &str,
-) -> Result<TurnRun>
+) -> Result<AcceptTurnOutcome>
 where
     C: ConnectionTrait,
 {
@@ -719,19 +718,22 @@ where
                 TurnId(existing.id)
             ))
         })?;
-    if existing.chat_id != chat_id.0
-        || existing.model != model
-        || message.chat_id != chat_id.0
+    if message.chat_id != existing.chat_id
         || message.turn_id != existing.id
         || message.role != "user"
-        || message.content != content
     {
         return Err(AgentError::Store(format!(
-            "turn {} was already accepted with different input",
+            "turn {} has inconsistent accepted input",
             TurnId(existing.id)
         )));
     }
-    turn_run_from_model(existing)
+    let exact =
+        existing.chat_id == chat_id.0 && existing.model == model && message.content == content;
+    Ok(if exact {
+        AcceptTurnOutcome::Existing(turn_run_from_model(existing)?)
+    } else {
+        AcceptTurnOutcome::IdentityConflict
+    })
 }
 
 fn turn_run_from_model(model: entities::turn_run::Model) -> Result<TurnRun> {

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4979,14 +4979,20 @@ async fn turn_acceptance_is_atomic_idempotent_and_chat_scoped() {
     assert_eq!(store.list_turn_runs(chat.id).await.unwrap().len(), 1);
     assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
 
-    assert!(store
-        .accept_turn(turn_id, chat.id, "gpt-5", "different")
-        .await
-        .is_err());
-    assert!(store
-        .accept_turn(turn_id, chat.id, "other-model", "hello")
-        .await
-        .is_err());
+    assert!(matches!(
+        store
+            .accept_turn(turn_id, chat.id, "gpt-5", "different")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::IdentityConflict
+    ));
+    assert!(matches!(
+        store
+            .accept_turn(turn_id, chat.id, "other-model", "hello")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::IdentityConflict
+    ));
 
     let busy = match store
         .accept_turn(TurnId::new(), chat.id, "gpt-5", "next")
@@ -5000,10 +5006,13 @@ async fn turn_acceptance_is_atomic_idempotent_and_chat_scoped() {
 
     let other = sample_chat();
     store.create_chat(&other).await.unwrap();
-    assert!(store
-        .accept_turn(turn_id, other.id, "gpt-5", "hello")
-        .await
-        .is_err());
+    assert!(matches!(
+        store
+            .accept_turn(turn_id, other.id, "gpt-5", "hello")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::IdentityConflict
+    ));
 
     let missing = ChatId::new();
     assert!(store
@@ -5028,6 +5037,20 @@ async fn turn_acceptance_is_atomic_idempotent_and_chat_scoped() {
         .is_err());
     assert!(store.list_turn_runs(other.id).await.unwrap().is_empty());
     assert!(store.list_messages(other.id).await.unwrap().is_empty());
+
+    entities::message::Entity::update_many()
+        .col_expr(
+            entities::message::Column::Role,
+            sea_orm::sea_query::Expr::value("assistant"),
+        )
+        .filter(entities::message::Column::Id.eq(accepted.input_message_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert!(store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .is_err());
 }
 
 #[tokio::test]
@@ -5130,16 +5153,16 @@ async fn concurrent_cross_chat_reuse_of_a_turn_id_commits_once() {
     }
 
     let mut accepted = 0;
-    let mut rejected = 0;
+    let mut conflicted = 0;
     for task in tasks {
         match task.await.unwrap() {
             Ok(AcceptTurnOutcome::Accepted(_)) => accepted += 1,
-            Err(_) => rejected += 1,
+            Ok(AcceptTurnOutcome::IdentityConflict) => conflicted += 1,
             outcome => panic!("unexpected cross-chat outcome: {outcome:?}"),
         }
     }
     assert_eq!(accepted, 1);
-    assert_eq!(rejected, 1);
+    assert_eq!(conflicted, 1);
     assert_eq!(
         store.get_turn_run(turn_id).await.unwrap().unwrap().id,
         turn_id

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -92,6 +92,8 @@ pub enum AcceptTurnOutcome {
     Accepted(TurnRun),
     /// This exact turn identity and request were already committed.
     Existing(TurnRun),
+    /// The turn identity was already committed for different request data.
+    IdentityConflict,
     /// Another nonterminal turn already owns the chat's single live slot.
     ChatBusy(TurnRun),
 }
@@ -632,8 +634,10 @@ pub trait Store: Send + Sync {
     ///
     /// `id` is the caller-visible idempotency identity. Repeating the same id,
     /// chat, model, and byte-exact content returns [`AcceptTurnOutcome::Existing`]
-    /// without another message or turn. Reusing an id for different input is an
-    /// error. A different live turn for the chat returns `ChatBusy`.
+    /// without another message or turn. Reusing an id with a different chat,
+    /// model, or byte-exact content returns
+    /// [`AcceptTurnOutcome::IdentityConflict`]. A different live turn for the
+    /// chat returns [`AcceptTurnOutcome::ChatBusy`].
     async fn accept_turn(
         &self,
         _id: TurnId,

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -536,4 +536,52 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         )
         .await
         .is_err());
+
+    // Keep this global-queue fixture last: its winning turn deliberately remains
+    // queued so the race proves only acceptance rollback/recovery behavior.
+    let first_collision_chat = sample_chat();
+    let second_collision_chat = sample_chat();
+    store.create_chat(&first_collision_chat).await.unwrap();
+    store.create_chat(&second_collision_chat).await.unwrap();
+    let collision_turn_id = TurnId::new();
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let mut collision_tasks = Vec::new();
+    for collision_chat_id in [first_collision_chat.id, second_collision_chat.id] {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        collision_tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .accept_turn(
+                    collision_turn_id,
+                    collision_chat_id,
+                    "gpt-5",
+                    "colliding input",
+                )
+                .await
+        }));
+    }
+    let mut collision_accepted = 0;
+    let mut collision_conflicted = 0;
+    for task in collision_tasks {
+        match task.await.unwrap() {
+            Ok(AcceptTurnOutcome::Accepted(_)) => collision_accepted += 1,
+            Ok(AcceptTurnOutcome::IdentityConflict) => collision_conflicted += 1,
+            outcome => panic!("unexpected cross-chat collision outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!((collision_accepted, collision_conflicted), (1, 1));
+    assert_eq!(
+        store
+            .list_messages(first_collision_chat.id)
+            .await
+            .unwrap()
+            .len()
+            + store
+                .list_messages(second_collision_chat.id)
+                .await
+                .unwrap()
+                .len(),
+        1
+    );
 }


### PR DESCRIPTION
## Summary
- return a typed identity-conflict outcome when a turn ID is reused for different request data
- keep relational corruption as a store error while preserving exact retry recovery
- cover content, model, cross-chat, and concurrent identity reuse

## Validation
- `cargo test -p openwave-core --all-features --locked`
- `bw dev lint --rust`