### PR TITLE
feat(core): add durable client execution state

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -33,12 +33,18 @@ use crate::context;
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{CallId, MessageId, TurnId};
-use crate::model::{Chat, Message, Role, ToolCallRecord, TurnRunStatus};
+use crate::model::{
+    Chat, Message, Role, ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus,
+    TurnRunStatus,
+};
 use crate::provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, StopReason, Usage,
 };
 use crate::steer::SteerInbox;
-use crate::storage::{ApplyTurnSteerOutcome, JournaledTurnSteerOutcome, Store};
+use crate::storage::{
+    AcceptToolCallOutcome, ApplyTurnSteerOutcome, JournaledTurnSteerOutcome,
+    ResolveToolCallOutcome, Store,
+};
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 
 /// A name-keyed registry of the tools available to the agent.
@@ -583,6 +589,7 @@ impl Agent {
                         .await?;
                 }
             }
+            let mut recovered_results: HashMap<CallId, ToolOutput> = HashMap::new();
             for call in &calls {
                 let args = parse_args(&call.args);
                 blocks.push(ContentBlock::ToolUse {
@@ -592,20 +599,52 @@ impl Agent {
                 });
                 // Persist the call as soon as args are known so a crash mid-tool
                 // still leaves a reconstructable ToolUse on the next turn.
-                self.store
-                    .upsert_tool_call(&ToolCallRecord {
+                let outcome = self
+                    .store
+                    .accept_tool_call(&ToolCallRecord {
                         id: call.call_id,
                         chat_id: chat.id,
                         turn_id,
                         provider_id: call.provider_id.clone(),
                         name: call.name.clone(),
                         arguments: args,
+                        execution: ToolCallExecution::Server,
+                        status: ToolCallStatus::Pending,
                         result: None,
-                        is_error: false,
+                        error_code: None,
+                        error_detail: None,
+                        client_executor_id: None,
+                        client_lease_expires_at: None,
                         created_at: Utc::now(),
-                        completed_at: None,
+                        resolved_at: None,
                     })
                     .await?;
+                match outcome {
+                    AcceptToolCallOutcome::Accepted(_) => {}
+                    AcceptToolCallOutcome::Existing(existing) if existing.status.is_terminal() => {
+                        let content = existing.result.ok_or_else(|| {
+                            AgentError::Store(format!(
+                                "terminal tool call {} is missing its result",
+                                call.call_id
+                            ))
+                        })?;
+                        recovered_results.insert(
+                            call.call_id,
+                            ToolOutput {
+                                content,
+                                data: None,
+                                is_error: existing.status != ToolCallStatus::Completed,
+                            },
+                        );
+                    }
+                    AcceptToolCallOutcome::Existing(_) => {}
+                    AcceptToolCallOutcome::IdentityConflict => {
+                        return Err(AgentError::Store(format!(
+                            "tool call {} identity conflicts with its canonical request",
+                            call.call_id
+                        )));
+                    }
+                }
             }
             if !blocks.is_empty() {
                 transcript.push(ChatMessage {
@@ -703,25 +742,40 @@ impl Agent {
             // Run the tool calls and feed the results back for the next step.
             let mut results: Vec<ContentBlock> = Vec::new();
             for call in &calls {
-                let output = self.run_tool(chat, turn_id, call, events).await;
+                let (output, needs_resolution) = match recovered_results.remove(&call.call_id) {
+                    Some(output) => (output, false),
+                    None => (self.run_tool(chat, turn_id, call, events).await, true),
+                };
                 events.send(AgentEvent::ToolCallCompleted {
                     call_id: call.call_id,
                     output: output.clone(),
                 });
-                self.store
-                    .upsert_tool_call(&ToolCallRecord {
-                        id: call.call_id,
-                        chat_id: chat.id,
-                        turn_id,
-                        provider_id: call.provider_id.clone(),
-                        name: call.name.clone(),
-                        arguments: parse_args(&call.args),
-                        result: Some(output.content.clone()),
-                        is_error: output.is_error,
-                        created_at: Utc::now(),
-                        completed_at: Some(Utc::now()),
-                    })
-                    .await?;
+                if needs_resolution {
+                    let resolution = if output.is_error {
+                        ToolCallResolution::Failed {
+                            result: output.content.clone(),
+                            error_code: "tool_error".into(),
+                            error_detail: None,
+                        }
+                    } else {
+                        ToolCallResolution::Completed {
+                            result: output.content.clone(),
+                        }
+                    };
+                    let outcome = self
+                        .store
+                        .resolve_server_tool_call(call.call_id, &resolution, Utc::now())
+                        .await?;
+                    if !matches!(
+                        outcome,
+                        ResolveToolCallOutcome::Resolved | ResolveToolCallOutcome::Existing
+                    ) {
+                        return Err(AgentError::Store(format!(
+                            "tool call {} could not be resolved: {outcome:?}",
+                            call.call_id
+                        )));
+                    }
+                }
                 results.push(ContentBlock::ToolResult {
                     tool_use_id: call.provider_id.clone(),
                     content: output.content,
@@ -1093,7 +1147,7 @@ impl Agent {
 /// Merge text messages and structured tool-call rows into the provider transcript.
 ///
 /// Tool calls are partitioned into *batches*: a new batch starts when a call's
-/// `created_at` is at or after the previous batch's latest `completed_at`. That
+/// `created_at` is at or after the previous batch's latest `resolved_at`. That
 /// matches the agent loop (upsert all args for a model step, then complete them,
 /// then the next model step). Batches that fall after an assistant text message
 /// and before the next message attach as `ToolUse` on that assistant; otherwise
@@ -1179,7 +1233,7 @@ fn batch_tool_calls(tool_calls: &[ToolCallRecord]) -> Vec<Vec<&ToolCallRecord>> 
             }
         }
         current.push(call);
-        if let Some(completed) = call.completed_at {
+        if let Some(completed) = call.resolved_at {
             batch_done_at = Some(match batch_done_at {
                 Some(done) => done.max(completed),
                 None => completed,
@@ -1224,7 +1278,7 @@ fn push_tool_batch(
                 .map(|content| ContentBlock::ToolResult {
                     tool_use_id: call.provider_id.clone(),
                     content: content.clone(),
-                    is_error: call.is_error,
+                    is_error: call.status != ToolCallStatus::Completed,
                 })
         })
         .collect();
@@ -1444,8 +1498,8 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].name, "read_file");
         assert_eq!(calls[0].result.as_deref(), Some("hello from disk"));
-        assert!(!calls[0].is_error);
-        assert!(calls[0].completed_at.is_some());
+        assert_eq!(calls[0].status, ToolCallStatus::Completed);
+        assert!(calls[0].resolved_at.is_some());
     }
 
     #[tokio::test]
@@ -2747,10 +2801,15 @@ mod tests {
             provider_id: "tu_1".into(),
             name: "read_file".into(),
             arguments: serde_json::json!({"path": "a"}),
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Completed,
             result: Some("ok".into()),
-            is_error: false,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
             created_at: t2,
-            completed_at: Some(DateTime::<Utc>::from_timestamp(1_003, 0).unwrap()),
+            resolved_at: Some(DateTime::<Utc>::from_timestamp(1_003, 0).unwrap()),
         }];
         let rebuilt = rebuild_transcript(&messages, &calls);
         assert_eq!(rebuilt.len(), 3);
@@ -2804,10 +2863,15 @@ mod tests {
             provider_id: "tu_1".into(),
             name: "read_file".into(),
             arguments: serde_json::json!({}),
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Completed,
             result: Some("data".into()),
-            is_error: false,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
             created_at: t1,
-            completed_at: Some(t1),
+            resolved_at: Some(t1),
         }];
         let rebuilt = rebuild_transcript(&messages, &calls);
         assert_eq!(rebuilt.len(), 4);

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -330,10 +330,16 @@ pub mod tool_call {
         pub name: String,
         #[sea_orm(column_type = "JsonBinary")]
         pub arguments: Json,
+        pub execution: String,
+        pub status: String,
         pub result: Option<String>,
-        pub is_error: bool,
+        pub error_code: Option<String>,
+        pub error_detail: Option<String>,
+        pub client_executor_id: Option<Uuid>,
+        pub client_lease_token: Option<Uuid>,
+        pub client_lease_expires_at: Option<DateTimeUtc>,
         pub created_at: DateTimeUtc,
-        pub completed_at: Option<DateTimeUtc>,
+        pub resolved_at: Option<DateTimeUtc>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -1064,24 +1064,134 @@ impl MigrationTrait for AddToolCalls {
                     .col(ColumnDef::new(ToolCall::ProviderId).text().not_null())
                     .col(ColumnDef::new(ToolCall::Name).text().not_null())
                     .col(ColumnDef::new(ToolCall::Arguments).json_binary().not_null())
+                    .col(ColumnDef::new(ToolCall::Execution).text().not_null())
+                    .col(ColumnDef::new(ToolCall::Status).text().not_null())
                     .col(ColumnDef::new(ToolCall::Result).text())
-                    .col(
-                        ColumnDef::new(ToolCall::IsError)
-                            .boolean()
-                            .not_null()
-                            .default(false),
-                    )
+                    .col(ColumnDef::new(ToolCall::ErrorCode).text())
+                    .col(ColumnDef::new(ToolCall::ErrorDetail).text())
+                    .col(ColumnDef::new(ToolCall::ClientExecutorId).uuid())
+                    .col(ColumnDef::new(ToolCall::ClientLeaseToken).uuid())
+                    .col(ColumnDef::new(ToolCall::ClientLeaseExpiresAt).timestamp_with_time_zone())
                     .col(
                         ColumnDef::new(ToolCall::CreatedAt)
                             .timestamp_with_time_zone()
                             .not_null(),
                     )
-                    .col(ColumnDef::new(ToolCall::CompletedAt).timestamp_with_time_zone())
+                    .col(ColumnDef::new(ToolCall::ResolvedAt).timestamp_with_time_zone())
                     .foreign_key(
                         ForeignKey::create()
                             .name("fk_tool_call_chat")
                             .from(ToolCall::Table, ToolCall::ChatId)
                             .to(Chat::Table, Chat::Id),
+                    )
+                    .check(Expr::col(ToolCall::Execution).is_in([
+                        crate::model::ToolCallExecution::Server.as_str(),
+                        crate::model::ToolCallExecution::Client.as_str(),
+                    ]))
+                    .check(Expr::col(ToolCall::Status).is_in([
+                        crate::model::ToolCallStatus::Pending.as_str(),
+                        crate::model::ToolCallStatus::Completed.as_str(),
+                        crate::model::ToolCallStatus::Failed.as_str(),
+                        crate::model::ToolCallStatus::Cancelled.as_str(),
+                    ]))
+                    .check(
+                        Func::char_length(Expr::col(ToolCall::ProviderId))
+                            .between(1, crate::model::ToolCallRecord::MAX_LABEL_LEN as i32),
+                    )
+                    .check(
+                        Func::char_length(Expr::col(ToolCall::Name))
+                            .between(1, crate::model::ToolCallRecord::MAX_LABEL_LEN as i32),
+                    )
+                    .check(
+                        Expr::col(ToolCall::Result).is_null().or(Func::char_length(
+                            Expr::col(ToolCall::Result),
+                        )
+                        .lte(crate::model::ToolCallRecord::MAX_RESULT_BYTES as i32)),
+                    )
+                    .check(
+                        Expr::col(ToolCall::ErrorCode).is_null().or(Func::char_length(
+                            Expr::col(ToolCall::ErrorCode),
+                        )
+                        .between(
+                            1,
+                            crate::model::ToolCallRecord::MAX_ERROR_CODE_LEN as i32,
+                        )),
+                    )
+                    .check(
+                        Expr::col(ToolCall::ErrorDetail).is_null().or(Func::char_length(
+                            Expr::col(ToolCall::ErrorDetail),
+                        )
+                        .between(
+                            1,
+                            crate::model::ToolCallRecord::MAX_ERROR_DETAIL_LEN as i32,
+                        )),
+                    )
+                    .check(
+                        Expr::col(ToolCall::ResolvedAt)
+                            .is_null()
+                            .or(Expr::col(ToolCall::ResolvedAt)
+                                .gte(Expr::col(ToolCall::CreatedAt))),
+                    )
+                    .check(
+                        Expr::col(ToolCall::ClientLeaseExpiresAt)
+                            .is_null()
+                            .or(Expr::col(ToolCall::ClientLeaseExpiresAt)
+                                .gt(Expr::col(ToolCall::CreatedAt))),
+                    )
+                    .check(
+                        Expr::col(ToolCall::Status)
+                            .eq(crate::model::ToolCallStatus::Pending.as_str())
+                            .and(Expr::col(ToolCall::Result).is_null())
+                            .and(Expr::col(ToolCall::ErrorCode).is_null())
+                            .and(Expr::col(ToolCall::ErrorDetail).is_null())
+                            .and(Expr::col(ToolCall::ResolvedAt).is_null())
+                            .or(Expr::col(ToolCall::Status)
+                                .ne(crate::model::ToolCallStatus::Pending.as_str())
+                                .and(Expr::col(ToolCall::Result).is_not_null())
+                                .and(Expr::col(ToolCall::ResolvedAt).is_not_null())
+                                .and(Expr::col(ToolCall::ClientLeaseExpiresAt).is_null())),
+                    )
+                    .check(
+                        Expr::col(ToolCall::Status)
+                            .eq(crate::model::ToolCallStatus::Failed.as_str())
+                            .and(Expr::col(ToolCall::ErrorCode).is_not_null())
+                            .or(Expr::col(ToolCall::Status)
+                                .ne(crate::model::ToolCallStatus::Failed.as_str())
+                                .and(Expr::col(ToolCall::ErrorCode).is_null())
+                                .and(Expr::col(ToolCall::ErrorDetail).is_null())),
+                    )
+                    .check(
+                        Expr::col(ToolCall::Execution)
+                            .eq(crate::model::ToolCallExecution::Server.as_str())
+                            .and(Expr::col(ToolCall::ClientExecutorId).is_null())
+                            .and(Expr::col(ToolCall::ClientLeaseToken).is_null())
+                            .and(Expr::col(ToolCall::ClientLeaseExpiresAt).is_null())
+                            .or(Expr::col(ToolCall::Execution)
+                                .eq(crate::model::ToolCallExecution::Client.as_str())
+                                .and(
+                                    Expr::col(ToolCall::Status)
+                                        .eq(crate::model::ToolCallStatus::Pending.as_str())
+                                        .and(
+                                            Expr::col(ToolCall::ClientExecutorId)
+                                                .is_null()
+                                                .and(
+                                                    Expr::col(ToolCall::ClientLeaseToken).is_null(),
+                                                )
+                                                .and(
+                                                    Expr::col(ToolCall::ClientLeaseExpiresAt)
+                                                        .is_null(),
+                                                )
+                                                .or(Expr::col(ToolCall::ClientExecutorId)
+                                                    .is_not_null()
+                                                    .and(Expr::col(ToolCall::ClientLeaseToken).is_not_null())
+                                                    .and(Expr::col(ToolCall::ClientLeaseExpiresAt).is_not_null())),
+                                        )
+                                        .or(Expr::col(ToolCall::Status)
+                                            .ne(crate::model::ToolCallStatus::Pending.as_str())
+                                            .and(Expr::col(ToolCall::ClientExecutorId).is_not_null())
+                                            .and(Expr::col(ToolCall::ClientLeaseToken).is_not_null())
+                                            .and(Expr::col(ToolCall::ClientLeaseExpiresAt).is_null())),
+                                )),
                     )
                     .to_owned(),
             )
@@ -1094,6 +1204,18 @@ impl MigrationTrait for AddToolCalls {
                     .table(ToolCall::Table)
                     .col(ToolCall::ChatId)
                     .col(ToolCall::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_tool_call_client_pending")
+                    .table(ToolCall::Table)
+                    .col(ToolCall::ChatId)
+                    .col(ToolCall::Execution)
+                    .col(ToolCall::Status)
+                    .col(ToolCall::ClientLeaseExpiresAt)
                     .to_owned(),
             )
             .await?;
@@ -1961,10 +2083,16 @@ enum ToolCall {
     ProviderId,
     Name,
     Arguments,
+    Execution,
+    Status,
     Result,
-    IsError,
+    ErrorCode,
+    ErrorDetail,
+    ClientExecutorId,
+    ClientLeaseToken,
+    ClientLeaseExpiresAt,
     CreatedAt,
-    CompletedAt,
+    ResolvedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -21,23 +21,24 @@ use serde_json::Value;
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 #[cfg(test)]
-use crate::id::{CallId, MessageId};
-use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId, TurnId, TurnSteerId};
+use crate::id::MessageId;
+use crate::id::{CallId, ChatId, DocumentId, DocumentJobId, ProjectId, TurnId, TurnSteerId};
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
     BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
     DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
     DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
-    DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, TurnFailureRetry, TurnRun,
-    TurnRunStatus, TurnSteerStatus,
+    DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, ToolCallResolution,
+    TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteerStatus,
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, ClaimTurnRunOutcome, CompleteTurnRunOutcome,
-    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
-    FinishTurnCancellationOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
-    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, Store,
+    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, ClaimClientToolCallOutcome,
+    ClaimTurnRunOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
+    HeartbeatClientToolCallOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome, Store,
 };
 
 mod ops;
@@ -1846,8 +1847,97 @@ impl Store for DbStore {
         ops::conversation::list_messages(self, chat_id).await
     }
 
-    async fn upsert_tool_call(&self, call: &ToolCallRecord) -> Result<()> {
-        ops::conversation::upsert_tool_call(self, call).await
+    async fn accept_tool_call(&self, call: &ToolCallRecord) -> Result<AcceptToolCallOutcome> {
+        ops::client_execution::accept_tool_call(self, call).await
+    }
+
+    async fn claim_client_tool_call(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        executor_id: uuid::Uuid,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        lease_expires_at: chrono::DateTime<Utc>,
+    ) -> Result<ClaimClientToolCallOutcome> {
+        ops::client_execution::claim_client_tool_call(
+            self,
+            id,
+            chat_id,
+            executor_id,
+            lease_token,
+            now,
+            lease_expires_at,
+        )
+        .await
+    }
+
+    async fn heartbeat_client_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        lease_expires_at: chrono::DateTime<Utc>,
+    ) -> Result<HeartbeatClientToolCallOutcome> {
+        ops::client_execution::heartbeat_client_tool_call(
+            self,
+            id,
+            lease_token,
+            now,
+            lease_expires_at,
+        )
+        .await
+    }
+
+    async fn resolve_server_tool_call(
+        &self,
+        id: CallId,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<Utc>,
+    ) -> Result<ResolveToolCallOutcome> {
+        ops::client_execution::resolve_server_tool_call(self, id, resolution, resolved_at).await
+    }
+
+    async fn resolve_client_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<Utc>,
+    ) -> Result<ResolveToolCallOutcome> {
+        ops::client_execution::resolve_client_tool_call(
+            self,
+            id,
+            lease_token,
+            now,
+            resolution,
+            resolved_at,
+        )
+        .await
+    }
+
+    async fn resolve_expired_client_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<Utc>,
+    ) -> Result<ResolveToolCallOutcome> {
+        ops::client_execution::resolve_expired_client_tool_call(
+            self,
+            id,
+            lease_token,
+            now,
+            resolution,
+            resolved_at,
+        )
+        .await
+    }
+
+    async fn list_pending_client_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {
+        ops::client_execution::list_pending_client_tool_calls(self, chat_id).await
     }
 
     async fn list_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {

--- a/crates/openwave-core/src/db/ops/client_execution.rs
+++ b/crates/openwave-core/src/db/ops/client_execution.rs
@@ -1,0 +1,520 @@
+use chrono::{DateTime, Utc};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
+
+use crate::error::{AgentError, Result};
+use crate::id::{CallId, ChatId};
+use crate::model::{ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus};
+use crate::storage::{
+    AcceptToolCallOutcome, ClaimClientToolCallOutcome, ClientToolCallClaim,
+    HeartbeatClientToolCallOutcome, ResolveToolCallOutcome,
+};
+
+use super::super::{entities, store_err, DbStore};
+use super::turn::canonical_db_timestamp;
+use super::{acquire_chat_write_lock, acquire_tool_call_write_lock};
+
+pub(in crate::db) async fn accept_tool_call(
+    store: &DbStore,
+    call: &ToolCallRecord,
+) -> Result<AcceptToolCallOutcome> {
+    validate_accept(call)?;
+    let created_at = canonical_db_timestamp(call.created_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, call.chat_id).await? {
+        return Err(AgentError::Store(format!(
+            "chat {} does not exist",
+            call.chat_id
+        )));
+    }
+    if let Some(existing) = entities::tool_call::Entity::find_by_id(call.id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let outcome = if immutable_request_matches(&existing, call, created_at) {
+            AcceptToolCallOutcome::Existing(tool_call_from_model(existing)?)
+        } else {
+            AcceptToolCallOutcome::IdentityConflict
+        };
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(outcome);
+    }
+
+    let inserted = entities::tool_call::ActiveModel {
+        id: Set(call.id.0),
+        chat_id: Set(call.chat_id.0),
+        turn_id: Set(call.turn_id.0),
+        provider_id: Set(call.provider_id.clone()),
+        name: Set(call.name.clone()),
+        arguments: Set(call.arguments.clone()),
+        execution: Set(call.execution.as_str().into()),
+        status: Set(ToolCallStatus::Pending.as_str().into()),
+        result: Set(None),
+        error_code: Set(None),
+        error_detail: Set(None),
+        client_executor_id: Set(None),
+        client_lease_token: Set(None),
+        client_lease_expires_at: Set(None),
+        created_at: Set(created_at),
+        resolved_at: Set(None),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    let inserted = tool_call_from_model(inserted)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(AcceptToolCallOutcome::Accepted(inserted))
+}
+
+pub(in crate::db) async fn claim_client_tool_call(
+    store: &DbStore,
+    id: CallId,
+    chat_id: ChatId,
+    executor_id: uuid::Uuid,
+    lease_token: uuid::Uuid,
+    now: DateTime<Utc>,
+    lease_expires_at: DateTime<Utc>,
+) -> Result<ClaimClientToolCallOutcome> {
+    let now = canonical_db_timestamp(now)?;
+    let lease_expires_at = canonical_db_timestamp(lease_expires_at)?;
+    if executor_id.is_nil() || lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "client executor id and lease token must not be nil".into(),
+        ));
+    }
+    if lease_expires_at <= now {
+        return Ok(ClaimClientToolCallOutcome::Unavailable);
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_tool_call_write_lock(&transaction, id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ClaimClientToolCallOutcome::Unavailable);
+    }
+    let existing = entities::tool_call::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .expect("locked tool call exists");
+    if existing.chat_id != chat_id.0
+        || existing.execution != ToolCallExecution::Client.as_str()
+        || existing.status != ToolCallStatus::Pending.as_str()
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ClaimClientToolCallOutcome::Unavailable);
+    }
+    if existing.client_executor_id == Some(executor_id)
+        && existing.client_lease_token == Some(lease_token)
+        && existing.client_lease_expires_at == Some(lease_expires_at)
+        && lease_expires_at > now
+    {
+        let claim = client_claim_from_model(existing)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ClaimClientToolCallOutcome::Existing(claim));
+    }
+    if existing.client_executor_id.is_some() {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ClaimClientToolCallOutcome::Unavailable);
+    }
+
+    let mut active: entities::tool_call::ActiveModel = existing.into();
+    active.client_executor_id = Set(Some(executor_id));
+    active.client_lease_token = Set(Some(lease_token));
+    active.client_lease_expires_at = Set(Some(lease_expires_at));
+    let claimed = active.update(&transaction).await.map_err(store_err)?;
+    let claim = client_claim_from_model(claimed)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(ClaimClientToolCallOutcome::Claimed(claim))
+}
+
+pub(in crate::db) async fn heartbeat_client_tool_call(
+    store: &DbStore,
+    id: CallId,
+    lease_token: uuid::Uuid,
+    now: DateTime<Utc>,
+    lease_expires_at: DateTime<Utc>,
+) -> Result<HeartbeatClientToolCallOutcome> {
+    let now = canonical_db_timestamp(now)?;
+    let lease_expires_at = canonical_db_timestamp(lease_expires_at)?;
+    validate_lease(lease_token, now, lease_expires_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_tool_call_write_lock(&transaction, id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(HeartbeatClientToolCallOutcome::LeaseLost);
+    }
+    let existing = entities::tool_call::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .expect("locked tool call exists");
+    let current_expiry = existing.client_lease_expires_at;
+    if existing.execution != ToolCallExecution::Client.as_str()
+        || existing.status != ToolCallStatus::Pending.as_str()
+        || existing.client_lease_token != Some(lease_token)
+        || current_expiry.is_none_or(|expiry| expiry <= now || lease_expires_at < expiry)
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(HeartbeatClientToolCallOutcome::LeaseLost);
+    }
+    if current_expiry == Some(lease_expires_at) {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(HeartbeatClientToolCallOutcome::Existing);
+    }
+    let mut active: entities::tool_call::ActiveModel = existing.into();
+    active.client_lease_expires_at = Set(Some(lease_expires_at));
+    active.update(&transaction).await.map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(HeartbeatClientToolCallOutcome::Extended)
+}
+
+pub(in crate::db) async fn resolve_server_tool_call(
+    store: &DbStore,
+    id: CallId,
+    resolution: &ToolCallResolution,
+    resolved_at: DateTime<Utc>,
+) -> Result<ResolveToolCallOutcome> {
+    resolve_tool_call(
+        store,
+        id,
+        ResolutionAuthority::Server,
+        resolved_at,
+        resolution,
+    )
+    .await
+}
+
+pub(in crate::db) async fn resolve_client_tool_call(
+    store: &DbStore,
+    id: CallId,
+    lease_token: uuid::Uuid,
+    now: DateTime<Utc>,
+    resolution: &ToolCallResolution,
+    resolved_at: DateTime<Utc>,
+) -> Result<ResolveToolCallOutcome> {
+    if lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "client lease token must not be nil".into(),
+        ));
+    }
+    resolve_tool_call(
+        store,
+        id,
+        ResolutionAuthority::LiveClient { lease_token, now },
+        resolved_at,
+        resolution,
+    )
+    .await
+}
+
+pub(in crate::db) async fn resolve_expired_client_tool_call(
+    store: &DbStore,
+    id: CallId,
+    lease_token: uuid::Uuid,
+    now: DateTime<Utc>,
+    resolution: &ToolCallResolution,
+    resolved_at: DateTime<Utc>,
+) -> Result<ResolveToolCallOutcome> {
+    if lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "client lease token must not be nil".into(),
+        ));
+    }
+    resolve_tool_call(
+        store,
+        id,
+        ResolutionAuthority::ExpiredClient { lease_token, now },
+        resolved_at,
+        resolution,
+    )
+    .await
+}
+
+pub(in crate::db) async fn list_pending_client_tool_calls(
+    store: &DbStore,
+    chat_id: ChatId,
+) -> Result<Vec<ToolCallRecord>> {
+    let models = entities::tool_call::Entity::find()
+        .filter(entities::tool_call::Column::ChatId.eq(chat_id.0))
+        .filter(entities::tool_call::Column::Execution.eq(ToolCallExecution::Client.as_str()))
+        .filter(entities::tool_call::Column::Status.eq(ToolCallStatus::Pending.as_str()))
+        .order_by_asc(entities::tool_call::Column::CreatedAt)
+        .order_by_asc(entities::tool_call::Column::Id)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    models.into_iter().map(tool_call_from_model).collect()
+}
+
+async fn resolve_tool_call(
+    store: &DbStore,
+    id: CallId,
+    authority: ResolutionAuthority,
+    resolved_at: DateTime<Utc>,
+    resolution: &ToolCallResolution,
+) -> Result<ResolveToolCallOutcome> {
+    validate_resolution(resolution)?;
+    let resolved_at = canonical_db_timestamp(resolved_at)?;
+    let authority = authority.canonicalized()?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_tool_call_write_lock(&transaction, id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ResolveToolCallOutcome::NotFound);
+    }
+    let existing = entities::tool_call::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .expect("locked tool call exists");
+    if resolved_at < existing.created_at {
+        transaction.commit().await.map_err(store_err)?;
+        return Err(AgentError::Store(
+            "tool call cannot resolve before it was created".into(),
+        ));
+    }
+    if existing.status != ToolCallStatus::Pending.as_str() {
+        let outcome = if !terminal_authority_matches(&existing, authority) {
+            ResolveToolCallOutcome::LeaseLost
+        } else if terminal_payload_matches(&existing, resolution, resolved_at) {
+            ResolveToolCallOutcome::Existing
+        } else {
+            ResolveToolCallOutcome::AlreadyTerminal
+        };
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(outcome);
+    }
+
+    let owns = match authority {
+        ResolutionAuthority::Server => existing.execution == ToolCallExecution::Server.as_str(),
+        ResolutionAuthority::LiveClient { lease_token, now } => {
+            existing.execution == ToolCallExecution::Client.as_str()
+                && existing.client_lease_token == Some(lease_token)
+                && existing
+                    .client_lease_expires_at
+                    .is_some_and(|expiry| expiry > now)
+        }
+        ResolutionAuthority::ExpiredClient { lease_token, now } => {
+            existing.execution == ToolCallExecution::Client.as_str()
+                && existing.client_lease_token == Some(lease_token)
+                && existing
+                    .client_lease_expires_at
+                    .is_some_and(|expiry| expiry <= now)
+        }
+    };
+    if !owns {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ResolveToolCallOutcome::LeaseLost);
+    }
+
+    let (error_code, error_detail) = resolution_error(resolution);
+    let mut active: entities::tool_call::ActiveModel = existing.into();
+    active.status = Set(resolution.status().as_str().into());
+    active.result = Set(Some(resolution.result().to_owned()));
+    active.error_code = Set(error_code);
+    active.error_detail = Set(error_detail);
+    active.client_lease_expires_at = Set(None);
+    active.resolved_at = Set(Some(resolved_at));
+    active.update(&transaction).await.map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(ResolveToolCallOutcome::Resolved)
+}
+
+#[derive(Clone, Copy)]
+enum ResolutionAuthority {
+    Server,
+    LiveClient {
+        lease_token: uuid::Uuid,
+        now: DateTime<Utc>,
+    },
+    ExpiredClient {
+        lease_token: uuid::Uuid,
+        now: DateTime<Utc>,
+    },
+}
+
+impl ResolutionAuthority {
+    fn canonicalized(self) -> Result<Self> {
+        Ok(match self {
+            Self::Server => Self::Server,
+            Self::LiveClient { lease_token, now } => Self::LiveClient {
+                lease_token,
+                now: canonical_db_timestamp(now)?,
+            },
+            Self::ExpiredClient { lease_token, now } => Self::ExpiredClient {
+                lease_token,
+                now: canonical_db_timestamp(now)?,
+            },
+        })
+    }
+
+    const fn lease_token(self) -> Option<uuid::Uuid> {
+        match self {
+            Self::Server => None,
+            Self::LiveClient { lease_token, .. } | Self::ExpiredClient { lease_token, .. } => {
+                Some(lease_token)
+            }
+        }
+    }
+}
+
+fn validate_accept(call: &ToolCallRecord) -> Result<()> {
+    let labels_valid = [call.provider_id.as_str(), call.name.as_str()]
+        .into_iter()
+        .all(|value| {
+            !value.is_empty()
+                && value.len() <= ToolCallRecord::MAX_LABEL_LEN
+                && !value.contains('\0')
+        });
+    let args_len = serde_json::to_vec(&call.arguments)
+        .map_err(|error| AgentError::Store(format!("serialize tool arguments: {error}")))?
+        .len();
+    if call.id.0.is_nil()
+        || !labels_valid
+        || args_len > ToolCallRecord::MAX_ARGUMENT_BYTES
+        || call.status != ToolCallStatus::Pending
+        || call.result.is_some()
+        || call.error_code.is_some()
+        || call.error_detail.is_some()
+        || call.client_executor_id.is_some()
+        || call.client_lease_expires_at.is_some()
+        || call.resolved_at.is_some()
+    {
+        return Err(AgentError::Store("invalid accepted tool call".into()));
+    }
+    Ok(())
+}
+
+fn validate_lease(
+    lease_token: uuid::Uuid,
+    now: DateTime<Utc>,
+    lease_expires_at: DateTime<Utc>,
+) -> Result<()> {
+    if lease_token.is_nil() || lease_expires_at <= now {
+        return Err(AgentError::Store("invalid client execution lease".into()));
+    }
+    Ok(())
+}
+
+fn validate_resolution(resolution: &ToolCallResolution) -> Result<()> {
+    let (error_code, error_detail) = resolution_error(resolution);
+    if resolution.result().len() > ToolCallRecord::MAX_RESULT_BYTES
+        || resolution.result().contains('\0')
+        || error_code.as_deref().is_some_and(|code| {
+            code.is_empty()
+                || code.len() > ToolCallRecord::MAX_ERROR_CODE_LEN
+                || code.contains('\0')
+        })
+        || error_detail.as_deref().is_some_and(|detail| {
+            detail.is_empty()
+                || detail.len() > ToolCallRecord::MAX_ERROR_DETAIL_LEN
+                || detail.contains('\0')
+        })
+    {
+        return Err(AgentError::Store("invalid tool call resolution".into()));
+    }
+    Ok(())
+}
+
+fn resolution_error(resolution: &ToolCallResolution) -> (Option<String>, Option<String>) {
+    match resolution {
+        ToolCallResolution::Failed {
+            error_code,
+            error_detail,
+            ..
+        } => (Some(error_code.clone()), error_detail.clone()),
+        ToolCallResolution::Completed { .. } | ToolCallResolution::Cancelled { .. } => (None, None),
+    }
+}
+
+fn immutable_request_matches(
+    model: &entities::tool_call::Model,
+    call: &ToolCallRecord,
+    created_at: DateTime<Utc>,
+) -> bool {
+    model.chat_id == call.chat_id.0
+        && model.turn_id == call.turn_id.0
+        && model.provider_id == call.provider_id
+        && model.name == call.name
+        && model.arguments == call.arguments
+        && model.execution == call.execution.as_str()
+        && model.created_at == created_at
+}
+
+fn terminal_authority_matches(
+    model: &entities::tool_call::Model,
+    authority: ResolutionAuthority,
+) -> bool {
+    match authority {
+        ResolutionAuthority::Server => {
+            model.execution == ToolCallExecution::Server.as_str()
+                && model.client_lease_token.is_none()
+        }
+        ResolutionAuthority::LiveClient { .. } | ResolutionAuthority::ExpiredClient { .. } => {
+            model.execution == ToolCallExecution::Client.as_str()
+                && model.client_lease_token == authority.lease_token()
+        }
+    }
+}
+
+fn terminal_payload_matches(
+    model: &entities::tool_call::Model,
+    resolution: &ToolCallResolution,
+    resolved_at: DateTime<Utc>,
+) -> bool {
+    let (error_code, error_detail) = resolution_error(resolution);
+    model.status == resolution.status().as_str()
+        && model.result.as_deref() == Some(resolution.result())
+        && model.error_code == error_code
+        && model.error_detail == error_detail
+        && model.resolved_at == Some(resolved_at)
+}
+
+pub(in crate::db) fn tool_call_from_model(
+    model: entities::tool_call::Model,
+) -> Result<ToolCallRecord> {
+    Ok(ToolCallRecord {
+        id: CallId(model.id),
+        chat_id: ChatId(model.chat_id),
+        turn_id: crate::id::TurnId(model.turn_id),
+        provider_id: model.provider_id,
+        name: model.name,
+        arguments: model.arguments,
+        execution: execution_from_db(&model.execution)?,
+        status: status_from_db(&model.status)?,
+        result: model.result,
+        error_code: model.error_code,
+        error_detail: model.error_detail,
+        client_executor_id: model.client_executor_id,
+        client_lease_expires_at: model.client_lease_expires_at,
+        created_at: model.created_at,
+        resolved_at: model.resolved_at,
+    })
+}
+
+fn client_claim_from_model(model: entities::tool_call::Model) -> Result<ClientToolCallClaim> {
+    let lease_token = model.client_lease_token.ok_or_else(|| {
+        AgentError::Store("claimed client tool call is missing its lease token".into())
+    })?;
+    Ok(ClientToolCallClaim {
+        call: tool_call_from_model(model)?,
+        lease_token,
+    })
+}
+
+fn execution_from_db(value: &str) -> Result<ToolCallExecution> {
+    match value {
+        "server" => Ok(ToolCallExecution::Server),
+        "client" => Ok(ToolCallExecution::Client),
+        _ => Err(AgentError::Store(format!("invalid tool execution {value}"))),
+    }
+}
+
+fn status_from_db(value: &str) -> Result<ToolCallStatus> {
+    match value {
+        "pending" => Ok(ToolCallStatus::Pending),
+        "completed" => Ok(ToolCallStatus::Completed),
+        "failed" => Ok(ToolCallStatus::Failed),
+        "cancelled" => Ok(ToolCallStatus::Cancelled),
+        _ => Err(AgentError::Store(format!("invalid tool status {value}"))),
+    }
+}

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -9,7 +9,7 @@ use sea_orm::{
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{CallId, ChatId, MessageId, ProjectId, TurnId};
+use crate::id::{ChatId, MessageId, ProjectId, TurnId};
 use crate::model::{Chat, Message, Role, ToolCallRecord, TurnRunStatus};
 
 use super::super::{entities, store_err, DbStore};
@@ -194,49 +194,19 @@ pub(in crate::db) async fn list_messages(store: &DbStore, chat_id: ChatId) -> Re
         .collect()
 }
 
