### PR TITLE
fix(core): journal applied turn steering atomically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,6 +2976,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5746,6 +5752,7 @@ dependencies = [
  "cap-std",
  "chrono",
  "futures",
+ "futures-timer",
  "keyring",
  "sea-orm",
  "sea-orm-migration",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1"
 cap-std = "4.0.2"
 cap-fs-ext = "4.0.2"
 futures = "0.3"
+futures-timer = "3"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -39,6 +39,7 @@ async-trait = { workspace = true }
 cap-std = { workspace = true, optional = true }
 cap-fs-ext = { workspace = true, optional = true }
 futures = { workspace = true }
+futures-timer = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -16,27 +16,29 @@
 //!   retries with progressive reduction on provider prompt-too-long errors.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
-use std::task::Poll;
+use std::time::Duration;
 
 use chrono::Utc;
-use futures::channel::mpsc::UnboundedSender;
+use futures::channel::{mpsc::UnboundedSender, oneshot};
 use futures::future::{self, Either};
 use futures::StreamExt;
+use futures_timer::Delay;
 use serde_json::Value;
 
 use crate::approval::{ApprovalDecision, ApprovalGate, ApprovalRequest, RefuseGate};
 use crate::cancel::CancelToken;
 use crate::context;
 use crate::error::{AgentError, Result};
-use crate::event::AgentEvent;
+use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{CallId, MessageId, TurnId};
 use crate::model::{Chat, Message, Role, ToolCallRecord, TurnRunStatus};
 use crate::provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, StopReason, Usage,
 };
 use crate::steer::SteerInbox;
-use crate::storage::{ApplyTurnSteerOutcome, Store};
+use crate::storage::{ApplyTurnSteerOutcome, JournaledTurnSteerOutcome, Store};
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 
 /// A name-keyed registry of the tools available to the agent.
@@ -155,6 +157,87 @@ pub enum AgentTurnOutcome {
     },
 }
 
+/// One emission from a durably claimed agent generation.
+///
+/// Ordinary events still need the worker to append them. A committed event was
+/// journaled atomically with another state transition and only needs live
+/// publication. Flush barriers let the agent wait until every preceding
+/// ordinary event is durable before it performs such a transition.
+pub enum ClaimedAgentEvent {
+    /// Append this event under its exact attempt ordinal.
+    Pending { ordinal: i32, event: AgentEvent },
+    /// Publish an event whose journal transaction already committed.
+    Committed { ordinal: i32, event: SequencedEvent },
+    /// Acknowledge after all preceding channel items have been handled.
+    Flush(oneshot::Sender<()>),
+}
+
+enum EventSink<'a> {
+    Legacy(&'a UnboundedSender<AgentEvent>),
+    Claimed {
+        sender: &'a UnboundedSender<ClaimedAgentEvent>,
+        next_ordinal: AtomicI32,
+    },
+}
+
+impl EventSink<'_> {
+    fn send(&self, event: AgentEvent) {
+        match self {
+            Self::Legacy(sender) => {
+                let _ = sender.unbounded_send(event);
+            }
+            Self::Claimed {
+                sender,
+                next_ordinal,
+            } => {
+                if let Ok(ordinal) = reserve_event_ordinal(next_ordinal) {
+                    let _ = sender.unbounded_send(ClaimedAgentEvent::Pending { ordinal, event });
+                }
+            }
+        }
+    }
+
+    async fn flush(&self) -> Result<()> {
+        let Self::Claimed { sender, .. } = self else {
+            return Ok(());
+        };
+        let (acknowledge, acknowledged) = oneshot::channel();
+        sender
+            .unbounded_send(ClaimedAgentEvent::Flush(acknowledge))
+            .map_err(|_| AgentError::Store("claimed turn event channel closed".into()))?;
+        acknowledged
+            .await
+            .map_err(|_| AgentError::Store("claimed turn event flush was abandoned".into()))
+    }
+
+    fn reserve_ordinal(&self) -> Result<i32> {
+        match self {
+            Self::Claimed { next_ordinal, .. } => reserve_event_ordinal(next_ordinal),
+            Self::Legacy(_) => Err(AgentError::Store(
+                "legacy turn cannot reserve a durable event ordinal".into(),
+            )),
+        }
+    }
+
+    fn send_committed(&self, ordinal: i32, event: SequencedEvent) -> Result<()> {
+        let Self::Claimed { sender, .. } = self else {
+            return Err(AgentError::Store(
+                "legacy turn cannot publish a committed durable event".into(),
+            ));
+        };
+        sender
+            .unbounded_send(ClaimedAgentEvent::Committed { ordinal, event })
+            .map_err(|_| AgentError::Store("claimed turn event channel closed".into()))
+    }
+}
+
+fn reserve_event_ordinal(next: &AtomicI32) -> Result<i32> {
+    next.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |ordinal| {
+        ordinal.checked_add(1).filter(|next| *next < i32::MAX)
+    })
+    .map_err(|_| AgentError::Store("turn event ordinal exhausted".into()))
+}
+
 #[derive(Clone, Copy)]
 struct TurnExecution<'a> {
     turn_id: TurnId,
