### PR TITLE
feat(server): deliver durable turn steering

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::task::Poll;
 
 use chrono::Utc;
 use futures::channel::mpsc::UnboundedSender;
@@ -30,12 +31,12 @@ use crate::context;
 use crate::error::{AgentError, Result};
 use crate::event::AgentEvent;
 use crate::id::{CallId, MessageId, TurnId};
-use crate::model::{Chat, Message, Role, ToolCallRecord};
+use crate::model::{Chat, Message, Role, ToolCallRecord, TurnRunStatus};
 use crate::provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, StopReason, Usage,
 };
 use crate::steer::SteerInbox;
-use crate::storage::Store;
+use crate::storage::{ApplyTurnSteerOutcome, Store};
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 
 /// A name-keyed registry of the tools available to the agent.
@@ -140,11 +141,17 @@ pub enum AgentTurnOutcome {
         usage: Usage,
         /// Provider stop reason for the eventual terminal event.
         stop_reason: StopReason,
+        /// Durable steering epoch captured immediately before the final model call.
+        steer_revision: Option<i64>,
+        /// Model-call steps consumed from the turn-wide execution budget.
+        model_steps: usize,
     },
     /// The loop observed its cancellation token and stopped cooperatively.
     Cancelled {
         /// Aggregate provider usage for the eventual terminal event.
         usage: Usage,
+        /// Model-call steps consumed from the turn-wide execution budget.
+        model_steps: usize,
     },
 }
 
@@ -167,6 +174,7 @@ pub struct Agent {
     approvals: Arc<dyn ApprovalGate>,
     cancel: CancelToken,
     steer: SteerInbox,
+    durable_steer_lease: Option<uuid::Uuid>,
 }
 
 /// A tool call accumulated from the provider stream.
@@ -196,6 +204,7 @@ impl Agent {
             approvals: Arc::new(RefuseGate),
             cancel: CancelToken::new(),
             steer: SteerInbox::new(),
+            durable_steer_lease: None,
         }
     }
 
