### PR TITLE
feat(host): persist broker authority and receipts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5791,6 +5791,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ futures-timer = "3"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+windows-sys = "0.61"
 sea-orm = { version = "1", default-features = false, features = ["macros", "runtime-tokio-rustls", "with-uuid", "with-chrono", "with-json"] }
 sea-orm-migration = { version = "1", default-features = false, features = ["runtime-tokio-rustls"] }
 tokio = { version = "1", features = ["rt", "macros", "fs"] }

--- a/crates/openwave-host-broker/Cargo.toml
+++ b/crates/openwave-host-broker/Cargo.toml
@@ -13,11 +13,14 @@ cap-fs-ext.workspace = true
 cap-std.workspace = true
 chrono.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
-serde_json.workspace = true
 tempfile = "3"
 
 [lints]

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -7,15 +7,19 @@
 //! operations that were already in flight.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     io::{self, Read},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, MutexGuard,
+    },
 };
 
 use cap_fs_ext::OpenOptionsSyncExt;
 use cap_std::fs::{Dir, OpenOptions};
 use chrono::Utc;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -31,6 +35,9 @@ use crate::{
     GrantSubject, OperationId, RelativePath, RootAttachment, RootId, RootPolicy, RootPolicyError,
     Scope, SubjectKind, ValidatedRoot,
 };
+
+mod state_file;
+use state_file::StateFile;
 
 const MAX_READ_FILE_BYTES: usize = 64 * 1024;
 const MAX_LIST_DIR_BYTES: usize = 64 * 1024;
