### PR TITLE
feat(desktop): connect folders through host broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist/
 
 # Tauri codegen (regenerated on build)
 crates/openwave-desktop/gen/
+crates/openwave-desktop/binaries/openwave-host-broker-*
 
 # OS / editor cruft
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3877,6 +3877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3885,6 +3894,16 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -4139,7 +4158,7 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
- "zbus",
+ "zbus 4.4.0",
  "zeroize",
 ]
 
@@ -5602,6 +5621,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -5722,6 +5742,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "open"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5771,12 +5802,18 @@ name = "openwave-desktop"
 version = "0.0.0"
 dependencies = [
  "openwave-core",
+ "openwave-host-broker",
  "openwave-server",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
+ "thiserror 2.0.18",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -5899,6 +5936,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6938,6 +6985,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7397,7 +7468,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "sha2",
- "zbus",
+ "zbus 4.4.0",
 ]
 
 [[package]]
@@ -7703,10 +7774,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -8505,6 +8608,101 @@ dependencies = [
  "syn 2.0.118",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus 5.17.0",
 ]
 
 [[package]]
@@ -10323,9 +10521,44 @@ dependencies = [
  "uds_windows",
  "windows-sys 0.52.0",
  "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros 5.17.0",
+ "zbus_names 4.3.3",
+ "zvariant 5.13.0",
 ]
 
 [[package]]
@@ -10338,7 +10571,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "zvariant_utils",
+ "zvariant_utils 2.1.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus_names 4.3.3",
+ "zvariant 5.13.0",
+ "zvariant_utils 3.5.0",
 ]
 
 [[package]]
@@ -10349,7 +10597,18 @@ checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
 dependencies = [
  "serde",
  "static_assertions",
- "zvariant",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant 5.13.0",
 ]
 
 [[package]]
@@ -10492,7 +10751,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
- "zvariant_derive",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive 5.13.0",
+ "zvariant_utils 3.5.0",
 ]
 
 [[package]]
@@ -10505,7 +10778,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
- "zvariant_utils",
+ "zvariant_utils 2.1.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils 3.5.0",
 ]
 
 [[package]]
@@ -10517,4 +10803,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.118",
+ "winnow 1.0.3",
 ]

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -20,11 +20,20 @@ path = "src/main.rs"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
+serde_json = { workspace = true }
 
 [dependencies]
 openwave-core = { path = "../openwave-core", default-features = false }
+openwave-host-broker = { path = "../openwave-host-broker" }
 openwave-server = { path = "../openwave-server" }
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
+tauri-plugin-shell = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "process", "rt-multi-thread", "macros", "sync", "time"] }
+uuid = { workspace = true }
+
+[target.'cfg(any(target_os = "macos", target_os = "linux", windows))'.dependencies]
+tauri-plugin-single-instance = "2"

--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -3,6 +3,8 @@
 Tauri shell for OpenWave. On launch it binds `openwave-server` to an ephemeral
 loopback port, mints a per-launch bearer token, and hosts the React chat UI in a
 webview. The UI talks to that local API over HTTP + WebSocket (subprotocol auth).
+The native host also owns the folder picker and a private host-broker sidecar;
+the renderer receives opaque folder IDs and display names, never absolute paths.
 
 ## Prerequisites
 
@@ -23,7 +25,15 @@ cargo tauri dev
 
 That starts Vite on `http://localhost:1420` and opens the OpenWave window. The
 Rust host boots the in-process API; the webview calls `server_info` to learn the
-base URL and token.
+base URL and token. The Tauri pre-dev command builds and stages the broker
+sidecar for the current target automatically.
+
+Create an installable bundle. The before-build hook compiles the target-specific
+broker and the default Tauri configuration includes it automatically:
+
+```sh
+cargo tauri build
+```
 
 ## Run locally (browser UI against `openwave serve`)
 
@@ -50,8 +60,10 @@ pnpm --dir ui dev
 
 | Path | Role |
 | --- | --- |
-| `src/` | Tauri host (`server_info`, private app-data/scratch, boot server) |
+| `src/` | Tauri host (server boot, sidecar lifecycle, native folder consent) |
 | `ui/` | React + Vite frontend |
-| `tauri.conf.json` | Window, icons, beforeDev/beforeBuild commands |
+| `scripts/` | Cross-platform sidecar staging for Tauri dev/build |
+| `binaries/` | Generated target-specific sidecar (gitignored) |
+| `tauri.conf.json` | Window, CSP, sidecar bundle, and build commands |
 | `icons/` | App icons (generated from the brand mark) |
 | `capabilities/` | Tauri ACL (loopback remote URLs for the local API) |

--- a/crates/openwave-desktop/build.rs
+++ b/crates/openwave-desktop/build.rs
@@ -1,3 +1,31 @@
 fn main() {
+    let target = std::env::var("TARGET").expect("Cargo did not provide TARGET");
+    let extension = if target.contains("windows") {
+        ".exe"
+    } else {
+        ""
+    };
+    let sidecar = format!("binaries/openwave-host-broker-{target}{extension}");
+    println!("cargo:rerun-if-changed={sidecar}");
+
+    // Plain `cargo check` and `cargo test` do not run Tauri's before-build
+    // hook. Keep those workflows usable from a clean checkout; Tauri dev/build
+    // runs prepare-sidecar first, so the default config always packages the
+    // real target-specific executable.
+    if !std::path::Path::new(&sidecar).is_file() {
+        if std::env::var("PROFILE").as_deref() == Ok("release") {
+            panic!(
+                "release sidecar is missing at {sidecar}; build the desktop through `cargo tauri build`"
+            );
+        }
+        let mut overlay = std::env::var("TAURI_CONFIG")
+            .ok()
+            .and_then(|value| serde_json::from_str::<serde_json::Value>(&value).ok())
+            .unwrap_or_else(|| serde_json::json!({}));
+        overlay["bundle"]["externalBin"] = serde_json::Value::Null;
+        let overlay = overlay.to_string();
+        std::env::set_var("TAURI_CONFIG", &overlay);
+        println!("cargo:rustc-env=TAURI_CONFIG={overlay}");
+    }
     tauri_build::build()
 }

--- a/crates/openwave-desktop/scripts/prepare-sidecar.mjs
+++ b/crates/openwave-desktop/scripts/prepare-sidecar.mjs
@@ -1,0 +1,51 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, copyFileSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const desktopDir = resolve(scriptDir, "..");
+const workspaceDir = resolve(desktopDir, "../..");
+const release = process.argv.includes("--release");
+const profile = release ? "release" : "debug";
+const configuredTarget = process.env.TAURI_ENV_TARGET_TRIPLE?.trim();
+const triple =
+  configuredTarget ||
+  execFileSync("rustc", ["--print", "host-tuple"], {
+    encoding: "utf8",
+  }).trim();
+
+if (!triple) {
+  throw new Error("rustc did not report a host target triple");
+}
+const extension = triple.includes("windows") ? ".exe" : "";
+
+const cargoArgs = [
+  "build",
+  "-p",
+  "openwave-host-broker",
+  "--bin",
+  "openwave-host-broker",
+];
+if (release) cargoArgs.push("--release");
+if (configuredTarget) cargoArgs.push("--target", configuredTarget);
+execFileSync("cargo", cargoArgs, { cwd: workspaceDir, stdio: "inherit" });
+
+const targetRoot = process.env.CARGO_TARGET_DIR
+  ? resolve(workspaceDir, process.env.CARGO_TARGET_DIR)
+  : join(workspaceDir, "target");
+const source = join(
+  targetRoot,
+  ...(configuredTarget ? [configuredTarget] : []),
+  profile,
+  `openwave-host-broker${extension}`,
+);
+const destinationDir = join(desktopDir, "binaries");
+const destination = join(
+  destinationDir,
+  `openwave-host-broker-${triple}${extension}`,
+);
+
+mkdirSync(destinationDir, { recursive: true });
+copyFileSync(source, destination);
+if (process.platform !== "win32") chmodSync(destination, 0o755);

