### PR TITLE
fix(desktop): use private scratch by default

### DIFF
--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -37,7 +37,7 @@ cargo run -p openwave-cli -- serve
 # terminal 2
 cp ui/.env.example ui/.env.local
 # edit ui/.env.local: VITE_OPENWAVE_URL, VITE_OPENWAVE_TOKEN,
-# and an absolute VITE_OPENWAVE_WORKSPACE on the machine running serve
+# and an explicit absolute VITE_OPENWAVE_SCRATCH on the machine running serve
 
 pnpm --dir ui install
 pnpm --dir ui dev
@@ -50,7 +50,7 @@ pnpm --dir ui dev
 
 | Path | Role |
 | --- | --- |
-| `src/` | Tauri host (`server_info`, data/workspace dirs, boot server) |
+| `src/` | Tauri host (`server_info`, private app-data/scratch, boot server) |
 | `ui/` | React + Vite frontend |
 | `tauri.conf.json` | Window, icons, beforeDev/beforeBuild commands |
 | `icons/` | App icons (generated from the brand mark) |

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -22,8 +22,9 @@ pub struct ServerInfo {
     pub base_url: String,
     /// Per-launch bearer token.
     pub token: String,
-    /// Absolute workspace path used for new chats in this session.
-    pub workspace_dir: String,
+    /// App-private scratch path used by legacy direct file tools until they are
+    /// routed through the host broker.
+    pub scratch_dir: String,
 }
 
 struct AppState {
@@ -55,15 +56,18 @@ fn data_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
     Ok(dir)
 }
 
