### PR TITLE
feat(core): checkpoint turns across client execution

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -250,6 +250,30 @@ pub mod turn_claim_lock {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod turn_client_wait {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "turn_client_wait")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub call_id: Uuid,
+        pub turn_id: Uuid,
+        pub chat_id: Uuid,
+        pub park_lease_token: Uuid,
+        pub attempt_count: i32,
+        pub claim_count: i32,
+        pub status: String,
+        pub parked_at: DateTimeUtc,
+        pub closed_at: Option<DateTimeUtc>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod message_identity {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -2,7 +2,7 @@ use sea_orm_migration::prelude::*;
 
 use super::{
     BlobRetirementStatus, DocumentJobKind, DocumentJobStatus, DocumentProcessingStatus,
-    TurnRunStatus, TurnSteerStatus,
+    TurnClientWaitStatus, TurnRunStatus, TurnSteerStatus,
 };
 
 pub struct Migrator;
@@ -232,6 +232,8 @@ impl MigrationTrait for Init {
             TurnRunStatus::Queued.as_str(),
             TurnRunStatus::Running.as_str(),
             TurnRunStatus::Cancelling.as_str(),
+            TurnRunStatus::WaitingForClient.as_str(),
+            TurnRunStatus::CancellingClient.as_str(),
             TurnRunStatus::Resuming.as_str(),
             TurnRunStatus::RetryWait.as_str(),
             TurnRunStatus::Completed.as_str(),
@@ -268,6 +270,8 @@ impl MigrationTrait for Init {
                 TurnRunStatus::Queued.as_str(),
                 TurnRunStatus::Running.as_str(),
                 TurnRunStatus::Cancelling.as_str(),
+                TurnRunStatus::WaitingForClient.as_str(),
+                TurnRunStatus::CancellingClient.as_str(),
                 TurnRunStatus::Resuming.as_str(),
                 TurnRunStatus::RetryWait.as_str(),
             ])
@@ -289,8 +293,12 @@ impl MigrationTrait for Init {
             .and(Expr::col(TurnRun::AttemptCount).gte(1))
             .and(Expr::col(TurnRun::AttemptCount).lt(Expr::col(TurnRun::MaxAttempts)))
             .and(Expr::col(TurnRun::StartedAt).is_not_null());
-        let resuming_attempt = Expr::col(TurnRun::Status)
-            .eq(TurnRunStatus::Resuming.as_str())
+        let client_checkpoint_attempt = Expr::col(TurnRun::Status)
+            .is_in([
+                TurnRunStatus::WaitingForClient.as_str(),
+                TurnRunStatus::CancellingClient.as_str(),
+                TurnRunStatus::Resuming.as_str(),
+            ])
             .and(Expr::col(TurnRun::AttemptCount).gte(1))
             .and(Expr::col(TurnRun::StartedAt).is_not_null());
         let resolved_attempt = Expr::col(TurnRun::Status)
@@ -322,6 +330,8 @@ impl MigrationTrait for Init {
                 TurnRunStatus::Queued.as_str(),
                 TurnRunStatus::Running.as_str(),
                 TurnRunStatus::Cancelling.as_str(),
+                TurnRunStatus::WaitingForClient.as_str(),
+                TurnRunStatus::CancellingClient.as_str(),
                 TurnRunStatus::Resuming.as_str(),
                 TurnRunStatus::Completed.as_str(),
                 TurnRunStatus::Cancelled.as_str(),
@@ -476,7 +486,7 @@ impl MigrationTrait for Init {
                     .check(
                         queued_attempt
                             .or(leased_attempt)
-                            .or(resuming_attempt)
+                            .or(client_checkpoint_attempt)
                             .or(retryable_attempt)
                             .or(resolved_attempt)
                             .or(cancelled_attempt),
@@ -542,6 +552,8 @@ impl MigrationTrait for Init {
                         TurnRunStatus::Queued.as_str(),
                         TurnRunStatus::Running.as_str(),
                         TurnRunStatus::Cancelling.as_str(),
+                        TurnRunStatus::WaitingForClient.as_str(),
+                        TurnRunStatus::CancellingClient.as_str(),
                         TurnRunStatus::Resuming.as_str(),
                         TurnRunStatus::RetryWait.as_str(),
                     ]))
@@ -1227,6 +1239,11 @@ impl MigrationTrait for AddToolCalls {
                                             .ne(crate::model::ToolCallStatus::Pending.as_str())
                                             .and(Expr::col(ToolCall::ClientExecutorId).is_not_null())
                                             .and(Expr::col(ToolCall::ClientLeaseToken).is_not_null())
+                                            .and(Expr::col(ToolCall::ClientLeaseExpiresAt).is_null()))
+                                        .or(Expr::col(ToolCall::Status)
+                                            .eq(crate::model::ToolCallStatus::Cancelled.as_str())
+                                            .and(Expr::col(ToolCall::ClientExecutorId).is_null())
+                                            .and(Expr::col(ToolCall::ClientLeaseToken).is_null())
                                             .and(Expr::col(ToolCall::ClientLeaseExpiresAt).is_null())),
                                 )),
                     )
@@ -1247,6 +1264,18 @@ impl MigrationTrait for AddToolCalls {
         manager
             .create_index(
                 Index::create()
+                    .name("idx_tool_call_wait_identity")
+                    .table(ToolCall::Table)
+                    .col(ToolCall::Id)
+                    .col(ToolCall::ChatId)
+                    .col(ToolCall::TurnId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
                     .name("idx_tool_call_client_pending")
                     .table(ToolCall::Table)
                     .col(ToolCall::ChatId)
@@ -1256,10 +1285,123 @@ impl MigrationTrait for AddToolCalls {
                     .to_owned(),
             )
             .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(TurnClientWait::Table)
+                    .col(
+                        ColumnDef::new(TurnClientWait::CallId)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(TurnClientWait::TurnId).uuid().not_null())
+                    .col(ColumnDef::new(TurnClientWait::ChatId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(TurnClientWait::ParkLeaseToken)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnClientWait::AttemptCount)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnClientWait::ClaimCount)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(TurnClientWait::Status).text().not_null())
+                    .col(
+                        ColumnDef::new(TurnClientWait::ParkedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(TurnClientWait::ClosedAt).timestamp_with_time_zone())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_client_wait_call")
+                            .from_tbl(TurnClientWait::Table)
+                            .from_col(TurnClientWait::CallId)
+                            .from_col(TurnClientWait::ChatId)
+                            .from_col(TurnClientWait::TurnId)
+                            .to_tbl(ToolCall::Table)
+                            .to_col(ToolCall::Id)
+                            .to_col(ToolCall::ChatId)
+                            .to_col(ToolCall::TurnId)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_client_wait_claim")
+                            .from_tbl(TurnClientWait::Table)
+                            .from_col(TurnClientWait::ParkLeaseToken)
+                            .from_col(TurnClientWait::TurnId)
+                            .from_col(TurnClientWait::AttemptCount)
+                            .from_col(TurnClientWait::ClaimCount)
+                            .to_tbl(TurnClaim::Table)
+                            .to_col(TurnClaim::Token)
+                            .to_col(TurnClaim::TurnId)
+                            .to_col(TurnClaim::AttemptCount)
+                            .to_col(TurnClaim::ClaimCount)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .check(Expr::col(TurnClientWait::Status).is_in([
+                        TurnClientWaitStatus::Waiting.as_str(),
+                        TurnClientWaitStatus::Resumed.as_str(),
+                        TurnClientWaitStatus::Cancelled.as_str(),
+                    ]))
+                    .check(
+                        Expr::col(TurnClientWait::Status)
+                            .eq(TurnClientWaitStatus::Waiting.as_str())
+                            .and(Expr::col(TurnClientWait::ClosedAt).is_null())
+                            .or(Expr::col(TurnClientWait::Status)
+                                .ne(TurnClientWaitStatus::Waiting.as_str())
+                                .and(Expr::col(TurnClientWait::ClosedAt).is_not_null())),
+                    )
+                    .check(
+                        Expr::col(TurnClientWait::ClosedAt)
+                            .is_null()
+                            .or(Expr::col(TurnClientWait::ClosedAt)
+                                .gte(Expr::col(TurnClientWait::ParkedAt))),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_client_wait_one_open")
+                    .table(TurnClientWait::Table)
+                    .col(TurnClientWait::TurnId)
+                    .unique()
+                    .and_where(
+                        Expr::col(TurnClientWait::Status)
+                            .eq(TurnClientWaitStatus::Waiting.as_str()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_client_wait_history")
+                    .table(TurnClientWait::Table)
+                    .col(TurnClientWait::TurnId)
+                    .col(TurnClientWait::ParkedAt)
+                    .col(TurnClientWait::CallId)
+                    .to_owned(),
+            )
+            .await?;
         Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(TurnClientWait::Table).to_owned())
+            .await?;
         manager
             .drop_table(Table::drop().table(ToolCall::Table).to_owned())
             .await?;
@@ -2132,6 +2274,20 @@ enum ToolCall {
     ClientLeaseExpiresAt,
     CreatedAt,
     ResolvedAt,
+}
+
+#[derive(DeriveIden)]
+enum TurnClientWait {
+    Table,
+    CallId,
+    TurnId,
+    ChatId,
+    ParkLeaseToken,
+    AttemptCount,
+    ClaimCount,
+    Status,
+    ParkedAt,
+    ClosedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -30,15 +30,16 @@ use crate::model::{
     DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
     DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
     DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, ToolCallResolution,
-    TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteerStatus,
+    TurnClientWaitStatus, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteerStatus,
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
     AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, ClaimClientToolCallOutcome,
     ClaimTurnRunOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
     EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
-    HeartbeatClientToolCallOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
-    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome, Store,
+    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledTurnOutcome,
+    JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
+    RequestTurnCancellationOutcome, ResolveToolCallOutcome, Store,
 };
 
 mod ops;
@@ -1839,6 +1840,25 @@ impl Store for DbStore {
             .await
     }
 
+    async fn park_turn_for_client_tool_call(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
+        now: chrono::DateTime<Utc>,
+        call: &crate::model::ClientToolCallRequest,
+    ) -> Result<Option<ParkTurnForClientCallOutcome>> {
+        ops::turn::park_turn_for_client_tool_call(
+            self,
+            turn_id,
+            lease_token,
+            expected_steer_revision,
+            now,
+            call,
+        )
+        .await
+    }
+
     async fn append_message(&self, message: &Message) -> Result<()> {
         ops::conversation::append_message(self, message).await
     }
@@ -1900,7 +1920,7 @@ impl Store for DbStore {
         ops::client_execution::resolve_server_tool_call(self, id, resolution, resolved_at).await
     }
 
-    async fn resolve_client_tool_call(
+    async fn resolve_client_tool_call_and_append_event(
         &self,
         id: CallId,
         chat_id: ChatId,
@@ -1908,8 +1928,8 @@ impl Store for DbStore {
         now: chrono::DateTime<Utc>,
         resolution: &ToolCallResolution,
         resolved_at: chrono::DateTime<Utc>,
-    ) -> Result<ResolveToolCallOutcome> {
-        ops::client_execution::resolve_client_tool_call(
+    ) -> Result<JournaledClientToolCallOutcome> {
+        ops::client_execution::resolve_client_tool_call_and_append_event(
             self,
             id,
             chat_id,
@@ -1921,7 +1941,7 @@ impl Store for DbStore {
         .await
     }
 
-    async fn resolve_expired_client_tool_call(
+    async fn resolve_expired_client_tool_call_and_append_event(
         &self,
         id: CallId,
         chat_id: ChatId,
@@ -1929,8 +1949,8 @@ impl Store for DbStore {
         now: chrono::DateTime<Utc>,
         resolution: &ToolCallResolution,
         resolved_at: chrono::DateTime<Utc>,
-    ) -> Result<ResolveToolCallOutcome> {
-        ops::client_execution::resolve_expired_client_tool_call(
+    ) -> Result<JournaledClientToolCallOutcome> {
+        ops::client_execution::resolve_expired_client_tool_call_and_append_event(
             self,
             id,
             chat_id,

--- a/crates/openwave-core/src/db/ops/client_execution.rs
+++ b/crates/openwave-core/src/db/ops/client_execution.rs
@@ -8,7 +8,7 @@ use crate::id::{CallId, ChatId};
 use crate::model::{ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus};
 use crate::storage::{
     AcceptToolCallOutcome, ClaimClientToolCallOutcome, ClientToolCallClaim,
-    HeartbeatClientToolCallOutcome, ResolveToolCallOutcome,
+    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, ResolveToolCallOutcome,
 };
 
 use super::super::{entities, store_err, DbStore};
@@ -88,6 +88,10 @@ pub(in crate::db) async fn claim_client_tool_call(
         return Ok(ClaimClientToolCallOutcome::Unavailable);
     }
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, chat_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ClaimClientToolCallOutcome::Unavailable);
+    }
     if !acquire_tool_call_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(ClaimClientToolCallOutcome::Unavailable);
@@ -141,6 +145,10 @@ pub(in crate::db) async fn heartbeat_client_tool_call(
     let lease_expires_at = canonical_db_timestamp(lease_expires_at)?;
     validate_lease(lease_token, now, lease_expires_at)?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, chat_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(HeartbeatClientToolCallOutcome::LeaseLost);
+    }
     if !acquire_tool_call_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(HeartbeatClientToolCallOutcome::LeaseLost);
@@ -177,17 +185,18 @@ pub(in crate::db) async fn resolve_server_tool_call(
     resolution: &ToolCallResolution,
     resolved_at: DateTime<Utc>,
 ) -> Result<ResolveToolCallOutcome> {
-    resolve_tool_call(
+    Ok(resolve_tool_call(
         store,
         id,
         ResolutionAuthority::Server,
         resolved_at,
         resolution,
     )
-    .await
+    .await?
+    .outcome)
 }
 
-pub(in crate::db) async fn resolve_client_tool_call(
+pub(in crate::db) async fn resolve_client_tool_call_and_append_event(
     store: &DbStore,
     id: CallId,
     chat_id: ChatId,
@@ -195,7 +204,7 @@ pub(in crate::db) async fn resolve_client_tool_call(
     now: DateTime<Utc>,
     resolution: &ToolCallResolution,
     resolved_at: DateTime<Utc>,
-) -> Result<ResolveToolCallOutcome> {
+) -> Result<JournaledClientToolCallOutcome> {
     if lease_token.is_nil() {
         return Err(AgentError::Store(
             "client lease token must not be nil".into(),
@@ -215,7 +224,7 @@ pub(in crate::db) async fn resolve_client_tool_call(
     .await
 }
 
-pub(in crate::db) async fn resolve_expired_client_tool_call(
+pub(in crate::db) async fn resolve_expired_client_tool_call_and_append_event(
     store: &DbStore,
     id: CallId,
     chat_id: ChatId,
@@ -223,7 +232,7 @@ pub(in crate::db) async fn resolve_expired_client_tool_call(
     now: DateTime<Utc>,
     resolution: &ToolCallResolution,
     resolved_at: DateTime<Utc>,
-) -> Result<ResolveToolCallOutcome> {
+) -> Result<JournaledClientToolCallOutcome> {
     if lease_token.is_nil() {
         return Err(AgentError::Store(
             "client lease token must not be nil".into(),
@@ -265,14 +274,20 @@ async fn resolve_tool_call(
     authority: ResolutionAuthority,
     resolved_at: DateTime<Utc>,
     resolution: &ToolCallResolution,
-) -> Result<ResolveToolCallOutcome> {
+) -> Result<JournaledClientToolCallOutcome> {
     validate_resolution(resolution)?;
     let resolved_at = canonical_db_timestamp(resolved_at)?;
     let authority = authority.canonicalized()?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    if let Some(chat_id) = authority.chat_id() {
+        if !acquire_chat_write_lock(&transaction, chat_id).await? {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(journaled_call_outcome(ResolveToolCallOutcome::LeaseLost));
+        }
+    }
     if !acquire_tool_call_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
-        return Ok(ResolveToolCallOutcome::NotFound);
+        return Ok(journaled_call_outcome(ResolveToolCallOutcome::NotFound));
     }
     let existing = entities::tool_call::Entity::find_by_id(id.0)
         .one(&transaction)
@@ -293,8 +308,19 @@ async fn resolve_tool_call(
         } else {
             ResolveToolCallOutcome::AlreadyTerminal
         };
+        let transition = if outcome == ResolveToolCallOutcome::Existing
+            && authority.chat_id().is_some()
+        {
+            super::turn::recover_turn_after_client_resolution_on(&transaction, &existing).await?
+        } else {
+            None
+        };
         transaction.commit().await.map_err(store_err)?;
-        return Ok(outcome);
+        return Ok(JournaledClientToolCallOutcome {
+            outcome,
+            turn: transition.as_ref().map(|item| item.turn.clone()),
+            terminal_event: transition.and_then(|item| item.terminal_event),
+        });
     }
 
     let owns = match authority {
@@ -326,7 +352,7 @@ async fn resolve_tool_call(
     };
     if !owns {
         transaction.commit().await.map_err(store_err)?;
-        return Ok(ResolveToolCallOutcome::LeaseLost);
+        return Ok(journaled_call_outcome(ResolveToolCallOutcome::LeaseLost));
     }
 
     let (error_code, error_detail) = resolution_error(resolution);
@@ -337,9 +363,27 @@ async fn resolve_tool_call(
     active.error_detail = Set(error_detail);
     active.client_lease_expires_at = Set(None);
     active.resolved_at = Set(Some(resolved_at));
-    active.update(&transaction).await.map_err(store_err)?;
+    let resolved = active.update(&transaction).await.map_err(store_err)?;
+    let transition = if authority.chat_id().is_some() {
+        super::turn::advance_turn_after_client_resolution_on(&transaction, &resolved, resolved_at)
+            .await?
+    } else {
+        None
+    };
     transaction.commit().await.map_err(store_err)?;
-    Ok(ResolveToolCallOutcome::Resolved)
+    Ok(JournaledClientToolCallOutcome {
+        outcome: ResolveToolCallOutcome::Resolved,
+        turn: transition.as_ref().map(|item| item.turn.clone()),
+        terminal_event: transition.and_then(|item| item.terminal_event),
+    })
+}
+
+fn journaled_call_outcome(outcome: ResolveToolCallOutcome) -> JournaledClientToolCallOutcome {
+    JournaledClientToolCallOutcome {
+        outcome,
+        turn: None,
+        terminal_event: None,
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -19,8 +19,14 @@ use super::{
     },
 };
 
+mod client_wait;
 mod resolution;
 mod steer;
+
+pub(in crate::db) use client_wait::{
+    advance_turn_after_client_resolution_on, park_turn_for_client_tool_call,
+    recover_turn_after_client_resolution_on,
+};
 
 pub(in crate::db) use resolution::{
     complete_turn_run, complete_turn_run_and_append_event, finish_turn_cancellation,
@@ -776,6 +782,8 @@ where
             TurnRunStatus::Queued.as_str(),
             TurnRunStatus::Running.as_str(),
             TurnRunStatus::Cancelling.as_str(),
+            TurnRunStatus::WaitingForClient.as_str(),
+            TurnRunStatus::CancellingClient.as_str(),
             TurnRunStatus::Resuming.as_str(),
             TurnRunStatus::RetryWait.as_str(),
         ]))
@@ -852,6 +860,8 @@ fn turn_run_status_from_db(text: &str) -> Result<TurnRunStatus> {
         "queued" => Ok(TurnRunStatus::Queued),
         "running" => Ok(TurnRunStatus::Running),
         "cancelling" => Ok(TurnRunStatus::Cancelling),
+        "waiting_for_client" => Ok(TurnRunStatus::WaitingForClient),
+        "cancelling_client" => Ok(TurnRunStatus::CancellingClient),
         "resuming" => Ok(TurnRunStatus::Resuming),
         "retry_wait" => Ok(TurnRunStatus::RetryWait),
         "completed" => Ok(TurnRunStatus::Completed),

--- a/crates/openwave-core/src/db/ops/turn/client_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/client_wait.rs
@@ -1,0 +1,537 @@
+use chrono::Utc;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set,
+    TransactionTrait, TryInsertResult,
+};
+
+use crate::error::{AgentError, Result};
+use crate::model::{
+    ClientToolCallRequest, ToolCallExecution, ToolCallRecord, ToolCallStatus, TurnClientWait,
+    TurnClientWaitStatus, TurnRunStatus, TurnSteerStatus,
+};
+use crate::storage::ParkTurnForClientCallOutcome;
+use crate::{AgentEvent, ChatId, SequencedEvent, TurnId, TurnRun};
+
+use super::super::super::{entities, store_err, DbStore};
+use super::super::{acquire_chat_write_lock, acquire_turn_write_lock};
+use super::{canonical_db_timestamp, turn_run_from_model};
+
+pub(in crate::db) struct ClientWaitTurnTransition {
+    pub turn: TurnRun,
+    pub terminal_event: Option<SequencedEvent>,
+}
+
+pub(in crate::db) async fn park_turn_for_client_tool_call(
+    store: &DbStore,
+    turn_id: crate::TurnId,
+    lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
+    now: chrono::DateTime<Utc>,
+    call: &ClientToolCallRequest,
+) -> Result<Option<ParkTurnForClientCallOutcome>> {
+    validate_request(turn_id, lease_token, call)?;
+    let now = canonical_db_timestamp(now)?;
+    let Some(scope) = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    if scope.chat_id != call.chat_id.0 {
+        return Ok(None);
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, call.chat_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    if !acquire_turn_write_lock(&transaction, turn_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    if let Some(wait) = entities::turn_client_wait::Entity::find_by_id(call.id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let existing_call = entities::tool_call::Entity::find_by_id(call.id.0)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| {
+                AgentError::Store(format!("client wait {} is missing its tool call", call.id))
+            })?;
+        let turn = entities::turn_run::Entity::find_by_id(turn_id.0)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| AgentError::Store(format!("parked turn {turn_id} disappeared")))?;
+        let exact = wait.turn_id == turn_id.0
+            && wait.chat_id == call.chat_id.0
+            && wait.park_lease_token == lease_token
+            && exact_call_request(&existing_call, call);
+        let outcome = if exact {
+            ParkTurnForClientCallOutcome::Existing {
+                turn: turn_run_from_model(turn)?,
+                call: super::super::client_execution::tool_call_from_model(existing_call)?,
+                wait: wait_from_model(wait)?,
+            }
+        } else {
+            ParkTurnForClientCallOutcome::IdentityConflict
+        };
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(outcome));
+    }
+
+    let turn = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .expect("locked turn exists");
+    if turn.chat_id != call.chat_id.0
+        || turn.status != TurnRunStatus::Running.as_str()
+        || turn.lease_token != Some(lease_token)
+        || turn
+            .lease_expires_at
+            .is_none_or(|lease_expires_at| lease_expires_at <= now)
+        || turn.updated_at > now
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let steer_pending = entities::turn_steer::Entity::find()
+        .filter(entities::turn_steer::Column::TurnId.eq(turn_id.0))
+        .filter(entities::turn_steer::Column::Status.eq(TurnSteerStatus::Pending.as_str()))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .is_some();
+    let stale_output = turn.steer_revision != expected_steer_revision;
+    if stale_output || steer_pending {
+        let turn = turn_run_from_model(turn)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(if steer_pending {
+            ParkTurnForClientCallOutcome::SteerPending(turn)
+        } else {
+            ParkTurnForClientCallOutcome::OutputSuperseded(turn)
+        }));
+    }
+    if entities::tool_call::Entity::find_by_id(call.id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .is_some()
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(ParkTurnForClientCallOutcome::IdentityConflict));
+    }
+
+    let inserted = entities::tool_call::Entity::insert(entities::tool_call::ActiveModel {
+        id: Set(call.id.0),
+        chat_id: Set(call.chat_id.0),
+        turn_id: Set(turn_id.0),
+        provider_id: Set(call.provider_id.clone()),
+        name: Set(call.name.clone()),
+        arguments: Set(call.arguments.clone()),
+        execution: Set(ToolCallExecution::Client.as_str().into()),
+        status: Set(ToolCallStatus::Pending.as_str().into()),
+        result: Set(None),
+        error_code: Set(None),
+        error_detail: Set(None),
+        client_executor_id: Set(None),
+        client_lease_token: Set(None),
+        client_lease_expires_at: Set(None),
+        created_at: Set(now),
+        resolved_at: Set(None),
+    })
+    .on_conflict(
+        sea_orm::sea_query::OnConflict::column(entities::tool_call::Column::Id)
+            .do_nothing()
+            .to_owned(),
+    )
+    .do_nothing()
+    .exec_without_returning(&transaction)
+    .await
+    .map_err(store_err)?;
+    if !matches!(inserted, TryInsertResult::Inserted(1)) {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(Some(ParkTurnForClientCallOutcome::IdentityConflict));
+    }
+    let wait = entities::turn_client_wait::ActiveModel {
+        call_id: Set(call.id.0),
+        turn_id: Set(turn_id.0),
+        chat_id: Set(call.chat_id.0),
+        park_lease_token: Set(lease_token),
+        attempt_count: Set(turn.attempt_count),
+        claim_count: Set(turn.claim_count),
+        status: Set(TurnClientWaitStatus::Waiting.as_str().into()),
+        parked_at: Set(now),
+        closed_at: Set(None),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    let parked = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnRunStatus::WaitingForClient.as_str()),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
+        .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
+        .filter(entities::turn_run::Column::AttemptCount.eq(turn.attempt_count))
+        .filter(entities::turn_run::Column::ClaimCount.eq(turn.claim_count))
+        .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.eq(turn.lease_expires_at))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::turn_run::Column::SteerRevision.eq(expected_steer_revision))
+        .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at))
+        .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if parked.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let parked_turn = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("parked turn {turn_id} disappeared")))?;
+    let inserted_call = entities::tool_call::Entity::find_by_id(call.id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("parked call {} disappeared", call.id)))?;
+    let outcome = ParkTurnForClientCallOutcome::Parked {
+        turn: turn_run_from_model(parked_turn)?,
+        call: super::super::client_execution::tool_call_from_model(inserted_call)?,
+        wait: wait_from_model(wait)?,
+    };
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(outcome))
+}
+
+fn validate_request(
+    turn_id: crate::TurnId,
+    lease_token: uuid::Uuid,
+    call: &ClientToolCallRequest,
+) -> Result<()> {
+    let labels_valid = [call.provider_id.as_str(), call.name.as_str()]
+        .into_iter()
+        .all(|value| {
+            !value.is_empty()
+                && value.len() <= ToolCallRecord::MAX_LABEL_LEN
+                && !value.contains('\0')
+        });
+    let args_len = serde_json::to_vec(&call.arguments)
+        .map_err(|error| AgentError::Store(format!("serialize tool arguments: {error}")))?
+        .len();
+    if turn_id.0.is_nil()
+        || lease_token.is_nil()
+        || call.id.0.is_nil()
+        || call.chat_id.0.is_nil()
+        || call.turn_id != turn_id
+        || !labels_valid
+        || args_len > ToolCallRecord::MAX_ARGUMENT_BYTES
+    {
+        return Err(AgentError::Store(
+            "invalid client tool call checkpoint request".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn exact_call_request(
+    existing: &entities::tool_call::Model,
+    request: &ClientToolCallRequest,
+) -> bool {
+    existing.id == request.id.0
+        && existing.chat_id == request.chat_id.0
+        && existing.turn_id == request.turn_id.0
+        && existing.provider_id == request.provider_id
+        && existing.name == request.name
+        && existing.arguments == request.arguments
+        && existing.execution == ToolCallExecution::Client.as_str()
+}
+
+pub(super) fn wait_from_model(model: entities::turn_client_wait::Model) -> Result<TurnClientWait> {
+    let status = match model.status.as_str() {
+        "waiting" => TurnClientWaitStatus::Waiting,
+        "resumed" => TurnClientWaitStatus::Resumed,
+        "cancelled" => TurnClientWaitStatus::Cancelled,
+        other => {
+            return Err(AgentError::Store(format!(
+                "unknown durable turn client wait status: {other}"
+            )))
+        }
+    };
+    Ok(TurnClientWait {
+        call_id: crate::CallId(model.call_id),
+        turn_id: crate::TurnId(model.turn_id),
+        chat_id: crate::ChatId(model.chat_id),
+        park_lease_token: model.park_lease_token,
+        attempt_count: model.attempt_count,
+        claim_count: model.claim_count,
+        status,
+        parked_at: model.parked_at,
+        closed_at: model.closed_at,
+    })
+}
+
+pub(in crate::db) async fn advance_turn_after_client_resolution_on<C>(
+    conn: &C,
+    call: &entities::tool_call::Model,
+    resolved_at: chrono::DateTime<Utc>,
+) -> Result<Option<ClientWaitTurnTransition>>
+where
+    C: ConnectionTrait,
+{
+    let Some(wait) = entities::turn_client_wait::Entity::find_by_id(call.id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    if wait.status != TurnClientWaitStatus::Waiting.as_str() {
+        return recover_turn_after_client_resolution_on(conn, call).await;
+    }
+    if wait.chat_id != call.chat_id || wait.turn_id != call.turn_id {
+        return Err(AgentError::Store(format!(
+            "client wait {} is scoped differently from its tool call",
+            crate::CallId(call.id)
+        )));
+    }
+    let turn_id = TurnId(wait.turn_id);
+    if !acquire_turn_write_lock(conn, turn_id).await? {
+        return Err(AgentError::Store(format!(
+            "client wait {} references missing turn {turn_id}",
+            crate::CallId(call.id)
+        )));
+    }
+    let turn = entities::turn_run::Entity::find_by_id(wait.turn_id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .expect("locked client-wait turn exists");
+    if turn.chat_id != wait.chat_id
+        || !matches!(
+            turn.status.as_str(),
+            "waiting_for_client" | "cancelling_client"
+        )
+        || turn.attempt_count != wait.attempt_count
+        || turn.claim_count != wait.claim_count
+        || turn.lease_token.is_some()
+        || turn.lease_expires_at.is_some()
+        || resolved_at < wait.parked_at
+        || resolved_at < turn.updated_at
+    {
+        return Err(AgentError::Store(format!(
+            "client wait {} does not match its blocking turn state",
+            crate::CallId(call.id)
+        )));
+    }
+    let cancelling = turn.status == TurnRunStatus::CancellingClient.as_str();
+    let wait_status = if cancelling {
+        TurnClientWaitStatus::Cancelled
+    } else {
+        TurnClientWaitStatus::Resumed
+    };
+    let closed = entities::turn_client_wait::Entity::update_many()
+        .col_expr(
+            entities::turn_client_wait::Column::Status,
+            sea_orm::sea_query::Expr::value(wait_status.as_str()),
+        )
+        .col_expr(
+            entities::turn_client_wait::Column::ClosedAt,
+            sea_orm::sea_query::Expr::value(Some(resolved_at)),
+        )
+        .filter(entities::turn_client_wait::Column::CallId.eq(call.id))
+        .filter(
+            entities::turn_client_wait::Column::Status.eq(TurnClientWaitStatus::Waiting.as_str()),
+        )
+        .filter(entities::turn_client_wait::Column::ClosedAt.is_null())
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    if closed.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "client wait {} changed while closing",
+            crate::CallId(call.id)
+        )));
+    }
+    let next_status = if cancelling {
+        TurnRunStatus::Cancelled
+    } else {
+        TurnRunStatus::Resuming
+    };
+    let mut update = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(next_status.as_str()),
+        )
+        .col_expr(
+            entities::turn_run::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(resolved_at),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(resolved_at),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn.id))
+        .filter(entities::turn_run::Column::Status.eq(&turn.status))
+        .filter(entities::turn_run::Column::AttemptCount.eq(turn.attempt_count))
+        .filter(entities::turn_run::Column::ClaimCount.eq(turn.claim_count))
+        .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at));
+    if cancelling {
+        update = update.col_expr(
+            entities::turn_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(resolved_at)),
+        );
+    }
+    let advanced = update.exec(conn).await.map_err(store_err)?;
+    if advanced.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "client wait {} lost its blocking turn transition",
+            crate::CallId(call.id)
+        )));
+    }
+    let terminal_event = if cancelling {
+        super::steer::reject_pending_turn_steers_on(conn, turn_id, resolved_at).await?;
+        let event = AgentEvent::TurnCancelled {
+            usage: crate::provider::Usage::default(),
+        };
+        super::resolution::append_terminal_event_on(
+            conn,
+            turn_id,
+            ChatId(turn.chat_id),
+            None,
+            Some(&event),
+        )
+        .await?
+    } else {
+        None
+    };
+    let updated = entities::turn_run::Entity::find_by_id(turn.id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!("resolved client-wait turn {turn_id} disappeared"))
+        })?;
+    Ok(Some(ClientWaitTurnTransition {
+        turn: turn_run_from_model(updated)?,
+        terminal_event,
+    }))
+}
+
+pub(in crate::db) async fn recover_turn_after_client_resolution_on<C>(
+    conn: &C,
+    call: &entities::tool_call::Model,
+) -> Result<Option<ClientWaitTurnTransition>>
+where
+    C: ConnectionTrait,
+{
+    let Some(wait) = entities::turn_client_wait::Entity::find_by_id(call.id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    if wait.chat_id != call.chat_id || wait.turn_id != call.turn_id {
+        return Err(AgentError::Store(format!(
+            "client wait {} is scoped differently from its tool call",
+            crate::CallId(call.id)
+        )));
+    }
+    if wait.status == TurnClientWaitStatus::Waiting.as_str() {
+        return Err(AgentError::Store(format!(
+            "terminal client call {} still has an open wait",
+            crate::CallId(call.id)
+        )));
+    }
+    let turn_id = TurnId(wait.turn_id);
+    let turn = entities::turn_run::Entity::find_by_id(wait.turn_id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "closed client wait {} references missing turn {turn_id}",
+                crate::CallId(call.id)
+            ))
+        })?;
+    if turn.chat_id != wait.chat_id {
+        return Err(AgentError::Store(format!(
+            "closed client wait {} no longer matches its turn scope",
+            crate::CallId(call.id)
+        )));
+    }
+    let terminal_event = if wait.status == TurnClientWaitStatus::Cancelled.as_str() {
+        if turn.status != TurnRunStatus::Cancelled.as_str() {
+            return Err(AgentError::Store(format!(
+                "cancelled client wait {} has a non-cancelled turn",
+                crate::CallId(call.id)
+            )));
+        }
+        Some(existing_client_cancellation_event_on(conn, turn_id).await?)
+    } else if wait.status == TurnClientWaitStatus::Resumed.as_str() {
+        None
+    } else {
+        return Err(AgentError::Store(format!(
+            "client wait {} has unknown status {}",
+            crate::CallId(call.id),
+            wait.status
+        )));
+    };
+    Ok(Some(ClientWaitTurnTransition {
+        turn: turn_run_from_model(turn)?,
+        terminal_event,
+    }))
+}
+
+async fn existing_client_cancellation_event_on<C>(
+    conn: &C,
+    turn_id: TurnId,
+) -> Result<SequencedEvent>
+where
+    C: ConnectionTrait,
+{
+    let stored = entities::event::Entity::find()
+        .filter(entities::event::Column::TurnId.eq(turn_id.0))
+        .filter(entities::event::Column::Terminal.eq(true))
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "client-cancelled turn {turn_id} is missing its terminal event"
+            ))
+        })?;
+    let event = serde_json::from_value::<AgentEvent>(stored.payload)?;
+    if !matches!(event, AgentEvent::TurnCancelled { .. }) {
+        return Err(AgentError::Store(format!(
+            "client-cancelled turn {turn_id} has a different terminal event"
+        )));
+    }
+    Ok(SequencedEvent {
+        seq: stored.seq,
+        event,
+    })
+}

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -710,7 +710,7 @@ async fn journal_chat_id(
         .map(|turn| ChatId(turn.chat_id)))
 }
 
