### PR TITLE
feat(server): expose durable client execution API

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1875,6 +1875,7 @@ impl Store for DbStore {
     async fn heartbeat_client_tool_call(
         &self,
         id: CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<Utc>,
         lease_expires_at: chrono::DateTime<Utc>,
@@ -1882,6 +1883,7 @@ impl Store for DbStore {
         ops::client_execution::heartbeat_client_tool_call(
             self,
             id,
+            chat_id,
             lease_token,
             now,
             lease_expires_at,
@@ -1901,6 +1903,7 @@ impl Store for DbStore {
     async fn resolve_client_tool_call(
         &self,
         id: CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<Utc>,
         resolution: &ToolCallResolution,
@@ -1909,6 +1912,7 @@ impl Store for DbStore {
         ops::client_execution::resolve_client_tool_call(
             self,
             id,
+            chat_id,
             lease_token,
             now,
             resolution,
@@ -1920,6 +1924,7 @@ impl Store for DbStore {
     async fn resolve_expired_client_tool_call(
         &self,
         id: CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<Utc>,
         resolution: &ToolCallResolution,
@@ -1928,6 +1933,7 @@ impl Store for DbStore {
         ops::client_execution::resolve_expired_client_tool_call(
             self,
             id,
+            chat_id,
             lease_token,
             now,
             resolution,

--- a/crates/openwave-core/src/db/ops/client_execution.rs
+++ b/crates/openwave-core/src/db/ops/client_execution.rs
@@ -106,8 +106,9 @@ pub(in crate::db) async fn claim_client_tool_call(
     }
     if existing.client_executor_id == Some(executor_id)
         && existing.client_lease_token == Some(lease_token)
-        && existing.client_lease_expires_at == Some(lease_expires_at)
-        && lease_expires_at > now
+        && existing
+            .client_lease_expires_at
+            .is_some_and(|expiry| expiry > now)
     {
         let claim = client_claim_from_model(existing)?;
         transaction.commit().await.map_err(store_err)?;
@@ -131,6 +132,7 @@ pub(in crate::db) async fn claim_client_tool_call(
 pub(in crate::db) async fn heartbeat_client_tool_call(
     store: &DbStore,
     id: CallId,
+    chat_id: ChatId,
     lease_token: uuid::Uuid,
     now: DateTime<Utc>,
     lease_expires_at: DateTime<Utc>,
@@ -149,7 +151,8 @@ pub(in crate::db) async fn heartbeat_client_tool_call(
         .map_err(store_err)?
         .expect("locked tool call exists");
     let current_expiry = existing.client_lease_expires_at;
-    if existing.execution != ToolCallExecution::Client.as_str()
+    if existing.chat_id != chat_id.0
+        || existing.execution != ToolCallExecution::Client.as_str()
         || existing.status != ToolCallStatus::Pending.as_str()
         || existing.client_lease_token != Some(lease_token)
         || current_expiry.is_none_or(|expiry| expiry <= now || lease_expires_at < expiry)
@@ -187,6 +190,7 @@ pub(in crate::db) async fn resolve_server_tool_call(
 pub(in crate::db) async fn resolve_client_tool_call(
     store: &DbStore,
     id: CallId,
+    chat_id: ChatId,
     lease_token: uuid::Uuid,
     now: DateTime<Utc>,
     resolution: &ToolCallResolution,
@@ -200,7 +204,11 @@ pub(in crate::db) async fn resolve_client_tool_call(
     resolve_tool_call(
         store,
         id,
-        ResolutionAuthority::LiveClient { lease_token, now },
+        ResolutionAuthority::LiveClient {
+            chat_id,
+            lease_token,
+            now,
+        },
         resolved_at,
         resolution,
     )
@@ -210,6 +218,7 @@ pub(in crate::db) async fn resolve_client_tool_call(
 pub(in crate::db) async fn resolve_expired_client_tool_call(
     store: &DbStore,
     id: CallId,
+    chat_id: ChatId,
     lease_token: uuid::Uuid,
     now: DateTime<Utc>,
     resolution: &ToolCallResolution,
@@ -223,7 +232,11 @@ pub(in crate::db) async fn resolve_expired_client_tool_call(
     resolve_tool_call(
         store,
         id,
-        ResolutionAuthority::ExpiredClient { lease_token, now },
+        ResolutionAuthority::ExpiredClient {
+            chat_id,
+            lease_token,
+            now,
+        },
         resolved_at,
         resolution,
     )
@@ -275,7 +288,7 @@ async fn resolve_tool_call(
     if existing.status != ToolCallStatus::Pending.as_str() {
         let outcome = if !terminal_authority_matches(&existing, authority) {
             ResolveToolCallOutcome::LeaseLost
-        } else if terminal_payload_matches(&existing, resolution, resolved_at) {
+        } else if terminal_payload_matches(&existing, resolution) {
             ResolveToolCallOutcome::Existing
         } else {
             ResolveToolCallOutcome::AlreadyTerminal
@@ -286,15 +299,25 @@ async fn resolve_tool_call(
 
     let owns = match authority {
         ResolutionAuthority::Server => existing.execution == ToolCallExecution::Server.as_str(),
-        ResolutionAuthority::LiveClient { lease_token, now } => {
-            existing.execution == ToolCallExecution::Client.as_str()
+        ResolutionAuthority::LiveClient {
+            chat_id,
+            lease_token,
+            now,
+        } => {
+            existing.chat_id == chat_id.0
+                && existing.execution == ToolCallExecution::Client.as_str()
                 && existing.client_lease_token == Some(lease_token)
                 && existing
                     .client_lease_expires_at
                     .is_some_and(|expiry| expiry > now)
         }
-        ResolutionAuthority::ExpiredClient { lease_token, now } => {
-            existing.execution == ToolCallExecution::Client.as_str()
+        ResolutionAuthority::ExpiredClient {
+            chat_id,
+            lease_token,
+            now,
+        } => {
+            existing.chat_id == chat_id.0
+                && existing.execution == ToolCallExecution::Client.as_str()
                 && existing.client_lease_token == Some(lease_token)
                 && existing
                     .client_lease_expires_at
@@ -323,10 +346,12 @@ async fn resolve_tool_call(
 enum ResolutionAuthority {
     Server,
     LiveClient {
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: DateTime<Utc>,
     },
     ExpiredClient {
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: DateTime<Utc>,
     },
@@ -336,11 +361,21 @@ impl ResolutionAuthority {
     fn canonicalized(self) -> Result<Self> {
         Ok(match self {
             Self::Server => Self::Server,
-            Self::LiveClient { lease_token, now } => Self::LiveClient {
+            Self::LiveClient {
+                chat_id,
+                lease_token,
+                now,
+            } => Self::LiveClient {
+                chat_id,
                 lease_token,
                 now: canonical_db_timestamp(now)?,
             },
-            Self::ExpiredClient { lease_token, now } => Self::ExpiredClient {
+            Self::ExpiredClient {
+                chat_id,
+                lease_token,
+                now,
+            } => Self::ExpiredClient {
+                chat_id,
                 lease_token,
                 now: canonical_db_timestamp(now)?,
             },
@@ -353,6 +388,13 @@ impl ResolutionAuthority {
             Self::LiveClient { lease_token, .. } | Self::ExpiredClient { lease_token, .. } => {
                 Some(lease_token)
             }
+        }
+    }
+
+    const fn chat_id(self) -> Option<ChatId> {
+        match self {
+            Self::Server => None,
+            Self::LiveClient { chat_id, .. } | Self::ExpiredClient { chat_id, .. } => Some(chat_id),
         }
     }
 }
@@ -451,6 +493,7 @@ fn terminal_authority_matches(
         }
         ResolutionAuthority::LiveClient { .. } | ResolutionAuthority::ExpiredClient { .. } => {
             model.execution == ToolCallExecution::Client.as_str()
+                && Some(ChatId(model.chat_id)) == authority.chat_id()
                 && model.client_lease_token == authority.lease_token()
         }
     }
@@ -459,14 +502,12 @@ fn terminal_authority_matches(
 fn terminal_payload_matches(
     model: &entities::tool_call::Model,
     resolution: &ToolCallResolution,
-    resolved_at: DateTime<Utc>,
 ) -> bool {
     let (error_code, error_detail) = resolution_error(resolution);
     model.status == resolution.status().as_str()
         && model.result.as_deref() == Some(resolution.result())
         && model.error_code == error_code
         && model.error_detail == error_detail
-        && model.resolved_at == Some(resolved_at)
 }
 
 pub(in crate::db) fn tool_call_from_model(

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -8016,8 +8016,8 @@ async fn client_tool_call_is_fenced_by_its_exact_lease() {
                 chat.id,
                 executor,
                 lease_token,
-                claimed_at,
-                first_expiry,
+                claimed_at + chrono::Duration::milliseconds(1),
+                first_expiry + chrono::Duration::milliseconds(1),
             )
             .await
             .unwrap(),
@@ -8057,6 +8057,20 @@ async fn client_tool_call_is_fenced_by_its_exact_lease() {
         store
             .heartbeat_client_tool_call(
                 call.id,
+                ChatId::new(),
+                lease_token,
+                claimed_at + chrono::Duration::seconds(1),
+                extended_expiry,
+            )
+            .await
+            .unwrap(),
+        HeartbeatClientToolCallOutcome::LeaseLost
+    );
+    assert_eq!(
+        store
+            .heartbeat_client_tool_call(
+                call.id,
+                chat.id,
                 lease_token,
                 claimed_at + chrono::Duration::seconds(1),
                 extended_expiry,
@@ -8069,6 +8083,7 @@ async fn client_tool_call_is_fenced_by_its_exact_lease() {
         store
             .heartbeat_client_tool_call(
                 call.id,
+                chat.id,
                 lease_token,
                 claimed_at + chrono::Duration::seconds(1),
                 extended_expiry,
@@ -8087,6 +8102,21 @@ async fn client_tool_call_is_fenced_by_its_exact_lease() {
         store
             .resolve_client_tool_call(
                 call.id,
+                ChatId::new(),
+                lease_token,
+                resolved_at,
+                &resolution,
+                resolved_at,
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::LeaseLost
+    );
+    assert_eq!(
+        store
+            .resolve_client_tool_call(
+                call.id,
+                chat.id,
                 uuid::Uuid::new_v4(),
                 resolved_at,
                 &resolution,
@@ -8098,14 +8128,28 @@ async fn client_tool_call_is_fenced_by_its_exact_lease() {
     );
     assert_eq!(
         store
-            .resolve_client_tool_call(call.id, lease_token, resolved_at, &resolution, resolved_at)
+            .resolve_client_tool_call(
+                call.id,
+                chat.id,
+                lease_token,
+                resolved_at + chrono::Duration::milliseconds(1),
+                &resolution,
+                resolved_at + chrono::Duration::milliseconds(1),
+            )
             .await
             .unwrap(),
         ResolveToolCallOutcome::Resolved
     );
     assert_eq!(
         store
-            .resolve_client_tool_call(call.id, lease_token, resolved_at, &resolution, resolved_at)
+            .resolve_client_tool_call(
+                call.id,
+                chat.id,
+                lease_token,
+                resolved_at,
+                &resolution,
+                resolved_at,
+            )
             .await
             .unwrap(),
         ResolveToolCallOutcome::Existing
@@ -8114,6 +8158,21 @@ async fn client_tool_call_is_fenced_by_its_exact_lease() {
         store
             .resolve_client_tool_call(
                 call.id,
+                ChatId::new(),
+                lease_token,
+                resolved_at,
+                &resolution,
+                resolved_at,
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::LeaseLost
+    );
+    assert_eq!(
+        store
+            .resolve_client_tool_call(
+                call.id,
+                chat.id,
                 uuid::Uuid::new_v4(),
                 resolved_at,
                 &resolution,
@@ -8208,6 +8267,7 @@ async fn expired_client_lease_is_not_transferred_implicitly() {
         store
             .resolve_client_tool_call(
                 call.id,
+                chat.id,
                 lease_token,
                 after_expiry,
                 &ToolCallResolution::Cancelled {
@@ -8226,6 +8286,7 @@ async fn expired_client_lease_is_not_transferred_implicitly() {
         store
             .resolve_expired_client_tool_call(
                 call.id,
+                chat.id,
                 lease_token,
                 after_expiry,
                 &recovered,
@@ -8239,6 +8300,7 @@ async fn expired_client_lease_is_not_transferred_implicitly() {
         store
             .resolve_expired_client_tool_call(
                 call.id,
+                chat.id,
                 lease_token,
                 after_expiry,
                 &recovered,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -990,6 +990,8 @@ pub trait Store: Send + Sync {
     async fn accept_tool_call(&self, call: &ToolCallRecord) -> Result<AcceptToolCallOutcome>;
 
     /// Claim the first lease with a caller-generated secret fencing token.
+    /// A retry with the same executor and token recovers the original live
+    /// claim even when the caller proposes a newly calculated expiry.
     async fn claim_client_tool_call(
         &self,
         id: CallId,
@@ -1004,6 +1006,7 @@ pub trait Store: Send + Sync {
     async fn heartbeat_client_tool_call(
         &self,
         id: CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         lease_expires_at: chrono::DateTime<chrono::Utc>,
@@ -1018,9 +1021,13 @@ pub trait Store: Send + Sync {
     ) -> Result<ResolveToolCallOutcome>;
 
     /// Resolve a pending client call under its exact unexpired executor lease.
+    /// Once committed, the token and terminal payload are the stable retry
+    /// identity; `resolved_at` records the first commit and is not compared on
+    /// an ambiguous retry.
     async fn resolve_client_tool_call(
         &self,
         id: CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         resolution: &ToolCallResolution,
@@ -1034,6 +1041,7 @@ pub trait Store: Send + Sync {
     async fn resolve_expired_client_tool_call(
         &self,
         id: CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         resolution: &ToolCallResolution,

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -35,7 +35,7 @@ impl MemStore {
     fn resolve_mem_tool_call(
         &self,
         id: CallId,
-        client_authority: Option<(uuid::Uuid, chrono::DateTime<chrono::Utc>, bool)>,
+        client_authority: Option<(ChatId, uuid::Uuid, chrono::DateTime<chrono::Utc>, bool)>,
         resolution: &ToolCallResolution,
         resolved_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<ResolveToolCallOutcome> {
@@ -62,8 +62,9 @@ impl MemStore {
         if call.status.is_terminal() {
             let authority_matches = match client_authority {
                 None => call.execution == ToolCallExecution::Server && stored_lease_token.is_none(),
-                Some((lease_token, _, _)) => {
-                    call.execution == ToolCallExecution::Client
+                Some((chat_id, lease_token, _, _)) => {
+                    call.chat_id == chat_id
+                        && call.execution == ToolCallExecution::Client
                         && stored_lease_token == Some(lease_token)
                 }
             };
@@ -73,8 +74,7 @@ impl MemStore {
             let exact = call.status == resolution.status()
                 && call.result.as_deref() == Some(resolution.result())
                 && call.error_code == error_code
-                && call.error_detail == error_detail
-                && call.resolved_at == Some(resolved_at);
+                && call.error_detail == error_detail;
             return Ok(if exact {
                 ResolveToolCallOutcome::Existing
             } else {
@@ -83,8 +83,9 @@ impl MemStore {
         }
         let owns = match client_authority {
             None => call.execution == ToolCallExecution::Server,
-            Some((lease_token, now, expired)) => {
-                call.execution == ToolCallExecution::Client
+            Some((chat_id, lease_token, now, expired)) => {
+                call.chat_id == chat_id
+                    && call.execution == ToolCallExecution::Client
                     && stored_lease_token == Some(lease_token)
                     && call.client_lease_expires_at.is_some_and(|expiry| {
                         if expired {
@@ -1251,8 +1252,9 @@ impl Store for MemStore {
             return Ok(ClaimClientToolCallOutcome::Unavailable);
         }
         if call.client_executor_id == Some(executor_id)
-            && call.client_lease_expires_at == Some(lease_expires_at)
-            && lease_expires_at > now
+            && call
+                .client_lease_expires_at
+                .is_some_and(|expiry| expiry > now)
         {
             let stored_lease_token = self
                 .tool_call_lease_tokens
@@ -1290,6 +1292,7 @@ impl Store for MemStore {
     async fn heartbeat_client_tool_call(
         &self,
         id: CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         lease_expires_at: chrono::DateTime<chrono::Utc>,
@@ -1301,7 +1304,8 @@ impl Store for MemStore {
         let Some(current_expiry) = call.client_lease_expires_at else {
             return Ok(HeartbeatClientToolCallOutcome::LeaseLost);
         };
-        if call.execution != ToolCallExecution::Client
+        if call.chat_id != chat_id
+            || call.execution != ToolCallExecution::Client
             || call.status != ToolCallStatus::Pending
             || self
                 .tool_call_lease_tokens
@@ -1332,22 +1336,34 @@ impl Store for MemStore {
     async fn resolve_client_tool_call(
         &self,
         id: CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         resolution: &ToolCallResolution,
         resolved_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<ResolveToolCallOutcome> {
-        self.resolve_mem_tool_call(id, Some((lease_token, now, false)), resolution, resolved_at)
+        self.resolve_mem_tool_call(
+            id,
+            Some((chat_id, lease_token, now, false)),
+            resolution,
+            resolved_at,
+        )
     }
     async fn resolve_expired_client_tool_call(
         &self,
         id: CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         resolution: &ToolCallResolution,
         resolved_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<ResolveToolCallOutcome> {
-        self.resolve_mem_tool_call(id, Some((lease_token, now, true)), resolution, resolved_at)
+        self.resolve_mem_tool_call(
+            id,
+            Some((chat_id, lease_token, now, true)),
+            resolution,
+            resolved_at,
+        )
     }
     async fn list_pending_client_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {
         let mut calls: Vec<_> = self

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -118,8 +118,8 @@ async fn postgres_client_execution_claim_has_one_winner() {
                 chat.id,
                 winner,
                 lease_token,
-                claim_at,
-                lease_expires_at,
+                claim_at + Duration::microseconds(1),
+                lease_expires_at + Duration::microseconds(1),
             )
             .await
             .unwrap(),
@@ -130,6 +130,7 @@ async fn postgres_client_execution_claim_has_one_winner() {
         store
             .heartbeat_client_tool_call(
                 call.id,
+                chat.id,
                 lease_token,
                 claim_at + Duration::seconds(1),
                 extended_expiry,
@@ -142,6 +143,7 @@ async fn postgres_client_execution_claim_has_one_winner() {
         store
             .heartbeat_client_tool_call(
                 call.id,
+                chat.id,
                 lease_token,
                 claim_at + Duration::seconds(1),
                 extended_expiry,
@@ -156,14 +158,28 @@ async fn postgres_client_execution_claim_has_one_winner() {
     };
     assert_eq!(
         store
-            .resolve_client_tool_call(call.id, lease_token, resolved_at, &resolution, resolved_at,)
+            .resolve_client_tool_call(
+                call.id,
+                chat.id,
+                lease_token,
+                resolved_at + Duration::microseconds(1),
+                &resolution,
+                resolved_at + Duration::microseconds(1),
+            )
             .await
             .unwrap(),
         ResolveToolCallOutcome::Resolved
     );
     assert_eq!(
         store
-            .resolve_client_tool_call(call.id, lease_token, resolved_at, &resolution, resolved_at,)
+            .resolve_client_tool_call(
+                call.id,
+                chat.id,
+                lease_token,
+                resolved_at,
+                &resolution,
+                resolved_at,
+            )
             .await
             .unwrap(),
         ResolveToolCallOutcome::Existing

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -127,6 +127,22 @@ pub fn app(state: AppState) -> Router {
         .route("/chats/{id}/cancel", post(routes::post_cancel))
         .route("/chats/{id}/steer", post(routes::post_steer))
         .route(
+            "/chats/{id}/client-executions/pending",
+            get(routes::list_pending_client_executions),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/claim",
+            post(routes::claim_client_execution),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/heartbeat",
+            post(routes::heartbeat_client_execution),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/resolve",
+            post(routes::resolve_client_execution),
+        )
+        .route(
             "/chats/{id}/approvals/{call_id}",
             post(routes::post_approval),
         )

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -26,7 +26,9 @@ use crate::extract::{Json, Path, Query};
 use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
 use crate::state::AppState;
 
+mod client_execution;
 mod document;
+pub use client_execution::*;
 pub use document::*;
 
 /// The store-settings key for the selected model.

--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -1,0 +1,292 @@
+//! Durable HTTP control plane for work that executes in a trusted client.
+//!
+//! Polling is authoritative; event streams are only a latency hint. A client
+//! generates a fresh secret lease token before claiming, then retains it across
+//! ambiguous HTTP responses and presents it for every heartbeat or resolution.
+
+use axum::extract::State;
+use serde::{Deserialize, Serialize};
+
+use chrono::{Duration, Utc};
+use openwave_core::{
+    CallId, ChatId, ClaimClientToolCallOutcome, HeartbeatClientToolCallOutcome,
+    ResolveToolCallOutcome, ToolCallRecord, ToolCallResolution,
+};
+
+use crate::error::ServerError;
+use crate::extract::{Json, Path};
+use crate::state::AppState;
+
+const CLIENT_EXECUTION_LEASE: Duration = Duration::seconds(60);
+
+/// Caller-owned claim identity. The lease token is a secret capability and
+/// must be generated freshly for a new claim attempt.
+#[derive(Deserialize)]
+pub struct ClaimClientExecution {
+    pub executor_id: uuid::Uuid,
+    pub lease_token: uuid::Uuid,
+}
+
+/// Whether a claim was first installed or recovered after a lost response.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimDisposition {
+    Claimed,
+    Existing,
+}
+
+/// Canonical claimed work plus the secret receipt needed to operate it.
+#[derive(Serialize)]
+pub struct ClaimedClientExecution {
+    pub disposition: ClaimDisposition,
+    pub call: ToolCallRecord,
+    pub lease_token: uuid::Uuid,
+}
+
+/// Secret receipt for extending a live claim.
+#[derive(Deserialize)]
+pub struct HeartbeatClientExecution {
+    pub lease_token: uuid::Uuid,
+}
+
+/// Whether a heartbeat advanced the lease or proposed its current expiry.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HeartbeatDisposition {
+    Extended,
+    Existing,
+}
+
+#[derive(Serialize)]
+pub struct ClientExecutionHeartbeat {
+    pub disposition: HeartbeatDisposition,
+}
+
+/// Terminal client outcome. The model-facing `result` is retained for every
+/// variant; failures additionally carry a stable machine code and bounded local
+/// diagnostic detail.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ClientExecutionResolution {
+    Completed {
+        result: String,
+    },
+    Failed {
+        result: String,
+        error_code: String,
+        #[serde(default)]
+        error_detail: Option<String>,
+    },
+    Cancelled {
+        result: String,
+    },
+}
+
+impl ClientExecutionResolution {
+    fn into_core(self) -> ToolCallResolution {
+        match self {
+            Self::Completed { result } => ToolCallResolution::Completed { result },
+            Self::Failed {
+                result,
+                error_code,
+                error_detail,
+            } => ToolCallResolution::Failed {
+                result,
+                error_code,
+                error_detail,
+            },
+            Self::Cancelled { result } => ToolCallResolution::Cancelled { result },
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ResolveClientExecution {
+    pub lease_token: uuid::Uuid,
+    pub resolution: ClientExecutionResolution,
+}
+
+/// Whether this request committed the terminal state or recovered it.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolutionDisposition {
+    Resolved,
+    Existing,
+}
+
+#[derive(Serialize)]
+pub struct ResolvedClientExecution {
+    pub disposition: ResolutionDisposition,
+}
+
+/// `GET /chats/{id}/client-executions/pending` — authoritative pending work.
+///
+/// Includes visible executor and expiry metadata for recovery, but never the
+/// secret lease token. Unknown chats return `404` rather than an empty list.
+pub async fn list_pending_client_executions(
+    State(state): State<AppState>,
+    Path(id): Path<ChatId>,
+) -> Result<Json<Vec<ToolCallRecord>>, ServerError> {
+    ensure_chat(&state, id).await?;
+    Ok(Json(state.store.list_pending_client_tool_calls(id).await?))
+}
+
+/// `POST .../{call_id}/claim` — atomically acquire or recover one exact claim.
+pub async fn claim_client_execution(
+    State(state): State<AppState>,
+    Path((id, call_id)): Path<(ChatId, CallId)>,
+    Json(body): Json<ClaimClientExecution>,
+) -> Result<Json<ClaimedClientExecution>, ServerError> {
+    ensure_chat(&state, id).await?;
+    ensure_non_nil(body.executor_id, "executor_id")?;
+    ensure_non_nil(body.lease_token, "lease_token")?;
+    let now = Utc::now();
+    let outcome = state
+        .store
+        .claim_client_tool_call(
+            call_id,
+            id,
+            body.executor_id,
+            body.lease_token,
+            now,
+            now + CLIENT_EXECUTION_LEASE,
+        )
+        .await?;
+    let (disposition, claim) = match outcome {
+        ClaimClientToolCallOutcome::Claimed(claim) => (ClaimDisposition::Claimed, claim),
+        ClaimClientToolCallOutcome::Existing(claim) => (ClaimDisposition::Existing, claim),
+        ClaimClientToolCallOutcome::Unavailable => {
+            return Err(ServerError::conflict(format!(
+                "client execution {call_id} is not claimable for chat {id}"
+            )));
+        }
+    };
+    Ok(Json(ClaimedClientExecution {
+        disposition,
+        call: claim.call,
+        lease_token: claim.lease_token,
+    }))
+}
+
+/// `POST .../{call_id}/heartbeat` — renew the exact live lease for 60 seconds.
+/// Heartbeats are monotonic liveness updates rather than exact commands: a
+/// repeated request can extend the lease again from its new server receive time.
+pub async fn heartbeat_client_execution(
+    State(state): State<AppState>,
+    Path((id, call_id)): Path<(ChatId, CallId)>,
+    Json(body): Json<HeartbeatClientExecution>,
+) -> Result<Json<ClientExecutionHeartbeat>, ServerError> {
+    ensure_chat(&state, id).await?;
+    ensure_non_nil(body.lease_token, "lease_token")?;
+    let now = Utc::now();
+    let disposition = match state
+        .store
+        .heartbeat_client_tool_call(
+            call_id,
+            id,
+            body.lease_token,
+            now,
+            now + CLIENT_EXECUTION_LEASE,
+        )
+        .await?
+    {
+        HeartbeatClientToolCallOutcome::Extended => HeartbeatDisposition::Extended,
+        HeartbeatClientToolCallOutcome::Existing => HeartbeatDisposition::Existing,
+        HeartbeatClientToolCallOutcome::LeaseLost => {
+            return Err(ServerError::conflict(format!(
+                "client execution {call_id} lease is not live"
+            )));
+        }
+    };
+    Ok(Json(ClientExecutionHeartbeat { disposition }))
+}
+
+/// `POST .../{call_id}/resolve` — terminalize a known native outcome once.
+///
+/// The exact token can also reconcile a known outcome after lease expiry. Work
+/// is never transferred to another executor, and a different payload conflicts
+/// with the first committed result.
+pub async fn resolve_client_execution(
+    State(state): State<AppState>,
+    Path((id, call_id)): Path<(ChatId, CallId)>,
+    Json(body): Json<ResolveClientExecution>,
+) -> Result<Json<ResolvedClientExecution>, ServerError> {
+    ensure_chat(&state, id).await?;
+    ensure_non_nil(body.lease_token, "lease_token")?;
+    let resolution = body.resolution.into_core();
+    validate_resolution(&resolution)?;
+    let now = Utc::now();
+    let mut outcome = state
+        .store
+        .resolve_client_tool_call(call_id, id, body.lease_token, now, &resolution, now)
+        .await?;
+    if outcome == ResolveToolCallOutcome::LeaseLost {
+        outcome = state
+            .store
+            .resolve_expired_client_tool_call(call_id, id, body.lease_token, now, &resolution, now)
+            .await?;
+    }
+    let disposition = match outcome {
+        ResolveToolCallOutcome::Resolved => ResolutionDisposition::Resolved,
+        ResolveToolCallOutcome::Existing => ResolutionDisposition::Existing,
+        ResolveToolCallOutcome::AlreadyTerminal => {
+            return Err(ServerError::conflict(format!(
+                "client execution {call_id} already has a different terminal result"
+            )));
+        }
+        ResolveToolCallOutcome::LeaseLost => {
+            return Err(ServerError::conflict(format!(
+                "client execution {call_id} is not owned by this lease"
+            )));
+        }
+        ResolveToolCallOutcome::NotFound => {
+            return Err(ServerError::not_found(format!(
+                "client execution {call_id} not found"
+            )));
+        }
+    };
+    Ok(Json(ResolvedClientExecution { disposition }))
+}
+
+async fn ensure_chat(state: &AppState, id: ChatId) -> Result<(), ServerError> {
+    if state.store.get_chat(id).await?.is_none() {
+        return Err(ServerError::not_found(format!("chat {id} not found")));
+    }
+    Ok(())
+}
+
+fn ensure_non_nil(value: uuid::Uuid, field: &str) -> Result<(), ServerError> {
+    if value.is_nil() {
+        return Err(ServerError::bad_request(format!("{field} must not be nil")));
+    }
+    Ok(())
+}
+
+fn validate_resolution(resolution: &ToolCallResolution) -> Result<(), ServerError> {
+    let (error_code, error_detail) = match resolution {
+        ToolCallResolution::Failed {
+            error_code,
+            error_detail,
+            ..
+        } => (Some(error_code.as_str()), error_detail.as_deref()),
+        ToolCallResolution::Completed { .. } | ToolCallResolution::Cancelled { .. } => (None, None),
+    };
+    let invalid = resolution.result().len() > ToolCallRecord::MAX_RESULT_BYTES
+        || resolution.result().contains('\0')
+        || error_code.is_some_and(|code| {
+            code.is_empty()
+                || code.len() > ToolCallRecord::MAX_ERROR_CODE_LEN
+                || code.contains('\0')
+        })
+        || error_detail.is_some_and(|detail| {
+            detail.is_empty()
+                || detail.len() > ToolCallRecord::MAX_ERROR_DETAIL_LEN
+                || detail.contains('\0')
+        });
+    if invalid {
+        return Err(ServerError::bad_request(
+            "client execution resolution contains invalid or oversized fields",
+        ));
+    }
+    Ok(())
+}

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -9,9 +9,10 @@ use axum::http::{header, Request, StatusCode};
 use futures::stream::{self, BoxStream, StreamExt};
 // Tests use the in-memory store; production wires LanceDB in `bind`.
 use openwave_core::{
-    AgentErrorInfo, AgentEvent, ApprovalClass, BlobStore, Chat, ChatId, ChatRequest, Message,
-    ModelProvider, Project, ProjectId, ProviderEvent, ProviderId, SecretProvider, SequencedEvent,
-    StopReason, Tool, ToolCtx, ToolOutput, ToolSpec, TurnId, TurnSteerId, Usage,
+    AgentErrorInfo, AgentEvent, ApprovalClass, BlobStore, CallId, Chat, ChatId, ChatRequest,
+    Message, ModelProvider, Project, ProjectId, ProviderEvent, ProviderId, SecretProvider,
+    SequencedEvent, StopReason, Tool, ToolCallExecution, ToolCallRecord, ToolCallStatus, ToolCtx,
+    ToolOutput, ToolSpec, TurnId, TurnSteerId, Usage,
 };
 use openwave_retrieval::{
     Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
@@ -966,12 +967,13 @@ impl Store for PauseTerminalStore {
     async fn heartbeat_client_tool_call(
         &self,
         id: openwave_core::CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         lease_expires_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<openwave_core::HeartbeatClientToolCallOutcome> {
         self.inner
-            .heartbeat_client_tool_call(id, lease_token, now, lease_expires_at)
+            .heartbeat_client_tool_call(id, chat_id, lease_token, now, lease_expires_at)
             .await
     }
     async fn resolve_server_tool_call(
@@ -987,25 +989,34 @@ impl Store for PauseTerminalStore {
     async fn resolve_client_tool_call(
         &self,
         id: openwave_core::CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         resolution: &openwave_core::ToolCallResolution,
         resolved_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<openwave_core::ResolveToolCallOutcome> {
         self.inner
-            .resolve_client_tool_call(id, lease_token, now, resolution, resolved_at)
+            .resolve_client_tool_call(id, chat_id, lease_token, now, resolution, resolved_at)
             .await
     }
     async fn resolve_expired_client_tool_call(
         &self,
         id: openwave_core::CallId,
+        chat_id: ChatId,
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         resolution: &openwave_core::ToolCallResolution,
         resolved_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<openwave_core::ResolveToolCallOutcome> {
         self.inner
-            .resolve_expired_client_tool_call(id, lease_token, now, resolution, resolved_at)
+            .resolve_expired_client_tool_call(
+                id,
+                chat_id,
+                lease_token,
+                now,
+                resolution,
+                resolved_at,
+            )
             .await
     }
     async fn list_pending_client_tool_calls(
@@ -2389,6 +2400,325 @@ async fn post_json(
         )
         .await
         .unwrap()
+}
+
+#[tokio::test]
+async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let other_chat = make_chat(&router, &bearer).await;
+    let proposed_call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "native_1".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({"suggested_name": "Documents"}),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: chrono::Utc::now(),
+        resolved_at: None,
+    };
+    let call = match store.accept_tool_call(&proposed_call).await.unwrap() {
+        openwave_core::AcceptToolCallOutcome::Accepted(call)
+        | openwave_core::AcceptToolCallOutcome::Existing(call) => call,
+        openwave_core::AcceptToolCallOutcome::IdentityConflict => {
+            panic!("fresh client tool call identity conflicted")
+        }
+    };
+
+    let pending = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/client-executions/pending", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(pending.status(), StatusCode::OK);
+    let pending: Vec<ToolCallRecord> = json_body(pending).await;
+    assert_eq!(pending, vec![call.clone()]);
+
+    let executor_id = uuid::Uuid::new_v4();
+    let lease_token = uuid::Uuid::new_v4();
+    let claim_uri = format!("/chats/{}/client-executions/{}/claim", chat.id, call.id);
+    let claim_body = serde_json::json!({
+        "executor_id": executor_id,
+        "lease_token": lease_token,
+    });
+    let first = post_json(&router, &bearer, &claim_uri, claim_body.clone()).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let first: serde_json::Value = json_body(first).await;
+    assert_eq!(first["disposition"], "claimed");
+    assert_eq!(first["lease_token"], lease_token.to_string());
+    assert_eq!(first["call"]["arguments"], call.arguments);
+
+    // A lost response can be retried with the stable secret token even though
+    // the server calculates a fresh proposed expiry for the second request.
+    let retry = post_json(&router, &bearer, &claim_uri, claim_body).await;
+    assert_eq!(retry.status(), StatusCode::OK);
+    let retry: serde_json::Value = json_body(retry).await;
+    assert_eq!(retry["disposition"], "existing");
+    assert_eq!(retry["lease_token"], lease_token.to_string());
+
+    let stolen = post_json(
+        &router,
+        &bearer,
+        &claim_uri,
+        serde_json::json!({
+            "executor_id": executor_id,
+            "lease_token": uuid::Uuid::new_v4(),
+        }),
+    )
+    .await;
+    assert_eq!(stolen.status(), StatusCode::CONFLICT);
+
+    let pending = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/client-executions/pending", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let pending_bytes = to_bytes(pending.into_body(), usize::MAX).await.unwrap();
+    assert!(
+        !String::from_utf8_lossy(&pending_bytes).contains(&lease_token.to_string()),
+        "authoritative polling must never disclose the secret lease token"
+    );
+
+    let wrong_chat_heartbeat = post_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/client-executions/{}/heartbeat",
+            other_chat.id, call.id
+        ),
+        serde_json::json!({"lease_token": lease_token}),
+    )
+    .await;
+    assert_eq!(wrong_chat_heartbeat.status(), StatusCode::CONFLICT);
+
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    let heartbeat = post_json(
+        &router,
+        &bearer,
+        &format!("/chats/{}/client-executions/{}/heartbeat", chat.id, call.id),
+        serde_json::json!({"lease_token": lease_token}),
+    )
+    .await;
+    assert_eq!(heartbeat.status(), StatusCode::OK);
+    let heartbeat: serde_json::Value = json_body(heartbeat).await;
+    assert_eq!(heartbeat["disposition"], "extended");
+
+    let resolve_uri = format!("/chats/{}/client-executions/{}/resolve", chat.id, call.id);
+    let resolution = serde_json::json!({
+        "lease_token": lease_token,
+        "resolution": {"status": "completed", "result": "folder connected"},
+    });
+    let wrong_chat_resolve = post_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/client-executions/{}/resolve",
+            other_chat.id, call.id
+        ),
+        resolution.clone(),
+    )
+    .await;
+    assert_eq!(wrong_chat_resolve.status(), StatusCode::CONFLICT);
+    let wrong_token = post_json(
+        &router,
+        &bearer,
+        &resolve_uri,
+        serde_json::json!({
+            "lease_token": uuid::Uuid::new_v4(),
+            "resolution": {"status": "completed", "result": "folder connected"},
+        }),
+    )
+    .await;
+    assert_eq!(wrong_token.status(), StatusCode::CONFLICT);
+
+    let resolved = post_json(&router, &bearer, &resolve_uri, resolution.clone()).await;
+    assert_eq!(resolved.status(), StatusCode::OK);
+    let resolved: serde_json::Value = json_body(resolved).await;
+    assert_eq!(resolved["disposition"], "resolved");
+
+    // Resolution time is server-owned metadata, not part of the stable command
+    // identity, so an ambiguous retry converges on token + terminal payload.
+    tokio::time::sleep(Duration::from_millis(2)).await;
+    let retry = post_json(&router, &bearer, &resolve_uri, resolution).await;
+    assert_eq!(retry.status(), StatusCode::OK);
+    let retry: serde_json::Value = json_body(retry).await;
+    assert_eq!(retry["disposition"], "existing");
+
+    let conflicting = post_json(
+        &router,
+        &bearer,
+        &resolve_uri,
+        serde_json::json!({
+            "lease_token": lease_token,
+            "resolution": {"status": "cancelled", "result": "not connected"},
+        }),
+    )
+    .await;
+    assert_eq!(conflicting.status(), StatusCode::CONFLICT);
+    assert!(store
+        .list_pending_client_tool_calls(chat.id)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn client_execution_api_reconciles_a_known_result_after_exact_lease_expiry() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "native_expired".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({}),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: chrono::Utc::now(),
+        resolved_at: None,
+    };
+    store.accept_tool_call(&call).await.unwrap();
+    let lease_token = uuid::Uuid::new_v4();
+    let claimed_at = chrono::Utc::now();
+    assert!(matches!(
+        store
+            .claim_client_tool_call(
+                call.id,
+                chat.id,
+                uuid::Uuid::new_v4(),
+                lease_token,
+                claimed_at,
+                claimed_at + chrono::Duration::milliseconds(2),
+            )
+            .await
+            .unwrap(),
+        openwave_core::ClaimClientToolCallOutcome::Claimed(_)
+    ));
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let resolved = post_json(
+        &router,
+        &bearer,
+        &format!("/chats/{}/client-executions/{}/resolve", chat.id, call.id),
+        serde_json::json!({
+            "lease_token": lease_token,
+            "resolution": {
+                "status": "cancelled",
+                "result": "folder picker was cancelled",
+            },
+        }),
+    )
+    .await;
+    assert_eq!(resolved.status(), StatusCode::OK);
+    let resolved: serde_json::Value = json_body(resolved).await;
+    assert_eq!(resolved["disposition"], "resolved");
+}
+
+#[tokio::test]
+async fn client_execution_api_validates_scope_identity_and_terminal_payloads() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let missing_chat = ChatId::new();
+    let missing = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{missing_chat}/client-executions/pending"))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "native_validation".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({}),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: chrono::Utc::now(),
+        resolved_at: None,
+    };
+    store.accept_tool_call(&call).await.unwrap();
+    let claim_uri = format!("/chats/{}/client-executions/{}/claim", chat.id, call.id);
+    let nil = post_json(
+        &router,
+        &bearer,
+        &claim_uri,
+        serde_json::json!({
+            "executor_id": uuid::Uuid::nil(),
+            "lease_token": uuid::Uuid::new_v4(),
+        }),
+    )
+    .await;
+    assert_eq!(nil.status(), StatusCode::BAD_REQUEST);
+
+    let lease_token = uuid::Uuid::new_v4();
+    let claimed = post_json(
+        &router,
+        &bearer,
+        &claim_uri,
+        serde_json::json!({
+            "executor_id": uuid::Uuid::new_v4(),
+            "lease_token": lease_token,
+        }),
+    )
+    .await;
+    assert_eq!(claimed.status(), StatusCode::OK);
+
+    let oversized = post_json(
+        &router,
+        &bearer,
+        &format!("/chats/{}/client-executions/{}/resolve", chat.id, call.id),
+        serde_json::json!({
+            "lease_token": lease_token,
+            "resolution": {
+                "status": "failed",
+                "result": "failure",
+                "error_code": "x".repeat(ToolCallRecord::MAX_ERROR_CODE_LEN + 1),
+            },
+        }),
+    )
+    .await;
+    assert_eq!(oversized.status(), StatusCode::BAD_REQUEST);
 }
 
 /// POST exact bytes to a raw document route.

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -144,6 +144,11 @@ headless clients. It owns route orchestration and the durable document,
 retirement, and audit workers while core state transitions remain in
 `openwave-core`.
 
+Client-owned tool work is exposed through authenticated per-chat polling,
+claim, heartbeat, and resolution routes. General records show visible lease
+metadata but never the secret claim token; only the claim response returns that
+receipt.
+
 **Depends on:** `openwave-core`, `openwave-router`, `openwave-retrieval`.
 
 ## `openwave-cli` — headless daemon + CLI 🟡

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -270,8 +270,9 @@ This will land in independently reviewable pieces:
    generic tool-execution foundation is now present: canonical requests are
    immutable, client work is durably discoverable, and per-claim fencing tokens
    guard heartbeat, terminal resolution, and explicit expired-claim recovery.
-   The API, atomic turn parking, folder request tool, and desktop executor remain
-   to be layered on it.
+   Authenticated per-chat pending/claim/heartbeat/resolve routes now expose that
+   state machine without leaking tokens through polling. Atomic turn parking,
+   the folder request tool, and the desktop executor remain to be layered on it.
 8. Replace project/chat `workspace_dir` with persisted host-access context
    identity and connected-root APIs. This can update the pre-v1 baseline schema
    directly.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -201,11 +201,23 @@ pending ----execute----->+----failure----> failed
 client execution adds: unclaimed ----claim/heartbeat----> leased
 ```
 
-This is the durable execution boundary. The agent still executes its current
-built-in tools inside the turn worker. Parking a turn while a native client acts,
-exposing the client-execution API, and running the desktop executor are the next
-layers; notifications will be wake-up hints, while the pending-work query
-remains authoritative.
+The local API exposes this durable boundary through authenticated per-chat
+pending, claim, heartbeat, and resolve routes. Lease times are server-owned. The
+client supplies the stable executor identity and fresh secret token, so retrying
+a claim after a lost HTTP response recovers the original claim without trusting
+the client clock. Resolution retries converge on the token and terminal payload;
+the first server timestamp remains metadata rather than request identity. The
+resolve route can also reconcile a known result after expiry under the exact
+token, but it never transfers ambiguous native work to a second executor.
+Heartbeats are simpler monotonic liveness updates: each accepted repeat renews
+the lease from the server's current receive time. Heartbeat and resolution
+enforce the immutable chat owner inside the same locked state transition rather
+than loading conversation history first.
+
+The agent still executes its current built-in tools inside the turn worker.
+Parking a turn atomically while a native client acts and running the desktop
+executor are the next layers. Notifications will be wake-up hints, while the
+pending-work query remains authoritative.
 
 ### 4. Events drive the live client
 
@@ -477,7 +489,7 @@ object storage, and multi-process ownership remain future integration work.
 | Agent loop | `crates/openwave-core/src/agent.rs` | Model/tool loop, context fitting, cancellation, steering |
 | Operational database | `crates/openwave-core/src/db/` | Schema plus transactional SQLite/Postgres state transitions |
 | Model providers | `crates/openwave-router/src/` | Anthropic/OpenAI adapters and model-to-provider routing |
-| Local API | `crates/openwave-server/src/lib.rs`, `routes.rs` | Authentication, API assembly, chat and turn routes |
+| Local API | `crates/openwave-server/src/lib.rs`, `routes.rs`, `routes/client_execution.rs` | Authentication, API assembly, chat, turn, and leased client-execution routes |
 | Turn execution | `crates/openwave-server/src/turn_worker.rs` | Claiming, heartbeats, event journaling, terminal resolution |
 | Documents | `crates/openwave-server/src/routes/document.rs`, `document_worker.rs` | Upload API and Parse/Index worker orchestration |
 | Retrieval | `crates/openwave-retrieval/src/` | Parsing, chunks, embeddings, Lance, ranking, citations |
@@ -526,8 +538,8 @@ The main next steps are:
 
 - replace raw chat/project workspace paths with broker-mediated, per-context
   connected roots while keeping OpenWave's private app data separate;
-- expose durable pending/claim/heartbeat/result client-execution APIs, park turns
-  atomically while a client acts, and run native folder requests in the desktop;
+- park turns atomically while a client acts, notify clients of durable pending
+  work, and run native folder requests in the desktop;
 - add resumable checkpoints and explicit idempotency policy around remaining
   server-side tool effects;
 - make approvals resumable rather than process-local;


### PR DESCRIPTION
## Summary

- add authenticated per-chat polling, claim, heartbeat, and resolution routes for client-owned tool work
- keep lease timing server-owned while using caller-generated secret claim tokens for fencing and ambiguous retry recovery
- enforce immutable chat scope, bounded terminal payloads, exact terminal conflicts, and known-result reconciliation after lease expiry
- document the HTTP boundary and remaining atomic turn-parking work

## Validation

- 216 openwave-core library tests
- 156 openwave-server tests
- PostgreSQL client-execution and turn-state integration tests
- bw dev lint --rust --check --repo-root "$PWD"
- cargo fmt --all -- --check