-/// Default workspace for chats created from the shell (Documents/OpenWave).
-fn default_workspace(app: &tauri::AppHandle) -> Result<PathBuf, String> {
-    let docs = app
-        .path()
-        .document_dir()
-        .map_err(|e| format!("documents dir: {e}"))?;
-    let workspace = docs.join("OpenWave");
-    std::fs::create_dir_all(&workspace).map_err(|e| format!("create workspace: {e}"))?;
-    Ok(workspace)
+/// Private scratch for the current desktop profile. This is operational app
+/// data, not a connected user folder and never appears in a native picker.
+fn private_scratch(data_dir: &std::path::Path) -> Result<PathBuf, String> {
+    let scratch = data_dir.join("scratch");
+    std::fs::create_dir_all(&scratch).map_err(|e| format!("create private scratch: {e}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&scratch, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| format!("restrict private scratch: {e}"))?;
+    }
+    Ok(scratch)
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -77,10 +81,10 @@ pub fn run() {
         .setup(move |app| {
             let handle = app.handle().clone();
             let data = data_dir(&handle)?;
-            let workspace = default_workspace(&handle)?;
+            let scratch = private_scratch(&data)?;
 
             tauri::async_runtime::spawn(async move {
-                if let Err(error) = boot_server(info_tx, data, workspace).await {
+                if let Err(error) = boot_server(info_tx, data, scratch).await {
                     eprintln!("openwave-desktop: {error}");
                 }
             });
@@ -94,7 +98,7 @@ pub fn run() {
 async fn boot_server(
     info_tx: watch::Sender<Option<ServerInfo>>,
     data_dir: PathBuf,
-    workspace_dir: PathBuf,
+    scratch_dir: PathBuf,
 ) -> Result<(), String> {
     let server = openwave_server::bind(Config::desktop(data_dir))
         .await
@@ -102,7 +106,7 @@ async fn boot_server(
     let info = ServerInfo {
         base_url: format!("http://{}", server.local_addr()),
         token: server.token().to_string(),
-        workspace_dir: workspace_dir.display().to_string(),
+        scratch_dir: scratch_dir.display().to_string(),
     };
     let _ = info_tx.send(Some(info));
     server.serve().await.map_err(|e| e.to_string())

--- a/crates/openwave-desktop/ui/.env.example
+++ b/crates/openwave-desktop/ui/.env.example
@@ -6,5 +6,5 @@
 #
 VITE_OPENWAVE_URL=http://127.0.0.1:PORT
 VITE_OPENWAVE_TOKEN=paste-token-here
-# Absolute path on the machine running `openwave serve` (required for new chats).
-VITE_OPENWAVE_WORKSPACE=/tmp/openwave-workspace
+# Explicit app-private scratch on the machine running `openwave serve`.
+VITE_OPENWAVE_SCRATCH=/tmp/openwave-private-scratch

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -78,7 +78,7 @@ export default function App() {
         setModels(catalog.models);
         setProviders(providerList.providers);
         const created = await client.createChat(
-          info.workspaceDir,
+          info.scratchDir,
           catalog.models[0]?.id,
         );
         if (cancelled) return;
@@ -345,7 +345,7 @@ export default function App() {
               }}
             />
             <span title={chat.workspace_dir}>
-              workspace · {shortPath(chat.workspace_dir)}
+              private scratch · {shortPath(chat.workspace_dir)}
             </span>
           </div>
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -2,7 +2,7 @@
 export type ServerInfo = {
   baseUrl: string;
   token: string;
-  workspaceDir: string;
+  scratchDir: string;
 };
 
 export type ProviderKind = "anthropic" | "openai" | "openai_compatible";
@@ -118,12 +118,14 @@ export class ApiClient {
     return this.json("/models", { headers: this.headers() });
   }
 
-  createChat(workspaceDir: string, model?: string): Promise<Chat> {
+  createChat(scratchDir: string, model?: string): Promise<Chat> {
     return this.json("/chats", {
       method: "POST",
       headers: this.headers(true),
       body: JSON.stringify({
-        workspace_dir: workspaceDir,
+        // Temporary server field: this now points only at app-private scratch.
+        // Connected user folders are broker capabilities, not chat workspaces.
+        workspace_dir: scratchDir,
         model: model || undefined,
       }),
     });

--- a/crates/openwave-desktop/ui/src/boot.ts
+++ b/crates/openwave-desktop/ui/src/boot.ts
@@ -6,7 +6,7 @@ import type { ServerInfo } from "./api";
  *
  * - Inside Tauri: `server_info` from the host (in-process server).
  * - In a plain browser (`pnpm --dir ui dev`): `VITE_OPENWAVE_URL` +
- *   `VITE_OPENWAVE_TOKEN` (+ optional `VITE_OPENWAVE_WORKSPACE`), so the same
+ *   `VITE_OPENWAVE_TOKEN` + explicit `VITE_OPENWAVE_SCRATCH`, so the same
  *   React app can be exercised against `openwave serve`.
  */
 export async function resolveServerInfo(): Promise<ServerInfo> {
@@ -18,7 +18,8 @@ export async function resolveServerInfo(): Promise<ServerInfo> {
   if (fromEnv) return fromEnv;
 
   throw new Error(
-    "Set VITE_OPENWAVE_URL and VITE_OPENWAVE_TOKEN (from `openwave serve`) " +
+    "Set VITE_OPENWAVE_URL, VITE_OPENWAVE_TOKEN, and VITE_OPENWAVE_SCRATCH " +
+      "(for `openwave serve`) " +
       "to run the UI in a browser, or launch via `cargo tauri dev`.",
   );
 }
@@ -28,19 +29,12 @@ function envServerInfo(): ServerInfo | null {
   const token = import.meta.env.VITE_OPENWAVE_TOKEN?.trim();
   if (!baseUrl || !token) return null;
 
-  const workspaceDir =
-    import.meta.env.VITE_OPENWAVE_WORKSPACE?.trim() ||
-    defaultWorkspaceFallback();
+  const scratchDir = import.meta.env.VITE_OPENWAVE_SCRATCH?.trim();
+  if (!scratchDir) return null;
 
   return {
     baseUrl: baseUrl.replace(/\/$/, ""),
     token,
-    workspaceDir,
+    scratchDir,
   };
-}
-
-function defaultWorkspaceFallback(): string {
-  // Absolute path required by the API; browser-dev users should set
-  // VITE_OPENWAVE_WORKSPACE to a real directory on the machine running serve.
-  return "/tmp/openwave-workspace";
 }

--- a/crates/openwave-desktop/ui/src/vite-env.d.ts
+++ b/crates/openwave-desktop/ui/src/vite-env.d.ts
@@ -3,7 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_OPENWAVE_URL?: string;
   readonly VITE_OPENWAVE_TOKEN?: string;
-  readonly VITE_OPENWAVE_WORKSPACE?: string;
+  readonly VITE_OPENWAVE_SCRATCH?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- stop creating and claiming `Documents/OpenWave` when the desktop app starts
- keep the temporary legacy file-tool path inside owner-only app-private scratch
- require browser development to configure that scratch path explicitly
- label the temporary path accurately in the desktop UI and setup docs

## Validation

- `bw dev lint --rust --check --repo-root "$PWD"`
- `cargo test -p openwave-desktop --locked`
- `pnpm --dir crates/openwave-desktop/ui build`
- `git diff --check origin/main...HEAD`
