### PR TITLE
docs: define brokered host access

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ Project documentation, versioned alongside the code.
   they fit together.
 - [How OpenWave works](how-openwave-works.md) — a plain-language maintainer tour
   of the product, runtime, state machines, document model, and unfinished edges.
+- [Host access and connected folders](host-access.md) — how projects and
+  conversations receive user-approved access to folders on the host machine.
 
 More to come as the product surfaces land (running locally, API reference, and
 writing tools).

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -12,6 +12,7 @@ libraries.
                                └────── openwave-server
                                             │
       libraries          openwave-mcp   openwave-retrieval   openwave-router
+                         openwave-host-broker (planned)          │
                                │             │                   │
                                └─────────────┴───────────────────┘
                                             │
@@ -79,6 +80,16 @@ Scaffold reserved for loopback OAuth (RFC 8252 + PKCE), token refresh, and
 connector tools that list and fetch from sources like Drive and Box.
 
 **Depends on:** nothing in the workspace yet.
+
+## `openwave-host-broker` — consented host access ⚪
+
+The planned runtime-neutral trust boundary for connected local folders. It will
+own capability grants, root registration, path policy, audited filesystem
+operations, and a versioned sidecar protocol. The Tauri host will own native
+consent UI; agent execution will receive only the operation interface. See
+[Host access and connected folders](host-access.md).
+
+**Depends on:** no OpenWave client crate.
 
 ## `openwave-retrieval` — parsing, search, citations 🟢
 

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -1,0 +1,195 @@
+# Host access and connected folders
+
+OpenWave is local-first, but "local" should not mean that every agent can see
+every file on the machine. This document describes the intended boundary between
+OpenWave's product state and user-approved access to the host computer.
+
+The design follows the same basic product split as Brightwave web plus desktop.
+The important difference at first is deployment: OpenWave's control plane runs
+locally. The boundary is still explicit so that a self-hosted or managed control
+plane can use the same contracts later.
+
+## The product model
+
+OpenWave owns an application data directory. It contains the operational
+database, retained source blobs, the search index, broker state, audit records,
+and private scratch data. It is not a user project and should not appear as the
+one folder all conversations work in.
+
+A folder elsewhere on the machine is a **connected root**. It becomes available
+only after the user chooses it through a trusted desktop action, such as a native
+folder picker. Different projects or conversations can resolve to different
+host-access contexts, and each context can contain more than one connected root.
+
+In practical terms:
+
+- OpenWave may always use its own private application data and scratch space.
+- A project can have its own ordered set of connected folders.
+- A standalone conversation can have its own ordered set of connected folders.
+- A conversation in a project can use project roots plus an explicit attached
+  subset or conversation-specific roots. Adding a project root must not silently
+  widen an already-running turn.
+- The model sees an opaque root identifier, a display name, and root-relative
+  paths. It never receives authority by naming an absolute host path.
+- Connecting one folder never grants access to its siblings, the user's whole
+  home directory, or another project's roots.
+
+The current `workspace_dir` fields on projects and chats do not express this
+model. They are temporary pre-alpha implementation details and will be replaced
+rather than preserved as a compatibility layer.
+
+## The four layers
+
+```text
+             web UI / desktop renderer
+                 product actions
+                        |
+                        v
+          OpenWave control plane (local first)
+       projects, chats, turns, documents, tools
+                        |
+             capability-checked operations
+                        v
+             host-broker sidecar process
+       grants, path policy, host I/O, audit log
+                        ^
+                        |
+             trusted consent controls only
+                        |
+                 Tauri desktop host
+          native picker and permission dialogs
+```
+
+The **control plane** owns product meaning. Today it is the loopback
+`openwave-server` embedded in the desktop app or started by `openwave serve`.
+Later it may be self-hosted or managed. Agent turns can request host operations,
+but the control plane cannot turn an agent request into a new grant.
+
+The **desktop host** owns native, human-originated consent. It can open a folder
+picker and send the selected path to the broker's trusted control channel. It
+does not implement path policy or filesystem tools itself.
+
+The **host broker** is the machine trust boundary. Its transport-neutral core
+owns the root registry, capability grants, path confinement, filesystem
+operations, and audit trail. The desktop runs it behind a sidecar adapter for
+independent lifecycle, protocol-version checking, and a smaller ambient-authority
+surface than the complete desktop or server. Process separation is useful
+defense in depth, not a substitute for authorization: the broker validates every
+operation even when its caller is local.
+
+The **renderer** presents connected folders and permission choices. It receives
+safe summaries, not the broker's persisted absolute-path registry.
+
+## Two channels, not one privileged API
+
+Broker requests are divided into two typed channels:
+
+1. **Control requests** record trusted user actions: negotiate a protocol
+   version, register a folder returned by the native picker, inspect grants, or
+   revoke access. Only the desktop host or an equivalent explicit local CLI
+   action may send them.
+2. **Operation requests** come from agent execution: list connected roots, list
+   a directory, read a file, import bytes, write allowed output, or later run a
+   confined command. Every operation is denied unless a matching grant exists.
+
+Code should expose different controller and operator interfaces so an agent
+executor cannot accidentally call the control channel. The broker still
+validates every request; the type split is defense in depth, not the only check.
+
+The host-access context and the conversation's attached-root set are supplied by
+trusted conversation execution state, not by model-generated tool arguments.
+This stops a model from selecting a different project's context even if it
+guesses an identifier.
+
+## Capabilities and paths
+
+Grants are deny-by-default and scoped to one access context. The initial useful
+capabilities are:
+
+- discover connected roots;
+- list and read files under a connected root;
+- import selected file bytes into OpenWave's private data plane;
+- write under a connected root with an explicit, bounded policy;
+- later, run commands inside an OS-confined environment.
+
+Capabilities should remain separate. Choosing a folder can grant low-risk file
+access, but command execution requires a permission action that names the added
+risk. Revocation must take effect at the broker, rather than relying on stale UI
+or server state.
+
+Root identifiers are random host-local identities rather than hashes of absolute
+paths. This avoids leaking that two product contexts refer to the same machine
+location. Operations address `{root_id, relative_path}`. The broker canonicalizes
+a root when it is registered, rejects dangerous or overly broad roots, rejects
+absolute and escaping relative paths, and defends against symlink traversal at
+the time of use. A lexical `starts_with` check is not a security boundary.
+Cached directory handles never become grants by themselves; every operation
+rechecks live authorization so revocation takes effect immediately.
+
+Read access is privacy-sensitive even though it does not mutate the filesystem:
+file bytes may become model input and leave the machine when a hosted provider is
+selected. Permission UI should make that consequence understandable.
+
+## Data movement
+
+Broker-private scratch space and user-connected roots are different data
+planes. Imported bytes should cross the process boundary through bounded,
+by-reference handoffs rather than being placed in agent-addressable scratch.
+Outbound writes should similarly originate from a broker-confined staging area
+or bounded inline payload. Keeping handoffs separate prevents composing an
+import from one root with a write to another root into an unintended
+cross-folder copy primitive.
+
+Every machine-touching operation is audited with its access context, capability,
+target summary, outcome, and authorizing grant. Stable operation identities and
+receipts are required before ambiguous mutations can be retried safely.
+Security-sensitive writes and command execution must fail closed when their
+intent cannot be recorded durably. App-private scratch may allow replacement;
+connected roots default to additive, no-clobber writes, with replacement and
+deletion modeled as distinct higher-risk actions.
+
+## Deployment evolution
+
+The trust boundary does not move when deployment changes:
+
+| Deployment | Product control plane | Host consent and I/O |
+| --- | --- | --- |
+| Local desktop | In-process local server | Tauri host + local broker |
+| Self-hosted | User-operated service | Desktop host + broker on each user's machine |
+| Managed | Hosted OpenWave service | Desktop host + broker on each user's machine |
+
+Only the transport between the control plane and desktop changes. The broker
+continues to accept the same typed operations, keep grants on the user's
+machine, and require local consent controls. Provider routing, turn state, and
+document state remain control-plane concerns.
+
+Headless mode needs an equally explicit consent action. An absolute path in an
+ordinary HTTP request is not consent. A future interactive local CLI command can
+register a root for a chosen access context; automation can use deliberately
+provisioned grants with clear operator intent.
+
+## Implementation slices
+
+This will land in independently reviewable pieces:
+
+1. Add `openwave-host-broker` with typed capabilities, grants, access-context and
+   root identifiers, deny-by-default authorization, and path policy tests.
+2. Add the versioned control/operation protocol and a minimal sidecar vertical
+   slice: hello, register/revoke/list roots, list directory, and read file.
+3. Add the Tauri sidecar client and native folder-picker controls. Broker state,
+   audit, scratch, and handoffs live under OpenWave's application data directory;
+   remove the automatic `Documents/OpenWave` folder.
+4. Replace project/chat `workspace_dir` with persisted host-access context
+   identity and connected-root APIs. This can update the pre-v1 baseline schema
+   directly.
+5. Route built-in file tools through the operation interface and remove direct
+   ambient host-directory opening from `ToolCtx`.
+6. Port bounded imports, writes, approvals, and confined command execution as
+   separate capability slices.
+7. Adapt the explicit-workspace MCP command to the same broker policy instead of
+   maintaining a second filesystem authority model.
+
+Each intermediate state must fail closed. In particular, adding the data model
+must not expose roots before tools use the broker, and adding broker code must
+not imply that the current direct-workspace tools are already safe for untrusted
+paths.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -11,9 +11,10 @@ change.
 
 ## OpenWave in one minute
 
