### PR TITLE
feat(host): add broker policy core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5780,6 +5780,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "openwave-host-broker"
+version = "0.0.0"
+dependencies = [
+ "cap-fs-ext",
+ "cap-std",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "openwave-mcp"
 version = "0.0.0"
 dependencies = [

--- a/crates/openwave-host-broker/Cargo.toml
+++ b/crates/openwave-host-broker/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "openwave-host-broker"
+description = "Capability-gated access to user-approved host resources."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[dependencies]
+cap-fs-ext.workspace = true
+cap-std.workspace = true
+chrono.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/openwave-host-broker/src/capability.rs
+++ b/crates/openwave-host-broker/src/capability.rs
@@ -1,0 +1,585 @@
+//! Deny-by-default capability grants and conversation attachments.
+//!
+//! These are persistence and protocol-safe value types. The matcher in this
+//! module exists only in tests to specify the intended grant and attachment
+//! intersection. A later broker operation layer must derive the capability and
+//! resource from a typed request, reauthorize, and perform the effect without
+//! handing callers a reusable authorization token.
+
+use chrono::{DateTime, Utc};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+#[cfg(test)]
+use crate::ExecutionContext;
+use crate::{GrantId, GrantSubject, RelativePath, RootId};
+
+/// A class of host action guarded independently by the broker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Capability {
+    /// Discover safe summaries of roots connected to this subject.
+    ListRoots,
+    /// List directories and read file bytes within a connected root.
+    ReadFiles,
+}
+
+/// Resource scope covered by one grant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Scope {
+    /// A subject-wide action that touches no root, such as listing roots.
+    Subject,
+    /// An entire connected root.
+    Root { root_id: RootId },
+    /// One non-root subtree within a connected root.
+    PathSubtree {
+        root_id: RootId,
+        relative: RelativePath,
+    },
+}
+
+/// How the user expressed consent for a grant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ConsentMethod {
+    /// The user chose a folder through a trusted native picker.
+    FolderPicker,
+    /// The user approved a capability in an explicit permission dialog.
+    PermissionDialog,
+    /// A local operator deliberately provisioned a headless installation.
+    OperatorConfig,
+}
+
+/// Auditable evidence attached to a grant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsentRecord {
+    method: ConsentMethod,
+    granted_at: DateTime<Utc>,
+}
+
+impl ConsentRecord {
+    #[cfg(test)]
+    pub(crate) const fn new(method: ConsentMethod, granted_at: DateTime<Utc>) -> Self {
+        Self { method, granted_at }
+    }
+
+    /// Trusted interaction through which consent was captured.
+    pub const fn method(&self) -> ConsentMethod {
+        self.method
+    }
+
+    /// Host-stamped time at which the user granted access.
+    pub const fn granted_at(&self) -> DateTime<Utc> {
+        self.granted_at
+    }
+}
+
+/// A persisted authorization for one exact product subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Grant {
+    id: GrantId,
+    subject: GrantSubject,
+    capability: Capability,
+    scope: Scope,
+    consent: ConsentRecord,
+}
+
+impl Grant {
+    pub(crate) fn from_consent(
+        id: GrantId,
+        subject: GrantSubject,
+        capability: Capability,
+        scope: Scope,
+        consent: ConsentRecord,
+    ) -> Result<Self, GrantError> {
+        validate_capability_scope(capability, &scope)?;
+        Ok(Self {
+            id,
+            subject,
+            capability,
+            scope,
+            consent,
+        })
+    }
+
+    /// Stable identity recorded in operation receipts and audit entries.
+    pub const fn id(&self) -> GrantId {
+        self.id
+    }
+
+    /// Project or conversation to which the standing consent belongs.
+    pub const fn subject(&self) -> GrantSubject {
+        self.subject
+    }
+
+    /// Action class the user allowed.
+    pub const fn capability(&self) -> Capability {
+        self.capability
+    }
+
+    /// Root or subtree in which the action is allowed.
+    pub const fn scope(&self) -> &Scope {
+        &self.scope
+    }
+
+    /// How and when the grant was created.
+    pub const fn consent(&self) -> &ConsentRecord {
+        &self.consent
+    }
+}
+
+impl<'de> Deserialize<'de> for Grant {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireGrant {
+            id: GrantId,
+            subject: GrantSubject,
+            capability: Capability,
+            scope: Scope,
+            consent: ConsentRecord,
+        }
+
+        let wire = WireGrant::deserialize(deserializer)?;
+        Self::from_consent(
+            wire.id,
+            wire.subject,
+            wire.capability,
+            wire.scope,
+            wire.consent,
+        )
+        .map_err(D::Error::custom)
+    }
+}
+
+/// A root explicitly attached to one conversation.
+///
+/// Standing project consent alone is insufficient: every root operation must
+/// also match one of these broker-owned attachments for the active conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub struct RootAttachment {
+    conversation_id: Uuid,
+    root_id: RootId,
+}
+
+impl RootAttachment {
+    pub(crate) fn new(conversation_id: Uuid, root_id: RootId) -> Result<Self, GrantError> {
+        if conversation_id.is_nil() {
+            return Err(GrantError::NilConversation);
+        }
+        Ok(Self {
+            conversation_id,
+            root_id,
+        })
+    }
+
+    /// Conversation that explicitly selected this root.
+    pub const fn conversation_id(self) -> Uuid {
+        self.conversation_id
+    }
+
+    /// Attached broker root.
+    pub const fn root_id(self) -> RootId {
+        self.root_id
+    }
+}
+
+impl<'de> Deserialize<'de> for RootAttachment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireAttachment {
+            conversation_id: Uuid,
+            root_id: RootId,
+        }
+
+        let wire = WireAttachment::deserialize(deserializer)?;
+        Self::new(wire.conversation_id, wire.root_id).map_err(D::Error::custom)
+    }
+}
+
+/// Invalid trusted-control or persisted grant data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum GrantError {
+    /// Capability and scope do not describe a meaningful operation class.
+    #[error("capability cannot be granted with this scope")]
+    InvalidCapabilityScope,
+    /// A subtree grant must name at least one path segment.
+    #[error("a subtree grant cannot cover the root")]
+    EmptySubtree,
+    /// Nil conversation IDs cannot own attachments.
+    #[error("attachment conversation must not be nil")]
+    NilConversation,
+}
+
+fn validate_capability_scope(capability: Capability, scope: &Scope) -> Result<(), GrantError> {
+    match (capability, scope) {
+        (Capability::ListRoots, Scope::Subject) | (Capability::ReadFiles, Scope::Root { .. }) => {
+            Ok(())
+        }
+        (Capability::ReadFiles, Scope::PathSubtree { relative, .. }) if !relative.is_root() => {
+            Ok(())
+        }
+        (Capability::ReadFiles, Scope::PathSubtree { .. }) => Err(GrantError::EmptySubtree),
+        _ => Err(GrantError::InvalidCapabilityScope),
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Resource<'a> {
+    Subject,
+    Root(&'a RootId),
+    Path {
+        root_id: &'a RootId,
+        relative: &'a RelativePath,
+    },
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Authorization {
+    pub(crate) grant_id: GrantId,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Denied {
+    pub(crate) capability: Capability,
+}
+
+#[cfg(test)]
+pub(crate) fn authorize(
+    grants: &[Grant],
+    attachments: &[RootAttachment],
+    context: ExecutionContext,
+    capability: Capability,
+    resource: Resource<'_>,
+) -> Result<Authorization, Denied> {
+    let attached = match resource {
+        Resource::Subject => true,
+        Resource::Root(root_id) | Resource::Path { root_id, .. } => {
+            attachments.iter().any(|item| {
+                item.conversation_id == context.conversation_id() && item.root_id == *root_id
+            })
+        }
+    };
+    if !attached {
+        return Err(Denied { capability });
+    }
+
+    grants
+        .iter()
+        .find(|grant| {
+            context.grant_subject_matches(grant.subject)
+                && grant.capability == capability
+                && scope_covers(&grant.scope, resource)
+        })
+        .map(|grant| Authorization { grant_id: grant.id })
+        .ok_or(Denied { capability })
+}
+
+#[cfg(test)]
+fn scope_covers(scope: &Scope, resource: Resource<'_>) -> bool {
+    match (scope, resource) {
+        (Scope::Subject, Resource::Subject) => true,
+        (Scope::Root { root_id }, Resource::Root(requested)) => root_id == requested,
+        (
+            Scope::Root { root_id },
+            Resource::Path {
+                root_id: requested, ..
+            },
+        ) => root_id == requested,
+        (
+            Scope::PathSubtree { root_id, relative },
+            Resource::Path {
+                root_id: requested,
+                relative: requested_relative,
+            },
+        ) => root_id == requested && path_starts_with(requested_relative, relative),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+fn path_starts_with(candidate: &RelativePath, prefix: &RelativePath) -> bool {
+    let candidate = candidate.segments().collect::<Vec<_>>();
+    let prefix = prefix.segments().collect::<Vec<_>>();
+    candidate.len() >= prefix.len()
+        && prefix
+            .iter()
+            .zip(candidate.iter())
+            .all(|(left, right)| left == right)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    fn subject_project(id: Uuid) -> GrantSubject {
+        GrantSubject::project(id).unwrap()
+    }
+
+    fn subject_conversation(id: Uuid) -> GrantSubject {
+        GrantSubject::conversation(id).unwrap()
+    }
+
+    fn grant(subject: GrantSubject, capability: Capability, scope: Scope) -> Grant {
+        Grant::from_consent(
+            GrantId::new(),
+            subject,
+            capability,
+            scope,
+            ConsentRecord::new(
+                ConsentMethod::FolderPicker,
+                Utc.with_ymd_and_hms(2026, 7, 14, 0, 0, 0).unwrap(),
+            ),
+        )
+        .unwrap()
+    }
+
+    fn attachment(conversation_id: Uuid, root_id: RootId) -> RootAttachment {
+        RootAttachment::new(conversation_id, root_id).unwrap()
+    }
+
+    #[test]
+    fn denies_without_an_exact_live_grant_and_attachment() {
+        let conversation = Uuid::new_v4();
+        let context = ExecutionContext::standalone(conversation).unwrap();
+        let root = RootId::new();
+        let expected = Err(Denied {
+            capability: Capability::ReadFiles,
+        });
+        assert_eq!(
+            authorize(
+                &[],
+                &[attachment(conversation, root)],
+                context,
+                Capability::ReadFiles,
+                Resource::Root(&root),
+            ),
+            expected
+        );
+        let grants = [grant(
+            subject_conversation(conversation),
+            Capability::ReadFiles,
+            Scope::Root { root_id: root },
+        )];
+        assert_eq!(
+            authorize(
+                &grants,
+                &[],
+                context,
+                Capability::ReadFiles,
+                Resource::Root(&root),
+            ),
+            expected
+        );
+    }
+
+    #[test]
+    fn project_consent_is_intersected_with_conversation_attachment() {
+        let project = Uuid::new_v4();
+        let attached_conversation = Uuid::new_v4();
+        let other_conversation = Uuid::new_v4();
+        let root = RootId::new();
+        let grants = [grant(
+            subject_project(project),
+            Capability::ReadFiles,
+            Scope::Root { root_id: root },
+        )];
+        let attachments = [attachment(attached_conversation, root)];
+
+        assert!(authorize(
+            &grants,
+            &attachments,
+            ExecutionContext::project_chat(attached_conversation, project).unwrap(),
+            Capability::ReadFiles,
+            Resource::Root(&root),
+        )
+        .is_ok());
+        assert!(authorize(
+            &grants,
+            &attachments,
+            ExecutionContext::project_chat(other_conversation, project).unwrap(),
+            Capability::ReadFiles,
+            Resource::Root(&root),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn subject_wide_root_discovery_does_not_require_a_root_attachment() {
+        let project = Uuid::new_v4();
+        let conversation = Uuid::new_v4();
+        let grants = [grant(
+            subject_project(project),
+            Capability::ListRoots,
+            Scope::Subject,
+        )];
+        assert!(authorize(
+            &grants,
+            &[],
+            ExecutionContext::project_chat(conversation, project).unwrap(),
+            Capability::ListRoots,
+            Resource::Subject,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn rejects_a_grant_from_another_project_or_conversation() {
+        let conversation = Uuid::new_v4();
+        let project = Uuid::new_v4();
+        let root = RootId::new();
+        let attachments = [attachment(conversation, root)];
+        let context = ExecutionContext::project_chat(conversation, project).unwrap();
+        for subject in [
+            subject_project(Uuid::new_v4()),
+            subject_conversation(Uuid::new_v4()),
+        ] {
+            let grants = [grant(
+                subject,
+                Capability::ReadFiles,
+                Scope::Root { root_id: root },
+            )];
+            assert!(authorize(
+                &grants,
+                &attachments,
+                context,
+                Capability::ReadFiles,
+                Resource::Root(&root),
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn selects_the_exact_root_in_a_multi_root_context() {
+        let conversation = Uuid::new_v4();
+        let context = ExecutionContext::standalone(conversation).unwrap();
+        let allowed = RootId::new();
+        let other = RootId::new();
+        let grants = [grant(
+            subject_conversation(conversation),
+            Capability::ReadFiles,
+            Scope::Root { root_id: allowed },
+        )];
+        let attachments = [
+            attachment(conversation, allowed),
+            attachment(conversation, other),
+        ];
+        assert!(authorize(
+            &grants,
+            &attachments,
+            context,
+            Capability::ReadFiles,
+            Resource::Root(&allowed),
+        )
+        .is_ok());
+        assert!(authorize(
+            &grants,
+            &attachments,
+            context,
+            Capability::ReadFiles,
+            Resource::Root(&other),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn subtree_grants_cover_only_segment_aligned_descendants() {
+        let conversation = Uuid::new_v4();
+        let context = ExecutionContext::standalone(conversation).unwrap();
+        let root = RootId::new();
+        let subtree = RelativePath::parse("reports/approved").unwrap();
+        let inside = RelativePath::parse("reports/approved/q1.md").unwrap();
+        let sibling = RelativePath::parse("reports/approved-old/q1.md").unwrap();
+        let grants = [grant(
+            subject_conversation(conversation),
+            Capability::ReadFiles,
+            Scope::PathSubtree {
+                root_id: root,
+                relative: subtree,
+            },
+        )];
+        let attachments = [attachment(conversation, root)];
+        assert!(authorize(
+            &grants,
+            &attachments,
+            context,
+            Capability::ReadFiles,
+            Resource::Path {
+                root_id: &root,
+                relative: &inside,
+            },
+        )
+        .is_ok());
+        assert!(authorize(
+            &grants,
+            &attachments,
+            context,
+            Capability::ReadFiles,
+            Resource::Path {
+                root_id: &root,
+                relative: &sibling,
+            },
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn invalid_capability_scope_pairs_cannot_deserialize() {
+        let subject = subject_project(Uuid::new_v4());
+        let consent = ConsentRecord::new(ConsentMethod::FolderPicker, Utc::now());
+        let invalid = serde_json::json!({
+            "id": GrantId::new(),
+            "subject": subject,
+            "capability": "list_roots",
+            "scope": { "kind": "root", "root_id": RootId::new() },
+            "consent": consent,
+        });
+        assert!(serde_json::from_value::<Grant>(invalid).is_err());
+    }
+
+    #[test]
+    fn revocation_is_a_fresh_snapshot_not_a_cached_directory_handle() {
+        let conversation = Uuid::new_v4();
+        let context = ExecutionContext::standalone(conversation).unwrap();
+        let root = RootId::new();
+        let mut grants = vec![grant(
+            subject_conversation(conversation),
+            Capability::ReadFiles,
+            Scope::Root { root_id: root },
+        )];
+        let attachments = [attachment(conversation, root)];
+        assert!(authorize(
+            &grants,
+            &attachments,
+            context,
+            Capability::ReadFiles,
+            Resource::Root(&root),
+        )
+        .is_ok());
+        grants.clear();
+        assert!(authorize(
+            &grants,
+            &attachments,
+            context,
+            Capability::ReadFiles,
+            Resource::Root(&root),
+        )
+        .is_err());
+    }
+}

--- a/crates/openwave-host-broker/src/id.rs
+++ b/crates/openwave-host-broker/src/id.rs
@@ -1,0 +1,265 @@
+//! Opaque identities and execution authority used at the host boundary.
+
+use std::{fmt, str::FromStr};
+
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// An identity or authority context violated a broker invariant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum IdError {
+    /// Nil is a sentinel, not a valid persisted broker identity.
+    #[error("broker identities must not be nil")]
+    Nil,
+}
+
+/// Text parsing failure for an opaque broker identity.
+#[derive(Debug, Error)]
+pub enum ParseIdError {
+    /// The value was not a UUID.
+    #[error(transparent)]
+    InvalidUuid(#[from] uuid::Error),
+    /// Nil is syntactically a UUID but not a broker identity.
+    #[error(transparent)]
+    InvalidIdentity(#[from] IdError),
+}
+
+macro_rules! uuid_id {
+    ($name:ident, $description:literal) => {
+        #[doc = $description]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(Uuid);
+
+        impl $name {
+            /// Allocate a fresh random identity.
+            pub fn new() -> Self {
+                Self(Uuid::new_v4())
+            }
+
+            /// Validate an identity received from trusted product state.
+            pub fn from_uuid(id: Uuid) -> Result<Self, IdError> {
+                if id.is_nil() {
+                    Err(IdError::Nil)
+                } else {
+                    Ok(Self(id))
+                }
+            }
+
+            /// Return the underlying UUID.
+            pub const fn as_uuid(self) -> Uuid {
+                self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(formatter)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = ParseIdError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Self::from_uuid(Uuid::parse_str(value)?).map_err(Into::into)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let id = Uuid::deserialize(deserializer)?;
+                Self::from_uuid(id).map_err(D::Error::custom)
+            }
+        }
+    };
+}
+
+uuid_id!(RootId, "Host-local identity for one registered root.");
+uuid_id!(
+    GrantId,
+    "Stable identity for one consented capability grant."
+);
+uuid_id!(
+    OperationId,
+    "Stable identity for an idempotent broker operation."
+);
+
+/// Product object to which standing host consent belongs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectKind {
+    /// Consent shared at project scope.
+    Project,
+    /// Consent belonging to a standalone or conversation-specific context.
+    Conversation,
+}
+
+/// Exact subject named by a standing grant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub struct GrantSubject {
+    kind: SubjectKind,
+    id: Uuid,
+}
+
+impl GrantSubject {
+    /// Build a project grant subject.
+    pub fn project(id: Uuid) -> Result<Self, IdError> {
+        Self::new(SubjectKind::Project, id)
+    }
+
+    /// Build a conversation grant subject.
+    pub fn conversation(id: Uuid) -> Result<Self, IdError> {
+        Self::new(SubjectKind::Conversation, id)
+    }
+
+    fn new(kind: SubjectKind, id: Uuid) -> Result<Self, IdError> {
+        if id.is_nil() {
+            Err(IdError::Nil)
+        } else {
+            Ok(Self { kind, id })
+        }
+    }
+
+    /// Semantic kind of this product subject.
+    pub const fn kind(self) -> SubjectKind {
+        self.kind
+    }
+
+    /// Product UUID without its semantic kind.
+    pub const fn id(self) -> Uuid {
+        self.id
+    }
+}
+
+impl<'de> Deserialize<'de> for GrantSubject {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireSubject {
+            kind: SubjectKind,
+            id: Uuid,
+        }
+
+        let wire = WireSubject::deserialize(deserializer)?;
+        Self::new(wire.kind, wire.id).map_err(D::Error::custom)
+    }
+}
+
+/// Trusted conversation identity supplied to one broker operation.
+///
+/// Project consent and conversation attachment are separate facts. A project
+/// chat therefore carries both IDs; a standalone chat carries only its
+/// conversation ID. The agent never chooses either value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+pub struct ExecutionContext {
+    conversation_id: Uuid,
+    project_id: Option<Uuid>,
+}
+
+impl ExecutionContext {
+    /// Context for a conversation inside a project.
+    pub fn project_chat(conversation_id: Uuid, project_id: Uuid) -> Result<Self, IdError> {
+        if conversation_id.is_nil() || project_id.is_nil() {
+            return Err(IdError::Nil);
+        }
+        Ok(Self {
+            conversation_id,
+            project_id: Some(project_id),
+        })
+    }
+
+    /// Context for a standalone conversation.
+    pub fn standalone(conversation_id: Uuid) -> Result<Self, IdError> {
+        if conversation_id.is_nil() {
+            return Err(IdError::Nil);
+        }
+        Ok(Self {
+            conversation_id,
+            project_id: None,
+        })
+    }
+
+    /// Exact conversation whose attached-root set must cover the operation.
+    pub const fn conversation_id(self) -> Uuid {
+        self.conversation_id
+    }
+
+    /// Optional project whose standing grants may authorize the conversation.
+    pub const fn project_id(self) -> Option<Uuid> {
+        self.project_id
+    }
+
+    #[cfg(test)]
+    pub(crate) fn grant_subject_matches(self, subject: GrantSubject) -> bool {
+        match subject.kind() {
+            SubjectKind::Project => self.project_id == Some(subject.id()),
+            SubjectKind::Conversation => self.conversation_id == subject.id(),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ExecutionContext {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WireContext {
+            conversation_id: Uuid,
+            project_id: Option<Uuid>,
+        }
+
+        let wire = WireContext::deserialize(deserializer)?;
+        match wire.project_id {
+            Some(project_id) => Self::project_chat(wire.conversation_id, project_id),
+            None => Self::standalone(wire.conversation_id),
+        }
+        .map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subject_kind_is_part_of_its_identity() {
+        let id = Uuid::new_v4();
+        assert_ne!(
+            GrantSubject::project(id).unwrap(),
+            GrantSubject::conversation(id).unwrap()
+        );
+    }
+
+    #[test]
+    fn opaque_ids_roundtrip_and_reject_nil() {
+        let root = RootId::new();
+        let encoded = serde_json::to_string(&root).unwrap();
+        assert_eq!(serde_json::from_str::<RootId>(&encoded).unwrap(), root);
+        assert_eq!(root.to_string().parse::<RootId>().unwrap(), root);
+        assert!(serde_json::from_str::<RootId>(&format!("\"{}\"", Uuid::nil())).is_err());
+    }
+
+    #[test]
+    fn execution_context_rejects_nil_ids_during_construction_and_serde() {
+        assert_eq!(ExecutionContext::standalone(Uuid::nil()), Err(IdError::Nil));
+        let encoded = format!(
+            r#"{{"conversation_id":"{}","project_id":null}}"#,
+            Uuid::nil()
+        );
+        assert!(serde_json::from_str::<ExecutionContext>(&encoded).is_err());
+    }
+}

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -1,0 +1,22 @@
+//! Capability and path-policy core for access to user-approved host resources.
+//!
+//! This crate defines the policy values and root-opening primitive that the
+//! broker will enforce; it does not yet expose agent-facing filesystem
+//! operations. A later operation layer will own authorization and the effect so
+//! callers cannot separate a successful check from the filesystem access it
+//! covered. No desktop runtime or transport is referenced here.
+
+pub mod capability;
+pub mod id;
+pub mod path_policy;
+pub mod relative_path;
+
+pub use capability::{
+    Capability, ConsentMethod, ConsentRecord, Grant, GrantError, RootAttachment, Scope,
+};
+pub use id::{
+    ExecutionContext, GrantId, GrantSubject, IdError, OperationId, ParseIdError, RootId,
+    SubjectKind,
+};
+pub use path_policy::{RootPolicy, RootPolicyError, ValidatedRoot};
+pub use relative_path::{RelativePath, RelativePathError};

--- a/crates/openwave-host-broker/src/path_policy.rs
+++ b/crates/openwave-host-broker/src/path_policy.rs
@@ -1,0 +1,566 @@
+//! Cross-platform root registration and containment policy.
+
+use std::{
+    ffi::OsString,
+    io,
+    path::{Component, Path, PathBuf, Prefix},
+};
+
+use cap_fs_ext::DirExt;
+use cap_std::{ambient_authority, fs::Dir};
+use thiserror::Error;
+
+/// Why a host folder cannot be opened as a registered root.
+#[derive(Debug, Error)]
+pub enum RootPolicyError {
+    /// The candidate is a filesystem root, home directory, or an ancestor that
+    /// would grant much more authority than one project folder.
+    #[error("root is not a specific project folder")]
+    TooBroad,
+    /// Trusted consent must name the exact absolute picker result. Resolving a
+    /// relative control path against broker process state would change what the
+    /// user selected.
+    #[error("root must be an absolute host path")]
+    NotAbsolute,
+    /// The candidate overlaps a protected system location.
+    #[error("root overlaps a protected system location")]
+    SensitiveLocation,
+    /// The candidate is an entire OS user profile.
+    #[error("root must be a folder inside a user profile, not the whole profile")]
+    WholeUserProfile,
+    /// Host filesystem resolution or descriptor pinning failed.
+    #[error("could not securely open root: {0}")]
+    Io(#[from] io::Error),
+    /// This target has no reviewed host-root policy and must fail closed.
+    #[error("host roots are unsupported on this target")]
+    UnsupportedPlatform,
+    /// Windows device and general verbatim namespaces can alias protected
+    /// volumes without a stable drive or share identity.
+    #[error("root uses an unsupported filesystem namespace")]
+    UnsupportedNamespace,
+    /// A required Windows known-folder location was unavailable. Root policy
+    /// must not silently become less restrictive when the host environment is
+    /// incomplete.
+    #[error("required host policy location is unavailable: {0}")]
+    MissingKnownFolder(&'static str),
+}
+
+/// A canonical root pinned to a descriptor after policy validation.
+///
+/// Its absolute path and directory handle remain crate-private. Future broker
+/// operations consume the handle directly; callers cannot turn validation into
+/// a reusable path string or substitute a different directory after the check.
+pub struct ValidatedRoot {
+    _canonical_path: PathBuf,
+    _directory: Dir,
+}
+
+impl std::fmt::Debug for ValidatedRoot {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ValidatedRoot")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ValidatedRoot {
+    #[cfg(test)]
+    pub(crate) fn canonical_path(&self) -> &Path {
+        &self._canonical_path
+    }
+
+    #[cfg(test)]
+    pub(crate) fn directory(&self) -> &Dir {
+        &self._directory
+    }
+}
+
+/// Which canonical host folders the user may register at all.
+#[derive(Debug, Clone)]
+pub struct RootPolicy {
+    sensitive: Vec<PathBuf>,
+    user_containers: Vec<PathBuf>,
+    broad: Vec<PathBuf>,
+    home: PathBuf,
+}
+
+impl RootPolicy {
+    /// Build the reviewed policy for the current desktop host platform.
+    ///
+    /// The home directory is resolved through the filesystem here instead of
+    /// read from ambient environment. Unsupported targets return an error rather
+    /// than receiving an empty allow-most policy.
+    pub fn for_host(home: PathBuf) -> Result<Self, RootPolicyError> {
+        let home = std::fs::canonicalize(home)?;
+        #[cfg(unix)]
+        let paths = |items: &[&str]| items.iter().map(PathBuf::from).collect();
+
+        #[cfg(target_os = "macos")]
+        let policy = Self {
+            sensitive: paths(&[
+                "/bin",
+                "/sbin",
+                "/usr",
+                "/etc",
+                "/var",
+                "/dev",
+                "/System",
+                "/Library",
+                "/Applications",
+                "/cores",
+                "/private",
+                "/opt",
+            ]),
+            user_containers: paths(&["/Users"]),
+            broad: paths(&["/Volumes", "/Network"]),
+            home,
+        };
+
+        #[cfg(all(unix, not(target_os = "macos")))]
+        let policy = Self {
+            sensitive: paths(&[
+                "/bin", "/sbin", "/usr", "/etc", "/var", "/lib", "/lib64", "/lib32", "/boot",
+                "/proc", "/sys", "/dev", "/run", "/srv", "/opt", "/root",
+            ]),
+            user_containers: paths(&["/home"]),
+            broad: paths(&["/mnt", "/media"]),
+            home,
+        };
+
+        #[cfg(windows)]
+        let policy = {
+            let sensitive = vec![
+                canonical_windows_known_folder(&["SystemRoot", "windir"])?,
+                canonical_windows_known_folder(&["ProgramFiles"])?,
+                canonical_windows_known_folder(&["ProgramFiles(x86)"])?,
+                canonical_windows_known_folder(&["ProgramData"])?,
+            ];
+            let profile_container = home
+                .parent()
+                .ok_or(RootPolicyError::WholeUserProfile)?
+                .to_path_buf();
+            Self {
+                sensitive,
+                user_containers: vec![profile_container],
+                broad: Vec::new(),
+                home,
+            }
+        };
+
+        #[cfg(not(any(unix, windows)))]
+        return Err(RootPolicyError::UnsupportedPlatform);
+
+        #[cfg(any(unix, windows))]
+        Ok(policy)
+    }
+
+    /// Resolve, validate, and descriptor-pin one user-selected directory.
+    ///
+    /// Canonicalization prevents a selected symlink from disguising a protected
+    /// target. The canonical path is then opened one component at a time without
+    /// following links, closing the replacement race between validation and the
+    /// descriptor used by later operations.
+    pub fn open_root(&self, candidate: &Path) -> Result<ValidatedRoot, RootPolicyError> {
+        if !candidate.is_absolute() {
+            return Err(RootPolicyError::NotAbsolute);
+        }
+        let canonical_path = std::fs::canonicalize(candidate)?;
+        self.validate_canonical(&canonical_path)?;
+        let directory = open_canonical_dir_nofollow(&canonical_path)?;
+        Ok(ValidatedRoot {
+            _canonical_path: canonical_path,
+            _directory: directory,
+        })
+    }
+
+    fn validate_canonical(&self, root: &Path) -> Result<(), RootPolicyError> {
+        if !root.is_absolute() || is_filesystem_root(root) {
+            return Err(RootPolicyError::TooBroad);
+        }
+        if !supported_canonical_namespace(root) {
+            return Err(RootPolicyError::UnsupportedNamespace);
+        }
+        if is_within(root, &self.home) {
+            return Err(RootPolicyError::TooBroad);
+        }
+        if self
+            .sensitive
+            .iter()
+            .any(|path| is_within(path, root) || is_within(root, path))
+        {
+            return Err(RootPolicyError::SensitiveLocation);
+        }
+        for container in &self.user_containers {
+            if is_within(root, container) {
+                return Err(RootPolicyError::TooBroad);
+            }
+            if is_direct_child(container, root) {
+                return Err(RootPolicyError::WholeUserProfile);
+            }
+        }
+        if self.broad.iter().any(|path| is_within(root, path)) {
+            return Err(RootPolicyError::TooBroad);
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn for_test(
+        home: PathBuf,
+        sensitive: Vec<PathBuf>,
+        user_containers: Vec<PathBuf>,
+        broad: Vec<PathBuf>,
+    ) -> Self {
+        Self {
+            sensitive,
+            user_containers,
+            broad,
+            home,
+        }
+    }
+}
+
+#[cfg(windows)]
+fn canonical_windows_known_folder(
+    variables: &'static [&'static str],
+) -> Result<PathBuf, RootPolicyError> {
+    let path = windows_known_folder_from(variables, |name| std::env::var_os(name))?;
+    std::fs::canonicalize(path).map_err(Into::into)
+}
+
+#[cfg(windows)]
+fn windows_known_folder_from(
+    variables: &'static [&'static str],
+    get: impl Fn(&str) -> Option<OsString>,
+) -> Result<PathBuf, RootPolicyError> {
+    let path = variables
+        .iter()
+        .find_map(|name| get(name).map(PathBuf::from))
+        .filter(|path| path.is_absolute())
+        .ok_or(RootPolicyError::MissingKnownFolder(variables[0]))?;
+    Ok(path)
+}
+
+fn supported_canonical_namespace(path: &Path) -> bool {
+    #[cfg(windows)]
+    {
+        return path.components().find_map(|component| match component {
+            Component::Prefix(prefix) => Some(matches!(
+                prefix.kind(),
+                Prefix::Disk(_)
+                    | Prefix::VerbatimDisk(_)
+                    | Prefix::UNC(_, _)
+                    | Prefix::VerbatimUNC(_, _)
+            )),
+            _ => None,
+        }) == Some(true);
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = path;
+        true
+    }
+}
+
+fn open_canonical_dir_nofollow(path: &Path) -> io::Result<Dir> {
+    let mut anchor = PathBuf::new();
+    let mut segments: Vec<OsString> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => anchor.push(prefix.as_os_str()),
+            Component::RootDir => anchor.push(component.as_os_str()),
+            Component::Normal(segment) => segments.push(segment.to_owned()),
+            Component::CurDir | Component::ParentDir => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "canonical root contained a relative component",
+                ));
+            }
+        }
+    }
+    if anchor.as_os_str().is_empty() || segments.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "canonical root did not have an absolute anchor and directory segment",
+        ));
+    }
+
+    let mut directory = Dir::open_ambient_dir(anchor, ambient_authority())?;
+    for segment in segments {
+        directory = directory.open_dir_nofollow(segment)?;
+    }
+    Ok(directory)
+}
+
+fn is_within(root: &Path, candidate: &Path) -> bool {
+    let root = normalized_components(root);
+    let candidate = normalized_components(candidate);
+    if !root
+        .iter()
+        .any(|component| matches!(component, Component::Normal(_)))
+        || candidate.len() < root.len()
+    {
+        return false;
+    }
+    root.iter()
+        .zip(candidate.iter())
+        .all(|(&left, &right)| component_eq(left, right))
+}
+
+fn normalized_components(path: &Path) -> Vec<Component<'_>> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir if matches!(components.last(), Some(Component::Normal(_))) => {
+                components.pop();
+            }
+            Component::ParentDir => {}
+            component => components.push(component),
+        }
+    }
+    components
+}
+
+fn component_eq(left: Component<'_>, right: Component<'_>) -> bool {
+    match (left, right) {
+        (Component::Normal(left), Component::Normal(right)) => os_component_eq(left, right),
+        (Component::Prefix(left), Component::Prefix(right)) => prefix_eq(left.kind(), right.kind()),
+        (left, right) => left == right,
+    }
+}
+
+fn os_component_eq(left: &std::ffi::OsStr, right: &std::ffi::OsStr) -> bool {
+    if cfg!(windows) {
+        left.eq_ignore_ascii_case(right)
+    } else {
+        left == right
+    }
+}
+
+fn prefix_eq(left: Prefix<'_>, right: Prefix<'_>) -> bool {
+    match (left, right) {
+        (Prefix::Disk(left), Prefix::Disk(right))
+        | (Prefix::Disk(left), Prefix::VerbatimDisk(right))
+        | (Prefix::VerbatimDisk(left), Prefix::Disk(right))
+        | (Prefix::VerbatimDisk(left), Prefix::VerbatimDisk(right)) => {
+            left.eq_ignore_ascii_case(&right)
+        }
+        (Prefix::UNC(left_server, left_share), Prefix::UNC(right_server, right_share))
+        | (Prefix::UNC(left_server, left_share), Prefix::VerbatimUNC(right_server, right_share))
+        | (Prefix::VerbatimUNC(left_server, left_share), Prefix::UNC(right_server, right_share))
+        | (
+            Prefix::VerbatimUNC(left_server, left_share),
+            Prefix::VerbatimUNC(right_server, right_share),
+        ) => {
+            left_server.eq_ignore_ascii_case(right_server)
+                && left_share.eq_ignore_ascii_case(right_share)
+        }
+        (Prefix::Verbatim(left), Prefix::Verbatim(right))
+        | (Prefix::DeviceNS(left), Prefix::DeviceNS(right)) => os_component_eq(left, right),
+        _ => false,
+    }
+}
+
+fn is_filesystem_root(path: &Path) -> bool {
+    let components = normalized_components(path);
+    !components.is_empty()
+        && !components
+            .iter()
+            .any(|component| matches!(component, Component::Normal(_)))
+}
+
+fn is_direct_child(parent: &Path, child: &Path) -> bool {
+    let parent = normalized_components(parent);
+    let child = normalized_components(child);
+    child.len() == parent.len() + 1
+        && matches!(child.last(), Some(Component::Normal(_)))
+        && parent
+            .iter()
+            .zip(child.iter())
+            .all(|(&left, &right)| component_eq(left, right))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    fn policy() -> RootPolicy {
+        RootPolicy::for_test(
+            PathBuf::from("/users/alice"),
+            vec![PathBuf::from("/system")],
+            vec![PathBuf::from("/users")],
+            vec![PathBuf::from("/volumes")],
+        )
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn containment_is_segment_aligned_and_normalized() {
+        assert!(is_within(
+            Path::new("/users/alice/work"),
+            Path::new("/users/alice/work/a/../report.md")
+        ));
+        assert!(!is_within(
+            Path::new("/users/alice/work"),
+            Path::new("/users/alice/work-old/report.md")
+        ));
+        assert!(!is_within(Path::new("/"), Path::new("/etc/passwd")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn canonical_windows_prefixes_match_lexical_policy_prefixes() {
+        assert!(is_within(
+            Path::new(r"C:\Windows"),
+            Path::new(r"\\?\C:\Windows\System32")
+        ));
+        assert!(is_within(
+            Path::new(r"\\server\share"),
+            Path::new(r"\\?\UNC\server\share\folder")
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rejects_windows_device_and_general_verbatim_namespaces() {
+        let policy = RootPolicy::for_test(
+            PathBuf::from(r"C:\Users\alice"),
+            vec![PathBuf::from(r"C:\Windows")],
+            vec![PathBuf::from(r"C:\Users")],
+            Vec::new(),
+        );
+        for path in [
+            r"\\.\GLOBALROOT\Device\HarddiskVolume1\Windows",
+            r"\\?\Volume{01234567-89ab-cdef-0123-456789abcdef}\Windows",
+        ] {
+            assert!(matches!(
+                policy.validate_canonical(Path::new(path)),
+                Err(RootPolicyError::UnsupportedNamespace)
+            ));
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn relocated_profile_container_rejects_other_whole_profiles() {
+        let home = PathBuf::from(r"D:\Users\alice");
+        let policy = RootPolicy::for_test(
+            home.clone(),
+            vec![PathBuf::from(r"D:\Windows")],
+            vec![home.parent().unwrap().to_path_buf()],
+            Vec::new(),
+        );
+        assert!(matches!(
+            policy.validate_canonical(Path::new(r"D:\Users\bob")),
+            Err(RootPolicyError::WholeUserProfile)
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_known_folders_fail_closed_without_required_host_data() {
+        let missing = windows_known_folder_from(&["ProgramData"], |_| None);
+        assert!(matches!(
+            missing,
+            Err(RootPolicyError::MissingKnownFolder("ProgramData"))
+        ));
+        let missing_x86_programs = windows_known_folder_from(&["ProgramFiles(x86)"], |_| None);
+        assert!(matches!(
+            missing_x86_programs,
+            Err(RootPolicyError::MissingKnownFolder("ProgramFiles(x86)"))
+        ));
+
+        let relocated = windows_known_folder_from(&["SystemRoot", "windir"], |name| {
+            (name == "SystemRoot").then(|| OsString::from(r"D:\Windows"))
+        })
+        .unwrap();
+        assert_eq!(relocated, PathBuf::from(r"D:\Windows"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn accepts_standard_and_project_folders_inside_the_current_profile() {
+        for path in [
+            "/users/alice/Documents",
+            "/users/alice/Downloads",
+            "/users/alice/work/project",
+        ] {
+            assert!(
+                policy().validate_canonical(Path::new(path)).is_ok(),
+                "{path}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_home_profiles_broad_roots_and_sensitive_overlap() {
+        assert!(matches!(
+            policy().validate_canonical(Path::new("/users/alice")),
+            Err(RootPolicyError::TooBroad)
+        ));
+        assert!(matches!(
+            policy().validate_canonical(Path::new("/users/bob")),
+            Err(RootPolicyError::WholeUserProfile)
+        ));
+        assert!(matches!(
+            policy().validate_canonical(Path::new("/volumes")),
+            Err(RootPolicyError::TooBroad)
+        ));
+        assert!(matches!(
+            policy().validate_canonical(Path::new("/system/secrets")),
+            Err(RootPolicyError::SensitiveLocation)
+        ));
+        assert!(matches!(
+            policy().validate_canonical(Path::new("/")),
+            Err(RootPolicyError::TooBroad)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opening_a_root_resolves_symlinks_before_policy_and_pins_a_directory() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        let allowed = home.join("Documents");
+        let sensitive = temp.path().join("sensitive");
+        std::fs::create_dir_all(&allowed).unwrap();
+        std::fs::create_dir_all(&sensitive).unwrap();
+        let policy = RootPolicy::for_test(
+            home.canonicalize().unwrap(),
+            vec![sensitive.canonicalize().unwrap()],
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let opened = policy.open_root(&allowed).unwrap();
+        assert!(opened.directory().dir_metadata().unwrap().is_dir());
+        assert_eq!(opened.canonical_path(), allowed.canonicalize().unwrap());
+
+        let disguised = temp.path().join("disguised");
+        symlink(&sensitive, &disguised).unwrap();
+        assert!(matches!(
+            policy.open_root(&disguised),
+            Err(RootPolicyError::SensitiveLocation)
+        ));
+    }
+
+    #[test]
+    fn opening_a_root_never_resolves_a_relative_control_path() {
+        let policy = RootPolicy::for_test(
+            PathBuf::from("/users/alice"),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        assert!(matches!(
+            policy.open_root(Path::new("Documents/project")),
+            Err(RootPolicyError::NotAbsolute)
+        ));
+    }
+}

--- a/crates/openwave-host-broker/src/relative_path.rs
+++ b/crates/openwave-host-broker/src/relative_path.rs
@@ -1,0 +1,199 @@
+//! OS-independent, validated paths relative to a registered root.
+
+use std::fmt;
+
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
+
+/// Why a requested root-relative path was refused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum RelativePathError {
+    /// Absolute paths are never part of the agent-facing protocol.
+    #[error("path must be relative to a registered root")]
+    Absolute,
+    /// Parent components are refused rather than normalized across authority.
+    #[error("path must not contain parent traversal")]
+    ParentTraversal,
+    /// Backslashes, colons, and NUL have platform-dependent or unsafe meaning.
+    #[error("path contains a character outside the portable path grammar")]
+    NonPortableCharacter,
+    /// Windows normalizes these names or routes them to device namespaces.
+    #[error("path contains a non-portable filename")]
+    NonPortableFilename,
+}
+
+/// A normalized path with one meaning on every supported host.
+///
+/// `/` is the only separator in the wire grammar. Empty and `.` components are
+/// removed; the root itself is represented as `.`. Backslashes, colons, parent
+/// traversal, absolute paths, Windows device names, and filenames Windows would
+/// normalize are rejected even on Unix. Invalid wire data therefore cannot
+/// instantiate this type and later change meaning on another host.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RelativePath(String);
+
+impl RelativePath {
+    /// Validate and normalize an untrusted protocol path.
+    pub fn parse(input: &str) -> Result<Self, RelativePathError> {
+        if input.starts_with('/') {
+            return Err(RelativePathError::Absolute);
+        }
+        if input.contains(['\0', '\\', ':']) {
+            return Err(RelativePathError::NonPortableCharacter);
+        }
+
+        let mut segments = Vec::new();
+        for segment in input.split('/') {
+            match segment {
+                "" | "." => {}
+                ".." => return Err(RelativePathError::ParentTraversal),
+                value if !portable_filename(value) => {
+                    return Err(RelativePathError::NonPortableFilename);
+                }
+                value => segments.push(value),
+            }
+        }
+
+        Ok(Self(if segments.is_empty() {
+            ".".to_owned()
+        } else {
+            segments.join("/")
+        }))
+    }
+
+    /// A path denoting the registered root itself.
+    pub fn root() -> Self {
+        Self(".".to_owned())
+    }
+
+    /// Stable slash-separated representation used by the broker protocol.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether this path denotes the registered root itself.
+    pub fn is_root(&self) -> bool {
+        self.0 == "."
+    }
+
+    #[cfg(test)]
+    pub(crate) fn segments(&self) -> impl Iterator<Item = &str> {
+        self.0.split('/').filter(|segment| *segment != ".")
+    }
+}
+
+fn portable_filename(value: &str) -> bool {
+    if value.ends_with(['.', ' '])
+        || value.chars().any(|character| {
+            character <= '\u{1f}' || matches!(character, '<' | '>' | '"' | '|' | '?' | '*')
+        })
+    {
+        return false;
+    }
+    let stem = value.split('.').next().unwrap_or_default();
+    let upper = stem.to_ascii_uppercase();
+    !matches!(
+        upper.as_str(),
+        "CON" | "PRN" | "AUX" | "NUL" | "CONIN$" | "CONOUT$" | "CLOCK$"
+    ) && !matches_device_number(&upper, "COM")
+        && !matches_device_number(&upper, "LPT")
+}
+
+fn matches_device_number(value: &str, prefix: &str) -> bool {
+    value.strip_prefix(prefix).is_some_and(|suffix| {
+        matches!(
+            suffix,
+            "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "¹" | "²" | "³"
+        )
+    })
+}
+
+impl fmt::Display for RelativePath {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl TryFrom<&str> for RelativePath {
+    type Error = RelativePathError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl Serialize for RelativePath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for RelativePath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::parse(&value).map_err(D::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_relative_paths_to_a_stable_wire_form() {
+        assert_eq!(RelativePath::parse("").unwrap().as_str(), ".");
+        assert_eq!(RelativePath::parse("./a//b").unwrap().as_str(), "a/b");
+    }
+
+    #[test]
+    fn rejects_absolute_parent_and_nonportable_paths_on_every_host() {
+        for absolute in ["/etc/passwd", "\\server\\share", "C:/Windows"] {
+            assert!(RelativePath::parse(absolute).is_err(), "{absolute}");
+        }
+        for traversal in ["../secret", "safe/../secret", "..\\secret"] {
+            assert!(RelativePath::parse(traversal).is_err(), "{traversal}");
+        }
+        for nonportable in [
+            "C:relative",
+            "mixed\\separator/file",
+            "file:stream",
+            "bad\0name",
+            "CON",
+            "aux.txt",
+            "LPT9.log",
+            "CONIN$",
+            "conout$.txt",
+            "CLOCK$",
+            "COM¹",
+            "lpt².log",
+            "trailing.",
+            "trailing ",
+            "question?.txt",
+            "control\u{1f}.txt",
+        ] {
+            assert!(RelativePath::parse(nonportable).is_err(), "{nonportable}");
+        }
+    }
+
+    #[test]
+    fn deserialization_cannot_bypass_validation() {
+        for json in [
+            r#""../secret""#,
+            r#""..\\secret""#,
+            r#""C:\\Windows""#,
+            r#""\\\\server\\share""#,
+            r#""mixed/..\\secret""#,
+        ] {
+            assert!(
+                serde_json::from_str::<RelativePath>(json).is_err(),
+                "{json}"
+            );
+        }
+    }
+}

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -12,7 +12,7 @@ libraries.
                                └────── openwave-server
                                             │
       libraries          openwave-mcp   openwave-retrieval   openwave-router
-                         openwave-host-broker (planned)          │
+                         openwave-host-broker                    │
                                │             │                   │
                                └─────────────┴───────────────────┘
                                             │
@@ -81,12 +81,13 @@ connector tools that list and fetch from sources like Drive and Box.
 
 **Depends on:** nothing in the workspace yet.
 
-## `openwave-host-broker` — consented host access ⚪
+## `openwave-host-broker` — consented host access 🟡
 
-The planned runtime-neutral trust boundary for connected local folders. It will
-own capability grants, root registration, path policy, audited filesystem
-operations, and a versioned sidecar protocol. The Tauri host will own native
-consent UI; agent execution will receive only the operation interface. See
+The runtime-neutral policy foundation for connected local folders. It now owns
+opaque root/grant/operation identities, validated grant and attachment values,
+portable relative paths, and descriptor-pinned root policy. The owning operation
+layer, durable registry, sidecar adapter, audit, and Tauri consent UI are the next
+slices; until those land, existing file tools do not use this boundary. See
 [Host access and connected folders](host-access.md).
 
 **Depends on:** no OpenWave client crate.

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -33,6 +33,9 @@ In practical terms:
   paths. It never receives authority by naming an absolute host path.
 - Connecting one folder never grants access to its siblings, the user's whole
   home directory, or another project's roots.
+- An agent can request access to another folder, including familiar locations
+  such as Documents or Downloads. The request can explain why and suggest where
+  to open the picker, but only the folder the user actually selects is granted.
 
 The current `workspace_dir` fields on projects and chats do not express this
 model. They are temporary pre-alpha implementation details and will be replaced
@@ -100,6 +103,38 @@ The host-access context and the conversation's attached-root set are supplied by
 trusted conversation execution state, not by model-generated tool arguments.
 This stops a model from selecting a different project's context even if it
 guesses an identifier.
+
+## Agent-requested access
+
+Agents need a safe way to ask for a folder they cannot currently see. This is a
+two-step product workflow, not a privileged broker operation:
+
+1. The agent records an access request with a stable identity, a user-readable
+   reason, untrusted proposals for the capabilities it needs, and an optional
+   folder hint such as `Documents`, `Downloads`, or a project name.
+2. The desktop renders a request card. Only after the user accepts that card does
+   it open a native folder picker. A hint may choose the picker's starting
+   location, but it confers no authority. Durable coalescing and rate limits keep
+   an agent from creating repeated modal prompts.
+3. If the user selects a folder, the trusted desktop host derives and displays a
+   fixed low-risk capability set, then sends a control request containing the
+   picker result and that host-defined set. It never copies the agent's proposed
+   capability list into a grant. The broker canonicalizes the root, applies
+   policy, and records only those capabilities. Command execution, destructive
+   writes, and other high-risk access require their own explicit permission
+   dialogs.
+4. The original operation can retry against the returned opaque root identity.
+   Cancelling or rejecting the picker resolves the request without any grant.
+
+The control plane should persist the request and its resolution so a restart or
+ambiguous response does not create duplicate prompts or grants. The broker
+control remains idempotent under its own stable operation identity. Agents never
+receive an API that accepts an absolute path, and they cannot silently connect a
+standard folder by naming it.
+
+Root policy intentionally refuses the user's entire home directory while
+allowing specific children such as `~/Documents`, `~/Downloads`, or a nested
+project folder when the user selects them.
 
 ## Capabilities and paths
 
@@ -173,11 +208,14 @@ provisioned grants with clear operator intent.
 This will land in independently reviewable pieces:
 
 1. Add `openwave-host-broker` with typed capabilities, grants, access-context and
-   root identifiers, deny-by-default authorization, and path policy tests.
-2. Add the versioned control/operation protocol and a minimal sidecar vertical
-   slice: hello, register/revoke/list roots, list directory, and read file.
-3. Add the Tauri sidecar client and native folder-picker controls. Broker state,
-   audit, scratch, and handoffs live under OpenWave's application data directory;
+   root identifiers, authorization value-model/specification tests, and
+   descriptor-pinned root policy.
+2. Add the versioned control/operation protocol and an owning broker that performs
+   live authorization and each filesystem effect together: hello,
+   register/revoke/list roots, list directory, and read file.
+3. Add the Tauri sidecar client, connected-folder UI, and the durable
+   agent-request → native-picker → grant → retry workflow. Broker state, audit,
+   scratch, and handoffs live under OpenWave's application data directory;
    remove the automatic `Documents/OpenWave` folder.
 4. Replace project/chat `workspace_dir` with persisted host-access context
    identity and connected-root APIs. This can update the pre-v1 baseline schema

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -161,7 +161,9 @@ stored on the chat. That is a temporary pre-alpha boundary, not the intended
 product model. Projects and conversations will instead resolve to distinct
 host-access contexts containing user-approved roots, and file operations will go
 through a capability-gated host-broker sidecar. See [Host access and connected
-folders](host-access.md). The model router supports Anthropic, OpenAI, and
+folders](host-access.md). An agent may ask the desktop to connect another folder,
+but the request only opens a native consent flow; it never grants a named path by
+itself. The model router supports Anthropic, OpenAI, and
 OpenAI-compatible endpoints. It fails closed: if no enabled provider with a
 usable credential can serve the selected model, no model request is sent.
 


### PR DESCRIPTION
## Summary

- add a runtime-neutral `openwave-host-broker` security core
- model isolated project and conversation subjects with opaque root, grant, and operation identities
- validate normalized root-relative paths at construction and deserialization
- model deny-by-default grant and conversation-attachment invariants across subjects, roots, and path subtrees
- reject broad, profile-wide, sensitive, and unsupported-namespace roots, then descriptor-pin accepted directories

## Scope

This establishes policy, wire-safe types, and the root-opening primitive only. It intentionally does not expose a detached production authorizer: the next broker operation slice will own each live authorization check and its filesystem effect. Root persistence, the sidecar protocol, and desktop consent UI remain separate follow-up slices.

## Validation

- `cargo test -p openwave-host-broker --locked`
- `cargo fmt --all --check`
- `bw dev lint --rust --check --repo-root "$PWD"`
