### PR TITLE
feat(host): add bounded sidecar adapter

### DIFF
--- a/crates/openwave-host-broker/Cargo.toml
+++ b/crates/openwave-host-broker/Cargo.toml
@@ -8,6 +8,10 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 
+[[bin]]
+name = "openwave-host-broker"
+path = "src/bin/openwave-host-broker.rs"
+
 [dependencies]
 cap-fs-ext.workspace = true
 cap-std.workspace = true

--- a/crates/openwave-host-broker/src/bin/openwave-host-broker.rs
+++ b/crates/openwave-host-broker/src/bin/openwave-host-broker.rs
@@ -1,0 +1,131 @@
+//! OpenWave host-broker sidecar process.
+
+use std::{
+    ffi::{OsStr, OsString},
+    io::{self, BufReader, BufWriter},
+    path::PathBuf,
+    process::ExitCode,
+};
+
+use openwave_host_broker::{sidecar, Broker, RootPolicy};
+
+fn main() -> ExitCode {
+    let args = match Args::parse(std::env::args_os().skip(1)) {
+        Ok(args) => args,
+        Err(error) => {
+            eprintln!("openwave-host-broker: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Err(error) = std::fs::create_dir_all(&args.data_dir) {
+        eprintln!("openwave-host-broker: could not create private data directory: {error}");
+        return ExitCode::FAILURE;
+    }
+    let data_dir = match args.data_dir.canonicalize() {
+        Ok(path) => path,
+        Err(error) => {
+            eprintln!("openwave-host-broker: could not resolve private data directory: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let policy = match RootPolicy::for_host(args.home)
+        .and_then(|policy| policy.with_private_directory(&data_dir))
+    {
+        Ok(policy) => policy,
+        Err(error) => {
+            eprintln!("openwave-host-broker: could not initialize root policy: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let broker = match Broker::open(policy, &data_dir) {
+        Ok(broker) => broker,
+        Err(error) => {
+            eprintln!("openwave-host-broker: could not open broker state: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let input = BufReader::new(io::stdin().lock());
+    let output = BufWriter::new(io::stdout().lock());
+    match sidecar::serve(&broker, input, output) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("openwave-host-broker: sidecar I/O failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+struct Args {
+    data_dir: PathBuf,
+    home: PathBuf,
+}
+
+impl Args {
+    fn parse(mut args: impl Iterator<Item = OsString>) -> Result<Self, &'static str> {
+        let mut data_dir = None;
+        let mut home = None;
+        while let Some(argument) = args.next() {
+            let destination = match argument.as_os_str() {
+                value if value == OsStr::new("--data-dir") && data_dir.is_none() => &mut data_dir,
+                value if value == OsStr::new("--home") && home.is_none() => &mut home,
+                value if value == OsStr::new("--data-dir") || value == OsStr::new("--home") => {
+                    return Err("duplicate sidecar argument")
+                }
+                _ => return Err("unknown sidecar argument"),
+            };
+            *destination = Some(PathBuf::from(
+                args.next().ok_or("sidecar argument requires a value")?,
+            ));
+        }
+        let data_dir = data_dir.ok_or("missing --data-dir")?;
+        let home = home.ok_or("missing --home")?;
+        if !data_dir.is_absolute() || !home.is_absolute() {
+            return Err("sidecar paths must be absolute");
+        }
+        Ok(Self { data_dir, home })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arguments_require_one_absolute_value_per_path() {
+        let base = std::env::temp_dir();
+        let data_dir = base.join("openwave");
+        let home = base.join("home");
+        let parsed = Args::parse(
+            [
+                OsString::from("--data-dir"),
+                data_dir.clone().into_os_string(),
+                OsString::from("--home"),
+                home.clone().into_os_string(),
+            ]
+            .into_iter(),
+        )
+        .unwrap();
+        assert_eq!(parsed.data_dir, data_dir);
+        assert!(Args::parse(
+            [
+                OsString::from("--data-dir"),
+                OsString::from("relative"),
+                OsString::from("--home"),
+                home.clone().into_os_string(),
+            ]
+            .into_iter()
+        )
+        .is_err());
+        assert!(Args::parse(
+            [
+                OsString::from("--home"),
+                home.clone().into_os_string(),
+                OsString::from("--home"),
+                home.into_os_string(),
+            ]
+            .into_iter()
+        )
+        .is_err());
+    }
+}

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -46,6 +46,8 @@ use state_file::StateFile;
 const MAX_READ_FILE_BYTES: usize = 64 * 1024;
 const MAX_LIST_DIR_BYTES: usize = 64 * 1024;
 const MAX_LIST_DIR_ENTRIES: usize = 4_096;
+const MAX_LIST_ROOTS: usize = 256;
+const MAX_ROOT_DISPLAY_BYTES: usize = 1024;
 
 /// A broker request failed without widening host access.
 #[derive(Debug, Error)]
@@ -76,6 +78,8 @@ pub enum BrokerError {
     NotUtf8,
     #[error("directory listing exceeds broker limits")]
     DirectoryTooLarge,
+    #[error("connected root listing exceeds broker limits")]
+    RootListTooLarge,
     #[error(transparent)]
     RootPolicy(#[from] RootPolicyError),
     #[error(transparent)]
@@ -439,11 +443,7 @@ impl Controller {
             return Err(BrokerError::InvalidConsentMethod);
         }
         let validated = self.shared.policy.open_root(&request.path)?;
-        let display_name = validated
-            .canonical_path()
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "Connected folder".to_owned());
+        let display_name = root_display_name(validated.canonical_path());
         let root_id = RootId::new();
         let result = RegisterRootResult {
             root: RootSummary {
@@ -761,13 +761,14 @@ fn error_response(error: BrokerError) -> ErrorResponse {
             "selected folder is not an allowed connected root",
             false,
         ),
-        BrokerError::FileTooLarge | BrokerError::DirectoryTooLarge | BrokerError::StateTooLarge => {
-            (
-                ErrorCode::TooLarge,
-                "host operation exceeded its limit",
-                false,
-            )
-        }
+        BrokerError::FileTooLarge
+        | BrokerError::DirectoryTooLarge
+        | BrokerError::RootListTooLarge
+        | BrokerError::StateTooLarge => (
+            ErrorCode::TooLarge,
+            "host operation exceeded its limit",
+            false,
+        ),
         BrokerError::NotRegularFile | BrokerError::NotUtf8 => (
             ErrorCode::UnsupportedContent,
             "host resource has an unsupported content type",
@@ -959,13 +960,32 @@ fn list_roots(
             root_id: *root_id,
             display_name: root.display_name.clone(),
         })
+        .take(MAX_LIST_ROOTS + 1)
         .collect::<Vec<_>>();
+    if roots.len() > MAX_LIST_ROOTS {
+        return Err(BrokerError::RootListTooLarge);
+    }
     roots.sort_by(|left, right| {
         left.display_name
             .cmp(&right.display_name)
             .then_with(|| left.root_id.to_string().cmp(&right.root_id.to_string()))
     });
     Ok((OperationResult::ListRoots { roots }, grant_id))
+}
+
+fn root_display_name(path: &Path) -> String {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "Connected folder".to_owned());
+    if name.len() <= MAX_ROOT_DISPLAY_BYTES {
+        return name;
+    }
+    let mut boundary = MAX_ROOT_DISPLAY_BYTES;
+    while !name.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    name[..boundary].to_owned()
 }
 
 fn list_directory(root: &Dir, path: &RelativePath) -> Result<OperationResult, BrokerError> {
@@ -1494,6 +1514,62 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn connected_root_results_are_bounded_before_transport_serialization() {
+        let (_temp, broker, path) = setup();
+        let conversation = Uuid::new_v4();
+        let subject = GrantSubject::conversation(conversation).unwrap();
+        let consent = ConsentRecord::new(ConsentMethod::FolderPicker, Utc::now());
+        let pinned = Arc::new(broker.shared.policy.open_root(&path).unwrap());
+        let mut state = State::default();
+        state.grants.push(
+            Grant::from_consent(
+                GrantId::new(),
+                subject,
+                Capability::ListRoots,
+                Scope::Subject,
+                consent.clone(),
+            )
+            .unwrap(),
+        );
+        for _ in 0..=MAX_LIST_ROOTS {
+            let root_id = RootId::new();
+            state.roots.insert(
+                root_id,
+                RegisteredRoot {
+                    owner: subject,
+                    display_name: "Documents".to_owned(),
+                    root: pinned.clone(),
+                },
+            );
+            state
+                .attachments
+                .push(RootAttachment::new(conversation, root_id).unwrap());
+            state.grants.push(
+                Grant::from_consent(
+                    GrantId::new(),
+                    subject,
+                    Capability::ReadFiles,
+                    Scope::Root { root_id },
+                    consent.clone(),
+                )
+                .unwrap(),
+            );
+        }
+        assert!(matches!(
+            list_roots(&state, ExecutionContext::standalone(conversation).unwrap()),
+            Err(BrokerError::RootListTooLarge)
+        ));
+    }
+
+    #[test]
+    fn connected_root_display_names_are_bounded_on_utf8_boundaries() {
+        let component = "é".repeat(MAX_ROOT_DISPLAY_BYTES);
+        let display = root_display_name(Path::new(&component));
+        assert!(display.len() <= MAX_ROOT_DISPLAY_BYTES);
+        assert!(display.is_char_boundary(display.len()));
     }
 
     #[test]

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -13,7 +13,7 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 use serde::{Deserialize, Serialize};
 
-use super::{BrokerError, MutationRecord, RegisteredRoot, State};
+use super::{root_display_name, BrokerError, MutationRecord, RegisteredRoot, State};
 use crate::{
     path_policy::RootIdentity, Grant, GrantSubject, OperationId, RootAttachment, RootId,
     RootPolicy, Scope,
@@ -123,11 +123,7 @@ impl StateFile {
             if validated.identity() != item.identity {
                 return Err(invalid_data("persisted root identity changed").into());
             }
-            let display_name = validated
-                .canonical_path()
-                .file_name()
-                .map(|name| name.to_string_lossy().into_owned())
-                .unwrap_or_else(|| "Connected folder".to_owned());
+            let display_name = root_display_name(validated.canonical_path());
             if roots
                 .insert(
                     item.id,

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -14,6 +14,7 @@ pub mod id;
 pub mod path_policy;
 pub mod protocol;
 pub mod relative_path;
+pub mod sidecar;
 
 pub use audit::{
     AuditActor, AuditError, AuditEvent, AuditLabel, AuditOperation, AuditOutcome, AuditSink,

--- a/crates/openwave-host-broker/src/path_policy.rs
+++ b/crates/openwave-host-broker/src/path_policy.rs
@@ -186,6 +186,16 @@ impl RootPolicy {
         })
     }
 
+    /// Add an application-private directory that connected roots must never
+    /// contain or overlap, such as the broker's own state and audit directory.
+    pub fn with_private_directory(mut self, path: &Path) -> Result<Self, RootPolicyError> {
+        if !path.is_absolute() {
+            return Err(RootPolicyError::NotAbsolute);
+        }
+        self.sensitive.push(std::fs::canonicalize(path)?);
+        Ok(self)
+    }
+
     fn validate_canonical(&self, root: &Path) -> Result<(), RootPolicyError> {
         if !root.is_absolute() || is_filesystem_root(root) {
             return Err(RootPolicyError::TooBroad);
@@ -545,6 +555,25 @@ mod tests {
                 "{path}"
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn application_private_directories_cannot_be_connected_or_contained() {
+        let temp = tempfile::tempdir().unwrap();
+        let private = temp.path().join("app-data");
+        std::fs::create_dir(&private).unwrap();
+        let policy = policy().with_private_directory(&private).unwrap();
+        let private = private.canonicalize().unwrap();
+        let parent = temp.path().canonicalize().unwrap();
+        assert!(matches!(
+            policy.validate_canonical(&private),
+            Err(RootPolicyError::SensitiveLocation)
+        ));
+        assert!(matches!(
+            policy.validate_canonical(&parent),
+            Err(RootPolicyError::SensitiveLocation)
+        ));
     }
 
     #[cfg(unix)]

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -40,7 +40,12 @@ pub struct OperationEnvelope {
 
 /// Trusted control actions. Agent code must not receive a [`crate::Controller`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "control", content = "payload", rename_all = "snake_case")]
+#[serde(
+    tag = "control",
+    content = "payload",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
 #[non_exhaustive]
 pub enum ControlRequest {
     /// Version negotiation. This request is accepted even when its envelope
@@ -79,7 +84,12 @@ pub struct RevokeRootRequest {
 
 /// Capability-checked agent operations.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(
+    tag = "operation",
+    content = "payload",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
 #[non_exhaustive]
 pub enum OperationRequest {
     /// Discover safe summaries of roots available to the active conversation.
@@ -267,6 +277,21 @@ mod tests {
             RootId::new(),
         );
         assert!(serde_json::from_str::<OperationEnvelope>(&encoded).is_err());
+    }
+
+    #[test]
+    fn request_variants_reject_unknown_sibling_fields() {
+        let control = format!(
+            r#"{{"protocol_version":1,"request_id":"{}","request":{{"control":"hello","extra":true}}}}"#,
+            RequestId::new()
+        );
+        assert!(serde_json::from_str::<ControlEnvelope>(&control).is_err());
+        let operation = format!(
+            r#"{{"protocol_version":1,"request_id":"{}","context":{{"conversation_id":"{}","project_id":null}},"request":{{"operation":"list_roots","extra":true}}}}"#,
+            RequestId::new(),
+            Uuid::new_v4(),
+        );
+        assert!(serde_json::from_str::<OperationEnvelope>(&operation).is_err());
     }
 
     #[test]

--- a/crates/openwave-host-broker/src/sidecar.rs
+++ b/crates/openwave-host-broker/src/sidecar.rs
@@ -1,0 +1,237 @@
+//! Bounded newline-delimited JSON adapter for the broker sidecar process.
+
+use std::io::{self, BufRead, Write};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    Broker, ControlEnvelope, ControlResponseEnvelope, OperationEnvelope, OperationResponseEnvelope,
+    RequestId,
+};
+
+const MAX_REQUEST_BYTES: usize = 128 * 1024;
+const MAX_RESPONSE_BYTES: usize = 512 * 1024;
+
+/// One strictly typed request on the desktop-owned sidecar pipe.
+#[derive(Debug, Deserialize)]
+#[serde(
+    tag = "channel",
+    content = "envelope",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
+enum SidecarRequest {
+    Control(ControlEnvelope),
+    Operation(OperationEnvelope),
+}
+
+/// One response for one non-empty input line.
+#[derive(Debug, Serialize)]
+#[serde(tag = "channel", content = "envelope", rename_all = "snake_case")]
+enum SidecarResponse {
+    Control(ControlResponseEnvelope),
+    Operation(OperationResponseEnvelope),
+    TransportError(TransportError),
+}
+
+#[derive(Debug, Serialize)]
+#[serde(deny_unknown_fields)]
+struct TransportError {
+    request_id: Option<RequestId>,
+    code: TransportErrorCode,
+    message: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TransportErrorCode {
+    MalformedRequest,
+    RequestTooLarge,
+    ResponseTooLarge,
+}
+
+/// Serve requests synchronously until EOF. The desktop owns this pipe and
+/// awaits exactly one output line for every non-empty input line.
+pub fn serve(broker: &Broker, mut input: impl BufRead, mut output: impl Write) -> io::Result<()> {
+    while let Some(line) = read_bounded_line(&mut input)? {
+        let response = match line {
+            BoundedLine::Data(line) if line.is_empty() => continue,
+            BoundedLine::Data(line) => dispatch(broker, &line),
+            BoundedLine::TooLarge => SidecarResponse::TransportError(TransportError {
+                request_id: None,
+                code: TransportErrorCode::RequestTooLarge,
+                message: "sidecar request exceeded its size limit",
+            }),
+        };
+        let mut encoded = serde_json::to_vec(&response).map_err(io::Error::other)?;
+        if encoded.len() > MAX_RESPONSE_BYTES {
+            encoded = serde_json::to_vec(&SidecarResponse::TransportError(TransportError {
+                request_id: response_request_id(&response),
+                code: TransportErrorCode::ResponseTooLarge,
+                message: "sidecar response exceeded its size limit",
+            }))
+            .map_err(io::Error::other)?;
+        }
+        encoded.push(b'\n');
+        output.write_all(&encoded)?;
+        output.flush()?;
+    }
+    Ok(())
+}
+
+fn dispatch(broker: &Broker, line: &[u8]) -> SidecarResponse {
+    match serde_json::from_slice::<SidecarRequest>(line) {
+        Ok(SidecarRequest::Control(envelope)) => {
+            SidecarResponse::Control(broker.controller().handle(envelope))
+        }
+        Ok(SidecarRequest::Operation(envelope)) => {
+            SidecarResponse::Operation(broker.operator().handle(envelope))
+        }
+        Err(_) => SidecarResponse::TransportError(TransportError {
+            request_id: None,
+            code: TransportErrorCode::MalformedRequest,
+            message: "sidecar request was malformed",
+        }),
+    }
+}
+
+fn response_request_id(response: &SidecarResponse) -> Option<RequestId> {
+    match response {
+        SidecarResponse::Control(envelope) => Some(envelope.request_id),
+        SidecarResponse::Operation(envelope) => Some(envelope.request_id),
+        SidecarResponse::TransportError(error) => error.request_id,
+    }
+}
+
+enum BoundedLine {
+    Data(Vec<u8>),
+    TooLarge,
+}
+
+fn read_bounded_line(input: &mut impl BufRead) -> io::Result<Option<BoundedLine>> {
+    let mut line = Vec::new();
+    let mut too_large = false;
+    let mut observed_any = false;
+    loop {
+        let available = input.fill_buf()?;
+        if available.is_empty() {
+            return if observed_any {
+                Ok(Some(if too_large {
+                    BoundedLine::TooLarge
+                } else {
+                    BoundedLine::Data(line)
+                }))
+            } else {
+                Ok(None)
+            };
+        }
+        observed_any = true;
+        let through_newline = available
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(available.len(), |position| position + 1);
+        let chunk = &available[..through_newline];
+        if !too_large {
+            if line.len().saturating_add(chunk.len()) > MAX_REQUEST_BYTES {
+                too_large = true;
+                line.clear();
+            } else {
+                line.extend_from_slice(chunk);
+            }
+        }
+        let ended = chunk.last() == Some(&b'\n');
+        input.consume(through_newline);
+        if ended {
+            if !too_large {
+                line.pop();
+                if line.last() == Some(&b'\r') {
+                    line.pop();
+                }
+            }
+            return Ok(Some(if too_large {
+                BoundedLine::TooLarge
+            } else {
+                BoundedLine::Data(line)
+            }));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_broker() -> (tempfile::TempDir, Broker) {
+        let temp = tempfile::tempdir().unwrap();
+        let policy = crate::RootPolicy::for_test(
+            temp.path().join("home"),
+            Vec::new(),
+            vec![temp.path().to_path_buf()],
+            Vec::new(),
+        );
+        (temp, Broker::new(policy))
+    }
+
+    #[test]
+    fn bounded_reader_drains_an_oversized_line_and_resynchronizes() {
+        let bytes = [vec![b'x'; MAX_REQUEST_BYTES + 1], b"\nnext\n".to_vec()].concat();
+        let mut input = io::BufReader::new(bytes.as_slice());
+        assert!(matches!(
+            read_bounded_line(&mut input).unwrap(),
+            Some(BoundedLine::TooLarge)
+        ));
+        let Some(BoundedLine::Data(next)) = read_bounded_line(&mut input).unwrap() else {
+            panic!("expected next bounded line")
+        };
+        assert_eq!(next, b"next");
+    }
+
+    #[test]
+    fn request_union_rejects_unknown_top_level_fields() {
+        let request = format!(
+            r#"{{"channel":"control","envelope":{{"protocol_version":1,"request_id":"{}","request":{{"control":"hello"}}}},"extra":true}}"#,
+            RequestId::new()
+        );
+        assert!(serde_json::from_str::<SidecarRequest>(&request).is_err());
+        let nested = format!(
+            r#"{{"channel":"control","envelope":{{"protocol_version":1,"request_id":"{}","request":{{"control":"hello","extra":true}}}}}}"#,
+            RequestId::new()
+        );
+        assert!(serde_json::from_str::<SidecarRequest>(&nested).is_err());
+    }
+
+    #[test]
+    fn serve_returns_one_safe_error_then_resynchronizes() {
+        let (_temp, broker) = test_broker();
+        let hello = serde_json::to_vec(&serde_json::json!({
+            "channel": "control",
+            "envelope": {
+                "protocol_version": crate::PROTOCOL_VERSION,
+                "request_id": RequestId::new(),
+                "request": { "control": "hello" }
+            }
+        }))
+        .unwrap();
+        let input = [
+            vec![b'x'; MAX_REQUEST_BYTES + 1],
+            b"\n   \n".to_vec(),
+            hello,
+            b"\n".to_vec(),
+        ]
+        .concat();
+        let mut output = Vec::new();
+        serve(&broker, io::Cursor::new(input), &mut output).unwrap();
+        let responses = output
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| serde_json::from_slice::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(responses.len(), 3);
+        assert_eq!(responses[0]["channel"], "transport_error");
+        assert_eq!(responses[0]["envelope"]["code"], "request_too_large");
+        assert_eq!(responses[1]["channel"], "transport_error");
+        assert_eq!(responses[1]["envelope"]["code"], "malformed_request");
+        assert_eq!(responses[2]["channel"], "control");
+        assert_eq!(responses[2]["envelope"]["response"]["status"], "ok");
+    }
+}

--- a/crates/openwave-host-broker/tests/sidecar.rs
+++ b/crates/openwave-host-broker/tests/sidecar.rs
@@ -1,0 +1,150 @@
+use std::{
+    io::{BufRead, BufReader, Write},
+    path::{Path, PathBuf},
+    process::{Child, ChildStdin, ChildStdout, Command, Stdio},
+};
+
+use openwave_host_broker::{
+    ConsentMethod, ControlEnvelope, ControlRequest, ExecutionContext, GrantSubject,
+    OperationEnvelope, OperationId, OperationRequest, RegisterRootRequest, RequestId,
+    PROTOCOL_VERSION,
+};
+use serde::Serialize;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+fn spawn(temp: &TempDir, home: &Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_openwave-host-broker"))
+        .args([
+            "--data-dir",
+            temp.path().join("app-data").to_str().unwrap(),
+            "--home",
+            home.to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .unwrap()
+}
+
+fn exchange<T: Serialize>(
+    input: &mut ChildStdin,
+    output: &mut BufReader<ChildStdout>,
+    channel: &str,
+    envelope: &T,
+) -> serde_json::Value {
+    serde_json::to_writer(
+        &mut *input,
+        &serde_json::json!({ "channel": channel, "envelope": envelope }),
+    )
+    .unwrap();
+    input.write_all(b"\n").unwrap();
+    input.flush().unwrap();
+    let mut line = String::new();
+    output.read_line(&mut line).unwrap();
+    assert!(!line.is_empty(), "sidecar exited before responding");
+    serde_json::from_str(&line).unwrap()
+}
+
+#[test]
+fn stdio_sidecar_persists_authority_and_audit_across_restart() {
+    #[cfg(unix)]
+    let home = PathBuf::from(std::env::var_os("HOME").unwrap());
+    #[cfg(windows)]
+    let home = PathBuf::from(std::env::var_os("USERPROFILE").unwrap());
+    let home = home.canonicalize().unwrap();
+    let temp = tempfile::Builder::new()
+        .prefix(".openwave-sidecar-test-")
+        .tempdir_in(&home)
+        .unwrap();
+    let root = temp.path().join("Documents/project");
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("note.txt"), "sidecar read").unwrap();
+    let conversation_id = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation_id).unwrap();
+
+    let root_id = {
+        let mut child = spawn(&temp, &home);
+        let mut input = child.stdin.take().unwrap();
+        let mut output = BufReader::new(child.stdout.take().unwrap());
+        let response = exchange(
+            &mut input,
+            &mut output,
+            "control",
+            &ControlEnvelope {
+                protocol_version: PROTOCOL_VERSION,
+                request_id: RequestId::new(),
+                request: ControlRequest::RegisterRoot(RegisterRootRequest {
+                    operation_id: OperationId::new(),
+                    subject,
+                    conversation_id,
+                    path: root.clone(),
+                    consent_method: ConsentMethod::FolderPicker,
+                }),
+            },
+        );
+        assert_eq!(response["channel"], "control");
+        assert_eq!(
+            response["envelope"]["response"]["payload"]["result"], "register_root",
+            "{response}"
+        );
+        let root_id = response["envelope"]["response"]["payload"]["root"]["root_id"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+        assert!(!response.to_string().contains(root.to_str().unwrap()));
+        drop(input);
+        assert!(child.wait().unwrap().success());
+        root_id
+    };
+
+    let mut child = spawn(&temp, &home);
+    let mut input = child.stdin.take().unwrap();
+    let mut output = BufReader::new(child.stdout.take().unwrap());
+    let response = exchange(
+        &mut input,
+        &mut output,
+        "operation",
+        &OperationEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            context: ExecutionContext::standalone(conversation_id).unwrap(),
+            request: OperationRequest::ListRoots,
+        },
+    );
+    assert_eq!(response["channel"], "operation");
+    assert_eq!(
+        response["envelope"]["response"]["payload"]["roots"][0]["root_id"],
+        root_id
+    );
+    let private_response = exchange(
+        &mut input,
+        &mut output,
+        "control",
+        &ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            request: ControlRequest::RegisterRoot(RegisterRootRequest {
+                operation_id: OperationId::new(),
+                subject,
+                conversation_id,
+                path: temp.path().join("app-data"),
+                consent_method: ConsentMethod::FolderPicker,
+            }),
+        },
+    );
+    assert_eq!(
+        private_response["envelope"]["response"]["payload"]["code"],
+        "invalid_root"
+    );
+    drop(input);
+    assert!(child.wait().unwrap().success());
+
+    let audit =
+        std::fs::read_to_string(temp.path().join("app-data/host-broker-audit.jsonl")).unwrap();
+    assert!(audit.contains("register_root"));
+    assert!(audit.contains("list_roots"));
+    assert!(!audit.contains(root.to_str().unwrap()));
+    assert!(!audit.contains("sidecar read"));
+}

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -96,9 +96,11 @@ audit event naming its result and authorizing grant; synced JSONL rotation bound
 local retention without recording absolute paths or contents. Partial writes
 are rolled back before retry, interrupted tails/rotations recover on restart,
 and degraded read-tier audit does not withhold the user's existing file access.
-The sidecar adapter and Tauri consent UI are the next slices; until those land,
-existing file tools do not use this boundary. See [Host access and connected
-folders](host-access.md).
+A runnable sidecar exposes the same core over bounded, strict JSONL stdio,
+resynchronizes after oversized input, and protects its own app-data directory
+from ever becoming a connected root. The Tauri client and consent UI are the
+next slices; until those land, existing file tools do not use this boundary. See
+[Host access and connected folders](host-access.md).
 
 **Depends on:** no OpenWave client crate.
 

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -80,6 +80,21 @@ surface than the complete desktop or server. Process separation is useful
 defense in depth, not a substitute for authorization: the broker validates every
 operation even when its caller is local.
 
+The sidecar adapter is a small `openwave-host-broker` process owned by the
+desktop host. The host supplies absolute app-data and home-directory paths at
+spawn time; the broker never guesses them from an agent request. Its stdio wire
+format is strict, bounded newline-delimited JSON with an explicit control or
+operation channel and exactly one safe response per non-empty input line.
+Oversized lines are drained without unbounded allocation so the next request can
+still be parsed; whitespace-only or malformed non-empty frames receive a safe
+transport error rather than hanging a request/response client. Root counts,
+display names, directory results, and file bytes are bounded before response
+serialization, so the response cap is also an allocation bound. The app-private
+broker directory is added to root policy as a protected location, so it and any
+ancestor containing it cannot be connected.
+This process adapter does not itself grant the renderer access to the trusted
+control handle—the forthcoming Tauri client owns that routing distinction.
+
 The **renderer** presents connected folders and permission choices. It receives
 safe summaries, not the broker's persisted absolute-path registry.
 
@@ -237,7 +252,8 @@ This will land in independently reviewable pieces:
 4. Add bounded audit records for every machine-touching operation, including
    the exact grant that authorized an operation, de-sensitized targets, and
    local two-generation retention.
-5. Expose the same contract through a versioned sidecar adapter.
+5. Expose the same contract through a bounded, versioned sidecar adapter with
+   strict control/operation wire variants and app-private-directory protection.
 6. Add the Tauri sidecar client, connected-folder UI, and the durable
    agent-request → native-picker → grant → retry workflow. Broker state, audit,
    scratch, and handoffs live under OpenWave's application data directory;


### PR DESCRIPTION
## Summary

- add a runnable `openwave-host-broker` process with strict control/operation JSONL framing over desktop-owned stdio
- bound request reads, response-producing broker results, and serialized responses; drain oversized frames and resynchronize for the next request
- return one safe response for every non-empty frame, reject unknown nested fields, and keep absolute host paths out of transport errors/results
- accept only explicit absolute host configuration and protect broker app data from being connected as a user root
- cover restart persistence and audit behavior through the real process boundary

## Validation

- `cargo test -p openwave-host-broker --locked` (62 library tests, 1 binary test, 1 process integration test)
- `bw dev lint --rust --check --repo-root "$PWD"`
- `git diff --check`
