### PR TITLE
feat(core): separate turn attempts from lease segments

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -193,6 +193,7 @@ pub mod turn_run {
         pub status: String,
         pub attempt_count: i32,
         pub max_attempts: i32,
+        pub claim_count: i32,
         pub available_at: DateTimeUtc,
         pub lease_token: Option<Uuid>,
         pub lease_expires_at: Option<DateTimeUtc>,
@@ -222,6 +223,7 @@ pub mod turn_claim {
         pub token: Uuid,
         pub turn_id: Uuid,
         pub attempt_count: i32,
+        pub claim_count: i32,
         pub claimed_at: DateTimeUtc,
         pub lease_expires_at: DateTimeUtc,
     }

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -141,6 +141,7 @@ impl MigrationTrait for Init {
                     )
                     .col(ColumnDef::new(TurnClaim::TurnId).uuid().not_null())
                     .col(ColumnDef::new(TurnClaim::AttemptCount).integer().not_null())
+                    .col(ColumnDef::new(TurnClaim::ClaimCount).integer().not_null())
                     .col(
                         ColumnDef::new(TurnClaim::ClaimedAt)
                             .timestamp_with_time_zone()
@@ -152,6 +153,7 @@ impl MigrationTrait for Init {
                             .not_null(),
                     )
                     .check(Expr::col(TurnClaim::AttemptCount).gte(1))
+                    .check(Expr::col(TurnClaim::ClaimCount).gte(Expr::col(TurnClaim::AttemptCount)))
                     .check(Expr::col(TurnClaim::LeaseExpiresAt).gt(Expr::col(TurnClaim::ClaimedAt)))
                     .to_owned(),
             )
@@ -164,6 +166,21 @@ impl MigrationTrait for Init {
                     .col(TurnClaim::Token)
                     .col(TurnClaim::TurnId)
                     .col(TurnClaim::AttemptCount)
+                    .col(TurnClaim::ClaimCount)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+        // Failure receipts remain attempt-scoped even when one attempt spans
+        // multiple worker lease segments.
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_claim_failure_identity")
+                    .table(TurnClaim::Table)
+                    .col(TurnClaim::Token)
+                    .col(TurnClaim::TurnId)
+                    .col(TurnClaim::AttemptCount)
                     .unique()
                     .to_owned(),
             )
@@ -171,10 +188,10 @@ impl MigrationTrait for Init {
         manager
             .create_index(
                 Index::create()
-                    .name("idx_turn_claim_attempt")
+                    .name("idx_turn_claim_count")
                     .table(TurnClaim::Table)
                     .col(TurnClaim::TurnId)
-                    .col(TurnClaim::AttemptCount)
+                    .col(TurnClaim::ClaimCount)
                     .unique()
                     .to_owned(),
             )
@@ -215,6 +232,7 @@ impl MigrationTrait for Init {
             TurnRunStatus::Queued.as_str(),
             TurnRunStatus::Running.as_str(),
             TurnRunStatus::Cancelling.as_str(),
+            TurnRunStatus::Resuming.as_str(),
             TurnRunStatus::RetryWait.as_str(),
             TurnRunStatus::Completed.as_str(),
             TurnRunStatus::Failed.as_str(),
@@ -250,12 +268,14 @@ impl MigrationTrait for Init {
                 TurnRunStatus::Queued.as_str(),
                 TurnRunStatus::Running.as_str(),
                 TurnRunStatus::Cancelling.as_str(),
+                TurnRunStatus::Resuming.as_str(),
                 TurnRunStatus::RetryWait.as_str(),
             ])
             .and(Expr::col(TurnRun::FinishedAt).is_null());
         let queued_attempt = Expr::col(TurnRun::Status)
             .eq(TurnRunStatus::Queued.as_str())
             .and(Expr::col(TurnRun::AttemptCount).eq(0))
+            .and(Expr::col(TurnRun::ClaimCount).eq(0))
             .and(Expr::col(TurnRun::StartedAt).is_null());
         let leased_attempt = Expr::col(TurnRun::Status)
             .is_in([
@@ -269,6 +289,10 @@ impl MigrationTrait for Init {
             .and(Expr::col(TurnRun::AttemptCount).gte(1))
             .and(Expr::col(TurnRun::AttemptCount).lt(Expr::col(TurnRun::MaxAttempts)))
             .and(Expr::col(TurnRun::StartedAt).is_not_null());
+        let resuming_attempt = Expr::col(TurnRun::Status)
+            .eq(TurnRunStatus::Resuming.as_str())
+            .and(Expr::col(TurnRun::AttemptCount).gte(1))
+            .and(Expr::col(TurnRun::StartedAt).is_not_null());
         let resolved_attempt = Expr::col(TurnRun::Status)
             .is_in([
                 TurnRunStatus::Completed.as_str(),
@@ -281,6 +305,7 @@ impl MigrationTrait for Init {
             .and(
                 Expr::col(TurnRun::AttemptCount)
                     .eq(0)
+                    .and(Expr::col(TurnRun::ClaimCount).eq(0))
                     .and(Expr::col(TurnRun::StartedAt).is_null())
                     .or(Expr::col(TurnRun::AttemptCount)
                         .gte(1)
@@ -297,6 +322,7 @@ impl MigrationTrait for Init {
                 TurnRunStatus::Queued.as_str(),
                 TurnRunStatus::Running.as_str(),
                 TurnRunStatus::Cancelling.as_str(),
+                TurnRunStatus::Resuming.as_str(),
                 TurnRunStatus::Completed.as_str(),
                 TurnRunStatus::Cancelled.as_str(),
             ])
@@ -340,6 +366,12 @@ impl MigrationTrait for Init {
                             .integer()
                             .not_null()
                             .default(crate::model::TurnRun::DEFAULT_MAX_ATTEMPTS),
+                    )
+                    .col(
+                        ColumnDef::new(TurnRun::ClaimCount)
+                            .integer()
+                            .not_null()
+                            .default(0),
                     )
                     .col(
                         ColumnDef::new(TurnRun::AvailableAt)
@@ -415,10 +447,12 @@ impl MigrationTrait for Init {
                             .from_col(TurnRun::LeaseToken)
                             .from_col(TurnRun::Id)
                             .from_col(TurnRun::AttemptCount)
+                            .from_col(TurnRun::ClaimCount)
                             .to_tbl(TurnClaim::Table)
                             .to_col(TurnClaim::Token)
                             .to_col(TurnClaim::TurnId)
                             .to_col(TurnClaim::AttemptCount)
+                            .to_col(TurnClaim::ClaimCount)
                             .on_delete(ForeignKeyAction::Restrict),
                     )
                     .check(
@@ -435,12 +469,14 @@ impl MigrationTrait for Init {
                                     .lte(Expr::col(TurnRun::MaxAttempts)),
                             ),
                     )
+                    .check(Expr::col(TurnRun::ClaimCount).gte(Expr::col(TurnRun::AttemptCount)))
                     .check(active_lease.or(no_lease))
                     .check(completed_output.or(no_output))
                     .check(terminal_finished.or(nonterminal_unfinished))
                     .check(
                         queued_attempt
                             .or(leased_attempt)
+                            .or(resuming_attempt)
                             .or(retryable_attempt)
                             .or(resolved_attempt)
                             .or(cancelled_attempt),
@@ -506,6 +542,7 @@ impl MigrationTrait for Init {
                         TurnRunStatus::Queued.as_str(),
                         TurnRunStatus::Running.as_str(),
                         TurnRunStatus::Cancelling.as_str(),
+                        TurnRunStatus::Resuming.as_str(),
                         TurnRunStatus::RetryWait.as_str(),
                     ]))
                     .to_owned(),
@@ -2017,6 +2054,7 @@ enum TurnRun {
     Status,
     AttemptCount,
     MaxAttempts,
+    ClaimCount,
     AvailableAt,
     LeaseToken,
     LeaseExpiresAt,
@@ -2036,6 +2074,7 @@ enum TurnClaim {
     Token,
     TurnId,
     AttemptCount,
+    ClaimCount,
     ClaimedAt,
     LeaseExpiresAt,
 }

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -339,6 +339,7 @@ pub(in crate::db) async fn append_turn_event(
     }
     if turn.status != TurnRunStatus::Running.as_str()
         || turn.attempt_count != claim.attempt_count
+        || turn.claim_count != claim.claim_count
         || turn.lease_token != Some(lease_token)
         || turn
             .lease_expires_at

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -155,6 +155,7 @@ pub(in crate::db) async fn accept_turn(
         status: Set(TurnRunStatus::Queued.as_str().into()),
         attempt_count: Set(0),
         max_attempts: Set(TurnRun::DEFAULT_MAX_ATTEMPTS),
+        claim_count: Set(0),
         available_at: Set(now),
         lease_token: Set(None),
         lease_expires_at: Set(None),
@@ -235,6 +236,7 @@ pub(in crate::db) async fn claim_turn_run(
                 .filter(|run| {
                     run.status == TurnRunStatus::Running.as_str()
                         && run.attempt_count == receipt.attempt_count
+                        && run.claim_count == receipt.claim_count
                         && run.lease_token == Some(lease_token)
                         && run
                             .lease_expires_at
@@ -249,17 +251,27 @@ pub(in crate::db) async fn claim_turn_run(
             });
         }
         let due = entities::turn_run::Entity::find()
-            .filter(entities::turn_run::Column::Status.is_in([
-                TurnRunStatus::Queued.as_str(),
-                TurnRunStatus::RetryWait.as_str(),
-            ]))
+            .filter(
+                sea_orm::Condition::any()
+                    .add(entities::turn_run::Column::Status.eq(TurnRunStatus::Resuming.as_str()))
+                    .add(
+                        sea_orm::Condition::all()
+                            .add(entities::turn_run::Column::Status.is_in([
+                                TurnRunStatus::Queued.as_str(),
+                                TurnRunStatus::RetryWait.as_str(),
+                            ]))
+                            .add(
+                                sea_orm::sea_query::Expr::col(
+                                    entities::turn_run::Column::AttemptCount,
+                                )
+                                .lt(sea_orm::sea_query::Expr::col(
+                                    entities::turn_run::Column::MaxAttempts,
+                                )),
+                            ),
+                    ),
+            )
             .filter(entities::turn_run::Column::AvailableAt.lte(now))
             .filter(entities::turn_run::Column::UpdatedAt.lte(now))
-            .filter(
-                sea_orm::sea_query::Expr::col(entities::turn_run::Column::AttemptCount).lt(
-                    sea_orm::sea_query::Expr::col(entities::turn_run::Column::MaxAttempts),
-                ),
-            )
             .order_by_asc(entities::turn_run::Column::AvailableAt)
             .order_by_asc(entities::turn_run::Column::CreatedAt)
             .order_by_asc(entities::turn_run::Column::Id)
@@ -461,13 +473,22 @@ pub(in crate::db) async fn claim_turn_run(
             });
         }
 
-        let next_attempt = candidate.attempt_count.checked_add(1).ok_or_else(|| {
-            AgentError::Store(format!("turn {} attempt overflow", TurnId(candidate.id)))
+        let resuming = candidate.status == TurnRunStatus::Resuming.as_str();
+        let next_attempt = if resuming {
+            candidate.attempt_count
+        } else {
+            candidate.attempt_count.checked_add(1).ok_or_else(|| {
+                AgentError::Store(format!("turn {} attempt overflow", TurnId(candidate.id)))
+            })?
+        };
+        let next_claim = candidate.claim_count.checked_add(1).ok_or_else(|| {
+            AgentError::Store(format!("turn {} claim overflow", TurnId(candidate.id)))
         })?;
         let receipt = entities::turn_claim::Entity::insert(entities::turn_claim::ActiveModel {
             token: Set(lease_token),
             turn_id: Set(candidate.id),
             attempt_count: Set(next_attempt),
+            claim_count: Set(next_claim),
             claimed_at: Set(now),
             lease_expires_at: Set(lease_expires_at),
         })
@@ -490,9 +511,9 @@ pub(in crate::db) async fn claim_turn_run(
             {
                 continue;
             }
-            let conflicting_attempt = entities::turn_claim::Entity::find()
+            let conflicting_claim = entities::turn_claim::Entity::find()
                 .filter(entities::turn_claim::Column::TurnId.eq(candidate.id))
-                .filter(entities::turn_claim::Column::AttemptCount.eq(next_attempt))
+                .filter(entities::turn_claim::Column::ClaimCount.eq(next_claim))
                 .one(&store.conn)
                 .await
                 .map_err(store_err)?;
@@ -500,15 +521,15 @@ pub(in crate::db) async fn claim_turn_run(
                 .one(&store.conn)
                 .await
                 .map_err(store_err)?;
-            if conflicting_attempt.is_some()
+            if conflicting_claim.is_some()
                 && current
                     .as_ref()
-                    .is_some_and(|turn| turn.attempt_count >= next_attempt)
+                    .is_some_and(|turn| turn.claim_count >= next_claim)
             {
                 continue;
             }
             return Err(AgentError::Store(format!(
-                "turn {} claim receipt for attempt {next_attempt} exists before the turn advanced",
+                "turn {} receipt for claim {next_claim} exists before the turn advanced",
                 TurnId(candidate.id)
             )));
         }
@@ -520,6 +541,10 @@ pub(in crate::db) async fn claim_turn_run(
             .col_expr(
                 entities::turn_run::Column::AttemptCount,
                 sea_orm::sea_query::Expr::value(next_attempt),
+            )
+            .col_expr(
+                entities::turn_run::Column::ClaimCount,
+                sea_orm::sea_query::Expr::value(next_claim),
             )
             .col_expr(
                 entities::turn_run::Column::LeaseToken,
@@ -548,6 +573,7 @@ pub(in crate::db) async fn claim_turn_run(
             .filter(entities::turn_run::Column::Id.eq(candidate.id))
             .filter(entities::turn_run::Column::Status.eq(&candidate.status))
             .filter(entities::turn_run::Column::AttemptCount.eq(candidate.attempt_count))
+            .filter(entities::turn_run::Column::ClaimCount.eq(candidate.claim_count))
             .filter(entities::turn_run::Column::UpdatedAt.eq(candidate.updated_at));
         let claim = if reclaiming {
             claim
@@ -750,6 +776,7 @@ where
             TurnRunStatus::Queued.as_str(),
             TurnRunStatus::Running.as_str(),
             TurnRunStatus::Cancelling.as_str(),
+            TurnRunStatus::Resuming.as_str(),
             TurnRunStatus::RetryWait.as_str(),
         ]))
         .one(conn)
@@ -805,6 +832,7 @@ fn turn_run_from_model(model: entities::turn_run::Model) -> Result<TurnRun> {
         status: turn_run_status_from_db(&model.status)?,
         attempt_count: model.attempt_count,
         max_attempts: model.max_attempts,
+        claim_count: model.claim_count,
         available_at: model.available_at,
         lease_token: model.lease_token,
         lease_expires_at: model.lease_expires_at,
@@ -824,6 +852,7 @@ fn turn_run_status_from_db(text: &str) -> Result<TurnRunStatus> {
         "queued" => Ok(TurnRunStatus::Queued),
         "running" => Ok(TurnRunStatus::Running),
         "cancelling" => Ok(TurnRunStatus::Cancelling),
+        "resuming" => Ok(TurnRunStatus::Resuming),
         "retry_wait" => Ok(TurnRunStatus::RetryWait),
         "completed" => Ok(TurnRunStatus::Completed),
         "failed" => Ok(TurnRunStatus::Failed),

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -133,6 +133,7 @@ async fn complete_turn_run_inner(
 
     if existing.status == TurnRunStatus::Completed.as_str()
         && existing.attempt_count == receipt.attempt_count
+        && existing.claim_count == receipt.claim_count
     {
         if existing.output_message_id != Some(output.id.0)
             || !exact_completed_output_on(&transaction, output).await?
@@ -152,6 +153,7 @@ async fn complete_turn_run_inner(
     }
     if existing.status != TurnRunStatus::Running.as_str()
         || existing.attempt_count != receipt.attempt_count
+        || existing.claim_count != receipt.claim_count
         || existing.lease_token != Some(lease_token)
         || existing
             .lease_expires_at
@@ -255,6 +257,7 @@ async fn complete_turn_run_inner(
         .filter(entities::turn_run::Column::Id.eq(id.0))
         .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
         .filter(entities::turn_run::Column::AttemptCount.eq(receipt.attempt_count))
+        .filter(entities::turn_run::Column::ClaimCount.eq(receipt.claim_count))
         .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
         .filter(entities::turn_run::Column::LeaseExpiresAt.eq(existing.lease_expires_at))
         .filter(entities::turn_run::Column::LeaseExpiresAt.gt(now))
@@ -448,6 +451,7 @@ async fn record_turn_run_failure_inner(
     };
     if turn.status != TurnRunStatus::Running.as_str()
         || turn.attempt_count != claim.attempt_count
+        || turn.claim_count != claim.claim_count
         || turn.lease_token != Some(lease_token)
         || turn
             .lease_expires_at
@@ -519,6 +523,7 @@ async fn record_turn_run_failure_inner(
         .filter(entities::turn_run::Column::Id.eq(id.0))
         .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
         .filter(entities::turn_run::Column::AttemptCount.eq(claim.attempt_count))
+        .filter(entities::turn_run::Column::ClaimCount.eq(claim.claim_count))
         .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
         .filter(entities::turn_run::Column::LeaseExpiresAt.eq(turn.lease_expires_at))
         .filter(entities::turn_run::Column::LeaseExpiresAt.gt(now))
@@ -676,6 +681,7 @@ async fn exact_completed_turn_on(
     };
     if existing.status != TurnRunStatus::Completed.as_str()
         || existing.attempt_count != receipt.attempt_count
+        || existing.claim_count != receipt.claim_count
     {
         return Ok(None);
     }

--- a/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
@@ -75,7 +75,10 @@ async fn request_turn_cancellation_inner(
                 terminal_event: None,
             }));
         }
-        TurnRunStatus::Queued | TurnRunStatus::Running | TurnRunStatus::RetryWait => {}
+        TurnRunStatus::Queued
+        | TurnRunStatus::Running
+        | TurnRunStatus::Resuming
+        | TurnRunStatus::RetryWait => {}
     }
     if turn.updated_at > now {
         transaction.commit().await.map_err(store_err)?;
@@ -224,7 +227,9 @@ async fn finish_turn_cancellation_inner(
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     };
-    if turn.status == TurnRunStatus::Cancelled.as_str() && turn.attempt_count == claim.attempt_count
+    if turn.status == TurnRunStatus::Cancelled.as_str()
+        && turn.attempt_count == claim.attempt_count
+        && turn.claim_count == claim.claim_count
     {
         let sequenced_event =
             exact_terminal_event_on(&transaction, id, Some(lease_token), terminal_event).await?;
@@ -237,6 +242,7 @@ async fn finish_turn_cancellation_inner(
     }
     if turn.status != TurnRunStatus::Cancelling.as_str()
         || turn.attempt_count != claim.attempt_count
+        || turn.claim_count != claim.claim_count
         || turn.lease_token != Some(lease_token)
         || turn.updated_at > now
     {
@@ -268,6 +274,7 @@ async fn finish_turn_cancellation_inner(
         .filter(entities::turn_run::Column::Id.eq(id.0))
         .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Cancelling.as_str()))
         .filter(entities::turn_run::Column::AttemptCount.eq(claim.attempt_count))
+        .filter(entities::turn_run::Column::ClaimCount.eq(claim.claim_count))
         .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
         .filter(entities::turn_run::Column::LeaseExpiresAt.eq(turn.lease_expires_at))
         .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at))

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -84,7 +84,10 @@ pub(in crate::db) async fn accept_turn_steer(
         && turn.updated_at <= now
         && matches!(
             status,
-            TurnRunStatus::Queued | TurnRunStatus::Running | TurnRunStatus::RetryWait
+            TurnRunStatus::Queued
+                | TurnRunStatus::Running
+                | TurnRunStatus::Resuming
+                | TurnRunStatus::RetryWait
         )
         && (status != TurnRunStatus::Running
             || turn
@@ -212,6 +215,7 @@ pub(in crate::db) async fn list_pending_turn_steers(
         .is_some_and(|turn| {
             turn.status == TurnRunStatus::Running.as_str()
                 && turn.attempt_count == claim.attempt_count
+                && turn.claim_count == claim.claim_count
                 && turn.lease_token == Some(lease_token)
                 && turn
                     .lease_expires_at
@@ -338,6 +342,7 @@ pub(in crate::db) async fn apply_turn_steer(
     };
     if turn.status != TurnRunStatus::Running.as_str()
         || turn.attempt_count != claim.attempt_count
+        || turn.claim_count != claim.claim_count
         || turn.lease_token != Some(lease_token)
         || turn
             .lease_expires_at
@@ -459,6 +464,7 @@ pub(in crate::db) async fn apply_turn_steer(
         .filter(entities::turn_run::Column::Id.eq(turn_id.0))
         .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
         .filter(entities::turn_run::Column::AttemptCount.eq(claim.attempt_count))
+        .filter(entities::turn_run::Column::ClaimCount.eq(claim.claim_count))
         .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
         .filter(entities::turn_run::Column::LeaseExpiresAt.eq(turn.lease_expires_at))
         .filter(entities::turn_run::Column::LeaseExpiresAt.gt(now))

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5545,13 +5545,11 @@ async fn resuming_turn_claims_a_new_lease_without_consuming_failure_budget() {
             .unwrap(),
         Some(CompleteTurnRunOutcome::Completed(_))
     ));
-    assert!(matches!(
-        store
-            .complete_turn_run(turn_id, first_token, 0, output.created_at, &output)
-            .await
-            .unwrap(),
-        None
-    ));
+    assert!(store
+        .complete_turn_run(turn_id, first_token, 0, output.created_at, &output)
+        .await
+        .unwrap()
+        .is_none());
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4611,6 +4611,7 @@ async fn make_queued_turn(
         status: Set(TurnRunStatus::Queued.as_str().into()),
         attempt_count: Set(0),
         max_attempts: Set(crate::model::TurnRun::DEFAULT_MAX_ATTEMPTS),
+        claim_count: Set(0),
         available_at: Set(now),
         lease_token: Set(None),
         lease_expires_at: Set(None),
@@ -4676,6 +4677,10 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
             sea_orm::sea_query::Expr::value(1),
         )
         .col_expr(
+            entities::turn_run::Column::ClaimCount,
+            sea_orm::sea_query::Expr::value(1),
+        )
+        .col_expr(
             entities::turn_run::Column::OutputMessageId,
             sea_orm::sea_query::Expr::value(Some(first_output_id.0)),
         )
@@ -4703,6 +4708,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let mut running_without_lease = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     running_without_lease.status = Set(TurnRunStatus::Running.as_str().into());
     running_without_lease.attempt_count = Set(1);
+    running_without_lease.claim_count = Set(1);
     running_without_lease.started_at = Set(Some(now));
     assert!(running_without_lease.insert(&store.conn).await.is_err());
 
@@ -4710,12 +4716,14 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     cancelling_without_lease.status = Set(TurnRunStatus::Cancelling.as_str().into());
     cancelling_without_lease.attempt_count = Set(1);
+    cancelling_without_lease.claim_count = Set(1);
     cancelling_without_lease.started_at = Set(Some(now));
     assert!(cancelling_without_lease.insert(&store.conn).await.is_err());
 
     let mut retry_without_error = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     retry_without_error.status = Set(TurnRunStatus::RetryWait.as_str().into());
     retry_without_error.attempt_count = Set(1);
+    retry_without_error.claim_count = Set(1);
     retry_without_error.max_attempts = Set(2);
     retry_without_error.started_at = Set(Some(now));
     assert!(retry_without_error.insert(&store.conn).await.is_err());
@@ -4723,6 +4731,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let mut failed_without_finish = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     failed_without_finish.status = Set(TurnRunStatus::Failed.as_str().into());
     failed_without_finish.attempt_count = Set(1);
+    failed_without_finish.claim_count = Set(1);
     failed_without_finish.started_at = Set(Some(now));
     failed_without_finish.last_error_code = Set(Some("provider_error".into()));
     assert!(failed_without_finish.insert(&store.conn).await.is_err());
@@ -4731,6 +4740,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     completed_without_output.status = Set(TurnRunStatus::Completed.as_str().into());
     completed_without_output.attempt_count = Set(1);
+    completed_without_output.claim_count = Set(1);
     completed_without_output.started_at = Set(Some(now));
     completed_without_output.finished_at = Set(Some(now));
     assert!(completed_without_output.insert(&store.conn).await.is_err());
@@ -4743,6 +4753,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     completed_with_wrong_output.status = Set(TurnRunStatus::Completed.as_str().into());
     completed_with_wrong_output.attempt_count = Set(1);
+    completed_with_wrong_output.claim_count = Set(1);
     completed_with_wrong_output.started_at = Set(Some(now));
     completed_with_wrong_output.finished_at = Set(Some(now));
     completed_with_wrong_output.output_message_id = Set(Some(first_output_id.0));
@@ -4779,6 +4790,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let mut oversized_error = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     oversized_error.status = Set(TurnRunStatus::Failed.as_str().into());
     oversized_error.attempt_count = Set(1);
+    oversized_error.claim_count = Set(1);
     oversized_error.started_at = Set(Some(now));
     oversized_error.finished_at = Set(Some(now));
     oversized_error.last_error_code = Set(Some(
@@ -4801,6 +4813,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let running_turn_id = running.id.clone().unwrap();
     running.status = Set(TurnRunStatus::Running.as_str().into());
     running.attempt_count = Set(1);
+    running.claim_count = Set(1);
     running.started_at = Set(Some(now));
     let running_token = uuid::Uuid::new_v4();
     running.lease_token = Set(Some(running_token));
@@ -4809,6 +4822,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         token: Set(running_token),
         turn_id: Set(running_turn_id),
         attempt_count: Set(1),
+        claim_count: Set(1),
         claimed_at: Set(now),
         lease_expires_at: Set(now + chrono::Duration::minutes(1)),
     }
@@ -4859,6 +4873,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         token: Set(uuid::Uuid::new_v4()),
         turn_id: Set(running_turn_id),
         attempt_count: Set(1),
+        claim_count: Set(1),
         claimed_at: Set(now),
         lease_expires_at: Set(now + chrono::Duration::minutes(1)),
     }
@@ -4871,6 +4886,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let mut duplicate_lease = make_queued_turn(&store, duplicate_lease_chat.id, "gpt-5", now).await;
     duplicate_lease.status = Set(TurnRunStatus::Running.as_str().into());
     duplicate_lease.attempt_count = Set(1);
+    duplicate_lease.claim_count = Set(1);
     duplicate_lease.started_at = Set(Some(now));
     duplicate_lease.lease_token = Set(Some(running_token));
     duplicate_lease.lease_expires_at = Set(Some(now + chrono::Duration::minutes(1)));
@@ -4886,6 +4902,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         token: Set(mismatched_token),
         turn_id: Set(mismatched_turn_id),
         attempt_count: Set(2),
+        claim_count: Set(2),
         claimed_at: Set(now),
         lease_expires_at: Set(now + chrono::Duration::minutes(1)),
     }
@@ -4894,6 +4911,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     .unwrap();
     mismatched_receipt.status = Set(TurnRunStatus::Running.as_str().into());
     mismatched_receipt.attempt_count = Set(1);
+    mismatched_receipt.claim_count = Set(2);
     mismatched_receipt.started_at = Set(Some(now));
     mismatched_receipt.lease_token = Set(Some(mismatched_token));
     mismatched_receipt.lease_expires_at = Set(Some(now + chrono::Duration::minutes(1)));
@@ -4904,6 +4922,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let mut retry_wait = make_queued_turn(&store, retry_chat.id, "gpt-5", now).await;
     retry_wait.status = Set(TurnRunStatus::RetryWait.as_str().into());
     retry_wait.attempt_count = Set(1);
+    retry_wait.claim_count = Set(1);
     retry_wait.max_attempts = Set(2);
     retry_wait.started_at = Set(Some(now));
     retry_wait.last_error_code = Set(Some("provider_unavailable".into()));
@@ -4914,6 +4933,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let mut failed = make_queued_turn(&store, failed_chat.id, "gpt-5", now).await;
     failed.status = Set(TurnRunStatus::Failed.as_str().into());
     failed.attempt_count = Set(1);
+    failed.claim_count = Set(1);
     failed.started_at = Set(Some(now));
     failed.finished_at = Set(Some(now));
     failed.last_error_code = Set(Some("unsafe_to_retry".into()));
@@ -4928,6 +4948,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         cancelled.finished_at = Set(Some(now));
         if started {
             cancelled.attempt_count = Set(1);
+            cancelled.claim_count = Set(1);
             cancelled.started_at = Set(Some(now));
         }
         cancelled.insert(&store.conn).await.unwrap();
@@ -5253,6 +5274,7 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
     );
     assert_eq!(first.status, TurnRunStatus::Running);
     assert_eq!(first.attempt_count, 1);
+    assert_eq!(first.claim_count, 1);
     assert_eq!(first.started_at, Some(claimed_at));
     assert_eq!(first.lease_expires_at, Some(first_expiry));
 
@@ -5324,6 +5346,7 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
     assert_eq!(second.id, turn_id);
     assert_eq!(second.status, TurnRunStatus::Running);
     assert_eq!(second.attempt_count, 2);
+    assert_eq!(second.claim_count, 2);
     assert_eq!(second.started_at, first.started_at);
     assert_eq!(second.lease_token, Some(second_token));
     assert_eq!(second.last_error_code, None);
@@ -5419,6 +5442,119 @@ async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
 }
 
 #[tokio::test]
+async fn resuming_turn_claims_a_new_lease_without_consuming_failure_budget() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let first_claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let first_token = uuid::Uuid::new_v4();
+    let first = store
+        .claim_turn_run(
+            first_token,
+            first_claimed_at,
+            first_claimed_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!((first.attempt_count, first.claim_count), (1, 1));
+    assert_eq!(first.max_attempts, 1);
+
+    let resume_at = first_claimed_at + chrono::Duration::seconds(10);
+    let parked = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnRunStatus::Resuming.as_str()),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(resume_at),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(resume_at),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
+        .filter(entities::turn_run::Column::LeaseToken.eq(first.lease_token))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert_eq!(parked.rows_affected, 1);
+    assert!(matches!(
+        store
+            .accept_turn(TurnId::new(), chat.id, "gpt-5", "must stay busy")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::ChatBusy(existing) if existing.id == turn_id
+    ));
+
+    let resumed_token = uuid::Uuid::new_v4();
+    let resumed = store
+        .claim_turn_run(
+            resumed_token,
+            resume_at,
+            resume_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(resumed.id, turn_id);
+    assert_eq!(resumed.status, TurnRunStatus::Running);
+    assert_eq!((resumed.attempt_count, resumed.claim_count), (1, 2));
+    assert_eq!(resumed.max_attempts, 1);
+
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "resumed answer".into(),
+        created_at: resume_at + chrono::Duration::seconds(1),
+    };
+    assert_eq!(
+        store
+            .complete_turn_run(turn_id, first_token, 0, output.created_at, &output)
+            .await
+            .unwrap(),
+        None,
+        "the earlier lease segment must not complete the resumed turn"
+    );
+    assert!(matches!(
+        store
+            .complete_turn_run(turn_id, resumed_token, 0, output.created_at, &output)
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::Completed(_))
+    ));
+    assert!(matches!(
+        store
+            .complete_turn_run(turn_id, first_token, 0, output.created_at, &output)
+            .await
+            .unwrap(),
+        None
+    ));
+}
+
+#[tokio::test]
 async fn turn_claim_rejects_a_receipt_for_an_attempt_that_never_advanced() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
@@ -5436,6 +5572,7 @@ async fn turn_claim_rejects_a_receipt_for_an_attempt_that_never_advanced() {
         token: Set(uuid::Uuid::new_v4()),
         turn_id: Set(accepted.id.0),
         attempt_count: Set(1),
+        claim_count: Set(1),
         claimed_at: Set(claimed_at),
         lease_expires_at: Set(claimed_at + chrono::Duration::minutes(1)),
     }

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -633,11 +633,15 @@ pub struct TurnRun {
     pub model: String,
     /// Durable delivery state.
     pub status: TurnRunStatus,
-    /// Claims already made, including the current claim when running.
+    /// Failure attempts already started. Client-execution resumptions stay
+    /// within the same attempt and do not consume this retry budget.
     pub attempt_count: i32,
-    /// Maximum claims permitted for this turn.
+    /// Maximum failure attempts permitted for this turn.
     pub max_attempts: i32,
-    /// Earliest time queued or retry-wait work may be claimed.
+    /// Worker lease segments already issued, including resumptions within one
+    /// failure attempt.
+    pub claim_count: i32,
+    /// Earliest time queued, retry-wait, or resuming work may be claimed.
     pub available_at: DateTime<Utc>,
     /// Exact claim identity required for heartbeat and resolution writes.
     pub lease_token: Option<Uuid>,
@@ -686,6 +690,9 @@ pub enum TurnRunStatus {
     /// The chat remains occupied until that worker acknowledges quiescence or
     /// the expired lease is cleaned up.
     Cancelling,
+    /// The blocking client call resolved and the checkpoint is eligible for a
+    /// fresh worker lease without consuming another failure attempt.
+    Resuming,
     /// Failed safely before an ambiguous side effect and awaits another claim.
     RetryWait,
     /// Produced a final answer successfully.
@@ -704,6 +711,7 @@ impl TurnRunStatus {
             Self::Queued => "queued",
             Self::Running => "running",
             Self::Cancelling => "cancelling",
+            Self::Resuming => "resuming",
             Self::RetryWait => "retry_wait",
             Self::Completed => "completed",
             Self::Failed => "failed",

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -759,12 +759,14 @@ pub trait Store: Send + Sync {
     /// `lease_token` is the caller's idempotency identity: retrying it while its
     /// lease remains live returns the same running turn. Callers must retain it
     /// across an ambiguous commit and use a fresh token for a new claim attempt.
-    /// A successful claim increments `attempt_count` and moves the turn to
-    /// `running`. Expired work is reclaimed only while another attempt is
-    /// permitted. An expired cancellation or final attempt is terminalized with
-    /// its exact routed journal event and returned instead of claiming another
-    /// turn; the caller publishes it before scanning again. `lease_expires_at`
-    /// must be after `now`.
+    /// Every successful claim increments `claim_count` and moves the turn to
+    /// `running`. Queued, retry-wait, and expired-running claims also increment
+    /// `attempt_count`; resuming claims retain the current failure attempt.
+    /// Expired work is reclaimed only while another attempt is permitted. An
+    /// expired cancellation or final attempt is terminalized with its exact
+    /// routed journal event and returned instead of claiming another turn; the
+    /// caller publishes it before scanning again. `lease_expires_at` must be
+    /// after `now`.
     async fn claim_turn_run(
         &self,
         _lease_token: uuid::Uuid,
@@ -792,8 +794,9 @@ pub trait Store: Send + Sync {
     ///
     /// The non-nil caller-supplied `id` also names the eventual user message.
     /// Exact retries compare chat, turn, byte-exact content, and interrupt intent.
-    /// Queued, running, and retry-wait turns accept instructions; cancelling or
-    /// terminal turns return [`AcceptTurnSteerOutcome::TurnUnavailable`].
+    /// Queued, running, resuming, and retry-wait turns accept instructions;
+    /// cancelling or terminal turns return
+    /// [`AcceptTurnSteerOutcome::TurnUnavailable`].
     async fn accept_turn_steer(
         &self,
         _id: TurnSteerId,
@@ -925,11 +928,12 @@ pub trait Store: Send + Sync {
 
     /// Durably request cancellation for one exact turn.
     ///
-    /// Queued and retry-wait work becomes terminal immediately. Running work
-    /// enters `cancelling` while retaining its exact lease, so the database's
-    /// one-live-turn-per-chat invariant remains held until the cooperative
-    /// worker actually stops. The empty-payload request converges on the exact
-    /// turn identity, so cancelling/cancelled retries return `Existing`.
+    /// Queued, retry-wait, and resuming work becomes terminal immediately.
+    /// Running work enters `cancelling` while retaining its exact lease, so the
+    /// database's one-live-turn-per-chat invariant remains held until the
+    /// cooperative worker actually stops. The empty-payload request converges
+    /// on the exact turn identity, so cancelling/cancelled retries return
+    /// `Existing`.
     async fn request_turn_cancellation(
         &self,
         _id: TurnId,
@@ -940,9 +944,9 @@ pub trait Store: Send + Sync {
 
     /// Request cancellation and publish an immediate terminal outcome atomically.
     ///
-    /// Queued and retry-wait turns commit `TurnCancelled` with their terminal
-    /// transition. Running turns only enter `cancelling`; their worker publishes
-    /// the terminal event when it acknowledges quiescence.
+    /// Queued, retry-wait, and resuming turns commit `TurnCancelled` with their
+    /// terminal transition. Running turns only enter `cancelling`; their worker
+    /// publishes the terminal event when it acknowledges quiescence.
     async fn request_turn_cancellation_and_append_event(
         &self,
         _id: TurnId,

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -214,10 +214,12 @@ the lease from the server's current receive time. Heartbeat and resolution
 enforce the immutable chat owner inside the same locked state transition rather
 than loading conversation history first.
 
-The agent still executes its current built-in tools inside the turn worker.
-Parking a turn atomically while a native client acts and running the desktop
-executor are the next layers. Notifications will be wake-up hints, while the
-pending-work query remains authoritative.
+The agent still executes its current built-in tools inside the turn worker. The
+turn model now distinguishes failure attempts from worker lease segments and
+reserves an explicit resumable claim state for native client work. The atomic
+wait receipt, park/resolve transitions, and desktop executor are the next layers.
+Notifications will be wake-up hints, while the pending-work query remains
+authoritative.
 
 ### 4. Events drive the live client
 
@@ -251,9 +253,15 @@ queued ----claim----> running ----success----> completed
   |
   +----cancel-----------------------------------------------> cancelled
 
-retry_wait exists for safely replayable work, but ordinary turns currently use
-one attempt because external and filesystem tool effects are not checkpointed.
+resuming ----same attempt, fresh claim----> running
 ```
+
+retry_wait exists for safely replayable failures. `attempt_count` tracks that
+failure/replay budget, while `claim_count` advances for every worker lease. A
+resume therefore gets a fresh exact lease without pretending the client round
+trip was a failure or consuming another attempt. Ordinary turns still default
+to one failure attempt because external and filesystem effects are not yet
+fully checkpointed.
 
 ## Cancellation, approvals, and steering
 


### PR DESCRIPTION
## Summary

- separate failure-attempt accounting from worker lease segments
- add a resumable turn state that can claim a fresh lease without consuming retry budget
- fence completion, failure, cancellation, conversation writes, and steering by the exact claim segment
- keep resuming turns chat-active and document the durable state-machine boundary

## Validation

- `cargo test -p openwave-core --lib`
- `cargo test -p openwave-server --lib --no-run`
- PostgreSQL 17 `postgres_turn_state` integration suite
- `bw dev lint --rust --check --repo-root "$PWD"`
- `cargo fmt --all -- --check`