-pub(in crate::db) async fn upsert_tool_call(store: &DbStore, call: &ToolCallRecord) -> Result<()> {
-    let model = entities::tool_call::ActiveModel {
-        id: Set(call.id.0),
-        chat_id: Set(call.chat_id.0),
-        turn_id: Set(call.turn_id.0),
-        provider_id: Set(call.provider_id.clone()),
-        name: Set(call.name.clone()),
-        arguments: Set(call.arguments.clone()),
-        result: Set(call.result.clone()),
-        is_error: Set(call.is_error),
-        created_at: Set(call.created_at),
-        completed_at: Set(call.completed_at),
-    };
-    entities::tool_call::Entity::insert(model)
-        .on_conflict(
-            OnConflict::column(entities::tool_call::Column::Id)
-                .update_columns([
-                    entities::tool_call::Column::Arguments,
-                    entities::tool_call::Column::Result,
-                    entities::tool_call::Column::IsError,
-                    entities::tool_call::Column::CompletedAt,
-                ])
-                .to_owned(),
-        )
-        .exec(&store.conn)
-        .await
-        .map_err(store_err)?;
-    Ok(())
-}
-
 pub(in crate::db) async fn list_tool_calls(
     store: &DbStore,
     chat_id: ChatId,
 ) -> Result<Vec<ToolCallRecord>> {
-    Ok(entities::tool_call::Entity::find()
+    entities::tool_call::Entity::find()
         .filter(entities::tool_call::Column::ChatId.eq(chat_id.0))
         .order_by_asc(entities::tool_call::Column::CreatedAt)
         .all(&store.conn)
         .await
         .map_err(store_err)?
         .into_iter()
-        .map(tool_call_from_model)
-        .collect())
+        .map(super::client_execution::tool_call_from_model)
+        .collect()
 }
 
 pub(in crate::db) async fn append_event(
@@ -482,21 +452,6 @@ fn message_from_model(model: entities::message::Model) -> Result<Message> {
         content: model.content,
         created_at: model.created_at,
     })
