### PR TITLE
feat(core): make turn steering transactional

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1246,6 +1246,7 @@ mod tests {
             .complete_turn_run_and_append_event(
                 turn_id,
                 lease_token,
+                0,
                 Utc::now(),
                 &output,
                 usage,
@@ -1274,6 +1275,7 @@ mod tests {
             .complete_turn_run_and_append_event(
                 turn_id,
                 lease_token,
+                0,
                 claimed_at + chrono::Duration::hours(1),
                 &output,
                 usage,

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -166,6 +166,7 @@ pub mod message {
         pub id: Uuid,
         pub chat_id: Uuid,
         pub turn_id: Uuid,
+        pub seq: i64,
         pub role: String,
         pub content: String,
         pub created_at: DateTimeUtc,
@@ -199,6 +200,8 @@ pub mod turn_run {
         pub finished_at: Option<DateTimeUtc>,
         pub last_error_code: Option<String>,
         pub last_error_detail: Option<String>,
+        pub steer_revision: i64,
+        pub last_steer_applied_at: Option<DateTimeUtc>,
         pub created_at: DateTimeUtc,
         pub updated_at: DateTimeUtc,
     }
@@ -237,6 +240,25 @@ pub mod turn_claim_lock {
     pub struct Model {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: i32,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod message_identity {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "message_identity")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub chat_id: Uuid,
+        pub turn_id: Uuid,
+        pub owner: String,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -52,11 +52,41 @@ impl MigrationTrait for Init {
         manager
             .create_table(
                 Table::create()
+                    .table(MessageIdentity::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(MessageIdentity::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(MessageIdentity::ChatId).uuid().not_null())
+                    .col(ColumnDef::new(MessageIdentity::TurnId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(MessageIdentity::Owner)
+                            .string_len(16)
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_message_identity_chat")
+                            .from(MessageIdentity::Table, MessageIdentity::ChatId)
+                            .to(Chat::Table, Chat::Id),
+                    )
+                    .check(Expr::col(MessageIdentity::Owner).is_in(["message", "turn_steer"]))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
                     .table(Message::Table)
                     .if_not_exists()
                     .col(ColumnDef::new(Message::Id).uuid().not_null().primary_key())
                     .col(ColumnDef::new(Message::ChatId).uuid().not_null())
                     .col(ColumnDef::new(Message::TurnId).uuid().not_null())
+                    .col(ColumnDef::new(Message::Seq).big_integer().not_null())
                     .col(ColumnDef::new(Message::Role).text().not_null())
                     .col(ColumnDef::new(Message::Content).text().not_null())
                     .col(
@@ -80,7 +110,8 @@ impl MigrationTrait for Init {
                     .name("idx_message_chat")
                     .table(Message::Table)
                     .col(Message::ChatId)
-                    .col(Message::CreatedAt)
+                    .col(Message::Seq)
+                    .unique()
                     .to_owned(),
             )
             .await?;
@@ -271,6 +302,12 @@ impl MigrationTrait for Init {
             ])
             .and(Expr::col(TurnRun::LastErrorCode).is_null())
             .and(Expr::col(TurnRun::LastErrorDetail).is_null());
+        let coherent_steer_generation = Expr::col(TurnRun::SteerRevision)
+            .eq(0)
+            .and(Expr::col(TurnRun::LastSteerAppliedAt).is_null())
+            .or(Expr::col(TurnRun::SteerRevision)
+                .gte(1)
+                .and(Expr::col(TurnRun::LastSteerAppliedAt).is_not_null()));
 
         manager
             .create_table(
@@ -321,6 +358,13 @@ impl MigrationTrait for Init {
                         ColumnDef::new(TurnRun::LastErrorDetail)
                             .string_len(crate::model::TurnRun::MAX_ERROR_DETAIL_LEN as u32),
                     )
+                    .col(
+                        ColumnDef::new(TurnRun::SteerRevision)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(ColumnDef::new(TurnRun::LastSteerAppliedAt).timestamp_with_time_zone())
                     .col(
                         ColumnDef::new(TurnRun::CreatedAt)
                             .timestamp_with_time_zone()
@@ -413,6 +457,18 @@ impl MigrationTrait for Init {
                             .is_null()
                             .or(Func::char_length(Expr::col(TurnRun::LastErrorDetail))
                                 .between(1, crate::model::TurnRun::MAX_ERROR_DETAIL_LEN as i32)),
+                    )
+                    .check(Expr::col(TurnRun::SteerRevision).gte(0))
+                    .check(coherent_steer_generation)
+                    .check(
+                        Expr::col(TurnRun::LastSteerAppliedAt)
+                            .is_null()
+                            .or(Expr::col(TurnRun::LastSteerAppliedAt)
+                                .gte(Expr::col(TurnRun::CreatedAt))
+                                .and(
+                                    Expr::col(TurnRun::LastSteerAppliedAt)
+                                        .lte(Expr::col(TurnRun::UpdatedAt)),
+                                )),
                     )
                     .to_owned(),
             )
@@ -732,6 +788,9 @@ impl MigrationTrait for Init {
             .await?;
         manager
             .drop_table(Table::drop().table(Message::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(MessageIdentity::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(TurnClaim::Table).to_owned())
@@ -1810,9 +1869,19 @@ enum Message {
     Id,
     ChatId,
     TurnId,
+    Seq,
     Role,
     Content,
     CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum MessageIdentity {
+    Table,
+    Id,
+    ChatId,
+    TurnId,
+    Owner,
 }
 
 #[derive(DeriveIden)]
@@ -1833,6 +1902,8 @@ enum TurnRun {
     FinishedAt,
     LastErrorCode,
     LastErrorDetail,
+    SteerRevision,
+    LastSteerAppliedAt,
     CreatedAt,
     UpdatedAt,
 }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -22,7 +22,7 @@ use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 #[cfg(test)]
 use crate::id::{CallId, MessageId};
-use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId, TurnId};
+use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId, TurnId, TurnSteerId};
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
@@ -34,9 +34,10 @@ use crate::model::{
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
-    AcceptTurnOutcome, ClaimTurnRunOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
-    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
-    JournaledTurnOutcome, RecordTurnFailureOutcome, RequestTurnCancellationOutcome, Store,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, ApplyTurnSteerOutcome, ClaimTurnRunOutcome,
+    CompleteTurnRunOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
+    EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome, JournaledTurnOutcome,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, Store,
 };
 
 mod ops;
@@ -1683,20 +1684,53 @@ impl Store for DbStore {
         ops::turn::heartbeat_turn_run(self, id, lease_token, now, lease_expires_at).await
     }
 
+    async fn accept_turn_steer(
+        &self,
+        id: TurnSteerId,
+        turn_id: TurnId,
+        chat_id: ChatId,
+        content: &str,
+        interrupt: bool,
+    ) -> Result<AcceptTurnSteerOutcome> {
+        ops::turn::accept_turn_steer(self, id, turn_id, chat_id, content, interrupt).await
+    }
+
+    async fn list_pending_turn_steers(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<Option<Vec<crate::model::TurnSteer>>> {
+        ops::turn::list_pending_turn_steers(self, turn_id, lease_token, now).await
+    }
+
+    async fn apply_turn_steer(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        steer_id: TurnSteerId,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<Option<ApplyTurnSteerOutcome>> {
+        ops::turn::apply_turn_steer(self, turn_id, lease_token, steer_id, now).await
+    }
+
     async fn complete_turn_run(
         &self,
         id: TurnId,
         lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
         now: chrono::DateTime<Utc>,
         output: &Message,
     ) -> Result<Option<CompleteTurnRunOutcome>> {
-        ops::turn::complete_turn_run(self, id, lease_token, now, output).await
+        ops::turn::complete_turn_run(self, id, lease_token, expected_steer_revision, now, output)
+            .await
     }
 
     async fn complete_turn_run_and_append_event(
         &self,
         id: TurnId,
         lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
         now: chrono::DateTime<Utc>,
         output: &Message,
         usage: Usage,
@@ -1706,6 +1740,7 @@ impl Store for DbStore {
             self,
             id,
             lease_token,
+            expected_steer_revision,
             now,
             output,
             usage,

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use sea_orm::sea_query::OnConflict;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set,
-    TransactionTrait,
+    TransactionTrait, TryInsertResult,
 };
 
 use crate::error::{AgentError, Result};
@@ -15,6 +15,79 @@ use crate::model::{Chat, Message, Role, ToolCallRecord, TurnRunStatus};
 use super::super::{entities, store_err, DbStore};
 use super::turn::canonical_db_timestamp;
 use super::{acquire_chat_write_lock, acquire_turn_write_lock};
+
+pub(in crate::db) const MESSAGE_IDENTITY_OWNER_MESSAGE: &str = "message";
+pub(in crate::db) const MESSAGE_IDENTITY_OWNER_STEER: &str = "turn_steer";
+
+pub(in crate::db) async fn reserve_message_identity_on<C>(
+    conn: &C,
+    id: MessageId,
+    chat_id: ChatId,
+    turn_id: TurnId,
+    owner: &str,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let inserted =
+        entities::message_identity::Entity::insert(entities::message_identity::ActiveModel {
+            id: Set(id.0),
+            chat_id: Set(chat_id.0),
+            turn_id: Set(turn_id.0),
+            owner: Set(owner.to_owned()),
+        })
+        .on_conflict(
+            OnConflict::column(entities::message_identity::Column::Id)
+                .do_nothing()
+                .to_owned(),
+        )
+        .do_nothing()
+        .exec_without_returning(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(matches!(inserted, TryInsertResult::Inserted(1)))
+}
+
+pub(in crate::db) async fn transfer_steer_message_identity_on<C>(
+    conn: &C,
+    id: MessageId,
+    chat_id: ChatId,
+    turn_id: TurnId,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let transferred = entities::message_identity::Entity::update_many()
+        .col_expr(
+            entities::message_identity::Column::Owner,
+            sea_orm::sea_query::Expr::value(MESSAGE_IDENTITY_OWNER_MESSAGE),
+        )
+        .filter(entities::message_identity::Column::Id.eq(id.0))
+        .filter(entities::message_identity::Column::ChatId.eq(chat_id.0))
+        .filter(entities::message_identity::Column::TurnId.eq(turn_id.0))
+        .filter(entities::message_identity::Column::Owner.eq(MESSAGE_IDENTITY_OWNER_STEER))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(transferred.rows_affected == 1)
+}
+
+pub(in crate::db) async fn next_message_seq_on<C>(conn: &C, chat_id: ChatId) -> Result<i64>
+where
+    C: ConnectionTrait,
+{
+    entities::message::Entity::find()
+        .filter(entities::message::Column::ChatId.eq(chat_id.0))
+        .order_by_desc(entities::message::Column::Seq)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .map_or(Ok(1), |message| {
+            message.seq.checked_add(1).ok_or_else(|| {
+                AgentError::Store(format!("chat {chat_id} message sequence overflow"))
+            })
+        })
+}
 
 pub(in crate::db) async fn create_chat(store: &DbStore, chat: &Chat) -> Result<()> {
     entities::chat::ActiveModel {
@@ -68,24 +141,51 @@ pub(in crate::db) async fn list_chats(store: &DbStore) -> Result<Vec<Chat>> {
 }
 
 pub(in crate::db) async fn append_message(store: &DbStore, message: &Message) -> Result<()> {
-    entities::message::ActiveModel {
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, message.chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "chat {} does not exist",
+            message.chat_id
+        )));
+    }
+    if !reserve_message_identity_on(
+        &transaction,
+        message.id,
+        message.chat_id,
+        message.turn_id,
+        MESSAGE_IDENTITY_OWNER_MESSAGE,
+    )
+    .await?
+    {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "message identity {} is already reserved",
+            message.id
+        )));
+    }
+    let seq = next_message_seq_on(&transaction, message.chat_id).await?;
+    let active = entities::message::ActiveModel {
         id: Set(message.id.0),
         chat_id: Set(message.chat_id.0),
         turn_id: Set(message.turn_id.0),
+        seq: Set(seq),
         role: Set(role_to_db(message.role).to_string()),
         content: Set(message.content.clone()),
         created_at: Set(message.created_at),
+    };
+    if let Err(error) = active.insert(&transaction).await {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(store_err(error));
     }
-    .insert(&store.conn)
-    .await
-    .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
     Ok(())
 }
 
 pub(in crate::db) async fn list_messages(store: &DbStore, chat_id: ChatId) -> Result<Vec<Message>> {
     entities::message::Entity::find()
         .filter(entities::message::Column::ChatId.eq(chat_id.0))
-        .order_by_asc(entities::message::Column::CreatedAt)
+        .order_by_asc(entities::message::Column::Seq)
         .all(&store.conn)
         .await
         .map_err(store_err)?

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -11,9 +11,16 @@ use crate::model::{TurnRun, TurnRunStatus};
 use crate::storage::{AcceptTurnOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome};
 
 use super::super::{entities, store_err, DbStore};
-use super::{acquire_chat_write_lock, conversation::append_event_on};
+use super::{
+    acquire_chat_write_lock,
+    conversation::{
+        append_event_on, next_message_seq_on, reserve_message_identity_on,
+        MESSAGE_IDENTITY_OWNER_MESSAGE,
+    },
+};
 
 mod resolution;
+mod steer;
 
 pub(in crate::db) use resolution::{
     complete_turn_run, complete_turn_run_and_append_event, finish_turn_cancellation,
@@ -21,6 +28,7 @@ pub(in crate::db) use resolution::{
     record_turn_run_failure_and_append_event, request_turn_cancellation,
     request_turn_cancellation_and_append_event,
 };
+pub(in crate::db) use steer::{accept_turn_steer, apply_turn_steer, list_pending_turn_steers};
 
 pub(in crate::db) async fn get_turn_run(store: &DbStore, id: TurnId) -> Result<Option<TurnRun>> {
     entities::turn_run::Entity::find_by_id(id.0)
@@ -110,10 +118,25 @@ pub(in crate::db) async fn accept_turn(
 
     let now = canonical_db_timestamp(Utc::now())?;
     let input_message_id = MessageId::new();
+    if !reserve_message_identity_on(
+        &transaction,
+        input_message_id,
+        chat_id,
+        id,
+        MESSAGE_IDENTITY_OWNER_MESSAGE,
+    )
+    .await?
+    {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "turn input message identity {input_message_id} is already reserved"
+        )));
+    }
     let message = entities::message::ActiveModel {
         id: Set(input_message_id.0),
         chat_id: Set(chat_id.0),
         turn_id: Set(id.0),
+        seq: Set(next_message_seq_on(&transaction, chat_id).await?),
         role: Set("user".into()),
         content: Set(content.into()),
         created_at: Set(now),
@@ -139,6 +162,8 @@ pub(in crate::db) async fn accept_turn(
         finished_at: Set(None),
         last_error_code: Set(None),
         last_error_detail: Set(None),
+        steer_revision: Set(0),
+        last_steer_applied_at: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
     };
@@ -317,6 +342,7 @@ pub(in crate::db) async fn claim_turn_run(
                 transaction.rollback().await.map_err(store_err)?;
                 continue;
             }
+            steer::reject_pending_turn_steers_on(&transaction, TurnId(candidate.id), now).await?;
             let event = AgentEvent::TurnCancelled {
                 usage: crate::provider::Usage::default(),
             };
@@ -390,6 +416,7 @@ pub(in crate::db) async fn claim_turn_run(
                 transaction.rollback().await.map_err(store_err)?;
                 continue;
             }
+            steer::reject_pending_turn_steers_on(&transaction, TurnId(candidate.id), now).await?;
             let event = AgentEvent::TurnFailed {
                 error: AgentErrorInfo {
                     kind: "lease_expired".into(),
@@ -786,6 +813,8 @@ fn turn_run_from_model(model: entities::turn_run::Model) -> Result<TurnRun> {
         finished_at: model.finished_at,
         last_error_code: model.last_error_code,
         last_error_detail: model.last_error_detail,
+        steer_revision: model.steer_revision,
+        last_steer_applied_at: model.last_steer_applied_at,
         created_at: model.created_at,
         updated_at: model.updated_at,
     })

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -6,7 +6,9 @@ use sea_orm::{
 use crate::error::{AgentError, AgentErrorInfo, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, TurnId};
-use crate::model::{Message, Role, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus};
+use crate::model::{
+    Message, Role, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteerStatus,
+};
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
     CompleteTurnRunOutcome, FinishTurnCancellationOutcome, JournaledTurnOutcome,
@@ -15,7 +17,11 @@ use crate::storage::{
 
 use super::super::super::{entities, store_err, DbStore};
 use super::super::{
-    acquire_chat_write_lock, acquire_turn_write_lock, conversation::append_event_on,
+    acquire_chat_write_lock, acquire_turn_write_lock,
+    conversation::{
+        append_event_on, next_message_seq_on, reserve_message_identity_on,
+        MESSAGE_IDENTITY_OWNER_MESSAGE,
+    },
 };
 use super::{canonical_db_timestamp, turn_run_from_model, turn_run_status_from_db};
 
@@ -30,14 +36,21 @@ pub(in crate::db) async fn complete_turn_run(
     store: &DbStore,
     id: TurnId,
     lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
     now: chrono::DateTime<Utc>,
     output: &Message,
 ) -> Result<Option<CompleteTurnRunOutcome>> {
-    Ok(
-        complete_turn_run_inner(store, id, lease_token, now, output, None)
-            .await?
-            .map(|resolution| resolution.outcome),
+    Ok(complete_turn_run_inner(
+        store,
+        id,
+        lease_token,
+        expected_steer_revision,
+        now,
+        output,
+        None,
     )
+    .await?
+    .map(|resolution| resolution.outcome))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -45,19 +58,30 @@ pub(in crate::db) async fn complete_turn_run_and_append_event(
     store: &DbStore,
     id: TurnId,
     lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
     now: chrono::DateTime<Utc>,
     output: &Message,
     usage: Usage,
     stop_reason: StopReason,
 ) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
     let event = AgentEvent::TurnCompleted { usage, stop_reason };
-    complete_turn_run_inner(store, id, lease_token, now, output, Some(&event)).await
+    complete_turn_run_inner(
+        store,
+        id,
+        lease_token,
+        expected_steer_revision,
+        now,
+        output,
+        Some(&event),
+    )
+    .await
 }
 
 async fn complete_turn_run_inner(
     store: &DbStore,
     id: TurnId,
     lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
     now: chrono::DateTime<Utc>,
     output: &Message,
     terminal_event: Option<&AgentEvent>,
@@ -71,17 +95,14 @@ async fn complete_turn_run_inner(
         ));
     }
 
-    let journal_chat_id = journal_chat_id(store, id, terminal_event.is_some()).await?;
-    if terminal_event.is_some() && journal_chat_id.is_none() {
+    let Some(journal_chat_id) = journal_chat_id(store, id, true).await? else {
         return Ok(None);
-    }
+    };
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    if let Some(chat_id) = journal_chat_id {
-        if !acquire_chat_write_lock(&transaction, chat_id).await? {
-            return Err(AgentError::Store(format!(
-                "turn {id} references missing chat {chat_id}"
-            )));
-        }
+    if !acquire_chat_write_lock(&transaction, journal_chat_id).await? {
+        return Err(AgentError::Store(format!(
+            "turn {id} references missing chat {journal_chat_id}"
+        )));
     }
     if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
@@ -140,11 +161,55 @@ async fn complete_turn_run_inner(
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
+    let stale_output = existing.steer_revision != expected_steer_revision;
+    let steer_pending = entities::turn_steer::Entity::find()
+        .filter(entities::turn_steer::Column::TurnId.eq(id.0))
+        .filter(entities::turn_steer::Column::Status.eq(TurnSteerStatus::Pending.as_str()))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .is_some();
+    if stale_output || steer_pending {
+        let existing = turn_run_from_model(existing)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(JournaledTurnOutcome {
+            outcome: if steer_pending {
+                CompleteTurnRunOutcome::SteerPending(existing)
+            } else {
+                CompleteTurnRunOutcome::OutputSuperseded(existing)
+            },
+            terminal_event: None,
+        }));
+    }
 
+    if !reserve_message_identity_on(
+        &transaction,
+        output.id,
+        output.chat_id,
+        output.turn_id,
+        MESSAGE_IDENTITY_OWNER_MESSAGE,
+    )
+    .await?
+    {
+        transaction.rollback().await.map_err(store_err)?;
+        if let Some(existing) = exact_completed_turn_on(store, id, lease_token, output).await? {
+            let sequenced_event =
+                exact_terminal_event_on(&store.conn, id, Some(lease_token), terminal_event).await?;
+            return Ok(Some(JournaledTurnOutcome {
+                outcome: CompleteTurnRunOutcome::Existing(existing),
+                terminal_event: sequenced_event,
+            }));
+        }
+        return Err(AgentError::Store(format!(
+            "turn output message identity {} is already reserved",
+            output.id
+        )));
+    }
     let message = entities::message::ActiveModel {
         id: Set(output.id.0),
         chat_id: Set(output.chat_id.0),
         turn_id: Set(output.turn_id.0),
+        seq: Set(next_message_seq_on(&transaction, output.chat_id).await?),
         role: Set("assistant".into()),
         content: Set(output.content.clone()),
         created_at: Set(output_created_at),
@@ -202,6 +267,7 @@ async fn complete_turn_run_inner(
         transaction.rollback().await.map_err(store_err)?;
         return Ok(None);
     }
+    super::steer::reject_pending_turn_steers_on(&transaction, id, now).await?;
     let sequenced_event = append_terminal_event_on(
         &transaction,
         id,
@@ -467,6 +533,7 @@ async fn record_turn_run_failure_inner(
     }
 
     let sequenced_event = if result_status == TurnRunStatus::Failed {
+        super::steer::reject_pending_turn_steers_on(&transaction, id, now).await?;
         append_terminal_event_on(
             &transaction,
             id,

--- a/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
@@ -131,6 +131,7 @@ async fn request_turn_cancellation_inner(
         transaction.rollback().await.map_err(store_err)?;
         return Ok(None);
     }
+    super::super::steer::reject_pending_turn_steers_on(&transaction, id, now).await?;
     let updated = entities::turn_run::Entity::find_by_id(id.0)
         .one(&transaction)
         .await
@@ -278,6 +279,7 @@ async fn finish_turn_cancellation_inner(
         transaction.rollback().await.map_err(store_err)?;
         return Ok(None);
     }
+    super::super::steer::reject_pending_turn_steers_on(&transaction, id, now).await?;
     let cancelled = entities::turn_run::Entity::find_by_id(id.0)
         .one(&transaction)
         .await

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -1,0 +1,571 @@
+use chrono::Utc;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait,
+};
+
+use crate::error::{AgentError, Result};
+use crate::id::{ChatId, MessageId, TurnId, TurnSteerId};
+use crate::model::{TurnRunStatus, TurnSteer, TurnSteerStatus};
+use crate::storage::{AcceptTurnSteerOutcome, ApplyTurnSteerOutcome};
+
+use super::super::super::{entities, store_err, DbStore};
+use super::super::{
+    acquire_chat_write_lock, acquire_turn_write_lock,
+    conversation::{
+        next_message_seq_on, reserve_message_identity_on, transfer_steer_message_identity_on,
+        MESSAGE_IDENTITY_OWNER_MESSAGE, MESSAGE_IDENTITY_OWNER_STEER,
+    },
+};
+use super::{canonical_db_timestamp, turn_run_status_from_db};
+
+pub(in crate::db) async fn accept_turn_steer(
+    store: &DbStore,
+    id: TurnSteerId,
+    turn_id: TurnId,
+    chat_id: ChatId,
+    content: &str,
+    interrupt: bool,
+) -> Result<AcceptTurnSteerOutcome> {
+    validate_steer_input(id, turn_id, chat_id, content)?;
+    if let Some(existing) = entities::turn_steer::Entity::find_by_id(id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    {
+        return exact_accepted_steer(existing, turn_id, chat_id, content, interrupt);
+    }
+    if entities::message::Entity::find_by_id(id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .is_some()
+    {
+        return Ok(AcceptTurnSteerOutcome::IdentityConflict);
+    }
+    let now = canonical_db_timestamp(Utc::now())?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, chat_id).await? {
+        return Err(AgentError::Store(format!("chat {chat_id} does not exist")));
+    }
+    if !acquire_turn_write_lock(&transaction, turn_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(AcceptTurnSteerOutcome::TurnUnavailable);
+    }
+
+    if let Some(existing) = entities::turn_steer::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let outcome = exact_accepted_steer(existing, turn_id, chat_id, content, interrupt)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(outcome);
+    }
+    if entities::message::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .is_some()
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(AcceptTurnSteerOutcome::IdentityConflict);
+    }
+
+    let turn = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("turn {turn_id} disappeared while locked")))?;
+    let status = turn_run_status_from_db(&turn.status)?;
+    let accepts_steer = turn.chat_id == chat_id.0
+        && turn.updated_at <= now
+        && matches!(
+            status,
+            TurnRunStatus::Queued | TurnRunStatus::Running | TurnRunStatus::RetryWait
+        )
+        && (status != TurnRunStatus::Running
+            || turn
+                .lease_expires_at
+                .is_some_and(|lease_expires_at| lease_expires_at > now));
+    if !accepts_steer {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(AcceptTurnSteerOutcome::TurnUnavailable);
+    }
+
+    if !reserve_message_identity_on(
+        &transaction,
+        MessageId(id.0),
+        chat_id,
+        turn_id,
+        MESSAGE_IDENTITY_OWNER_STEER,
+    )
+    .await?
+    {
+        transaction.rollback().await.map_err(store_err)?;
+        if let Some(existing) = entities::turn_steer::Entity::find_by_id(id.0)
+            .one(&store.conn)
+            .await
+            .map_err(store_err)?
+        {
+            return exact_accepted_steer(existing, turn_id, chat_id, content, interrupt);
+        }
+        return Ok(AcceptTurnSteerOutcome::IdentityConflict);
+    }
+
+    let steer = entities::turn_steer::ActiveModel {
+        id: Set(id.0),
+        turn_id: Set(turn_id.0),
+        chat_id: Set(chat_id.0),
+        content: Set(content.to_owned()),
+        interrupt: Set(interrupt),
+        status: Set(TurnSteerStatus::Pending.as_str().into()),
+        applied_lease_token: Set(None),
+        message_id: Set(None),
+        created_at: Set(now),
+        resolved_at: Set(None),
+    }
+    .insert(&transaction)
+    .await;
+    let steer = match steer {
+        Ok(steer) => steer,
+        Err(error) => {
+            transaction.rollback().await.map_err(store_err)?;
+            if let Some(existing) = entities::turn_steer::Entity::find_by_id(id.0)
+                .one(&store.conn)
+                .await
+                .map_err(store_err)?
+            {
+                return exact_accepted_steer(existing, turn_id, chat_id, content, interrupt);
+            }
+            if entities::message::Entity::find_by_id(id.0)
+                .one(&store.conn)
+                .await
+                .map_err(store_err)?
+                .is_some()
+            {
+                return Ok(AcceptTurnSteerOutcome::IdentityConflict);
+            }
+            return Err(store_err(error));
+        }
+    };
+
+    let touched = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
+        .filter(entities::turn_run::Column::Status.eq(&turn.status))
+        .filter(entities::turn_run::Column::AttemptCount.eq(turn.attempt_count))
+        .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at))
+        .filter(entities::turn_run::Column::UpdatedAt.lte(now));
+    let touched = if status == TurnRunStatus::Running {
+        touched
+            .filter(entities::turn_run::Column::LeaseToken.eq(turn.lease_token))
+            .filter(entities::turn_run::Column::LeaseExpiresAt.eq(turn.lease_expires_at))
+    } else {
+        touched
+    }
+    .exec(&transaction)
+    .await
+    .map_err(store_err)?;
+    if touched.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "turn {turn_id} changed while accepting steer {id}"
+        )));
+    }
+
+    transaction.commit().await.map_err(store_err)?;
+    Ok(AcceptTurnSteerOutcome::Accepted(turn_steer_from_model(
+        steer,
+    )?))
+}
+
+pub(in crate::db) async fn list_pending_turn_steers(
+    store: &DbStore,
+    turn_id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<Vec<TurnSteer>>> {
+    if turn_id.0.is_nil() || lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "turn and lease identities must not be nil".into(),
+        ));
+    }
+    let now = canonical_db_timestamp(now)?;
+    let Some(claim) = entities::turn_claim::Entity::find_by_id(lease_token)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .filter(|claim| claim.turn_id == turn_id.0)
+    else {
+        return Ok(None);
+    };
+    let live = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .is_some_and(|turn| {
+            turn.status == TurnRunStatus::Running.as_str()
+                && turn.attempt_count == claim.attempt_count
+                && turn.lease_token == Some(lease_token)
+                && turn
+                    .lease_expires_at
+                    .is_some_and(|lease_expires_at| lease_expires_at > now)
+                && turn.updated_at <= now
+        });
+    if !live {
+        return Ok(None);
+    }
+    entities::turn_steer::Entity::find()
+        .filter(entities::turn_steer::Column::TurnId.eq(turn_id.0))
+        .filter(entities::turn_steer::Column::Status.eq(TurnSteerStatus::Pending.as_str()))
+        .order_by_asc(entities::turn_steer::Column::CreatedAt)
+        .order_by_asc(entities::turn_steer::Column::Id)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(turn_steer_from_model)
+        .collect::<Result<Vec<_>>>()
+        .map(Some)
+}
+
+pub(in crate::db) async fn apply_turn_steer(
+    store: &DbStore,
+    turn_id: TurnId,
+    lease_token: uuid::Uuid,
+    steer_id: TurnSteerId,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<ApplyTurnSteerOutcome>> {
+    if turn_id.0.is_nil() || lease_token.is_nil() || steer_id.0.is_nil() {
+        return Err(AgentError::Store(
+            "turn, lease, and steer identities must not be nil".into(),
+        ));
+    }
+    let now = canonical_db_timestamp(now)?;
+    let Some(chat_id) = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(|turn| ChatId(turn.chat_id))
+    else {
+        return Ok(None);
+    };
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, chat_id).await? {
+        return Err(AgentError::Store(format!(
+            "turn {turn_id} references missing chat {chat_id}"
+        )));
+    }
+    if !acquire_turn_write_lock(&transaction, turn_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let Some(steer) = entities::turn_steer::Entity::find_by_id(steer_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let status = turn_steer_status_from_db(&steer.status)?;
+    if status == TurnSteerStatus::Applied {
+        let exact = steer.turn_id == turn_id.0 && steer.applied_lease_token == Some(lease_token);
+        let outcome = if exact {
+            ensure_exact_applied_message_on(&transaction, &steer).await?;
+            Some(ApplyTurnSteerOutcome::Existing(turn_steer_from_model(
+                steer,
+            )?))
+        } else {
+            None
+        };
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(outcome);
+    }
+    if status == TurnSteerStatus::Rejected || steer.turn_id != turn_id.0 {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let earliest_pending = entities::turn_steer::Entity::find()
+        .filter(entities::turn_steer::Column::TurnId.eq(turn_id.0))
+        .filter(entities::turn_steer::Column::Status.eq(TurnSteerStatus::Pending.as_str()))
+        .order_by_asc(entities::turn_steer::Column::CreatedAt)
+        .order_by_asc(entities::turn_steer::Column::Id)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?;
+    if earliest_pending.as_ref().map(|pending| pending.id) != Some(steer.id) {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let Some(claim) = entities::turn_claim::Entity::find_by_id(lease_token)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .filter(|claim| claim.turn_id == turn_id.0)
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let Some(turn) = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if turn.status != TurnRunStatus::Running.as_str()
+        || turn.attempt_count != claim.attempt_count
+        || turn.lease_token != Some(lease_token)
+        || turn
+            .lease_expires_at
+            .is_none_or(|lease_expires_at| lease_expires_at <= now)
+        || turn.updated_at > now
+        || steer.chat_id != turn.chat_id
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let next_steer_revision = turn
+        .steer_revision
+        .checked_add(1)
+        .ok_or_else(|| AgentError::Store(format!("turn {turn_id} steer revision overflow")))?;
+
+    if !transfer_steer_message_identity_on(
+        &transaction,
+        MessageId(steer.id),
+        ChatId(steer.chat_id),
+        TurnId(steer.turn_id),
+    )
+    .await?
+    {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "turn steer {steer_id} has a missing or conflicting message reservation"
+        )));
+    }
+    let message = entities::message::ActiveModel {
+        id: Set(steer.id),
+        chat_id: Set(steer.chat_id),
+        turn_id: Set(steer.turn_id),
+        seq: Set(next_message_seq_on(&transaction, ChatId(steer.chat_id)).await?),
+        role: Set("user".into()),
+        content: Set(steer.content.clone()),
+        created_at: Set(now),
+    };
+    if let Err(error) = message.insert(&transaction).await {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(store_err(error));
+    }
+
+    let applied = entities::turn_steer::Entity::update_many()
+        .col_expr(
+            entities::turn_steer::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnSteerStatus::Applied.as_str()),
+        )
+        .col_expr(
+            entities::turn_steer::Column::AppliedLeaseToken,
+            sea_orm::sea_query::Expr::value(Some(lease_token)),
+        )
+        .col_expr(
+            entities::turn_steer::Column::MessageId,
+            sea_orm::sea_query::Expr::value(Some(steer.id)),
+        )
+        .col_expr(
+            entities::turn_steer::Column::ResolvedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .filter(entities::turn_steer::Column::Id.eq(steer.id))
+        .filter(entities::turn_steer::Column::Status.eq(TurnSteerStatus::Pending.as_str()))
+        .filter(entities::turn_steer::Column::AppliedLeaseToken.is_null())
+        .filter(entities::turn_steer::Column::MessageId.is_null())
+        .filter(entities::turn_steer::Column::ResolvedAt.is_null())
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if applied.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let touched = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .col_expr(
+            entities::turn_run::Column::SteerRevision,
+            sea_orm::sea_query::Expr::value(next_steer_revision),
+        )
+        .col_expr(
+            entities::turn_run::Column::LastSteerAppliedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
+        .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
+        .filter(entities::turn_run::Column::AttemptCount.eq(claim.attempt_count))
+        .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.eq(turn.lease_expires_at))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::turn_run::Column::SteerRevision.eq(turn.steer_revision))
+        .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at))
+        .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if touched.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let applied = entities::turn_steer::Entity::find_by_id(steer.id)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("applied steer {steer_id} disappeared")))?;
+    ensure_exact_applied_message_on(&transaction, &applied).await?;
+    let applied = turn_steer_from_model(applied)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(ApplyTurnSteerOutcome::Applied(applied)))
+}
+
+pub(super) async fn reject_pending_turn_steers_on<C>(
+    conn: &C,
+    turn_id: TurnId,
+    resolved_at: chrono::DateTime<Utc>,
+) -> Result<u64>
+where
+    C: ConnectionTrait,
+{
+    let rejected = entities::turn_steer::Entity::update_many()
+        .col_expr(
+            entities::turn_steer::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnSteerStatus::Rejected.as_str()),
+        )
+        .col_expr(
+            entities::turn_steer::Column::ResolvedAt,
+            sea_orm::sea_query::Expr::value(Some(resolved_at)),
+        )
+        .filter(entities::turn_steer::Column::TurnId.eq(turn_id.0))
+        .filter(entities::turn_steer::Column::Status.eq(TurnSteerStatus::Pending.as_str()))
+        .filter(entities::turn_steer::Column::AppliedLeaseToken.is_null())
+        .filter(entities::turn_steer::Column::MessageId.is_null())
+        .filter(entities::turn_steer::Column::ResolvedAt.is_null())
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(rejected.rows_affected)
+}
+
+fn validate_steer_input(
+    id: TurnSteerId,
+    turn_id: TurnId,
+    chat_id: ChatId,
+    content: &str,
+) -> Result<()> {
+    let content_len = content.chars().count();
+    if id.0.is_nil() || turn_id.0.is_nil() || chat_id.0.is_nil() {
+        return Err(AgentError::Store(
+            "steer, turn, and chat identities must not be nil".into(),
+        ));
+    }
+    if content.trim().is_empty()
+        || content.contains('\0')
+        || !(1..=TurnSteer::MAX_CONTENT_LEN).contains(&content_len)
+    {
+        return Err(AgentError::Store(format!(
+            "turn steer content must contain 1 to {} non-NUL characters",
+            TurnSteer::MAX_CONTENT_LEN
+        )));
+    }
+    Ok(())
+}
+
+fn exact_accepted_steer(
+    existing: entities::turn_steer::Model,
+    turn_id: TurnId,
+    chat_id: ChatId,
+    content: &str,
+    interrupt: bool,
+) -> Result<AcceptTurnSteerOutcome> {
+    if existing.turn_id != turn_id.0
+        || existing.chat_id != chat_id.0
+        || existing.content != content
+        || existing.interrupt != interrupt
+    {
+        return Ok(AcceptTurnSteerOutcome::IdentityConflict);
+    }
+    Ok(AcceptTurnSteerOutcome::Existing(turn_steer_from_model(
+        existing,
+    )?))
+}
+
+async fn ensure_exact_applied_message_on<C>(
+    conn: &C,
+    steer: &entities::turn_steer::Model,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let exact = entities::message::Entity::find_by_id(steer.id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .is_some_and(|message| {
+            message.chat_id == steer.chat_id
+                && message.turn_id == steer.turn_id
+                && message.role == "user"
+                && message.content == steer.content
+                && steer
+                    .resolved_at
+                    .is_some_and(|resolved_at| message.created_at == resolved_at)
+        });
+    let exact_identity = entities::message_identity::Entity::find_by_id(steer.id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .is_some_and(|identity| {
+            identity.chat_id == steer.chat_id
+                && identity.turn_id == steer.turn_id
+                && identity.owner == MESSAGE_IDENTITY_OWNER_MESSAGE
+        });
+    if !exact || !exact_identity {
+        return Err(AgentError::Store(format!(
+            "applied turn steer {} has a different or missing message",
+            TurnSteerId(steer.id)
+        )));
+    }
+    Ok(())
+}
+
+fn turn_steer_from_model(model: entities::turn_steer::Model) -> Result<TurnSteer> {
+    Ok(TurnSteer {
+        id: TurnSteerId(model.id),
+        turn_id: TurnId(model.turn_id),
+        chat_id: ChatId(model.chat_id),
+        content: model.content,
+        interrupt: model.interrupt,
+        status: turn_steer_status_from_db(&model.status)?,
+        applied_lease_token: model.applied_lease_token,
+        message_id: model.message_id.map(MessageId),
+        created_at: model.created_at,
+        resolved_at: model.resolved_at,
+    })
+}
+
+fn turn_steer_status_from_db(value: &str) -> Result<TurnSteerStatus> {
+    match value {
+        "pending" => Ok(TurnSteerStatus::Pending),
+        "applied" => Ok(TurnSteerStatus::Applied),
+        "rejected" => Ok(TurnSteerStatus::Rejected),
+        other => Err(AgentError::Store(format!(
+            "invalid durable turn steer status: {other}"
+        ))),
+    }
+}

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4,6 +4,8 @@ use crate::model::{
 };
 use chrono::{DateTime, Utc};
 
+mod turn_steer;
+
 async fn temp_store() -> (tempfile::TempDir, DbStore) {
     let dir = tempfile::tempdir().unwrap();
     let url = format!("sqlite://{}?mode=rwc", dir.path().join("test.db").display());
@@ -4583,10 +4585,14 @@ async fn make_queued_turn(
 ) -> entities::turn_run::ActiveModel {
     let turn_id = TurnId::new();
     let input_message_id = MessageId::new();
+    let seq = super::ops::conversation::next_message_seq_on(&store.conn, chat_id)
+        .await
+        .unwrap();
     entities::message::ActiveModel {
         id: Set(input_message_id.0),
         chat_id: Set(chat_id.0),
         turn_id: Set(turn_id.0),
+        seq: Set(seq),
         role: Set("user".into()),
         content: Set("turn input".into()),
         created_at: Set(now),
@@ -4611,154 +4617,11 @@ async fn make_queued_turn(
         finished_at: Set(None),
         last_error_code: Set(None),
         last_error_detail: Set(None),
+        steer_revision: Set(0),
+        last_steer_applied_at: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
     }
-}
-
-fn pending_turn_steer(
-    turn: &crate::model::TurnRun,
-    id: crate::id::TurnSteerId,
-    content: &str,
-    now: DateTime<Utc>,
-) -> entities::turn_steer::ActiveModel {
-    entities::turn_steer::ActiveModel {
-        id: Set(id.0),
-        turn_id: Set(turn.id.0),
-        chat_id: Set(turn.chat_id.0),
-        content: Set(content.into()),
-        interrupt: Set(false),
-        status: Set(TurnSteerStatus::Pending.as_str().into()),
-        applied_lease_token: Set(None),
-        message_id: Set(None),
-        created_at: Set(now),
-        resolved_at: Set(None),
-    }
-}
-
-#[tokio::test]
-async fn turn_steer_schema_enforces_durable_delivery_identity() {
-    let (_dir, store) = temp_store().await;
-    let chat = sample_chat();
-    store.create_chat(&chat).await.unwrap();
-    let queued = store
-        .accept_turn(TurnId::new(), chat.id, "gpt-5", "initial input")
-        .await
-        .unwrap();
-    let queued = match queued {
-        AcceptTurnOutcome::Accepted(turn) => turn,
-        other => panic!("unexpected acceptance: {other:?}"),
-    };
-    let now = Utc::now();
-    let claim_token = uuid::Uuid::new_v4();
-    let claimed = store
-        .claim_turn_run(claim_token, now, now + chrono::Duration::minutes(1))
-        .await
-        .unwrap()
-        .turn
-        .expect("turn claimed");
-    assert_eq!(claimed.id, queued.id);
-
-    let first_id = crate::id::TurnSteerId::new();
-    pending_turn_steer(&claimed, first_id, "change course", now)
-        .insert(&store.conn)
-        .await
-        .unwrap();
-
-    let mut empty = pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "", now);
-    assert!(empty.clone().insert(&store.conn).await.is_err());
-    empty.content = Set("x".repeat(crate::model::TurnSteer::MAX_CONTENT_LEN + 1));
-    assert!(empty.insert(&store.conn).await.is_err());
-
-    let mut pending_with_resolution =
-        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "pending", now);
-    pending_with_resolution.resolved_at = Set(Some(now));
-    assert!(pending_with_resolution.insert(&store.conn).await.is_err());
-
-    let mut applied_without_receipt =
-        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "applied", now);
-    applied_without_receipt.status = Set(TurnSteerStatus::Applied.as_str().into());
-    applied_without_receipt.resolved_at = Set(Some(now));
-    assert!(applied_without_receipt.insert(&store.conn).await.is_err());
-
-    let message_id = MessageId(first_id.0);
-    entities::message::ActiveModel {
-        id: Set(message_id.0),
-        chat_id: Set(chat.id.0),
-        turn_id: Set(claimed.id.0),
-        role: Set("user".into()),
-        content: Set("change course".into()),
-        created_at: Set(now),
-    }
-    .insert(&store.conn)
-    .await
-    .unwrap();
-    entities::turn_steer::Entity::update_many()
-        .col_expr(
-            entities::turn_steer::Column::Status,
-            sea_orm::sea_query::Expr::value(TurnSteerStatus::Applied.as_str()),
-        )
-        .col_expr(
-            entities::turn_steer::Column::AppliedLeaseToken,
-            sea_orm::sea_query::Expr::value(Some(claim_token)),
-        )
-        .col_expr(
-            entities::turn_steer::Column::MessageId,
-            sea_orm::sea_query::Expr::value(Some(message_id.0)),
-        )
-        .col_expr(
-            entities::turn_steer::Column::ResolvedAt,
-            sea_orm::sea_query::Expr::value(Some(now)),
-        )
-        .filter(entities::turn_steer::Column::Id.eq(first_id.0))
-        .exec(&store.conn)
-        .await
-        .unwrap();
-
-    let applied = entities::turn_steer::Entity::find_by_id(first_id.0)
-        .one(&store.conn)
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(applied.status, TurnSteerStatus::Applied.as_str());
-    assert_eq!(applied.applied_lease_token, Some(claim_token));
-    assert_eq!(applied.message_id, Some(message_id.0));
-
-    let mismatched_message_id = MessageId::new();
-    entities::message::ActiveModel {
-        id: Set(mismatched_message_id.0),
-        chat_id: Set(chat.id.0),
-        turn_id: Set(claimed.id.0),
-        role: Set("user".into()),
-        content: Set("mismatched identity".into()),
-        created_at: Set(now),
-    }
-    .insert(&store.conn)
-    .await
-    .unwrap();
-    let mut mismatched_receipt = pending_turn_steer(
-        &claimed,
-        crate::id::TurnSteerId::new(),
-        "mismatched identity",
-        now,
-    );
-    mismatched_receipt.status = Set(TurnSteerStatus::Applied.as_str().into());
-    mismatched_receipt.applied_lease_token = Set(Some(claim_token));
-    mismatched_receipt.message_id = Set(Some(mismatched_message_id.0));
-    mismatched_receipt.resolved_at = Set(Some(now));
-    assert!(mismatched_receipt.insert(&store.conn).await.is_err());
-
-    let mut wrong_turn =
-        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "wrong turn", now);
-    wrong_turn.turn_id = Set(TurnId::new().0);
-    assert!(wrong_turn.insert(&store.conn).await.is_err());
-
-    let mut rejected_with_message =
-        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "rejected", now);
-    rejected_with_message.status = Set(TurnSteerStatus::Rejected.as_str().into());
-    rejected_with_message.message_id = Set(Some(message_id.0));
-    rejected_with_message.resolved_at = Set(Some(now));
-    assert!(rejected_with_message.insert(&store.conn).await.is_err());
 }
 
 #[tokio::test]
@@ -4787,10 +4650,14 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         .is_err());
 
     let first_output_id = MessageId::new();
+    let first_output_seq = super::ops::conversation::next_message_seq_on(&store.conn, chat.id)
+        .await
+        .unwrap();
     entities::message::ActiveModel {
         id: Set(first_output_id.0),
         chat_id: Set(chat.id.0),
         turn_id: Set(first.id),
+        seq: Set(first_output_seq),
         role: Set("assistant".into()),
         content: Set("done".into()),
         created_at: Set(now),
@@ -4886,6 +4753,12 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let mut unknown_status = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     unknown_status.status = Set("waiting_for_magic".into());
     assert!(unknown_status.insert(&store.conn).await.is_err());
+    let mut negative_steer_revision = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
+    negative_steer_revision.steer_revision = Set(-1);
+    assert!(negative_steer_revision.insert(&store.conn).await.is_err());
+    let mut missing_steer_timestamp = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
+    missing_steer_timestamp.steer_revision = Set(1);
+    assert!(missing_steer_timestamp.insert(&store.conn).await.is_err());
     assert!(make_queued_turn(&store, invalid_chat.id, "", now)
         .await
         .insert(&store.conn)
@@ -5628,7 +5501,7 @@ async fn turn_completion_atomically_persists_exact_output_and_recovers_retries()
 
     assert_eq!(
         store
-            .complete_turn_run(turn_id, uuid::Uuid::new_v4(), output.created_at, &output)
+            .complete_turn_run(turn_id, uuid::Uuid::new_v4(), 0, output.created_at, &output)
             .await
             .unwrap(),
         None
@@ -5638,25 +5511,25 @@ async fn turn_completion_atomically_persists_exact_output_and_recovers_retries()
     let mut invalid = output.clone();
     invalid.role = Role::User;
     assert!(store
-        .complete_turn_run(turn_id, lease_token, output.created_at, &invalid)
+        .complete_turn_run(turn_id, lease_token, 0, output.created_at, &invalid)
         .await
         .is_err());
     invalid = output.clone();
     invalid.turn_id = TurnId::new();
     assert!(store
-        .complete_turn_run(turn_id, lease_token, output.created_at, &invalid)
+        .complete_turn_run(turn_id, lease_token, 0, output.created_at, &invalid)
         .await
         .is_err());
     invalid = output.clone();
     invalid.chat_id = ChatId::new();
     assert!(store
-        .complete_turn_run(turn_id, lease_token, output.created_at, &invalid)
+        .complete_turn_run(turn_id, lease_token, 0, output.created_at, &invalid)
         .await
         .is_err());
     assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
 
     let CompleteTurnRunOutcome::Completed(completed) = store
-        .complete_turn_run(turn_id, lease_token, output.created_at, &output)
+        .complete_turn_run(turn_id, lease_token, 0, output.created_at, &output)
         .await
         .unwrap()
         .unwrap()
@@ -5682,6 +5555,7 @@ async fn turn_completion_atomically_persists_exact_output_and_recovers_retries()
             .complete_turn_run(
                 turn_id,
                 lease_token,
+                0,
                 lease_expires_at + chrono::Duration::seconds(1),
                 &output,
             )
@@ -5694,13 +5568,13 @@ async fn turn_completion_atomically_persists_exact_output_and_recovers_retries()
     let mut mismatched = output.clone();
     mismatched.content = "different answer".into();
     assert!(store
-        .complete_turn_run(turn_id, lease_token, lease_expires_at, &mismatched)
+        .complete_turn_run(turn_id, lease_token, 0, lease_expires_at, &mismatched)
         .await
         .is_err());
     mismatched = output.clone();
     mismatched.id = MessageId::new();
     assert!(store
-        .complete_turn_run(turn_id, lease_token, lease_expires_at, &mismatched)
+        .complete_turn_run(turn_id, lease_token, 0, lease_expires_at, &mismatched)
         .await
         .is_err());
     assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
@@ -5864,7 +5738,7 @@ async fn turn_failure_receipt_recovers_exact_retries_after_the_turn_advances() {
     };
     assert!(matches!(
         store
-            .complete_turn_run(turn_id, second_token, output.created_at, &output)
+            .complete_turn_run(turn_id, second_token, 0, output.created_at, &output)
             .await
             .unwrap(),
         Some(CompleteTurnRunOutcome::Completed(_))
@@ -6406,7 +6280,7 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
     };
     assert_eq!(
         store
-            .complete_turn_run(turn.id, token, output.created_at, &output)
+            .complete_turn_run(turn.id, token, 0, output.created_at, &output)
             .await
             .unwrap(),
         None
@@ -6843,7 +6717,7 @@ async fn turn_completion_and_cancellation_serialize_to_one_decision() {
         tokio::spawn(async move {
             barrier.wait().await;
             store
-                .complete_turn_run(turn.id, token, decided_at, &output)
+                .complete_turn_run(turn.id, token, 0, decided_at, &output)
                 .await
         })
     };
@@ -6922,7 +6796,7 @@ async fn turn_completion_and_failure_serialize_to_one_terminal_decision() {
         tokio::spawn(async move {
             barrier.wait().await;
             store
-                .complete_turn_run(turn_id, token, resolved_at, &output)
+                .complete_turn_run(turn_id, token, 0, resolved_at, &output)
                 .await
         })
     };
@@ -7013,6 +6887,7 @@ async fn turn_completion_uses_the_heartbeated_lease_and_fences_operation_time() 
         .complete_turn_run(
             turn_id,
             token,
+            0,
             heartbeat_at + chrono::Duration::seconds(1),
             &future_output,
         )
@@ -7026,7 +6901,7 @@ async fn turn_completion_uses_the_heartbeated_lease_and_fences_operation_time() 
     };
     assert!(matches!(
         store
-            .complete_turn_run(turn_id, token, output.created_at, &output)
+            .complete_turn_run(turn_id, token, 0, output.created_at, &output)
             .await
             .unwrap(),
         Some(CompleteTurnRunOutcome::Completed(_))
@@ -7068,7 +6943,7 @@ async fn turn_completion_rejects_prepared_output_retried_after_expiry() {
 
     assert_eq!(
         store
-            .complete_turn_run(turn_id, token, lease_expires_at, &prepared_output)
+            .complete_turn_run(turn_id, token, 0, lease_expires_at, &prepared_output)
             .await
             .unwrap(),
         None
@@ -7132,7 +7007,13 @@ async fn stale_turn_attempt_cannot_complete_a_reclaimed_turn() {
     };
     assert_eq!(
         store
-            .complete_turn_run(turn_id, first_token, stale_output.created_at, &stale_output)
+            .complete_turn_run(
+                turn_id,
+                first_token,
+                0,
+                stale_output.created_at,
+                &stale_output
+            )
             .await
             .unwrap(),
         None
@@ -7144,7 +7025,7 @@ async fn stale_turn_attempt_cannot_complete_a_reclaimed_turn() {
     };
     assert!(matches!(
         store
-            .complete_turn_run(turn_id, second_token, output.created_at, &output)
+            .complete_turn_run(turn_id, second_token, 0, output.created_at, &output)
             .await
             .unwrap(),
         Some(CompleteTurnRunOutcome::Completed(_))
@@ -7196,7 +7077,7 @@ async fn concurrent_different_turn_completions_commit_one_output_once() {
         tasks.push(tokio::spawn(async move {
             barrier.wait().await;
             store
-                .complete_turn_run(turn_id, token, output.created_at, &output)
+                .complete_turn_run(turn_id, token, 0, output.created_at, &output)
                 .await
         }));
     }
@@ -7258,7 +7139,7 @@ async fn turn_completion_rolls_back_output_when_state_update_fails() {
         created_at: claimed_at + chrono::Duration::seconds(1),
     };
     assert!(store
-        .complete_turn_run(turn_id, token, output.created_at, &output)
+        .complete_turn_run(turn_id, token, 0, output.created_at, &output)
         .await
         .is_err());
     assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
@@ -7326,6 +7207,7 @@ async fn turn_completion_rolls_back_state_and_output_when_terminal_event_fails()
         .complete_turn_run_and_append_event(
             turn_id,
             token,
+            0,
             output.created_at,
             &output,
             Usage::default(),
@@ -7624,7 +7506,7 @@ async fn settings_roundtrip_and_overwrite() {
 }
 
 #[tokio::test]
-async fn list_chats_is_newest_first_and_messages_oldest_first() {
+async fn list_chats_is_newest_first_and_messages_follow_commit_sequence() {
     let (_dir, store) = temp_store().await;
     let mut older = sample_chat();
     older.created_at = DateTime::<Utc>::from_timestamp(1_000, 0).unwrap();
@@ -7638,7 +7520,8 @@ async fn list_chats_is_newest_first_and_messages_oldest_first() {
         vec![newer.clone(), older.clone()]
     );
 
-    // Messages come back oldest-first regardless of insert order.
+    // Transcript order follows the durable per-chat commit sequence, even when
+    // caller-provided timestamps move backwards.
     let msg = |ts: i64| Message {
         id: MessageId::new(),
         chat_id: newer.id,
@@ -7651,7 +7534,7 @@ async fn list_chats_is_newest_first_and_messages_oldest_first() {
     store.append_message(&m1).await.unwrap();
     store.append_message(&m2).await.unwrap();
     let listed = store.list_messages(newer.id).await.unwrap();
-    assert_eq!(listed, vec![m2, m1]);
+    assert_eq!(listed, vec![m1, m2]);
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/db/tests/turn_steer.rs
+++ b/crates/openwave-core/src/db/tests/turn_steer.rs
@@ -1,0 +1,1174 @@
+use super::*;
+
+fn pending_turn_steer(
+    turn: &crate::model::TurnRun,
+    id: crate::id::TurnSteerId,
+    content: &str,
+    now: DateTime<Utc>,
+) -> entities::turn_steer::ActiveModel {
+    entities::turn_steer::ActiveModel {
+        id: Set(id.0),
+        turn_id: Set(turn.id.0),
+        chat_id: Set(turn.chat_id.0),
+        content: Set(content.into()),
+        interrupt: Set(false),
+        status: Set(TurnSteerStatus::Pending.as_str().into()),
+        applied_lease_token: Set(None),
+        message_id: Set(None),
+        created_at: Set(now),
+        resolved_at: Set(None),
+    }
+}
+
+#[tokio::test]
+async fn turn_steer_schema_enforces_durable_delivery_identity() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let queued = store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "initial input")
+        .await
+        .unwrap();
+    let queued = match queued {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected acceptance: {other:?}"),
+    };
+    let now = Utc::now();
+    let claim_token = uuid::Uuid::new_v4();
+    let claimed = store
+        .claim_turn_run(claim_token, now, now + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .turn
+        .expect("turn claimed");
+    assert_eq!(claimed.id, queued.id);
+
+    let first_id = crate::id::TurnSteerId::new();
+    pending_turn_steer(&claimed, first_id, "change course", now)
+        .insert(&store.conn)
+        .await
+        .unwrap();
+
+    let mut empty = pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "", now);
+    assert!(empty.clone().insert(&store.conn).await.is_err());
+    empty.content = Set("x".repeat(crate::model::TurnSteer::MAX_CONTENT_LEN + 1));
+    assert!(empty.insert(&store.conn).await.is_err());
+
+    let mut pending_with_resolution =
+        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "pending", now);
+    pending_with_resolution.resolved_at = Set(Some(now));
+    assert!(pending_with_resolution.insert(&store.conn).await.is_err());
+
+    let mut applied_without_receipt =
+        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "applied", now);
+    applied_without_receipt.status = Set(TurnSteerStatus::Applied.as_str().into());
+    applied_without_receipt.resolved_at = Set(Some(now));
+    assert!(applied_without_receipt.insert(&store.conn).await.is_err());
+
+    let message_id = MessageId(first_id.0);
+    entities::message::ActiveModel {
+        id: Set(message_id.0),
+        chat_id: Set(chat.id.0),
+        turn_id: Set(claimed.id.0),
+        seq: Set(2),
+        role: Set("user".into()),
+        content: Set("change course".into()),
+        created_at: Set(now),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    entities::turn_steer::Entity::update_many()
+        .col_expr(
+            entities::turn_steer::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnSteerStatus::Applied.as_str()),
+        )
+        .col_expr(
+            entities::turn_steer::Column::AppliedLeaseToken,
+            sea_orm::sea_query::Expr::value(Some(claim_token)),
+        )
+        .col_expr(
+            entities::turn_steer::Column::MessageId,
+            sea_orm::sea_query::Expr::value(Some(message_id.0)),
+        )
+        .col_expr(
+            entities::turn_steer::Column::ResolvedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .filter(entities::turn_steer::Column::Id.eq(first_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let applied = entities::turn_steer::Entity::find_by_id(first_id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(applied.status, TurnSteerStatus::Applied.as_str());
+    assert_eq!(applied.applied_lease_token, Some(claim_token));
+    assert_eq!(applied.message_id, Some(message_id.0));
+
+    let mismatched_message_id = MessageId::new();
+    entities::message::ActiveModel {
+        id: Set(mismatched_message_id.0),
+        chat_id: Set(chat.id.0),
+        turn_id: Set(claimed.id.0),
+        seq: Set(3),
+        role: Set("user".into()),
+        content: Set("mismatched identity".into()),
+        created_at: Set(now),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    let mut mismatched_receipt = pending_turn_steer(
+        &claimed,
+        crate::id::TurnSteerId::new(),
+        "mismatched identity",
+        now,
+    );
+    mismatched_receipt.status = Set(TurnSteerStatus::Applied.as_str().into());
+    mismatched_receipt.applied_lease_token = Set(Some(claim_token));
+    mismatched_receipt.message_id = Set(Some(mismatched_message_id.0));
+    mismatched_receipt.resolved_at = Set(Some(now));
+    assert!(mismatched_receipt.insert(&store.conn).await.is_err());
+
+    let mut wrong_turn =
+        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "wrong turn", now);
+    wrong_turn.turn_id = Set(TurnId::new().0);
+    assert!(wrong_turn.insert(&store.conn).await.is_err());
+
+    let mut rejected_with_message =
+        pending_turn_steer(&claimed, crate::id::TurnSteerId::new(), "rejected", now);
+    rejected_with_message.status = Set(TurnSteerStatus::Rejected.as_str().into());
+    rejected_with_message.message_id = Set(Some(message_id.0));
+    rejected_with_message.resolved_at = Set(Some(now));
+    assert!(rejected_with_message.insert(&store.conn).await.is_err());
+}
+
+fn accepted_steer(outcome: AcceptTurnSteerOutcome) -> crate::model::TurnSteer {
+    match outcome {
+        AcceptTurnSteerOutcome::Accepted(steer) => steer,
+        other => panic!("unexpected steer acceptance: {other:?}"),
+    }
+}
+
+fn existing_steer(outcome: AcceptTurnSteerOutcome) -> crate::model::TurnSteer {
+    match outcome {
+        AcceptTurnSteerOutcome::Existing(steer) => steer,
+        other => panic!("unexpected steer retry: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "initial input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    let steer_id = crate::id::TurnSteerId::new();
+    let pending = accepted_steer(
+        store
+            .accept_turn_steer(steer_id, turn.id, chat.id, "change course", false)
+            .await
+            .unwrap(),
+    );
+    assert_eq!(pending.status, TurnSteerStatus::Pending);
+    assert_eq!(pending.message_id, None);
+
+    let claim_at = Utc::now();
+    let lease_token = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(
+            lease_token,
+            claim_at,
+            claim_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .expect("turn claimed");
+    let pending = store
+        .list_pending_turn_steers(turn.id, lease_token, Utc::now())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        pending.iter().map(|steer| steer.id).collect::<Vec<_>>(),
+        vec![steer_id]
+    );
+    assert_eq!(
+        store
+            .list_pending_turn_steers(turn.id, uuid::Uuid::new_v4(), Utc::now())
+            .await
+            .unwrap(),
+        None
+    );
+
+    let candidate = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: turn.id,
+        role: Role::Assistant,
+        content: "candidate before steer".into(),
+        created_at: Utc::now(),
+    };
+    store.append_message(&candidate).await.unwrap();
+    let apply_at = Utc::now();
+    let applied = store
+        .apply_turn_steer(turn.id, lease_token, steer_id, apply_at)
+        .await
+        .unwrap()
+        .unwrap();
+    let applied = match applied {
+        ApplyTurnSteerOutcome::Applied(steer) => steer,
+        other => panic!("unexpected steer application: {other:?}"),
+    };
+    assert_eq!(applied.status, TurnSteerStatus::Applied);
+    assert_eq!(applied.applied_lease_token, Some(lease_token));
+    assert_eq!(applied.message_id, Some(MessageId(steer_id.0)));
+    assert_eq!(
+        applied.resolved_at,
+        Some(DateTime::<Utc>::from_timestamp_micros(apply_at.timestamp_micros()).unwrap())
+    );
+    assert_eq!(
+        store
+            .get_turn_run(turn.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .steer_revision,
+        1
+    );
+    assert_eq!(
+        store
+            .list_pending_turn_steers(turn.id, lease_token, Utc::now())
+            .await
+            .unwrap(),
+        Some(vec![])
+    );
+
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| (message.role, message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Role::User, "initial input"),
+            (Role::Assistant, "candidate before steer"),
+            (Role::User, "change course"),
+        ]
+    );
+    assert_eq!(messages[2].created_at, applied.resolved_at.unwrap());
+
+    let second_id = crate::id::TurnSteerId::new();
+    accepted_steer(
+        store
+            .accept_turn_steer(second_id, turn.id, chat.id, "one more thing", true)
+            .await
+            .unwrap(),
+    );
+    let completed_at = Utc::now();
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: turn.id,
+        role: Role::Assistant,
+        content: "final answer".into(),
+        created_at: completed_at,
+    };
+    assert!(matches!(
+        store
+            .complete_turn_run(turn.id, lease_token, 1, completed_at, &output)
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::SteerPending(_))
+    ));
+
+    let recovered = store
+        .apply_turn_steer(turn.id, lease_token, steer_id, Utc::now())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(recovered, ApplyTurnSteerOutcome::Existing(_)));
+    let second = match store
+        .apply_turn_steer(turn.id, lease_token, second_id, Utc::now())
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        ApplyTurnSteerOutcome::Applied(steer) => steer,
+        other => panic!("unexpected second steer application: {other:?}"),
+    };
+    assert_eq!(
+        store
+            .get_turn_run(turn.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .steer_revision,
+        2
+    );
+    let stale_after_apply_at = second.resolved_at.unwrap() + chrono::Duration::microseconds(1);
+    let stale_after_apply = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: turn.id,
+        role: Role::Assistant,
+        content: "generated from revision one".into(),
+        created_at: stale_after_apply_at,
+    };
+    assert!(matches!(
+        store
+            .complete_turn_run(
+                turn.id,
+                lease_token,
+                1,
+                stale_after_apply_at,
+                &stale_after_apply,
+            )
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::OutputSuperseded(_))
+    ));
+    let fresh_completed_at = second.resolved_at.unwrap() + chrono::Duration::microseconds(1);
+    let fresh_output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: turn.id,
+        role: Role::Assistant,
+        content: "fresh final answer".into(),
+        created_at: fresh_completed_at,
+    };
+    assert!(matches!(
+        store
+            .complete_turn_run(turn.id, lease_token, 2, fresh_completed_at, &fresh_output)
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::Completed(_))
+    ));
+    assert!(matches!(
+        store
+            .accept_turn_steer(
+                crate::id::TurnSteerId::new(),
+                turn.id,
+                chat.id,
+                "too late",
+                false,
+            )
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::TurnUnavailable
+    ));
+}
+
+#[tokio::test]
+async fn turn_steer_admission_validates_identity_payload_and_monotonic_time() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "initial input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    assert!(store
+        .accept_turn_steer(
+            crate::id::TurnSteerId(uuid::Uuid::nil()),
+            turn.id,
+            chat.id,
+            "valid",
+            false,
+        )
+        .await
+        .is_err());
+    for invalid in ["", "   ", "nul\0content"] {
+        assert!(store
+            .accept_turn_steer(
+                crate::id::TurnSteerId::new(),
+                turn.id,
+                chat.id,
+                invalid,
+                false,
+            )
+            .await
+            .is_err());
+    }
+    assert!(store
+        .accept_turn_steer(
+            crate::id::TurnSteerId::new(),
+            turn.id,
+            chat.id,
+            &"x".repeat(crate::model::TurnSteer::MAX_CONTENT_LEN + 1),
+            false,
+        )
+        .await
+        .is_err());
+
+    let id = crate::id::TurnSteerId::new();
+    accepted_steer(
+        store
+            .accept_turn_steer(id, turn.id, chat.id, "exact", false)
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        existing_steer(
+            store
+                .accept_turn_steer(id, turn.id, chat.id, "exact", false)
+                .await
+                .unwrap()
+        )
+        .id,
+        id
+    );
+    assert!(matches!(
+        store
+            .accept_turn_steer(id, turn.id, chat.id, "different", false)
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::IdentityConflict
+    ));
+    assert!(matches!(
+        store
+            .accept_turn_steer(id, turn.id, chat.id, "exact", true)
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::IdentityConflict
+    ));
+    assert!(matches!(
+        store
+            .accept_turn_steer(id, TurnId::new(), ChatId::new(), "exact", false,)
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::IdentityConflict
+    ));
+
+    let collision_id = crate::id::TurnSteerId::new();
+    store
+        .append_message(&Message {
+            id: MessageId(collision_id.0),
+            chat_id: chat.id,
+            turn_id: turn.id,
+            role: Role::User,
+            content: "already used".into(),
+            created_at: Utc::now(),
+        })
+        .await
+        .unwrap();
+    assert!(matches!(
+        store
+            .accept_turn_steer(collision_id, turn.id, chat.id, "collision", false)
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::IdentityConflict
+    ));
+
+    let future = DateTime::from_timestamp_micros(
+        (Utc::now() + chrono::Duration::hours(1)).timestamp_micros(),
+    )
+    .unwrap();
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(future),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert!(matches!(
+        store
+            .accept_turn_steer(
+                crate::id::TurnSteerId::new(),
+                turn.id,
+                chat.id,
+                "clock skew",
+                false,
+            )
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::TurnUnavailable
+    ));
+    assert_eq!(
+        store
+            .get_turn_run(turn.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .updated_at,
+        future
+    );
+}
+
+#[tokio::test]
+async fn turn_steer_application_enforces_fifo_and_message_sequence_on_timestamp_ties() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "initial input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    let high_id = crate::id::TurnSteerId(uuid::Uuid::from_u128(2));
+    let low_id = crate::id::TurnSteerId(uuid::Uuid::from_u128(1));
+    let high = accepted_steer(
+        store
+            .accept_turn_steer(high_id, turn.id, chat.id, "high id", false)
+            .await
+            .unwrap(),
+    );
+    let low = accepted_steer(
+        store
+            .accept_turn_steer(low_id, turn.id, chat.id, "low id", false)
+            .await
+            .unwrap(),
+    );
+    let tied_at = high.created_at.min(low.created_at);
+    entities::turn_steer::Entity::update_many()
+        .col_expr(
+            entities::turn_steer::Column::CreatedAt,
+            sea_orm::sea_query::Expr::value(tied_at),
+        )
+        .filter(entities::turn_steer::Column::Id.is_in([high_id.0, low_id.0]))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let lease = uuid::Uuid::new_v4();
+    let claimed_at = Utc::now();
+    store
+        .claim_turn_run(lease, claimed_at, claimed_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let pending = store
+        .list_pending_turn_steers(turn.id, lease, Utc::now())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        pending.iter().map(|steer| steer.id).collect::<Vec<_>>(),
+        vec![low_id, high_id]
+    );
+    let applied_at = Utc::now();
+    assert_eq!(
+        store
+            .apply_turn_steer(turn.id, lease, high_id, applied_at)
+            .await
+            .unwrap(),
+        None
+    );
+    assert!(matches!(
+        store
+            .apply_turn_steer(turn.id, lease, low_id, applied_at)
+            .await
+            .unwrap(),
+        Some(ApplyTurnSteerOutcome::Applied(_))
+    ));
+    assert!(matches!(
+        store
+            .apply_turn_steer(turn.id, lease, high_id, applied_at)
+            .await
+            .unwrap(),
+        Some(ApplyTurnSteerOutcome::Applied(_))
+    ));
+    assert_eq!(
+        store
+            .list_messages(chat.id)
+            .await
+            .unwrap()
+            .iter()
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>(),
+        vec!["initial input", "low id", "high id"]
+    );
+}
+
+#[tokio::test]
+async fn concurrent_apply_and_completion_leave_no_pending_steer() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "initial input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    let lease_token = uuid::Uuid::new_v4();
+    let claim_at = Utc::now();
+    store
+        .claim_turn_run(
+            lease_token,
+            claim_at,
+            claim_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let steer_id = crate::id::TurnSteerId::new();
+    accepted_steer(
+        store
+            .accept_turn_steer(steer_id, turn.id, chat.id, "race", true)
+            .await
+            .unwrap(),
+    );
+    let stale_output_at = Utc::now();
+    let stale_output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: turn.id,
+        role: Role::Assistant,
+        content: "stale completion".into(),
+        created_at: stale_output_at,
+    };
+
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let apply_store = store.clone();
+    let apply_barrier = barrier.clone();
+    let apply = tokio::spawn(async move {
+        apply_barrier.wait().await;
+        apply_store
+            .apply_turn_steer(turn.id, lease_token, steer_id, Utc::now())
+            .await
+            .unwrap()
+    });
+    let complete_store = store.clone();
+    let complete_barrier = barrier.clone();
+    let complete = tokio::spawn(async move {
+        complete_barrier.wait().await;
+        complete_store
+            .complete_turn_run(turn.id, lease_token, 0, Utc::now(), &stale_output)
+            .await
+            .unwrap()
+    });
+    let applied = match apply.await.unwrap() {
+        Some(ApplyTurnSteerOutcome::Applied(steer)) => steer,
+        other => panic!("pending steer did not win completion race: {other:?}"),
+    };
+    assert!(matches!(
+        complete.await.unwrap(),
+        Some(CompleteTurnRunOutcome::SteerPending(_))
+            | Some(CompleteTurnRunOutcome::OutputSuperseded(_))
+    ));
+
+    let steer = existing_steer(
+        store
+            .accept_turn_steer(steer_id, turn.id, chat.id, "race", true)
+            .await
+            .unwrap(),
+    );
+    assert_eq!(steer.status, TurnSteerStatus::Applied);
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 2);
+
+    let completed_at = applied.resolved_at.unwrap() + chrono::Duration::microseconds(1);
+    assert!(store
+        .complete_turn_run(
+            turn.id,
+            lease_token,
+            1,
+            completed_at,
+            &Message {
+                id: MessageId::new(),
+                chat_id: chat.id,
+                turn_id: turn.id,
+                role: Role::Assistant,
+                content: "fresh completion".into(),
+                created_at: completed_at,
+            },
+        )
+        .await
+        .unwrap()
+        .is_some());
+    assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn concurrent_turn_steer_admission_converges_by_exact_identity() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "initial input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    let steer_id = crate::id::TurnSteerId::new();
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .accept_turn_steer(steer_id, turn.id, chat.id, "same request", true)
+                .await
+                .unwrap()
+        }));
+    }
+    let mut accepted = 0;
+    let mut existing = 0;
+    for task in tasks {
+        match task.await.unwrap() {
+            AcceptTurnSteerOutcome::Accepted(_) => accepted += 1,
+            AcceptTurnSteerOutcome::Existing(_) => existing += 1,
+            other => panic!("unexpected concurrent outcome: {other:?}"),
+        }
+    }
+    assert_eq!((accepted, existing), (1, 7));
+
+    let conflict_id = crate::id::TurnSteerId::new();
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let mut tasks = Vec::new();
+    for content in ["first payload", "second payload"] {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .accept_turn_steer(conflict_id, turn.id, chat.id, content, false)
+                .await
+                .unwrap()
+        }));
+    }
+    let outcomes = futures::future::join_all(tasks)
+        .await
+        .into_iter()
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, AcceptTurnSteerOutcome::Accepted(_)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, AcceptTurnSteerOutcome::IdentityConflict))
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn concurrent_message_and_steer_reserve_one_shared_identity() {
+    let (_dir, store) = temp_store().await;
+    let steer_chat = sample_chat();
+    let message_chat = sample_chat();
+    store.create_chat(&steer_chat).await.unwrap();
+    store.create_chat(&message_chat).await.unwrap();
+    let steer_turn = match store
+        .accept_turn(TurnId::new(), steer_chat.id, "gpt-5", "steer turn")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    let lease = uuid::Uuid::new_v4();
+    let claimed_at = Utc::now();
+    assert_eq!(
+        store
+            .claim_turn_run(lease, claimed_at, claimed_at + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .turn
+            .unwrap()
+            .id,
+        steer_turn.id
+    );
+    let message_turn = match store
+        .accept_turn(TurnId::new(), message_chat.id, "gpt-5", "message turn")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    let shared_id = crate::id::TurnSteerId::new();
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let steer_store = store.clone();
+    let steer_barrier = barrier.clone();
+    let steer = tokio::spawn(async move {
+        steer_barrier.wait().await;
+        steer_store
+            .accept_turn_steer(
+                shared_id,
+                steer_turn.id,
+                steer_chat.id,
+                "shared identity",
+                false,
+            )
+            .await
+            .unwrap()
+    });
+    let message_store = store.clone();
+    let message_barrier = barrier.clone();
+    let message = tokio::spawn(async move {
+        message_barrier.wait().await;
+        message_store
+            .append_message(&Message {
+                id: MessageId(shared_id.0),
+                chat_id: message_chat.id,
+                turn_id: message_turn.id,
+                role: Role::Assistant,
+                content: "shared identity".into(),
+                created_at: Utc::now(),
+            })
+            .await
+    });
+    let steer = steer.await.unwrap();
+    let message = message.await.unwrap();
+    match steer {
+        AcceptTurnSteerOutcome::Accepted(_) => {
+            assert!(message.is_err());
+            assert!(matches!(
+                store
+                    .apply_turn_steer(steer_turn.id, lease, shared_id, Utc::now())
+                    .await
+                    .unwrap(),
+                Some(ApplyTurnSteerOutcome::Applied(_))
+            ));
+        }
+        AcceptTurnSteerOutcome::IdentityConflict => {
+            message.expect("message won the shared reservation");
+            assert!(matches!(
+                store
+                    .accept_turn_steer(
+                        shared_id,
+                        steer_turn.id,
+                        steer_chat.id,
+                        "shared identity",
+                        false,
+                    )
+                    .await
+                    .unwrap(),
+                AcceptTurnSteerOutcome::IdentityConflict
+            ));
+        }
+        other => panic!("unexpected steer reservation outcome: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn terminal_turn_paths_reject_pending_steers_but_retry_wait_preserves_them() {
+    let (_dir, store) = temp_store().await;
+
+    let cancelled_chat = sample_chat();
+    store.create_chat(&cancelled_chat).await.unwrap();
+    let cancelled_turn = match store
+        .accept_turn(TurnId::new(), cancelled_chat.id, "gpt-5", "cancel queued")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    let cancelled_steer = crate::id::TurnSteerId::new();
+    accepted_steer(
+        store
+            .accept_turn_steer(
+                cancelled_steer,
+                cancelled_turn.id,
+                cancelled_chat.id,
+                "pending cancellation",
+                false,
+            )
+            .await
+            .unwrap(),
+    );
+    store
+        .request_turn_cancellation(cancelled_turn.id, Utc::now())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        existing_steer(
+            store
+                .accept_turn_steer(
+                    cancelled_steer,
+                    cancelled_turn.id,
+                    cancelled_chat.id,
+                    "pending cancellation",
+                    false,
+                )
+                .await
+                .unwrap()
+        )
+        .status,
+        TurnSteerStatus::Rejected
+    );
+
+    let retry_chat = sample_chat();
+    store.create_chat(&retry_chat).await.unwrap();
+    let retry_turn = match store
+        .accept_turn(TurnId::new(), retry_chat.id, "gpt-5", "retry once")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(2),
+        )
+        .filter(entities::turn_run::Column::Id.eq(retry_turn.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let first_lease = uuid::Uuid::new_v4();
+    let first_claim_at = Utc::now();
+    store
+        .claim_turn_run(
+            first_lease,
+            first_claim_at,
+            first_claim_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let retry_steer = crate::id::TurnSteerId::new();
+    accepted_steer(
+        store
+            .accept_turn_steer(
+                retry_steer,
+                retry_turn.id,
+                retry_chat.id,
+                "survive retry",
+                false,
+            )
+            .await
+            .unwrap(),
+    );
+    let failed_at = Utc::now();
+    let retry_at = failed_at + chrono::Duration::seconds(1);
+    let failure = store
+        .record_turn_run_failure(
+            retry_turn.id,
+            first_lease,
+            failed_at,
+            TurnFailureRetry::RetryAt(retry_at),
+            "retryable",
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        failure,
+        RecordTurnFailureOutcome::Recorded(receipt)
+            if receipt.result_status == TurnRunStatus::RetryWait
+    ));
+    assert_eq!(
+        existing_steer(
+            store
+                .accept_turn_steer(
+                    retry_steer,
+                    retry_turn.id,
+                    retry_chat.id,
+                    "survive retry",
+                    false,
+                )
+                .await
+                .unwrap()
+        )
+        .status,
+        TurnSteerStatus::Pending
+    );
+    let second_lease = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(
+            second_lease,
+            retry_at,
+            retry_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(
+        store
+            .list_pending_turn_steers(retry_turn.id, second_lease, retry_at)
+            .await
+            .unwrap()
+            .unwrap()
+            .iter()
+            .map(|steer| steer.id)
+            .collect::<Vec<_>>(),
+        vec![retry_steer]
+    );
+    let terminal_at = retry_at + chrono::Duration::seconds(1);
+    store
+        .record_turn_run_failure(
+            retry_turn.id,
+            second_lease,
+            terminal_at,
+            TurnFailureRetry::Permanent,
+            "permanent",
+            None,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        existing_steer(
+            store
+                .accept_turn_steer(
+                    retry_steer,
+                    retry_turn.id,
+                    retry_chat.id,
+                    "survive retry",
+                    false,
+                )
+                .await
+                .unwrap()
+        )
+        .status,
+        TurnSteerStatus::Rejected
+    );
+
+    let expired_chat = sample_chat();
+    store.create_chat(&expired_chat).await.unwrap();
+    let expired_turn = match store
+        .accept_turn(TurnId::new(), expired_chat.id, "gpt-5", "expire")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    let expired_lease = uuid::Uuid::new_v4();
+    let expired_claim_at = Utc::now();
+    let expires_at = expired_claim_at + chrono::Duration::seconds(1);
+    store
+        .claim_turn_run(expired_lease, expired_claim_at, expires_at)
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let expired_steer = crate::id::TurnSteerId::new();
+    accepted_steer(
+        store
+            .accept_turn_steer(
+                expired_steer,
+                expired_turn.id,
+                expired_chat.id,
+                "scanner pending",
+                true,
+            )
+            .await
+            .unwrap(),
+    );
+    store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            expires_at,
+            expires_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .terminal_event
+        .expect("scanner terminalized final attempt");
+    assert_eq!(
+        existing_steer(
+            store
+                .accept_turn_steer(
+                    expired_steer,
+                    expired_turn.id,
+                    expired_chat.id,
+                    "scanner pending",
+                    true,
+                )
+                .await
+                .unwrap()
+        )
+        .status,
+        TurnSteerStatus::Rejected
+    );
+}
+
+#[tokio::test]
+async fn failed_steer_message_insert_rolls_back_the_application_receipt() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "initial input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    let lease = uuid::Uuid::new_v4();
+    let claimed_at = Utc::now();
+    store
+        .claim_turn_run(lease, claimed_at, claimed_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let steer_id = crate::id::TurnSteerId::new();
+    accepted_steer(
+        store
+            .accept_turn_steer(steer_id, turn.id, chat.id, "will collide", false)
+            .await
+            .unwrap(),
+    );
+    entities::message::ActiveModel {
+        id: Set(steer_id.0),
+        chat_id: Set(chat.id.0),
+        turn_id: Set(turn.id.0),
+        seq: Set(2),
+        role: Set("assistant".into()),
+        content: Set("occupy identity".into()),
+        created_at: Set(Utc::now()),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    assert!(store
+        .apply_turn_steer(turn.id, lease, steer_id, Utc::now())
+        .await
+        .is_err());
+    let pending = existing_steer(
+        store
+            .accept_turn_steer(steer_id, turn.id, chat.id, "will collide", false)
+            .await
+            .unwrap(),
+    );
+    assert_eq!(pending.status, TurnSteerStatus::Pending);
+    assert_eq!(pending.applied_lease_token, None);
+    assert_eq!(pending.message_id, None);
+    assert_eq!(pending.resolved_at, None);
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -66,10 +66,11 @@ pub use provider::{
 };
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
-    AcceptTurnOutcome, BlobStore, ClaimScanTerminalEvent, ClaimTurnRunOutcome,
-    CompleteTurnRunOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
-    EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome, JournaledTurnOutcome,
-    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, SecretProvider, Store,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, ApplyTurnSteerOutcome, BlobStore,
+    ClaimScanTerminalEvent, ClaimTurnRunOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
+    JournaledTurnOutcome, RecordTurnFailureOutcome, RequestTurnCancellationOutcome, SecretProvider,
+    Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -651,6 +651,10 @@ pub struct TurnRun {
     pub last_error_code: Option<String>,
     /// Bounded diagnostic detail for local operators.
     pub last_error_detail: Option<String>,
+    /// Durable generation revision captured before model work begins.
+    pub steer_revision: i64,
+    /// When the most recent durable steer application committed.
+    pub last_steer_applied_at: Option<DateTime<Utc>>,
     /// When this turn was accepted.
     pub created_at: DateTime<Utc>,
     /// When its durable state last changed.
@@ -756,7 +760,7 @@ pub enum TurnSteerStatus {
     Pending,
     /// User message and delivery receipt committed atomically.
     Applied,
-    /// The turn terminalized before this instruction could be applied.
+    /// The turn stopped accepting instructions before this one could be applied.
     Rejected,
 }
 

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -20,12 +20,12 @@ use serde_json::Value;
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId, TurnId};
+use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId, TurnId, TurnSteerId};
 use crate::model::{
     BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
     DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentRecord, DocumentScope,
     DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
-    TurnFailureReceipt, TurnFailureRetry, TurnRun,
+    TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
 };
 use crate::provider::{StopReason, Usage};
 
@@ -98,6 +98,28 @@ pub enum AcceptTurnOutcome {
     ChatBusy(TurnRun),
 }
 
+/// Result of atomically accepting one exact steering instruction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AcceptTurnSteerOutcome {
+    /// This call committed the pending instruction.
+    Accepted(TurnSteer),
+    /// This exact instruction identity and payload were already committed.
+    Existing(TurnSteer),
+    /// The identity was already used for different request data or a message.
+    IdentityConflict,
+    /// The target is missing, cross-chat, expired, cancelling, or terminal.
+    TurnUnavailable,
+}
+
+/// Result of atomically applying one exact pending steering instruction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplyTurnSteerOutcome {
+    /// This call committed the user message and application receipt.
+    Applied(TurnSteer),
+    /// This exact worker lease already committed the same application.
+    Existing(TurnSteer),
+}
+
 /// Result of atomically completing one exact claimed turn.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompleteTurnRunOutcome {
@@ -105,6 +127,10 @@ pub enum CompleteTurnRunOutcome {
     Completed(TurnRun),
     /// This exact completion was already committed by an earlier call.
     Existing(TurnRun),
+    /// Completion was fenced because an accepted steer still needs application.
+    SteerPending(TurnRun),
+    /// The output was generated from an older steer revision and must be regenerated.
+    OutputSuperseded(TurnRun),
 }
 
 /// Result of recording one exact claimed turn failure.
@@ -682,6 +708,52 @@ pub trait Store: Send + Sync {
         turn_storage_unavailable()
     }
 
+    /// Atomically accept one idempotent steering instruction for a live turn.
+    ///
+    /// The non-nil caller-supplied `id` also names the eventual user message.
+    /// Exact retries compare chat, turn, byte-exact content, and interrupt intent.
+    /// Queued, running, and retry-wait turns accept instructions; cancelling or
+    /// terminal turns return [`AcceptTurnSteerOutcome::TurnUnavailable`].
+    async fn accept_turn_steer(
+        &self,
+        _id: TurnSteerId,
+        _turn_id: TurnId,
+        _chat_id: ChatId,
+        _content: &str,
+        _interrupt: bool,
+    ) -> Result<AcceptTurnSteerOutcome> {
+        turn_storage_unavailable()
+    }
+
+    /// List pending instructions only while the caller owns the exact live lease.
+    ///
+    /// `Some` is ordered by durable acceptance time then identity. `None` means
+    /// the lease is stale, expired, cancelling, or otherwise no longer running.
+    async fn list_pending_turn_steers(
+        &self,
+        _turn_id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<Vec<TurnSteer>>> {
+        turn_storage_unavailable()
+    }
+
+    /// Persist one pending steer as a user message under the exact live lease.
+    ///
+    /// The message and application receipt commit atomically. Exact retries by
+    /// the same lease return [`ApplyTurnSteerOutcome::Existing`] even after the
+    /// turn advances. A stale lease, rejected steer, or different winning lease
+    /// returns `None`.
+    async fn apply_turn_steer(
+        &self,
+        _turn_id: TurnId,
+        _lease_token: uuid::Uuid,
+        _steer_id: TurnSteerId,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<ApplyTurnSteerOutcome>> {
+        turn_storage_unavailable()
+    }
+
     /// Atomically persist the final assistant message and complete its turn.
     ///
     /// The exact claim must still be live at the fresh operational `now`, and
@@ -690,11 +762,16 @@ pub trait Store: Send + Sync {
     /// an ambiguous commit returns the completed turn even after lease expiry,
     /// without inserting another message. Returns
     /// `None` when the token never owned this turn, its lease was lost, or
-    /// another terminal outcome already won.
+    /// another terminal outcome already won. Pending steering and stale model
+    /// output return explicit nonterminal outcomes so callers can continue the
+    /// same live attempt rather than mistaking them for lease loss. The caller
+    /// must pass the `steer_revision` captured before generation;
+    /// completion is fenced if another steer was applied in the meantime.
     async fn complete_turn_run(
         &self,
         _id: TurnId,
         _lease_token: uuid::Uuid,
+        _expected_steer_revision: i64,
         _now: chrono::DateTime<chrono::Utc>,
         _output: &Message,
     ) -> Result<Option<CompleteTurnRunOutcome>> {
@@ -711,6 +788,7 @@ pub trait Store: Send + Sync {
         &self,
         _id: TurnId,
         _lease_token: uuid::Uuid,
+        _expected_steer_revision: i64,
         _now: chrono::DateTime<chrono::Utc>,
         _output: &Message,
         _usage: Usage,

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 
 use chrono::{Duration, Utc};
 use openwave_core::{
-    AcceptTurnOutcome, AgentEvent, Chat, ChatId, CompleteTurnRunOutcome, DbStore,
-    FinishTurnCancellationOutcome, Message, MessageId, RecordTurnFailureOutcome,
-    RequestTurnCancellationOutcome, Role, StopReason, Store, TurnFailureRetry, TurnId,
-    TurnRunStatus, Usage,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentEvent, ApplyTurnSteerOutcome, Chat, ChatId,
+    CompleteTurnRunOutcome, DbStore, FinishTurnCancellationOutcome, Message, MessageId,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, Role, StopReason, Store,
+    TurnFailureRetry, TurnId, TurnRunStatus, TurnSteerId, TurnSteerStatus, Usage,
 };
 
 fn sample_chat() -> Chat {
@@ -180,6 +180,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
                 .complete_turn_run_and_append_event(
                     next.id,
                     completion_token,
+                    0,
                     output.created_at,
                     &output,
                     Usage::default(),
@@ -198,6 +199,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         match completion.outcome {
             CompleteTurnRunOutcome::Completed(_) => committed += 1,
             CompleteTurnRunOutcome::Existing(_) => existing += 1,
+            outcome => panic!("unexpected completion outcome: {outcome:?}"),
         }
         terminal_events.push(completion.terminal_event.unwrap());
     }
@@ -469,6 +471,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         .complete_turn_run(
             turn_event.id,
             event_lease_token,
+            0,
             turn_event_output.created_at,
             &turn_event_output,
         )
@@ -536,6 +539,242 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         )
         .await
         .is_err());
+
+    let steer_chat = sample_chat();
+    store.create_chat(&steer_chat).await.unwrap();
+    let steer_turn = match store
+        .accept_turn(TurnId::new(), steer_chat.id, "gpt-5", "steer input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected steer turn acceptance: {outcome:?}"),
+    };
+    let steer_id = TurnSteerId::new();
+    let barrier = Arc::new(tokio::sync::Barrier::new(4));
+    let mut steer_tasks = Vec::new();
+    for _ in 0..4 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        steer_tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .accept_turn_steer(
+                    steer_id,
+                    steer_turn.id,
+                    steer_chat.id,
+                    "postgres steer",
+                    true,
+                )
+                .await
+                .unwrap()
+        }));
+    }
+    let mut steer_accepted = 0;
+    let mut steer_existing = 0;
+    for task in steer_tasks {
+        match task.await.unwrap() {
+            AcceptTurnSteerOutcome::Accepted(_) => steer_accepted += 1,
+            AcceptTurnSteerOutcome::Existing(_) => steer_existing += 1,
+            outcome => panic!("unexpected concurrent steer acceptance: {outcome:?}"),
+        }
+    }
+    assert_eq!((steer_accepted, steer_existing), (1, 3));
+
+    let steer_lease = uuid::Uuid::new_v4();
+    let steer_claimed_at = Utc::now();
+    store
+        .claim_turn_run(
+            steer_lease,
+            steer_claimed_at,
+            steer_claimed_at + Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(
+        store
+            .list_pending_turn_steers(steer_turn.id, steer_lease, Utc::now())
+            .await
+            .unwrap()
+            .unwrap()
+            .iter()
+            .map(|steer| steer.id)
+            .collect::<Vec<_>>(),
+        vec![steer_id]
+    );
+    let applied = store
+        .apply_turn_steer(steer_turn.id, steer_lease, steer_id, Utc::now())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(applied, ApplyTurnSteerOutcome::Applied(_)));
+
+    let second_steer_id = TurnSteerId::new();
+    assert!(matches!(
+        store
+            .accept_turn_steer(
+                second_steer_id,
+                steer_turn.id,
+                steer_chat.id,
+                "apply before completion",
+                false,
+            )
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::Accepted(_)
+    ));
+    let steer_completed_at = Utc::now();
+    assert!(matches!(
+        store
+            .complete_turn_run(
+                steer_turn.id,
+                steer_lease,
+                0,
+                steer_completed_at,
+                &Message {
+                    id: MessageId::new(),
+                    chat_id: steer_chat.id,
+                    turn_id: steer_turn.id,
+                    role: Role::Assistant,
+                    content: "stale steer completion".into(),
+                    created_at: steer_completed_at,
+                },
+            )
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::SteerPending(_))
+    ));
+    let second_steer = match store
+        .apply_turn_steer(steer_turn.id, steer_lease, second_steer_id, Utc::now())
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        ApplyTurnSteerOutcome::Applied(steer) => steer,
+        outcome => panic!("unexpected postgres second steer: {outcome:?}"),
+    };
+    let fresh_completed_at = second_steer.resolved_at.unwrap() + chrono::Duration::microseconds(1);
+    store
+        .complete_turn_run(
+            steer_turn.id,
+            steer_lease,
+            1,
+            fresh_completed_at,
+            &Message {
+                id: MessageId::new(),
+                chat_id: steer_chat.id,
+                turn_id: steer_turn.id,
+                role: Role::Assistant,
+                content: "fresh steer completion".into(),
+                created_at: fresh_completed_at,
+            },
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        store
+            .apply_turn_steer(steer_turn.id, steer_lease, steer_id, Utc::now())
+            .await
+            .unwrap(),
+        Some(ApplyTurnSteerOutcome::Existing(_))
+    ));
+    assert!(matches!(
+        store
+            .accept_turn_steer(
+                second_steer_id,
+                steer_turn.id,
+                steer_chat.id,
+                "apply before completion",
+                false,
+            )
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::Existing(steer)
+            if steer.status == TurnSteerStatus::Applied
+    ));
+
+    let registry_steer_chat = sample_chat();
+    let registry_message_chat = sample_chat();
+    store.create_chat(&registry_steer_chat).await.unwrap();
+    store.create_chat(&registry_message_chat).await.unwrap();
+    let registry_steer_turn = match store
+        .accept_turn(
+            TurnId::new(),
+            registry_steer_chat.id,
+            "gpt-5",
+            "registry steer",
+        )
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected registry steer turn: {outcome:?}"),
+    };
+    let registry_message_turn = match store
+        .accept_turn(
+            TurnId::new(),
+            registry_message_chat.id,
+            "gpt-5",
+            "registry message",
+        )
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected registry message turn: {outcome:?}"),
+    };
+    let shared_identity = TurnSteerId::new();
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let steer_store = store.clone();
+    let steer_barrier = barrier.clone();
+    let steer_task = tokio::spawn(async move {
+        steer_barrier.wait().await;
+        steer_store
+            .accept_turn_steer(
+                shared_identity,
+                registry_steer_turn.id,
+                registry_steer_chat.id,
+                "shared postgres identity",
+                false,
+            )
+            .await
+            .unwrap()
+    });
+    let message_store = store.clone();
+    let message_barrier = barrier.clone();
+    let message_task = tokio::spawn(async move {
+        message_barrier.wait().await;
+        message_store
+            .append_message(&Message {
+                id: MessageId(shared_identity.0),
+                chat_id: registry_message_chat.id,
+                turn_id: registry_message_turn.id,
+                role: Role::Assistant,
+                content: "shared postgres identity".into(),
+                created_at: Utc::now(),
+            })
+            .await
+    });
+    let steer_result = steer_task.await.unwrap();
+    let message_result = message_task.await.unwrap();
+    match steer_result {
+        AcceptTurnSteerOutcome::Accepted(_) => assert!(message_result.is_err()),
+        AcceptTurnSteerOutcome::IdentityConflict => {
+            message_result.expect("postgres message won shared identity")
+        }
+        outcome => panic!("unexpected postgres registry race: {outcome:?}"),
+    }
+    store
+        .request_turn_cancellation(registry_steer_turn.id, Utc::now())
+        .await
+        .unwrap();
+    store
+        .request_turn_cancellation(registry_message_turn.id, Utc::now())
+        .await
+        .unwrap();
 
     // Keep this global-queue fixture last: its winning turn deliberately remains
     // queued so the race proves only acceptance rollback/recovery behavior.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -681,6 +681,7 @@ impl Store for PauseTerminalStore {
         &self,
         id: TurnId,
         lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
         now: chrono::DateTime<chrono::Utc>,
         output: &Message,
         usage: Usage,