@@ -219,6 +228,13 @@ impl Agent {
     #[must_use]
     pub fn with_steer(mut self, steer: SteerInbox) -> Self {
         self.steer = steer;
+        self
+    }
+
+    /// Apply durable steering under the exact claimed-turn lease.
+    #[must_use]
+    pub fn with_durable_steer(mut self, lease_token: uuid::Uuid) -> Self {
+        self.durable_steer_lease = Some(lease_token);
         self
     }
 
@@ -341,11 +357,15 @@ impl Agent {
         for step in 0..self.config.max_steps {
             // Between steps: stop before starting a fresh model call if cancelled.
             if self.cancel.is_cancelled() {
-                return Ok(self.finish_cancelled(events, total_usage, publish_terminal));
+                return Ok(self.finish_cancelled(events, total_usage, step, publish_terminal));
             }
             // Boundary steer: inject any queued messages before the next model call.
             self.apply_steers(chat, turn_id, &mut transcript, None, events)
                 .await?;
+            // Fence this exact provider request, not the later worker handoff.
+            // A steer applied after this snapshot must supersede its output;
+            // one applied at the boundary above is already part of the prompt.
+            let generation_steer_revision = self.durable_generation_revision(turn_id).await?;
 
             // Fit the transcript to the context window, retrying with tighter
             // budgets on prompt-too-long errors from the provider.
@@ -450,7 +470,7 @@ impl Agent {
             // the left arm of the nested select). Also catch a cancel that raced
             // the final stream event.
             if matches!(stream_end, StreamEnd::Cancelled) || self.cancel.is_cancelled() {
-                return Ok(self.finish_cancelled(events, total_usage, publish_terminal));
+                return Ok(self.finish_cancelled(events, total_usage, step + 1, publish_terminal));
             }
             if matches!(stream_end, StreamEnd::Steered) {
                 // Discard this step's partial output — nothing from it was
@@ -532,7 +552,12 @@ impl Agent {
                 // concurrent push cannot 202 and then be orphaned.
                 loop {
                     if self.cancel.is_cancelled() {
-                        return Ok(self.finish_cancelled(events, total_usage, publish_terminal));
+                        return Ok(self.finish_cancelled(
+                            events,
+                            total_usage,
+                            step + 1,
+                            publish_terminal,
+                        ));
                     }
                     if self
                         .apply_steers(
@@ -546,6 +571,15 @@ impl Agent {
                     {
                         break; // continue the outer step loop below
                     }
+                    if self.durable_steer_lease.is_some() {
+                        return Ok(AgentTurnOutcome::Completed {
+                            output,
+                            usage: total_usage,
+                            stop_reason,
+                            steer_revision: generation_steer_revision,
+                            model_steps: step + 1,
+                        });
+                    }
                     if self.steer.try_complete(|| {
                         if publish_terminal {
                             let _ = events.unbounded_send(AgentEvent::TurnCompleted {
@@ -558,6 +592,8 @@ impl Agent {
                             output,
                             usage: total_usage,
                             stop_reason,
+                            steer_revision: generation_steer_revision,
+                            model_steps: step + 1,
                         });
                     }
                     // Steer arrived between drain and try_complete — loop.
@@ -602,7 +638,12 @@ impl Agent {
                 // A cancel that arrived during this tool (including while it was
                 // parked on approval) stops the turn before the next model call.
                 if self.cancel.is_cancelled() {
-                    return Ok(self.finish_cancelled(events, total_usage, publish_terminal));
+                    return Ok(self.finish_cancelled(
+                        events,
+                        total_usage,
+                        step + 1,
+                        publish_terminal,
+                    ));
                 }
             }
             // Tool results ride in a user-role message (the Messages convention).
@@ -624,12 +665,13 @@ impl Agent {
         &self,
         events: &UnboundedSender<AgentEvent>,
         usage: Usage,
+        model_steps: usize,
         publish_terminal_event: bool,
     ) -> AgentTurnOutcome {
         if publish_terminal_event {
             let _ = events.unbounded_send(AgentEvent::TurnCancelled { usage });
         }
-        AgentTurnOutcome::Cancelled { usage }
+        AgentTurnOutcome::Cancelled { usage, model_steps }
     }
 
     /// Drain the steer inbox into the transcript. Returns whether any messages
@@ -643,12 +685,23 @@ impl Agent {
         events: &UnboundedSender<AgentEvent>,
     ) -> Result<bool> {
         let msgs = self.steer.drain();
-        if msgs.is_empty() {
+        let durable = match self.durable_steer_lease {
+            Some(lease_token) => self.list_durable_steers_retry(turn_id, lease_token).await?,
+            None => Vec::new(),
+        };
+        if msgs.is_empty() && durable.is_empty() {
             return Ok(false);
         }
-        if let Some(text) = preceding_assistant {
-            self.persist(chat.id, turn_id, Role::Assistant, text)
-                .await?;
+        if self.durable_steer_lease.is_some() && !msgs.is_empty() {
+            return Err(AgentError::Store(format!(
+                "turn {turn_id} mixed process-local messages with durable steering"
+            )));
+        }
+        if self.durable_steer_lease.is_none() {
+            if let Some(text) = preceding_assistant {
+                self.persist(chat.id, turn_id, Role::Assistant, text)
+                    .await?;
+            }
         }
         for msg in msgs {
             self.persist(chat.id, turn_id, Role::User, &msg.content)
@@ -663,7 +716,161 @@ impl Agent {
                 content: msg.content,
             });
         }
+        let preceding = preceding_assistant
+            .filter(|text| !text.is_empty() && !durable.is_empty())
+            .map(|text| Message {
+                id: MessageId::new(),
+                chat_id: chat.id,
+                turn_id,
+                role: Role::Assistant,
+                content: text.to_owned(),
+                created_at: Utc::now(),
+            });
+        let lease_token = self.durable_steer_lease;
+        for (index, steer) in durable.into_iter().enumerate() {
+            let preceding_assistant = if index == 0 { preceding.as_ref() } else { None };
+            let applied = self
+                .apply_durable_steer_retry(
+                    turn_id,
+                    lease_token.expect("durable steering has a lease"),
+                    steer.id,
+                    preceding_assistant,
+                )
+                .await?;
+            let steer = match applied {
+                ApplyTurnSteerOutcome::Applied(steer) | ApplyTurnSteerOutcome::Existing(steer) => {
+                    steer
+                }
+            };
+            transcript.push(ChatMessage {
+                role: Role::User,
+                content: vec![ContentBlock::Text {
+                    text: steer.content.clone(),
+                }],
+            });
+            let _ = events.unbounded_send(AgentEvent::UserSteered {
+                content: steer.content,
+            });
+        }
         Ok(true)
+    }
+
+    async fn durable_generation_revision(&self, turn_id: TurnId) -> Result<Option<i64>> {
+        match self.durable_steer_lease {
+            Some(lease_token) => self
+                .durable_turn_revision_retry(turn_id, lease_token)
+                .await
+                .map(Some),
+            None => Ok(None),
+        }
+    }
+
+    async fn durable_turn_revision_retry(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+    ) -> Result<i64> {
+        loop {
+            match self.store.get_turn_run(turn_id).await {
+                Ok(Some(turn))
+                    if turn.status == TurnRunStatus::Running
+                        && turn.lease_token == Some(lease_token)
+                        && turn
+                            .lease_expires_at
+                            .is_some_and(|expires_at| expires_at > Utc::now()) =>
+                {
+                    return Ok(turn.steer_revision);
+                }
+                Ok(_) => {
+                    return Err(AgentError::Store(format!(
+                        "turn {turn_id} no longer has live lease {lease_token}"
+                    )));
+                }
+                Err(_) => self.wait_for_durable_store_retry(turn_id).await?,
+            }
+        }
+    }
+
+    async fn list_durable_steers_retry(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+    ) -> Result<Vec<crate::model::TurnSteer>> {
+        loop {
+            match self
+                .store
+                .list_pending_turn_steers(turn_id, lease_token, Utc::now())
+                .await
+            {
+                Ok(Some(steers)) => return Ok(steers),
+                Ok(None) | Err(_) => {
+                    // Heartbeat and admission both advance `updated_at`. A
+                    // timestamp captured just before either commit can produce
+                    // a harmless `None`; prove the exact lease and replay with
+                    // a fresh operational time. The same loop also recovers an
+                    // ambiguous database response.
+                    self.durable_turn_revision_retry(turn_id, lease_token)
+                        .await?;
+                    self.wait_for_durable_store_retry(turn_id).await?;
+                }
+            }
+        }
+    }
+
+    async fn apply_durable_steer_retry(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        steer_id: crate::id::TurnSteerId,
+        preceding_assistant: Option<&Message>,
+    ) -> Result<ApplyTurnSteerOutcome> {
+        loop {
+            match self
+                .store
+                .apply_turn_steer(
+                    turn_id,
+                    lease_token,
+                    steer_id,
+                    preceding_assistant,
+                    Utc::now(),
+                )
+                .await
+            {
+                Ok(Some(applied)) => return Ok(applied),
+                Ok(None) | Err(_) => {
+                    // Retrying the same identity recovers `Existing` when the
+                    // commit won but its response was lost.
+                    self.durable_turn_revision_retry(turn_id, lease_token)
+                        .await?;
+                    self.wait_for_durable_store_retry(turn_id).await?;
+                }
+            }
+        }
+    }
+
+    async fn wait_for_durable_store_retry(&self, turn_id: TurnId) -> Result<()> {
+        if self.cancel.is_cancelled() {
+            return Err(AgentError::Store(format!(
+                "turn {turn_id} was cancelled while retrying durable steering"
+            )));
+        }
+        let mut yielded = false;
+        future::poll_fn(|cx| {
+            if yielded {
+                Poll::Ready(())
+            } else {
+                yielded = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        })
+        .await;
+        if self.cancel.is_cancelled() {
+            return Err(AgentError::Store(format!(
+                "turn {turn_id} was cancelled while retrying durable steering"
+            )));
+        }
+        Ok(())
     }
 
     /// Resolve approval and execute one tool call, returning its output. Tool and
@@ -1198,6 +1405,7 @@ mod tests {
             output,
             usage,
             stop_reason,
+            ..
         } = outcome
         else {
             panic!("claimed turn should complete");
@@ -1458,7 +1666,8 @@ mod tests {
         assert_eq!(
             outcome,
             AgentTurnOutcome::Cancelled {
-                usage: Usage::default()
+                usage: Usage::default(),
+                model_steps: 0,
             }
         );
         let cancellation_events: Vec<AgentEvent> = cancellation_rx.collect().await;

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1709,9 +1709,18 @@ impl Store for DbStore {
         turn_id: TurnId,
         lease_token: uuid::Uuid,
         steer_id: TurnSteerId,
+        preceding_assistant: Option<&Message>,
         now: chrono::DateTime<Utc>,
     ) -> Result<Option<ApplyTurnSteerOutcome>> {
-        ops::turn::apply_turn_steer(self, turn_id, lease_token, steer_id, now).await
+        ops::turn::apply_turn_steer(
+            self,
+            turn_id,
+            lease_token,
+            steer_id,
+            preceding_assistant,
+            now,
+        )
+        .await
     }
 
     async fn complete_turn_run(

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -238,6 +238,7 @@ pub(in crate::db) async fn apply_turn_steer(
     turn_id: TurnId,
     lease_token: uuid::Uuid,
     steer_id: TurnSteerId,
+    preceding_assistant: Option<&crate::model::Message>,
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<ApplyTurnSteerOutcome>> {
     if turn_id.0.is_nil() || lease_token.is_nil() || steer_id.0.is_nil() {
@@ -277,6 +278,9 @@ pub(in crate::db) async fn apply_turn_steer(
         let exact = steer.turn_id == turn_id.0 && steer.applied_lease_token == Some(lease_token);
         let outcome = if exact {
             ensure_exact_applied_message_on(&transaction, &steer).await?;
+            if let Some(preceding) = preceding_assistant {
+                ensure_exact_preceding_message_on(&transaction, &steer, preceding).await?;
+            }
             Some(ApplyTurnSteerOutcome::Existing(turn_steer_from_model(
                 steer,
             )?))
@@ -336,6 +340,39 @@ pub(in crate::db) async fn apply_turn_steer(
         .steer_revision
         .checked_add(1)
         .ok_or_else(|| AgentError::Store(format!("turn {turn_id} steer revision overflow")))?;
+
+    if let Some(preceding) = preceding_assistant {
+        validate_preceding_assistant(preceding, turn_id, ChatId(turn.chat_id), now)?;
+        if !reserve_message_identity_on(
+            &transaction,
+            preceding.id,
+            preceding.chat_id,
+            preceding.turn_id,
+            MESSAGE_IDENTITY_OWNER_MESSAGE,
+        )
+        .await?
+        {
+            transaction.rollback().await.map_err(store_err)?;
+            return Err(AgentError::Store(format!(
+                "preceding assistant identity {} is already reserved",
+                preceding.id
+            )));
+        }
+        let preceding_created_at = canonical_db_timestamp(preceding.created_at)?;
+        let message = entities::message::ActiveModel {
+            id: Set(preceding.id.0),
+            chat_id: Set(preceding.chat_id.0),
+            turn_id: Set(preceding.turn_id.0),
+            seq: Set(next_message_seq_on(&transaction, preceding.chat_id).await?),
+            role: Set("assistant".into()),
+            content: Set(preceding.content.clone()),
+            created_at: Set(preceding_created_at),
+        };
+        if let Err(error) = message.insert(&transaction).await {
+            transaction.rollback().await.map_err(store_err)?;
+            return Err(store_err(error));
+        }
+    }
 
     if !transfer_steer_message_identity_on(
         &transaction,
@@ -540,6 +577,73 @@ where
             "applied turn steer {} has a different or missing message",
             TurnSteerId(steer.id)
         )));
+    }
+    Ok(())
+}
+
+async fn ensure_exact_preceding_message_on<C>(
+    conn: &C,
+    steer: &entities::turn_steer::Model,
+    preceding: &crate::model::Message,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    let created_at = canonical_db_timestamp(preceding.created_at)?;
+    let applied_message = entities::message::Entity::find_by_id(steer.id)
+        .one(conn)
+        .await
+        .map_err(store_err)?;
+    let exact = entities::message::Entity::find_by_id(preceding.id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .zip(applied_message)
+        .is_some_and(|(message, applied)| {
+            message.chat_id == preceding.chat_id.0
+                && message.turn_id == preceding.turn_id.0
+                && message.role == "assistant"
+                && message.content == preceding.content
+                && message.created_at == created_at
+                && message.seq.checked_add(1) == Some(applied.seq)
+        });
+    let exact_identity = entities::message_identity::Entity::find_by_id(preceding.id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .is_some_and(|identity| {
+            identity.chat_id == preceding.chat_id.0
+                && identity.turn_id == preceding.turn_id.0
+                && identity.owner == MESSAGE_IDENTITY_OWNER_MESSAGE
+        });
+    if !exact || !exact_identity {
+        return Err(AgentError::Store(format!(
+            "applied turn steer {} has a different or missing preceding assistant {}",
+            TurnSteerId(steer.id),
+            preceding.id
+        )));
+    }
+    Ok(())
+}
+
+fn validate_preceding_assistant(
+    message: &crate::model::Message,
+    turn_id: TurnId,
+    chat_id: ChatId,
+    now: chrono::DateTime<Utc>,
+) -> Result<()> {
+    let created_at = canonical_db_timestamp(message.created_at)?;
+    if message.id.0.is_nil()
+        || message.chat_id != chat_id
+        || message.turn_id != turn_id
+        || message.role != crate::model::Role::Assistant
+        || message.content.is_empty()
+        || message.content.contains('\0')
+        || created_at > now
+    {
+        return Err(AgentError::Store(
+            "preceding assistant must be a valid non-empty message for the exact turn".into(),
+        ));
     }
     Ok(())
 }

--- a/crates/openwave-core/src/db/tests/turn_steer.rs
+++ b/crates/openwave-core/src/db/tests/turn_steer.rs
@@ -221,10 +221,9 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
         content: "candidate before steer".into(),
         created_at: Utc::now(),
     };
-    store.append_message(&candidate).await.unwrap();
     let apply_at = Utc::now();
     let applied = store
-        .apply_turn_steer(turn.id, lease_token, steer_id, apply_at)
+        .apply_turn_steer(turn.id, lease_token, steer_id, Some(&candidate), apply_at)
         .await
         .unwrap()
         .unwrap();
@@ -295,13 +294,13 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
     ));
 
     let recovered = store
-        .apply_turn_steer(turn.id, lease_token, steer_id, Utc::now())
+        .apply_turn_steer(turn.id, lease_token, steer_id, Some(&candidate), Utc::now())
         .await
         .unwrap()
         .unwrap();
     assert!(matches!(recovered, ApplyTurnSteerOutcome::Existing(_)));
     let second = match store
-        .apply_turn_steer(turn.id, lease_token, second_id, Utc::now())
+        .apply_turn_steer(turn.id, lease_token, second_id, None, Utc::now())
         .await
         .unwrap()
         .unwrap()
@@ -571,21 +570,21 @@ async fn turn_steer_application_enforces_fifo_and_message_sequence_on_timestamp_
     let applied_at = Utc::now();
     assert_eq!(
         store
-            .apply_turn_steer(turn.id, lease, high_id, applied_at)
+            .apply_turn_steer(turn.id, lease, high_id, None, applied_at)
             .await
             .unwrap(),
         None
     );
     assert!(matches!(
         store
-            .apply_turn_steer(turn.id, lease, low_id, applied_at)
+            .apply_turn_steer(turn.id, lease, low_id, None, applied_at)
             .await
             .unwrap(),
         Some(ApplyTurnSteerOutcome::Applied(_))
     ));
     assert!(matches!(
         store
-            .apply_turn_steer(turn.id, lease, high_id, applied_at)
+            .apply_turn_steer(turn.id, lease, high_id, None, applied_at)
             .await
             .unwrap(),
         Some(ApplyTurnSteerOutcome::Applied(_))
@@ -650,7 +649,7 @@ async fn concurrent_apply_and_completion_leave_no_pending_steer() {
     let apply = tokio::spawn(async move {
         apply_barrier.wait().await;
         apply_store
-            .apply_turn_steer(turn.id, lease_token, steer_id, Utc::now())
+            .apply_turn_steer(turn.id, lease_token, steer_id, None, Utc::now())
             .await
             .unwrap()
     });
@@ -851,7 +850,7 @@ async fn concurrent_message_and_steer_reserve_one_shared_identity() {
             assert!(message.is_err());
             assert!(matches!(
                 store
-                    .apply_turn_steer(steer_turn.id, lease, shared_id, Utc::now())
+                    .apply_turn_steer(steer_turn.id, lease, shared_id, None, Utc::now())
                     .await
                     .unwrap(),
                 Some(ApplyTurnSteerOutcome::Applied(_))
@@ -1158,7 +1157,7 @@ async fn failed_steer_message_insert_rolls_back_the_application_receipt() {
     .await
     .unwrap();
     assert!(store
-        .apply_turn_steer(turn.id, lease, steer_id, Utc::now())
+        .apply_turn_steer(turn.id, lease, steer_id, None, Utc::now())
         .await
         .is_err());
     let pending = existing_steer(

--- a/crates/openwave-core/src/steer.rs
+++ b/crates/openwave-core/src/steer.rs
@@ -34,12 +34,17 @@ pub struct SteerInbox {
 
 #[derive(Default)]
 struct Inner {
-    queue: Mutex<VecDeque<SteerMessage>>,
+    queue: Mutex<VecDeque<InboxItem>>,
     interrupt: AtomicBool,
     /// Set when the turn is about to emit `TurnCompleted`, so a concurrent
     /// [`SteerInbox::push`] cannot land a message that will never be drained.
     sealed: AtomicBool,
     waker: AtomicWaker,
+}
+
+enum InboxItem {
+    Message(SteerMessage),
+    DurableSignal,
 }
 
 impl SteerInbox {
@@ -63,7 +68,30 @@ impl SteerInbox {
         if self.inner.sealed.load(Ordering::Acquire) {
             return false;
         }
-        queue.push_back(SteerMessage { content });
+        queue.push_back(InboxItem::Message(SteerMessage { content }));
+        if interrupt {
+            self.inner.interrupt.store(true, Ordering::Release);
+            self.inner.waker.wake();
+        }
+        true
+    }
+
+    /// Wake a claimed turn after durable steering admission commits.
+    ///
+    /// The instruction content remains in the store and is applied under the
+    /// worker's exact lease. This marker only supplies low-latency boundary or
+    /// interrupt delivery; the database remains the source of truth.
+    pub fn signal_durable(&self, interrupt: bool) -> bool {
+        let mut queue = self.inner.queue.lock().unwrap();
+        if self.inner.sealed.load(Ordering::Acquire) {
+            return false;
+        }
+        if !queue
+            .iter()
+            .any(|item| matches!(item, InboxItem::DurableSignal))
+        {
+            queue.push_back(InboxItem::DurableSignal);
+        }
         if interrupt {
             self.inner.interrupt.store(true, Ordering::Release);
             self.inner.waker.wake();
@@ -74,7 +102,13 @@ impl SteerInbox {
     /// Drain every queued message (order preserved). Clears the interrupt flag.
     pub fn drain(&self) -> Vec<SteerMessage> {
         let mut queue = self.inner.queue.lock().unwrap();
-        let out: Vec<_> = queue.drain(..).collect();
+        let out = queue
+            .drain(..)
+            .filter_map(|item| match item {
+                InboxItem::Message(message) => Some(message),
+                InboxItem::DurableSignal => None,
+            })
+            .collect();
         self.inner.interrupt.store(false, Ordering::Release);
         out
     }
@@ -177,6 +211,19 @@ mod tests {
         assert!(!inbox.try_complete(|| panic!("must not complete")));
         assert_eq!(inbox.drain()[0].content, "pending");
         assert!(inbox.push("after", false));
+    }
+
+    #[test]
+    fn durable_signal_coalesces_and_fences_completion() {
+        let inbox = SteerInbox::new();
+        assert!(inbox.signal_durable(false));
+        assert!(inbox.signal_durable(true));
+        assert!(inbox.interrupt_requested());
+        assert!(!inbox.try_complete(|| panic!("durable work is pending")));
+        assert!(inbox.drain().is_empty());
+        assert!(!inbox.interrupt_requested());
+        assert!(inbox.try_complete(|| {}));
+        assert!(!inbox.signal_durable(true));
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -740,15 +740,17 @@ pub trait Store: Send + Sync {
 
     /// Persist one pending steer as a user message under the exact live lease.
     ///
-    /// The message and application receipt commit atomically. Exact retries by
-    /// the same lease return [`ApplyTurnSteerOutcome::Existing`] even after the
-    /// turn advances. A stale lease, rejected steer, or different winning lease
-    /// returns `None`.
+    /// An optional preceding assistant candidate, the steer message, the
+    /// application receipt, and the revision increment commit atomically in
+    /// transcript order. Exact retries by the same lease return
+    /// [`ApplyTurnSteerOutcome::Existing`] even after the turn advances. A stale
+    /// lease, rejected steer, or different winning lease returns `None`.
     async fn apply_turn_steer(
         &self,
         _turn_id: TurnId,
         _lease_token: uuid::Uuid,
         _steer_id: TurnSteerId,
+        _preceding_assistant: Option<&Message>,
         _now: chrono::DateTime<chrono::Utc>,
     ) -> Result<Option<ApplyTurnSteerOutcome>> {
         turn_storage_unavailable()

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -604,12 +604,40 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
             .collect::<Vec<_>>(),
         vec![steer_id]
     );
+    let preceding = Message {
+        id: MessageId::new(),
+        chat_id: steer_chat.id,
+        turn_id: steer_turn.id,
+        role: Role::Assistant,
+        content: "postgres candidate".into(),
+        created_at: Utc::now(),
+    };
     let applied = store
-        .apply_turn_steer(steer_turn.id, steer_lease, steer_id, Utc::now())
+        .apply_turn_steer(
+            steer_turn.id,
+            steer_lease,
+            steer_id,
+            Some(&preceding),
+            Utc::now(),
+        )
         .await
         .unwrap()
         .unwrap();
     assert!(matches!(applied, ApplyTurnSteerOutcome::Applied(_)));
+    assert_eq!(
+        store
+            .list_messages(steer_chat.id)
+            .await
+            .unwrap()
+            .iter()
+            .map(|message| (message.role, message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (Role::User, "steer input"),
+            (Role::Assistant, "postgres candidate"),
+            (Role::User, "postgres steer"),
+        ]
+    );
 
     let second_steer_id = TurnSteerId::new();
     assert!(matches!(
@@ -647,7 +675,13 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         Some(CompleteTurnRunOutcome::SteerPending(_))
     ));
     let second_steer = match store
-        .apply_turn_steer(steer_turn.id, steer_lease, second_steer_id, Utc::now())
+        .apply_turn_steer(
+            steer_turn.id,
+            steer_lease,
+            second_steer_id,
+            None,
+            Utc::now(),
+        )
         .await
         .unwrap()
         .unwrap()
@@ -676,7 +710,13 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         .unwrap();
     assert!(matches!(
         store
-            .apply_turn_steer(steer_turn.id, steer_lease, steer_id, Utc::now())
+            .apply_turn_steer(
+                steer_turn.id,
+                steer_lease,
+                steer_id,
+                Some(&preceding),
+                Utc::now(),
+            )
             .await
             .unwrap(),
         Some(ApplyTurnSteerOutcome::Existing(_))

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -148,13 +148,14 @@ export class ApiClient {
   steer(
     chatId: string,
     turnId: string,
+    steerId: string,
     content: string,
     interrupt = false,
   ): Promise<void> {
     return this.json(`/chats/${chatId}/steer`, {
       method: "POST",
       headers: this.headers(true),
-      body: JSON.stringify({ turn_id: turnId, content, interrupt }),
+      body: JSON.stringify({ steer_id: steerId, turn_id: turnId, content, interrupt }),
     });
   }
 

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -15,8 +15,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{
-    AcceptTurnOutcome, ApprovalDecision, CallId, Chat, ChatId, Project, ProjectId,
-    RequestTurnCancellationOutcome, SecretProvider, SequencedEvent, Store, TurnId,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, ApprovalDecision, CallId, Chat, ChatId, Project,
+    ProjectId, RequestTurnCancellationOutcome, SecretProvider, SequencedEvent, Store, TurnId,
+    TurnSteer, TurnSteerId,
 };
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
@@ -502,6 +503,8 @@ pub async fn post_message(
 /// Body of `POST /chats/{id}/steer`.
 #[derive(Debug, Deserialize)]
 pub struct SteerBody {
+    /// Stable client-generated identity for admission and ambiguous retries.
+    pub steer_id: TurnSteerId,
     /// Exact durable turn to steer.
     pub turn_id: TurnId,
     /// User text to inject into the running turn.
@@ -512,32 +515,58 @@ pub struct SteerBody {
     pub interrupt: bool,
 }
 
-/// `POST /chats/{id}/steer` — inject a message into the turn currently running.
+/// `POST /chats/{id}/steer` — durably enqueue an instruction for an active turn.
 ///
-/// `202 Accepted` once the message is queued (and interrupt signalled, if
-/// requested). The turn continues after injecting — watch the event stream for
-/// `UserSteered`. `404` if the chat doesn't exist, `409` if no turn is running,
-/// `400` if `content` is empty.
+/// `202 Accepted` only after the exact instruction commits. A local notification
+/// can reduce delivery latency, but the claimed worker always applies pending
+/// instructions from the database. Repeating the same identity and payload is
+/// idempotent. `404` if the chat doesn't exist, `409` for conflicting identity or
+/// unavailable turn, and `400` for malformed input.
 pub async fn post_steer(
     State(state): State<AppState>,
     Path(id): Path<ChatId>,
     Json(body): Json<SteerBody>,
 ) -> Result<StatusCode, ServerError> {
-    if body.content.trim().is_empty() {
-        return Err(ServerError::bad_request("steer content must not be empty"));
+    if body.steer_id.0.is_nil() {
+        return Err(ServerError::bad_request("steer_id must not be nil"));
+    }
+    if body.content.trim().is_empty()
+        || body.content.contains('\0')
+        || body.content.chars().count() > TurnSteer::MAX_CONTENT_LEN
+    {
+        return Err(ServerError::bad_request(
+            "steer content must be non-empty, contain no NUL characters, and fit the size limit",
+        ));
     }
     if state.store.get_chat(id).await?.is_none() {
         return Err(ServerError::not_found(format!("chat {id} not found")));
     }
-    if state
-        .active_turns
-        .steer(id, body.turn_id, body.content, body.interrupt)
+    match state
+        .store
+        .accept_turn_steer(
+            body.steer_id,
+            body.turn_id,
+            id,
+            &body.content,
+            body.interrupt,
+        )
+        .await?
     {
-        Ok(StatusCode::ACCEPTED)
-    } else {
-        Err(ServerError::conflict(format!(
-            "chat {id} has no turn in progress"
-        )))
+        AcceptTurnSteerOutcome::Accepted(_) | AcceptTurnSteerOutcome::Existing(_) => {
+            state
+                .active_turns
+                .signal_steer(id, body.turn_id, body.interrupt);
+            state.turn_job_wake.notify_one();
+            Ok(StatusCode::ACCEPTED)
+        }
+        AcceptTurnSteerOutcome::IdentityConflict => Err(ServerError::conflict(format!(
+            "steer {} was already used by different request data",
+            body.steer_id
+        ))),
+        AcceptTurnSteerOutcome::TurnUnavailable => Err(ServerError::conflict(format!(
+            "turn {} is not accepting steering instructions",
+            body.turn_id
+        ))),
     }
 }
 

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -237,19 +237,13 @@ impl TurnGuard {
         }
     }
 
-    /// Push a steer message into the turn running for `chat_id`, if any. Returns
-    /// whether a turn was found and still accepting steer. When `interrupt` is
-    /// true the agent preempts the provider stream; otherwise the message waits
-    /// for the next step boundary.
-    pub fn steer(
-        &self,
-        chat_id: ChatId,
-        turn_id: TurnId,
-        content: String,
-        interrupt: bool,
-    ) -> bool {
+    /// Wake the exact local worker after durable steering admission commits.
+    ///
+    /// The instruction remains in the store; this process-local signal only
+    /// reduces delivery latency and optionally preempts the provider stream.
+    pub fn signal_steer(&self, chat_id: ChatId, turn_id: TurnId, interrupt: bool) -> bool {
         match self.active.lock().unwrap().get(&chat_id) {
-            Some(handles) if handles.turn_id == turn_id => handles.steer.push(content, interrupt),
+            Some(handles) if handles.turn_id == turn_id => handles.steer.signal_durable(interrupt),
             _ => false,
         }
     }
@@ -272,8 +266,8 @@ impl ActiveTurn {
         self.cancel.clone()
     }
 
-    /// The steer inbox for this turn — handed to the agent so a `POST .../steer`
-    /// routed through [`TurnGuard::steer`] injects mid-turn.
+    /// The steer inbox for this turn — handed to the agent so a durable steer
+    /// notification injects mid-turn.
     pub fn steer_inbox(&self) -> SteerInbox {
         self.steer.clone()
     }
@@ -362,19 +356,18 @@ mod tests {
     }
 
     #[test]
-    fn steer_pushes_into_the_held_inbox() {
+    fn steer_signal_wakes_the_held_inbox() {
         let guard = Arc::new(TurnGuard::default());
         let chat = ChatId::new();
         let turn = TurnId::new();
 
-        assert!(!guard.steer(chat, turn, "x".into(), false));
+        assert!(!guard.signal_steer(chat, turn, false));
         let held = guard
             .register(chat, turn, Uuid::new_v4())
             .expect("register");
-        assert!(!guard.steer(chat, TurnId::new(), "wrong".into(), true));
-        assert!(guard.steer(chat, turn, "course correct".into(), true));
-        let msgs = held.steer_inbox().drain();
-        assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs[0].content, "course correct");
+        assert!(!guard.signal_steer(chat, TurnId::new(), true));
+        assert!(guard.signal_steer(chat, turn, true));
+        assert!(held.steer_inbox().interrupt_requested());
+        assert!(held.steer_inbox().drain().is_empty());
     }
 }

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -11,7 +11,7 @@ use futures::stream::{self, BoxStream, StreamExt};
 use openwave_core::{
     AgentErrorInfo, AgentEvent, ApprovalClass, BlobStore, Chat, ChatId, ChatRequest, Message,
     ModelProvider, Project, ProjectId, ProviderEvent, ProviderId, SecretProvider, SequencedEvent,
-    StopReason, Tool, ToolCtx, ToolOutput, ToolSpec, TurnId, Usage,
+    StopReason, Tool, ToolCtx, ToolOutput, ToolSpec, TurnId, TurnSteerId, Usage,
 };
 use openwave_retrieval::{
     Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
@@ -305,6 +305,8 @@ struct PauseTerminalStore {
     pause_after_claim_commit: std::sync::atomic::AtomicBool,
     fail_after_heartbeat_commit: std::sync::atomic::AtomicBool,
     fail_after_completion_commit: std::sync::atomic::AtomicBool,
+    fail_after_apply_steer_commit: std::sync::atomic::AtomicBool,
+    advance_before_steer_read: std::sync::atomic::AtomicBool,
     fail_terminal_recovery: std::sync::atomic::AtomicBool,
     terminal_recovery_calls: AtomicUsize,
     scan_before_failure_resolution: std::sync::atomic::AtomicBool,
@@ -326,6 +328,8 @@ impl PauseTerminalStore {
             pause_after_claim_commit: std::sync::atomic::AtomicBool::new(false),
             fail_after_heartbeat_commit: std::sync::atomic::AtomicBool::new(false),
             fail_after_completion_commit: std::sync::atomic::AtomicBool::new(false),
+            fail_after_apply_steer_commit: std::sync::atomic::AtomicBool::new(false),
+            advance_before_steer_read: std::sync::atomic::AtomicBool::new(false),
             fail_terminal_recovery: std::sync::atomic::AtomicBool::new(false),
             terminal_recovery_calls: AtomicUsize::new(0),
             scan_before_failure_resolution: std::sync::atomic::AtomicBool::new(false),
@@ -356,6 +360,15 @@ impl PauseTerminalStore {
     fn fail_after_next_completion_commit(&self) {
         self.fail_after_completion_commit
             .store(true, Ordering::SeqCst);
+    }
+
+    fn fail_after_next_apply_steer_commit(&self) {
+        self.fail_after_apply_steer_commit
+            .store(true, Ordering::SeqCst);
+    }
+
+    fn advance_before_next_steer_read(&self) {
+        self.advance_before_steer_read.store(true, Ordering::SeqCst);
     }
 
     fn fail_next_terminal_recovery(&self) {
@@ -630,6 +643,72 @@ impl Store for PauseTerminalStore {
             self.release.notified().await;
         }
         self.inner.accept_turn(id, chat_id, model, content).await
+    }
+    async fn accept_turn_steer(
+        &self,
+        id: TurnSteerId,
+        turn_id: TurnId,
+        chat_id: ChatId,
+        content: &str,
+        interrupt: bool,
+    ) -> Result<openwave_core::AcceptTurnSteerOutcome> {
+        self.inner
+            .accept_turn_steer(id, turn_id, chat_id, content, interrupt)
+            .await
+    }
+    async fn list_pending_turn_steers(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<Vec<openwave_core::TurnSteer>>> {
+        if self.advance_before_steer_read.swap(false, Ordering::SeqCst) {
+            let turn = self
+                .inner
+                .get_turn_run(turn_id)
+                .await?
+                .ok_or_else(|| AgentError::Store("injected steer read lost turn".into()))?;
+            let lease_expires_at = turn
+                .lease_expires_at
+                .ok_or_else(|| AgentError::Store("injected steer read lost lease".into()))?
+                + chrono::Duration::seconds(1);
+            let advanced = now + chrono::Duration::milliseconds(1);
+            if !self
+                .inner
+                .heartbeat_turn_run(turn_id, lease_token, advanced, lease_expires_at)
+                .await?
+            {
+                return Err(AgentError::Store(
+                    "injected steer read could not advance heartbeat".into(),
+                ));
+            }
+        }
+        self.inner
+            .list_pending_turn_steers(turn_id, lease_token, now)
+            .await
+    }
+    async fn apply_turn_steer(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        steer_id: TurnSteerId,
+        preceding_assistant: Option<&Message>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<openwave_core::ApplyTurnSteerOutcome>> {
+        let applied = self
+            .inner
+            .apply_turn_steer(turn_id, lease_token, steer_id, preceding_assistant, now)
+            .await?;
+        if applied.is_some()
+            && self
+                .fail_after_apply_steer_commit
+                .swap(false, Ordering::SeqCst)
+        {
+            return Err(AgentError::Store(
+                "injected ambiguous steer application response".into(),
+            ));
+        }
+        Ok(applied)
     }
     async fn claim_turn_run(
         &self,
@@ -1270,6 +1349,27 @@ async fn steer_turn(
     content: &str,
     interrupt: bool,
 ) -> StatusCode {
+    steer_turn_with_id(
+        router,
+        bearer,
+        chat,
+        TurnSteerId::new(),
+        turn_id,
+        content,
+        interrupt,
+    )
+    .await
+}
+
+async fn steer_turn_with_id(
+    router: &Router,
+    bearer: &str,
+    chat: ChatId,
+    steer_id: TurnSteerId,
+    turn_id: TurnId,
+    content: &str,
+    interrupt: bool,
+) -> StatusCode {
     router
         .clone()
         .oneshot(
@@ -1280,6 +1380,7 @@ async fn steer_turn(
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
                     serde_json::json!({
+                        "steer_id": steer_id,
                         "turn_id": turn_id,
                         "content": content,
                         "interrupt": interrupt
@@ -1309,6 +1410,43 @@ async fn steer_without_a_running_turn_is_a_conflict_and_unknown_chat_is_404() {
     );
     assert_eq!(
         steer_turn(&router, &bearer, chat.id, TurnId::new(), "  ", false).await,
+        StatusCode::BAD_REQUEST
+    );
+    assert_eq!(
+        steer_turn_with_id(
+            &router,
+            &bearer,
+            chat.id,
+            TurnSteerId(uuid::Uuid::nil()),
+            TurnId::new(),
+            "hi",
+            false,
+        )
+        .await,
+        StatusCode::BAD_REQUEST
+    );
+    assert_eq!(
+        steer_turn(
+            &router,
+            &bearer,
+            chat.id,
+            TurnId::new(),
+            "contains\0nul",
+            false,
+        )
+        .await,
+        StatusCode::BAD_REQUEST
+    );
+    assert_eq!(
+        steer_turn(
+            &router,
+            &bearer,
+            chat.id,
+            TurnId::new(),
+            &"x".repeat(openwave_core::TurnSteer::MAX_CONTENT_LEN + 1),
+            false,
+        )
+        .await,
         StatusCode::BAD_REQUEST
     );
 }
@@ -1357,9 +1495,47 @@ async fn interrupt_steer_preempts_a_running_turn_and_continues() {
     );
     // Give the turn a moment to enter the stalled stream.
     tokio::time::sleep(Duration::from_millis(30)).await;
+    let steer_id = TurnSteerId::new();
     assert_eq!(
-        steer_turn(&router, &bearer, chat.id, turn_id, "change course", true,).await,
+        steer_turn_with_id(
+            &router,
+            &bearer,
+            chat.id,
+            steer_id,
+            turn_id,
+            "change course",
+            true,
+        )
+        .await,
         StatusCode::ACCEPTED
+    );
+    assert_eq!(
+        steer_turn_with_id(
+            &router,
+            &bearer,
+            chat.id,
+            steer_id,
+            turn_id,
+            "change course",
+            true,
+        )
+        .await,
+        StatusCode::ACCEPTED,
+        "an exact admission retry is idempotent"
+    );
+    assert_eq!(
+        steer_turn_with_id(
+            &router,
+            &bearer,
+            chat.id,
+            steer_id,
+            turn_id,
+            "different request data",
+            true,
+        )
+        .await,
+        StatusCode::CONFLICT,
+        "reusing an identity for different input must fail"
     );
 
     let events = wait_for_turn(&store, chat.id).await;
@@ -1398,6 +1574,407 @@ async fn interrupt_steer_preempts_a_running_turn_and_continues() {
             .iter()
             .any(|e| matches!(e.event, AgentEvent::TurnCancelled { .. })),
         "steer continues the turn"
+    );
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| (message.id, message.role, message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (messages[0].id, openwave_core::Role::User, "go"),
+            (
+                openwave_core::MessageId(steer_id.0),
+                openwave_core::Role::User,
+                "change course",
+            ),
+            (
+                messages[2].id,
+                openwave_core::Role::Assistant,
+                "after steer"
+            ),
+        ]
+    );
+    assert!(matches!(
+        store
+            .accept_turn_steer(steer_id, turn_id, chat.id, "change course", true)
+            .await
+            .unwrap(),
+        openwave_core::AcceptTurnSteerOutcome::Existing(openwave_core::TurnSteer {
+            status: openwave_core::TurnSteerStatus::Applied,
+            ..
+        })
+    ));
+}
+
+#[tokio::test]
+async fn boundary_steer_commits_the_candidate_and_instruction_atomically() {
+    struct FinishAfterGate {
+        calls: Arc<AtomicUsize>,
+        gate: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for FinishAfterGate {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("finish-after-gate")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                let gate = self.gate.clone();
+                return Ok(stream::iter(vec![ProviderEvent::TextDelta {
+                    text: "candidate".into(),
+                }])
+                .chain(stream::once(async move {
+                    gate.notified().await;
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    }
+                }))
+                .boxed());
+            }
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "final".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let gate = Arc::new(Notify::new());
+    let (router, token, store, _dir) = test_app_with(Arc::new(FinishAfterGate {
+        calls: calls.clone(),
+        gate: gate.clone(),
+    }))
+    .await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
+        StatusCode::ACCEPTED
+    );
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let steer_id = TurnSteerId::new();
+    assert_eq!(
+        steer_turn_with_id(
+            &router,
+            &bearer,
+            chat.id,
+            steer_id,
+            turn_id,
+            "continue with this",
+            false,
+        )
+        .await,
+        StatusCode::ACCEPTED
+    );
+    gate.notify_one();
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCompleted { .. })
+    ));
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| (message.id, message.role, message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (messages[0].id, openwave_core::Role::User, "go"),
+            (messages[1].id, openwave_core::Role::Assistant, "candidate",),
+            (
+                openwave_core::MessageId(steer_id.0),
+                openwave_core::Role::User,
+                "continue with this",
+            ),
+            (messages[3].id, openwave_core::Role::Assistant, "final"),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn durable_steer_poll_recovers_a_missing_local_notification() {
+    struct StallThenFinish {
+        calls: AtomicUsize,
+    }
+    #[async_trait]
+    impl ModelProvider for StallThenFinish {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("durable-steer-poll")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Ok(stream::pending().boxed());
+            }
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "after durable poll".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    let provider = Arc::new(StallThenFinish {
+        calls: AtomicUsize::new(0),
+    });
+    let (router, token, store, _dir) = test_app_with(provider.clone()).await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
+        StatusCode::ACCEPTED
+    );
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let steer_id = TurnSteerId::new();
+    assert!(matches!(
+        store
+            .accept_turn_steer(
+                steer_id,
+                turn_id,
+                chat.id,
+                "recover from the database",
+                true,
+            )
+            .await
+            .unwrap(),
+        openwave_core::AcceptTurnSteerOutcome::Accepted(_)
+    ));
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+    assert!(events.iter().any(|event| matches!(
+        &event.event,
+        AgentEvent::UserSteered { content } if content == "recover from the database"
+    )));
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCompleted { .. })
+    ));
+    assert!(matches!(
+        store
+            .accept_turn_steer(
+                steer_id,
+                turn_id,
+                chat.id,
+                "recover from the database",
+                true,
+            )
+            .await
+            .unwrap(),
+        openwave_core::AcceptTurnSteerOutcome::Existing(openwave_core::TurnSteer {
+            status: openwave_core::TurnSteerStatus::Applied,
+            ..
+        })
+    ));
+}
+
+#[tokio::test]
+async fn durable_steer_retries_heartbeat_races_and_ambiguous_application() {
+    struct StallThenFinish {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for StallThenFinish {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("durable-steer-retry")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Ok(stream::pending().boxed());
+            }
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "recovered".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let inner: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let injected = Arc::new(PauseTerminalStore::new(
+        inner,
+        Arc::new(Notify::new()),
+        Arc::new(Notify::new()),
+    ));
+    injected.do_not_pause_terminal();
+    let store: Arc<dyn Store> = injected.clone();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(StallThenFinish {
+            calls: calls.clone(),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
+        StatusCode::ACCEPTED
+    );
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    injected.advance_before_next_steer_read();
+    injected.fail_after_next_apply_steer_commit();
+    let steer_id = TurnSteerId::new();
+    assert_eq!(
+        steer_turn_with_id(
+            &router,
+            &bearer,
+            chat.id,
+            steer_id,
+            turn_id,
+            "recover exactly",
+            true,
+        )
+        .await,
+        StatusCode::ACCEPTED
+    );
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCompleted { .. })
+    ));
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| (message.id, message.role, message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (messages[0].id, openwave_core::Role::User, "go"),
+            (
+                openwave_core::MessageId(steer_id.0),
+                openwave_core::Role::User,
+                "recover exactly",
+            ),
+            (messages[2].id, openwave_core::Role::Assistant, "recovered"),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn queued_steer_is_applied_when_the_worker_claims_the_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    let router = app(state.clone());
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
+        StatusCode::ACCEPTED
+    );
+    let steer_id = TurnSteerId::new();
+    assert_eq!(
+        steer_turn_with_id(
+            &router,
+            &bearer,
+            chat.id,
+            steer_id,
+            turn_id,
+            "queued direction",
+            false,
+        )
+        .await,
+        StatusCode::ACCEPTED
+    );
+
+    spawn_turn_worker(&state);
+    let events = wait_for_turn(&store, chat.id).await;
+    assert!(events.iter().any(|event| matches!(
+        &event.event,
+        AgentEvent::UserSteered { content } if content == "queued direction"
+    )));
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| (message.id, message.role, message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (messages[0].id, openwave_core::Role::User, "go"),
+            (
+                openwave_core::MessageId(steer_id.0),
+                openwave_core::Role::User,
+                "queued direction",
+            ),
+            (messages[2].id, openwave_core::Role::Assistant, "hi"),
+        ]
     );
 }
 
@@ -4551,6 +5128,7 @@ async fn worker_renews_a_near_expiry_ambiguous_claim_before_execution() {
         turn_worker::TurnWorkerConfig {
             lease: Duration::from_millis(600),
             heartbeat: Duration::from_millis(200),
+            steer_poll: Duration::from_millis(10),
             idle_min: Duration::from_millis(10),
             idle_cap: Duration::from_millis(20),
             failure_delay: Duration::from_millis(10),
@@ -4643,6 +5221,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
         turn_worker::TurnWorkerConfig {
             lease: Duration::from_millis(250),
             heartbeat: Duration::from_millis(50),
+            steer_poll: Duration::from_millis(10),
             idle_min: Duration::from_millis(10),
             idle_cap: Duration::from_millis(20),
             failure_delay: Duration::from_millis(10),
@@ -4663,7 +5242,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
         .await
         .expect("worker reached the blocked event append");
     tokio::time::sleep(Duration::from_millis(400)).await;
-    release.notify_waiters();
+    release.notify_one();
 
     let events = wait_for_turn(&store, chat.id).await;
     assert!(
@@ -4885,8 +5464,8 @@ async fn durable_slot_stays_held_and_cancel_can_win_terminal_commit_race() {
     );
     assert_eq!(
         steer_turn(&router, &bearer, chat.id, turn_id, "late", false).await,
-        StatusCode::CONFLICT,
-        "steer must not reach an agent that has already quiesced"
+        StatusCode::ACCEPTED,
+        "a live durable turn must accept steering even while completion is in flight"
     );
     assert_eq!(
         cancel_turn(&router, &bearer, chat.id, turn_id).await,
@@ -4894,15 +5473,268 @@ async fn durable_slot_stays_held_and_cancel_can_win_terminal_commit_race() {
         "durable cancellation may win until completion commits"
     );
 
-    release.notify_waiters();
+    release.notify_one();
     let events = wait_for_turn(&store, chat.id).await;
     assert!(matches!(
         events.last().map(|event| &event.event),
         Some(AgentEvent::TurnCancelled { .. })
     ));
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| (message.role, message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(openwave_core::Role::User, "one")],
+        "cancellation rejects the pending steer without an orphan assistant candidate"
+    );
     assert_eq!(
         send_message(&router, &bearer, chat.id, "two").await,
         StatusCode::ACCEPTED
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn steer_wins_a_completion_race_and_restarts_generation() {
+    struct FinishTwice {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for FinishTwice {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("finish-twice")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let text = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                "before steer"
+            } else {
+                "after steer"
+            };
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta { text: text.into() },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let inner: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let store: Arc<dyn Store> = Arc::new(PauseTerminalStore::new(
+        inner,
+        entered.clone(),
+        release.clone(),
+    ));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FinishTwice {
+            calls: calls.clone(),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
+        StatusCode::ACCEPTED
+    );
+    tokio::time::timeout(Duration::from_secs(2), entered.notified())
+        .await
+        .expect("first generation reached its atomic completion");
+
+    let steer_id = TurnSteerId::new();
+    assert_eq!(
+        steer_turn_with_id(
+            &router,
+            &bearer,
+            chat.id,
+            steer_id,
+            turn_id,
+            "replace the answer",
+            false,
+        )
+        .await,
+        StatusCode::ACCEPTED
+    );
+    release.notify_one();
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    let interrupted_at = events
+        .iter()
+        .position(|event| matches!(event.event, AgentEvent::StreamInterrupted))
+        .expect("superseded output clears already-streamed deltas");
+    let steered_at = events
+        .iter()
+        .position(|event| {
+            matches!(
+                &event.event,
+                AgentEvent::UserSteered { content } if content == "replace the answer"
+            )
+        })
+        .expect("the next generation applies the durable steer");
+    assert!(interrupted_at < steered_at);
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCompleted { .. })
+    ));
+
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| (message.id, message.role, message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (messages[0].id, openwave_core::Role::User, "go"),
+            (
+                openwave_core::MessageId(steer_id.0),
+                openwave_core::Role::User,
+                "replace the answer",
+            ),
+            (
+                messages[2].id,
+                openwave_core::Role::Assistant,
+                "after steer"
+            ),
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn late_steers_share_the_turn_wide_model_step_budget() {
+    struct CountedFinish {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for CountedFinish {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("counted-finish")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "candidate".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let inner: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let store: Arc<dyn Store> = Arc::new(PauseTerminalStore::new(
+        inner,
+        entered.clone(),
+        release.clone(),
+    ));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(CountedFinish {
+            calls: calls.clone(),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            max_steps: 1,
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
+        StatusCode::ACCEPTED
+    );
+    tokio::time::timeout(Duration::from_secs(2), entered.notified())
+        .await
+        .expect("model output reached atomic completion");
+    assert_eq!(
+        steer_turn(
+            &router,
+            &bearer,
+            chat.id,
+            turn_id,
+            "too late for another call",
+            false,
+        )
+        .await,
+        StatusCode::ACCEPTED
+    );
+    release.notify_one();
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnFailed { error }) if error.kind == "max_steps_exceeded"
+    ));
+    assert_eq!(
+        store
+            .list_messages(chat.id)
+            .await
+            .unwrap()
+            .iter()
+            .map(|message| (message.role, message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(openwave_core::Role::User, "go")]
     );
 }
 

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -22,6 +22,7 @@ use crate::state::TurnGuard;
 pub(crate) struct TurnWorkerConfig {
     pub(crate) lease: Duration,
     pub(crate) heartbeat: Duration,
+    pub(crate) steer_poll: Duration,
     pub(crate) idle_min: Duration,
     pub(crate) idle_cap: Duration,
     pub(crate) failure_delay: Duration,
@@ -33,6 +34,7 @@ impl Default for TurnWorkerConfig {
         Self {
             lease: Duration::from_secs(60),
             heartbeat: Duration::from_secs(15),
+            steer_poll: Duration::from_millis(250),
             idle_min: Duration::from_millis(250),
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
@@ -81,6 +83,12 @@ enum HeartbeatOutcome {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum LeaseState {
+    Running,
+    Cancelling,
+    Lost,
+}
+
+enum LiveTurnState {
     Running,
     Cancelling,
     Lost,
@@ -169,6 +177,7 @@ impl TurnWorker {
     ) -> Self {
         assert!(!config.lease.is_zero());
         assert!(!config.heartbeat.is_zero());
+        assert!(!config.steer_poll.is_zero());
         assert!(config.heartbeat < config.lease);
         assert!(config.max_concurrency > 0);
         Self {
@@ -313,13 +322,6 @@ impl TurnWorker {
             }
             LeaseState::Lost => return Ok(TurnWorkerOutcome::LeaseLost(turn.id)),
         }
-        let mut heartbeat = AbortOnDrop(tokio::spawn(self.clone().heartbeat_lease(
-            turn.clone(),
-            lease_token,
-            cancel.clone(),
-        )));
-        let mut heartbeat_open = true;
-
         let started = AgentEvent::TurnStarted { turn_id: turn.id };
         match self.append_event(&turn, lease_token, 1, &started).await? {
             EventAppend::Committed => {}
@@ -332,185 +334,303 @@ impl TurnWorker {
             EventAppend::LeaseLost => return Ok(TurnWorkerOutcome::LeaseLost(turn.id)),
         }
 
-        let mut config = self.agent_config.clone();
-        config.model = turn.model.clone();
-        let provider = self.resolver.resolve().await;
-        let agent = Agent::new(provider, self.tools.clone(), self.store.clone(), config)
-            .with_approvals(self.approvals.clone())
-            .with_cancel(cancel.clone())
-            .with_steer(active.steer_inbox());
-        let output_message_id = MessageId::new();
-        let (events_tx, mut events_rx) = unbounded();
-        let mut drive = AbortOnDrop(tokio::spawn(async move {
-            agent
-                .run_claimed_turn(&chat, turn.id, output_message_id, &events_tx)
-                .await
-        }));
-        let mut drive_result = None;
-        let mut channel_open = true;
         let mut ordinal = 2_i32;
+        let mut total_usage = openwave_core::Usage::default();
+        let mut remaining_steps = self.agent_config.max_steps;
+        let output_message_id = MessageId::new();
+        loop {
+            let mut heartbeat = AbortOnDrop(tokio::spawn(self.clone().heartbeat_lease(
+                turn.clone(),
+                lease_token,
+                cancel.clone(),
+            )));
+            let mut heartbeat_open = true;
+            let mut config = self.agent_config.clone();
+            config.model = turn.model.clone();
+            config.max_steps = remaining_steps;
+            let provider = self.resolver.resolve().await;
+            let steer = active.steer_inbox();
+            let agent = Agent::new(provider, self.tools.clone(), self.store.clone(), config)
+                .with_approvals(self.approvals.clone())
+                .with_cancel(cancel.clone())
+                .with_steer(steer.clone())
+                .with_durable_steer(lease_token);
+            let chat = chat.clone();
+            let (events_tx, mut events_rx) = unbounded();
+            let mut drive = AbortOnDrop(tokio::spawn(async move {
+                agent
+                    .run_claimed_turn(&chat, turn.id, output_message_id, &events_tx)
+                    .await
+            }));
+            let mut drive_result = None;
+            let mut channel_open = true;
+            let mut steer_poll = tokio::time::interval(self.config.steer_poll);
+            steer_poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
-        while drive_result.is_none() || channel_open {
-            tokio::select! {
-                result = &mut drive.0, if drive_result.is_none() => {
-                    drive_result = Some(result);
-                }
-                event = events_rx.next(), if channel_open => {
-                    match event {
-                        Some(event) => {
-                            match self.append_event(&turn, lease_token, ordinal, &event).await? {
-                                EventAppend::Committed => {
-                                    ordinal = ordinal.checked_add(1).ok_or_else(|| {
-                                        AgentError::msg(format!("turn {} event ordinal exhausted", turn.id))
-                                    })?;
-                                }
-                                EventAppend::Cancelling => cancel.cancel(),
-                                EventAppend::LeaseLost => {
-                                    drive.abort_and_wait().await;
-                                    if heartbeat_open {
-                                        heartbeat.abort_and_wait().await;
+            while drive_result.is_none() || channel_open {
+                tokio::select! {
+                    result = &mut drive.0, if drive_result.is_none() => {
+                        drive_result = Some(result);
+                    }
+                    event = events_rx.next(), if channel_open => {
+                        match event {
+                            Some(event) => {
+                                match self.append_event(&turn, lease_token, ordinal, &event).await? {
+                                    EventAppend::Committed => {
+                                        ordinal = ordinal.checked_add(1).ok_or_else(|| {
+                                            AgentError::msg(format!("turn {} event ordinal exhausted", turn.id))
+                                        })?;
                                     }
-                                    return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    EventAppend::Cancelling => cancel.cancel(),
+                                    EventAppend::LeaseLost => {
+                                        drive.abort_and_wait().await;
+                                        if heartbeat_open {
+                                            heartbeat.abort_and_wait().await;
+                                        }
+                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    }
                                 }
                             }
+                            None => channel_open = false,
                         }
-                        None => channel_open = false,
                     }
-                }
-                result = &mut heartbeat.0, if heartbeat_open => {
-                    match result {
-                        Ok(HeartbeatOutcome::Cancelling) => heartbeat_open = false,
-                        Ok(HeartbeatOutcome::LeaseLost) | Err(_) => {
-                            drive.abort_and_wait().await;
-                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                    result = &mut heartbeat.0, if heartbeat_open => {
+                        match result {
+                            Ok(HeartbeatOutcome::Cancelling) => heartbeat_open = false,
+                            Ok(HeartbeatOutcome::LeaseLost) | Err(_) => {
+                                drive.abort_and_wait().await;
+                                return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                            }
+                        }
+                    }
+                    _ = steer_poll.tick(), if drive_result.is_none() => {
+                        match self
+                            .store
+                            .list_pending_turn_steers(turn.id, lease_token, Utc::now())
+                            .await
+                        {
+                            Ok(Some(pending)) if !pending.is_empty() => {
+                                steer.signal_durable(pending.iter().any(|item| item.interrupt));
+                            }
+                            Ok(_) => {}
+                            Err(error) => {
+                                eprintln!(
+                                    "openwave: turn {} steer poll failed: {error}",
+                                    turn.id
+                                );
+                            }
                         }
                     }
                 }
             }
-        }
-        // Freeze periodic lease writes before terminal CAS. A concurrent
-        // heartbeat would legitimately change `updated_at` between the
-        // resolution read and update and make this worker race itself.
-        if heartbeat_open {
-            heartbeat.abort_and_wait().await;
-        }
-        let drive_result = match drive_result.expect("drive completed before its channel closed") {
-            Ok(result) => result,
-            Err(error) => Err(AgentError::msg(format!("agent task stopped: {error}"))),
-        };
-        // Prove a fresh full lease after stopping the periodic task. This both
-        // closes near-expiry ambiguous-claim recovery and gives exact terminal
-        // retries their full resolution window without a self-racing heartbeat.
-        match self.renew_lease(&turn, lease_token).await {
-            LeaseState::Running => {}
-            LeaseState::Cancelling => {
-                let usage = match &drive_result {
-                    Ok(AgentTurnOutcome::Completed { usage, .. })
-                    | Ok(AgentTurnOutcome::Cancelled { usage }) => *usage,
-                    Err(_) => openwave_core::Usage::default(),
+            if heartbeat_open {
+                heartbeat.abort_and_wait().await;
+            }
+            let drive_result =
+                match drive_result.expect("drive completed before its channel closed") {
+                    Ok(result) => result,
+                    Err(error) => Err(AgentError::msg(format!("agent task stopped: {error}"))),
                 };
-                drop(active);
-                return self
-                    .acknowledge_cancellation(&turn, lease_token, usage)
-                    .await;
-            }
-            LeaseState::Lost => return Ok(TurnWorkerOutcome::LeaseLost(turn.id)),
-        }
-        drop(active);
-
-        match drive_result {
-            Ok(AgentTurnOutcome::Completed {
-                output,
-                usage,
-                stop_reason,
-            }) => {
-                if output.content.contains('\0') {
+            match self.renew_lease(&turn, lease_token).await {
+                LeaseState::Running => {}
+                LeaseState::Cancelling => {
+                    let usage = match &drive_result {
+                        Ok(AgentTurnOutcome::Completed { usage, .. })
+                        | Ok(AgentTurnOutcome::Cancelled { usage, .. }) => *usage,
+                        Err(_) => openwave_core::Usage::default(),
+                    };
+                    total_usage += usage;
+                    drop(active);
                     return self
-                        .record_failure(
-                            &turn,
-                            lease_token,
-                            "invalid_agent_output",
-                            "agent output contained a NUL character",
-                        )
+                        .acknowledge_cancellation(&turn, lease_token, total_usage)
                         .await;
                 }
-                let terminal_event = AgentEvent::TurnCompleted { usage, stop_reason };
-                loop {
-                    match self
-                        .store
-                        .complete_turn_run_and_append_event(
-                            turn.id,
-                            lease_token,
-                            turn.steer_revision,
-                            Utc::now(),
-                            &output,
-                            usage,
-                            stop_reason,
-                        )
-                        .await
-                    {
-                        Ok(Some(resolution)) => match resolution.outcome {
-                            CompleteTurnRunOutcome::Completed(_)
-                            | CompleteTurnRunOutcome::Existing(_) => {
-                                if let Some(event) = resolution.terminal_event {
-                                    self.publish(turn.chat_id, event);
-                                }
-                                return Ok(TurnWorkerOutcome::Completed(turn.id));
-                            }
-                            CompleteTurnRunOutcome::SteerPending(_)
-                            | CompleteTurnRunOutcome::OutputSuperseded(_) => {
-                                return Err(AgentError::msg(format!(
-                                    "turn {} requires durable steer continuation",
-                                    turn.id
-                                )));
-                            }
-                        },
-                        Ok(None) => break,
-                        Err(error) => {
-                            self.retry_after("completion", turn.id, &error).await;
-                            match self
-                                .resolution_state_retry(
-                                    &turn,
-                                    lease_token,
-                                    TerminalIdentity::Completed {
-                                        output_message_id: output.id,
-                                        event: &terminal_event,
-                                    },
-                                )
-                                .await
-                            {
-                                ResolutionState::Retry => {}
-                                ResolutionState::Resolved(event) => {
-                                    self.publish(turn.chat_id, event);
+                LeaseState::Lost => return Ok(TurnWorkerOutcome::LeaseLost(turn.id)),
+            }
+
+            match drive_result {
+                Ok(AgentTurnOutcome::Completed {
+                    output,
+                    usage,
+                    stop_reason,
+                    steer_revision,
+                    model_steps,
+                }) => {
+                    if model_steps == 0 || model_steps > remaining_steps {
+                        return Err(AgentError::msg(format!(
+                            "turn {} returned an invalid model-step count {model_steps}",
+                            turn.id
+                        )));
+                    }
+                    remaining_steps -= model_steps;
+                    total_usage += usage;
+                    if output.content.contains('\0') {
+                        return self
+                            .record_failure(
+                                &turn,
+                                lease_token,
+                                "invalid_agent_output",
+                                "agent output contained a NUL character",
+                            )
+                            .await;
+                    }
+                    let expected_steer_revision = steer_revision.ok_or_else(|| {
+                        AgentError::msg(format!(
+                            "turn {} completed without a durable generation fence",
+                            turn.id
+                        ))
+                    })?;
+                    let terminal_event = AgentEvent::TurnCompleted {
+                        usage: total_usage,
+                        stop_reason,
+                    };
+                    let mut continue_after_steer = false;
+                    loop {
+                        match self
+                            .store
+                            .complete_turn_run_and_append_event(
+                                turn.id,
+                                lease_token,
+                                expected_steer_revision,
+                                Utc::now(),
+                                &output,
+                                total_usage,
+                                stop_reason,
+                            )
+                            .await
+                        {
+                            Ok(Some(resolution)) => match resolution.outcome {
+                                CompleteTurnRunOutcome::Completed(_)
+                                | CompleteTurnRunOutcome::Existing(_) => {
+                                    if let Some(event) = resolution.terminal_event {
+                                        self.publish(turn.chat_id, event);
+                                    }
                                     return Ok(TurnWorkerOutcome::Completed(turn.id));
                                 }
-                                ResolutionState::Cancelling => break,
-                                ResolutionState::Lost => {
-                                    return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                CompleteTurnRunOutcome::SteerPending(_)
+                                | CompleteTurnRunOutcome::OutputSuperseded(_) => {
+                                    continue_after_steer = true;
+                                    break;
+                                }
+                            },
+                            Ok(None) => {
+                                // A concurrent durable admission can advance
+                                // `updated_at` after this completion timestamp
+                                // without changing the generation. Re-read the
+                                // exact lease before deciding whether this was
+                                // cancellation, lease loss, or a retryable CAS
+                                // miss. Keep the original steer revision fence:
+                                // if the steer was applied concurrently, the
+                                // retry must supersede this output.
+                                match self.live_turn_state_retry(&turn, lease_token).await {
+                                    LiveTurnState::Running => tokio::task::yield_now().await,
+                                    LiveTurnState::Cancelling => break,
+                                    LiveTurnState::Lost => {
+                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    }
+                                }
+                            }
+                            Err(error) => {
+                                self.retry_after("completion", turn.id, &error).await;
+                                match self
+                                    .resolution_state_retry(
+                                        &turn,
+                                        lease_token,
+                                        TerminalIdentity::Completed {
+                                            output_message_id: output.id,
+                                            event: &terminal_event,
+                                        },
+                                    )
+                                    .await
+                                {
+                                    ResolutionState::Retry => {}
+                                    ResolutionState::Resolved(event) => {
+                                        self.publish(turn.chat_id, event);
+                                        return Ok(TurnWorkerOutcome::Completed(turn.id));
+                                    }
+                                    ResolutionState::Cancelling => break,
+                                    ResolutionState::Lost => {
+                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    }
                                 }
                             }
                         }
                     }
-                }
-                self.acknowledge_cancellation(&turn, lease_token, usage)
-                    .await
-            }
-            Ok(AgentTurnOutcome::Cancelled { usage }) => {
-                self.acknowledge_cancellation(&turn, lease_token, usage)
-                    .await
-            }
-            Err(error) => {
-                if self.is_cancelling_retry(&turn, lease_token).await {
+                    if continue_after_steer {
+                        if remaining_steps == 0 {
+                            drop(active);
+                            return self
+                                .record_failure(
+                                    &turn,
+                                    lease_token,
+                                    "max_steps_exceeded",
+                                    "max steps per turn exceeded while applying durable steering",
+                                )
+                                .await;
+                        }
+                        // Completion must stop the normal heartbeat to avoid
+                        // racing its own CAS. Once completion chooses a
+                        // nonterminal continuation, resume heartbeats while the
+                        // journal append retries so a transient store outage
+                        // cannot consume the accepted steer's lease.
+                        let mut continuation_heartbeat = AbortOnDrop(tokio::spawn(
+                            self.clone()
+                                .heartbeat_lease(turn.clone(), lease_token, cancel.clone()),
+                        ));
+                        match self
+                            .append_event(
+                                &turn,
+                                lease_token,
+                                ordinal,
+                                &AgentEvent::StreamInterrupted,
+                            )
+                            .await?
+                        {
+                            EventAppend::Committed => {
+                                ordinal = ordinal.checked_add(1).ok_or_else(|| {
+                                    AgentError::msg(format!(
+                                        "turn {} event ordinal exhausted",
+                                        turn.id
+                                    ))
+                                })?;
+                            }
+                            EventAppend::Cancelling => {
+                                cancel.cancel();
+                                drop(active);
+                                return self
+                                    .acknowledge_cancellation(&turn, lease_token, total_usage)
+                                    .await;
+                            }
+                            EventAppend::LeaseLost => {
+                                return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                            }
+                        }
+                        continuation_heartbeat.abort_and_wait().await;
+                        continue;
+                    }
+                    drop(active);
                     return self
-                        .acknowledge_cancellation(
-                            &turn,
-                            lease_token,
-                            openwave_core::Usage::default(),
-                        )
+                        .acknowledge_cancellation(&turn, lease_token, total_usage)
                         .await;
                 }
-                self.record_failure(&turn, lease_token, "agent_error", &error.to_string())
-                    .await
+                Ok(AgentTurnOutcome::Cancelled { usage, .. }) => {
+                    total_usage += usage;
+                    drop(active);
+                    return self
+                        .acknowledge_cancellation(&turn, lease_token, total_usage)
+                        .await;
+                }
+                Err(error) => {
+                    if self.is_cancelling_retry(&turn, lease_token).await {
+                        drop(active);
+                        return self
+                            .acknowledge_cancellation(&turn, lease_token, total_usage)
+                            .await;
+                    }
+                    return self
+                        .record_failure(&turn, lease_token, "agent_error", &error.to_string())
+                        .await;
+                }
             }
         }
     }
@@ -635,6 +755,35 @@ impl TurnWorker {
                 Err(error) => {
                     self.retry_after("cancellation check", turn.id, &error)
                         .await
+                }
+            }
+        }
+    }
+
+    async fn live_turn_state_retry(
+        &self,
+        turn: &TurnRun,
+        lease_token: uuid::Uuid,
+    ) -> LiveTurnState {
+        loop {
+            match self.store.get_turn_run(turn.id).await {
+                Ok(Some(current))
+                    if current.lease_token == Some(lease_token)
+                        && current.attempt_count == turn.attempt_count
+                        && current
+                            .lease_expires_at
+                            .is_some_and(|expires_at| expires_at > Utc::now()) =>
+                {
+                    return match current.status {
+                        TurnRunStatus::Running => LiveTurnState::Running,
+                        TurnRunStatus::Cancelling => LiveTurnState::Cancelling,
+                        _ => LiveTurnState::Lost,
+                    };
+                }
+                Ok(_) => return LiveTurnState::Lost,
+                Err(error) => {
+                    self.retry_after("turn generation fence read", turn.id, &error)
+                        .await;
                 }
             }
         }


### PR DESCRIPTION
## Summary

- admit steering instructions durably with caller-provided idempotency identities
- deliver pending instructions under the exact worker lease across restarts and process boundaries
- restart superseded generations without publishing stale assistant output
- poll the durable inbox so lost process-local notifications recover automatically
- preserve exact message ordering and cancellation/completion fencing

## Validation

- `cargo test -p openwave-core --locked steer`
- `cargo test -p openwave-server --locked`
- `cargo check --workspace --all-targets --all-features --locked`
- `bw dev lint --rust --check --repo-root "$PWD"`