-OpenWave is a local agent runtime. A user gives it a workspace, chooses a model,
-and starts a chat. The runtime can ask the model for an answer, call tools over
-the workspace, search an indexed document corpus, pause for approval before a
+OpenWave is a local agent runtime. A user chooses a model, starts a chat, and can
+connect one or more folders that the project or conversation is allowed to use.
+The runtime can ask the model for an answer, call tools over those connected
+folders, search an indexed document corpus, pause for approval before a
 sensitive action, and stream progress back to the client.
 
 The important architectural choice is that the user-facing request and the
@@ -46,9 +47,9 @@ are not exactly-once yet.
                      |      |       |
           model calls|      |       |file/search tools
                      |      |       |
-              +------v--+   |   +---v----------------+
-              | router  |   |   | workspace + search |
-              +---------+   |   +--------------------+
+              +------v--+   |   +---v------------------+
+              | router  |   |   | host broker + search |
+              +---------+   |   +----------------------+
                             |
         +-------------------+--------------------+
         |                   |                    |
@@ -155,10 +156,14 @@ The built-in server registry currently contains:
 - `search`, which queries the indexed corpus and requires approval only when its
   embedder, store, or reranker can send data outside the machine.
 
-Tools operate inside an explicitly opened workspace directory. The model router
-supports Anthropic, OpenAI, and OpenAI-compatible endpoints. It fails closed: if
-no enabled provider with a usable credential can serve the selected model, no
-model request is sent.
+Today these file tools operate inside one directly opened workspace directory
+stored on the chat. That is a temporary pre-alpha boundary, not the intended
+product model. Projects and conversations will instead resolve to distinct
+host-access contexts containing user-approved roots, and file operations will go
+through a capability-gated host-broker sidecar. See [Host access and connected
+folders](host-access.md). The model router supports Anthropic, OpenAI, and
+OpenAI-compatible endpoints. It fails closed: if no enabled provider with a
+usable credential can serve the selected model, no model request is sent.
 
 ### 4. Events drive the live client
 
