### PR TITLE
feat(core): model durable turn steering

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -245,6 +245,32 @@ pub mod turn_claim_lock {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+#[allow(dead_code)]
+pub mod turn_steer {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "turn_steer")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub turn_id: Uuid,
+        pub chat_id: Uuid,
+        pub content: String,
+        pub interrupt: bool,
+        pub status: String,
+        pub applied_lease_token: Option<Uuid>,
+        pub message_id: Option<Uuid>,
+        pub created_at: DateTimeUtc,
+        pub resolved_at: Option<DateTimeUtc>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod turn_failure {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -2,7 +2,7 @@ use sea_orm_migration::prelude::*;
 
 use super::{
     BlobRetirementStatus, DocumentJobKind, DocumentJobStatus, DocumentProcessingStatus,
-    TurnRunStatus,
+    TurnRunStatus, TurnSteerStatus,
 };
 
 pub struct Migrator;
@@ -588,10 +588,139 @@ impl MigrationTrait for Init {
             )
             .await?;
 
+        let pending_steer = Expr::col(TurnSteer::Status)
+            .eq(TurnSteerStatus::Pending.as_str())
+            .and(Expr::col(TurnSteer::AppliedLeaseToken).is_null())
+            .and(Expr::col(TurnSteer::MessageId).is_null())
+            .and(Expr::col(TurnSteer::ResolvedAt).is_null());
+        let applied_steer = Expr::col(TurnSteer::Status)
+            .eq(TurnSteerStatus::Applied.as_str())
+            .and(Expr::col(TurnSteer::AppliedLeaseToken).is_not_null())
+            .and(Expr::col(TurnSteer::MessageId).is_not_null())
+            .and(Expr::col(TurnSteer::ResolvedAt).is_not_null());
+        let rejected_steer = Expr::col(TurnSteer::Status)
+            .eq(TurnSteerStatus::Rejected.as_str())
+            .and(Expr::col(TurnSteer::AppliedLeaseToken).is_null())
+            .and(Expr::col(TurnSteer::MessageId).is_null())
+            .and(Expr::col(TurnSteer::ResolvedAt).is_not_null());
+        manager
+            .create_table(
+                Table::create()
+                    .table(TurnSteer::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(TurnSteer::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(TurnSteer::TurnId).uuid().not_null())
+                    .col(ColumnDef::new(TurnSteer::ChatId).uuid().not_null())
+                    .col(ColumnDef::new(TurnSteer::Content).text().not_null())
+                    .col(
+                        ColumnDef::new(TurnSteer::Interrupt)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(
+                        ColumnDef::new(TurnSteer::Status)
+                            .string_len(16)
+                            .not_null()
+                            .default(TurnSteerStatus::Pending.as_str()),
+                    )
+                    .col(ColumnDef::new(TurnSteer::AppliedLeaseToken).uuid())
+                    .col(ColumnDef::new(TurnSteer::MessageId).uuid())
+                    .col(
+                        ColumnDef::new(TurnSteer::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(TurnSteer::ResolvedAt).timestamp_with_time_zone())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_steer_turn")
+                            .from_tbl(TurnSteer::Table)
+                            .from_col(TurnSteer::ChatId)
+                            .from_col(TurnSteer::TurnId)
+                            .to_tbl(TurnRun::Table)
+                            .to_col(TurnRun::ChatId)
+                            .to_col(TurnRun::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_steer_claim")
+                            .from_tbl(TurnSteer::Table)
+                            .from_col(TurnSteer::AppliedLeaseToken)
+                            .from_col(TurnSteer::TurnId)
+                            .to_tbl(TurnClaim::Table)
+                            .to_col(TurnClaim::Token)
+                            .to_col(TurnClaim::TurnId)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_steer_message")
+                            .from_tbl(TurnSteer::Table)
+                            .from_col(TurnSteer::MessageId)
+                            .from_col(TurnSteer::ChatId)
+                            .from_col(TurnSteer::TurnId)
+                            .to_tbl(Message::Table)
+                            .to_col(Message::Id)
+                            .to_col(Message::ChatId)
+                            .to_col(Message::TurnId)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .check(
+                        Func::char_length(Expr::col(TurnSteer::Content))
+                            .between(1, crate::model::TurnSteer::MAX_CONTENT_LEN as i32),
+                    )
+                    .check(pending_steer.or(applied_steer).or(rejected_steer))
+                    .check(
+                        Expr::col(TurnSteer::MessageId)
+                            .is_null()
+                            .or(Expr::col(TurnSteer::MessageId).eq(Expr::col(TurnSteer::Id))),
+                    )
+                    .check(
+                        Expr::col(TurnSteer::ResolvedAt)
+                            .is_null()
+                            .or(Expr::col(TurnSteer::ResolvedAt)
+                                .gte(Expr::col(TurnSteer::CreatedAt))),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_steer_pending")
+                    .table(TurnSteer::Table)
+                    .col(TurnSteer::TurnId)
+                    .col(TurnSteer::Status)
+                    .col(TurnSteer::CreatedAt)
+                    .col(TurnSteer::Id)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_steer_message")
+                    .table(TurnSteer::Table)
+                    .col(TurnSteer::MessageId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
         Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(TurnSteer::Table).to_owned())
+            .await?;
         manager
             .drop_table(Table::drop().table(TurnFailure::Table).to_owned())
             .await?;
@@ -1735,6 +1864,21 @@ enum TurnFailure {
     ErrorDetail,
     ResolvedAt,
     ResultStatus,
+}
+
+#[derive(DeriveIden)]
+enum TurnSteer {
+    Table,
+    Id,
+    TurnId,
+    ChatId,
+    Content,
+    Interrupt,
+    Status,
+    AppliedLeaseToken,
+    MessageId,
+    CreatedAt,
+    ResolvedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -30,7 +30,7 @@ use crate::model::{
     DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
     DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
     DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, TurnFailureRetry, TurnRun,
-    TurnRunStatus,
+    TurnRunStatus, TurnSteerStatus,
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4616,6 +4616,151 @@ async fn make_queued_turn(
     }
 }
 
+fn pending_turn_steer(
+    turn: &crate::model::TurnRun,
+    id: crate::id::TurnSteerId,
+    content: &str,
+    now: DateTime<Utc>,
+) -> entities::turn_steer::ActiveModel {
+    entities::turn_steer::ActiveModel {
+        id: Set(id.0),
+        turn_id: Set(turn.id.0),
+        chat_id: Set(turn.chat_id.0),
+        content: Set(content.into()),
+        interrupt: Set(false),
+        status: Set(TurnSteerStatus::Pending.as_str().into()),
+        applied_lease_token: Set(None),
+        message_id: Set(None),
+        created_at: Set(now),
+        resolved_at: Set(None),
+    }
+}
+
+#[tokio::test]
+async fn turn_steer_schema_enforces_durable_delivery_identity() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let queued = store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "initial input")
+        .await
+        .unwrap();
+    let queued = match queued {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected acceptance: {other:?}"),
+    };
+    let now = Utc::now();
+    let claim_token = uuid::Uuid::new_v4();
+    let claimed = store
+        .claim_turn_run(claim_token, now, now + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .turn
+        .expect("turn claimed");
+    assert_eq!(claimed.id, queued.id);
+
+    let first_id = crate::id::TurnSteerId::new();
+    pending_turn_steer(&claimed, first_id, "change course", now)
+        .insert(&store.conn)
+        .await
+        .unwrap();
+
+    let mut empty = pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "", now);
+    assert!(empty.clone().insert(&store.conn).await.is_err());
+    empty.content = Set("x".repeat(crate::model::TurnSteer::MAX_CONTENT_LEN + 1));
+    assert!(empty.insert(&store.conn).await.is_err());
+
+    let mut pending_with_resolution =
+        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "pending", now);
+    pending_with_resolution.resolved_at = Set(Some(now));
+    assert!(pending_with_resolution.insert(&store.conn).await.is_err());
+
+    let mut applied_without_receipt =
+        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "applied", now);
+    applied_without_receipt.status = Set(TurnSteerStatus::Applied.as_str().into());
+    applied_without_receipt.resolved_at = Set(Some(now));
+    assert!(applied_without_receipt.insert(&store.conn).await.is_err());
+
+    let message_id = MessageId(first_id.0);
+    entities::message::ActiveModel {
+        id: Set(message_id.0),
+        chat_id: Set(chat.id.0),
+        turn_id: Set(claimed.id.0),
+        role: Set("user".into()),
+        content: Set("change course".into()),
+        created_at: Set(now),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    entities::turn_steer::Entity::update_many()
+        .col_expr(
+            entities::turn_steer::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnSteerStatus::Applied.as_str()),
+        )
+        .col_expr(
+            entities::turn_steer::Column::AppliedLeaseToken,
+            sea_orm::sea_query::Expr::value(Some(claim_token)),
+        )
+        .col_expr(
+            entities::turn_steer::Column::MessageId,
+            sea_orm::sea_query::Expr::value(Some(message_id.0)),
+        )
+        .col_expr(
+            entities::turn_steer::Column::ResolvedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .filter(entities::turn_steer::Column::Id.eq(first_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let applied = entities::turn_steer::Entity::find_by_id(first_id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(applied.status, TurnSteerStatus::Applied.as_str());
+    assert_eq!(applied.applied_lease_token, Some(claim_token));
+    assert_eq!(applied.message_id, Some(message_id.0));
+
+    let mismatched_message_id = MessageId::new();
+    entities::message::ActiveModel {
+        id: Set(mismatched_message_id.0),
+        chat_id: Set(chat.id.0),
+        turn_id: Set(claimed.id.0),
+        role: Set("user".into()),
+        content: Set("mismatched identity".into()),
+        created_at: Set(now),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    let mut mismatched_receipt = pending_turn_steer(
+        &claimed,
+        crate::id::TurnSteerId::new(),
+        "mismatched identity",
+        now,
+    );
+    mismatched_receipt.status = Set(TurnSteerStatus::Applied.as_str().into());
+    mismatched_receipt.applied_lease_token = Set(Some(claim_token));
+    mismatched_receipt.message_id = Set(Some(mismatched_message_id.0));
+    mismatched_receipt.resolved_at = Set(Some(now));
+    assert!(mismatched_receipt.insert(&store.conn).await.is_err());
+
+    let mut wrong_turn =
+        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "wrong turn", now);
+    wrong_turn.turn_id = Set(TurnId::new().0);
+    assert!(wrong_turn.insert(&store.conn).await.is_err());
+
+    let mut rejected_with_message =
+        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "rejected", now);
+    rejected_with_message.status = Set(TurnSteerStatus::Rejected.as_str().into());
+    rejected_with_message.message_id = Set(Some(message_id.0));
+    rejected_with_message.resolved_at = Set(Some(now));
+    assert!(rejected_with_message.insert(&store.conn).await.is_err());
+}
+
 #[tokio::test]
 async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let (_dir, store) = temp_store().await;

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -108,6 +108,10 @@ id_type!(
     TurnId
 );
 id_type!(
+    /// Identifies one idempotent steering instruction for a live turn.
+    TurnSteerId
+);
+id_type!(
     /// Identifies one step within a turn: a single LLM call and its tools.
     StepId
 );

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -47,7 +47,9 @@ pub use config::{Config, Profile};
 pub use db::DbStore;
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
-pub use id::{CallId, ChatId, DocumentId, DocumentJobId, MessageId, ProjectId, StepId, TurnId};
+pub use id::{
+    CallId, ChatId, DocumentId, DocumentJobId, MessageId, ProjectId, StepId, TurnId, TurnSteerId,
+};
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
 pub use model::{
@@ -56,7 +58,7 @@ pub use model::{
     DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
     DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
     Project, Role, SourceLocation, SourceRegion, ToolCallRecord, TurnFailureReceipt,
-    TurnFailureRetry, TurnRun, TurnRunStatus,
+    TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -714,6 +714,64 @@ impl TurnRunStatus {
     }
 }
 
+/// One durably accepted steering instruction for an active turn.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnSteer {
+    /// Caller-supplied idempotency identity.
+    pub id: crate::id::TurnSteerId,
+    /// Exact turn that receives this instruction.
+    pub turn_id: TurnId,
+    /// Owning chat, duplicated so the database can enforce turn/message scope.
+    pub chat_id: ChatId,
+    /// Byte-exact user instruction.
+    pub content: String,
+    /// Whether delivery should preempt the current model stream.
+    pub interrupt: bool,
+    /// Durable delivery state.
+    pub status: TurnSteerStatus,
+    /// Exact worker lease that applied the instruction.
+    pub applied_lease_token: Option<Uuid>,
+    /// User message committed atomically with application.
+    ///
+    /// When present, this carries the same UUID as `id`, so one caller identity
+    /// names both the instruction and its eventual conversation message.
+    pub message_id: Option<MessageId>,
+    /// When the instruction was accepted.
+    pub created_at: DateTime<Utc>,
+    /// When it was applied or rejected.
+    pub resolved_at: Option<DateTime<Utc>>,
+}
+
+impl TurnSteer {
+    /// Maximum accepted instruction size in Unicode scalar values.
+    pub const MAX_CONTENT_LEN: usize = 65_536;
+}
+
+/// Durable delivery state of a [`TurnSteer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TurnSteerStatus {
+    /// Accepted and waiting for the exact live worker to apply it.
+    Pending,
+    /// User message and delivery receipt committed atomically.
+    Applied,
+    /// The turn terminalized before this instruction could be applied.
+    Rejected,
+}
+
+impl TurnSteerStatus {
+    /// Stable database and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Applied => "applied",
+            Self::Rejected => "rejected",
+        }
+    }
+}
+
 /// Retry intent attached to one exact turn-attempt failure.
 ///
 /// Workers must retain this value across an ambiguous database commit. A new


### PR DESCRIPTION
## Summary

- add typed identities and durable pending/applied/rejected state for turn steering
- fold the pre-v1 steering table into the initial schema with exact turn, claim, and message scope constraints
- make the caller steer UUID the eventual user-message UUID and index pending work in deterministic order
- cover valid receipts and invalid content, state, scope, and identity combinations

## Validation

- `bw dev lint --rust --check`
- `cargo test -p openwave-core --all-features --locked`
- `git diff --check origin/main...HEAD`