-async fn append_terminal_event_on<C>(
+pub(super) async fn append_terminal_event_on<C>(
     conn: &C,
     id: TurnId,
     chat_id: ChatId,

--- a/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
@@ -28,8 +28,11 @@ async fn request_turn_cancellation_inner(
     terminal_event: Option<&AgentEvent>,
 ) -> Result<Option<JournaledTurnOutcome<RequestTurnCancellationOutcome>>> {
     let now = canonical_db_timestamp(now)?;
-    let journal_chat_id = journal_chat_id(store, id, terminal_event.is_some()).await?;
-    if terminal_event.is_some() && journal_chat_id.is_none() {
+    // Client claiming/resolution also takes this chat lock before its call and
+    // turn locks. Take it even for the non-journaling Store API so cancellation
+    // cannot invert that order while inspecting a parked client call.
+    let journal_chat_id = journal_chat_id(store, id, true).await?;
+    if journal_chat_id.is_none() {
         return Ok(None);
     }
     let transaction = store.conn.begin().await.map_err(store_err)?;
@@ -54,7 +57,7 @@ async fn request_turn_cancellation_inner(
     };
     let status = turn_run_status_from_db(&turn.status)?;
     match status {
-        TurnRunStatus::Cancelling | TurnRunStatus::Cancelled => {
+        TurnRunStatus::Cancelling | TurnRunStatus::CancellingClient | TurnRunStatus::Cancelled => {
             let sequenced_event = if status == TurnRunStatus::Cancelled {
                 existing_cancellation_event_on(&transaction, id, terminal_event.is_some()).await?
             } else {
@@ -77,6 +80,7 @@ async fn request_turn_cancellation_inner(
         }
         TurnRunStatus::Queued
         | TurnRunStatus::Running
+        | TurnRunStatus::WaitingForClient
         | TurnRunStatus::Resuming
         | TurnRunStatus::RetryWait => {}
     }
@@ -85,11 +89,109 @@ async fn request_turn_cancellation_inner(
         return Ok(None);
     }
 
-    let next_status = if status == TurnRunStatus::Running {
-        TurnRunStatus::Cancelling
-    } else {
-        TurnRunStatus::Cancelled
+    let mut cancel_unclaimed_call = None;
+    if status == TurnRunStatus::WaitingForClient {
+        let wait = entities::turn_client_wait::Entity::find()
+            .filter(entities::turn_client_wait::Column::TurnId.eq(id.0))
+            .filter(
+                entities::turn_client_wait::Column::Status
+                    .eq(crate::model::TurnClientWaitStatus::Waiting.as_str()),
+            )
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| {
+                AgentError::Store(format!("waiting turn {id} is missing its client receipt"))
+            })?;
+        if wait.chat_id != turn.chat_id
+            || wait.attempt_count != turn.attempt_count
+            || wait.claim_count != turn.claim_count
+        {
+            return Err(AgentError::Store(format!(
+                "waiting turn {id} has a mismatched client receipt"
+            )));
+        }
+        let call_id = crate::CallId(wait.call_id);
+        if !super::super::super::acquire_tool_call_write_lock(&transaction, call_id).await? {
+            return Err(AgentError::Store(format!(
+                "waiting turn {id} references missing client call {call_id}"
+            )));
+        }
+        let call = entities::tool_call::Entity::find_by_id(wait.call_id)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .expect("locked waiting client call exists");
+        if call.chat_id != turn.chat_id
+            || call.turn_id != turn.id
+            || call.execution != crate::model::ToolCallExecution::Client.as_str()
+            || call.status != crate::model::ToolCallStatus::Pending.as_str()
+        {
+            return Err(AgentError::Store(format!(
+                "waiting turn {id} has an invalid client call"
+            )));
+        }
+        if call.client_executor_id.is_none() {
+            cancel_unclaimed_call = Some((wait, call));
+        }
+    }
+
+    let next_status = match status {
+        TurnRunStatus::Running => TurnRunStatus::Cancelling,
+        TurnRunStatus::WaitingForClient if cancel_unclaimed_call.is_none() => {
+            TurnRunStatus::CancellingClient
+        }
+        _ => TurnRunStatus::Cancelled,
     };
+    if let Some((wait, call)) = cancel_unclaimed_call {
+        let cancelled_call = entities::tool_call::Entity::update_many()
+            .col_expr(
+                entities::tool_call::Column::Status,
+                sea_orm::sea_query::Expr::value(crate::model::ToolCallStatus::Cancelled.as_str()),
+            )
+            .col_expr(
+                entities::tool_call::Column::Result,
+                sea_orm::sea_query::Expr::value(Some(
+                    "cancelled before client execution".to_owned(),
+                )),
+            )
+            .col_expr(
+                entities::tool_call::Column::ResolvedAt,
+                sea_orm::sea_query::Expr::value(Some(now)),
+            )
+            .filter(entities::tool_call::Column::Id.eq(call.id))
+            .filter(
+                entities::tool_call::Column::Status
+                    .eq(crate::model::ToolCallStatus::Pending.as_str()),
+            )
+            .filter(entities::tool_call::Column::ClientExecutorId.is_null())
+            .exec(&transaction)
+            .await
+            .map_err(store_err)?;
+        let closed_wait = entities::turn_client_wait::Entity::update_many()
+            .col_expr(
+                entities::turn_client_wait::Column::Status,
+                sea_orm::sea_query::Expr::value(
+                    crate::model::TurnClientWaitStatus::Cancelled.as_str(),
+                ),
+            )
+            .col_expr(
+                entities::turn_client_wait::Column::ClosedAt,
+                sea_orm::sea_query::Expr::value(Some(now)),
+            )
+            .filter(entities::turn_client_wait::Column::CallId.eq(wait.call_id))
+            .filter(
+                entities::turn_client_wait::Column::Status
+                    .eq(crate::model::TurnClientWaitStatus::Waiting.as_str()),
+            )
+            .exec(&transaction)
+            .await
+            .map_err(store_err)?;
+        if cancelled_call.rows_affected != 1 || closed_wait.rows_affected != 1 {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(None);
+        }
+    }
     let update = entities::turn_run::Entity::update_many()
         .col_expr(
             entities::turn_run::Column::Status,
@@ -148,7 +250,10 @@ async fn request_turn_cancellation_inner(
         None
     };
     transaction.commit().await.map_err(store_err)?;
-    let outcome = if next_status == TurnRunStatus::Cancelling {
+    let outcome = if matches!(
+        next_status,
+        TurnRunStatus::Cancelling | TurnRunStatus::CancellingClient
+    ) {
         RequestTurnCancellationOutcome::Requested(updated)
     } else {
         RequestTurnCancellationOutcome::Cancelled(updated)

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -86,6 +86,7 @@ pub(in crate::db) async fn accept_turn_steer(
             status,
             TurnRunStatus::Queued
                 | TurnRunStatus::Running
+                | TurnRunStatus::WaitingForClient
                 | TurnRunStatus::Resuming
                 | TurnRunStatus::RetryWait
         )

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -3,6 +3,7 @@ use crate::model::{
     ByteSpan, DocumentParseOutput, DocumentSourceBlob, DocumentSourceUpsert, SourceLocation,
     ToolCallExecution, ToolCallResolution, ToolCallStatus,
 };
+use crate::storage::ApplyTurnSteerOutcome;
 use chrono::{DateTime, Utc};
 
 mod turn_steer;
@@ -5550,6 +5551,581 @@ async fn resuming_turn_claims_a_new_lease_without_consuming_failure_budget() {
         .await
         .unwrap()
         .is_none());
+}
+
+#[tokio::test]
+async fn client_wait_parks_resolves_and_recovers_exactly() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let _accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "connect a folder")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = Utc::now();
+    let turn_lease = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(
+            turn_lease,
+            claimed_at,
+            claimed_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let request = crate::model::ClientToolCallRequest {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id,
+        provider_id: "native".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({"suggested_name": "Documents"}),
+    };
+    let stale_steer_id = TurnSteerId::new();
+    assert!(matches!(
+        store
+            .accept_turn_steer(
+                stale_steer_id,
+                turn_id,
+                chat.id,
+                "apply before native checkpoint",
+                false,
+            )
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::Accepted(_)
+    ));
+    let first_steer_at = Utc::now();
+    assert!(matches!(
+        store
+            .apply_turn_steer(turn_id, turn_lease, stale_steer_id, 1, None, first_steer_at,)
+            .await
+            .unwrap()
+            .unwrap()
+            .outcome,
+        ApplyTurnSteerOutcome::Applied(_)
+    ));
+    let checkpoint_at = Utc::now();
+    assert!(matches!(
+        store
+            .park_turn_for_client_tool_call(turn_id, turn_lease, 0, checkpoint_at, &request)
+            .await
+            .unwrap()
+            .unwrap(),
+        ParkTurnForClientCallOutcome::OutputSuperseded(turn)
+            if turn.steer_revision == 1
+    ));
+
+    let pending_steer_id = TurnSteerId::new();
+    assert!(matches!(
+        store
+            .accept_turn_steer(
+                pending_steer_id,
+                turn_id,
+                chat.id,
+                "pending before native checkpoint",
+                false,
+            )
+            .await
+            .unwrap(),
+        AcceptTurnSteerOutcome::Accepted(_)
+    ));
+    let pending_checkpoint_at = Utc::now();
+    assert!(matches!(
+        store
+            .park_turn_for_client_tool_call(
+                turn_id,
+                turn_lease,
+                1,
+                pending_checkpoint_at,
+                &request,
+            )
+            .await
+            .unwrap()
+            .unwrap(),
+        ParkTurnForClientCallOutcome::SteerPending(turn)
+            if turn.steer_revision == 1
+    ));
+    let second_steer_at = Utc::now();
+    assert!(matches!(
+        store
+            .apply_turn_steer(
+                turn_id,
+                turn_lease,
+                pending_steer_id,
+                2,
+                None,
+                second_steer_at,
+            )
+            .await
+            .unwrap()
+            .unwrap()
+            .outcome,
+        ApplyTurnSteerOutcome::Applied(_)
+    ));
+
+    let parked_at = Utc::now();
+    assert_eq!(
+        store
+            .park_turn_for_client_tool_call(turn_id, uuid::Uuid::new_v4(), 2, parked_at, &request,)
+            .await
+            .unwrap(),
+        None
+    );
+    assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
+    let (parked_turn, parked_call, parked_wait) = match store
+        .park_turn_for_client_tool_call(turn_id, turn_lease, 2, parked_at, &request)
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        ParkTurnForClientCallOutcome::Parked { turn, call, wait } => (turn, call, wait),
+        outcome => panic!("unexpected park outcome: {outcome:?}"),
+    };
+    assert_eq!(parked_turn.status, TurnRunStatus::WaitingForClient);
+    assert_eq!(parked_turn.lease_token, None);
+    assert_eq!(parked_call.status, ToolCallStatus::Pending);
+    assert_eq!(
+        parked_wait.status,
+        crate::model::TurnClientWaitStatus::Waiting
+    );
+    assert_eq!((parked_wait.attempt_count, parked_wait.claim_count), (1, 1));
+    assert!(matches!(
+        store
+            .accept_turn(TurnId::new(), chat.id, "gpt-5", "must stay occupied")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::ChatBusy(turn) if turn.id == turn_id
+    ));
+
+    let executor_id = uuid::Uuid::new_v4();
+    let client_lease = uuid::Uuid::new_v4();
+    let client_claimed_at = parked_at + chrono::Duration::seconds(1);
+    assert!(matches!(
+        store
+            .claim_client_tool_call(
+                request.id,
+                chat.id,
+                executor_id,
+                client_lease,
+                client_claimed_at,
+                client_claimed_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        ClaimClientToolCallOutcome::Claimed(_)
+    ));
+    let resolved_at = client_claimed_at + chrono::Duration::seconds(1);
+    let resolution = ToolCallResolution::Completed {
+        result: "root-1".into(),
+    };
+    let journaled = store
+        .resolve_client_tool_call_and_append_event(
+            request.id,
+            chat.id,
+            client_lease,
+            resolved_at,
+            &resolution,
+            resolved_at,
+        )
+        .await
+        .unwrap();
+    assert_eq!(journaled.outcome, ResolveToolCallOutcome::Resolved);
+    assert_eq!(journaled.terminal_event, None);
+    assert_eq!(
+        journaled.turn.as_ref().map(|turn| turn.status),
+        Some(TurnRunStatus::Resuming)
+    );
+    let resumable = store.get_turn_run(turn_id).await.unwrap().unwrap();
+    assert_eq!(resumable.status, TurnRunStatus::Resuming);
+    assert_eq!((resumable.attempt_count, resumable.claim_count), (1, 1));
+    let wait = entities::turn_client_wait::Entity::find_by_id(request.id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        wait.status,
+        crate::model::TurnClientWaitStatus::Resumed.as_str()
+    );
+    assert_eq!(wait.closed_at, Some(resumable.updated_at));
+
+    assert!(matches!(
+        store
+            .park_turn_for_client_tool_call(turn_id, turn_lease, 2, Utc::now(), &request)
+            .await
+            .unwrap()
+            .unwrap(),
+        ParkTurnForClientCallOutcome::Existing { turn, wait, .. }
+            if turn.status == TurnRunStatus::Resuming
+                && wait.status == crate::model::TurnClientWaitStatus::Resumed
+    ));
+    let resumed = store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            resolved_at,
+            resolved_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!((resumed.attempt_count, resumed.claim_count), (1, 2));
+}
+
+async fn park_test_client_wait(
+    store: &DbStore,
+    chat_id: ChatId,
+) -> (TurnId, crate::model::ClientToolCallRequest, DateTime<Utc>) {
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat_id, "gpt-5", "native action")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let turn_lease = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(
+            turn_lease,
+            claimed_at,
+            claimed_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let request = crate::model::ClientToolCallRequest {
+        id: CallId::new(),
+        chat_id,
+        turn_id,
+        provider_id: "native".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({}),
+    };
+    let parked_at = claimed_at + chrono::Duration::seconds(1);
+    assert!(matches!(
+        store
+            .park_turn_for_client_tool_call(turn_id, turn_lease, 0, parked_at, &request)
+            .await
+            .unwrap()
+            .unwrap(),
+        ParkTurnForClientCallOutcome::Parked { .. }
+    ));
+    (turn_id, request, parked_at)
+}
+
+#[tokio::test]
+async fn client_wait_schema_rejects_invalid_scope_claim_and_lifecycle() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn_id, request, parked_at) = park_test_client_wait(&store, chat.id).await;
+    let wait = entities::turn_client_wait::Entity::find_by_id(request.id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let second_call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id,
+        provider_id: "native-second".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({}),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: parked_at + chrono::Duration::microseconds(1),
+        resolved_at: None,
+    };
+    assert!(matches!(
+        store.accept_tool_call(&second_call).await.unwrap(),
+        AcceptToolCallOutcome::Accepted(_)
+    ));
+
+    let valid_second = entities::turn_client_wait::ActiveModel {
+        call_id: Set(second_call.id.0),
+        turn_id: Set(turn_id.0),
+        chat_id: Set(chat.id.0),
+        park_lease_token: Set(wait.park_lease_token),
+        attempt_count: Set(wait.attempt_count),
+        claim_count: Set(wait.claim_count),
+        status: Set(crate::model::TurnClientWaitStatus::Waiting.as_str().into()),
+        parked_at: Set(second_call.created_at),
+        closed_at: Set(None),
+    };
+    assert!(valid_second.clone().insert(&store.conn).await.is_err());
+
+    let mut wrong_claim = valid_second.clone();
+    wrong_claim.claim_count = Set(wait.claim_count + 1);
+    wrong_claim.status = Set(crate::model::TurnClientWaitStatus::Cancelled
+        .as_str()
+        .into());
+    wrong_claim.closed_at = Set(Some(second_call.created_at));
+    assert!(wrong_claim.insert(&store.conn).await.is_err());
+
+    let mut wrong_scope = valid_second.clone();
+    wrong_scope.chat_id = Set(ChatId::new().0);
+    wrong_scope.status = Set(crate::model::TurnClientWaitStatus::Cancelled
+        .as_str()
+        .into());
+    wrong_scope.closed_at = Set(Some(second_call.created_at));
+    assert!(wrong_scope.insert(&store.conn).await.is_err());
+
+    let mut missing_close = valid_second.clone();
+    missing_close.status = Set(crate::model::TurnClientWaitStatus::Resumed.as_str().into());
+    assert!(missing_close.insert(&store.conn).await.is_err());
+
+    let mut close_before_park = valid_second;
+    close_before_park.status = Set(crate::model::TurnClientWaitStatus::Cancelled
+        .as_str()
+        .into());
+    close_before_park.closed_at = Set(Some(
+        second_call.created_at - chrono::Duration::microseconds(1),
+    ));
+    assert!(close_before_park.insert(&store.conn).await.is_err());
+}
+
+#[tokio::test]
+async fn client_wait_cancellation_fences_unclaimed_and_claimed_native_work() {
+    let (_dir, store) = temp_store().await;
+
+    let unclaimed_chat = sample_chat();
+    store.create_chat(&unclaimed_chat).await.unwrap();
+    let (unclaimed_turn, unclaimed_call, unclaimed_parked_at) =
+        park_test_client_wait(&store, unclaimed_chat.id).await;
+    let cancelled_at = unclaimed_parked_at + chrono::Duration::seconds(1);
+    let cancelled = store
+        .request_turn_cancellation_and_append_event(unclaimed_turn, cancelled_at)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        cancelled.outcome,
+        RequestTurnCancellationOutcome::Cancelled(ref turn)
+            if turn.status == TurnRunStatus::Cancelled
+    ));
+    assert!(cancelled.terminal_event.is_some());
+    assert_eq!(
+        store.list_tool_calls(unclaimed_chat.id).await.unwrap()[0].status,
+        ToolCallStatus::Cancelled
+    );
+    let unclaimed_wait = entities::turn_client_wait::Entity::find_by_id(unclaimed_call.id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        unclaimed_wait.status,
+        crate::model::TurnClientWaitStatus::Cancelled.as_str()
+    );
+
+    let claimed_chat = Chat {
+        id: ChatId::new(),
+        ..sample_chat()
+    };
+    store.create_chat(&claimed_chat).await.unwrap();
+    let (claimed_turn, claimed_call, claimed_parked_at) =
+        park_test_client_wait(&store, claimed_chat.id).await;
+    let client_claimed_at = claimed_parked_at + chrono::Duration::seconds(1);
+    let client_lease = uuid::Uuid::new_v4();
+    assert!(matches!(
+        store
+            .claim_client_tool_call(
+                claimed_call.id,
+                claimed_chat.id,
+                uuid::Uuid::new_v4(),
+                client_lease,
+                client_claimed_at,
+                client_claimed_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        ClaimClientToolCallOutcome::Claimed(_)
+    ));
+    let requested_at = client_claimed_at + chrono::Duration::seconds(1);
+    let requested = store
+        .request_turn_cancellation_and_append_event(claimed_turn, requested_at)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        requested.outcome,
+        RequestTurnCancellationOutcome::Requested(ref turn)
+            if turn.status == TurnRunStatus::CancellingClient
+    ));
+    assert_eq!(requested.terminal_event, None);
+    assert!(matches!(
+        store
+            .accept_turn(
+                TurnId::new(),
+                claimed_chat.id,
+                "gpt-5",
+                "must remain occupied",
+            )
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::ChatBusy(turn) if turn.id == claimed_turn
+    ));
+
+    let resolved_at = client_claimed_at + chrono::Duration::minutes(1);
+    let resolution = ToolCallResolution::Cancelled {
+        result: "cancelled by user".into(),
+    };
+    let live = store
+        .resolve_client_tool_call_and_append_event(
+            claimed_call.id,
+            claimed_chat.id,
+            client_lease,
+            resolved_at,
+            &resolution,
+            resolved_at,
+        )
+        .await
+        .unwrap();
+    assert_eq!(live.outcome, ResolveToolCallOutcome::LeaseLost);
+    assert_eq!(live.turn, None);
+    assert_eq!(live.terminal_event, None);
+    let journaled = store
+        .resolve_expired_client_tool_call_and_append_event(
+            claimed_call.id,
+            claimed_chat.id,
+            client_lease,
+            resolved_at,
+            &resolution,
+            resolved_at,
+        )
+        .await
+        .unwrap();
+    assert_eq!(journaled.outcome, ResolveToolCallOutcome::Resolved);
+    assert_eq!(
+        journaled.turn.as_ref().map(|turn| turn.status),
+        Some(TurnRunStatus::Cancelled)
+    );
+    let terminal_event = journaled.terminal_event.clone().unwrap();
+    assert_eq!(
+        store
+            .get_turn_run(claimed_turn)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        TurnRunStatus::Cancelled
+    );
+    let claimed_wait = entities::turn_client_wait::Entity::find_by_id(claimed_call.id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        claimed_wait.status,
+        crate::model::TurnClientWaitStatus::Cancelled.as_str()
+    );
+    let events = store.list_events(claimed_chat.id, 0).await.unwrap();
+    assert_eq!(events.len(), 1);
+    assert!(matches!(events[0].event, AgentEvent::TurnCancelled { .. }));
+    let recovered = store
+        .resolve_expired_client_tool_call_and_append_event(
+            claimed_call.id,
+            claimed_chat.id,
+            client_lease,
+            resolved_at,
+            &resolution,
+            resolved_at,
+        )
+        .await
+        .unwrap();
+    assert_eq!(recovered.outcome, ResolveToolCallOutcome::Existing);
+    assert_eq!(recovered.terminal_event, Some(terminal_event));
+}
+
+#[tokio::test]
+async fn concurrent_client_resolution_and_cancellation_do_not_invert_locks() {
+    let (_dir, store) = temp_store().await;
+    let store = std::sync::Arc::new(store);
+
+    for _ in 0..8 {
+        let chat = sample_chat();
+        store.create_chat(&chat).await.unwrap();
+        let (turn_id, call, parked_at) = park_test_client_wait(&store, chat.id).await;
+        let client_token = uuid::Uuid::new_v4();
+        let claimed_at = parked_at + chrono::Duration::seconds(1);
+        assert!(matches!(
+            store
+                .claim_client_tool_call(
+                    call.id,
+                    chat.id,
+                    uuid::Uuid::new_v4(),
+                    client_token,
+                    claimed_at,
+                    claimed_at + chrono::Duration::minutes(1),
+                )
+                .await
+                .unwrap(),
+            ClaimClientToolCallOutcome::Claimed(_)
+        ));
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+        let cancel_store = store.clone();
+        let cancel_barrier = barrier.clone();
+        let cancel_at = claimed_at + chrono::Duration::seconds(1);
+        let cancellation = tokio::spawn(async move {
+            cancel_barrier.wait().await;
+            cancel_store
+                .request_turn_cancellation(turn_id, cancel_at)
+                .await
+        });
+        let resolve_store = store.clone();
+        let resolution = tokio::spawn(async move {
+            barrier.wait().await;
+            resolve_store
+                .resolve_client_tool_call(
+                    call.id,
+                    chat.id,
+                    client_token,
+                    cancel_at,
+                    &ToolCallResolution::Completed {
+                        result: "connected".into(),
+                    },
+                    cancel_at,
+                )
+                .await
+        });
+        let (cancellation, resolution) =
+            tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                tokio::join!(cancellation, resolution)
+            })
+            .await
+            .expect("client resolution and cancellation must not deadlock");
+        assert!(matches!(
+            cancellation.unwrap().unwrap().unwrap(),
+            RequestTurnCancellationOutcome::Requested(_)
+                | RequestTurnCancellationOutcome::Cancelled(_)
+        ));
+        assert_eq!(
+            resolution.unwrap().unwrap(),
+            ResolveToolCallOutcome::Resolved
+        );
+        assert_eq!(
+            store.get_turn_run(turn_id).await.unwrap().unwrap().status,
+            TurnRunStatus::Cancelled
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -54,12 +54,12 @@ pub use id::{
 pub use keychain::KeychainSecretProvider;
 pub use model::{
     validate_source_regions, BlobRetirement, BlobRetirementStatus, ByteSpan, Chat,
-    DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
-    DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
-    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
-    Project, Role, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
-    ToolCallResolution, ToolCallStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun,
-    TurnRunStatus, TurnSteer, TurnSteerStatus,
+    ClientToolCallRequest, DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus,
+    DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus, DocumentRecord,
+    DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert,
+    Message, Project, Role, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
+    ToolCallResolution, ToolCallStatus, TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt,
+    TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
@@ -71,9 +71,9 @@ pub use storage::{
     BlobStore, ClaimClientToolCallOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome,
     ClientToolCallClaim, CompleteTurnRunOutcome, DocumentIndexJobReason,
     EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
-    HeartbeatClientToolCallOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
-    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome,
-    SecretProvider, Store,
+    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledTurnOutcome,
+    JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
+    RequestTurnCancellationOutcome, ResolveToolCallOutcome, SecretProvider, Store,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -92,7 +92,7 @@ pub fn validate_source_regions(
     Ok(())
 }
 
-use crate::id::{ChatId, DocumentId, DocumentJobId, MessageId, ProjectId, TurnId};
+use crate::id::{CallId, ChatId, DocumentId, DocumentJobId, MessageId, ProjectId, TurnId};
 
 /// An optional grouping of chats that share a workspace and (later) a document
 /// corpus. A chat may belong to a project or stand alone — unlike some designs
@@ -690,6 +690,12 @@ pub enum TurnRunStatus {
     /// The chat remains occupied until that worker acknowledges quiescence or
     /// the expired lease is cleaned up.
     Cancelling,
+    /// The worker checkpointed safely and released its lease while one exact
+    /// durable client call executes on the host.
+    WaitingForClient,
+    /// Cancellation was requested after the client call may have started. The
+    /// chat stays occupied until that exact call reports a terminal result.
+    CancellingClient,
     /// The blocking client call resolved and the checkpoint is eligible for a
     /// fresh worker lease without consuming another failure attempt.
     Resuming,
@@ -711,6 +717,8 @@ impl TurnRunStatus {
             Self::Queued => "queued",
             Self::Running => "running",
             Self::Cancelling => "cancelling",
+            Self::WaitingForClient => "waiting_for_client",
+            Self::CancellingClient => "cancelling_client",
             Self::Resuming => "resuming",
             Self::RetryWait => "retry_wait",
             Self::Completed => "completed",
@@ -723,6 +731,72 @@ impl TurnRunStatus {
     #[must_use]
     pub const fn is_terminal(self) -> bool {
         matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
+/// Immutable request for one tool operation that must execute in a trusted
+/// client rather than the server process.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClientToolCallRequest {
+    /// Caller-supplied idempotency identity.
+    pub id: CallId,
+    /// Owning conversation.
+    pub chat_id: ChatId,
+    /// Turn checkpointed for this call.
+    pub turn_id: TurnId,
+    /// Provider/tool namespace that produced the request.
+    pub provider_id: String,
+    /// Tool name understood by the trusted client.
+    pub name: String,
+    /// Canonical model-supplied arguments.
+    pub arguments: serde_json::Value,
+}
+
+/// Immutable receipt for one turn parked on a client tool call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnClientWait {
+    /// Exact durable client call.
+    pub call_id: CallId,
+    /// Turn that released its worker lease.
+    pub turn_id: TurnId,
+    /// Owning conversation.
+    pub chat_id: ChatId,
+    /// Worker lease segment that created the checkpoint.
+    pub park_lease_token: Uuid,
+    /// Failure attempt containing the checkpoint.
+    pub attempt_count: i32,
+    /// Exact lease-segment ordinal containing the checkpoint.
+    pub claim_count: i32,
+    /// Durable wait lifecycle.
+    pub status: TurnClientWaitStatus,
+    /// Store-owned time when parking committed.
+    pub parked_at: DateTime<Utc>,
+    /// Store-owned time when the wait stopped blocking the turn.
+    pub closed_at: Option<DateTime<Utc>>,
+}
+
+/// Durable lifecycle of a turn/client-call checkpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TurnClientWaitStatus {
+    /// The exact client call still blocks the turn.
+    Waiting,
+    /// The exact client call resolved and made the turn resumable.
+    Resumed,
+    /// Cancellation won and the turn will not resume from this checkpoint.
+    Cancelled,
+}
+
+impl TurnClientWaitStatus {
+    /// Stable database and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Waiting => "waiting",
+            Self::Resumed => "resumed",
+            Self::Cancelled => "cancelled",
+        }
     }
 }
 

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -22,10 +22,11 @@ use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{CallId, ChatId, DocumentId, DocumentJobId, ProjectId, TurnId, TurnSteerId};
 use crate::model::{
-    BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
-    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentRecord, DocumentScope,
-    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, ToolCallRecord,
-    ToolCallResolution, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
+    BlobRetirement, BlobRetirementStatus, Chat, ClientToolCallRequest, DocumentGeneration,
+    DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput,
+    DocumentRecord, DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert,
+    Message, Project, ToolCallRecord, ToolCallResolution, TurnClientWait, TurnFailureReceipt,
+    TurnFailureRetry, TurnRun, TurnSteer,
 };
 use crate::provider::{StopReason, Usage};
 
@@ -154,9 +155,9 @@ pub enum RecordTurnFailureOutcome {
 /// Result of requesting durable cancellation for one exact turn.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RequestTurnCancellationOutcome {
-    /// Queued or retry-wait work was cancelled before a worker owned it.
+    /// Queued, retry-wait, or unclaimed client work was cancelled immediately.
     Cancelled(TurnRun),
-    /// Running work entered the durable `cancelling` phase.
+    /// Running work or claimed client work entered a durable cancelling phase.
     Requested(TurnRun),
     /// This turn was already cancelling or cancelled.
     Existing(TurnRun),
@@ -242,6 +243,40 @@ pub enum ResolveToolCallOutcome {
     AlreadyTerminal,
     /// The requested execution surface or exact live client lease did not own it.
     LeaseLost,
+}
+
+/// Result of checkpointing a live worker on one exact client tool call.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParkTurnForClientCallOutcome {
+    /// The call, immutable wait receipt, and lease release committed together.
+    Parked {
+        turn: TurnRun,
+        call: ToolCallRecord,
+        wait: TurnClientWait,
+    },
+    /// An exact retry recovered the previously committed checkpoint.
+    Existing {
+        turn: TurnRun,
+        call: ToolCallRecord,
+        wait: TurnClientWait,
+    },
+    /// The call identity already names a different immutable request.
+    IdentityConflict,
+    /// A durable steer won the checkpoint race and must be applied first.
+    SteerPending(TurnRun),
+    /// The request came from provider output generated before an applied steer.
+    OutputSuperseded(TurnRun),
+}
+
+/// A client-call resolution together with the turn transition it triggered.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JournaledClientToolCallOutcome {
+    /// Terminal tool-call result.
+    pub outcome: ResolveToolCallOutcome,
+    /// Wait-backed turn after it resumed or terminalized, when applicable.
+    pub turn: Option<TurnRun>,
+    /// Exact terminal event committed by client-owned cancellation.
+    pub terminal_event: Option<SequencedEvent>,
 }
 
 /// A durable turn transition together with any terminal event committed by it.
@@ -984,6 +1019,23 @@ pub trait Store: Send + Sync {
         turn_storage_unavailable()
     }
 
+    /// Atomically persist one client-executed tool call, record the exact
+    /// originating worker claim, and release the turn lease.
+    ///
+    /// Exact retries recover through the immutable wait receipt even after the
+    /// client call resolves or the turn advances. A pending steer fences the
+    /// checkpoint so the worker can apply that instruction first.
+    async fn park_turn_for_client_tool_call(
+        &self,
+        _turn_id: TurnId,
+        _lease_token: uuid::Uuid,
+        _expected_steer_revision: i64,
+        _now: chrono::DateTime<chrono::Utc>,
+        _call: &ClientToolCallRequest,
+    ) -> Result<Option<ParkTurnForClientCallOutcome>> {
+        turn_storage_unavailable()
+    }
+
     /// Append a message to its chat.
     async fn append_message(&self, message: &Message) -> Result<()>;
 
@@ -1036,7 +1088,32 @@ pub trait Store: Send + Sync {
         now: chrono::DateTime<chrono::Utc>,
         resolution: &ToolCallResolution,
         resolved_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<ResolveToolCallOutcome>;
+    ) -> Result<ResolveToolCallOutcome> {
+        Ok(self
+            .resolve_client_tool_call_and_append_event(
+                id,
+                chat_id,
+                lease_token,
+                now,
+                resolution,
+                resolved_at,
+            )
+            .await?
+            .outcome)
+    }
+
+    /// Resolve a live client call and return any atomic turn transition receipt.
+    /// Exact retries recover the same terminal event when client-owned
+    /// cancellation completed with this resolution.
+    async fn resolve_client_tool_call_and_append_event(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<JournaledClientToolCallOutcome>;
 
     /// Resolve a known outcome after the exact client lease expired.
     ///
@@ -1050,7 +1127,31 @@ pub trait Store: Send + Sync {
         now: chrono::DateTime<chrono::Utc>,
         resolution: &ToolCallResolution,
         resolved_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<ResolveToolCallOutcome>;
+    ) -> Result<ResolveToolCallOutcome> {
+        Ok(self
+            .resolve_expired_client_tool_call_and_append_event(
+                id,
+                chat_id,
+                lease_token,
+                now,
+                resolution,
+                resolved_at,
+            )
+            .await?
+            .outcome)
+    }
+
+    /// Reconcile an expired client call and return any atomic turn transition
+    /// receipt, with the same retry behavior as the live resolution path.
+    async fn resolve_expired_client_tool_call_and_append_event(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<JournaledClientToolCallOutcome>;
 
     /// List unclaimed and claimed client work for authoritative recovery.
     async fn list_pending_client_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>>;

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -1349,6 +1349,26 @@ impl Store for MemStore {
             resolved_at,
         )
     }
+    async fn resolve_client_tool_call_and_append_event(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<JournaledClientToolCallOutcome> {
+        Ok(JournaledClientToolCallOutcome {
+            outcome: self.resolve_mem_tool_call(
+                id,
+                Some((chat_id, lease_token, now, false)),
+                resolution,
+                resolved_at,
+            )?,
+            turn: None,
+            terminal_event: None,
+        })
+    }
     async fn resolve_expired_client_tool_call(
         &self,
         id: CallId,
@@ -1364,6 +1384,26 @@ impl Store for MemStore {
             resolution,
             resolved_at,
         )
+    }
+    async fn resolve_expired_client_tool_call_and_append_event(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<JournaledClientToolCallOutcome> {
+        Ok(JournaledClientToolCallOutcome {
+            outcome: self.resolve_mem_tool_call(
+                id,
+                Some((chat_id, lease_token, now, true)),
+                resolution,
+                resolved_at,
+            )?,
+            turn: None,
+            terminal_event: None,
+        })
     }
     async fn list_pending_client_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>> {
         let mut calls: Vec<_> = self

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -6,12 +6,12 @@ use std::sync::Arc;
 use chrono::{Duration, Utc};
 use openwave_core::{
     AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentEvent,
-    ApplyTurnSteerOutcome, CallId, Chat, ChatId, ClaimClientToolCallOutcome,
+    ApplyTurnSteerOutcome, CallId, Chat, ChatId, ClaimClientToolCallOutcome, ClientToolCallRequest,
     CompleteTurnRunOutcome, DbStore, FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome,
-    Message, MessageId, RecordTurnFailureOutcome, RequestTurnCancellationOutcome,
-    ResolveToolCallOutcome, Role, StopReason, Store, ToolCallExecution, ToolCallRecord,
-    ToolCallResolution, ToolCallStatus, TurnFailureRetry, TurnId, TurnRunStatus, TurnSteerId,
-    TurnSteerStatus, Usage,
+    Message, MessageId, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
+    RequestTurnCancellationOutcome, ResolveToolCallOutcome, Role, StopReason, Store,
+    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnFailureRetry,
+    TurnId, TurnRunStatus, TurnSteerId, TurnSteerStatus, Usage,
 };
 
 static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
@@ -990,6 +990,126 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         .unwrap();
     store
         .request_turn_cancellation(registry_message_turn.id, Utc::now())
+        .await
+        .unwrap();
+
+    let client_wait_chat = sample_chat();
+    store.create_chat(&client_wait_chat).await.unwrap();
+    let client_wait_turn = match store
+        .accept_turn(
+            TurnId::new(),
+            client_wait_chat.id,
+            "gpt-5",
+            "postgres native action",
+        )
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected client-wait turn acceptance: {outcome:?}"),
+    };
+    let client_wait_claimed_at = client_wait_turn.available_at + Duration::seconds(1);
+    let client_wait_turn_token = uuid::Uuid::new_v4();
+    let client_wait_claim = store
+        .claim_turn_run(
+            client_wait_turn_token,
+            client_wait_claimed_at,
+            client_wait_claimed_at + Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(client_wait_claim.id, client_wait_turn.id);
+    let client_request = ClientToolCallRequest {
+        id: CallId::new(),
+        chat_id: client_wait_chat.id,
+        turn_id: client_wait_turn.id,
+        provider_id: "native".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({"reason": "postgres state test"}),
+    };
+    let client_wait_parked_at = client_wait_claimed_at + Duration::seconds(1);
+    assert!(matches!(
+        store
+            .park_turn_for_client_tool_call(
+                client_wait_turn.id,
+                client_wait_turn_token,
+                0,
+                client_wait_parked_at,
+                &client_request,
+            )
+            .await
+            .unwrap()
+            .unwrap(),
+        ParkTurnForClientCallOutcome::Parked { turn, .. }
+            if turn.status == TurnRunStatus::WaitingForClient
+    ));
+    let client_token = uuid::Uuid::new_v4();
+    let client_claimed_at = client_wait_parked_at + Duration::seconds(1);
+    assert!(matches!(
+        store
+            .claim_client_tool_call(
+                client_request.id,
+                client_wait_chat.id,
+                uuid::Uuid::new_v4(),
+                client_token,
+                client_claimed_at,
+                client_claimed_at + Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        ClaimClientToolCallOutcome::Claimed(_)
+    ));
+    let client_resolved_at = client_claimed_at + Duration::seconds(1);
+    assert_eq!(
+        store
+            .resolve_client_tool_call(
+                client_request.id,
+                client_wait_chat.id,
+                client_token,
+                client_resolved_at,
+                &ToolCallResolution::Completed {
+                    result: "root-postgres".into(),
+                },
+                client_resolved_at,
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Resolved
+    );
+    assert_eq!(
+        store
+            .get_turn_run(client_wait_turn.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        TurnRunStatus::Resuming
+    );
+    let resumed_token = uuid::Uuid::new_v4();
+    let resumed = store
+        .claim_turn_run(
+            resumed_token,
+            client_resolved_at,
+            client_resolved_at + Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(resumed.id, client_wait_turn.id);
+    assert_eq!((resumed.attempt_count, resumed.claim_count), (1, 2));
+    store
+        .request_turn_cancellation(resumed.id, client_resolved_at + Duration::seconds(1))
+        .await
+        .unwrap();
+    store
+        .finish_turn_cancellation(
+            resumed.id,
+            resumed_token,
+            client_resolved_at + Duration::seconds(2),
+        )
         .await
         .unwrap();
 

--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use chrono::{Duration, Utc};
 use openwave_core::{
     CallId, ChatId, ClaimClientToolCallOutcome, HeartbeatClientToolCallOutcome,
-    ResolveToolCallOutcome, ToolCallRecord, ToolCallResolution,
+    ResolveToolCallOutcome, ToolCallRecord, ToolCallResolution, TurnRunStatus,
 };
 
 use crate::error::ServerError;
@@ -216,17 +216,31 @@ pub async fn resolve_client_execution(
     let resolution = body.resolution.into_core();
     validate_resolution(&resolution)?;
     let now = Utc::now();
-    let mut outcome = state
+    let mut resolution_receipt = state
         .store
-        .resolve_client_tool_call(call_id, id, body.lease_token, now, &resolution, now)
+        .resolve_client_tool_call_and_append_event(
+            call_id,
+            id,
+            body.lease_token,
+            now,
+            &resolution,
+            now,
+        )
         .await?;
-    if outcome == ResolveToolCallOutcome::LeaseLost {
-        outcome = state
+    if resolution_receipt.outcome == ResolveToolCallOutcome::LeaseLost {
+        resolution_receipt = state
             .store
-            .resolve_expired_client_tool_call(call_id, id, body.lease_token, now, &resolution, now)
+            .resolve_expired_client_tool_call_and_append_event(
+                call_id,
+                id,
+                body.lease_token,
+                now,
+                &resolution,
+                now,
+            )
             .await?;
     }
-    let disposition = match outcome {
+    let disposition = match resolution_receipt.outcome {
         ResolveToolCallOutcome::Resolved => ResolutionDisposition::Resolved,
         ResolveToolCallOutcome::Existing => ResolutionDisposition::Existing,
         ResolveToolCallOutcome::AlreadyTerminal => {
@@ -245,6 +259,17 @@ pub async fn resolve_client_execution(
             )));
         }
     };
+    if let Some(event) = resolution_receipt.terminal_event {
+        // Exact retries may publish the same sequence again; WebSocket cursors
+        // deduplicate it while this closes the commit-to-live delivery gap.
+        let _ = state.events.sender(id).send(event);
+    }
+    if resolution_receipt
+        .turn
+        .is_some_and(|turn| turn.status == TurnRunStatus::Resuming)
+    {
+        state.turn_job_wake.notify_one();
+    }
     Ok(Json(ResolvedClientExecution { disposition }))
 }
 

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -10,9 +10,10 @@ use futures::stream::{self, BoxStream, StreamExt};
 // Tests use the in-memory store; production wires LanceDB in `bind`.
 use openwave_core::{
     AgentErrorInfo, AgentEvent, ApprovalClass, BlobStore, CallId, Chat, ChatId, ChatRequest,
-    Message, ModelProvider, Project, ProjectId, ProviderEvent, ProviderId, SecretProvider,
-    SequencedEvent, StopReason, Tool, ToolCallExecution, ToolCallRecord, ToolCallStatus, ToolCtx,
-    ToolOutput, ToolSpec, TurnId, TurnSteerId, Usage,
+    ClientToolCallRequest, Message, ModelProvider, ParkTurnForClientCallOutcome, Project,
+    ProjectId, ProviderEvent, ProviderId, SecretProvider, SequencedEvent, StopReason, Tool,
+    ToolCallExecution, ToolCallRecord, ToolCallStatus, ToolCtx, ToolOutput, ToolSpec, TurnId,
+    TurnRunStatus, TurnSteerId, Usage,
 };
 use openwave_retrieval::{
     Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
@@ -986,7 +987,7 @@ impl Store for PauseTerminalStore {
             .resolve_server_tool_call(id, resolution, resolved_at)
             .await
     }
-    async fn resolve_client_tool_call(
+    async fn resolve_client_tool_call_and_append_event(
         &self,
         id: openwave_core::CallId,
         chat_id: ChatId,
@@ -994,12 +995,19 @@ impl Store for PauseTerminalStore {
         now: chrono::DateTime<chrono::Utc>,
         resolution: &openwave_core::ToolCallResolution,
         resolved_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<openwave_core::ResolveToolCallOutcome> {
+    ) -> Result<openwave_core::JournaledClientToolCallOutcome> {
         self.inner
-            .resolve_client_tool_call(id, chat_id, lease_token, now, resolution, resolved_at)
+            .resolve_client_tool_call_and_append_event(
+                id,
+                chat_id,
+                lease_token,
+                now,
+                resolution,
+                resolved_at,
+            )
             .await
     }
-    async fn resolve_expired_client_tool_call(
+    async fn resolve_expired_client_tool_call_and_append_event(
         &self,
         id: openwave_core::CallId,
         chat_id: ChatId,
@@ -1007,9 +1015,9 @@ impl Store for PauseTerminalStore {
         now: chrono::DateTime<chrono::Utc>,
         resolution: &openwave_core::ToolCallResolution,
         resolved_at: chrono::DateTime<chrono::Utc>,
-    ) -> Result<openwave_core::ResolveToolCallOutcome> {
+    ) -> Result<openwave_core::JournaledClientToolCallOutcome> {
         self.inner
-            .resolve_expired_client_tool_call(
+            .resolve_expired_client_tool_call_and_append_event(
                 id,
                 chat_id,
                 lease_token,
@@ -2402,6 +2410,47 @@ async fn post_json(
         .unwrap()
 }
 
+async fn park_client_wait_for_route_test(
+    store: &dyn Store,
+    chat_id: ChatId,
+) -> (TurnId, ClientToolCallRequest) {
+    let turn_id = TurnId::new();
+    store
+        .accept_turn(turn_id, chat_id, "fake", "native action")
+        .await
+        .unwrap();
+    let turn_token = uuid::Uuid::new_v4();
+    let claimed_at = chrono::Utc::now();
+    let claimed = store
+        .claim_turn_run(
+            turn_token,
+            claimed_at,
+            claimed_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(claimed.id, turn_id);
+    let call = ClientToolCallRequest {
+        id: CallId::new(),
+        chat_id,
+        turn_id,
+        provider_id: "native".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({}),
+    };
+    assert!(matches!(
+        store
+            .park_turn_for_client_tool_call(turn_id, turn_token, 0, chrono::Utc::now(), &call,)
+            .await
+            .unwrap()
+            .unwrap(),
+        ParkTurnForClientCallOutcome::Parked { .. }
+    ));
+    (turn_id, call)
+}
+
 #[tokio::test]
 async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently() {
     let (router, token, store, _dir) = test_app().await;
@@ -2580,6 +2629,135 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         .await
         .unwrap()
         .is_empty());
+}
+
+#[tokio::test]
+async fn client_resolution_publishes_cancellation_and_wakes_resumable_turns() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    let router = app(state.clone());
+    let bearer = format!("Bearer {token}");
+
+    let resume_chat = make_chat(&router, &bearer).await;
+    let (resume_turn, resume_call) = park_client_wait_for_route_test(&*store, resume_chat.id).await;
+    let resume_token = uuid::Uuid::new_v4();
+    let claimed_at = chrono::Utc::now();
+    store
+        .claim_client_tool_call(
+            resume_call.id,
+            resume_chat.id,
+            uuid::Uuid::new_v4(),
+            resume_token,
+            claimed_at,
+            claimed_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap();
+    let resume_response = post_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/client-executions/{}/resolve",
+            resume_chat.id, resume_call.id
+        ),
+        serde_json::json!({
+            "lease_token": resume_token,
+            "resolution": {"status": "completed", "result": "root-1"},
+        }),
+    )
+    .await;
+    assert_eq!(resume_response.status(), StatusCode::OK);
+    tokio::time::timeout(Duration::from_secs(1), state.turn_job_wake.notified())
+        .await
+        .expect("resumable client resolution must wake the turn worker");
+    assert_eq!(
+        store
+            .get_turn_run(resume_turn)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        TurnRunStatus::Resuming
+    );
+    store
+        .request_turn_cancellation(resume_turn, chrono::Utc::now())
+        .await
+        .unwrap();
+
+    let cancel_chat = make_chat(&router, &bearer).await;
+    let (cancel_turn, cancel_call) = park_client_wait_for_route_test(&*store, cancel_chat.id).await;
+    let cancel_token = uuid::Uuid::new_v4();
+    let claimed_at = chrono::Utc::now();
+    store
+        .claim_client_tool_call(
+            cancel_call.id,
+            cancel_chat.id,
+            uuid::Uuid::new_v4(),
+            cancel_token,
+            claimed_at,
+            claimed_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        store
+            .request_turn_cancellation(cancel_turn, chrono::Utc::now())
+            .await
+            .unwrap()
+            .unwrap(),
+        openwave_core::RequestTurnCancellationOutcome::Requested(turn)
+            if turn.status == TurnRunStatus::CancellingClient
+    ));
+    let mut live = state.events.subscribe(cancel_chat.id);
+    let resolve_uri = format!(
+        "/chats/{}/client-executions/{}/resolve",
+        cancel_chat.id, cancel_call.id
+    );
+    let body = serde_json::json!({
+        "lease_token": cancel_token,
+        "resolution": {"status": "cancelled", "result": "cancelled by user"},
+    });
+    let cancelled = post_json(&router, &bearer, &resolve_uri, body.clone()).await;
+    assert_eq!(cancelled.status(), StatusCode::OK);
+    let first_live = tokio::time::timeout(Duration::from_secs(1), live.recv())
+        .await
+        .expect("client-owned cancellation must publish live")
+        .unwrap();
+    assert!(matches!(first_live.event, AgentEvent::TurnCancelled { .. }));
+
+    let retry = post_json(&router, &bearer, &resolve_uri, body).await;
+    assert_eq!(retry.status(), StatusCode::OK);
+    let retry: serde_json::Value = json_body(retry).await;
+    assert_eq!(retry["disposition"], "existing");
+    let recovered_live = tokio::time::timeout(Duration::from_secs(1), live.recv())
+        .await
+        .expect("exact retry must recover the terminal publication receipt")
+        .unwrap();
+    assert_eq!(recovered_live, first_live);
 }
 
 #[tokio::test]

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -214,12 +214,21 @@ the lease from the server's current receive time. Heartbeat and resolution
 enforce the immutable chat owner inside the same locked state transition rather
 than loading conversation history first.
 
-The agent still executes its current built-in tools inside the turn worker. The
-turn model now distinguishes failure attempts from worker lease segments and
-reserves an explicit resumable claim state for native client work. The atomic
-wait receipt, park/resolve transitions, and desktop executor are the next layers.
-Notifications will be wake-up hints, while the pending-work query remains
-authoritative.
+The store can now hand a turn across that process boundary without keeping its
+worker alive. In one transaction it records the immutable client call, records a
+wait receipt tied to the exact worker claim, moves the turn to
+`waiting_for_client`, and releases the worker lease. If the database commit is
+ambiguous, the worker can repeat the exact request and recover that receipt; a
+different request cannot reuse the identity.
+
+Resolving the client call closes the receipt and moves the turn to `resuming` in
+the same transaction. A turn worker then takes a fresh lease segment without
+spending another failure attempt. This is the durable equivalent of pausing a
+function, doing native work elsewhere, and continuing from a known checkpoint.
+The remaining integration work is to have the agent emit this checkpoint for
+folder-access tools and to run those pending calls from the desktop. Notifications
+will be wake-up hints; the pending-work query remains authoritative after a
+restart or missed notification.
 
 ### 4. Events drive the live client
 
@@ -250,10 +259,24 @@ queued ----claim----> running ----success----> completed
   |                     +----failure---------> failed
   |                     |
   |                     +----cancel request--> cancelling --> cancelled
+  |                     |
+  |                     +----park native call----> waiting_for_client
+  |                                                   |       |
+  |                                            resolve|       |cancel unclaimed
+  |                                                   v       v
+  |                                               resuming  cancelled
+  |                                                   |
+  |                                         fresh claim segment
+  |                                                   |
+  |                                                   +-----> running
   |
   +----cancel-----------------------------------------------> cancelled
 
-resuming ----same attempt, fresh claim----> running
+waiting_for_client ----cancel claimed call----> cancelling_client
+                                                    |
+                                         exact client resolution
+                                                    |
+                                                    +-----> cancelled
 ```
 
 retry_wait exists for safely replayable failures. `attempt_count` tracks that
@@ -273,8 +296,13 @@ but they have different durability today.
 Cancellation is a durable state transition. A queued turn can become cancelled
 immediately. A running turn first becomes `cancelling`; its exact worker receives
 a local cancellation signal, stops cooperatively, and acknowledges `cancelled`.
-The chat remains occupied until that handoff is resolved, so a new turn cannot
-race the old one.
+An unclaimed client call can also be cancelled immediately: the call, wait
+receipt, turn, and terminal event change together. If the native client already
+claimed the call, the turn becomes `cancelling_client` until that exact client
+lease reports a terminal result. This avoids pretending an in-flight folder
+picker or broker mutation never happened. In every case the chat remains
+occupied until the owner has quiesced or the store has atomically fenced the
+work, so a new turn cannot race the old one.
 
 ### Approvals
 
@@ -539,15 +567,15 @@ When changing the runtime, these rules matter more than the exact module layout:
 
 The strongest parts today are the core seams, database constraints, durable
 document pipeline, generation-aware Lance publication, durable turn acceptance
-and ownership, terminal turn commits, cancellation, reconnectable event stream,
-and fail-closed provider routing.
+and ownership, atomic client-wait checkpoints, terminal turn commits,
+cancellation, reconnectable event stream, and fail-closed provider routing.
 
 The main next steps are:
 
 - replace raw chat/project workspace paths with broker-mediated, per-context
   connected roots while keeping OpenWave's private app data separate;
-- park turns atomically while a client acts, notify clients of durable pending
-  work, and run native folder requests in the desktop;
+- teach the agent to emit client-wait checkpoints, notify clients of durable
+  pending work, and run native folder requests in the desktop;
 - add resumable checkpoints and explicit idempotency policy around remaining
   server-side tool effects;
 - make approvals resumable rather than process-local;


### PR DESCRIPTION
## Summary

- atomically checkpoint a running turn onto one immutable client tool call and a wait receipt bound to the exact originating worker claim
- close the wait and make the same failure attempt resumable when the client resolves, while using a fresh claim segment to fence the resumed worker
- make cancellation safe on both sides of the native boundary: unclaimed work terminalizes immediately, while claimed work keeps the chat occupied until the exact client lease resolves
- enforce wait scope, claim identity, lifecycle, timestamp, and one-open-wait invariants in the existing pre-v1 schema and document the resulting state machine

## Validation

- `cargo test -p openwave-core --lib` (221 tests)
- `cargo test -p openwave-core --features postgres --test postgres_turn_state -- --test-threads=1` against PostgreSQL 16
- `cargo test -p openwave-server` (157 tests)
- `cargo fmt --all -- --check`
- `bw dev lint --rust --check --repo-root "$PWD"`