-}
-
-fn tool_call_from_model(model: entities::tool_call::Model) -> ToolCallRecord {
-    ToolCallRecord {
-        id: CallId(model.id),
-        chat_id: ChatId(model.chat_id),
-        turn_id: TurnId(model.turn_id),
-        provider_id: model.provider_id,
-        name: model.name,
-        arguments: model.arguments,
-        result: model.result,
-        is_error: model.is_error,
-        created_at: model.created_at,
-        completed_at: model.completed_at,
-    }
 }
 
 /// `Role` is persisted as its snake_case name (matching its serde encoding).

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -1,11 +1,12 @@
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};
 
 use crate::error::Result;
-use crate::id::{ChatId, TurnId};
+use crate::id::{CallId, ChatId, TurnId};
 
 use super::{entities, store_err};
 
 pub(in crate::db) mod blob;
+pub(in crate::db) mod client_execution;
 pub(in crate::db) mod conversation;
 pub(in crate::db) mod document;
 pub(in crate::db) mod turn;
@@ -24,6 +25,23 @@ where
             sea_orm::sea_query::Expr::col(entities::chat::Column::Title).into(),
         )
         .filter(entities::chat::Column::Id.eq(chat_id.0))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(locked.rows_affected == 1)
+}
+
+/// Acquire the cross-backend write lock for one tool-call row.
+pub(in crate::db) async fn acquire_tool_call_write_lock<C>(conn: &C, id: CallId) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let locked = entities::tool_call::Entity::update_many()
+        .col_expr(
+            entities::tool_call::Column::ResolvedAt,
+            sea_orm::sea_query::Expr::col(entities::tool_call::Column::ResolvedAt).into(),
+        )
+        .filter(entities::tool_call::Column::Id.eq(id.0))
         .exec(conn)
         .await
         .map_err(store_err)?;

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -616,9 +616,8 @@ pub(in crate::db) async fn heartbeat_turn_run(
 pub(in crate::db) fn canonical_db_timestamp(
     timestamp: chrono::DateTime<Utc>,
 ) -> Result<chrono::DateTime<Utc>> {
-    chrono::DateTime::from_timestamp_micros(timestamp.timestamp_micros()).ok_or_else(|| {
-        AgentError::Store("turn output timestamp is outside the database range".into())
-    })
+    chrono::DateTime::from_timestamp_micros(timestamp.timestamp_micros())
+        .ok_or_else(|| AgentError::Store("timestamp is outside the database range".into()))
 }
 
 async fn acquire_turn_claim_write_lock<C>(conn: &C) -> Result<()>

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::model::{
     ByteSpan, DocumentParseOutput, DocumentSourceBlob, DocumentSourceUpsert, SourceLocation,
+    ToolCallExecution, ToolCallResolution, ToolCallStatus,
 };
 use chrono::{DateTime, Utc};
 
@@ -7846,7 +7847,7 @@ async fn all_roles_round_trip() {
 }
 
 #[tokio::test]
-async fn tool_calls_roundtrip_and_upsert_preserves_created_at() {
+async fn server_tool_call_lifecycle_is_atomic_and_idempotent() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
@@ -7859,29 +7860,454 @@ async fn tool_calls_roundtrip_and_upsert_preserves_created_at() {
         provider_id: "tu_1".into(),
         name: "read_file".into(),
         arguments: serde_json::json!({"path": "note.txt"}),
+        execution: ToolCallExecution::Server,
+        status: ToolCallStatus::Pending,
         result: None,
-        is_error: false,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
         created_at: created,
-        completed_at: None,
+        resolved_at: None,
     };
-    store.upsert_tool_call(&call).await.unwrap();
+    assert!(matches!(
+        store.accept_tool_call(&call).await.unwrap(),
+        AcceptToolCallOutcome::Accepted(_)
+    ));
+    assert!(matches!(
+        store.accept_tool_call(&call).await.unwrap(),
+        AcceptToolCallOutcome::Existing(_)
+    ));
+    assert_eq!(
+        store
+            .accept_tool_call(&ToolCallRecord {
+                arguments: serde_json::json!({"path": "other.txt"}),
+                ..call.clone()
+            })
+            .await
+            .unwrap(),
+        AcceptToolCallOutcome::IdentityConflict
+    );
 
     let completed = DateTime::<Utc>::from_timestamp(1_700_000_011, 0).unwrap();
-    store
-        .upsert_tool_call(&ToolCallRecord {
-            result: Some("hello".into()),
-            is_error: false,
-            created_at: Utc::now(), // must not overwrite the original
-            completed_at: Some(completed),
-            ..call.clone()
-        })
-        .await
-        .unwrap();
+    let resolution = ToolCallResolution::Completed {
+        result: "hello".into(),
+    };
+    assert_eq!(
+        store
+            .resolve_server_tool_call(call.id, &resolution, completed)
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Resolved
+    );
+    assert_eq!(
+        store
+            .resolve_server_tool_call(call.id, &resolution, completed)
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Existing
+    );
+    match store.accept_tool_call(&call).await.unwrap() {
+        AcceptToolCallOutcome::Existing(existing) => {
+            assert_eq!(existing.status, ToolCallStatus::Completed);
+            assert_eq!(existing.result.as_deref(), Some("hello"));
+        }
+        outcome => panic!("unexpected terminal acceptance retry: {outcome:?}"),
+    }
+    assert_eq!(
+        store
+            .resolve_server_tool_call(
+                call.id,
+                &ToolCallResolution::Completed {
+                    result: "different".into(),
+                },
+                completed,
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::AlreadyTerminal
+    );
 
     let listed = store.list_tool_calls(chat.id).await.unwrap();
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].created_at, created);
-    assert_eq!(listed[0].completed_at, Some(completed));
+    assert_eq!(listed[0].resolved_at, Some(completed));
+    assert_eq!(listed[0].status, ToolCallStatus::Completed);
     assert_eq!(listed[0].result.as_deref(), Some("hello"));
     assert_eq!(listed[0].arguments, serde_json::json!({"path": "note.txt"}));
+}
+
+#[tokio::test]
+async fn client_tool_call_is_fenced_by_its_exact_lease() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let created_at = DateTime::<Utc>::from_timestamp(1_700_000_020, 0).unwrap();
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "tu_client".into(),
+        name: "select_folder".into(),
+        arguments: serde_json::json!({"hint": "Documents"}),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at,
+        resolved_at: None,
+    };
+    assert!(matches!(
+        store.accept_tool_call(&call).await.unwrap(),
+        AcceptToolCallOutcome::Accepted(_)
+    ));
+    assert_eq!(
+        store
+            .resolve_server_tool_call(
+                call.id,
+                &ToolCallResolution::Cancelled {
+                    result: "not selected".into(),
+                },
+                created_at + chrono::Duration::seconds(1),
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::LeaseLost
+    );
+    assert_eq!(
+        store.list_pending_client_tool_calls(chat.id).await.unwrap(),
+        vec![call.clone()]
+    );
+
+    let executor = uuid::Uuid::new_v4();
+    let requested_lease_token = uuid::Uuid::new_v4();
+    let claimed_at = created_at + chrono::Duration::seconds(1);
+    let first_expiry = claimed_at + chrono::Duration::minutes(1);
+    let claimed = match store
+        .claim_client_tool_call(
+            call.id,
+            chat.id,
+            executor,
+            requested_lease_token,
+            claimed_at,
+            first_expiry,
+        )
+        .await
+        .unwrap()
+    {
+        ClaimClientToolCallOutcome::Claimed(claim) => claim,
+        outcome => panic!("unexpected claim outcome: {outcome:?}"),
+    };
+    assert_eq!(claimed.call.client_executor_id, Some(executor));
+    let lease_token = claimed.lease_token;
+    assert_eq!(lease_token, requested_lease_token);
+    assert!(!serde_json::to_string(&claimed.call)
+        .unwrap()
+        .contains(&lease_token.to_string()));
+    assert!(!format!("{claimed:?}").contains(&lease_token.to_string()));
+    assert_eq!(claimed.call.client_lease_expires_at, Some(first_expiry));
+    assert!(matches!(
+        store
+            .claim_client_tool_call(
+                call.id,
+                chat.id,
+                executor,
+                lease_token,
+                claimed_at,
+                first_expiry,
+            )
+            .await
+            .unwrap(),
+        ClaimClientToolCallOutcome::Existing(_)
+    ));
+    assert_eq!(
+        store
+            .claim_client_tool_call(
+                call.id,
+                chat.id,
+                executor,
+                uuid::Uuid::new_v4(),
+                claimed_at,
+                first_expiry,
+            )
+            .await
+            .unwrap(),
+        ClaimClientToolCallOutcome::Unavailable
+    );
+    assert_eq!(
+        store
+            .claim_client_tool_call(
+                call.id,
+                chat.id,
+                uuid::Uuid::new_v4(),
+                uuid::Uuid::new_v4(),
+                claimed_at,
+                first_expiry,
+            )
+            .await
+            .unwrap(),
+        ClaimClientToolCallOutcome::Unavailable
+    );
+
+    let extended_expiry = first_expiry + chrono::Duration::minutes(1);
+    assert_eq!(
+        store
+            .heartbeat_client_tool_call(
+                call.id,
+                lease_token,
+                claimed_at + chrono::Duration::seconds(1),
+                extended_expiry,
+            )
+            .await
+            .unwrap(),
+        HeartbeatClientToolCallOutcome::Extended
+    );
+    assert_eq!(
+        store
+            .heartbeat_client_tool_call(
+                call.id,
+                lease_token,
+                claimed_at + chrono::Duration::seconds(1),
+                extended_expiry,
+            )
+            .await
+            .unwrap(),
+        HeartbeatClientToolCallOutcome::Existing
+    );
+    let resolution = ToolCallResolution::Failed {
+        result: "folder picker failed".into(),
+        error_code: "picker_failed".into(),
+        error_detail: Some("native dialog closed unexpectedly".into()),
+    };
+    let resolved_at = claimed_at + chrono::Duration::seconds(2);
+    assert_eq!(
+        store
+            .resolve_client_tool_call(
+                call.id,
+                uuid::Uuid::new_v4(),
+                resolved_at,
+                &resolution,
+                resolved_at,
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::LeaseLost
+    );
+    assert_eq!(
+        store
+            .resolve_client_tool_call(call.id, lease_token, resolved_at, &resolution, resolved_at)
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Resolved
+    );
+    assert_eq!(
+        store
+            .resolve_client_tool_call(call.id, lease_token, resolved_at, &resolution, resolved_at)
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Existing
+    );
+    assert_eq!(
+        store
+            .resolve_client_tool_call(
+                call.id,
+                uuid::Uuid::new_v4(),
+                resolved_at,
+                &resolution,
+                resolved_at,
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::LeaseLost
+    );
+    assert_eq!(
+        store
+            .resolve_server_tool_call(call.id, &resolution, resolved_at)
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::LeaseLost
+    );
+    assert!(store
+        .list_pending_client_tool_calls(chat.id)
+        .await
+        .unwrap()
+        .is_empty());
+    let stored = store.list_tool_calls(chat.id).await.unwrap().pop().unwrap();
+    assert_eq!(stored.status, ToolCallStatus::Failed);
+    assert_eq!(stored.error_code.as_deref(), Some("picker_failed"));
+    assert_eq!(stored.client_executor_id, Some(executor));
+    assert_eq!(stored.client_lease_expires_at, None);
+}
+
+#[tokio::test]
+async fn expired_client_lease_is_not_transferred_implicitly() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let created_at = DateTime::<Utc>::from_timestamp(1_700_000_030, 0).unwrap();
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "tu_picker".into(),
+        name: "select_folder".into(),
+        arguments: serde_json::json!({}),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at,
+        resolved_at: None,
+    };
+    store.accept_tool_call(&call).await.unwrap();
+    assert!(matches!(
+        store.accept_tool_call(&call).await.unwrap(),
+        AcceptToolCallOutcome::Existing(_)
+    ));
+    let first = uuid::Uuid::new_v4();
+    let requested_lease_token = uuid::Uuid::new_v4();
+    let claimed_at = created_at + chrono::Duration::seconds(1);
+    let expiry = claimed_at + chrono::Duration::seconds(5);
+    let lease_token = match store
+        .claim_client_tool_call(
+            call.id,
+            chat.id,
+            first,
+            requested_lease_token,
+            claimed_at,
+            expiry,
+        )
+        .await
+        .unwrap()
+    {
+        ClaimClientToolCallOutcome::Claimed(claim) => claim.lease_token,
+        outcome => panic!("unexpected claim outcome: {outcome:?}"),
+    };
+    let after_expiry = expiry + chrono::Duration::seconds(1);
+    assert_eq!(
+        store
+            .claim_client_tool_call(
+                call.id,
+                chat.id,
+                uuid::Uuid::new_v4(),
+                uuid::Uuid::new_v4(),
+                after_expiry,
+                after_expiry + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        ClaimClientToolCallOutcome::Unavailable
+    );
+    assert_eq!(
+        store
+            .resolve_client_tool_call(
+                call.id,
+                lease_token,
+                after_expiry,
+                &ToolCallResolution::Cancelled {
+                    result: "cancelled".into(),
+                },
+                after_expiry,
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::LeaseLost
+    );
+    let recovered = ToolCallResolution::Cancelled {
+        result: "cancelled after native receipt recovery".into(),
+    };
+    assert_eq!(
+        store
+            .resolve_expired_client_tool_call(
+                call.id,
+                lease_token,
+                after_expiry,
+                &recovered,
+                after_expiry,
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Resolved
+    );
+    assert_eq!(
+        store
+            .resolve_expired_client_tool_call(
+                call.id,
+                lease_token,
+                after_expiry,
+                &recovered,
+                after_expiry,
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Existing
+    );
+}
+
+#[tokio::test]
+async fn concurrent_client_claim_has_one_sqlite_winner() {
+    let (_dir, store) = temp_store().await;
+    let store = std::sync::Arc::new(store);
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let created_at = DateTime::<Utc>::from_timestamp(1_700_000_040, 123_456_789).unwrap();
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "tu_race".into(),
+        name: "select_folder".into(),
+        arguments: serde_json::json!({}),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at,
+        resolved_at: None,
+    };
+    store.accept_tool_call(&call).await.unwrap();
+    let claim_at = created_at + chrono::Duration::seconds(1);
+    let lease_expires_at = claim_at + chrono::Duration::minutes(1);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        let executor_id = uuid::Uuid::new_v4();
+        let lease_token = uuid::Uuid::new_v4();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .claim_client_tool_call(
+                    call.id,
+                    chat.id,
+                    executor_id,
+                    lease_token,
+                    claim_at,
+                    lease_expires_at,
+                )
+                .await
+                .unwrap()
+        }));
+    }
+    let mut claimed = 0;
+    let mut unavailable = 0;
+    for task in tasks {
+        match task.await.unwrap() {
+            ClaimClientToolCallOutcome::Claimed(_) => claimed += 1,
+            ClaimClientToolCallOutcome::Unavailable => unavailable += 1,
+            outcome => panic!("unexpected concurrent claim outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!(claimed, 1);
+    assert_eq!(unavailable, 7);
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -57,8 +57,9 @@ pub use model::{
     DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
     DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
     DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
-    Project, Role, SourceLocation, SourceRegion, ToolCallRecord, TurnFailureReceipt,
-    TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus,
+    Project, Role, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
+    ToolCallResolution, ToolCallStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun,
+    TurnRunStatus, TurnSteer, TurnSteerStatus,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
@@ -66,11 +67,13 @@ pub use provider::{
 };
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, ApplyTurnSteerOutcome, BlobStore,
-    ClaimScanTerminalEvent, ClaimTurnRunOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
+    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, ApplyTurnSteerOutcome,
+    BlobStore, ClaimClientToolCallOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome,
+    ClientToolCallClaim, CompleteTurnRunOutcome, DocumentIndexJobReason,
     EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
-    JournaledTurnOutcome, JournaledTurnSteerOutcome, RecordTurnFailureOutcome,
-    RequestTurnCancellationOutcome, SecretProvider, Store,
+    HeartbeatClientToolCallOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome,
+    SecretProvider, Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -834,7 +834,98 @@ pub struct Message {
     pub created_at: DateTime<Utc>,
 }
 
-/// A persisted tool invocation — name, arguments, and (once finished) result.
+/// Where an accepted tool invocation must execute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolCallExecution {
+    /// Execute inside the server-owned agent runtime.
+    Server,
+    /// Execute through a separately leased trusted client surface.
+    Client,
+}
+
+impl ToolCallExecution {
+    /// Stable database and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Server => "server",
+            Self::Client => "client",
+        }
+    }
+}
+
+/// Durable lifecycle of one tool invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolCallStatus {
+    /// Canonical arguments are committed and execution has not resolved.
+    Pending,
+    /// Execution returned a successful model-facing result.
+    Completed,
+    /// Execution returned a stable failure and model-facing result.
+    Failed,
+    /// Execution was intentionally cancelled with a model-facing result.
+    Cancelled,
+}
+
+impl ToolCallStatus {
+    /// Stable database and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// Whether execution has a durable final result.
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        !matches!(self, Self::Pending)
+    }
+}
+
+/// Exact terminal payload used for idempotent tool-call resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolCallResolution {
+    /// Successful execution.
+    Completed { result: String },
+    /// Failed execution with stable machine and optional diagnostic detail.
+    Failed {
+        result: String,
+        error_code: String,
+        error_detail: Option<String>,
+    },
+    /// Intentional cancellation, including a user declining a native prompt.
+    Cancelled { result: String },
+}
+
+impl ToolCallResolution {
+    /// Terminal state represented by this payload.
+    #[must_use]
+    pub const fn status(&self) -> ToolCallStatus {
+        match self {
+            Self::Completed { .. } => ToolCallStatus::Completed,
+            Self::Failed { .. } => ToolCallStatus::Failed,
+            Self::Cancelled { .. } => ToolCallStatus::Cancelled,
+        }
+    }
+
+    /// Model-facing result for this terminal outcome.
+    #[must_use]
+    pub fn result(&self) -> &str {
+        match self {
+            Self::Completed { result }
+            | Self::Failed { result, .. }
+            | Self::Cancelled { result } => result,
+        }
+    }
+}
+
+/// A persisted tool invocation — canonical identity, arguments, and lifecycle.
 ///
 /// Distinct from [`Message`]: the model transcript rebuilds `ToolUse` /
 /// `ToolResult` blocks from these rows so cross-turn context keeps structured
