### PR TITLE
feat(host): add bounded local audit trail

### DIFF
--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -1,0 +1,728 @@
+//! Structured, privacy-preserving audit records for host operations.
+//!
+//! Audit targets contain opaque root identities and bounded root-relative paths,
+//! never absolute host paths or file contents. The durable sink appends one
+//! fsync'd JSON record at a time and rotates within a fixed local retention bound.
+
+use std::{
+    collections::VecDeque,
+    fs::{self, OpenOptions},
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+    sync::Mutex,
+    thread,
+    time::Duration,
+};
+
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+use chrono::{DateTime, Utc};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    Capability, ErrorCode, ExecutionContext, GrantId, GrantSubject, OperationId, RelativePath,
+    RequestId, RootId,
+};
+
+const AUDIT_FILE_NAME: &str = "host-broker-audit.jsonl";
+const AUDIT_ARCHIVE_NAME: &str = "host-broker-audit.previous.jsonl";
+const AUDIT_WRITE_ATTEMPTS: usize = 3;
+const AUDIT_RETRY_BACKOFF: Duration = Duration::from_millis(5);
+const MAX_AUDIT_RECORD_BYTES: usize = 4 * 1024;
+const MAX_AUDIT_FILE_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_AUDIT_LABEL_BYTES: usize = 1024;
+const MAX_MEMORY_EVENTS: usize = 4096;
+const MAX_AUDIT_DIRECTORY_ENTRIES: usize = 4096;
+
+/// An audit record could not be appended durably.
+#[derive(Debug, Error)]
+pub enum AuditError {
+    #[error("audit record exceeds its size limit")]
+    RecordTooLarge,
+    #[error("audit serialization failed: {0}")]
+    Serialize(#[from] serde_json::Error),
+    #[error("audit storage failed: {0}")]
+    Io(#[from] io::Error),
+    #[error("audit writer lock was poisoned")]
+    Poisoned,
+    #[error("audit storage is unavailable until restart")]
+    Unavailable,
+    #[error("audit publication is ambiguous; restart is required")]
+    PublicationAmbiguous,
+}
+
+/// Stable operation name recorded in the audit trail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditOperation {
+    RegisterRoot,
+    RevokeRoot,
+    ListRoots,
+    ListDirectory,
+    ReadFile,
+    ProtocolVersionMismatch,
+}
+
+/// Whether the broker performed, refused, or failed an operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditOutcome {
+    Allowed,
+    Denied,
+    Failed,
+}
+
+/// Trusted product identity responsible for a host operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AuditActor {
+    Control {
+        subject: GrantSubject,
+        conversation_id: Option<Uuid>,
+    },
+    Operation {
+        context: ExecutionContext,
+    },
+}
+
+/// De-sensitized operation target. Absolute paths cannot be represented.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AuditTarget {
+    Subject,
+    SelectedFolder {
+        display_name: AuditLabel,
+    },
+    Root {
+        root_id: RootId,
+    },
+    Path {
+        root_id: RootId,
+        relative: RelativePath,
+    },
+}
+
+/// Bounded picker-result leaf name used in audit and management UI.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct AuditLabel(String);
+
+impl AuditLabel {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn from_leaf(value: &str) -> Self {
+        let sanitized = value
+            .chars()
+            .map(|character| {
+                if matches!(character, '/' | '\\' | '\0') {
+                    '\u{fffd}'
+                } else {
+                    character
+                }
+            })
+            .collect::<String>();
+        let sanitized = if sanitized.is_empty() {
+            "Selected folder"
+        } else {
+            &sanitized
+        };
+        Self(truncate_utf8(sanitized, MAX_AUDIT_LABEL_BYTES))
+    }
+}
+
+impl<'de> Deserialize<'de> for AuditLabel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        if value.len() > MAX_AUDIT_LABEL_BYTES
+            || value.contains(['/', '\\', '\0'])
+            || value.is_empty()
+        {
+            return Err(D::Error::custom("invalid audit display label"));
+        }
+        Ok(Self(value))
+    }
+}
+
+impl AuditTarget {
+    pub(crate) fn selected_folder(path: &Path) -> Self {
+        let display_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "Selected folder".to_owned());
+        Self::SelectedFolder {
+            display_name: AuditLabel::from_leaf(&display_name),
+        }
+    }
+
+    pub(crate) fn path(root_id: RootId, path: &RelativePath) -> Self {
+        Self::Path {
+            root_id,
+            relative: path.clone(),
+        }
+    }
+}
+
+/// One bounded, structured machine-boundary audit event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuditEvent {
+    pub event_id: Uuid,
+    pub timestamp: DateTime<Utc>,
+    pub request_id: RequestId,
+    pub operation_id: Option<OperationId>,
+    pub actor: AuditActor,
+    pub operation: AuditOperation,
+    pub target: AuditTarget,
+    pub outcome: AuditOutcome,
+    pub capability: Option<Capability>,
+    pub grant_id: Option<GrantId>,
+    pub error_code: Option<ErrorCode>,
+    pub item_count: Option<usize>,
+    pub bytes: Option<usize>,
+}
+
+/// Append-only destination for broker audit events.
+pub trait AuditSink: Send + Sync {
+    /// Record one event durably enough for the sink's deployment tier.
+    fn record(&self, event: &AuditEvent) -> Result<(), AuditError>;
+}
+
+/// File-backed local audit with bounded two-generation retention.
+pub(crate) struct JsonlAuditSink {
+    path: PathBuf,
+    archive: PathBuf,
+    max_file_bytes: u64,
+    writer: Mutex<WriterState>,
+}
+
+struct WriterState {
+    available: bool,
+    #[cfg(test)]
+    fail_after_write_once: bool,
+    #[cfg(test)]
+    fail_rotation_after_archive_once: bool,
+}
+
+impl JsonlAuditSink {
+    pub(crate) fn open(data_dir: &Path) -> Result<Self, AuditError> {
+        fs::create_dir_all(data_dir)?;
+        #[cfg(unix)]
+        fs::set_permissions(data_dir, fs::Permissions::from_mode(0o700))?;
+        let sink = Self {
+            path: data_dir.join(AUDIT_FILE_NAME),
+            archive: data_dir.join(AUDIT_ARCHIVE_NAME),
+            max_file_bytes: MAX_AUDIT_FILE_BYTES,
+            writer: Mutex::new(WriterState {
+                available: true,
+                #[cfg(test)]
+                fail_after_write_once: false,
+                #[cfg(test)]
+                fail_rotation_after_archive_once: false,
+            }),
+        };
+        sink.recover()?;
+        Ok(sink)
+    }
+
+    fn recover(&self) -> io::Result<()> {
+        self.remove_stale_temporaries()?;
+        if !self.path.exists() {
+            self.create_active()?;
+        }
+        self.enforce_private_permissions()?;
+        self.repair_incomplete_tail()?;
+        match self.archive.metadata() {
+            Ok(metadata) if metadata.len() > self.max_file_bytes => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "audit archive exceeds its retention bound",
+                ))
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        Ok(())
+    }
+
+    fn enforce_private_permissions(&self) -> io::Result<()> {
+        #[cfg(unix)]
+        fs::set_permissions(&self.path, fs::Permissions::from_mode(0o600))?;
+        Ok(())
+    }
+
+    fn repair_incomplete_tail(&self) -> io::Result<()> {
+        let mut options = OpenOptions::new();
+        options.read(true).write(true);
+        let mut file = options.open(&self.path)?;
+        let length = file.metadata()?.len();
+        if length > self.max_file_bytes + MAX_AUDIT_RECORD_BYTES as u64 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "audit file exceeds its retention bound",
+            ));
+        }
+        let mut bytes = Vec::with_capacity(length as usize);
+        file.read_to_end(&mut bytes)?;
+        if bytes.last().is_none_or(|byte| *byte == b'\n') {
+            return Ok(());
+        }
+        let repaired_length = bytes
+            .iter()
+            .rposition(|byte| *byte == b'\n')
+            .map_or(0, |position| position + 1);
+        file.set_len(repaired_length as u64)?;
+        file.sync_all()?;
+        Ok(())
+    }
+
+    fn append_once(&self, line: &[u8], writer: &mut WriterState) -> Result<(), AppendFailure> {
+        if self
+            .path
+            .metadata()
+            .map_err(AppendFailure::safe)?
+            .len()
+            .saturating_add(line.len() as u64)
+            > self.max_file_bytes
+        {
+            self.rotate(writer).map_err(AppendFailure::ambiguous)?;
+        }
+        let mut options = OpenOptions::new();
+        options.append(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options.open(&self.path).map_err(AppendFailure::safe)?;
+        let original_length = file.metadata().map_err(AppendFailure::safe)?.len();
+        let write_result = file.write_all(line).and_then(|()| {
+            #[cfg(test)]
+            if std::mem::take(&mut writer.fail_after_write_once) {
+                return Err(io::Error::from(io::ErrorKind::WouldBlock));
+            }
+            file.sync_all()
+        });
+        if let Err(source) = write_result {
+            return match file.set_len(original_length).and_then(|()| file.sync_all()) {
+                Ok(()) => Err(AppendFailure::safe(source)),
+                Err(_) => Err(AppendFailure::ambiguous(source)),
+            };
+        }
+        Ok(())
+    }
+
+    fn rotate(&self, writer: &mut WriterState) -> io::Result<()> {
+        #[cfg(not(test))]
+        let _ = writer;
+        let temporary = self.create_empty_temporary()?;
+        let result = (|| {
+            replace_file(&self.path, &self.archive)?;
+            #[cfg(test)]
+            if std::mem::take(&mut writer.fail_rotation_after_archive_once) {
+                return Err(io::Error::from(io::ErrorKind::WouldBlock));
+            }
+            replace_file(&temporary, &self.path)?;
+            sync_directory(self.path.parent().expect("audit file has a parent"))
+        })();
+        if result.is_err() {
+            let _ = fs::remove_file(&temporary);
+        }
+        result
+    }
+
+    fn create_active(&self) -> io::Result<()> {
+        let temporary = self.create_empty_temporary()?;
+        let result = replace_file(&temporary, &self.path)
+            .and_then(|()| sync_directory(self.path.parent().expect("audit file has a parent")));
+        if result.is_err() {
+            let _ = fs::remove_file(temporary);
+        }
+        result
+    }
+
+    fn create_empty_temporary(&self) -> io::Result<PathBuf> {
+        let temporary = self
+            .path
+            .parent()
+            .expect("audit file has a parent")
+            .join(format!(".{AUDIT_FILE_NAME}.{}.tmp", Uuid::new_v4()));
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let file = options.open(&temporary)?;
+        file.sync_all()?;
+        Ok(temporary)
+    }
+
+    fn remove_stale_temporaries(&self) -> io::Result<()> {
+        let directory = self.path.parent().expect("audit file has a parent");
+        let prefix = format!(".{AUDIT_FILE_NAME}.");
+        for (index, entry) in fs::read_dir(directory)?.enumerate() {
+            if index >= MAX_AUDIT_DIRECTORY_ENTRIES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "audit directory contains too many entries",
+                ));
+            }
+            let entry = entry?;
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.starts_with(&prefix) && name.ends_with(".tmp") {
+                fs::remove_file(entry.path())?;
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn with_max_file_bytes(mut self, max_file_bytes: u64) -> Self {
+        self.max_file_bytes = max_file_bytes;
+        self
+    }
+}
+
+impl AuditSink for JsonlAuditSink {
+    fn record(&self, event: &AuditEvent) -> Result<(), AuditError> {
+        let mut line = serde_json::to_vec(event)?;
+        line.push(b'\n');
+        if line.len() > MAX_AUDIT_RECORD_BYTES {
+            return Err(AuditError::RecordTooLarge);
+        }
+        let mut writer = self.writer.lock().map_err(|_| AuditError::Poisoned)?;
+        if !writer.available {
+            return Err(AuditError::Unavailable);
+        }
+        let mut last_error = None;
+        for attempt in 0..AUDIT_WRITE_ATTEMPTS {
+            match self.append_once(&line, &mut writer) {
+                Ok(()) => return Ok(()),
+                Err(error) if error.safe_to_retry => {
+                    let retryable = transient_io_kind(error.source.kind());
+                    last_error = Some(error.source);
+                    if !retryable || attempt + 1 == AUDIT_WRITE_ATTEMPTS {
+                        break;
+                    }
+                    thread::sleep(AUDIT_RETRY_BACKOFF);
+                }
+                Err(_) => {
+                    writer.available = false;
+                    return Err(AuditError::PublicationAmbiguous);
+                }
+            }
+        }
+        Err(last_error
+            .expect("at least one append attempt was made")
+            .into())
+    }
+}
+
+struct AppendFailure {
+    source: io::Error,
+    safe_to_retry: bool,
+}
+
+impl AppendFailure {
+    fn safe(source: io::Error) -> Self {
+        Self {
+            source,
+            safe_to_retry: true,
+        }
+    }
+
+    fn ambiguous(source: io::Error) -> Self {
+        Self {
+            source,
+            safe_to_retry: false,
+        }
+    }
+}
+
+pub(crate) struct UnavailableAuditSink;
+
+impl AuditSink for UnavailableAuditSink {
+    fn record(&self, _event: &AuditEvent) -> Result<(), AuditError> {
+        Err(AuditError::Unavailable)
+    }
+}
+
+/// Bounded in-memory audit used by an explicitly ephemeral broker.
+pub(crate) struct MemoryAuditSink {
+    events: Mutex<VecDeque<AuditEvent>>,
+}
+
+impl MemoryAuditSink {
+    pub(crate) fn new() -> Self {
+        Self {
+            events: Mutex::new(VecDeque::new()),
+        }
+    }
+}
+
+impl AuditSink for MemoryAuditSink {
+    fn record(&self, event: &AuditEvent) -> Result<(), AuditError> {
+        let mut events = self.events.lock().map_err(|_| AuditError::Poisoned)?;
+        if events.len() == MAX_MEMORY_EVENTS {
+            events.pop_front();
+        }
+        events.push_back(event.clone());
+        Ok(())
+    }
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_owned();
+    }
+    let mut boundary = max_bytes;
+    while !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    value[..boundary].to_owned()
+}
+
+fn transient_io_kind(kind: io::ErrorKind) -> bool {
+    matches!(
+        kind,
+        io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+    )
+}
+
+#[cfg(unix)]
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    fs::rename(source, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let source = source
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let destination = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let succeeded = unsafe {
+        MoveFileExW(
+            source.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if succeeded == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn replace_file(_source: &Path, _destination: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "durable audit rotation is unsupported on this platform",
+    ))
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(target: AuditTarget) -> AuditEvent {
+        AuditEvent {
+            event_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            request_id: RequestId::new(),
+            operation_id: None,
+            actor: AuditActor::Operation {
+                context: ExecutionContext::standalone(Uuid::new_v4()).unwrap(),
+            },
+            operation: AuditOperation::ReadFile,
+            target,
+            outcome: AuditOutcome::Allowed,
+            capability: Some(Capability::ReadFiles),
+            grant_id: Some(GrantId::new()),
+            error_code: None,
+            item_count: None,
+            bytes: Some(12),
+        }
+    }
+
+    #[test]
+    fn audit_targets_never_include_an_absolute_path() {
+        let target = AuditTarget::selected_folder(Path::new("/Users/thet/Documents/private"));
+        let encoded = serde_json::to_string(&event(target)).unwrap();
+        assert!(encoded.contains("private"));
+        assert!(!encoded.contains("Users"));
+        assert!(!encoded.contains("Documents"));
+    }
+
+    #[test]
+    fn relative_targets_are_bounded_on_utf8_boundaries() {
+        let path = RelativePath::parse(&"é".repeat(512)).unwrap();
+        let AuditTarget::Path { relative, .. } = AuditTarget::path(RootId::new(), &path) else {
+            panic!("unexpected target")
+        };
+        assert!(relative.as_str().len() <= 1024);
+        assert!(relative.as_str().is_char_boundary(relative.as_str().len()));
+    }
+
+    #[test]
+    fn jsonl_sink_appends_private_records() {
+        let temp = tempfile::tempdir().unwrap();
+        let sink = JsonlAuditSink::open(temp.path()).unwrap();
+        let first = event(AuditTarget::Subject);
+        let second = event(AuditTarget::Root {
+            root_id: RootId::new(),
+        });
+        sink.record(&first).unwrap();
+        sink.record(&second).unwrap();
+        let contents = fs::read_to_string(temp.path().join(AUDIT_FILE_NAME)).unwrap();
+        let decoded = contents
+            .lines()
+            .map(|line| serde_json::from_str::<AuditEvent>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(decoded, [first, second]);
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(temp.path().join(AUDIT_FILE_NAME))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn memory_sink_retains_a_bounded_tail() {
+        let sink = MemoryAuditSink::new();
+        for _ in 0..=MAX_MEMORY_EVENTS {
+            sink.record(&event(AuditTarget::Subject)).unwrap();
+        }
+        assert_eq!(sink.events.lock().unwrap().len(), MAX_MEMORY_EVENTS);
+    }
+
+    #[test]
+    fn jsonl_sink_rotates_with_bounded_retention() {
+        let temp = tempfile::tempdir().unwrap();
+        let sink = JsonlAuditSink::open(temp.path())
+            .unwrap()
+            .with_max_file_bytes((MAX_AUDIT_RECORD_BYTES + 100) as u64);
+        for _ in 0..20 {
+            sink.record(&event(AuditTarget::Subject)).unwrap();
+        }
+        let current = fs::metadata(temp.path().join(AUDIT_FILE_NAME))
+            .unwrap()
+            .len();
+        let previous = fs::metadata(temp.path().join(AUDIT_ARCHIVE_NAME))
+            .unwrap()
+            .len();
+        assert!(current <= sink.max_file_bytes);
+        assert!(previous <= sink.max_file_bytes);
+    }
+
+    #[test]
+    fn transient_post_write_failure_rolls_back_before_retry() {
+        let temp = tempfile::tempdir().unwrap();
+        let sink = JsonlAuditSink::open(temp.path()).unwrap();
+        sink.writer.lock().unwrap().fail_after_write_once = true;
+        let expected = event(AuditTarget::Subject);
+        sink.record(&expected).unwrap();
+
+        let contents = fs::read_to_string(temp.path().join(AUDIT_FILE_NAME)).unwrap();
+        let lines = contents.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(
+            serde_json::from_str::<AuditEvent>(lines[0]).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn startup_repairs_an_incomplete_jsonl_tail() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = event(AuditTarget::Subject);
+        let sink = JsonlAuditSink::open(temp.path()).unwrap();
+        sink.record(&first).unwrap();
+        drop(sink);
+        let mut file = OpenOptions::new()
+            .append(true)
+            .open(temp.path().join(AUDIT_FILE_NAME))
+            .unwrap();
+        file.write_all(br#"{"partial":"#).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        let sink = JsonlAuditSink::open(temp.path()).unwrap();
+        let second = event(AuditTarget::Subject);
+        sink.record(&second).unwrap();
+        let decoded = fs::read_to_string(temp.path().join(AUDIT_FILE_NAME))
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<AuditEvent>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(decoded, [first, second]);
+    }
+
+    #[test]
+    fn interrupted_rotation_degrades_until_restart_then_recovers() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = event(AuditTarget::Subject);
+        let line_bytes = serde_json::to_vec(&first).unwrap().len() as u64 + 1;
+        let sink = JsonlAuditSink::open(temp.path())
+            .unwrap()
+            .with_max_file_bytes(line_bytes);
+        sink.record(&first).unwrap();
+        sink.writer.lock().unwrap().fail_rotation_after_archive_once = true;
+        assert!(matches!(
+            sink.record(&event(AuditTarget::Subject)),
+            Err(AuditError::PublicationAmbiguous)
+        ));
+        assert!(matches!(
+            sink.record(&event(AuditTarget::Subject)),
+            Err(AuditError::Unavailable)
+        ));
+        drop(sink);
+
+        let sink = JsonlAuditSink::open(temp.path()).unwrap();
+        let second = event(AuditTarget::Subject);
+        sink.record(&second).unwrap();
+        let archive = fs::read_to_string(temp.path().join(AUDIT_ARCHIVE_NAME)).unwrap();
+        let current = fs::read_to_string(temp.path().join(AUDIT_FILE_NAME)).unwrap();
+        assert_eq!(
+            serde_json::from_str::<AuditEvent>(archive.trim()).unwrap(),
+            first
+        );
+        assert_eq!(
+            serde_json::from_str::<AuditEvent>(current.trim()).unwrap(),
+            second
+        );
+    }
+}

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -24,6 +24,10 @@ use thiserror::Error;
 use uuid::Uuid;
 
 use crate::{
+    audit::{
+        AuditActor, AuditError, AuditEvent, AuditOperation, AuditOutcome, AuditSink, AuditTarget,
+        JsonlAuditSink, MemoryAuditSink, UnavailableAuditSink,
+    },
     protocol::{
         ControlEnvelope, ControlRequest, ControlResponseEnvelope, ControlResult, DirectoryEntry,
         EntryKind, ErrorCode, ErrorResponse, HelloResult, OperationEnvelope, OperationRequest,
@@ -76,6 +80,8 @@ pub enum BrokerError {
     RootPolicy(#[from] RootPolicyError),
     #[error(transparent)]
     InvalidGrant(#[from] GrantError),
+    #[error(transparent)]
+    Audit(#[from] AuditError),
     #[error("host filesystem operation failed: {0}")]
     Io(#[from] io::Error),
 }
@@ -102,7 +108,16 @@ struct Shared {
     policy: RootPolicy,
     state: Mutex<State>,
     state_file: Option<StateFile>,
+    audit: Arc<dyn AuditSink>,
     failed_closed: AtomicBool,
+}
+
+impl Shared {
+    fn record_audit(&self, event: &AuditEvent) {
+        if let Err(error) = self.audit.record(event) {
+            eprintln!("openwave host broker could not persist audit event: {error}");
+        }
+    }
 }
 
 #[derive(Clone, Default)]
@@ -161,6 +176,78 @@ struct PreparedRegistration {
     result: RegisterRootResult,
 }
 
+struct ControlAudit {
+    actor: AuditActor,
+    operation: AuditOperation,
+    operation_id: OperationId,
+    target: AuditTarget,
+}
+
+impl ControlAudit {
+    fn from_request(request: &ControlRequest) -> Option<Self> {
+        match request {
+            ControlRequest::Hello => None,
+            ControlRequest::RegisterRoot(request) => Some(Self {
+                actor: AuditActor::Control {
+                    subject: request.subject,
+                    conversation_id: Some(request.conversation_id),
+                },
+                operation: AuditOperation::RegisterRoot,
+                operation_id: request.operation_id,
+                target: AuditTarget::selected_folder(&request.path),
+            }),
+            ControlRequest::RevokeRoot(request) => Some(Self {
+                actor: AuditActor::Control {
+                    subject: request.subject,
+                    conversation_id: None,
+                },
+                operation: AuditOperation::RevokeRoot,
+                operation_id: request.operation_id,
+                target: AuditTarget::Root {
+                    root_id: request.root_id,
+                },
+            }),
+        }
+    }
+}
+
+struct OperationAudit {
+    actor: AuditActor,
+    operation: AuditOperation,
+    capability: Capability,
+    target: AuditTarget,
+}
+
+impl OperationAudit {
+    fn from_envelope(envelope: &OperationEnvelope) -> Self {
+        let (operation, capability, target) = match &envelope.request {
+            OperationRequest::ListRoots => (
+                AuditOperation::ListRoots,
+                Capability::ListRoots,
+                AuditTarget::Subject,
+            ),
+            OperationRequest::ListDirectory(request) => (
+                AuditOperation::ListDirectory,
+                Capability::ReadFiles,
+                AuditTarget::path(request.root_id, &request.path),
+            ),
+            OperationRequest::ReadFile(request) => (
+                AuditOperation::ReadFile,
+                Capability::ReadFiles,
+                AuditTarget::path(request.root_id, &request.path),
+            ),
+        };
+        Self {
+            actor: AuditActor::Operation {
+                context: envelope.context,
+            },
+            operation,
+            capability,
+            target,
+        }
+    }
+}
+
 impl Broker {
     /// Create an empty broker using the reviewed host-root policy.
     pub fn new(policy: RootPolicy) -> Self {
@@ -169,6 +256,20 @@ impl Broker {
                 policy,
                 state: Mutex::new(State::default()),
                 state_file: None,
+                audit: Arc::new(MemoryAuditSink::new()),
+                failed_closed: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Create an ephemeral broker with an embedder-provided audit sink.
+    pub fn with_audit_sink(policy: RootPolicy, audit: Arc<dyn AuditSink>) -> Self {
+        Self {
+            shared: Arc::new(Shared {
+                policy,
+                state: Mutex::new(State::default()),
+                state_file: None,
+                audit,
                 failed_closed: AtomicBool::new(false),
             }),
         }
@@ -180,11 +281,19 @@ impl Broker {
     pub fn open(policy: RootPolicy, data_dir: &Path) -> Result<Self, BrokerError> {
         let state_file = StateFile::open(data_dir)?;
         let state = state_file.load(&policy)?;
+        let audit: Arc<dyn AuditSink> = match JsonlAuditSink::open(data_dir) {
+            Ok(audit) => Arc::new(audit),
+            Err(error) => {
+                eprintln!("openwave host broker audit unavailable at startup: {error}");
+                Arc::new(UnavailableAuditSink)
+            }
+        };
         Ok(Self {
             shared: Arc::new(Shared {
                 policy,
                 state: Mutex::new(state),
                 state_file: Some(state_file),
+                audit,
                 failed_closed: AtomicBool::new(false),
             }),
         })
@@ -210,8 +319,42 @@ impl Controller {
     /// transport-safe response.
     pub fn handle(&self, envelope: ControlEnvelope) -> ControlResponseEnvelope {
         let request_id = envelope.request_id;
+        let audit = ControlAudit::from_request(&envelope.request);
         let result = self.execute(envelope);
+        if let Some(audit) = audit {
+            self.record_audit(request_id, audit, &result);
+        }
         response_envelope(request_id, result)
+    }
+
+    fn record_audit(
+        &self,
+        request_id: crate::RequestId,
+        metadata: ControlAudit,
+        result: &Result<ControlResult, ErrorResponse>,
+    ) {
+        let error = result.as_ref().err();
+        let operation = if error.is_some_and(|error| error.code == ErrorCode::ProtocolVersion) {
+            AuditOperation::ProtocolVersionMismatch
+        } else {
+            metadata.operation
+        };
+        let event = AuditEvent {
+            event_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            request_id,
+            operation_id: Some(metadata.operation_id),
+            actor: metadata.actor,
+            operation,
+            target: metadata.target,
+            outcome: audit_outcome(error),
+            capability: None,
+            grant_id: None,
+            error_code: error.map(|error| error.code),
+            item_count: None,
+            bytes: None,
+        };
+        self.shared.record_audit(&event);
     }
 
     fn execute(&self, envelope: ControlEnvelope) -> Result<ControlResult, ErrorResponse> {
@@ -405,30 +548,83 @@ impl Operator {
     /// response rather than exposing raw host errors.
     pub fn handle(&self, envelope: OperationEnvelope) -> OperationResponseEnvelope {
         let request_id = envelope.request_id;
-        let result = self.execute(envelope).map_err(error_response);
+        let audit = OperationAudit::from_envelope(&envelope);
+        let (result, grant_id) = self.execute(envelope);
+        let result = result.map_err(error_response);
+        self.record_audit(request_id, audit, grant_id, &result);
         response_envelope(request_id, result)
     }
 
-    fn execute(&self, envelope: OperationEnvelope) -> Result<OperationResult, BrokerError> {
-        require_version(envelope.protocol_version)?;
-        match envelope.request {
-            OperationRequest::ListRoots => {
-                let state = self.lock_state()?;
-                list_roots(&state, envelope.context)
+    fn execute(
+        &self,
+        envelope: OperationEnvelope,
+    ) -> (Result<OperationResult, BrokerError>, Option<GrantId>) {
+        let mut grant_id = None;
+        let result = (|| {
+            require_version(envelope.protocol_version)?;
+            match envelope.request {
+                OperationRequest::ListRoots => {
+                    let state = self.lock_state()?;
+                    let (result, authorized_by) = list_roots(&state, envelope.context)?;
+                    grant_id = Some(authorized_by);
+                    Ok(result)
+                }
+                OperationRequest::ListDirectory(PathRequest { root_id, path }) => {
+                    let (directory, authorized_by) =
+                        self.authorized_root(envelope.context, root_id, &path)?;
+                    grant_id = Some(authorized_by);
+                    let result = list_directory(&directory, &path)?;
+                    grant_id = Some(self.reauthorize(envelope.context, root_id, &path)?);
+                    Ok(result)
+                }
+                OperationRequest::ReadFile(PathRequest { root_id, path }) => {
+                    let (directory, authorized_by) =
+                        self.authorized_root(envelope.context, root_id, &path)?;
+                    grant_id = Some(authorized_by);
+                    let result = read_file(&directory, &path)?;
+                    grant_id = Some(self.reauthorize(envelope.context, root_id, &path)?);
+                    Ok(result)
+                }
             }
-            OperationRequest::ListDirectory(PathRequest { root_id, path }) => {
-                let directory = self.authorized_root(envelope.context, root_id, &path)?;
-                let result = list_directory(&directory, &path)?;
-                self.reauthorize(envelope.context, root_id, &path)?;
-                Ok(result)
-            }
-            OperationRequest::ReadFile(PathRequest { root_id, path }) => {
-                let directory = self.authorized_root(envelope.context, root_id, &path)?;
-                let result = read_file(&directory, &path)?;
-                self.reauthorize(envelope.context, root_id, &path)?;
-                Ok(result)
-            }
-        }
+        })();
+        (result, grant_id)
+    }
+
+    fn record_audit(
+        &self,
+        request_id: crate::RequestId,
+        metadata: OperationAudit,
+        grant_id: Option<GrantId>,
+        result: &Result<OperationResult, ErrorResponse>,
+    ) {
+        let error = result.as_ref().err();
+        let operation = if error.is_some_and(|error| error.code == ErrorCode::ProtocolVersion) {
+            AuditOperation::ProtocolVersionMismatch
+        } else {
+            metadata.operation
+        };
+        let (item_count, bytes) = match result.as_ref().ok() {
+            Some(OperationResult::ListRoots { roots }) => (Some(roots.len()), None),
+            Some(OperationResult::ListDirectory { entries }) => (Some(entries.len()), None),
+            Some(OperationResult::ReadFile(result)) => (None, Some(result.bytes)),
+            None => (None, None),
+        };
+        let event = AuditEvent {
+            event_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            request_id,
+            operation_id: None,
+            actor: metadata.actor,
+            operation,
+            target: metadata.target,
+            outcome: audit_outcome(error),
+            capability: Some(metadata.capability),
+            grant_id,
+            error_code: error.map(|error| error.code),
+            item_count,
+            bytes,
+        };
+        self.shared.record_audit(&event);
     }
 
     fn authorized_root(
@@ -436,9 +632,9 @@ impl Operator {
         context: ExecutionContext,
         root_id: RootId,
         path: &RelativePath,
-    ) -> Result<Dir, BrokerError> {
+    ) -> Result<(Dir, GrantId), BrokerError> {
         let state = self.lock_state()?;
-        authorize(
+        let grant_id = authorize(
             &state,
             context,
             Capability::ReadFiles,
@@ -447,14 +643,15 @@ impl Operator {
                 relative: path,
             },
         )?;
-        state
+        let directory = state
             .roots
             .get(&root_id)
             .ok_or(BrokerError::Denied)?
             .root
             .directory()
             .try_clone()
-            .map_err(Into::into)
+            .map_err(BrokerError::from)?;
+        Ok((directory, grant_id))
     }
 
     fn reauthorize(
@@ -462,9 +659,9 @@ impl Operator {
         context: ExecutionContext,
         root_id: RootId,
         path: &RelativePath,
-    ) -> Result<(), BrokerError> {
+    ) -> Result<GrantId, BrokerError> {
         let state = self.lock_state()?;
-        authorize(
+        let grant_id = authorize(
             &state,
             context,
             Capability::ReadFiles,
@@ -474,7 +671,7 @@ impl Operator {
             },
         )?;
         state.roots.get(&root_id).ok_or(BrokerError::Denied)?;
-        Ok(())
+        Ok(grant_id)
     }
 
     fn lock_state(&self) -> Result<MutexGuard<'_, State>, BrokerError> {
@@ -591,6 +788,11 @@ fn error_response(error: BrokerError) -> ErrorResponse {
             "broker state publication is ambiguous; restart the broker",
             false,
         ),
+        BrokerError::Audit(_) => (
+            ErrorCode::Internal,
+            "broker audit storage is unavailable",
+            false,
+        ),
     };
     ErrorResponse {
         code,
@@ -612,6 +814,14 @@ fn transient_io_kind(kind: io::ErrorKind) -> bool {
         kind,
         io::ErrorKind::Interrupted | io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
     )
+}
+
+fn audit_outcome(error: Option<&ErrorResponse>) -> AuditOutcome {
+    match error.map(|error| error.code) {
+        None => AuditOutcome::Allowed,
+        Some(ErrorCode::Denied) => AuditOutcome::Denied,
+        Some(_) => AuditOutcome::Failed,
+    }
 }
 
 enum Claim<T> {
@@ -727,8 +937,11 @@ fn complete_revoke(
     }
 }
 
-fn list_roots(state: &State, context: ExecutionContext) -> Result<OperationResult, BrokerError> {
-    authorize(state, context, Capability::ListRoots, Resource::Subject)?;
+fn list_roots(
+    state: &State,
+    context: ExecutionContext,
+) -> Result<(OperationResult, GrantId), BrokerError> {
+    let grant_id = authorize(state, context, Capability::ListRoots, Resource::Subject)?;
     let mut roots = state
         .roots
         .iter()
@@ -752,7 +965,7 @@ fn list_roots(state: &State, context: ExecutionContext) -> Result<OperationResul
             .cmp(&right.display_name)
             .then_with(|| left.root_id.to_string().cmp(&right.root_id.to_string()))
     });
-    Ok(OperationResult::ListRoots { roots })
+    Ok((OperationResult::ListRoots { roots }, grant_id))
 }
 
 fn list_directory(root: &Dir, path: &RelativePath) -> Result<OperationResult, BrokerError> {
@@ -897,6 +1110,26 @@ fn scope_targets_root(scope: &Scope, requested: RootId) -> bool {
 mod tests {
     use super::*;
 
+    #[derive(Default)]
+    struct CollectingAudit {
+        events: Mutex<Vec<AuditEvent>>,
+    }
+
+    impl AuditSink for CollectingAudit {
+        fn record(&self, event: &AuditEvent) -> Result<(), AuditError> {
+            self.events.lock().unwrap().push(event.clone());
+            Ok(())
+        }
+    }
+
+    struct FailingAudit;
+
+    impl AuditSink for FailingAudit {
+        fn record(&self, _event: &AuditEvent) -> Result<(), AuditError> {
+            Err(AuditError::Io(io::Error::other("injected audit failure")))
+        }
+    }
+
     fn test_policy(temp: &tempfile::TempDir) -> RootPolicy {
         RootPolicy::for_test(
             temp.path().join("home"),
@@ -925,6 +1158,16 @@ mod tests {
         let state_dir = temp.path().join("app-data/host-broker");
         let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
         (temp, broker, root, state_dir)
+    }
+
+    fn audited_setup() -> (tempfile::TempDir, Broker, PathBuf, Arc<CollectingAudit>) {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("home/Documents");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("note.txt"), "hello from broker").unwrap();
+        let audit = Arc::new(CollectingAudit::default());
+        let broker = Broker::with_audit_sink(test_policy(&temp), audit.clone());
+        (temp, broker, root, audit)
     }
 
     fn register(
@@ -1056,6 +1299,98 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn broker_audits_control_reads_denials_and_authorizing_grants() {
+        let (_temp, broker, path, audit) = audited_setup();
+        let hello = broker.controller().handle(ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request: ControlRequest::Hello,
+        });
+        assert!(matches!(hello.response, Response::Ok(_)));
+        assert!(audit.events.lock().unwrap().is_empty());
+
+        let conversation = Uuid::new_v4();
+        let subject = GrantSubject::conversation(conversation).unwrap();
+        let registered = register(
+            &broker.controller(),
+            subject,
+            conversation,
+            path,
+            OperationId::new(),
+        );
+        let request = OperationRequest::ReadFile(PathRequest {
+            root_id: registered.root.root_id,
+            path: RelativePath::parse("note.txt").unwrap(),
+        });
+        operate(
+            &broker.operator(),
+            ExecutionContext::standalone(conversation).unwrap(),
+            request.clone(),
+        )
+        .unwrap();
+        assert!(matches!(
+            operate(
+                &broker.operator(),
+                ExecutionContext::standalone(Uuid::new_v4()).unwrap(),
+                request,
+            ),
+            Err(ErrorResponse {
+                code: ErrorCode::Denied,
+                ..
+            })
+        ));
+
+        let events = audit.events.lock().unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].operation, AuditOperation::RegisterRoot);
+        assert!(matches!(
+            &events[0].target,
+            AuditTarget::SelectedFolder { display_name } if display_name.as_str() == "Documents"
+        ));
+        assert_eq!(events[1].operation, AuditOperation::ReadFile);
+        assert_eq!(events[1].outcome, AuditOutcome::Allowed);
+        assert!(events[1].grant_id.is_some());
+        assert_eq!(events[1].bytes, Some(17));
+        assert!(matches!(
+            &events[1].target,
+            AuditTarget::Path { root_id, relative }
+                if *root_id == registered.root.root_id && relative.as_str() == "note.txt"
+        ));
+        assert_eq!(events[2].outcome, AuditOutcome::Denied);
+        assert_eq!(events[2].error_code, Some(ErrorCode::Denied));
+        assert!(events[2].grant_id.is_none());
+        let encoded = serde_json::to_string(&*events).unwrap();
+        assert!(!encoded.contains("home/Documents"));
+        assert!(!encoded.contains("hello from broker"));
+    }
+
+    #[test]
+    fn read_tier_audit_failure_does_not_block_user_access() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("home/Documents");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("note.txt"), "hello from broker").unwrap();
+        let broker = Broker::with_audit_sink(test_policy(&temp), Arc::new(FailingAudit));
+        let conversation = Uuid::new_v4();
+        let registered = register(
+            &broker.controller(),
+            GrantSubject::conversation(conversation).unwrap(),
+            conversation,
+            root,
+            OperationId::new(),
+        );
+        let result = operate(
+            &broker.operator(),
+            ExecutionContext::standalone(conversation).unwrap(),
+            OperationRequest::ReadFile(PathRequest {
+                root_id: registered.root.root_id,
+                path: RelativePath::parse("note.txt").unwrap(),
+            }),
+        );
+        assert!(result.is_ok());
     }
 
     #[test]
@@ -1290,7 +1625,7 @@ mod tests {
         let context = ExecutionContext::standalone(conversation).unwrap();
         let relative = RelativePath::parse("note.txt").unwrap();
         let operator = broker.operator();
-        let directory = operator
+        let (directory, _) = operator
             .authorized_root(context, registered.root.root_id, &relative)
             .unwrap();
         let buffered = read_file(&directory, &relative).unwrap();
@@ -1437,6 +1772,36 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn unavailable_audit_does_not_block_restart_or_read_access() {
+        let (temp, broker, path, state_dir) = durable_setup();
+        let conversation = Uuid::new_v4();
+        let registered = register(
+            &broker.controller(),
+            GrantSubject::conversation(conversation).unwrap(),
+            conversation,
+            path,
+            OperationId::new(),
+        );
+        drop(broker);
+        std::fs::write(
+            state_dir.join("host-broker-audit.previous.jsonl"),
+            vec![b'x'; 8 * 1024 * 1024 + 1],
+        )
+        .unwrap();
+
+        let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+        let result = operate(
+            &broker.operator(),
+            ExecutionContext::standalone(conversation).unwrap(),
+            OperationRequest::ReadFile(PathRequest {
+                root_id: registered.root.root_id,
+                path: RelativePath::parse("note.txt").unwrap(),
+            }),
+        );
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -7,6 +7,7 @@
 //! revocation therefore fences in-flight results without waiting on host I/O.
 //! No desktop runtime or concrete transport is referenced here.
 
+pub mod audit;
 pub mod broker;
 pub mod capability;
 pub mod id;
@@ -14,6 +15,10 @@ pub mod path_policy;
 pub mod protocol;
 pub mod relative_path;
 
+pub use audit::{
+    AuditActor, AuditError, AuditEvent, AuditLabel, AuditOperation, AuditOutcome, AuditSink,
+    AuditTarget,
+};
 pub use broker::{Broker, BrokerError, Controller, Operator};
 pub use capability::{
     Capability, ConsentMethod, ConsentRecord, Grant, GrantError, RootAttachment, Scope,

--- a/crates/openwave-host-broker/src/relative_path.rs
+++ b/crates/openwave-host-broker/src/relative_path.rs
@@ -8,6 +8,9 @@ use thiserror::Error;
 /// Why a requested root-relative path was refused.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum RelativePathError {
+    /// Paths are bounded before filesystem or audit processing.
+    #[error("path exceeds its size limit")]
+    TooLong,
     /// Absolute paths are never part of the agent-facing protocol.
     #[error("path must be relative to a registered root")]
     Absolute,
@@ -35,6 +38,9 @@ pub struct RelativePath(String);
 impl RelativePath {
     /// Validate and normalize an untrusted protocol path.
     pub fn parse(input: &str) -> Result<Self, RelativePathError> {
+        if input.len() > 1024 {
+            return Err(RelativePathError::TooLong);
+        }
         if input.starts_with('/') {
             return Err(RelativePathError::Absolute);
         }
@@ -152,6 +158,10 @@ mod tests {
 
     #[test]
     fn rejects_absolute_parent_and_nonportable_paths_on_every_host() {
+        assert!(matches!(
+            RelativePath::parse(&"a".repeat(1025)),
+            Err(RelativePathError::TooLong)
+        ));
         for absolute in ["/etc/passwd", "\\server\\share", "C:/Windows"] {
             assert!(RelativePath::parse(absolute).is_err(), "{absolute}");
         }

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -91,9 +91,14 @@ idempotent across restart through an atomically published, size-bounded private
 registry. Restart revalidates and pins every connected root before making it
 available, and ambiguous publication fails closed. List/read operations
 reauthorize before releasing bounded results so completed revocation fences
-in-flight work. Bounded audit, the sidecar adapter, and Tauri consent UI are the
-next slices; until those land, existing file tools do not use this boundary. See
-[Host access and connected folders](host-access.md).
+in-flight work. Every control/read attempt writes a bounded, de-sensitized local
+audit event naming its result and authorizing grant; synced JSONL rotation bounds
+local retention without recording absolute paths or contents. Partial writes
+are rolled back before retry, interrupted tails/rotations recover on restart,
+and degraded read-tier audit does not withhold the user's existing file access.
+The sidecar adapter and Tauri consent UI are the next slices; until those land,
+existing file tools do not use this boundary. See [Host access and connected
+folders](host-access.md).
 
 **Depends on:** no OpenWave client crate.
 

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -183,6 +183,21 @@ intent cannot be recorded durably. App-private scratch may allow replacement;
 connected roots default to additive, no-clobber writes, with replacement and
 deletion modeled as distinct higher-risk actions.
 
+The local audit is structured JSONL under the broker-private data directory. It
+records opaque root IDs and bounded root-relative paths, never absolute host
+paths, raw OS errors, or file contents. Each append is synced before returning;
+the active file and one previous generation provide bounded local retention.
+Transient append failures retry only after the partial attempt has been rolled
+back and synced; an ambiguous append or rotation degrades the sink until restart,
+where an incomplete tail and interrupted rotation are repaired before new
+records are accepted. Unix rotation syncs the containing directory and Windows
+uses write-through file moves. Read-tier audit initialization or append failure
+is reported locally but does not prevent the user from reading their own files.
+Future write, command, and computer-control operations must durably record a
+bounded intent before acting and refuse the action if that record cannot be
+written. Forwarding this local trail off-device is a separate, explicit privacy
+decision, not a side effect of choosing a hosted model.
+
 ## Deployment evolution
 
 The trust boundary does not move when deployment changes:
@@ -219,7 +234,9 @@ This will land in independently reviewable pieces:
    validate the bounded state file and revalidate and descriptor-pin every
    persisted root before advertising it. A mutation with ambiguous publication
    fails the broker closed until restart.
-4. Add bounded audit records for every machine-touching operation.
+4. Add bounded audit records for every machine-touching operation, including
+   the exact grant that authorized an operation, de-sensitized targets, and
+   local two-generation retention.
 5. Expose the same contract through a versioned sidecar adapter.
 6. Add the Tauri sidecar client, connected-folder UI, and the durable
    agent-request → native-picker → grant → retry workflow. Broker state, audit,


### PR DESCRIPTION
## Summary

- add structured local audit events for trusted control actions and capability-checked reads, including the exact authorizing grant
- prevent absolute paths, file contents, raw host errors, and unbounded relative paths from entering audit records
- append and sync bounded JSONL records with active/previous retention, rollback-before-retry, restart tail repair, and recoverable rotation
- keep existing read access available when audit storage is degraded while leaving a checked sink contract for future mutating operations
- use synced Unix directory updates and write-through Windows file moves for rotation

## Validation

- `cargo test -p openwave-host-broker --locked` (55 tests)
- `bw dev lint --rust --check --repo-root "$PWD"`
- `git diff --check`