@@ -239,11 +244,10 @@ pending ----worker applies----> applied
    +----turn fails/cancels-----> rejected
 ```
 
-One narrow recovery seam remains: applying the steering message and emitting its
-`UserSteered` replay event are separate commits. A crash or cancellation in that
-gap can leave the persisted transcript correct while the replay journal lacks
-that notification. The intended fix is to make the message, application receipt,
-and journal event one exact transaction.
+Applying a steer commits its user message, application receipt, revision, and
+`UserSteered` replay event in one transaction. If the response to that commit is
+lost, the worker retries the same identity and recovers the exact existing
+result rather than applying the instruction twice.
 
 ## What happens when a document is added
 
@@ -380,9 +384,13 @@ The browser-facing API is not exposed on a public network interface.
 
 The current UI is a walking skeleton, not the complete product. It creates a new
 loose chat on each launch and supports provider setup, model selection, basic
-chat streaming, and approval prompts. It does not yet provide a chat picker,
-history reconstruction, projects, document ingestion, document search, cancel,
-or steer controls, even though much of that backend API already exists.
+chat streaming, and approval prompts. It also creates and assigns one
+`Documents/OpenWave` directory automatically. That single-directory behavior is
+temporary: the desktop should keep OpenWave's private data in app storage and
+let each project or conversation connect user-chosen folders through the host
+broker. The UI does not yet provide a chat picker, history reconstruction,
+projects, document ingestion, document search, cancel, or steer controls, even
+though much of that backend API already exists.
 
 Because that chat is projectless, its `search` tool can see only the unscoped
 document corpus. Project-scoped documents are not reachable through the current
@@ -431,6 +439,7 @@ object storage, and multi-process ownership remain future integration work.
 | Documents | `crates/openwave-server/src/routes/document.rs`, `document_worker.rs` | Upload API and Parse/Index worker orchestration |
 | Retrieval | `crates/openwave-retrieval/src/` | Parsing, chunks, embeddings, Lance, ranking, citations |
 | Desktop | `crates/openwave-desktop/src/`, `crates/openwave-desktop/ui/src/App.tsx` | Tauri host and current React shell |
+| Host access (planned) | `docs/host-access.md` | Broker trust boundary, connected-root model, and delivery slices |
 | MCP | `crates/openwave-mcp/src/`, `crates/openwave-cli/src/main.rs` | MCP protocol server and stdio command |
 | Connectors and Slack | `crates/openwave-connectors`, `crates/openwave-slack` | Placeholders, not working product surfaces yet |
 
@@ -472,7 +481,8 @@ and fail-closed provider routing.
 
 The main next steps are:
 
-- close the steering application/event atomicity gap;
+- replace raw chat/project workspace paths with broker-mediated, per-context
+  connected roots while keeping OpenWave's private app data separate;
 - add resumable checkpoints and explicit idempotency policy around tool effects;
 - make approvals resumable rather than process-local;
 - expose existing backend capabilities through a real desktop information
@@ -518,7 +528,11 @@ steps; the migrations should be condensed into a clean baseline before v1.
 
 ## Glossary
 
-- **Chat:** a conversation container and workspace context.
+- **Chat:** a conversation container that resolves an explicit host-access
+  context; it does not own an arbitrary absolute workspace path in the intended
+  model.
+- **Connected root:** a user-approved host folder known to tools by an opaque
+  root identifier and root-relative paths.
 - **Turn:** one accepted unit of user-to-agent work inside a chat.
 - **Message:** durable user or assistant text; tool calls are stored separately.
 - **Event journal:** ordered receipts used to rebuild a live client stream.


### PR DESCRIPTION
## Summary

- define OpenWave app data separately from user-connected host folders
- document per-project and per-conversation multi-root access
- establish the control-plane, native-consent, and host-broker boundaries
- outline independently reviewable backend, desktop UI, and MCP migration slices

## Current behavior

Projects and chats still persist raw `workspace_dir` paths, and the desktop still creates `Documents/OpenWave` automatically. The docs call those out as temporary pre-alpha behavior rather than the intended authority model.

## Validation

- `git diff --check`