@@ -53,6 +60,10 @@ pub enum BrokerError {
     InvalidConsentMethod,
     #[error("broker state lock was poisoned")]
     StatePoisoned,
+    #[error("broker state publication may have committed; restart is required")]
+    PersistenceAmbiguous,
+    #[error("broker state exceeds its durable size limit")]
+    StateTooLarge,
     #[error("path is not a regular file")]
     NotRegularFile,
     #[error("file is too large (maximum {MAX_READ_FILE_BYTES} bytes)")]
@@ -90,23 +101,27 @@ pub struct Operator {
 struct Shared {
     policy: RootPolicy,
     state: Mutex<State>,
+    state_file: Option<StateFile>,
+    failed_closed: AtomicBool,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct State {
     roots: HashMap<RootId, RegisteredRoot>,
     grants: Vec<Grant>,
     attachments: Vec<RootAttachment>,
     mutations: HashMap<OperationId, MutationRecord>,
+    active_mutations: HashSet<OperationId>,
 }
 
+#[derive(Clone)]
 struct RegisteredRoot {
     owner: GrantSubject,
     display_name: String,
-    root: ValidatedRoot,
+    root: Arc<ValidatedRoot>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 enum MutationRecord {
     Register {
         request: RegisterFingerprint,
@@ -118,13 +133,13 @@ enum MutationRecord {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 enum MutationOutcome<T> {
-    InFlight,
+    Pending,
     Complete(Result<T, ErrorResponse>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct RegisterFingerprint {
     subject: GrantSubject,
     conversation_id: Uuid,
@@ -132,7 +147,7 @@ struct RegisterFingerprint {
     consent_method: ConsentMethod,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 struct RevokeFingerprint {
     subject: GrantSubject,
     root_id: RootId,
@@ -153,8 +168,26 @@ impl Broker {
             shared: Arc::new(Shared {
                 policy,
                 state: Mutex::new(State::default()),
+                state_file: None,
+                failed_closed: AtomicBool::new(false),
             }),
         }
+    }
+
+    /// Open durable broker state under the application-private data directory.
+    /// Persisted roots are revalidated and descriptor-pinned before this
+    /// constructor returns, so stale state is never advertised.
+    pub fn open(policy: RootPolicy, data_dir: &Path) -> Result<Self, BrokerError> {
+        let state_file = StateFile::open(data_dir)?;
+        let state = state_file.load(&policy)?;
+        Ok(Self {
+            shared: Arc::new(Shared {
+                policy,
+                state: Mutex::new(state),
+                state_file: Some(state_file),
+                failed_closed: AtomicBool::new(false),
+            }),
+        })
     }
 
     /// Obtain the trusted host-only interface.
@@ -210,25 +243,40 @@ impl Controller {
         };
         {
             let mut state = self.lock_state().map_err(error_response)?;
-            match claim_register(&mut state, operation_id, &fingerprint).map_err(error_response)? {
+            let mut next = state.clone();
+            match claim_register(&mut next, operation_id, &fingerprint).map_err(error_response)? {
                 Claim::Start => {}
                 Claim::Complete(result) => return result,
             }
+            self.commit_state(&mut state, next)
+                .map_err(error_response)?;
         }
 
-        let prepared = self.prepare_registration(request).map_err(error_response);
+        let prepared = match self.prepare_registration(request) {
+            Err(error) if retryable_registration_error(&error) => {
+                let mut state = self.lock_state().map_err(error_response)?;
+                state.active_mutations.remove(&operation_id);
+                return Err(error_response(error));
+            }
+            result => result.map_err(error_response),
+        };
         let outcome = prepared
             .as_ref()
             .map(|item| item.result.clone())
             .map_err(Clone::clone);
         let mut state = self.lock_state().map_err(error_response)?;
+        let mut next = state.clone();
         if let Ok(prepared) = prepared {
-            state.roots.insert(prepared.root_id, prepared.root);
-            state.grants.extend(prepared.grants);
-            state.attachments.push(prepared.attachment);
+            next.roots.insert(prepared.root_id, prepared.root);
+            next.grants.extend(prepared.grants);
+            next.attachments.push(prepared.attachment);
         }
-        complete_register(&mut state, operation_id, &fingerprint, outcome.clone())
+        complete_register(&mut next, operation_id, &fingerprint, outcome.clone())
             .map_err(error_response)?;
+        if let Err(error) = self.commit_state(&mut state, next) {
+            state.active_mutations.remove(&operation_id);
+            return Err(error_response(error));
+        }
         outcome
     }
 
@@ -280,7 +328,7 @@ impl Controller {
             root: RegisteredRoot {
                 owner: request.subject,
                 display_name,
-                root: validated,
+                root: Arc::new(validated),
             },
             grants: [list_grant, read_grant],
             attachment: RootAttachment::new(request.conversation_id, root_id)?,
@@ -295,34 +343,60 @@ impl Controller {
             root_id: request.root_id,
         };
         let mut state = self.lock_state().map_err(error_response)?;
-        match claim_revoke(&mut state, operation_id, fingerprint).map_err(error_response)? {
+        let mut next = state.clone();
+        match claim_revoke(&mut next, operation_id, fingerprint).map_err(error_response)? {
             Claim::Complete(result) => return result,
             Claim::Start => {}
         }
-        let owned = state
+        let owned = next
             .roots
             .get(&request.root_id)
             .is_some_and(|root| root.owner == request.subject);
         if owned {
-            state.roots.remove(&request.root_id);
-            state
-                .grants
+            next.roots.remove(&request.root_id);
+            next.grants
                 .retain(|grant| !scope_targets_root(grant.scope(), request.root_id));
-            state
-                .attachments
+            next.attachments
                 .retain(|attachment| attachment.root_id() != request.root_id);
         }
         let result = Ok(RevokeRootResult { revoked: owned });
-        complete_revoke(&mut state, operation_id, fingerprint, result.clone())
+        complete_revoke(&mut next, operation_id, fingerprint, result.clone())
+            .map_err(error_response)?;
+        self.commit_state(&mut state, next)
             .map_err(error_response)?;
         result
     }
 
+    fn commit_state(
+        &self,
+        current: &mut MutexGuard<'_, State>,
+        next: State,
+    ) -> Result<(), BrokerError> {
+        if let Some(state_file) = &self.shared.state_file {
+            if let Err(error) = state_file.save(&next) {
+                if matches!(error, BrokerError::PersistenceAmbiguous) {
+                    self.shared.failed_closed.store(true, Ordering::SeqCst);
+                }
+                return Err(error);
+            }
+        }
+        **current = next;
+        Ok(())
+    }
+
     fn lock_state(&self) -> Result<MutexGuard<'_, State>, BrokerError> {
-        self.shared
+        if self.shared.failed_closed.load(Ordering::SeqCst) {
+            return Err(BrokerError::PersistenceAmbiguous);
+        }
+        let state = self
+            .shared
             .state
             .lock()
-            .map_err(|_| BrokerError::StatePoisoned)
+            .map_err(|_| BrokerError::StatePoisoned)?;
+        if self.shared.failed_closed.load(Ordering::SeqCst) {
+            return Err(BrokerError::PersistenceAmbiguous);
+        }
+        Ok(state)
     }
 }
 
@@ -404,10 +478,18 @@ impl Operator {
     }
 
     fn lock_state(&self) -> Result<MutexGuard<'_, State>, BrokerError> {
-        self.shared
+        if self.shared.failed_closed.load(Ordering::SeqCst) {
+            return Err(BrokerError::PersistenceAmbiguous);
+        }
+        let state = self
+            .shared
             .state
             .lock()
-            .map_err(|_| BrokerError::StatePoisoned)
+            .map_err(|_| BrokerError::StatePoisoned)?;
+        if self.shared.failed_closed.load(Ordering::SeqCst) {
+            return Err(BrokerError::PersistenceAmbiguous);
+        }
+        Ok(state)
     }
 }
 
@@ -472,16 +554,23 @@ fn error_response(error: BrokerError) -> ErrorResponse {
             "host operation request is invalid",
             false,
         ),
+        BrokerError::RootPolicy(RootPolicyError::Io(error)) => (
+            ErrorCode::HostIo,
+            "host filesystem operation failed",
+            transient_io_kind(error.kind()),
+        ),
         BrokerError::RootPolicy(_) => (
             ErrorCode::InvalidRoot,
             "selected folder is not an allowed connected root",
             false,
         ),
-        BrokerError::FileTooLarge | BrokerError::DirectoryTooLarge => (
-            ErrorCode::TooLarge,
-            "host operation exceeded its limit",
-            false,
-        ),
+        BrokerError::FileTooLarge | BrokerError::DirectoryTooLarge | BrokerError::StateTooLarge => {
+            (
+                ErrorCode::TooLarge,
+                "host operation exceeded its limit",
+                false,
+            )
+        }
         BrokerError::NotRegularFile | BrokerError::NotUtf8 => (
             ErrorCode::UnsupportedContent,
             "host resource has an unsupported content type",
@@ -497,12 +586,25 @@ fn error_response(error: BrokerError) -> ErrorResponse {
             "broker state is unavailable; restart the broker",
             false,
         ),
+        BrokerError::PersistenceAmbiguous => (
+            ErrorCode::Internal,
+            "broker state publication is ambiguous; restart the broker",
+            false,
+        ),
     };
     ErrorResponse {
         code,
         message: message.to_owned(),
         retryable,
     }
+}
+
+fn retryable_registration_error(error: &BrokerError) -> bool {
+    matches!(
+        error,
+        BrokerError::RootPolicy(RootPolicyError::Io(source))
+            if transient_io_kind(source.kind())
+    )
 }
 
 fn transient_io_kind(kind: io::ErrorKind) -> bool {
@@ -528,9 +630,10 @@ fn claim_register(
                 operation_id,
                 MutationRecord::Register {
                     request: request.clone(),
-                    outcome: MutationOutcome::InFlight,
+                    outcome: MutationOutcome::Pending,
                 },
             );
+            state.active_mutations.insert(operation_id);
             Ok(Claim::Start)
         }
         Some(MutationRecord::Register {
@@ -539,8 +642,14 @@ fn claim_register(
         }) if existing == request => Ok(Claim::Complete(result.clone())),
         Some(MutationRecord::Register {
             request: existing,
-            outcome: MutationOutcome::InFlight,
-        }) if existing == request => Err(BrokerError::OperationInProgress),
+            outcome: MutationOutcome::Pending,
+        }) if existing == request => {
+            if state.active_mutations.insert(operation_id) {
+                Ok(Claim::Start)
+            } else {
+                Err(BrokerError::OperationInProgress)
+            }
+        }
         Some(_) => Err(BrokerError::OperationIdConflict),
     }
 }
@@ -555,8 +664,9 @@ fn complete_register(
         Some(MutationRecord::Register {
             request: existing,
             outcome,
-        }) if existing == request && matches!(outcome, MutationOutcome::InFlight) => {
+        }) if existing == request && matches!(outcome, MutationOutcome::Pending) => {
             *outcome = MutationOutcome::Complete(result);
+            state.active_mutations.remove(&operation_id);
             Ok(())
         }
         _ => Err(BrokerError::OperationIdConflict),
@@ -574,9 +684,10 @@ fn claim_revoke(
                 operation_id,
                 MutationRecord::Revoke {
                     request,
-                    outcome: MutationOutcome::InFlight,
+                    outcome: MutationOutcome::Pending,
                 },
             );
+            state.active_mutations.insert(operation_id);
             Ok(Claim::Start)
         }
         Some(MutationRecord::Revoke {
@@ -585,8 +696,14 @@ fn claim_revoke(
         }) if *existing == request => Ok(Claim::Complete(result.clone())),
         Some(MutationRecord::Revoke {
             request: existing,
-            outcome: MutationOutcome::InFlight,
-        }) if *existing == request => Err(BrokerError::OperationInProgress),
+            outcome: MutationOutcome::Pending,
+        }) if *existing == request => {
+            if state.active_mutations.insert(operation_id) {
+                Ok(Claim::Start)
+            } else {
+                Err(BrokerError::OperationInProgress)
+            }
+        }
         Some(_) => Err(BrokerError::OperationIdConflict),
     }
 }