@@ -853,15 +944,37 @@ pub struct ToolCallRecord {
     pub name: String,
     /// Parsed JSON arguments.
     pub arguments: serde_json::Value,
-    /// Result text fed back to the model, once completed.
+    /// Which trusted surface owns execution.
+    pub execution: ToolCallExecution,
+    /// Durable execution state.
+    pub status: ToolCallStatus,
+    /// Result text fed back to the model once terminal.
     pub result: Option<String>,
-    /// Whether the tool reported a failure.
-    #[serde(default)]
-    pub is_error: bool,
+    /// Stable machine-readable failure code, only for `failed`.
+    pub error_code: Option<String>,
+    /// Bounded diagnostic failure detail, only for `failed`.
+    pub error_detail: Option<String>,
+    /// Exact client executor that owns the pending lease or resolved the call.
+    pub client_executor_id: Option<Uuid>,
+    /// Expiry of the exact client executor lease.
+    pub client_lease_expires_at: Option<DateTime<Utc>>,
     /// When the call was recorded (args known).
     pub created_at: DateTime<Utc>,
-    /// When the result was written, if completed.
-    pub completed_at: Option<DateTime<Utc>>,
+    /// When the terminal outcome was written.
+    pub resolved_at: Option<DateTime<Utc>>,
+}
+
+impl ToolCallRecord {
+    /// Maximum UTF-8 bytes accepted for provider identity or tool name.
+    pub const MAX_LABEL_LEN: usize = 256;
+    /// Maximum serialized canonical argument bytes.
+    pub const MAX_ARGUMENT_BYTES: usize = 128 * 1024;
+    /// Maximum model-facing terminal result bytes.
+    pub const MAX_RESULT_BYTES: usize = 512 * 1024;
+    /// Maximum stable failure code bytes.
+    pub const MAX_ERROR_CODE_LEN: usize = 128;
+    /// Maximum diagnostic failure detail bytes.
+    pub const MAX_ERROR_DETAIL_LEN: usize = 4 * 1024;
 }
 
 #[cfg(test)]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -20,12 +20,12 @@ use serde_json::Value;
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{ChatId, DocumentId, DocumentJobId, ProjectId, TurnId, TurnSteerId};
+use crate::id::{CallId, ChatId, DocumentId, DocumentJobId, ProjectId, TurnId, TurnSteerId};
 use crate::model::{
     BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
     DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentRecord, DocumentScope,
     DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
-    TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
+    ToolCallResolution, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
 };
 use crate::provider::{StopReason, Usage};
 