@@ -252,6 +335,7 @@ impl Agent {
     ) -> Result<()> {
         let turn_id = TurnId::new();
         let output_message_id = MessageId::new();
+        let events = EventSink::Legacy(events);
         self.run_turn_inner(
             chat,
             TurnExecution {
@@ -262,7 +346,7 @@ impl Agent {
                 publish_started: true,
                 publish_terminal: true,
             },
-            events,
+            &events,
         )
         .await
         .map(|_| ())
@@ -284,13 +368,21 @@ impl Agent {
         chat: &Chat,
         turn_id: TurnId,
         output_message_id: MessageId,
-        events: &UnboundedSender<AgentEvent>,
+        first_event_ordinal: i32,
+        events: &UnboundedSender<ClaimedAgentEvent>,
     ) -> Result<AgentTurnOutcome> {
-        if turn_id.0.is_nil() || output_message_id.0.is_nil() {
+        if turn_id.0.is_nil()
+            || output_message_id.0.is_nil()
+            || !(1..i32::MAX).contains(&first_event_ordinal)
+        {
             return Err(AgentError::Store(
-                "claimed turn and output message ids must not be nil".into(),
+                "claimed turn identities and first event ordinal must be valid".into(),
             ));
         }
+        let events = EventSink::Claimed {
+            sender: events,
+            next_ordinal: AtomicI32::new(first_event_ordinal),
+        };
         self.run_turn_inner(
             chat,
             TurnExecution {
@@ -301,7 +393,7 @@ impl Agent {
                 publish_started: false,
                 publish_terminal: false,
             },
-            events,
+            &events,
         )
         .await
     }
@@ -310,10 +402,10 @@ impl Agent {
         &self,
         chat: &Chat,
         execution: TurnExecution<'_>,
-        events: &UnboundedSender<AgentEvent>,
+        events: &EventSink<'_>,
     ) -> Result<AgentTurnOutcome> {
         if execution.publish_started {
-            let _ = events.unbounded_send(AgentEvent::TurnStarted {
+            events.send(AgentEvent::TurnStarted {
                 turn_id: execution.turn_id,
             });
         }
@@ -321,7 +413,7 @@ impl Agent {
             Ok(outcome) => Ok(outcome),
             Err(err) => {
                 if execution.publish_terminal {
-                    let _ = events.unbounded_send(AgentEvent::TurnFailed {
+                    events.send(AgentEvent::TurnFailed {
                         error: (&err).into(),
                     });
                 }
@@ -334,7 +426,7 @@ impl Agent {
         &self,
         chat: &Chat,
         execution: TurnExecution<'_>,
-        events: &UnboundedSender<AgentEvent>,
+        events: &EventSink<'_>,
     ) -> Result<AgentTurnOutcome> {
         let TurnExecution {
             turn_id,
@@ -387,7 +479,7 @@ impl Agent {
                         // a UI can surface it. Emitted only for the request that
                         // actually went out (after any retry climb).
                         if reduced {
-                            let _ = events.unbounded_send(AgentEvent::ContextTruncated {
+                            events.send(AgentEvent::ContextTruncated {
                                 original_tokens: context::estimate_transcript_tokens(&transcript)
                                     as u32,
                                 fitted_tokens: fitted_tokens as u32,
@@ -431,17 +523,17 @@ impl Agent {
                 };
                 match event {
                     ProviderEvent::TextDelta { text: delta } => {
-                        let _ = events.unbounded_send(AgentEvent::TextDelta {
+                        events.send(AgentEvent::TextDelta {
                             text: delta.clone(),
                         });
                         text.push_str(&delta);
                     }
                     ProviderEvent::ReasoningDelta { text: delta } => {
-                        let _ = events.unbounded_send(AgentEvent::ReasoningDelta { text: delta });
+                        events.send(AgentEvent::ReasoningDelta { text: delta });
                     }
                     ProviderEvent::ToolCallStarted { index, id, name } => {
                         let call_id = CallId::new();
-                        let _ = events.unbounded_send(AgentEvent::ToolCallStarted {
+                        events.send(AgentEvent::ToolCallStarted {
                             call_id,
                             name: name.clone(),
                         });
@@ -455,7 +547,7 @@ impl Agent {
                     }
                     ProviderEvent::ToolCallArgsDelta { index, fragment } => {
                         if let Some(&i) = by_index.get(&index) {
-                            let _ = events.unbounded_send(AgentEvent::ToolCallArgsDelta {
+                            events.send(AgentEvent::ToolCallArgsDelta {
                                 call_id: calls[i].call_id,
                                 fragment: fragment.clone(),
                             });
@@ -476,7 +568,7 @@ impl Agent {
                 // Discard this step's partial output — nothing from it was
                 // persisted. The marker lets replay/live clients clear deltas
                 // that were already streamed for this abandoned provider step.
-                let _ = events.unbounded_send(AgentEvent::StreamInterrupted);
+                events.send(AgentEvent::StreamInterrupted);
                 self.apply_steers(chat, turn_id, &mut transcript, None, events)
                     .await?;
                 continue;
@@ -582,7 +674,7 @@ impl Agent {
                     }
                     if self.steer.try_complete(|| {
                         if publish_terminal {
-                            let _ = events.unbounded_send(AgentEvent::TurnCompleted {
+                            events.send(AgentEvent::TurnCompleted {
                                 usage: total_usage,
                                 stop_reason,
                             });
@@ -612,7 +704,7 @@ impl Agent {
             let mut results: Vec<ContentBlock> = Vec::new();
             for call in &calls {
                 let output = self.run_tool(chat, turn_id, call, events).await;
-                let _ = events.unbounded_send(AgentEvent::ToolCallCompleted {
+                events.send(AgentEvent::ToolCallCompleted {
                     call_id: call.call_id,
                     output: output.clone(),
                 });
@@ -663,13 +755,13 @@ impl Agent {
     /// success — the client asked for the stop, so it isn't a `TurnFailed`.
     fn finish_cancelled(
         &self,
-        events: &UnboundedSender<AgentEvent>,
+        events: &EventSink<'_>,
         usage: Usage,
         model_steps: usize,
         publish_terminal_event: bool,
     ) -> AgentTurnOutcome {
         if publish_terminal_event {
-            let _ = events.unbounded_send(AgentEvent::TurnCancelled { usage });
+            events.send(AgentEvent::TurnCancelled { usage });
         }
         AgentTurnOutcome::Cancelled { usage, model_steps }
     }
@@ -682,7 +774,7 @@ impl Agent {
         turn_id: TurnId,
         transcript: &mut Vec<ChatMessage>,
         preceding_assistant: Option<&str>,
-        events: &UnboundedSender<AgentEvent>,
+        events: &EventSink<'_>,
     ) -> Result<bool> {
         let msgs = self.steer.drain();
         let durable = match self.durable_steer_lease {
@@ -712,7 +804,7 @@ impl Agent {
                     text: msg.content.clone(),
                 }],
             });
-            let _ = events.unbounded_send(AgentEvent::UserSteered {
+            events.send(AgentEvent::UserSteered {
                 content: msg.content,
             });
         }
@@ -726,31 +818,35 @@ impl Agent {
                 content: text.to_owned(),
                 created_at: Utc::now(),
             });
+        if !durable.is_empty() {
+            events.flush().await?;
+        }
         let lease_token = self.durable_steer_lease;
         for (index, steer) in durable.into_iter().enumerate() {
             let preceding_assistant = if index == 0 { preceding.as_ref() } else { None };
-            let applied = self
+            let event_ordinal = events.reserve_ordinal()?;
+            let journaled = self
                 .apply_durable_steer_retry(
                     turn_id,
                     lease_token.expect("durable steering has a lease"),
                     steer.id,
+                    event_ordinal,
                     preceding_assistant,
                 )
                 .await?;
-            let steer = match applied {
+            let steer = match journaled.outcome {
                 ApplyTurnSteerOutcome::Applied(steer) | ApplyTurnSteerOutcome::Existing(steer) => {
                     steer
                 }
             };
+            let event = journaled.event;
             transcript.push(ChatMessage {
                 role: Role::User,
                 content: vec![ContentBlock::Text {
                     text: steer.content.clone(),
                 }],
             });
-            let _ = events.unbounded_send(AgentEvent::UserSteered {
-                content: steer.content,
-            });
+            events.send_committed(event_ordinal, event)?;
         }
         Ok(true)
     }
@@ -822,8 +918,10 @@ impl Agent {
         turn_id: TurnId,
         lease_token: uuid::Uuid,
         steer_id: crate::id::TurnSteerId,
+        attempt_event_ordinal: i32,
         preceding_assistant: Option<&Message>,
-    ) -> Result<ApplyTurnSteerOutcome> {
+    ) -> Result<JournaledTurnSteerOutcome> {
+        let mut exact_retry_attempted = false;
         loop {
             match self
                 .store
@@ -831,46 +929,46 @@ impl Agent {
                     turn_id,
                     lease_token,
                     steer_id,
+                    attempt_event_ordinal,
                     preceding_assistant,
                     Utc::now(),
                 )
                 .await
             {
                 Ok(Some(applied)) => return Ok(applied),
-                Ok(None) | Err(_) => {
-                    // Retrying the same identity recovers `Existing` when the
-                    // commit won but its response was lost.
+                Ok(None) => {
                     self.durable_turn_revision_retry(turn_id, lease_token)
                         .await?;
                     self.wait_for_durable_store_retry(turn_id).await?;
+                }
+                Err(_) => {
+                    // Retry the exact identity before classifying current turn
+                    // state. A committed application remains recoverable after
+                    // cancellation or lease expiry through its immutable
+                    // receipt and journal identity.
+                    if exact_retry_attempted {
+                        self.wait_for_durable_store_retry(turn_id).await?;
+                    } else {
+                        exact_retry_attempted = true;
+                        Delay::new(Duration::from_millis(10)).await;
+                    }
                 }
             }
         }
     }
 
     async fn wait_for_durable_store_retry(&self, turn_id: TurnId) -> Result<()> {
-        if self.cancel.is_cancelled() {
-            return Err(AgentError::Store(format!(
+        match future::select(
+            self.cancel.cancelled(),
+            Delay::new(Duration::from_millis(10)),
+        )
+        .await
+        {
+            Either::Left(((), _)) => Err(AgentError::Store(format!(
                 "turn {turn_id} was cancelled while retrying durable steering"
-            )));
+            ))),
+            Either::Right(((), _)) => Ok(()),
         }
-        let mut yielded = false;
-        future::poll_fn(|cx| {
-            if yielded {
-                Poll::Ready(())
-            } else {
-                yielded = true;
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
-        })
-        .await;
-        if self.cancel.is_cancelled() {
-            return Err(AgentError::Store(format!(
-                "turn {turn_id} was cancelled while retrying durable steering"
-            )));
-        }
-        Ok(())
     }
 
     /// Resolve approval and execute one tool call, returning its output. Tool and
@@ -880,7 +978,7 @@ impl Agent {
         chat: &Chat,
         turn_id: TurnId,
         call: &PendingCall,
-        events: &UnboundedSender<AgentEvent>,
+        events: &EventSink<'_>,
     ) -> ToolOutput {
         let Some(tool) = self.tools.get(&call.name) else {
             return ToolOutput::error(format!("unknown tool: {}", call.name));
@@ -898,7 +996,7 @@ impl Agent {
                 class: ApprovalClass::Sensitive,
                 summary: summary.clone(),
             });
-            let _ = events.unbounded_send(AgentEvent::ApprovalRequired {
+            events.send(AgentEvent::ApprovalRequired {
                 call_id: call.call_id,
                 class: ApprovalClass::Sensitive,
                 summary,
@@ -915,7 +1013,7 @@ impl Agent {
             let decision = match future::select(pending, self.cancel.cancelled()).await {
                 Either::Left((decision, _)) if !self.cancel.is_cancelled() => decision,
                 Either::Left(_) | Either::Right(((), _)) => {
-                    let _ = events.unbounded_send(AgentEvent::ApprovalDecided {
+                    events.send(AgentEvent::ApprovalDecided {
                         call_id: call.call_id,
                         approved: false,
                     });
@@ -923,7 +1021,7 @@ impl Agent {
                 }
             };
             let approved = matches!(decision, ApprovalDecision::Approve);
-            let _ = events.unbounded_send(AgentEvent::ApprovalDecided {
+            events.send(AgentEvent::ApprovalDecided {
                 call_id: call.call_id,
                 approved,
             });
@@ -1183,6 +1281,17 @@ mod tests {
     use crate::provider::ProviderId;
     use crate::tools::ReadFile;
 
+    fn emitted_events(emissions: Vec<ClaimedAgentEvent>) -> Vec<AgentEvent> {
+        emissions
+            .into_iter()
+            .map(|emission| match emission {
+                ClaimedAgentEvent::Pending { event, .. } => event,
+                ClaimedAgentEvent::Committed { event, .. } => event.event,
+                ClaimedAgentEvent::Flush(_) => panic!("unhandled claimed-event flush"),
+            })
+            .collect()
+    }
+
     /// A scripted provider: step 0 calls `read_file`, step 1 gives a final answer.
     struct FakeProvider {
         calls: AtomicUsize,
@@ -1395,11 +1504,11 @@ mod tests {
         let output_message_id = MessageId::new();
         let (tx, rx) = unbounded();
         let outcome = agent
-            .run_claimed_turn(&chat, turn_id, output_message_id, &tx)
+            .run_claimed_turn(&chat, turn_id, output_message_id, 1, &tx)
             .await
             .unwrap();
         drop(tx);
-        let events: Vec<AgentEvent> = rx.collect().await;
+        let events = emitted_events(rx.collect().await);
 
         let AgentTurnOutcome::Completed {
             output,
@@ -1546,11 +1655,11 @@ mod tests {
         );
         let (failure_tx, failure_rx) = unbounded();
         let error = failing_agent
-            .run_claimed_turn(&chat, failed_turn_id, MessageId::new(), &failure_tx)
+            .run_claimed_turn(&chat, failed_turn_id, MessageId::new(), 1, &failure_tx)
             .await
             .expect_err("the zero-step guard fails execution");
         drop(failure_tx);
-        let failure_events: Vec<AgentEvent> = failure_rx.collect().await;
+        let failure_events = emitted_events(failure_rx.collect().await);
         assert!(failure_events.iter().all(|event| !matches!(
             event,
             AgentEvent::TurnStarted { .. }
@@ -1659,7 +1768,13 @@ mod tests {
         .with_cancel(cancel);
         let (cancellation_tx, cancellation_rx) = unbounded();
         let outcome = cancelled_agent
-            .run_claimed_turn(&chat, cancelled_turn_id, MessageId::new(), &cancellation_tx)
+            .run_claimed_turn(
+                &chat,
+                cancelled_turn_id,
+                MessageId::new(),
+                1,
+                &cancellation_tx,
+            )
             .await
             .unwrap();
         drop(cancellation_tx);
@@ -1670,7 +1785,7 @@ mod tests {
                 model_steps: 0,
             }
         );
-        let cancellation_events: Vec<AgentEvent> = cancellation_rx.collect().await;
+        let cancellation_events = emitted_events(cancellation_rx.collect().await);
         assert!(cancellation_events.iter().all(|event| !matches!(
             event,
             AgentEvent::TurnStarted { .. }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -34,9 +34,9 @@ use crate::model::{
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, ApplyTurnSteerOutcome, ClaimTurnRunOutcome,
-    CompleteTurnRunOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
-    EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome, JournaledTurnOutcome,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, ClaimTurnRunOutcome, CompleteTurnRunOutcome,
+    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
+    FinishTurnCancellationOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
     RecordTurnFailureOutcome, RequestTurnCancellationOutcome, Store,
 };
 
@@ -1709,14 +1709,16 @@ impl Store for DbStore {
         turn_id: TurnId,
         lease_token: uuid::Uuid,
         steer_id: TurnSteerId,
+        attempt_event_ordinal: i32,
         preceding_assistant: Option<&Message>,
         now: chrono::DateTime<Utc>,
-    ) -> Result<Option<ApplyTurnSteerOutcome>> {
+    ) -> Result<Option<JournaledTurnSteerOutcome>> {
         ops::turn::apply_turn_steer(
             self,
             turn_id,
             lease_token,
             steer_id,
+            attempt_event_ordinal,
             preceding_assistant,
             now,
         )

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -5,16 +5,18 @@ use sea_orm::{
 };
 
 use crate::error::{AgentError, Result};
+use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, MessageId, TurnId, TurnSteerId};
 use crate::model::{TurnRunStatus, TurnSteer, TurnSteerStatus};
-use crate::storage::{AcceptTurnSteerOutcome, ApplyTurnSteerOutcome};
+use crate::storage::{AcceptTurnSteerOutcome, ApplyTurnSteerOutcome, JournaledTurnSteerOutcome};
 
 use super::super::super::{entities, store_err, DbStore};
 use super::super::{
     acquire_chat_write_lock, acquire_turn_write_lock,
     conversation::{
-        next_message_seq_on, reserve_message_identity_on, transfer_steer_message_identity_on,
-        MESSAGE_IDENTITY_OWNER_MESSAGE, MESSAGE_IDENTITY_OWNER_STEER,
+        append_event_on, next_message_seq_on, reserve_message_identity_on,
+        transfer_steer_message_identity_on, MESSAGE_IDENTITY_OWNER_MESSAGE,
+        MESSAGE_IDENTITY_OWNER_STEER,
     },
 };
 use super::{canonical_db_timestamp, turn_run_status_from_db};
@@ -238,12 +240,18 @@ pub(in crate::db) async fn apply_turn_steer(
     turn_id: TurnId,
     lease_token: uuid::Uuid,
     steer_id: TurnSteerId,
+    attempt_event_ordinal: i32,
     preceding_assistant: Option<&crate::model::Message>,
     now: chrono::DateTime<Utc>,
-) -> Result<Option<ApplyTurnSteerOutcome>> {
+) -> Result<Option<JournaledTurnSteerOutcome>> {
     if turn_id.0.is_nil() || lease_token.is_nil() || steer_id.0.is_nil() {
         return Err(AgentError::Store(
             "turn, lease, and steer identities must not be nil".into(),
+        ));
+    }
+    if !(1..i32::MAX).contains(&attempt_event_ordinal) {
+        return Err(AgentError::Store(
+            "steer event ordinal must be positive and below the terminal slot".into(),
         ));
     }
     let now = canonical_db_timestamp(now)?;
@@ -281,9 +289,13 @@ pub(in crate::db) async fn apply_turn_steer(
             if let Some(preceding) = preceding_assistant {
                 ensure_exact_preceding_message_on(&transaction, &steer, preceding).await?;
             }
-            Some(ApplyTurnSteerOutcome::Existing(turn_steer_from_model(
-                steer,
-            )?))
+            let event =
+                exact_applied_event_on(&transaction, &steer, lease_token, attempt_event_ordinal)
+                    .await?;
+            Some(JournaledTurnSteerOutcome {
+                outcome: ApplyTurnSteerOutcome::Existing(turn_steer_from_model(steer)?),
+                event,
+            })
         } else {
             None
         };
@@ -467,9 +479,25 @@ pub(in crate::db) async fn apply_turn_steer(
         .map_err(store_err)?
         .ok_or_else(|| AgentError::Store(format!("applied steer {steer_id} disappeared")))?;
     ensure_exact_applied_message_on(&transaction, &applied).await?;
+    let event = AgentEvent::UserSteered {
+        content: applied.content.clone(),
+    };
+    let seq = append_event_on(
+        &transaction,
+        ChatId(applied.chat_id),
+        Some(turn_id),
+        Some(lease_token),
+        Some(attempt_event_ordinal),
+        None,
+        &event,
+    )
+    .await?;
     let applied = turn_steer_from_model(applied)?;
     transaction.commit().await.map_err(store_err)?;
-    Ok(Some(ApplyTurnSteerOutcome::Applied(applied)))
+    Ok(Some(JournaledTurnSteerOutcome {
+        outcome: ApplyTurnSteerOutcome::Applied(applied),
+        event: SequencedEvent { seq, event },
+    }))
 }
 
 pub(super) async fn reject_pending_turn_steers_on<C>(
@@ -579,6 +607,49 @@ where
         )));
     }
     Ok(())
+}
+
+async fn exact_applied_event_on<C>(
+    conn: &C,
+    steer: &entities::turn_steer::Model,
+    lease_token: uuid::Uuid,
+    attempt_event_ordinal: i32,
+) -> Result<SequencedEvent>
+where
+    C: ConnectionTrait,
+{
+    let event = entities::event::Entity::find()
+        .filter(entities::event::Column::LeaseToken.eq(lease_token))
+        .filter(entities::event::Column::AttemptEventOrdinal.eq(attempt_event_ordinal))
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "applied turn steer {} has no exact journal event",
+                TurnSteerId(steer.id)
+            ))
+        })?;
+    let payload = serde_json::from_value::<AgentEvent>(event.payload.clone())?;
+    let expected = AgentEvent::UserSteered {
+        content: steer.content.clone(),
+    };
+    if event.chat_id != steer.chat_id
+        || event.turn_id != Some(steer.turn_id)
+        || event.lease_token != Some(lease_token)
+        || event.attempt_event_ordinal != Some(attempt_event_ordinal)
+        || event.terminal
+        || payload != expected
+    {
+        return Err(AgentError::Store(format!(
+            "applied turn steer {} has a different journal event",
+            TurnSteerId(steer.id)
+        )));
+    }
+    Ok(SequencedEvent {
+        seq: event.seq,
+        event: payload,
+    })
 }
 
 async fn ensure_exact_preceding_message_on<C>(

--- a/crates/openwave-core/src/db/tests/turn_steer.rs
+++ b/crates/openwave-core/src/db/tests/turn_steer.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::storage::ApplyTurnSteerOutcome;
 
 fn pending_turn_steer(
     turn: &crate::model::TurnRun,
@@ -223,11 +224,25 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
     };
     let apply_at = Utc::now();
     let applied = store
-        .apply_turn_steer(turn.id, lease_token, steer_id, Some(&candidate), apply_at)
+        .apply_turn_steer(
+            turn.id,
+            lease_token,
+            steer_id,
+            1,
+            Some(&candidate),
+            apply_at,
+        )
         .await
         .unwrap()
         .unwrap();
-    let applied = match applied {
+    assert_eq!(
+        applied.event.event,
+        AgentEvent::UserSteered {
+            content: "change course".into(),
+        }
+    );
+    let applied_event = applied.event.clone();
+    let applied = match applied.outcome {
         ApplyTurnSteerOutcome::Applied(steer) => steer,
         other => panic!("unexpected steer application: {other:?}"),
     };
@@ -294,17 +309,34 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
     ));
 
     let recovered = store
-        .apply_turn_steer(turn.id, lease_token, steer_id, Some(&candidate), Utc::now())
+        .apply_turn_steer(
+            turn.id,
+            lease_token,
+            steer_id,
+            1,
+            Some(&candidate),
+            Utc::now(),
+        )
         .await
         .unwrap()
         .unwrap();
-    assert!(matches!(recovered, ApplyTurnSteerOutcome::Existing(_)));
-    let second = match store
-        .apply_turn_steer(turn.id, lease_token, second_id, None, Utc::now())
+    assert!(matches!(
+        recovered.outcome,
+        ApplyTurnSteerOutcome::Existing(_)
+    ));
+    assert_eq!(recovered.event, applied_event);
+    let second = store
+        .apply_turn_steer(turn.id, lease_token, second_id, 2, None, Utc::now())
         .await
         .unwrap()
-        .unwrap()
-    {
+        .unwrap();
+    assert_eq!(
+        second.event.event,
+        AgentEvent::UserSteered {
+            content: "one more thing".into(),
+        }
+    );
+    let second = match second.outcome {
         ApplyTurnSteerOutcome::Applied(steer) => steer,
         other => panic!("unexpected second steer application: {other:?}"),
     };
@@ -570,25 +602,23 @@ async fn turn_steer_application_enforces_fifo_and_message_sequence_on_timestamp_
     let applied_at = Utc::now();
     assert_eq!(
         store
-            .apply_turn_steer(turn.id, lease, high_id, None, applied_at)
+            .apply_turn_steer(turn.id, lease, high_id, 1, None, applied_at)
             .await
             .unwrap(),
         None
     );
-    assert!(matches!(
-        store
-            .apply_turn_steer(turn.id, lease, low_id, None, applied_at)
-            .await
-            .unwrap(),
-        Some(ApplyTurnSteerOutcome::Applied(_))
-    ));
-    assert!(matches!(
-        store
-            .apply_turn_steer(turn.id, lease, high_id, None, applied_at)
-            .await
-            .unwrap(),
-        Some(ApplyTurnSteerOutcome::Applied(_))
-    ));
+    let low = store
+        .apply_turn_steer(turn.id, lease, low_id, 1, None, applied_at)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(low.outcome, ApplyTurnSteerOutcome::Applied(_)));
+    let high = store
+        .apply_turn_steer(turn.id, lease, high_id, 2, None, applied_at)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(high.outcome, ApplyTurnSteerOutcome::Applied(_)));
     assert_eq!(
         store
             .list_messages(chat.id)
@@ -649,7 +679,7 @@ async fn concurrent_apply_and_completion_leave_no_pending_steer() {
     let apply = tokio::spawn(async move {
         apply_barrier.wait().await;
         apply_store
-            .apply_turn_steer(turn.id, lease_token, steer_id, None, Utc::now())
+            .apply_turn_steer(turn.id, lease_token, steer_id, 1, None, Utc::now())
             .await
             .unwrap()
     });
@@ -662,8 +692,9 @@ async fn concurrent_apply_and_completion_leave_no_pending_steer() {
             .await
             .unwrap()
     });
-    let applied = match apply.await.unwrap() {
-        Some(ApplyTurnSteerOutcome::Applied(steer)) => steer,
+    let applied = apply.await.unwrap().unwrap();
+    let applied = match applied.outcome {
+        ApplyTurnSteerOutcome::Applied(steer) => steer,
         other => panic!("pending steer did not win completion race: {other:?}"),
     };
     assert!(matches!(
@@ -848,13 +879,12 @@ async fn concurrent_message_and_steer_reserve_one_shared_identity() {
     match steer {
         AcceptTurnSteerOutcome::Accepted(_) => {
             assert!(message.is_err());
-            assert!(matches!(
-                store
-                    .apply_turn_steer(steer_turn.id, lease, shared_id, None, Utc::now())
-                    .await
-                    .unwrap(),
-                Some(ApplyTurnSteerOutcome::Applied(_))
-            ));
+            let applied = store
+                .apply_turn_steer(steer_turn.id, lease, shared_id, 1, None, Utc::now())
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(matches!(applied.outcome, ApplyTurnSteerOutcome::Applied(_)));
         }
         AcceptTurnSteerOutcome::IdentityConflict => {
             message.expect("message won the shared reservation");
@@ -1157,7 +1187,7 @@ async fn failed_steer_message_insert_rolls_back_the_application_receipt() {
     .await
     .unwrap();
     assert!(store
-        .apply_turn_steer(turn.id, lease, steer_id, None, Utc::now())
+        .apply_turn_steer(turn.id, lease, steer_id, 1, None, Utc::now())
         .await
         .is_err());
     let pending = existing_steer(
@@ -1170,4 +1200,79 @@ async fn failed_steer_message_insert_rolls_back_the_application_receipt() {
     assert_eq!(pending.applied_lease_token, None);
     assert_eq!(pending.message_id, None);
     assert_eq!(pending.resolved_at, None);
+    assert!(store.list_events(chat.id, 0).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn failed_steer_event_insert_rolls_back_message_receipt_and_revision() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "initial input")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        other => panic!("unexpected turn acceptance: {other:?}"),
+    };
+    let lease = uuid::Uuid::new_v4();
+    let claimed_at = Utc::now();
+    store
+        .claim_turn_run(lease, claimed_at, claimed_at + chrono::Duration::minutes(1))
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let steer_id = crate::id::TurnSteerId::new();
+    accepted_steer(
+        store
+            .accept_turn_steer(steer_id, turn.id, chat.id, "must stay atomic", false)
+            .await
+            .unwrap(),
+    );
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_steer_event BEFORE INSERT ON event
+             BEGIN SELECT RAISE(FAIL, 'injected steer event failure'); END",
+        )
+        .await
+        .unwrap();
+
+    assert!(store
+        .apply_turn_steer(turn.id, lease, steer_id, 1, None, Utc::now())
+        .await
+        .is_err());
+
+    let pending = existing_steer(
+        store
+            .accept_turn_steer(steer_id, turn.id, chat.id, "must stay atomic", false)
+            .await
+            .unwrap(),
+    );
+    assert_eq!(pending.status, TurnSteerStatus::Pending);
+    assert_eq!(pending.applied_lease_token, None);
+    assert_eq!(pending.message_id, None);
+    assert_eq!(pending.resolved_at, None);
+    assert_eq!(
+        store
+            .get_turn_run(turn.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .steer_revision,
+        0
+    );
+    assert_eq!(
+        store
+            .list_messages(chat.id)
+            .await
+            .unwrap()
+            .iter()
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>(),
+        vec!["initial input"]
+    );
+    assert!(store.list_events(chat.id, 0).await.unwrap().is_empty());
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -35,7 +35,7 @@ pub mod tool;
 #[cfg(feature = "tools")]
 pub mod tools;
 
-pub use agent::{Agent, AgentConfig, AgentTurnOutcome, ToolRegistry};
+pub use agent::{Agent, AgentConfig, AgentTurnOutcome, ClaimedAgentEvent, ToolRegistry};
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalRequest, AutoApproveGate, RefuseGate,
 };
@@ -69,8 +69,8 @@ pub use storage::{
     AcceptTurnOutcome, AcceptTurnSteerOutcome, ApplyTurnSteerOutcome, BlobStore,
     ClaimScanTerminalEvent, ClaimTurnRunOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
     EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
-    JournaledTurnOutcome, RecordTurnFailureOutcome, RequestTurnCancellationOutcome, SecretProvider,
-    Store,
+    JournaledTurnOutcome, JournaledTurnSteerOutcome, RecordTurnFailureOutcome,
+    RequestTurnCancellationOutcome, SecretProvider, Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -120,6 +120,15 @@ pub enum ApplyTurnSteerOutcome {
     Existing(TurnSteer),
 }
 
+/// One applied steering result and the replay event committed with it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JournaledTurnSteerOutcome {
+    /// The steer application result.
+    pub outcome: ApplyTurnSteerOutcome,
+    /// The exact nonterminal journal row committed by the application.
+    pub event: SequencedEvent,
+}
+
 /// Result of atomically completing one exact claimed turn.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompleteTurnRunOutcome {
@@ -741,18 +750,21 @@ pub trait Store: Send + Sync {
     /// Persist one pending steer as a user message under the exact live lease.
     ///
     /// An optional preceding assistant candidate, the steer message, the
-    /// application receipt, and the revision increment commit atomically in
-    /// transcript order. Exact retries by the same lease return
-    /// [`ApplyTurnSteerOutcome::Existing`] even after the turn advances. A stale
-    /// lease, rejected steer, or different winning lease returns `None`.
+    /// application receipt, the revision increment, and its [`AgentEvent::UserSteered`]
+    /// journal row commit atomically in transcript order. The event ordinal is
+    /// the worker's exact attempt identity. Exact retries by the same lease and
+    /// ordinal return [`ApplyTurnSteerOutcome::Existing`] with the same journal
+    /// row even after the turn advances. A stale lease, rejected steer, or
+    /// different winning lease returns `None`.
     async fn apply_turn_steer(
         &self,
         _turn_id: TurnId,
         _lease_token: uuid::Uuid,
         _steer_id: TurnSteerId,
+        _attempt_event_ordinal: i32,
         _preceding_assistant: Option<&Message>,
         _now: chrono::DateTime<chrono::Utc>,
-    ) -> Result<Option<ApplyTurnSteerOutcome>> {
+    ) -> Result<Option<JournaledTurnSteerOutcome>> {
         turn_storage_unavailable()
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -617,13 +617,20 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
             steer_turn.id,
             steer_lease,
             steer_id,
+            1,
             Some(&preceding),
             Utc::now(),
         )
         .await
         .unwrap()
         .unwrap();
-    assert!(matches!(applied, ApplyTurnSteerOutcome::Applied(_)));
+    assert!(matches!(applied.outcome, ApplyTurnSteerOutcome::Applied(_)));
+    assert_eq!(
+        applied.event.event,
+        AgentEvent::UserSteered {
+            content: "postgres steer".into(),
+        }
+    );
     assert_eq!(
         store
             .list_messages(steer_chat.id)
@@ -674,18 +681,19 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
             .unwrap(),
         Some(CompleteTurnRunOutcome::SteerPending(_))
     ));
-    let second_steer = match store
+    let second_steer = store
         .apply_turn_steer(
             steer_turn.id,
             steer_lease,
             second_steer_id,
+            2,
             None,
             Utc::now(),
         )
         .await
         .unwrap()
-        .unwrap()
-    {
+        .unwrap();
+    let second_steer = match second_steer.outcome {
         ApplyTurnSteerOutcome::Applied(steer) => steer,
         outcome => panic!("unexpected postgres second steer: {outcome:?}"),
     };
@@ -708,19 +716,23 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         .await
         .unwrap()
         .unwrap();
+    let recovered = store
+        .apply_turn_steer(
+            steer_turn.id,
+            steer_lease,
+            steer_id,
+            1,
+            Some(&preceding),
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
     assert!(matches!(
-        store
-            .apply_turn_steer(
-                steer_turn.id,
-                steer_lease,
-                steer_id,
-                Some(&preceding),
-                Utc::now(),
-            )
-            .await
-            .unwrap(),
-        Some(ApplyTurnSteerOutcome::Existing(_))
+        recovered.outcome,
+        ApplyTurnSteerOutcome::Existing(_)
     ));
+    assert_eq!(recovered.event, applied.event);
     assert!(matches!(
         store
             .accept_turn_steer(

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -306,6 +306,7 @@ struct PauseTerminalStore {
     fail_after_heartbeat_commit: std::sync::atomic::AtomicBool,
     fail_after_completion_commit: std::sync::atomic::AtomicBool,
     fail_after_apply_steer_commit: std::sync::atomic::AtomicBool,
+    cancel_after_apply_steer_commit: std::sync::atomic::AtomicBool,
     advance_before_steer_read: std::sync::atomic::AtomicBool,
     fail_terminal_recovery: std::sync::atomic::AtomicBool,
     terminal_recovery_calls: AtomicUsize,
@@ -329,6 +330,7 @@ impl PauseTerminalStore {
             fail_after_heartbeat_commit: std::sync::atomic::AtomicBool::new(false),
             fail_after_completion_commit: std::sync::atomic::AtomicBool::new(false),
             fail_after_apply_steer_commit: std::sync::atomic::AtomicBool::new(false),
+            cancel_after_apply_steer_commit: std::sync::atomic::AtomicBool::new(false),
             advance_before_steer_read: std::sync::atomic::AtomicBool::new(false),
             fail_terminal_recovery: std::sync::atomic::AtomicBool::new(false),
             terminal_recovery_calls: AtomicUsize::new(0),
@@ -364,6 +366,11 @@ impl PauseTerminalStore {
 
     fn fail_after_next_apply_steer_commit(&self) {
         self.fail_after_apply_steer_commit
+            .store(true, Ordering::SeqCst);
+    }
+
+    fn cancel_after_next_apply_steer_commit(&self) {
+        self.cancel_after_apply_steer_commit
             .store(true, Ordering::SeqCst);
     }
 
@@ -692,13 +699,38 @@ impl Store for PauseTerminalStore {
         turn_id: TurnId,
         lease_token: uuid::Uuid,
         steer_id: TurnSteerId,
+        attempt_event_ordinal: i32,
         preceding_assistant: Option<&Message>,
         now: chrono::DateTime<chrono::Utc>,
-    ) -> Result<Option<openwave_core::ApplyTurnSteerOutcome>> {
+    ) -> Result<Option<openwave_core::JournaledTurnSteerOutcome>> {
         let applied = self
             .inner
-            .apply_turn_steer(turn_id, lease_token, steer_id, preceding_assistant, now)
+            .apply_turn_steer(
+                turn_id,
+                lease_token,
+                steer_id,
+                attempt_event_ordinal,
+                preceding_assistant,
+                now,
+            )
             .await?;
+        if applied.is_some()
+            && self
+                .cancel_after_apply_steer_commit
+                .swap(false, Ordering::SeqCst)
+        {
+            self.inner
+                .request_turn_cancellation_and_append_event(turn_id, chrono::Utc::now())
+                .await?
+                .ok_or_else(|| {
+                    AgentError::Store(
+                        "injected cancellation could not follow steer application".into(),
+                    )
+                })?;
+            return Err(AgentError::Store(
+                "injected cancelled ambiguous steer application response".into(),
+            ));
+        }
         if applied.is_some()
             && self
                 .fail_after_apply_steer_commit
@@ -1294,6 +1326,109 @@ async fn cancel_stops_a_running_turn() {
     ));
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn cancellation_drains_buffered_preassigned_event_ordinals() {
+    struct TwoDeltasThenPark {
+        second_yielded: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for TwoDeltasThenPark {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("two-deltas-then-park")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let second_yielded = self.second_yielded.clone();
+            Ok(stream::iter(vec![ProviderEvent::TextDelta {
+                text: "first".into(),
+            }])
+            .chain(stream::once(async move {
+                second_yielded.notify_one();
+                ProviderEvent::TextDelta {
+                    text: "second".into(),
+                }
+            }))
+            .chain(stream::pending())
+            .boxed())
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let inner: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let append_entered = Arc::new(Notify::new());
+    let append_release = Arc::new(Notify::new());
+    let injected = Arc::new(PauseTerminalStore::new(
+        inner,
+        append_entered.clone(),
+        append_release.clone(),
+    ));
+    injected.do_not_pause_terminal();
+    injected.pause_next_nonterminal_event();
+    let store: Arc<dyn Store> = injected;
+    let second_yielded = Arc::new(Notify::new());
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(TwoDeltasThenPark {
+            second_yielded: second_yielded.clone(),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker_with_config(
+        &state,
+        turn_worker::TurnWorkerConfig {
+            max_concurrency: 1,
+            ..turn_worker::TurnWorkerConfig::default()
+        },
+    );
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    let append_blocked = append_entered.notified();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
+        StatusCode::ACCEPTED
+    );
+    tokio::time::timeout(Duration::from_secs(2), append_blocked)
+        .await
+        .expect("worker reached the first buffered event append");
+    tokio::time::timeout(Duration::from_secs(2), second_yielded.notified())
+        .await
+        .expect("agent yielded the following preassigned event");
+
+    assert_eq!(
+        cancel_turn(&router, &bearer, chat.id, turn_id).await,
+        StatusCode::ACCEPTED
+    );
+    append_release.notify_one();
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCancelled { .. })
+    ));
+}
+
 #[tokio::test]
 async fn cancel_without_a_running_turn_is_a_conflict_and_unknown_chat_is_404() {
     let (router, token, _store, _dir) = test_app().await;
@@ -1611,6 +1746,7 @@ async fn interrupt_steer_preempts_a_running_turn_and_continues() {
 async fn boundary_steer_commits_the_candidate_and_instruction_atomically() {
     struct FinishAfterGate {
         calls: Arc<AtomicUsize>,
+        entered: Arc<Notify>,
         gate: Arc<Notify>,
     }
 
@@ -1622,6 +1758,7 @@ async fn boundary_steer_commits_the_candidate_and_instruction_atomically() {
 
         async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
             if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                self.entered.notify_one();
                 let gate = self.gate.clone();
                 return Ok(stream::iter(vec![ProviderEvent::TextDelta {
                     text: "candidate".into(),
@@ -1647,9 +1784,11 @@ async fn boundary_steer_commits_the_candidate_and_instruction_atomically() {
     }
 
     let calls = Arc::new(AtomicUsize::new(0));
+    let entered = Arc::new(Notify::new());
     let gate = Arc::new(Notify::new());
     let (router, token, store, _dir) = test_app_with(Arc::new(FinishAfterGate {
         calls: calls.clone(),
+        entered: entered.clone(),
         gate: gate.clone(),
     }))
     .await;
@@ -1660,7 +1799,9 @@ async fn boundary_steer_commits_the_candidate_and_instruction_atomically() {
         send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
         StatusCode::ACCEPTED
     );
-    tokio::time::sleep(Duration::from_millis(30)).await;
+    tokio::time::timeout(Duration::from_secs(2), entered.notified())
+        .await
+        .expect("provider entered the first boundary generation");
 
     let steer_id = TurnSteerId::new();
     assert_eq!(
@@ -1680,6 +1821,17 @@ async fn boundary_steer_commits_the_candidate_and_instruction_atomically() {
 
     let events = wait_for_turn(&store, chat.id).await;
     assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                &event.event,
+                AgentEvent::UserSteered { content } if content == "continue with this"
+            ))
+            .count(),
+        1,
+        "boundary steering must publish its committed event once"
+    );
     assert!(matches!(
         events.last().map(|event| &event.event),
         Some(AgentEvent::TurnCompleted { .. })
@@ -1707,6 +1859,7 @@ async fn boundary_steer_commits_the_candidate_and_instruction_atomically() {
 async fn durable_steer_poll_recovers_a_missing_local_notification() {
     struct StallThenFinish {
         calls: AtomicUsize,
+        entered: Arc<Notify>,
     }
     #[async_trait]
     impl ModelProvider for StallThenFinish {
@@ -1716,6 +1869,7 @@ async fn durable_steer_poll_recovers_a_missing_local_notification() {
 
         async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
             if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                self.entered.notify_one();
                 return Ok(stream::pending().boxed());
             }
             Ok(stream::iter(vec![
@@ -1732,7 +1886,9 @@ async fn durable_steer_poll_recovers_a_missing_local_notification() {
 
     let provider = Arc::new(StallThenFinish {
         calls: AtomicUsize::new(0),
+        entered: Arc::new(Notify::new()),
     });
+    let entered = provider.entered.clone();
     let (router, token, store, _dir) = test_app_with(provider.clone()).await;
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
@@ -1741,7 +1897,9 @@ async fn durable_steer_poll_recovers_a_missing_local_notification() {
         send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
         StatusCode::ACCEPTED
     );
-    tokio::time::sleep(Duration::from_millis(30)).await;
+    tokio::time::timeout(Duration::from_secs(2), entered.notified())
+        .await
+        .expect("provider entered the generation before durable admission");
 
     let steer_id = TurnSteerId::new();
     assert!(matches!(
@@ -1790,6 +1948,7 @@ async fn durable_steer_poll_recovers_a_missing_local_notification() {
 async fn durable_steer_retries_heartbeat_races_and_ambiguous_application() {
     struct StallThenFinish {
         calls: Arc<AtomicUsize>,
+        entered: Arc<Notify>,
     }
 
     #[async_trait]
@@ -1800,6 +1959,7 @@ async fn durable_steer_retries_heartbeat_races_and_ambiguous_application() {
 
         async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
             if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                self.entered.notify_one();
                 return Ok(stream::pending().boxed());
             }
             Ok(stream::iter(vec![
@@ -1831,6 +1991,7 @@ async fn durable_steer_retries_heartbeat_races_and_ambiguous_application() {
     injected.do_not_pause_terminal();
     let store: Arc<dyn Store> = injected.clone();
     let calls = Arc::new(AtomicUsize::new(0));
+    let entered = Arc::new(Notify::new());
     let (retrieval, _search) = build_retrieval(
         Arc::new(HashEmbedder::default()),
         Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
@@ -1840,6 +2001,7 @@ async fn durable_steer_retries_heartbeat_races_and_ambiguous_application() {
         store.clone(),
         Arc::new(FixedResolver(Arc::new(StallThenFinish {
             calls: calls.clone(),
+            entered: entered.clone(),
         }))),
         Arc::new(MemSecrets::default()),
         Arc::new(ToolRegistry::new()),
@@ -1859,7 +2021,9 @@ async fn durable_steer_retries_heartbeat_races_and_ambiguous_application() {
         send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
         StatusCode::ACCEPTED
     );
-    tokio::time::sleep(Duration::from_millis(30)).await;
+    tokio::time::timeout(Duration::from_secs(2), entered.notified())
+        .await
+        .expect("provider entered before the ambiguous application race");
 
     injected.advance_before_next_steer_read();
     injected.fail_after_next_apply_steer_commit();
@@ -1880,6 +2044,17 @@ async fn durable_steer_retries_heartbeat_races_and_ambiguous_application() {
 
     let events = wait_for_turn(&store, chat.id).await;
     assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                &event.event,
+                AgentEvent::UserSteered { content } if content == "recover exactly"
+            ))
+            .count(),
+        1,
+        "ambiguous application recovery must publish its committed event once"
+    );
     assert!(matches!(
         events.last().map(|event| &event.event),
         Some(AgentEvent::TurnCompleted { .. })
@@ -1898,6 +2073,133 @@ async fn durable_steer_retries_heartbeat_races_and_ambiguous_application() {
                 "recover exactly",
             ),
             (messages[2].id, openwave_core::Role::Assistant, "recovered"),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn committed_steer_event_recovers_when_cancellation_wins_ambiguous_response() {
+    struct NeverFinish {
+        entered: Arc<Notify>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for NeverFinish {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("never-finish")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            self.entered.notify_one();
+            Ok(stream::pending().boxed())
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let inner: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let injected = Arc::new(PauseTerminalStore::new(
+        inner,
+        Arc::new(Notify::new()),
+        Arc::new(Notify::new()),
+    ));
+    injected.do_not_pause_terminal();
+    injected.cancel_after_next_apply_steer_commit();
+    let store: Arc<dyn Store> = injected;
+    let entered = Arc::new(Notify::new());
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(NeverFinish {
+            entered: entered.clone(),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker_with_config(
+        &state,
+        turn_worker::TurnWorkerConfig {
+            lease: Duration::from_millis(500),
+            heartbeat: Duration::from_millis(20),
+            steer_poll: Duration::from_millis(5),
+            idle_min: Duration::from_millis(5),
+            idle_cap: Duration::from_millis(20),
+            failure_delay: Duration::from_millis(5),
+            max_concurrency: 1,
+        },
+    );
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "go").await,
+        StatusCode::ACCEPTED
+    );
+    tokio::time::timeout(Duration::from_secs(2), entered.notified())
+        .await
+        .expect("provider entered before the cancellation race");
+
+    let steer_id = TurnSteerId::new();
+    assert_eq!(
+        steer_turn_with_id(
+            &router,
+            &bearer,
+            chat.id,
+            steer_id,
+            turn_id,
+            "apply before cancellation",
+            true,
+        )
+        .await,
+        StatusCode::ACCEPTED
+    );
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                &event.event,
+                AgentEvent::UserSteered { content } if content == "apply before cancellation"
+            ))
+            .count(),
+        1,
+        "exact recovery must publish the atomically committed steer event"
+    );
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCancelled { .. })
+    ));
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| (message.id, message.role, message.content.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (messages[0].id, openwave_core::Role::User, "go"),
+            (
+                openwave_core::MessageId(steer_id.0),
+                openwave_core::Role::User,
+                "apply before cancellation",
+            ),
         ]
     );
 }

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -7,9 +7,9 @@ use chrono::Utc;
 use futures::channel::mpsc::unbounded;
 use futures::StreamExt;
 use openwave_core::{
-    Agent, AgentConfig, AgentError, AgentEvent, AgentTurnOutcome, CompleteTurnRunOutcome,
-    MessageId, RecordTurnFailureOutcome, Result, SequencedEvent, Store, ToolRegistry,
-    TurnFailureRetry, TurnId, TurnRun, TurnRunStatus,
+    Agent, AgentConfig, AgentError, AgentEvent, AgentTurnOutcome, ClaimedAgentEvent,
+    CompleteTurnRunOutcome, MessageId, RecordTurnFailureOutcome, Result, SequencedEvent, Store,
+    ToolRegistry, TurnFailureRetry, TurnId, TurnRun, TurnRunStatus,
 };
 use tokio::sync::Notify;
 
@@ -359,7 +359,7 @@ impl TurnWorker {
             let (events_tx, mut events_rx) = unbounded();
             let mut drive = AbortOnDrop(tokio::spawn(async move {
                 agent
-                    .run_claimed_turn(&chat, turn.id, output_message_id, &events_tx)
+                    .run_claimed_turn(&chat, turn.id, output_message_id, ordinal, &events_tx)
                     .await
             }));
             let mut drive_result = None;
@@ -372,16 +372,35 @@ impl TurnWorker {
                     result = &mut drive.0, if drive_result.is_none() => {
                         drive_result = Some(result);
                     }
-                    event = events_rx.next(), if channel_open => {
-                        match event {
-                            Some(event) => {
-                                match self.append_event(&turn, lease_token, ordinal, &event).await? {
+                    emission = events_rx.next(), if channel_open => {
+                        match emission {
+                            Some(ClaimedAgentEvent::Pending { ordinal: event_ordinal, event }) => {
+                                if event_ordinal != ordinal {
+                                    return Err(AgentError::msg(format!(
+                                        "turn {} emitted event ordinal {event_ordinal}, expected {ordinal}",
+                                        turn.id
+                                    )));
+                                }
+                                match self.append_event(&turn, lease_token, event_ordinal, &event).await? {
                                     EventAppend::Committed => {
                                         ordinal = ordinal.checked_add(1).ok_or_else(|| {
                                             AgentError::msg(format!("turn {} event ordinal exhausted", turn.id))
                                         })?;
                                     }
-                                    EventAppend::Cancelling => cancel.cancel(),
+                                    EventAppend::Cancelling => {
+                                        // The agent assigns ordinals before enqueueing. This
+                                        // emission is consumed even though cancellation won its
+                                        // append, so advance past it before draining any already
+                                        // buffered emissions. A later atomically committed event
+                                        // may legitimately follow this journal gap.
+                                        ordinal = ordinal.checked_add(1).ok_or_else(|| {
+                                            AgentError::msg(format!(
+                                                "turn {} event ordinal exhausted",
+                                                turn.id
+                                            ))
+                                        })?;
+                                        cancel.cancel();
+                                    }
                                     EventAppend::LeaseLost => {
                                         drive.abort_and_wait().await;
                                         if heartbeat_open {
@@ -390,6 +409,21 @@ impl TurnWorker {
                                         return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
                                     }
                                 }
+                            }
+                            Some(ClaimedAgentEvent::Committed { ordinal: event_ordinal, event }) => {
+                                if event_ordinal != ordinal {
+                                    return Err(AgentError::msg(format!(
+                                        "turn {} committed event ordinal {event_ordinal}, expected {ordinal}",
+                                        turn.id
+                                    )));
+                                }
+                                self.publish(turn.chat_id, event);
+                                ordinal = ordinal.checked_add(1).ok_or_else(|| {
+                                    AgentError::msg(format!("turn {} event ordinal exhausted", turn.id))
+                                })?;
+                            }
+                            Some(ClaimedAgentEvent::Flush(acknowledge)) => {
+                                let _ = acknowledge.send(());
                             }
                             None => channel_open = false,
                         }


### PR DESCRIPTION
## Summary

- commit durable steer messages, receipts, revision increments, and `UserSteered` journal events in one transaction
- preserve event ordering with worker-assigned ordinals, flush barriers, and committed-event publication
- recover ambiguous steer applications by exact lease and event identity, including cancellation races
- drain preassigned event ordinals safely when cancellation wins an append

## Validation

- `cargo test --workspace --locked -q`
- `bw dev lint --rust --check --repo-root "$PWD"`
- `cargo fmt --all --check`
- `git diff --check`