--- a/crates/openwave-desktop/src/broker.rs
+++ b/crates/openwave-desktop/src/broker.rs
@@ -1,0 +1,572 @@
+//! Native-only lifecycle client for the capability-gated host-broker sidecar.
+
+use std::{
+    ffi::{OsStr, OsString},
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::Mutex as StdMutex,
+    time::Duration,
+};
+
+use openwave_host_broker::{
+    sidecar::{SidecarRequest, SidecarResponse, MAX_REQUEST_BYTES, MAX_RESPONSE_BYTES},
+    ControlEnvelope, ControlRequest, ControlResult, OperationEnvelope, OperationResult, RequestId,
+    Response, PROTOCOL_VERSION,
+};
+use tauri::{async_runtime::JoinHandle, AppHandle};
+use tauri_plugin_shell::ShellExt;
+use thiserror::Error;
+use tokio::{
+    io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::{Child, ChildStdin, ChildStdout, Command},
+    sync::{mpsc, oneshot},
+    time::timeout,
+};
+
+const SIDECAR_NAME: &str = "openwave-host-broker";
+const HELLO_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const COMMAND_QUEUE_CAPACITY: usize = 32;
+
+const MINIMAL_ENV_KEYS: &[&str] = &[
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "SystemRoot",
+    "SystemDrive",
+    "USERPROFILE",
+    "PATHEXT",
+    "windir",
+];
+
+/// Serializes the synchronous sidecar protocol behind one lazy child process.
+pub(crate) struct BrokerClient {
+    commands: mpsc::Sender<BrokerCommand>,
+    task: StdMutex<Option<JoinHandle<()>>>,
+}
+
+impl BrokerClient {
+    pub(crate) fn new(app: AppHandle, data_dir: PathBuf, home_dir: PathBuf) -> Self {
+        let (commands, receiver) = mpsc::channel(COMMAND_QUEUE_CAPACITY);
+        let task = tauri::async_runtime::spawn(
+            BrokerWorker {
+                app,
+                data_dir,
+                home_dir,
+                session: None,
+            }
+            .run(receiver),
+        );
+        Self {
+            commands,
+            task: StdMutex::new(Some(task)),
+        }
+    }
+
+    pub(crate) async fn control(
+        &self,
+        request: ControlRequest,
+    ) -> Result<ControlResult, BrokerClientError> {
+        let (reply, result) = oneshot::channel();
+        self.commands
+            .try_send(BrokerCommand::Control { request, reply })
+            .map_err(map_admission_error)?;
+        result.await.map_err(|_| BrokerClientError::Closed)?
+    }
+
+    pub(crate) async fn operation(
+        &self,
+        envelope: OperationEnvelope,
+    ) -> Result<OperationResult, BrokerClientError> {
+        let (reply, result) = oneshot::channel();
+        self.commands
+            .try_send(BrokerCommand::Operation { envelope, reply })
+            .map_err(map_admission_error)?;
+        result.await.map_err(|_| BrokerClientError::Closed)?
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        let (reply, finished) = oneshot::channel();
+        let acknowledged = matches!(
+            timeout(SHUTDOWN_TIMEOUT + SHUTDOWN_TIMEOUT, async {
+                self.commands
+                    .send(BrokerCommand::Shutdown { reply })
+                    .await
+                    .map_err(|_| ())?;
+                finished.await.map_err(|_| ())
+            })
+            .await,
+            Ok(Ok(()))
+        );
+        let task = self
+            .task
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(task) = task {
+            if !acknowledged {
+                task.abort();
+            }
+            let _ = task.await;
+        }
+    }
+}
+
+enum BrokerCommand {
+    Control {
+        request: ControlRequest,
+        reply: oneshot::Sender<Result<ControlResult, BrokerClientError>>,
+    },
+    Operation {
+        envelope: OperationEnvelope,
+        reply: oneshot::Sender<Result<OperationResult, BrokerClientError>>,
+    },
+    Shutdown {
+        reply: oneshot::Sender<()>,
+    },
+}
+
+fn map_admission_error(error: mpsc::error::TrySendError<BrokerCommand>) -> BrokerClientError {
+    match error {
+        mpsc::error::TrySendError::Full(_) => BrokerClientError::Busy,
+        mpsc::error::TrySendError::Closed(_) => BrokerClientError::Closed,
+    }
+}
+
+struct BrokerWorker {
+    app: AppHandle,
+    data_dir: PathBuf,
+    home_dir: PathBuf,
+    session: Option<Session>,
+}
+
+impl BrokerWorker {
+    async fn run(mut self, mut commands: mpsc::Receiver<BrokerCommand>) {
+        while let Some(command) = commands.recv().await {
+            match command {
+                BrokerCommand::Control { request, reply } => {
+                    let _ = reply.send(self.control(request).await);
+                }
+                BrokerCommand::Operation { envelope, reply } => {
+                    let result = self
+                        .exchange(SidecarRequest::Operation(envelope))
+                        .await
+                        .and_then(|result| match result {
+                            ExchangeResult::Operation(result) => Ok(result),
+                            ExchangeResult::Control(_) => Err(BrokerClientError::Protocol),
+                        });
+                    let _ = reply.send(result);
+                }
+                BrokerCommand::Shutdown { reply } => {
+                    self.stop_session().await;
+                    let _ = reply.send(());
+                    return;
+                }
+            }
+        }
+        self.stop_session().await;
+    }
+
+    async fn control(
+        &mut self,
+        request: ControlRequest,
+    ) -> Result<ControlResult, BrokerClientError> {
+        let first = self.control_once(request.clone()).await;
+        if first
+            .as_ref()
+            .is_err_and(BrokerClientError::retryable_control)
+        {
+            return self.control_once(request).await;
+        }
+        first
+    }
+
+    async fn control_once(
+        &mut self,
+        request: ControlRequest,
+    ) -> Result<ControlResult, BrokerClientError> {
+        let envelope = ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            request,
+        };
+        match self.exchange(SidecarRequest::Control(envelope)).await? {
+            ExchangeResult::Control(result) => Ok(result),
+            ExchangeResult::Operation(_) => Err(BrokerClientError::Protocol),
+        }
+    }
+
+    async fn exchange(
+        &mut self,
+        request: SidecarRequest,
+    ) -> Result<ExchangeResult, BrokerClientError> {
+        if self.session.is_none() {
+            self.session = Some(Session::start(&self.app, &self.data_dir, &self.home_dir).await?);
+        }
+        let result = timeout(
+            REQUEST_TIMEOUT,
+            self.session
+                .as_mut()
+                .expect("session initialized")
+                .exchange(request),
+        )
+        .await
+        .map_err(|_| BrokerClientError::Timeout)
+        .and_then(|result| result);
+        if result
+            .as_ref()
+            .is_err_and(BrokerClientError::poisons_session)
+        {
+            self.stop_session().await;
+        }
+        result
+    }
+
+    async fn stop_session(&mut self) {
+        if let Some(session) = self.session.take() {
+            session.stop().await;
+        }
+    }
+}
+
+struct Session {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    stdout: BufReader<ChildStdout>,
+}
+
+impl Session {
+    async fn start(
+        app: &AppHandle,
+        data_dir: &Path,
+        home_dir: &Path,
+    ) -> Result<Self, BrokerClientError> {
+        let mut sidecar = app
+            .shell()
+            .sidecar(SIDECAR_NAME)
+            .map_err(|_| BrokerClientError::Start)?
+            .args([
+                OsStr::new("--data-dir"),
+                data_dir.as_os_str(),
+                OsStr::new("--home"),
+                home_dir.as_os_str(),
+            ])
+            .env_clear();
+        sidecar = sidecar.envs(minimal_environment());
+
+        let command: std::process::Command = sidecar.into();
+        let mut command = Command::from(command);
+        command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true);
+        let mut child = command.spawn().map_err(|_| BrokerClientError::Start)?;
+        let stdin = child.stdin.take().ok_or(BrokerClientError::Start)?;
+        let stdout = child.stdout.take().ok_or(BrokerClientError::Start)?;
+        let mut session = Self {
+            child,
+            stdin: Some(stdin),
+            stdout: BufReader::new(stdout),
+        };
+
+        let hello_id = RequestId::new();
+        let hello = SidecarRequest::Control(ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: hello_id,
+            request: ControlRequest::Hello,
+        });
+        let result = timeout(HELLO_TIMEOUT, session.exchange(hello))
+            .await
+            .map_err(|_| BrokerClientError::Timeout)
+            .and_then(|result| result);
+        match result {
+            Ok(ExchangeResult::Control(ControlResult::Hello(hello)))
+                if hello.protocol_version == PROTOCOL_VERSION =>
+            {
+                Ok(session)
+            }
+            Ok(_) => {
+                session.stop().await;
+                Err(BrokerClientError::Protocol)
+            }
+            Err(error) => {
+                session.stop().await;
+                Err(error)
+            }
+        }
+    }
+
+    async fn exchange(
+        &mut self,
+        request: SidecarRequest,
+    ) -> Result<ExchangeResult, BrokerClientError> {
+        let (expected_channel, expected_id) = match &request {
+            SidecarRequest::Control(envelope) => (Channel::Control, envelope.request_id),
+            SidecarRequest::Operation(envelope) => (Channel::Operation, envelope.request_id),
+        };
+        let mut encoded = serde_json::to_vec(&request).map_err(|_| BrokerClientError::Protocol)?;
+        if encoded.len() > MAX_REQUEST_BYTES {
+            return Err(BrokerClientError::Protocol);
+        }
+        encoded.push(b'\n');
+        let stdin = self.stdin.as_mut().ok_or(BrokerClientError::Closed)?;
+        stdin
+            .write_all(&encoded)
+            .await
+            .map_err(|_| BrokerClientError::Closed)?;
+        stdin.flush().await.map_err(|_| BrokerClientError::Closed)?;
+
+        let frame = read_frame(&mut self.stdout).await?;
+        let response: SidecarResponse =
+            serde_json::from_slice(&frame).map_err(|_| BrokerClientError::Protocol)?;
+        decode_response(response, expected_channel, expected_id)
+    }
+
+    async fn stop(mut self) {
+        drop(self.stdin.take());
+        if timeout(SHUTDOWN_TIMEOUT, self.child.wait()).await.is_ok() {
+            return;
+        }
+        let _ = self.child.kill().await;
+        let _ = self.child.wait().await;
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Channel {
+    Control,
+    Operation,
+}
+
+enum ExchangeResult {
+    Control(ControlResult),
+    Operation(OperationResult),
+}
+
+fn decode_response(
+    response: SidecarResponse,
+    expected_channel: Channel,
+    expected_id: RequestId,
+) -> Result<ExchangeResult, BrokerClientError> {
+    match response {
+        SidecarResponse::Control(envelope) if expected_channel == Channel::Control => {
+            validate_envelope(envelope.protocol_version, envelope.request_id, expected_id)?;
+            match envelope.response {
+                Response::Ok(result) => Ok(ExchangeResult::Control(result)),
+                Response::Error(error) => Err(BrokerClientError::Broker {
+                    message: error.message,
+                    retryable: error.retryable,
+                }),
+            }
+        }
+        SidecarResponse::Operation(envelope) if expected_channel == Channel::Operation => {
+            validate_envelope(envelope.protocol_version, envelope.request_id, expected_id)?;
+            match envelope.response {
+                Response::Ok(result) => Ok(ExchangeResult::Operation(result)),
+                Response::Error(error) => Err(BrokerClientError::Broker {
+                    message: error.message,
+                    retryable: error.retryable,
+                }),
+            }
+        }
+        SidecarResponse::TransportError(error) => {
+            if error
+                .request_id
+                .is_some_and(|request_id| request_id != expected_id)
+            {
+                return Err(BrokerClientError::Protocol);
+            }
+            Err(BrokerClientError::Transport(error.message))
+        }
+        SidecarResponse::Control(_) | SidecarResponse::Operation(_) => {
+            Err(BrokerClientError::Protocol)
+        }
+    }
+}
+
+fn validate_envelope(
+    protocol_version: u32,
+    request_id: RequestId,
+    expected_id: RequestId,
+) -> Result<(), BrokerClientError> {
+    if protocol_version != PROTOCOL_VERSION || request_id != expected_id {
+        return Err(BrokerClientError::Protocol);
+    }
+    Ok(())
+}
+
+async fn read_frame(input: &mut (impl AsyncBufRead + Unpin)) -> Result<Vec<u8>, BrokerClientError> {
+    let mut frame = Vec::new();
+    loop {
+        let available = input
+            .fill_buf()
+            .await
+            .map_err(|_| BrokerClientError::Closed)?;
+        if available.is_empty() {
+            return Err(BrokerClientError::Closed);
+        }
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let data_len = newline.unwrap_or(available.len());
+        if frame.len().saturating_add(data_len) > MAX_RESPONSE_BYTES {
+            return Err(BrokerClientError::ResponseTooLarge);
+        }
+        frame.extend_from_slice(&available[..data_len]);
+        let consumed = newline.map_or(available.len(), |position| position + 1);
+        input.consume(consumed);
+        if newline.is_some() {
+            if frame.last() == Some(&b'\r') {
+                frame.pop();
+            }
+            if frame.is_empty() {
+                return Err(BrokerClientError::Protocol);
+            }
+            return Ok(frame);
+        }
+    }
+}
+
+fn minimal_environment() -> Vec<(OsString, OsString)> {
+    MINIMAL_ENV_KEYS
+        .iter()
+        .filter_map(|key| std::env::var_os(key).map(|value| (OsString::from(key), value)))
+        .collect()
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum BrokerClientError {
+    #[error("host broker could not start")]
+    Start,
+    #[error("host broker is busy; try again")]
+    Busy,
+    #[error("host broker connection closed")]
+    Closed,
+    #[error("host broker request timed out")]
+    Timeout,
+    #[error("host broker returned an invalid response")]
+    Protocol,
+    #[error("host broker response exceeded its size limit")]
+    ResponseTooLarge,
+    #[error("host broker transport error: {0}")]
+    Transport(String),
+    #[error("{message}")]
+    Broker { message: String, retryable: bool },
+}
+
+impl BrokerClientError {
+    fn poisons_session(&self) -> bool {
+        !matches!(self, Self::Broker { .. })
+    }
+
+    fn retryable_control(&self) -> bool {
+        matches!(
+            self,
+            Self::Closed
+                | Self::Timeout
+                | Self::Broker {
+                    retryable: true,
+                    ..
+                }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openwave_host_broker::{
+        sidecar::{SidecarResponse, TransportError, TransportErrorCode},
+        ControlResponseEnvelope, ControlResult, HelloResult, Response,
+    };
+
+    use super::*;
+
+    #[test]
+    fn validates_channel_version_and_correlation() {
+        let request_id = RequestId::new();
+        let ok = SidecarResponse::Control(ControlResponseEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id,
+            response: Response::Ok(ControlResult::Hello(HelloResult {
+                protocol_version: PROTOCOL_VERSION,
+                operations: vec!["list_roots".to_owned()],
+            })),
+        });
+        assert!(matches!(
+            decode_response(ok, Channel::Control, request_id),
+            Ok(ExchangeResult::Control(ControlResult::Hello(_)))
+        ));
+
+        let wrong_channel = SidecarResponse::Control(ControlResponseEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id,
+            response: Response::Ok(ControlResult::Hello(HelloResult {
+                protocol_version: PROTOCOL_VERSION,
+                operations: Vec::new(),
+            })),
+        });
+        assert!(matches!(
+            decode_response(wrong_channel, Channel::Operation, request_id),
+            Err(BrokerClientError::Protocol)
+        ));
+
+        let wrong_id = SidecarResponse::Control(ControlResponseEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            response: Response::Ok(ControlResult::Hello(HelloResult {
+                protocol_version: PROTOCOL_VERSION,
+                operations: Vec::new(),
+            })),
+        });
+        assert!(matches!(
+            decode_response(wrong_id, Channel::Control, request_id),
+            Err(BrokerClientError::Protocol)
+        ));
+    }
+
+    #[test]
+    fn uncorrelated_transport_error_applies_only_to_serialized_request() {
+        let request_id = RequestId::new();
+        let error = SidecarResponse::TransportError(TransportError {
+            request_id: None,
+            code: TransportErrorCode::MalformedRequest,
+            message: "bad frame".to_owned(),
+        });
+        assert!(matches!(
+            decode_response(error, Channel::Control, request_id),
+            Err(BrokerClientError::Transport(message)) if message == "bad frame"
+        ));
+    }
+
+    #[test]
+    fn child_environment_is_allowlisted() {
+        let allowed = minimal_environment();
+        assert!(allowed.iter().all(|(key, _)| MINIMAL_ENV_KEYS
+            .iter()
+            .any(|candidate| key == OsStr::new(candidate))));
+    }
+
+    #[tokio::test]
+    async fn response_framing_is_bounded_and_requires_a_nonempty_line() {
+        let mut complete = BufReader::new(b"{\"ok\":true}\r\n".as_slice());
+        assert_eq!(read_frame(&mut complete).await.unwrap(), br#"{"ok":true}"#);
+
+        let mut empty = BufReader::new(b"\n".as_slice());
+        assert!(matches!(
+            read_frame(&mut empty).await,
+            Err(BrokerClientError::Protocol)
+        ));
+
+        let oversized = [vec![b'x'; MAX_RESPONSE_BYTES + 1], b"\n".to_vec()].concat();
+        let mut oversized = BufReader::new(oversized.as_slice());
+        assert!(matches!(
+            read_frame(&mut oversized).await,
+            Err(BrokerClientError::ResponseTooLarge)
+        ));
+    }
+}

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -1,0 +1,250 @@
+//! Narrow native consent surface for connected host folders.
+
+use std::path::PathBuf;
+
+use openwave_core::{ChatId, Store};
+use openwave_host_broker::{
+    ConsentMethod, ControlRequest, ExecutionContext, GrantSubject, OperationEnvelope, OperationId,
+    OperationRequest, OperationResult, RegisterRootRequest, RevokeRootRequest, RootId,
+};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_dialog::DialogExt;
+use tokio::sync::{oneshot, Mutex, OnceCell};
+use uuid::Uuid;
+
+use crate::broker::BrokerClient;
+
+pub(crate) struct HostAccess {
+    broker: BrokerClient,
+    picker: Mutex<()>,
+    store: OnceCell<std::sync::Arc<dyn Store>>,
+}
+
+impl HostAccess {
+    pub(crate) fn new(app: AppHandle, data_dir: PathBuf, home_dir: PathBuf) -> Self {
+        Self {
+            broker: BrokerClient::new(app, data_dir, home_dir),
+            picker: Mutex::const_new(()),
+            store: OnceCell::new(),
+        }
+    }
+
+    pub(crate) fn initialize_store(&self, store: std::sync::Arc<dyn Store>) -> Result<(), String> {
+        self.store
+            .set(store)
+            .map_err(|_| "host access store was initialized more than once".to_owned())
+    }
+
+    async fn context(&self, chat_id: Uuid) -> Result<AuthoritativeContext, String> {
+        if chat_id.is_nil() {
+            return Err("invalid conversation id".to_owned());
+        }
+        let store = self
+            .store
+            .get()
+            .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+        let chat = store
+            .get_chat(ChatId::from(chat_id))
+            .await
+            .map_err(|_| "could not load the conversation".to_owned())?
+            .ok_or_else(|| "conversation not found".to_owned())?;
+        let project_id = chat.project_id.map(|project_id| project_id.0);
+        authoritative_context(chat_id, project_id)
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        self.broker.shutdown().await;
+    }
+}
+
+#[derive(Clone, Copy)]
+struct AuthoritativeContext {
+    chat_id: Uuid,
+    execution: ExecutionContext,
+    subject: GrantSubject,
+}
+
+fn authoritative_context(
+    chat_id: Uuid,
+    project_id: Option<Uuid>,
+) -> Result<AuthoritativeContext, String> {
+    let execution = match project_id {
+        Some(project_id) => ExecutionContext::project_chat(chat_id, project_id),
+        None => ExecutionContext::standalone(chat_id),
+    }
+    .map_err(|_| "invalid conversation context".to_owned())?;
+    let subject = match project_id {
+        Some(project_id) => GrantSubject::project(project_id),
+        None => GrantSubject::conversation(chat_id),
+    }
+    .map_err(|_| "invalid conversation context".to_owned())?;
+    Ok(AuthoritativeContext {
+        chat_id,
+        execution,
+        subject,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ConnectFolderRequest {
+    chat_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DisconnectFolderRequest {
+    chat_id: Uuid,
+    root_id: RootId,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConnectedFolder {
+    root_id: RootId,
+    display_name: String,
+}
+
+#[tauri::command]
+pub(crate) async fn connect_folder(
+    app: AppHandle,
+    state: State<'_, HostAccess>,
+    request: ConnectFolderRequest,
+) -> Result<Option<ConnectedFolder>, String> {
+    let context = state.context(request.chat_id).await?;
+    let _picker = state
+        .picker
+        .try_lock()
+        .map_err(|_| "a folder picker is already open".to_owned())?;
+    let path = pick_folder(&app).await?;
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    if !path.is_absolute() {
+        return Err("the folder picker returned an invalid path".to_owned());
+    }
+
+    let result = state
+        .broker
+        .control(ControlRequest::RegisterRoot(RegisterRootRequest {
+            operation_id: OperationId::new(),
+            subject: context.subject,
+            conversation_id: context.chat_id,
+            path,
+            consent_method: ConsentMethod::FolderPicker,
+        }))
+        .await
+        .map_err(|error| error.to_string())?;
+    let openwave_host_broker::ControlResult::RegisterRoot(result) = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+    Ok(Some(ConnectedFolder {
+        root_id: result.root.root_id,
+        display_name: result.root.display_name,
+    }))
+}
+
+#[tauri::command]
+pub(crate) async fn list_connected_folders(
+    state: State<'_, HostAccess>,
+    chat_id: Uuid,
+) -> Result<Vec<ConnectedFolder>, String> {
+    let context = state.context(chat_id).await?;
+    let request_id = openwave_host_broker::RequestId::new();
+    let result = state
+        .broker
+        .operation(OperationEnvelope {
+            protocol_version: openwave_host_broker::PROTOCOL_VERSION,
+            request_id,
+            context: context.execution,
+            request: OperationRequest::ListRoots,
+        })
+        .await
+        .map_err(|error| error.to_string())?;
+    let OperationResult::ListRoots { roots } = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+    Ok(roots
+        .into_iter()
+        .map(|root| ConnectedFolder {
+            root_id: root.root_id,
+            display_name: root.display_name,
+        })
+        .collect())
+}
+
+#[tauri::command]
+pub(crate) async fn disconnect_folder(
+    state: State<'_, HostAccess>,
+    request: DisconnectFolderRequest,
+) -> Result<bool, String> {
+    let context = state.context(request.chat_id).await?;
+    let result = state
+        .broker
+        .control(ControlRequest::RevokeRoot(RevokeRootRequest {
+            operation_id: OperationId::new(),
+            subject: context.subject,
+            root_id: request.root_id,
+        }))
+        .await
+        .map_err(|error| error.to_string())?;
+    let openwave_host_broker::ControlResult::RevokeRoot(result) = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+    Ok(result.revoked)
+}
+
+async fn pick_folder(app: &AppHandle) -> Result<Option<PathBuf>, String> {
+    let (tx, rx) = oneshot::channel();
+    let mut picker = app
+        .dialog()
+        .file()
+        .set_title("Choose a folder OpenWave can read");
+    if let Some(window) = app.get_webview_window("main") {
+        picker = picker.set_parent(&window);
+    }
+    picker.pick_folder(move |path| {
+        let _ = tx.send(path);
+    });
+    rx.await
+        .map_err(|_| "folder picker closed unexpectedly".to_owned())?
+        .map(tauri_plugin_dialog::FilePath::into_path)
+        .transpose()
+        .map_err(|_| "the folder picker returned an invalid path".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn authoritative_chat_record_derives_exact_broker_authority() {
+        let chat_id = Uuid::new_v4();
+        let standalone = authoritative_context(chat_id, None).unwrap();
+        assert_eq!(standalone.execution.conversation_id(), chat_id);
+        assert_eq!(standalone.execution.project_id(), None);
+        assert_eq!(standalone.subject.id(), chat_id);
+
+        let project_id = Uuid::new_v4();
+        let project = authoritative_context(chat_id, Some(project_id)).unwrap();
+        assert_eq!(project.execution.conversation_id(), chat_id);
+        assert_eq!(project.execution.project_id(), Some(project_id));
+        assert_eq!(project.subject.id(), project_id);
+    }
+
+    #[test]
+    fn renderer_request_cannot_supply_project_authority() {
+        let chat_id = Uuid::new_v4();
+        let valid = serde_json::json!({ "chatId": chat_id });
+        let request = serde_json::from_value::<ConnectFolderRequest>(valid).unwrap();
+        assert_eq!(request.chat_id, chat_id);
+
+        let injected = serde_json::json!({
+            "chatId": chat_id,
+            "projectId": Uuid::new_v4(),
+        });
+        assert!(serde_json::from_value::<ConnectFolderRequest>(injected).is_err());
+        assert!(authoritative_context(Uuid::nil(), None).is_err());
+    }
+}

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -14,6 +14,9 @@ use tokio::sync::watch;
 
 use openwave_core::Config;
 
+mod broker;
+mod host_access;
+
 /// Connection details the webview needs to reach the in-process API.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -56,6 +59,15 @@ fn data_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
     Ok(dir)
 }
 
+fn home_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let home = app
+        .path()
+        .home_dir()
+        .map_err(|e| format!("home dir: {e}"))?;
+    home.canonicalize()
+        .map_err(|e| format!("resolve home dir: {e}"))
+}
+
 /// Private scratch for the current desktop profile. This is operational app
 /// data, not a connected user folder and never appears in a native picker.
 fn private_scratch(data_dir: &std::path::Path) -> Result<PathBuf, String> {
@@ -75,27 +87,56 @@ pub fn run() {
     let (info_tx, info_rx) = watch::channel(None);
     let state = Arc::new(AppState { info_rx });
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default();
+    #[cfg(desktop)]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.unminimize();
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+    }));
+
+    let app = builder
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_shell::init())
         .manage(state)
-        .invoke_handler(tauri::generate_handler![server_info])
+        .invoke_handler(tauri::generate_handler![
+            server_info,
+            host_access::connect_folder,
+            host_access::list_connected_folders,
+            host_access::disconnect_folder
+        ])
         .setup(move |app| {
             let handle = app.handle().clone();
             let data = data_dir(&handle)?;
+            let home = home_dir(&handle)?;
             let scratch = private_scratch(&data)?;
+            app.manage(host_access::HostAccess::new(
+                handle.clone(),
+                data.clone(),
+                home,
+            ));
 
             tauri::async_runtime::spawn(async move {
-                if let Err(error) = boot_server(info_tx, data, scratch).await {
+                if let Err(error) = boot_server(handle, info_tx, data, scratch).await {
                     eprintln!("openwave-desktop: {error}");
                 }
             });
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("error while running OpenWave");
+        .build(tauri::generate_context!())
+        .expect("error while building OpenWave");
+    app.run(|app, event| {
+        if matches!(event, tauri::RunEvent::Exit) {
+            tauri::async_runtime::block_on(app.state::<host_access::HostAccess>().shutdown());
+        }
+    });
 }
 
 /// Bind the local API and park the accept loop for the life of the process.
 async fn boot_server(
+    app: tauri::AppHandle,
     info_tx: watch::Sender<Option<ServerInfo>>,
     data_dir: PathBuf,
     scratch_dir: PathBuf,
@@ -103,6 +144,8 @@ async fn boot_server(
     let server = openwave_server::bind(Config::desktop(data_dir))
         .await
         .map_err(|e| e.to_string())?;
+    app.state::<host_access::HostAccess>()
+        .initialize_store(server.store())?;
     let info = ServerInfo {
         base_url: format!("http://{}", server.local_addr()),
         token: server.token().to_string(),

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -5,12 +5,12 @@
   "identifier": "io.brightwave.openwave",
   "build": {
     "beforeDevCommand": {
-      "script": "pnpm dev",
+      "script": "pnpm before-tauri-dev",
       "cwd": "ui"
     },
     "devUrl": "http://localhost:1420",
     "beforeBuildCommand": {
-      "script": "pnpm build",
+      "script": "pnpm before-tauri-build",
       "cwd": "ui"
     },
     "frontendDist": "ui/dist"
@@ -27,12 +27,15 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self' customprotocol: asset:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; img-src 'self' asset: data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
     }
   },
   "bundle": {
     "active": true,
     "targets": "all",
+    "externalBin": [
+      "binaries/openwave-host-broker"
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "before-tauri-dev": "node ../scripts/prepare-sidecar.mjs && vite",
+    "before-tauri-build": "node ../scripts/prepare-sidecar.mjs --release && tsc && vite build",
     "preview": "vite preview",
     "tauri": "cargo tauri"
   },

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -9,6 +9,13 @@ import {
   type ServerInfo,
 } from "./api";
 import { resolveServerInfo } from "./boot";
+import {
+  connectFolder,
+  disconnectFolder,
+  hasNativeHost,
+  listConnectedFolders,
+  type ConnectedFolder,
+} from "./host";
 import { Logomark } from "./Logomark";
 
 type Msg =
@@ -40,7 +47,9 @@ export default function App() {
   const [messages, setMessages] = useState<Msg[]>([]);
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
-  const [showSettings, setShowSettings] = useState(false);
+  const [settingsPanel, setSettingsPanel] = useState<
+    "providers" | "folders" | null
+  >(null);
   const [status, setStatus] = useState("starting…");
   const socketRef = useRef<WebSocket | null>(null);
   const lastSeqRef = useRef(0);
@@ -294,17 +303,34 @@ export default function App() {
         </div>
         <div className="topbar-actions">
           <span className="status">{status}</span>
+          {hasNativeHost() && (
+            <button
+              type="button"
+              className="btn"
+              onClick={() =>
+                setSettingsPanel((panel) =>
+                  panel === "folders" ? null : "folders",
+                )
+              }
+            >
+              {settingsPanel === "folders" ? "Hide folders" : "Folders"}
+            </button>
+          )}
           <button
             type="button"
             className="btn"
-            onClick={() => setShowSettings((v) => !v)}
+            onClick={() =>
+              setSettingsPanel((panel) =>
+                panel === "providers" ? null : "providers",
+              )
+            }
           >
-            {showSettings ? "Hide providers" : "Providers"}
+            {settingsPanel === "providers" ? "Hide providers" : "Providers"}
           </button>
         </div>
       </header>
 
-      <div className={`main${showSettings ? " with-settings" : ""}`}>
+      <div className={`main${settingsPanel ? " with-settings" : ""}`}>
         <section className="chat-pane">
           <div className="chat-meta">
             <label>
@@ -417,13 +443,14 @@ export default function App() {
           </form>
         </section>
 
-        {showSettings && (
+        {settingsPanel === "providers" && (
           <ProvidersPanel
             providers={providers}
             client={client}
             onChanged={() => void refreshCatalog()}
           />
         )}
+        {settingsPanel === "folders" && <FoldersPanel chat={chat} />}
       </div>
     </div>
   );
@@ -433,6 +460,94 @@ function shortPath(path: string): string {
   const parts = path.split(/[/\\]/).filter(Boolean);
   if (parts.length <= 2) return path;
   return `…/${parts.slice(-2).join("/")}`;
+}
+
+function FoldersPanel({ chat }: { chat: Chat }) {
+  const [folders, setFolders] = useState<ConnectedFolder[]>([]);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scopeLabel = chat.project_id ? "project" : "chat";
+
+  async function refresh() {
+    setError(null);
+    try {
+      setFolders(await listConnectedFolders(chat));
+    } catch (err) {
+      setError(String(err));
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+  }, [chat.id, chat.project_id]);
+
+  async function addFolder() {
+    setWorking(true);
+    setError(null);
+    try {
+      const connected = await connectFolder(chat);
+      if (connected) await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function removeFolder(rootId: string) {
+    setWorking(true);
+    setError(null);
+    try {
+      await disconnectFolder(chat, rootId);
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return (
+    <aside className="settings">
+      <h2>Connected folders</h2>
+      <p>
+        OpenWave can read only folders you choose for this {scopeLabel}. Folder
+        locations stay with the native host.
+      </p>
+      <button
+        type="button"
+        className="btn btn-primary"
+        disabled={working}
+        onClick={() => void addFolder()}
+      >
+        Choose folder…
+      </button>
+      <div className="folder-list">
+        {folders.length === 0 && !error && (
+          <div className="status">
+            No folders connected to this {scopeLabel}.
+          </div>
+        )}
+        {folders.map((folder) => (
+          <div className="folder" key={folder.rootId}>
+            <div>
+              <strong>{folder.displayName}</strong>
+              <div className="status">read access</div>
+            </div>
+            <button
+              type="button"
+              className="btn"
+              disabled={working}
+              onClick={() => void removeFolder(folder.rootId)}
+            >
+              Disconnect from {scopeLabel}
+            </button>
+          </div>
+        ))}
+      </div>
+      {error && <div className="folder-error">{error}</div>}
+    </aside>
+  );
 }
 
 function ProvidersPanel({

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -1,0 +1,27 @@
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import type { Chat } from "./api";
+
+export type ConnectedFolder = {
+  rootId: string;
+  displayName: string;
+};
+
+export function hasNativeHost(): boolean {
+  return isTauri();
+}
+
+export function listConnectedFolders(chat: Chat): Promise<ConnectedFolder[]> {
+  return invoke("list_connected_folders", { chatId: chat.id });
+}
+
+export function connectFolder(chat: Chat): Promise<ConnectedFolder | null> {
+  return invoke("connect_folder", {
+    request: { chatId: chat.id },
+  });
+}
+
+export function disconnectFolder(chat: Chat, rootId: string): Promise<boolean> {
+  return invoke("disconnect_folder", {
+    request: { chatId: chat.id, rootId },
+  });
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -244,6 +244,32 @@ button {
   text-transform: capitalize;
 }
 
+.folder-list {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.folder {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-top: 1px solid var(--line);
+  padding-top: 0.7rem;
+}
+
+.folder strong {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.folder-error {
+  margin-top: 0.75rem;
+  color: var(--danger);
+  font-size: 0.8rem;
+}
+
 .row {
   display: flex;
   flex-wrap: wrap;

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -173,11 +173,11 @@ struct RevokeFingerprint {
 }
 
 struct PreparedRegistration {
+    conversation_id: Uuid,
     root_id: RootId,
     root: RegisteredRoot,
     grants: [Grant; 2],
     attachment: RootAttachment,
-    result: RegisterRootResult,
 }
 
 struct ControlAudit {
@@ -407,17 +407,47 @@ impl Controller {
             }
             result => result.map_err(error_response),
         };
-        let outcome = prepared
-            .as_ref()
-            .map(|item| item.result.clone())
-            .map_err(Clone::clone);
         let mut state = self.lock_state().map_err(error_response)?;
         let mut next = state.clone();
-        if let Ok(prepared) = prepared {
-            next.roots.insert(prepared.root_id, prepared.root);
-            next.grants.extend(prepared.grants);
-            next.attachments.push(prepared.attachment);
-        }
+        let outcome = match prepared {
+            Ok(prepared) => {
+                let existing = next.roots.iter().find_map(|(root_id, root)| {
+                    (root.owner == prepared.root.owner
+                        && root.root.identity() == prepared.root.root.identity())
+                    .then(|| (*root_id, root.display_name.clone()))
+                });
+                if let Some((root_id, display_name)) = existing {
+                    if !next.attachments.iter().any(|attachment| {
+                        attachment.conversation_id() == prepared.conversation_id
+                            && attachment.root_id() == root_id
+                    }) {
+                        next.attachments.push(
+                            RootAttachment::new(prepared.conversation_id, root_id)
+                                .map_err(BrokerError::from)
+                                .map_err(error_response)?,
+                        );
+                    }
+                    Ok(RegisterRootResult {
+                        root: RootSummary {
+                            root_id,
+                            display_name,
+                        },
+                    })
+                } else {
+                    let result = RegisterRootResult {
+                        root: RootSummary {
+                            root_id: prepared.root_id,
+                            display_name: prepared.root.display_name.clone(),
+                        },
+                    };
+                    next.roots.insert(prepared.root_id, prepared.root);
+                    next.grants.extend(prepared.grants);
+                    next.attachments.push(prepared.attachment);
+                    Ok(result)
+                }
+            }
+            Err(error) => Err(error),
+        };
         complete_register(&mut next, operation_id, &fingerprint, outcome.clone())
             .map_err(error_response)?;
         if let Err(error) = self.commit_state(&mut state, next) {
@@ -445,12 +475,6 @@ impl Controller {
         let validated = self.shared.policy.open_root(&request.path)?;
         let display_name = root_display_name(validated.canonical_path());
         let root_id = RootId::new();
-        let result = RegisterRootResult {
-            root: RootSummary {
-                root_id,
-                display_name: display_name.clone(),
-            },
-        };
         let consent = ConsentRecord::new(request.consent_method, Utc::now());
         let list_grant = Grant::from_consent(
             GrantId::new(),
@@ -467,6 +491,7 @@ impl Controller {
             consent,
         )?;
         Ok(PreparedRegistration {
+            conversation_id: request.conversation_id,
             root_id,
             root: RegisteredRoot {
                 owner: request.subject,
@@ -475,7 +500,6 @@ impl Controller {
             },
             grants: [list_grant, read_grant],
             attachment: RootAttachment::new(request.conversation_id, root_id)?,
-            result,
         })
     }
 
@@ -1319,6 +1343,54 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn repeated_registration_reuses_the_same_root_and_attaches_new_project_chat() {
+        let (_temp, broker, path) = setup();
+        let project = Uuid::new_v4();
+        let first_chat = Uuid::new_v4();
+        let second_chat = Uuid::new_v4();
+        let subject = GrantSubject::project(project).unwrap();
+
+        let first = register(
+            &broker.controller(),
+            subject,
+            first_chat,
+            path.clone(),
+            OperationId::new(),
+        );
+        let repeated = register(
+            &broker.controller(),
+            subject,
+            first_chat,
+            path.clone(),
+            OperationId::new(),
+        );
+        let attached = register(
+            &broker.controller(),
+            subject,
+            second_chat,
+            path,
+            OperationId::new(),
+        );
+
+        assert_eq!(repeated.root, first.root);
+        assert_eq!(attached.root, first.root);
+        for chat in [first_chat, second_chat] {
+            let roots = operate(
+                &broker.operator(),
+                ExecutionContext::project_chat(chat, project).unwrap(),
+                OperationRequest::ListRoots,
+            )
+            .unwrap();
+            assert_eq!(
+                roots,
+                OperationResult::ListRoots {
+                    roots: vec![first.root.clone()]
+                }
+            );
+        }
     }
 
     #[test]

--- a/crates/openwave-host-broker/src/sidecar.rs
+++ b/crates/openwave-host-broker/src/sidecar.rs
@@ -9,42 +9,47 @@ use crate::{
     RequestId,
 };
 
-const MAX_REQUEST_BYTES: usize = 128 * 1024;
-const MAX_RESPONSE_BYTES: usize = 512 * 1024;
+pub const MAX_REQUEST_BYTES: usize = 128 * 1024;
+pub const MAX_RESPONSE_BYTES: usize = 512 * 1024;
 
 /// One strictly typed request on the desktop-owned sidecar pipe.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(
     tag = "channel",
     content = "envelope",
     rename_all = "snake_case",
     deny_unknown_fields
 )]
-enum SidecarRequest {
+pub enum SidecarRequest {
     Control(ControlEnvelope),
     Operation(OperationEnvelope),
 }
 
 /// One response for one non-empty input line.
-#[derive(Debug, Serialize)]
-#[serde(tag = "channel", content = "envelope", rename_all = "snake_case")]
-enum SidecarResponse {
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(
+    tag = "channel",
+    content = "envelope",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
+pub enum SidecarResponse {
     Control(ControlResponseEnvelope),
     Operation(OperationResponseEnvelope),
     TransportError(TransportError),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct TransportError {
-    request_id: Option<RequestId>,
-    code: TransportErrorCode,
-    message: &'static str,
+pub struct TransportError {
+    pub request_id: Option<RequestId>,
+    pub code: TransportErrorCode,
+    pub message: String,
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-enum TransportErrorCode {
+pub enum TransportErrorCode {
     MalformedRequest,
     RequestTooLarge,
     ResponseTooLarge,
@@ -60,7 +65,7 @@ pub fn serve(broker: &Broker, mut input: impl BufRead, mut output: impl Write) -
             BoundedLine::TooLarge => SidecarResponse::TransportError(TransportError {
                 request_id: None,
                 code: TransportErrorCode::RequestTooLarge,
-                message: "sidecar request exceeded its size limit",
+                message: "sidecar request exceeded its size limit".to_owned(),
             }),
         };
         let mut encoded = serde_json::to_vec(&response).map_err(io::Error::other)?;
@@ -68,7 +73,7 @@ pub fn serve(broker: &Broker, mut input: impl BufRead, mut output: impl Write) -
             encoded = serde_json::to_vec(&SidecarResponse::TransportError(TransportError {
                 request_id: response_request_id(&response),
                 code: TransportErrorCode::ResponseTooLarge,
-                message: "sidecar response exceeded its size limit",
+                message: "sidecar response exceeded its size limit".to_owned(),
             }))
             .map_err(io::Error::other)?;
         }
@@ -90,7 +95,7 @@ fn dispatch(broker: &Broker, line: &[u8]) -> SidecarResponse {
         Err(_) => SidecarResponse::TransportError(TransportError {
             request_id: None,
             code: TransportErrorCode::MalformedRequest,
-            message: "sidecar request was malformed",
+            message: "sidecar request was malformed".to_owned(),
         }),
     }
 }

--- a/crates/openwave-host-broker/tests/sidecar.rs
+++ b/crates/openwave-host-broker/tests/sidecar.rs
@@ -7,7 +7,7 @@ use std::{
 use openwave_host_broker::{
     ConsentMethod, ControlEnvelope, ControlRequest, ExecutionContext, GrantSubject,
     OperationEnvelope, OperationId, OperationRequest, RegisterRootRequest, RequestId,
-    PROTOCOL_VERSION,
+    RevokeRootRequest, RootId, PROTOCOL_VERSION,
 };
 use serde::Serialize;
 use tempfile::TempDir;
@@ -138,6 +138,36 @@ fn stdio_sidecar_persists_authority_and_audit_across_restart() {
         private_response["envelope"]["response"]["payload"]["code"],
         "invalid_root"
     );
+    let revoke = exchange(
+        &mut input,
+        &mut output,
+        "control",
+        &ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            request: ControlRequest::RevokeRoot(RevokeRootRequest {
+                operation_id: OperationId::new(),
+                subject,
+                root_id: root_id.parse::<RootId>().unwrap(),
+            }),
+        },
+    );
+    assert_eq!(revoke["envelope"]["response"]["payload"]["revoked"], true);
+    let after_revoke = exchange(
+        &mut input,
+        &mut output,
+        "operation",
+        &OperationEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            context: ExecutionContext::standalone(conversation_id).unwrap(),
+            request: OperationRequest::ListRoots,
+        },
+    );
+    assert_eq!(
+        after_revoke["envelope"]["response"]["payload"]["roots"],
+        serde_json::json!([])
+    );
     drop(input);
     assert!(child.wait().unwrap().success());
 
@@ -145,6 +175,7 @@ fn stdio_sidecar_persists_authority_and_audit_across_restart() {
         std::fs::read_to_string(temp.path().join("app-data/host-broker-audit.jsonl")).unwrap();
     assert!(audit.contains("register_root"));
     assert!(audit.contains("list_roots"));
+    assert!(audit.contains("revoke_root"));
     assert!(!audit.contains(root.to_str().unwrap()));
     assert!(!audit.contains("sidecar read"));
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -168,6 +168,7 @@ async fn healthz() -> &'static str {
 pub struct Server {
     local_addr: SocketAddr,
     token: Arc<str>,
+    store: Arc<dyn Store>,
     listener: TcpListener,
     router: Router,
     _document_auditor: AbortTask,
@@ -227,6 +228,14 @@ impl Server {
     /// The bearer token clients must present.
     pub fn token(&self) -> &str {
         &self.token
+    }
+
+    /// The authoritative durable store used by this server instance.
+    ///
+    /// Native embedders use this to resolve renderer-supplied entity IDs back
+    /// to server-owned records before granting host capabilities.
+    pub fn store(&self) -> Arc<dyn Store> {
+        self.store.clone()
     }
 
     /// Run the accept loop until the process exits.
@@ -306,6 +315,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         state.agent_config.clone(),
         turn_worker::TurnWorkerConfig::default(),
     );
+    let server_store = state.store.clone();
     let router = app(state);
 
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
@@ -324,6 +334,7 @@ pub async fn bind(config: Config) -> Result<Server> {
     Ok(Server {
         local_addr,
         token,
+        store: server_store,
         listener,
         router,
         _document_auditor: AbortTask(document_auditor),

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -6265,6 +6265,7 @@ async fn bind_yields_a_loopback_addr_and_token() {
     let server = bind(Config::desktop(dir.path())).await.unwrap();
     assert!(server.local_addr().ip().is_loopback());
     assert!(!server.token().is_empty());
+    assert!(server.store().list_chats().await.unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -98,9 +98,10 @@ are rolled back before retry, interrupted tails/rotations recover on restart,
 and degraded read-tier audit does not withhold the user's existing file access.
 A runnable sidecar exposes the same core over bounded, strict JSONL stdio,
 resynchronizes after oversized input, and protects its own app-data directory
-from ever becoming a connected root. The Tauri client and consent UI are the
-next slices; until those land, existing file tools do not use this boundary. See
-[Host access and connected folders](host-access.md).
+from ever becoming a connected root. The Tauri host owns its lifecycle and
+native folder consent behind narrow pick/list/revoke commands; the renderer sees
+only opaque summaries. Existing agent file tools do not use this boundary yet.
+See [Host access and connected folders](host-access.md).
 
 **Depends on:** no OpenWave client crate.
 
@@ -134,7 +135,7 @@ primary way most people will run OpenWave. See
 [`crates/openwave-desktop/README.md`](../crates/openwave-desktop/README.md) for
 local run instructions.
 
-**Depends on:** `openwave-core`, `openwave-server` (+ Tauri).
+**Depends on:** `openwave-core`, `openwave-host-broker`, `openwave-server` (+ Tauri).
 
 ## `openwave-server` — local API and workers 🟢
 

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -81,19 +81,27 @@ defense in depth, not a substitute for authorization: the broker validates every
 operation even when its caller is local.
 
 The sidecar adapter is a small `openwave-host-broker` process owned by the
-desktop host. The host supplies absolute app-data and home-directory paths at
-spawn time; the broker never guesses them from an agent request. Its stdio wire
-format is strict, bounded newline-delimited JSON with an explicit control or
-operation channel and exactly one safe response per non-empty input line.
+desktop host. The desktop builds and bundles it by default, starts one lazy
+process for the application profile, and restarts it after a bounded transport
+failure. The host supplies absolute app-data and home-directory paths at spawn
+time; the broker never guesses them from an agent request. Its stdio wire format
+is strict, bounded newline-delimited JSON with an explicit control or operation
+channel and exactly one safe response per non-empty input line.
 Oversized lines are drained without unbounded allocation so the next request can
 still be parsed; whitespace-only or malformed non-empty frames receive a safe
 transport error rather than hanging a request/response client. Root counts,
 display names, directory results, and file bytes are bounded before response
 serialization, so the response cap is also an allocation bound. The app-private
 broker directory is added to root policy as a protected location, so it and any
-ancestor containing it cannot be connected.
-This process adapter does not itself grant the renderer access to the trusted
-control handle—the forthcoming Tauri client owns that routing distinction.
+ancestor containing it cannot be connected. Queue admission is bounded and
+fails fast when full, and the desktop runs as a single instance so two native
+shells cannot contend for the same broker state.
+
+The Tauri host—not the renderer—owns the control handle. It opens the native
+folder picker, resolves the renderer's chat ID against the server's authoritative
+store, derives project or standalone ownership from that record, and forwards
+the picker result. Re-registering the same pinned filesystem object for the same
+subject reuses the root and only adds a missing conversation attachment.
 
 The **renderer** presents connected folders and permission choices. It receives
 safe summaries, not the broker's persisted absolute-path registry.
@@ -254,18 +262,19 @@ This will land in independently reviewable pieces:
    local two-generation retention.
 5. Expose the same contract through a bounded, versioned sidecar adapter with
    strict control/operation wire variants and app-private-directory protection.
-6. Add the Tauri sidecar client, connected-folder UI, and the durable
-   agent-request → native-picker → grant → retry workflow. Broker state, audit,
-   scratch, and handoffs live under OpenWave's application data directory;
-   remove the automatic `Documents/OpenWave` folder.
-7. Replace project/chat `workspace_dir` with persisted host-access context
+6. Add the native Tauri sidecar lifecycle and connected-folder UI. The renderer
+   can request only pick/list/revoke for its current conversation; it never
+   receives a raw control surface or absolute path. Broker state, audit, and
+   scratch live under the protected OpenWave application-data directory.
+7. Add the durable agent-request → native-picker → grant → retry workflow.
+8. Replace project/chat `workspace_dir` with persisted host-access context
    identity and connected-root APIs. This can update the pre-v1 baseline schema
    directly.
-8. Route built-in file tools through the operation interface and remove direct
+9. Route built-in file tools through the operation interface and remove direct
    ambient host-directory opening from `ToolCtx`.
-9. Port bounded imports, writes, approvals, and confined command execution as
+10. Port bounded imports, writes, approvals, and confined command execution as
    separate capability slices.
-10. Adapt the explicit-workspace MCP command to the same broker policy instead of
+11. Adapt the explicit-workspace MCP command to the same broker policy instead of
    maintaining a second filesystem authority model.
 
 Each intermediate state must fail closed. In particular, adding the data model

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -73,7 +73,9 @@ must not mean losing the source document.
 
 ## Startup, configuration, and local data
 
-Both the desktop and `openwave serve` use the same boot path. Startup acquires
+Both the desktop and `openwave serve` use the same server boot path. The native
+desktop additionally enforces one application instance, owns folder consent,
+and lazily starts its bundled host-broker sidecar. Server startup acquires
 exclusive ownership of the data directory, opens the operational database and
 Lance index, loads provider configuration, registers tools, starts the turn and
 document workers, and finally binds an ephemeral loopback port with a fresh
@@ -156,14 +158,15 @@ The built-in server registry currently contains:
 - `search`, which queries the indexed corpus and requires approval only when its
   embedder, store, or reranker can send data outside the machine.
 
-Today these file tools operate inside one directly opened workspace directory
-stored on the chat. That is a temporary pre-alpha boundary, not the intended
-product model. Projects and conversations will instead resolve to distinct
-host-access contexts containing user-approved roots, and file operations will go
-through a capability-gated host-broker sidecar. See [Host access and connected
-folders](host-access.md). An agent may ask the desktop to connect another folder,
-but the request only opens a native consent flow; it never grants a named path by
-itself. The model router supports Anthropic, OpenAI, and
+Today these file tools still operate inside one directly opened workspace
+directory stored on the chat. That temporary tool path is not the intended
+product boundary. The desktop can now connect, list, and revoke multiple folders
+through a native picker and capability-gated host-broker sidecar; it exposes only
+opaque root IDs and display names to the renderer. The next tool-routing slice
+will resolve file operations through those roots instead of the legacy workspace.
+See [Host access and connected folders](host-access.md). An agent may later ask
+the desktop to connect another folder, but the request only opens a native consent
+flow; it never grants a named path by itself. The model router supports Anthropic, OpenAI, and
 OpenAI-compatible endpoints. It fails closed: if no enabled provider with a
 usable credential can serve the selected model, no model request is sent.
 
@@ -386,13 +389,14 @@ The browser-facing API is not exposed on a public network interface.
 
 The current UI is a walking skeleton, not the complete product. It creates a new
 loose chat on each launch and supports provider setup, model selection, basic
-chat streaming, and approval prompts. It also creates and assigns one
-`Documents/OpenWave` directory automatically. That single-directory behavior is
-temporary: the desktop should keep OpenWave's private data in app storage and
-let each project or conversation connect user-chosen folders through the host
-broker. The UI does not yet provide a chat picker, history reconstruction,
-projects, document ingestion, document search, cancel, or steer controls, even
-though much of that backend API already exists.
+chat streaming, approval prompts, and native connected-folder pick/list/revoke.
+OpenWave's operational scratch stays in private app storage; user-selected paths
+cross only the native host-to-broker control boundary, while the renderer sees
+opaque folder summaries. Built-in agent file tools still use the temporary
+private scratch path and are not yet routed through those connected roots. The
+UI does not yet provide a chat picker, history reconstruction, projects,
+document ingestion, document search, cancel, or steer controls, even though much
+of that backend API already exists.
 
 Because that chat is projectless, its `search` tool can see only the unscoped
 document corpus. Project-scoped documents are not reachable through the current


### PR DESCRIPTION
## Summary

- bundle and supervise the host-broker sidecar from the native desktop shell
- add native picker-backed connect, list, and revoke commands with authoritative chat/project resolution
- expose connected folders in the desktop UI without returning absolute paths
- enforce bounded queue/framing, single-instance ownership, strict CSP, idempotent root reuse, and safe shutdown
- update host-access and maintainer documentation for the landed boundary

## Validation

- `cargo test -p openwave-host-broker -p openwave-desktop --locked`
- `cargo test -p openwave-server bind_yields_a_loopback_addr_and_token --locked`
- `pnpm --dir crates/openwave-desktop/ui build`
- `bw dev lint --rust --check --repo-root "$PWD"`
- `cargo tauri build --debug --no-bundle`
- `cargo tauri build --debug --bundles app`
- clean-checkout desktop `cargo check` without a staged sidecar
- bundled sidecar path, architecture, and code-signature inspection