@@ -171,6 +171,77 @@ pub enum FinishTurnCancellationOutcome {
     Cancelled(TurnRun),
     /// This exact claimed attempt already reached terminal cancellation.
     Existing(TurnRun),
+}
+
+/// Result of durably accepting canonical tool-call arguments.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AcceptToolCallOutcome {
+    /// The identity and immutable request were inserted.
+    Accepted(ToolCallRecord),
+    /// An exact retry found the same immutable request.
+    Existing(ToolCallRecord),
+    /// The call identity already names different immutable request bytes.
+    IdentityConflict,
+}
+
+/// A client claim and its secret per-claim fencing receipt.
+///
+/// The token is returned only by claim, never by general pending/history reads
+/// or by serializing [`ToolCallRecord`].
+#[derive(Clone, PartialEq)]
+pub struct ClientToolCallClaim {
+    /// Canonical committed work and visible lease metadata.
+    pub call: ToolCallRecord,
+    /// Secret capability required to heartbeat or resolve this claim.
+    pub lease_token: uuid::Uuid,
+}
+
+impl std::fmt::Debug for ClientToolCallClaim {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ClientToolCallClaim")
+            .field("call", &self.call)
+            .field("lease_token", &"[redacted]")
+            .finish()
+    }
+}
+
+/// Result of claiming one pending client-executed call.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ClaimClientToolCallOutcome {
+    /// This executor acquired the first lease.
+    Claimed(ClientToolCallClaim),
+    /// An exact retry by the same executor recovered its live lease.
+    Existing(ClientToolCallClaim),
+    /// The call is missing, terminal, server-executed, owned by another client,
+    /// or has an expired ambiguous client lease.
+    Unavailable,
+}
+
+/// Result of extending one exact client-execution lease.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeartbeatClientToolCallOutcome {
+    /// The lease expiry advanced.
+    Extended,
+    /// An exact retry found that expiry already installed.
+    Existing,
+    /// The call, pending state, executor, or live lease no longer matches.
+    LeaseLost,
+}
+
+/// Result of resolving one tool call under its required authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolveToolCallOutcome {
+    /// The pending call became terminal.
+    Resolved,
+    /// An exact ambiguous retry recovered the same terminal payload.
+    Existing,
+    /// The call identity was not found.
+    NotFound,
+    /// The call was already terminal under a different payload.
+    AlreadyTerminal,
+    /// The requested execution surface or exact live client lease did not own it.
+    LeaseLost,
 }
 
 /// A durable turn transition together with any terminal event committed by it.
