### PR TITLE
fix(server): replay journal gaps in live event streams

### DIFF
--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -707,9 +707,10 @@ pub struct EventsQuery {
 ///
 /// On connect the client gets **snapshot → replay → live**: journaled events with
 /// `seq > after` are replayed, then live events stream as they occur. Subscribing
-/// to the live tail *before* replaying, and dropping any live event whose `seq`
-/// was already replayed, means nothing is missed or duplicated across the handoff.
-/// `404` if the chat doesn't exist.
+/// to the live tail *before* replaying, dropping any live event whose `seq` was
+/// already replayed, and replaying whenever the live cursor jumps means nothing
+/// is missed or duplicated across the handoff or a worker-ownership race. `404`
+/// if the chat doesn't exist.
 ///
 /// Auth is checked by the bearer middleware. Browser clients authenticate via
 /// `Sec-WebSocket-Protocol` (`openwave-token.<token>`). When the client offered
@@ -759,6 +760,19 @@ async fn stream_events(mut socket: WebSocket, state: AppState, chat: ChatId, aft
                 Ok(event) => {
                     if event.seq <= last_seq {
                         continue; // already covered by replay
+                    }
+                    if event.seq > last_seq.saturating_add(1) {
+                        // Durable commits can be published out of order across
+                        // lease owners. Fill the gap from the journal before
+                        // accepting this live tail; replay includes the current
+                        // event because publication always follows commit.
+                        if replay_after(&mut socket, &*state.store, chat, &mut last_seq)
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                        continue;
                     }
                     last_seq = event.seq;
                     if send_event(&mut socket, &event).await.is_err() {

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -6494,6 +6494,100 @@ async fn read_until_turn_end(
     read_until_turns_end(addr, token, chat, after, 1).await
 }
 
+fn decode_ws_event(message: WsMessage) -> SequencedEvent {
+    let WsMessage::Text(text) = message else {
+        panic!("expected a JSON text event frame");
+    };
+    serde_json::from_str(text.as_str()).unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_replays_a_journal_gap_before_accepting_a_later_live_event() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig::default(),
+    );
+    let token = state.token.clone();
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let router = app(state.clone());
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router).await;
+    });
+    let client = reqwest::Client::new();
+    let chat = make_chat_http(&client, addr, &token).await;
+
+    let first = AgentEvent::TextDelta { text: "one".into() };
+    assert_eq!(store.append_event(chat.id, &first).await.unwrap(), 1);
+    let mut request = format!("ws://{addr}/chats/{}/events", chat.id)
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut socket, _) = connect_async(request).await.unwrap();
+    let replayed_first = tokio::time::timeout(Duration::from_secs(2), socket.next())
+        .await
+        .expect("initial journal replay timed out")
+        .expect("event socket closed")
+        .unwrap();
+    assert_eq!(decode_ws_event(replayed_first).seq, 1);
+
+    let second = AgentEvent::TextDelta { text: "two".into() };
+    let third = AgentEvent::TextDelta {
+        text: "three".into(),
+    };
+    assert_eq!(store.append_event(chat.id, &second).await.unwrap(), 2);
+    assert_eq!(store.append_event(chat.id, &third).await.unwrap(), 3);
+    let _ = state.events.sender(chat.id).send(SequencedEvent {
+        seq: 3,
+        event: third,
+    });
+    let _ = state.events.sender(chat.id).send(SequencedEvent {
+        seq: 2,
+        event: second.clone(),
+    });
+
+    let mut recovered = Vec::new();
+    for _ in 0..2 {
+        let frame = tokio::time::timeout(Duration::from_secs(2), socket.next())
+            .await
+            .expect("gap recovery timed out")
+            .expect("event socket closed")
+            .unwrap();
+        recovered.push(decode_ws_event(frame));
+    }
+    assert_eq!(
+        recovered.iter().map(|event| event.seq).collect::<Vec<_>>(),
+        vec![2, 3]
+    );
+    assert_eq!(recovered[0].event, second);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), socket.next())
+            .await
+            .is_err(),
+        "the late live seq 2 must be deduplicated after journal replay"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_replays_a_finished_turn_from_the_journal() {
     let (addr, token, store, _dir) = serve_app_with(Arc::new(FakeProvider)).await;


### PR DESCRIPTION
## Summary

- detect non-contiguous live event sequence numbers before advancing a WebSocket cursor
- replay missing and triggering events from the durable journal in sequence order
- deduplicate late out-of-order live publications after replay catches up
- cover a forced live `3 → 2` publication order with exact journal-ordered delivery

## Stack

- depends on #150

## Validation

- `cargo test -p openwave-server --locked -q`
- `bw dev lint --rust --check --repo-root "$PWD"`
- `cargo fmt --all --check`
- `git diff --check`