@@ -601,8 +718,9 @@ fn complete_revoke(
         Some(MutationRecord::Revoke {
             request: existing,
             outcome,
-        }) if *existing == request && matches!(outcome, MutationOutcome::InFlight) => {
+        }) if *existing == request && matches!(outcome, MutationOutcome::Pending) => {
             *outcome = MutationOutcome::Complete(result);
+            state.active_mutations.remove(&operation_id);
             Ok(())
         }
         _ => Err(BrokerError::OperationIdConflict),
@@ -779,6 +897,15 @@ fn scope_targets_root(scope: &Scope, requested: RootId) -> bool {
 mod tests {
     use super::*;
 
+    fn test_policy(temp: &tempfile::TempDir) -> RootPolicy {
+        RootPolicy::for_test(
+            temp.path().join("home"),
+            vec![temp.path().join("sensitive")],
+            vec![temp.path().to_path_buf()],
+            Vec::new(),
+        )
+    }
+
     fn setup() -> (tempfile::TempDir, Broker, PathBuf) {
         let temp = tempfile::tempdir().unwrap();
         let home = temp.path().join("home");
@@ -786,13 +913,18 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         std::fs::write(root.join("note.txt"), "hello from broker").unwrap();
         std::fs::create_dir(root.join("reports")).unwrap();
-        let policy = RootPolicy::for_test(
-            home,
-            vec![temp.path().join("sensitive")],
-            vec![temp.path().to_path_buf()],
-            Vec::new(),
-        );
+        let policy = test_policy(&temp);
         (temp, Broker::new(policy), root)
+    }
+
+    fn durable_setup() -> (tempfile::TempDir, Broker, PathBuf, PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("home/Documents");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("note.txt"), "hello from broker").unwrap();
+        let state_dir = temp.path().join("app-data/host-broker");
+        let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+        (temp, broker, root, state_dir)
     }
 
     fn register(
@@ -1230,5 +1362,352 @@ mod tests {
         let poisoned = error_response(BrokerError::StatePoisoned);
         assert_eq!(poisoned.code, ErrorCode::Internal);
         assert!(!poisoned.retryable);
+    }
+
+    #[test]
+    fn durable_registry_receipts_and_revocation_survive_restart() {
+        let (temp, broker, path, state_dir) = durable_setup();
+        let conversation = Uuid::new_v4();
+        let subject = GrantSubject::conversation(conversation).unwrap();
+        let register_id = OperationId::new();
+        let registered = register(
+            &broker.controller(),
+            subject,
+            conversation,
+            path.clone(),
+            register_id,
+        );
+        drop(broker);
+
+        let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+        let retry = register(
+            &broker.controller(),
+            subject,
+            conversation,
+            path,
+            register_id,
+        );
+        assert_eq!(retry, registered);
+        let context = ExecutionContext::standalone(conversation).unwrap();
+        assert!(operate(
+            &broker.operator(),
+            context,
+            OperationRequest::ReadFile(PathRequest {
+                root_id: registered.root.root_id,
+                path: RelativePath::parse("note.txt").unwrap(),
+            }),
+        )
+        .is_ok());
+
+        let revoke_id = OperationId::new();
+        let revoke = ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request: ControlRequest::RevokeRoot(RevokeRootRequest {
+                operation_id: revoke_id,
+                subject,
+                root_id: registered.root.root_id,
+            }),
+        };
+        let first = unwrap_response(broker.controller().handle(revoke.clone())).unwrap();
+        assert_eq!(
+            first,
+            ControlResult::RevokeRoot(RevokeRootResult { revoked: true })
+        );
+        drop(broker);
+
+        let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+        let retry = unwrap_response(broker.controller().handle(revoke)).unwrap();
+        assert_eq!(retry, first);
+        assert_eq!(
+            operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap(),
+            OperationResult::ListRoots { roots: Vec::new() }
+        );
+        assert!(matches!(
+            operate(
+                &broker.operator(),
+                context,
+                OperationRequest::ReadFile(PathRequest {
+                    root_id: registered.root.root_id,
+                    path: RelativePath::parse("note.txt").unwrap(),
+                }),
+            ),
+            Err(ErrorResponse {
+                code: ErrorCode::Denied,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn pending_registration_resumes_after_completion_save_failure_and_restart() {
+        let (temp, broker, path, state_dir) = durable_setup();
+        broker
+            .shared
+            .state_file
+            .as_ref()
+            .unwrap()
+            .fail_after_saves(1);
+        let conversation = Uuid::new_v4();
+        let subject = GrantSubject::conversation(conversation).unwrap();
+        let operation_id = OperationId::new();
+        let request = ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request: ControlRequest::RegisterRoot(RegisterRootRequest {
+                operation_id,
+                subject,
+                conversation_id: conversation,
+                path: path.clone(),
+                consent_method: ConsentMethod::FolderPicker,
+            }),
+        };
+        let failed = broker.controller().handle(request);
+        assert!(matches!(
+            failed.response,
+            Response::Error(ErrorResponse {
+                code: ErrorCode::HostIo,
+                ..
+            })
+        ));
+        drop(broker);
+
+        let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+        let completed = register(
+            &broker.controller(),
+            subject,
+            conversation,
+            path,
+            operation_id,
+        );
+        assert_eq!(completed.root.display_name, "Documents");
+    }
+
+    #[test]
+    fn ambiguous_state_publication_fails_closed_until_restart() {
+        let (temp, broker, path, state_dir) = durable_setup();
+        broker
+            .shared
+            .state_file
+            .as_ref()
+            .unwrap()
+            .fail_once_after_publish();
+        let conversation = Uuid::new_v4();
+        let subject = GrantSubject::conversation(conversation).unwrap();
+        let operation_id = OperationId::new();
+        let request = ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request: ControlRequest::RegisterRoot(RegisterRootRequest {
+                operation_id,
+                subject,
+                conversation_id: conversation,
+                path: path.clone(),
+                consent_method: ConsentMethod::FolderPicker,
+            }),
+        };
+        let ambiguous = broker.controller().handle(request);
+        assert!(matches!(
+            ambiguous.response,
+            Response::Error(ErrorResponse {
+                code: ErrorCode::Internal,
+                retryable: false,
+                ..
+            })
+        ));
+        let unavailable = broker.operator().handle(OperationEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            context: ExecutionContext::standalone(conversation).unwrap(),
+            request: OperationRequest::ListRoots,
+        });
+        assert!(matches!(
+            unavailable.response,
+            Response::Error(ErrorResponse {
+                code: ErrorCode::Internal,
+                retryable: false,
+                ..
+            })
+        ));
+        drop(broker);
+
+        let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+        let completed = register(
+            &broker.controller(),
+            subject,
+            conversation,
+            path,
+            operation_id,
+        );
+        assert_eq!(completed.root.display_name, "Documents");
+    }
+
+    #[test]
+    fn one_process_exclusively_owns_a_durable_broker_directory() {
+        let (temp, broker, _path, state_dir) = durable_setup();
+        assert!(matches!(
+            Broker::open(test_policy(&temp), &state_dir),
+            Err(BrokerError::Io(error)) if error.kind() == io::ErrorKind::WouldBlock
+        ));
+        drop(broker);
+        assert!(Broker::open(test_policy(&temp), &state_dir).is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_state_uses_private_directory_and_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_temp, broker, path, state_dir) = durable_setup();
+        let conversation = Uuid::new_v4();
+        register(
+            &broker.controller(),
+            GrantSubject::conversation(conversation).unwrap(),
+            conversation,
+            path,
+            OperationId::new(),
+        );
+        assert_eq!(
+            std::fs::metadata(&state_dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(state_dir.join("host-broker-state.json"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn restart_revalidates_every_persisted_root_before_advertising_state() {
+        let (temp, broker, path, state_dir) = durable_setup();
+        let conversation = Uuid::new_v4();
+        register(
+            &broker.controller(),
+            GrantSubject::conversation(conversation).unwrap(),
+            conversation,
+            path.clone(),
+            OperationId::new(),
+        );
+        drop(broker);
+        std::fs::remove_file(path.join("note.txt")).unwrap();
+        std::fs::remove_dir(path).unwrap();
+
+        assert!(matches!(
+            Broker::open(test_policy(&temp), &state_dir),
+            Err(BrokerError::RootPolicy(_))
+        ));
+    }
+
+    #[test]
+    fn restart_refuses_to_rebind_a_grant_to_a_replaced_folder() {
+        let (temp, broker, path, state_dir) = durable_setup();
+        let conversation = Uuid::new_v4();
+        register(
+            &broker.controller(),
+            GrantSubject::conversation(conversation).unwrap(),
+            conversation,
+            path.clone(),
+            OperationId::new(),
+        );
+        drop(broker);
+        let original = path.with_file_name("Documents-original");
+        std::fs::rename(&path, original).unwrap();
+        std::fs::create_dir(&path).unwrap();
+
+        assert!(matches!(
+            Broker::open(test_policy(&temp), &state_dir),
+            Err(BrokerError::Io(error)) if error.kind() == io::ErrorKind::InvalidData
+        ));
+    }
+
+    #[test]
+    fn persisted_receipts_must_match_authoritative_state() {
+        let (_temp, broker, path, _state_dir) = durable_setup();
+        let conversation = Uuid::new_v4();
+        let subject = GrantSubject::conversation(conversation).unwrap();
+        let registered = register(
+            &broker.controller(),
+            subject,
+            conversation,
+            path,
+            OperationId::new(),
+        );
+        let state = broker.shared.state.lock().unwrap().clone();
+
+        let mut inconsistent_revoke = state.clone();
+        inconsistent_revoke.mutations.insert(
+            OperationId::new(),
+            MutationRecord::Revoke {
+                request: RevokeFingerprint {
+                    subject,
+                    root_id: registered.root.root_id,
+                },
+                outcome: MutationOutcome::Complete(Ok(RevokeRootResult { revoked: true })),
+            },
+        );
+        assert!(state_file::validate_loaded_state(&inconsistent_revoke).is_err());
+
+        let mut inconsistent_register = state;
+        let record = inconsistent_register
+            .mutations
+            .values_mut()
+            .find(|record| matches!(record, MutationRecord::Register { .. }))
+            .unwrap();
+        let MutationRecord::Register {
+            outcome: MutationOutcome::Complete(Ok(result)),
+            ..
+        } = record
+        else {
+            panic!("expected successful registration receipt")
+        };
+        result.root.root_id = RootId::new();
+        assert!(state_file::validate_loaded_state(&inconsistent_register).is_err());
+    }
+
+    #[test]
+    fn negative_revoke_receipt_is_valid_when_the_subject_did_not_own_the_root() {
+        let mut state = State::default();
+        state.mutations.insert(
+            OperationId::new(),
+            MutationRecord::Revoke {
+                request: RevokeFingerprint {
+                    subject: GrantSubject::conversation(Uuid::new_v4()).unwrap(),
+                    root_id: RootId::new(),
+                },
+                outcome: MutationOutcome::Complete(Ok(RevokeRootResult { revoked: false })),
+            },
+        );
+        assert!(state_file::validate_loaded_state(&state).is_ok());
+    }
+
+    #[test]
+    fn transient_root_open_failures_remain_retryable() {
+        let error = BrokerError::RootPolicy(RootPolicyError::Io(io::Error::from(
+            io::ErrorKind::WouldBlock,
+        )));
+        assert!(retryable_registration_error(&error));
+        let response = error_response(error);
+        assert_eq!(response.code, ErrorCode::HostIo);
+        assert!(response.retryable);
+    }
+
+    #[test]
+    fn restart_rejects_an_oversized_state_file_before_parsing_it() {
+        let (temp, broker, _path, state_dir) = durable_setup();
+        drop(broker);
+        std::fs::write(
+            state_dir.join("host-broker-state.json"),
+            vec![b' '; state_file::MAX_STATE_FILE_BYTES + 1],
+        )
+        .unwrap();
+
+        assert!(matches!(
+            Broker::open(test_policy(&temp), &state_dir),
+            Err(BrokerError::StateTooLarge)
+        ));
     }
 }

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -1,0 +1,451 @@
+//! Durable broker registry and mutation receipts.
+
+use std::{
+    collections::HashMap,
+    fs::{self, File, OpenOptions, TryLockError},
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+use serde::{Deserialize, Serialize};
+
+use super::{BrokerError, MutationRecord, RegisteredRoot, State};
+use crate::{
+    path_policy::RootIdentity, Grant, GrantSubject, OperationId, RootAttachment, RootId,
+    RootPolicy, Scope,
+};
+
+const STATE_VERSION: u32 = 1;
+const STATE_FILE_NAME: &str = "host-broker-state.json";
+pub(super) const MAX_STATE_FILE_BYTES: usize = 16 * 1024 * 1024;
+
+pub(super) struct StateFile {
+    directory: PathBuf,
+    path: PathBuf,
+    _lock: File,
+    #[cfg(test)]
+    saves_until_failure: std::sync::atomic::AtomicUsize,
+    #[cfg(test)]
+    fail_after_publish: std::sync::atomic::AtomicBool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedState {
+    version: u32,
+    roots: Vec<PersistedRoot>,
+    grants: Vec<Grant>,
+    attachments: Vec<RootAttachment>,
+    mutations: Vec<PersistedMutation>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedRoot {
+    id: RootId,
+    owner: GrantSubject,
+    path: PathBuf,
+    identity: RootIdentity,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedMutation {
+    operation_id: OperationId,
+    record: MutationRecord,
+}
+
+impl StateFile {
+    pub(super) fn open(data_dir: &Path) -> Result<Self, BrokerError> {
+        fs::create_dir_all(data_dir)?;
+        let directory = fs::canonicalize(data_dir)?;
+        #[cfg(unix)]
+        fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))?;
+        let mut lock_options = OpenOptions::new();
+        lock_options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        lock_options.mode(0o600);
+        let lock = lock_options.open(directory.join("host-broker.lock"))?;
+        match lock.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "another broker already owns this state directory",
+                )
+                .into())
+            }
+            Err(TryLockError::Error(error)) => return Err(error.into()),
+        }
+        Ok(Self {
+            path: directory.join(STATE_FILE_NAME),
+            directory,
+            _lock: lock,
+            #[cfg(test)]
+            saves_until_failure: std::sync::atomic::AtomicUsize::new(usize::MAX),
+            #[cfg(test)]
+            fail_after_publish: std::sync::atomic::AtomicBool::new(false),
+        })
+    }
+
+    pub(super) fn load(&self, policy: &RootPolicy) -> Result<State, BrokerError> {
+        let mut file = match File::open(&self.path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(State::default()),
+            Err(error) => return Err(error.into()),
+        };
+        if file.metadata()?.len() > MAX_STATE_FILE_BYTES as u64 {
+            return Err(BrokerError::StateTooLarge);
+        }
+        let mut bytes = Vec::new();
+        Read::by_ref(&mut file)
+            .take((MAX_STATE_FILE_BYTES + 1) as u64)
+            .read_to_end(&mut bytes)?;
+        if bytes.len() > MAX_STATE_FILE_BYTES {
+            return Err(BrokerError::StateTooLarge);
+        }
+        let persisted: PersistedState = serde_json::from_slice(&bytes).map_err(invalid_data)?;
+        if persisted.version != STATE_VERSION {
+            return Err(invalid_data(format!(
+                "unsupported broker state version {}",
+                persisted.version
+            ))
+            .into());
+        }
+
+        let mut roots = HashMap::new();
+        for item in persisted.roots {
+            let validated = policy.open_root(&item.path)?;
+            if validated.identity() != item.identity {
+                return Err(invalid_data("persisted root identity changed").into());
+            }
+            let display_name = validated
+                .canonical_path()
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "Connected folder".to_owned());
+            if roots
+                .insert(
+                    item.id,
+                    RegisteredRoot {
+                        owner: item.owner,
+                        display_name,
+                        root: Arc::new(validated),
+                    },
+                )
+                .is_some()
+            {
+                return Err(invalid_data("duplicate persisted root identity").into());
+            }
+        }
+
+        let mut mutations = HashMap::new();
+        for item in persisted.mutations {
+            if mutations.insert(item.operation_id, item.record).is_some() {
+                return Err(invalid_data("duplicate persisted operation identity").into());
+            }
+        }
+        let state = State {
+            roots,
+            grants: persisted.grants,
+            attachments: persisted.attachments,
+            mutations,
+            active_mutations: Default::default(),
+        };
+        validate_loaded_state(&state)?;
+        Ok(state)
+    }
+
+    pub(super) fn save(&self, state: &State) -> Result<(), BrokerError> {
+        #[cfg(test)]
+        {
+            use std::sync::atomic::Ordering;
+
+            let remaining = self.saves_until_failure.load(Ordering::SeqCst);
+            if remaining != usize::MAX {
+                if remaining == 0 {
+                    self.saves_until_failure.store(usize::MAX, Ordering::SeqCst);
+                    return Err(io::Error::other("injected broker state save failure").into());
+                }
+                self.saves_until_failure.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+        let mut roots = state
+            .roots
+            .iter()
+            .map(|(id, root)| PersistedRoot {
+                id: *id,
+                owner: root.owner,
+                path: root.root.canonical_path().to_path_buf(),
+                identity: root.root.identity(),
+            })
+            .collect::<Vec<_>>();
+        roots.sort_by_key(|root| root.id.to_string());
+        let mut mutations = state
+            .mutations
+            .iter()
+            .map(|(operation_id, record)| PersistedMutation {
+                operation_id: *operation_id,
+                record: record.clone(),
+            })
+            .collect::<Vec<_>>();
+        mutations.sort_by_key(|item| item.operation_id.to_string());
+        let persisted = PersistedState {
+            version: STATE_VERSION,
+            roots,
+            grants: state.grants.clone(),
+            attachments: state.attachments.clone(),
+            mutations,
+        };
+        let bytes = serde_json::to_vec_pretty(&persisted).map_err(invalid_data)?;
+        if bytes.len() > MAX_STATE_FILE_BYTES {
+            return Err(BrokerError::StateTooLarge);
+        }
+        self.write_atomically(&bytes).map_err(|error| {
+            if error.published {
+                BrokerError::PersistenceAmbiguous
+            } else {
+                BrokerError::Io(error.source)
+            }
+        })?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_after_saves(&self, successful_saves: usize) {
+        use std::sync::atomic::Ordering;
+
+        self.saves_until_failure
+            .store(successful_saves, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_once_after_publish(&self) {
+        use std::sync::atomic::Ordering;
+
+        self.fail_after_publish.store(true, Ordering::SeqCst);
+    }
+
+    fn write_atomically(&self, bytes: &[u8]) -> Result<(), AtomicWriteError> {
+        let temporary = self
+            .directory
+            .join(format!(".{STATE_FILE_NAME}.{}.tmp", uuid::Uuid::new_v4()));
+        let result = (|| -> Result<(), AtomicWriteError> {
+            let mut options = OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            options.mode(0o600);
+            let mut file = options.open(&temporary).map_err(AtomicWriteError::before)?;
+            file.write_all(bytes).map_err(AtomicWriteError::before)?;
+            file.sync_all().map_err(AtomicWriteError::before)?;
+            drop(file);
+            replace_file(&temporary, &self.path).map_err(AtomicWriteError::before)?;
+            #[cfg(test)]
+            if self
+                .fail_after_publish
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(AtomicWriteError::after(io::Error::other(
+                    "injected post-publication failure",
+                )));
+            }
+            sync_directory(&self.directory).map_err(AtomicWriteError::after)
+        })();
+        if result.as_ref().is_err_and(|error| !error.published) {
+            let _ = fs::remove_file(&temporary);
+        }
+        result
+    }
+}
+
+struct AtomicWriteError {
+    source: io::Error,
+    published: bool,
+}
+
+impl AtomicWriteError {
+    fn before(source: io::Error) -> Self {
+        Self {
+            source,
+            published: false,
+        }
+    }
+
+    fn after(source: io::Error) -> Self {
+        Self {
+            source,
+            published: true,
+        }
+    }
+}
+
+pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
+    for grant in &state.grants {
+        let root_id = match grant.scope() {
+            Scope::Root { root_id } | Scope::PathSubtree { root_id, .. } => *root_id,
+            Scope::Subject => continue,
+        };
+        let root = state
+            .roots
+            .get(&root_id)
+            .ok_or_else(|| invalid_data("grant references an unknown root"))?;
+        if root.owner != grant.subject() {
+            return Err(invalid_data("grant subject does not own its root").into());
+        }
+    }
+    for attachment in &state.attachments {
+        if !state.roots.contains_key(&attachment.root_id()) {
+            return Err(invalid_data("attachment references an unknown root").into());
+        }
+    }
+    for (root_id, root) in &state.roots {
+        let has_grant = state.grants.iter().any(|grant| {
+            grant.subject() == root.owner
+                && matches!(
+                    grant.scope(),
+                    Scope::Root { root_id: granted }
+                        | Scope::PathSubtree {
+                            root_id: granted,
+                            ..
+                        } if granted == root_id
+                )
+        });
+        let has_attachment = state
+            .attachments
+            .iter()
+            .any(|attachment| attachment.root_id() == *root_id);
+        if !has_grant || !has_attachment {
+            return Err(invalid_data("persisted root is missing its grant or attachment").into());
+        }
+    }
+    for record in state.mutations.values() {
+        match record {
+            MutationRecord::Register {
+                request,
+                outcome: super::MutationOutcome::Complete(Ok(result)),
+            } => {
+                if let Some(root) = state.roots.get(&result.root.root_id) {
+                    if root.owner != request.subject
+                        || root.display_name != result.root.display_name
+                        || !state.attachments.iter().any(|attachment| {
+                            attachment.root_id() == result.root.root_id
+                                && attachment.conversation_id() == request.conversation_id
+                        })
+                    {
+                        return Err(invalid_data(
+                            "successful register receipt does not match authoritative state",
+                        )
+                        .into());
+                    }
+                } else {
+                    let was_revoked = state.mutations.values().any(|record| {
+                        matches!(
+                            record,
+                            MutationRecord::Revoke {
+                                request: revoke,
+                                outcome: super::MutationOutcome::Complete(Ok(revoke_result)),
+                            } if revoke_result.revoked
+                                && revoke.root_id == result.root.root_id
+                                && revoke.subject == request.subject
+                        )
+                    });
+                    if !was_revoked {
+                        return Err(invalid_data("successful register receipt has no root").into());
+                    }
+                }
+            }
+            MutationRecord::Revoke {
+                request,
+                outcome: super::MutationOutcome::Complete(Ok(result)),
+            } => {
+                let still_owned = state
+                    .roots
+                    .get(&request.root_id)
+                    .is_some_and(|root| root.owner == request.subject);
+                let root_still_exists = state.roots.contains_key(&request.root_id);
+                let was_registered = state.mutations.values().any(|record| {
+                    matches!(
+                        record,
+                        MutationRecord::Register {
+                            request: register,
+                            outcome: super::MutationOutcome::Complete(Ok(register_result)),
+                        } if register_result.root.root_id == request.root_id
+                            && register.subject == request.subject
+                    )
+                });
+                if (result.revoked && (root_still_exists || !was_registered))
+                    || (!result.revoked && still_owned)
+                {
+                    return Err(invalid_data(
+                        "successful revoke receipt does not match authoritative state",
+                    )
+                    .into());
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn invalid_data(error: impl std::fmt::Display) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+#[cfg(unix)]
+fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    fs::rename(temporary, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let temporary = temporary
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let destination = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let succeeded = unsafe {
+        MoveFileExW(
+            temporary.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if succeeded == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn replace_file(_temporary: &Path, _destination: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "atomic broker state replacement is unsupported on this platform",
+    ))
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> io::Result<()> {
+    Ok(())
+}

--- a/crates/openwave-host-broker/src/path_policy.rs
+++ b/crates/openwave-host-broker/src/path_policy.rs
@@ -8,6 +8,7 @@ use std::{
 
 use cap_fs_ext::DirExt;
 use cap_std::{ambient_authority, fs::Dir};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Why a host folder cannot be opened as a registered root.
@@ -53,6 +54,14 @@ pub enum RootPolicyError {
 pub struct ValidatedRoot {
     _canonical_path: PathBuf,
     _directory: Dir,
+    identity: RootIdentity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "platform", rename_all = "snake_case")]
+pub(crate) enum RootIdentity {
+    Unix { device: u64, inode: u64 },
+    Windows { volume: u32, file_index: u64 },
 }
 
 impl std::fmt::Debug for ValidatedRoot {
@@ -70,6 +79,10 @@ impl ValidatedRoot {
 
     pub(crate) fn directory(&self) -> &Dir {
         &self._directory
+    }
+
+    pub(crate) const fn identity(&self) -> RootIdentity {
+        self.identity
     }
 }
 
@@ -165,9 +178,11 @@ impl RootPolicy {
         let canonical_path = std::fs::canonicalize(candidate)?;
         self.validate_canonical(&canonical_path)?;
         let directory = open_canonical_dir_nofollow(&canonical_path)?;
+        let identity = root_identity(&directory)?;
         Ok(ValidatedRoot {
             _canonical_path: canonical_path,
             _directory: directory,
+            identity,
         })
     }
 
@@ -216,6 +231,45 @@ impl RootPolicy {
             home,
         }
     }
+}
+
+#[cfg(unix)]
+fn root_identity(directory: &Dir) -> io::Result<RootIdentity> {
+    use cap_fs_ext::MetadataExt;
+
+    let metadata = directory.dir_metadata()?;
+    Ok(RootIdentity::Unix {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+#[cfg(windows)]
+fn root_identity(directory: &Dir) -> io::Result<RootIdentity> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+    };
+
+    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    let succeeded =
+        unsafe { GetFileInformationByHandle(directory.as_raw_handle().cast(), &mut information) };
+    if succeeded == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(RootIdentity::Windows {
+        volume: information.dwVolumeSerialNumber,
+        file_index: u64::from(information.nFileIndexHigh) << 32
+            | u64::from(information.nFileIndexLow),
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn root_identity(_directory: &Dir) -> io::Result<RootIdentity> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "root identity is unsupported on this platform",
+    ))
 }
 
 #[cfg(windows)]

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -87,11 +87,13 @@ The runtime-neutral trust boundary for connected local folders. It owns opaque
 root/grant/operation identities, validated grant and attachment values, portable
 relative paths, descriptor-pinned root policy, and a versioned in-process broker
 with separate controller/operator handles. Register/revoke mutations are
-idempotent in process; list/read operations reauthorize before releasing bounded
-results so completed revocation fences in-flight work. Durable registry/audit,
-the sidecar adapter, and Tauri consent UI are the next slices; until those land,
-existing file tools do not use this boundary. See [Host access and connected
-folders](host-access.md).
+idempotent across restart through an atomically published, size-bounded private
+registry. Restart revalidates and pins every connected root before making it
+available, and ambiguous publication fails closed. List/read operations
+reauthorize before releasing bounded results so completed revocation fences
+in-flight work. Bounded audit, the sidecar adapter, and Tauri consent UI are the
+next slices; until those land, existing file tools do not use this boundary. See
+[Host access and connected folders](host-access.md).
 
 **Depends on:** no OpenWave client crate.
 

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -214,22 +214,25 @@ This will land in independently reviewable pieces:
    that authorizes pinned handles, performs bounded-result I/O, and reauthorizes
    before releasing bytes so completed revocation fences in-flight results:
    hello, register/revoke/list roots, list directory, and read file.
-3. Persist the root/grant/attachment registry and idempotency receipts atomically,
-   add bounded audit records, and expose the same contract through a sidecar
-   adapter. Restart must revalidate and descriptor-pin every persisted root before
-   advertising it.
-4. Add the Tauri sidecar client, connected-folder UI, and the durable
+3. Persist the root/grant/attachment registry and idempotency receipts atomically
+   under a broker-private, exclusively owned state directory. Restart must
+   validate the bounded state file and revalidate and descriptor-pin every
+   persisted root before advertising it. A mutation with ambiguous publication
+   fails the broker closed until restart.
+4. Add bounded audit records for every machine-touching operation.
+5. Expose the same contract through a versioned sidecar adapter.
+6. Add the Tauri sidecar client, connected-folder UI, and the durable
    agent-request → native-picker → grant → retry workflow. Broker state, audit,
    scratch, and handoffs live under OpenWave's application data directory;
    remove the automatic `Documents/OpenWave` folder.
-5. Replace project/chat `workspace_dir` with persisted host-access context
+7. Replace project/chat `workspace_dir` with persisted host-access context
    identity and connected-root APIs. This can update the pre-v1 baseline schema
    directly.
-6. Route built-in file tools through the operation interface and remove direct
+8. Route built-in file tools through the operation interface and remove direct
    ambient host-directory opening from `ToolCtx`.
-7. Port bounded imports, writes, approvals, and confined command execution as
+9. Port bounded imports, writes, approvals, and confined command execution as
    separate capability slices.
-8. Adapt the explicit-workspace MCP command to the same broker policy instead of
+10. Adapt the explicit-workspace MCP command to the same broker policy instead of
    maintaining a second filesystem authority model.
 
 Each intermediate state must fail closed. In particular, adding the data model


### PR DESCRIPTION
## Summary

- persist connected roots, grants, attachments, and idempotent mutation receipts in a broker-private registry
- atomically publish cloned state before swapping live authority, with durable pending registration recovery and fail-closed ambiguous publication
- exclusively own and size-bound the state directory, validate persisted references, and revalidate and descriptor-pin roots before restart exposes them
- document the persistence boundary and keep audit and sidecar transport as separate follow-up slices

## Validation

- `cargo test -p openwave-host-broker --locked` (40 tests)
- `bw dev lint --rust --check --repo-root "$PWD"`
- `git diff --check`