@@ -698,7 +699,15 @@ impl Store for PauseTerminalStore {
         }
         let outcome = self
             .inner
-            .complete_turn_run_and_append_event(id, lease_token, now, output, usage, stop_reason)
+            .complete_turn_run_and_append_event(
+                id,
+                lease_token,
+                expected_steer_revision,
+                now,
+                output,
+                usage,
+                stop_reason,
+            )
             .await?;
         if outcome.is_some()
             && self

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -7,9 +7,9 @@ use chrono::Utc;
 use futures::channel::mpsc::unbounded;
 use futures::StreamExt;
 use openwave_core::{
-    Agent, AgentConfig, AgentError, AgentEvent, AgentTurnOutcome, MessageId,
-    RecordTurnFailureOutcome, Result, SequencedEvent, Store, ToolRegistry, TurnFailureRetry,
-    TurnId, TurnRun, TurnRunStatus,
+    Agent, AgentConfig, AgentError, AgentEvent, AgentTurnOutcome, CompleteTurnRunOutcome,
+    MessageId, RecordTurnFailureOutcome, Result, SequencedEvent, Store, ToolRegistry,
+    TurnFailureRetry, TurnId, TurnRun, TurnRunStatus,
 };
 use tokio::sync::Notify;
 
@@ -441,6 +441,7 @@ impl TurnWorker {
                         .complete_turn_run_and_append_event(
                             turn.id,
                             lease_token,
+                            turn.steer_revision,
                             Utc::now(),
                             &output,
                             usage,
@@ -448,12 +449,22 @@ impl TurnWorker {
                         )
                         .await
                     {
-                        Ok(Some(resolution)) => {
-                            if let Some(event) = resolution.terminal_event {
-                                self.publish(turn.chat_id, event);
+                        Ok(Some(resolution)) => match resolution.outcome {
+                            CompleteTurnRunOutcome::Completed(_)
+                            | CompleteTurnRunOutcome::Existing(_) => {
+                                if let Some(event) = resolution.terminal_event {
+                                    self.publish(turn.chat_id, event);
+                                }
+                                return Ok(TurnWorkerOutcome::Completed(turn.id));
                             }
-                            return Ok(TurnWorkerOutcome::Completed(turn.id));
-                        }
+                            CompleteTurnRunOutcome::SteerPending(_)
+                            | CompleteTurnRunOutcome::OutputSuperseded(_) => {
+                                return Err(AgentError::msg(format!(
+                                    "turn {} requires durable steer continuation",
+                                    turn.id
+                                )));
+                            }
+                        },
                         Ok(None) => break,
                         Err(error) => {
                             self.retry_after("completion", turn.id, &error).await;


### PR DESCRIPTION
## Summary

- add exact, transactional admission and lease-fenced FIFO application for durable turn steering
- serialize message and steer identities through a shared registry and order transcripts by a per-chat commit sequence
- fence completion with a durable steer revision so pre-steer model output cannot commit after an applied instruction
- resolve pending instructions atomically across completion, failure, cancellation, and expired-lease terminal paths
- cover SQLite and PostgreSQL identity, contention, ordering, rollback, and completion races

## Validation

- `bw dev lint --rust --check --repo-root "$PWD"`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --exclude openwave-desktop --locked`
- `cargo test -p openwave-desktop --locked`
- `cargo test -p openwave-core --all-features --locked`
- repeated the focused turn-steer race suite ten times