@@ -915,8 +986,62 @@ pub trait Store: Send + Sync {
     /// List a chat's messages in creation order.
     async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>>;
 
-    /// Upsert a tool call (insert on first sight, update result on completion).
-    async fn upsert_tool_call(&self, call: &ToolCallRecord) -> Result<()>;
+    /// Accept immutable canonical tool-call identity and arguments exactly once.
+    async fn accept_tool_call(&self, call: &ToolCallRecord) -> Result<AcceptToolCallOutcome>;
+
+    /// Claim the first lease with a caller-generated secret fencing token.
+    async fn claim_client_tool_call(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        executor_id: uuid::Uuid,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ClaimClientToolCallOutcome>;
+
+    /// Monotonically extend an exact live client-execution lease.
+    async fn heartbeat_client_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<HeartbeatClientToolCallOutcome>;
+
+    /// Resolve a pending server-executed tool call exactly once.
+    async fn resolve_server_tool_call(
+        &self,
+        id: CallId,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ResolveToolCallOutcome>;
+
+    /// Resolve a pending client call under its exact unexpired executor lease.
+    async fn resolve_client_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ResolveToolCallOutcome>;
+
+    /// Resolve a known outcome after the exact client lease expired.
+    ///
+    /// This is the explicit recovery path for an ambiguous native interaction;
+    /// it never transfers the call to another executor.
+    async fn resolve_expired_client_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ResolveToolCallOutcome>;
+
+    /// List unclaimed and claimed client work for authoritative recovery.
+    async fn list_pending_client_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>>;
 
     /// List a chat's tool calls in creation order.
     async fn list_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>>;

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -5,7 +5,9 @@ use std::sync::Mutex;
 use futures::executor::block_on;
 
 use super::*;
-use crate::model::{DocumentJobKind, DocumentJobStatus, DocumentProcessingStatus};
+use crate::model::{
+    DocumentJobKind, DocumentJobStatus, DocumentProcessingStatus, ToolCallExecution, ToolCallStatus,
+};
 
 /// Minimal in-memory `Store` — proves the trait is object-safe and usable
 /// behind `Arc<dyn Store>`, and exercises the signatures.
@@ -26,6 +28,84 @@ struct MemStore {
     settings: Mutex<HashMap<String, Value>>,
     events: Mutex<Vec<(ChatId, SequencedEvent)>>,
     tool_calls: Mutex<HashMap<crate::id::CallId, ToolCallRecord>>,
+    tool_call_lease_tokens: Mutex<HashMap<crate::id::CallId, uuid::Uuid>>,
+}
+
+impl MemStore {
+    fn resolve_mem_tool_call(
+        &self,
+        id: CallId,
+        client_authority: Option<(uuid::Uuid, chrono::DateTime<chrono::Utc>, bool)>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ResolveToolCallOutcome> {
+        let mut calls = self.tool_calls.lock().unwrap();
+        let Some(call) = calls.get_mut(&id) else {
+            return Ok(ResolveToolCallOutcome::NotFound);
+        };
+        let stored_lease_token = self
+            .tool_call_lease_tokens
+            .lock()
+            .unwrap()
+            .get(&id)
+            .copied();
+        let (error_code, error_detail) = match resolution {
+            ToolCallResolution::Failed {
+                error_code,
+                error_detail,
+                ..
+            } => (Some(error_code.clone()), error_detail.clone()),
+            ToolCallResolution::Completed { .. } | ToolCallResolution::Cancelled { .. } => {
+                (None, None)
+            }
+        };
+        if call.status.is_terminal() {
+            let authority_matches = match client_authority {
+                None => call.execution == ToolCallExecution::Server && stored_lease_token.is_none(),
+                Some((lease_token, _, _)) => {
+                    call.execution == ToolCallExecution::Client
+                        && stored_lease_token == Some(lease_token)
+                }
+            };
+            if !authority_matches {
+                return Ok(ResolveToolCallOutcome::LeaseLost);
+            }
+            let exact = call.status == resolution.status()
+                && call.result.as_deref() == Some(resolution.result())
+                && call.error_code == error_code
+                && call.error_detail == error_detail
+                && call.resolved_at == Some(resolved_at);
+            return Ok(if exact {
+                ResolveToolCallOutcome::Existing
+            } else {
+                ResolveToolCallOutcome::AlreadyTerminal
+            });
+        }
+        let owns = match client_authority {
+            None => call.execution == ToolCallExecution::Server,
+            Some((lease_token, now, expired)) => {
+                call.execution == ToolCallExecution::Client
+                    && stored_lease_token == Some(lease_token)
+                    && call.client_lease_expires_at.is_some_and(|expiry| {
+                        if expired {
+                            expiry <= now
+                        } else {
+                            expiry > now
+                        }
+                    })
+            }
+        };
+        if !owns {
+            return Ok(ResolveToolCallOutcome::LeaseLost);
+        }
+        call.status = resolution.status();
+        call.result = Some(resolution.result().to_owned());
+        call.error_code = error_code;
+        call.error_detail = error_detail;
+        call.client_lease_expires_at = None;
+        call.resolved_at = Some(resolved_at);
+        Ok(ResolveToolCallOutcome::Resolved)
+    }
 }
 
 fn allocate_mem_generation(
@@ -1132,17 +1212,158 @@ impl Store for MemStore {
     async fn list_messages(&self, _chat_id: ChatId) -> Result<Vec<Message>> {
         Ok(vec![])
     }
-    async fn upsert_tool_call(&self, call: &ToolCallRecord) -> Result<()> {
+    async fn accept_tool_call(&self, call: &ToolCallRecord) -> Result<AcceptToolCallOutcome> {
         let mut calls = self.tool_calls.lock().unwrap();
-        if let Some(existing) = calls.get_mut(&call.id) {
-            existing.arguments = call.arguments.clone();
-            existing.result = call.result.clone();
-            existing.is_error = call.is_error;
-            existing.completed_at = call.completed_at;
-        } else {
-            calls.insert(call.id, call.clone());
+        if let Some(existing) = calls.get(&call.id) {
+            let matches = existing.chat_id == call.chat_id
+                && existing.turn_id == call.turn_id
+                && existing.provider_id == call.provider_id
+                && existing.name == call.name
+                && existing.arguments == call.arguments
+                && existing.execution == call.execution
+                && existing.created_at == call.created_at;
+            return Ok(if matches {
+                AcceptToolCallOutcome::Existing(existing.clone())
+            } else {
+                AcceptToolCallOutcome::IdentityConflict
+            });
         }
-        Ok(())
+        calls.insert(call.id, call.clone());
+        Ok(AcceptToolCallOutcome::Accepted(call.clone()))
+    }
+    async fn claim_client_tool_call(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        executor_id: uuid::Uuid,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ClaimClientToolCallOutcome> {
+        let mut calls = self.tool_calls.lock().unwrap();
+        let Some(call) = calls.get_mut(&id) else {
+            return Ok(ClaimClientToolCallOutcome::Unavailable);
+        };
+        if call.chat_id != chat_id
+            || call.execution != ToolCallExecution::Client
+            || call.status != ToolCallStatus::Pending
+        {
+            return Ok(ClaimClientToolCallOutcome::Unavailable);
+        }
+        if call.client_executor_id == Some(executor_id)
+            && call.client_lease_expires_at == Some(lease_expires_at)
+            && lease_expires_at > now
+        {
+            let stored_lease_token = self
+                .tool_call_lease_tokens
+                .lock()
+                .unwrap()
+                .get(&id)
+                .copied()
+                .ok_or_else(|| AgentError::Store("client claim token is missing".into()))?;
+            if stored_lease_token != lease_token {
+                return Ok(ClaimClientToolCallOutcome::Unavailable);
+            }
+            return Ok(ClaimClientToolCallOutcome::Existing(ClientToolCallClaim {
+                call: call.clone(),
+                lease_token: stored_lease_token,
+            }));
+        }
+        if call.client_executor_id.is_some()
+            || executor_id.is_nil()
+            || lease_token.is_nil()
+            || lease_expires_at <= now
+        {
+            return Ok(ClaimClientToolCallOutcome::Unavailable);
+        }
+        call.client_executor_id = Some(executor_id);
+        self.tool_call_lease_tokens
+            .lock()
+            .unwrap()
+            .insert(id, lease_token);
+        call.client_lease_expires_at = Some(lease_expires_at);
+        Ok(ClaimClientToolCallOutcome::Claimed(ClientToolCallClaim {
+            call: call.clone(),
+            lease_token,
+        }))
+    }
+    async fn heartbeat_client_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<HeartbeatClientToolCallOutcome> {
+        let mut calls = self.tool_calls.lock().unwrap();
+        let Some(call) = calls.get_mut(&id) else {
+            return Ok(HeartbeatClientToolCallOutcome::LeaseLost);
+        };
+        let Some(current_expiry) = call.client_lease_expires_at else {
+            return Ok(HeartbeatClientToolCallOutcome::LeaseLost);
+        };
+        if call.execution != ToolCallExecution::Client
+            || call.status != ToolCallStatus::Pending
+            || self
+                .tool_call_lease_tokens
+                .lock()
+                .unwrap()
+                .get(&id)
+                .copied()
+                != Some(lease_token)
+            || current_expiry <= now
+            || lease_expires_at < current_expiry
+        {
+            return Ok(HeartbeatClientToolCallOutcome::LeaseLost);
+        }
+        if lease_expires_at == current_expiry {
+            return Ok(HeartbeatClientToolCallOutcome::Existing);
+        }
+        call.client_lease_expires_at = Some(lease_expires_at);
+        Ok(HeartbeatClientToolCallOutcome::Extended)
+    }
+    async fn resolve_server_tool_call(
+        &self,
+        id: CallId,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ResolveToolCallOutcome> {
+        self.resolve_mem_tool_call(id, None, resolution, resolved_at)
+    }
+    async fn resolve_client_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ResolveToolCallOutcome> {
+        self.resolve_mem_tool_call(id, Some((lease_token, now, false)), resolution, resolved_at)
+    }
+    async fn resolve_expired_client_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ResolveToolCallOutcome> {
+        self.resolve_mem_tool_call(id, Some((lease_token, now, true)), resolution, resolved_at)
+    }
+    async fn list_pending_client_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {
+        let mut calls: Vec<_> = self
+            .tool_calls
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|call| {
+                call.chat_id == chat_id
+                    && call.execution == ToolCallExecution::Client
+                    && call.status == ToolCallStatus::Pending
+            })
+            .cloned()
+            .collect();
+        calls.sort_by_key(|call| (call.created_at, call.id.0));
+        Ok(calls)
     }
     async fn list_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {
         let mut calls: Vec<_> = self

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -5,11 +5,16 @@ use std::sync::Arc;
 
 use chrono::{Duration, Utc};
 use openwave_core::{
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentEvent, ApplyTurnSteerOutcome, Chat, ChatId,
-    CompleteTurnRunOutcome, DbStore, FinishTurnCancellationOutcome, Message, MessageId,
-    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, Role, StopReason, Store,
-    TurnFailureRetry, TurnId, TurnRunStatus, TurnSteerId, TurnSteerStatus, Usage,
+    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentEvent,
+    ApplyTurnSteerOutcome, CallId, Chat, ChatId, ClaimClientToolCallOutcome,
+    CompleteTurnRunOutcome, DbStore, FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome,
+    Message, MessageId, RecordTurnFailureOutcome, RequestTurnCancellationOutcome,
+    ResolveToolCallOutcome, Role, StopReason, Store, ToolCallExecution, ToolCallRecord,
+    ToolCallResolution, ToolCallStatus, TurnFailureRetry, TurnId, TurnRunStatus, TurnSteerId,
+    TurnSteerStatus, Usage,
 };
+
+static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 fn sample_chat() -> Chat {
     Chat {
@@ -23,7 +28,151 @@ fn sample_chat() -> Chat {
 }
 
 #[tokio::test]
+async fn postgres_client_execution_claim_has_one_winner() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = Arc::new(DbStore::connect(&url).await.unwrap());
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let created_at = chrono::DateTime::<Utc>::from_timestamp(1_800_000_000, 123_456_789).unwrap();
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "postgres_client_call".into(),
+        name: "select_folder".into(),
+        arguments: serde_json::json!({"reason": "test"}),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at,
+        resolved_at: None,
+    };
+    assert!(matches!(
+        store.accept_tool_call(&call).await.unwrap(),
+        AcceptToolCallOutcome::Accepted(_)
+    ));
+    assert!(matches!(
+        store.accept_tool_call(&call).await.unwrap(),
+        AcceptToolCallOutcome::Existing(_)
+    ));
+
+    let claim_at = created_at + Duration::seconds(1);
+    let lease_expires_at = claim_at + Duration::minutes(1);
+    let barrier = Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        let executor = uuid::Uuid::new_v4();
+        let lease_token = uuid::Uuid::new_v4();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            (
+                executor,
+                lease_token,
+                store
+                    .claim_client_tool_call(
+                        call.id,
+                        chat.id,
+                        executor,
+                        lease_token,
+                        claim_at,
+                        lease_expires_at,
+                    )
+                    .await
+                    .unwrap(),
+            )
+        }));
+    }
+    let mut winner = None;
+    for task in tasks {
+        let (executor, requested_lease_token, outcome) = task.await.unwrap();
+        match outcome {
+            ClaimClientToolCallOutcome::Claimed(claim) => {
+                assert_eq!(claim.lease_token, requested_lease_token);
+                assert!(
+                    winner.replace((executor, claim.lease_token)).is_none(),
+                    "multiple claim winners"
+                );
+            }
+            ClaimClientToolCallOutcome::Unavailable => {}
+            outcome => panic!("unexpected concurrent claim outcome: {outcome:?}"),
+        }
+    }
+    let (winner, lease_token) = winner.expect("one client executor claimed the call");
+    assert!(matches!(
+        store
+            .claim_client_tool_call(
+                call.id,
+                chat.id,
+                winner,
+                lease_token,
+                claim_at,
+                lease_expires_at,
+            )
+            .await
+            .unwrap(),
+        ClaimClientToolCallOutcome::Existing(_)
+    ));
+    let extended_expiry = lease_expires_at + Duration::minutes(1);
+    assert_eq!(
+        store
+            .heartbeat_client_tool_call(
+                call.id,
+                lease_token,
+                claim_at + Duration::seconds(1),
+                extended_expiry,
+            )
+            .await
+            .unwrap(),
+        HeartbeatClientToolCallOutcome::Extended
+    );
+    assert_eq!(
+        store
+            .heartbeat_client_tool_call(
+                call.id,
+                lease_token,
+                claim_at + Duration::seconds(1),
+                extended_expiry,
+            )
+            .await
+            .unwrap(),
+        HeartbeatClientToolCallOutcome::Existing
+    );
+    let resolved_at = claim_at + Duration::seconds(1);
+    let resolution = ToolCallResolution::Completed {
+        result: "selected".into(),
+    };
+    assert_eq!(
+        store
+            .resolve_client_tool_call(call.id, lease_token, resolved_at, &resolution, resolved_at,)
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Resolved
+    );
+    assert_eq!(
+        store
+            .resolve_client_tool_call(call.id, lease_token, resolved_at, &resolution, resolved_at,)
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Existing
+    );
+}
+
+#[tokio::test]
 async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
     let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
         Ok(url) => url,
         Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -944,8 +944,75 @@ impl Store for PauseTerminalStore {
     async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>> {
         self.inner.list_messages(chat_id).await
     }
-    async fn upsert_tool_call(&self, call: &openwave_core::ToolCallRecord) -> Result<()> {
-        self.inner.upsert_tool_call(call).await
+    async fn accept_tool_call(
+        &self,
+        call: &openwave_core::ToolCallRecord,
+    ) -> Result<openwave_core::AcceptToolCallOutcome> {
+        self.inner.accept_tool_call(call).await
+    }
+    async fn claim_client_tool_call(
+        &self,
+        id: openwave_core::CallId,
+        chat_id: ChatId,
+        executor_id: uuid::Uuid,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::ClaimClientToolCallOutcome> {
+        self.inner
+            .claim_client_tool_call(id, chat_id, executor_id, lease_token, now, lease_expires_at)
+            .await
+    }
+    async fn heartbeat_client_tool_call(
+        &self,
+        id: openwave_core::CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        lease_expires_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::HeartbeatClientToolCallOutcome> {
+        self.inner
+            .heartbeat_client_tool_call(id, lease_token, now, lease_expires_at)
+            .await
+    }
+    async fn resolve_server_tool_call(
+        &self,
+        id: openwave_core::CallId,
+        resolution: &openwave_core::ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::ResolveToolCallOutcome> {
+        self.inner
+            .resolve_server_tool_call(id, resolution, resolved_at)
+            .await
+    }
+    async fn resolve_client_tool_call(
+        &self,
+        id: openwave_core::CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &openwave_core::ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::ResolveToolCallOutcome> {
+        self.inner
+            .resolve_client_tool_call(id, lease_token, now, resolution, resolved_at)
+            .await
+    }
+    async fn resolve_expired_client_tool_call(
+        &self,
+        id: openwave_core::CallId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &openwave_core::ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::ResolveToolCallOutcome> {
+        self.inner
+            .resolve_expired_client_tool_call(id, lease_token, now, resolution, resolved_at)
+            .await
+    }
+    async fn list_pending_client_tool_calls(
+        &self,
+        chat_id: ChatId,
+    ) -> Result<Vec<openwave_core::ToolCallRecord>> {
+        self.inner.list_pending_client_tool_calls(chat_id).await
     }
     async fn list_tool_calls(&self, chat_id: ChatId) -> Result<Vec<openwave_core::ToolCallRecord>> {
         self.inner.list_tool_calls(chat_id).await

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -43,11 +43,11 @@ Major surfaces present today:
 | --- | --- |
 | `id` | Typed identifiers (`ChatId`, `TurnId`, `CallId`, …) — newtypes so the compiler stops you mixing them up. |
 | `error` | The crate-wide `AgentError` + `Result`. |
-| `model` | Persisted chats, projects, documents, jobs, leases, and lifecycle state. |
+| `model` | Persisted chats, projects, documents, jobs, tool executions, leases, and lifecycle state. |
 | `tool` | The tool contract (`Tool`, `ToolSpec`, `ToolOutput`, `ToolCtx`, `ApprovalClass`). |
 | `provider` | The model-provider contract (`ModelProvider`, `ChatRequest`, `ProviderEvent`, `Usage`). |
 | `agent` | The cancellable/steerable multi-step turn loop and durable event journal integration. |
-| `db` / `storage` | SQLite/PostgreSQL-capable state transitions plus in-memory implementations. |
+| `db` / `storage` | SQLite/PostgreSQL-capable state transitions plus in-memory implementations, including immutable accept/lease/terminal tool execution. |
 | `blob` / `keychain` | Immutable local blob storage and OS-backed secret storage. |
 
 **Depends on:** nothing in the workspace.

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -266,7 +266,12 @@ This will land in independently reviewable pieces:
    can request only pick/list/revoke for its current conversation; it never
    receives a raw control surface or absolute path. Broker state, audit, and
    scratch live under the protected OpenWave application-data directory.
-7. Add the durable agent-request → native-picker → grant → retry workflow.
+7. Add the durable agent-request → native-picker → grant → retry workflow. The
+   generic tool-execution foundation is now present: canonical requests are
+   immutable, client work is durably discoverable, and per-claim fencing tokens
+   guard heartbeat, terminal resolution, and explicit expired-claim recovery.
+   The API, atomic turn parking, folder request tool, and desktop executor remain
+   to be layered on it.
 8. Replace project/chat `workspace_dir` with persisted host-access context
    identity and connected-root APIs. This can update the pre-v1 baseline schema
    directly.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -147,7 +147,7 @@ tool-call records. It then loops for a bounded number of model steps:
 
 1. fit the transcript into the model's context window;
 2. call the selected provider and stream its output;
-3. persist and run any tool calls;
+3. durably accept each tool call's canonical name and arguments, then run it;
 4. feed tool results back to the model;
 5. repeat until the model produces a final answer.
 
@@ -169,6 +169,43 @@ the desktop to connect another folder, but the request only opens a native conse
 flow; it never grants a named path by itself. The model router supports Anthropic, OpenAI, and
 OpenAI-compatible endpoints. It fails closed: if no enabled provider with a
 usable credential can serve the selected model, no model request is sent.
+
+### Tool calls are small state machines too
+
+A tool call is not a mutable log row. Its `CallId`, provider identity, name,
+arguments, owning turn, and execution surface are accepted once and then remain
+immutable. Repeating the same acceptance recovers the existing call; reusing the
+identity with different arguments is a conflict. A server tool then makes one
+terminal transition to `completed`, `failed`, or `cancelled`, and an exact retry
+recovers that result rather than overwriting it.
+
+The same record can describe work that must execute on a trusted client, such as
+a future native folder-picker request. Client work starts unclaimed and is
+listed from durable storage for reconnect recovery. A client claims it with an
+executor identity and a fresh secret claim token; the store installs that token
+with the expiry. Heartbeat and completion require it, so an old callback from
+the same desktop process cannot act as a newer claim. The token is returned only
+by the claim operation; ordinary pending/history records and their serialized
+forms never contain it. Server code cannot complete client work, and a client
+cannot claim ordinary server tools. An expired native interaction
+is deliberately not handed to another client automatically: the first picker or
+broker mutation may have happened even if its receipt was lost. A separate
+exact-token recovery transition can record the broker's known result or an
+authoritative abandonment without replaying the native action.
+
+```text
+                         +----success----> completed
+pending ----execute----->+----failure----> failed
+                         +----decline----> cancelled
+
+client execution adds: unclaimed ----claim/heartbeat----> leased
+```
+
+This is the durable execution boundary. The agent still executes its current
+built-in tools inside the turn worker. Parking a turn while a native client acts,
+exposing the client-execution API, and running the desktop executor are the next
+layers; notifications will be wake-up hints, while the pending-work query
+remains authoritative.
 
 ### 4. Events drive the live client
 
@@ -489,7 +526,10 @@ The main next steps are:
 
 - replace raw chat/project workspace paths with broker-mediated, per-context
   connected roots while keeping OpenWave's private app data separate;
-- add resumable checkpoints and explicit idempotency policy around tool effects;
+- expose durable pending/claim/heartbeat/result client-execution APIs, park turns
+  atomically while a client acts, and run native folder requests in the desktop;
+- add resumable checkpoints and explicit idempotency policy around remaining
+  server-side tool effects;
 - make approvals resumable rather than process-local;
 - expose existing backend capabilities through a real desktop information
   architecture: chat history, projects, documents, search, cancel, and steer;
@@ -541,6 +581,8 @@ steps; the migrations should be condensed into a clean baseline before v1.
   root identifier and root-relative paths.
 - **Turn:** one accepted unit of user-to-agent work inside a chat.
 - **Message:** durable user or assistant text; tool calls are stored separately.
+- **Tool call:** an immutable canonical request plus a pending or terminal
+  execution state; client-owned calls also carry an exact temporary lease.
 - **Event journal:** ordered receipts used to rebuild a live client stream.
 - **Lease:** temporary, renewable worker ownership of exact work.
 - **Revision:** the monotonically increasing version number of a document or the


### PR DESCRIPTION
## Summary

- replace mutable tool-call upserts with immutable accept and terminal state transitions
- add client claim, secret fencing-token heartbeat, live resolution, and explicit expired-claim recovery
- keep claim tokens out of serializable pending/history records and preserve exact terminal receipts
- canonicalize workflow timestamps for SQLite/PostgreSQL retry parity and edit the pre-v1 tool-call migration in place
- move execution operations into a dedicated database module and update the runtime/docs for the new lifecycle

## Validation

- 216 openwave-core library tests
- 153 openwave-server tests
- SQLite eight-way client claim race
- PostgreSQL 17 state-machine tests, including eight-way claim contention and sub-microsecond exact retries
- PostgreSQL-only feature build
- bw Rust lint
- rustfmt and diff checks
- clean final adversarial state-machine review