### PR TITLE
feat(core): checkpoint client-owned tool calls

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -50,7 +50,12 @@ use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 /// A name-keyed registry of the tools available to the agent.
 #[derive(Default)]
 pub struct ToolRegistry {
-    tools: HashMap<String, Box<dyn Tool>>,
+    tools: HashMap<String, RegisteredTool>,
+}
+
+enum RegisteredTool {
+    Server(Box<dyn Tool>),
+    Client(ToolSpec),
 }
 
 impl ToolRegistry {
@@ -62,7 +67,14 @@ impl ToolRegistry {
 
     /// Register a tool under its advertised name (replacing any existing one).
     pub fn register(&mut self, tool: Box<dyn Tool>) {
-        self.tools.insert(tool.spec().name, tool);
+        self.tools
+            .insert(tool.spec().name, RegisteredTool::Server(tool));
+    }
+
+    /// Register a client-owned tool contract with no server-side executor.
+    pub fn register_client(&mut self, spec: ToolSpec) {
+        self.tools
+            .insert(spec.name.clone(), RegisteredTool::Client(spec));
     }
 
     /// Builder-style [`register`](Self::register).
@@ -75,13 +87,31 @@ impl ToolRegistry {
     /// Look up a tool by name.
     #[must_use]
     pub fn get(&self, name: &str) -> Option<&dyn Tool> {
-        self.tools.get(name).map(Box::as_ref)
+        match self.tools.get(name) {
+            Some(RegisteredTool::Server(tool)) => Some(tool.as_ref()),
+            Some(RegisteredTool::Client(_)) | None => None,
+        }
+    }
+
+    /// Resolve the trusted execution surface for a registered tool name.
+    #[must_use]
+    pub fn execution(&self, name: &str) -> Option<ToolCallExecution> {
+        self.tools.get(name).map(|tool| match tool {
+            RegisteredTool::Server(_) => ToolCallExecution::Server,
+            RegisteredTool::Client(_) => ToolCallExecution::Client,
+        })
     }
 
     /// The specs of every registered tool, to advertise to the model.
     #[must_use]
     pub fn specs(&self) -> Vec<ToolSpec> {
-        self.tools.values().map(|tool| tool.spec()).collect()
+        self.tools
+            .values()
+            .map(|tool| match tool {
+                RegisteredTool::Server(tool) => tool.spec(),
+                RegisteredTool::Client(spec) => spec.clone(),
+            })
+            .collect()
     }
 
     /// Whether no tools are registered.
@@ -159,6 +189,17 @@ pub enum AgentTurnOutcome {
         /// Aggregate provider usage for the eventual terminal event.
         usage: Usage,
         /// Model-call steps consumed from the turn-wide execution budget.
+        model_steps: usize,
+    },
+    /// The model requested one tool that must execute on a trusted client.
+    ClientToolCall {
+        /// Immutable call identity and canonical arguments to checkpoint.
+        request: crate::model::ClientToolCallRequest,
+        /// Provider usage incurred in this agent invocation.
+        usage: Usage,
+        /// Durable steering epoch captured before the producing model call.
+        steer_revision: i64,
+        /// Model-call steps consumed in this agent invocation.
         model_steps: usize,
     },
     /// Execution failed after consuming provider work that must be retained.
@@ -432,7 +473,16 @@ impl Agent {
         }
         let mut progress = AgentProgress::default();
         match self.drive(chat, execution, events, &mut progress).await {
-            Ok(outcome) => Ok(outcome),
+            Ok(outcome) => {
+                if execution.publish_terminal {
+                    if let AgentTurnOutcome::Failed { error, .. } = &outcome {
+                        events.send(AgentEvent::TurnFailed {
+                            error: error.clone(),
+                        });
+                    }
+                }
+                Ok(outcome)
+            }
             Err(err) => {
                 if execution.publish_terminal {
                     events.send(AgentEvent::TurnFailed {
@@ -607,6 +657,61 @@ impl Agent {
                 self.apply_steers(chat, turn_id, &mut transcript, None, events)
                     .await?;
                 continue;
+            }
+
+            let client_calls = calls
+                .iter()
+                .filter(|call| self.tools.execution(&call.name) == Some(ToolCallExecution::Client))
+                .collect::<Vec<_>>();
+            if !client_calls.is_empty() {
+                if calls.len() != 1 || client_calls.len() != 1 || !text.is_empty() {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text {
+                            text: "A client-executed tool must be requested alone, without assistant text or sibling tool calls. Retry the request in that form.".into(),
+                        }],
+                    });
+                    continue;
+                }
+                let call = client_calls[0];
+                let Some(arguments) = parse_client_args(&call.args) else {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text {
+                            text: "The client tool arguments were not valid JSON. Retry the request with a complete JSON value.".into(),
+                        }],
+                    });
+                    continue;
+                };
+                let request = crate::model::ClientToolCallRequest {
+                    id: call.call_id,
+                    chat_id: chat.id,
+                    turn_id,
+                    provider_id: call.provider_id.clone(),
+                    name: call.name.clone(),
+                    arguments,
+                };
+                if !request.is_well_formed() {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text {
+                            text: "The client tool request was too large or malformed. Retry it with a valid tool identity and smaller arguments.".into(),
+                        }],
+                    });
+                    continue;
+                }
+                let steer_revision = generation_steer_revision.ok_or_else(|| {
+                    AgentError::Store("client-executed tools require a durably claimed turn".into())
+                })?;
+                return Ok(AgentTurnOutcome::ClientToolCall {
+                    request,
+                    usage: total_usage,
+                    steer_revision,
+                    model_steps: step + 1,
+                });
             }
 
             // Record the assistant message (text + any tool-use blocks).
@@ -831,7 +936,17 @@ impl Agent {
                 .await?;
         }
 
-        Err(AgentError::msg("max steps per turn exceeded"))
+        if self.config.max_steps == 0 {
+            return Err(AgentError::msg("max steps per turn exceeded"));
+        }
+        Ok(AgentTurnOutcome::Failed {
+            error: crate::error::AgentErrorInfo {
+                kind: "max_steps_exceeded".into(),
+                message: "max steps per turn exceeded".into(),
+            },
+            usage: total_usage,
+            model_steps: self.config.max_steps,
+        })
     }
 
     /// Emit the cancellation terminal event and end the turn as a (non-error)
@@ -1346,6 +1461,15 @@ fn parse_args(raw: &str) -> Value {
     serde_json::from_str(raw).unwrap_or(Value::Object(Default::default()))
 }
 
+/// Client-owned calls cross a trusted execution boundary, so malformed input
+/// must be retried by the model rather than silently changed before dispatch.
+fn parse_client_args(raw: &str) -> Option<Value> {
+    if raw.trim().is_empty() {
+        return Some(Value::Object(Default::default()));
+    }
+    serde_json::from_str(raw).ok()
+}
+
 // The end-to-end test needs the SQLite store and the built-in tools.
 #[cfg(all(test, feature = "sqlite", feature = "tools"))]
 mod tests {
@@ -1375,9 +1499,26 @@ mod tests {
             .collect()
     }
 
+    #[test]
+    fn client_tool_arguments_are_parsed_without_forgiving_malformed_json() {
+        assert_eq!(
+            parse_client_args(""),
+            Some(Value::Object(Default::default()))
+        );
+        assert_eq!(
+            parse_client_args(r#"{"hint":"Documents"}"#),
+            Some(serde_json::json!({"hint": "Documents"}))
+        );
+        assert_eq!(parse_client_args(r#"{"hint":"Documents""#), None);
+    }
+
     /// A scripted provider: step 0 calls `read_file`, step 1 gives a final answer.
     struct FakeProvider {
         calls: AtomicUsize,
+    }
+
+    struct ClientToolProvider {
+        assistant_text: bool,
     }
 
     struct ContextRecordingTool {
@@ -1447,6 +1588,212 @@ mod tests {
             };
             Ok(stream::iter(events).boxed())
         }
+    }
+
+    #[async_trait]
+    impl ModelProvider for ClientToolProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("client-tool")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let mut events = vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "native_1".into(),
+                    name: "connect_folder".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: r#"{"hint":"Documents"}"#.into(),
+                },
+                ProviderEvent::Usage(Usage {
+                    input_tokens: 5,
+                    output_tokens: 2,
+                    ..Usage::default()
+                }),
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ];
+            if self.assistant_text {
+                events.insert(
+                    0,
+                    ProviderEvent::TextDelta {
+                        text: "I will connect it".into(),
+                    },
+                );
+            }
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    #[tokio::test]
+    async fn claimed_agent_returns_a_client_tool_checkpoint_without_executing_it() {
+        let workspace = tempfile::tempdir().unwrap();
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            workspace_dir: workspace.path().to_path_buf(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "fake", "connect documents")
+            .await
+            .unwrap();
+        let lease_token = uuid::Uuid::new_v4();
+        let claimed_at = Utc::now();
+        store
+            .claim_turn_run(
+                lease_token,
+                claimed_at,
+                claimed_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap();
+        let client_spec = ToolSpec {
+            name: "connect_folder".into(),
+            description: "Ask the desktop to connect a folder".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        };
+        let mut registry = ToolRegistry::new();
+        registry.register_client(client_spec.clone());
+        assert_eq!(
+            registry.execution("connect_folder"),
+            Some(ToolCallExecution::Client)
+        );
+        assert!(registry.get("connect_folder").is_none());
+        assert_eq!(registry.specs(), vec![client_spec]);
+        let agent = Agent::new(
+            Arc::new(ClientToolProvider {
+                assistant_text: false,
+            }),
+            Arc::new(registry),
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        )
+        .with_durable_steer(lease_token);
+        let (tx, rx) = unbounded();
+        let outcome = agent
+            .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
+            .await
+            .unwrap();
+        drop(tx);
+        let events = emitted_events(rx.collect().await);
+        let AgentTurnOutcome::ClientToolCall {
+            request,
+            usage,
+            steer_revision,
+            model_steps,
+        } = outcome
+        else {
+            panic!("claimed agent should return a client checkpoint");
+        };
+        assert_eq!(request.chat_id, chat.id);
+        assert_eq!(request.turn_id, turn_id);
+        assert_eq!(request.provider_id, "native_1");
+        assert_eq!(request.name, "connect_folder");
+        assert_eq!(request.arguments, serde_json::json!({"hint": "Documents"}));
+        assert_eq!(usage.input_tokens, 5);
+        assert_eq!(usage.output_tokens, 2);
+        assert_eq!(steer_revision, 0);
+        assert_eq!(model_steps, 1);
+        assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::ToolCallStarted { name, .. } if name == "connect_folder"
+        )));
+    }
+
+    #[tokio::test]
+    async fn claimed_agent_retries_a_mixed_client_call_then_preserves_exhausted_usage() {
+        let workspace = tempfile::tempdir().unwrap();
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            workspace_dir: workspace.path().to_path_buf(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "fake", "connect documents")
+            .await
+            .unwrap();
+        let lease_token = uuid::Uuid::new_v4();
+        let claimed_at = Utc::now();
+        store
+            .claim_turn_run(
+                lease_token,
+                claimed_at,
+                claimed_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.register_client(ToolSpec {
+            name: "connect_folder".into(),
+            description: "Ask the desktop to connect a folder".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        });
+        let agent = Agent::new(
+            Arc::new(ClientToolProvider {
+                assistant_text: true,
+            }),
+            Arc::new(registry),
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                max_steps: 2,
+                ..AgentConfig::default()
+            },
+        )
+        .with_durable_steer(lease_token);
+        let (tx, _rx) = unbounded();
+        let outcome = agent
+            .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
+            .await
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            AgentTurnOutcome::Failed {
+                error,
+                usage: Usage {
+                    input_tokens: 10,
+                    output_tokens: 4,
+                    ..
+                },
+                model_steps: 2,
+            } if error.kind == "max_steps_exceeded"
+        ));
+        assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/db/ops/turn/client_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/client_wait.rs
@@ -6,8 +6,8 @@ use sea_orm::{
 
 use crate::error::{AgentError, Result};
 use crate::model::{
-    ClientToolCallRequest, ToolCallExecution, ToolCallRecord, ToolCallStatus,
-    TurnCheckpointProgress, TurnClientWait, TurnClientWaitStatus, TurnRunStatus, TurnSteerStatus,
+    ClientToolCallRequest, ToolCallExecution, ToolCallStatus, TurnCheckpointProgress,
+    TurnClientWait, TurnClientWaitStatus, TurnRunStatus, TurnSteerStatus,
 };
 use crate::storage::ParkTurnForClientCallOutcome;
 use crate::{AgentEvent, ChatId, SequencedEvent, TurnId, TurnRun};
@@ -260,24 +260,11 @@ fn validate_request(
     progress: TurnCheckpointProgress,
     call: &ClientToolCallRequest,
 ) -> Result<()> {
-    let labels_valid = [call.provider_id.as_str(), call.name.as_str()]
-        .into_iter()
-        .all(|value| {
-            !value.is_empty()
-                && value.len() <= ToolCallRecord::MAX_LABEL_LEN
-                && !value.contains('\0')
-        });
-    let args_len = serde_json::to_vec(&call.arguments)
-        .map_err(|error| AgentError::Store(format!("serialize tool arguments: {error}")))?
-        .len();
     if turn_id.0.is_nil()
         || lease_token.is_nil()
-        || call.id.0.is_nil()
-        || call.chat_id.0.is_nil()
         || call.turn_id != turn_id
         || progress.model_steps <= 0
-        || !labels_valid
-        || args_len > ToolCallRecord::MAX_ARGUMENT_BYTES
+        || !call.is_well_formed()
     {
         return Err(AgentError::Store(
             "invalid client tool call checkpoint request".into(),

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -744,7 +744,7 @@ impl TurnRunStatus {
 
 /// Immutable request for one tool operation that must execute in a trusted
 /// client rather than the server process.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClientToolCallRequest {
     /// Caller-supplied idempotency identity.
     pub id: CallId,
@@ -758,6 +758,26 @@ pub struct ClientToolCallRequest {
     pub name: String,
     /// Canonical model-supplied arguments.
     pub arguments: serde_json::Value,
+}
+
+impl ClientToolCallRequest {
+    /// Whether this request fits the durable client-execution contract.
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        let labels_valid = [self.provider_id.as_str(), self.name.as_str()]
+            .into_iter()
+            .all(|value| {
+                !value.is_empty()
+                    && value.len() <= ToolCallRecord::MAX_LABEL_LEN
+                    && !value.contains('\0')
+            });
+        self.id.0 != Uuid::nil()
+            && self.chat_id.0 != Uuid::nil()
+            && self.turn_id.0 != Uuid::nil()
+            && labels_valid
+            && serde_json::to_vec(&self.arguments)
+                .is_ok_and(|arguments| arguments.len() <= ToolCallRecord::MAX_ARGUMENT_BYTES)
+    }
 }
 
 /// Progress atomically committed with one client-execution checkpoint.

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -191,6 +191,7 @@ struct TurnHandles {
 #[derive(Default)]
 pub struct TurnGuard {
     active: Mutex<HashMap<ChatId, TurnHandles>>,
+    released: tokio::sync::Notify,
 }
 
 impl TurnGuard {
@@ -224,6 +225,17 @@ impl TurnGuard {
             cancel,
             steer,
         })
+    }
+
+    /// Wait until no local worker owns this chat.
+    pub async fn wait_until_vacant(&self, chat_id: ChatId) {
+        loop {
+            let released = self.released.notified();
+            if !self.active.lock().unwrap().contains_key(&chat_id) {
+                return;
+            }
+            released.await;
+        }
     }
 
     /// Trip cancellation only for the exact turn currently executing locally.
@@ -280,6 +292,7 @@ impl Drop for ActiveTurn {
             handles.turn_id == self.turn_id && handles.lease_token == self.lease_token
         }) {
             active.remove(&self.chat_id);
+            self.guard.released.notify_waiters();
         }
     }
 }

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -307,6 +307,7 @@ struct PauseTerminalStore {
     pause_after_claim_commit: std::sync::atomic::AtomicBool,
     fail_after_heartbeat_commit: std::sync::atomic::AtomicBool,
     fail_after_completion_commit: std::sync::atomic::AtomicBool,
+    fail_after_park_commit: std::sync::atomic::AtomicBool,
     fail_after_apply_steer_commit: std::sync::atomic::AtomicBool,
     cancel_after_apply_steer_commit: std::sync::atomic::AtomicBool,
     pause_before_steer_read: std::sync::atomic::AtomicBool,
@@ -332,6 +333,7 @@ impl PauseTerminalStore {
             pause_after_claim_commit: std::sync::atomic::AtomicBool::new(false),
             fail_after_heartbeat_commit: std::sync::atomic::AtomicBool::new(false),
             fail_after_completion_commit: std::sync::atomic::AtomicBool::new(false),
+            fail_after_park_commit: std::sync::atomic::AtomicBool::new(false),
             fail_after_apply_steer_commit: std::sync::atomic::AtomicBool::new(false),
             cancel_after_apply_steer_commit: std::sync::atomic::AtomicBool::new(false),
             pause_before_steer_read: std::sync::atomic::AtomicBool::new(false),
@@ -366,6 +368,10 @@ impl PauseTerminalStore {
     fn fail_after_next_completion_commit(&self) {
         self.fail_after_completion_commit
             .store(true, Ordering::SeqCst);
+    }
+
+    fn fail_after_next_park_commit(&self) {
+        self.fail_after_park_commit.store(true, Ordering::SeqCst);
     }
 
     fn fail_after_next_apply_steer_commit(&self) {
@@ -839,6 +845,33 @@ impl Store for PauseTerminalStore {
         {
             return Err(AgentError::Store(
                 "injected ambiguous completion response".into(),
+            ));
+        }
+        Ok(outcome)
+    }
+    async fn park_turn_for_client_tool_call(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
+        progress: TurnCheckpointProgress,
+        now: chrono::DateTime<chrono::Utc>,
+        call: &ClientToolCallRequest,
+    ) -> Result<Option<ParkTurnForClientCallOutcome>> {
+        let outcome = self
+            .inner
+            .park_turn_for_client_tool_call(
+                turn_id,
+                lease_token,
+                expected_steer_revision,
+                progress,
+                now,
+                call,
+            )
+            .await?;
+        if outcome.is_some() && self.fail_after_park_commit.swap(false, Ordering::SeqCst) {
+            return Err(AgentError::Store(
+                "injected ambiguous client checkpoint response".into(),
             ));
         }
         Ok(outcome)
@@ -2932,6 +2965,248 @@ async fn resumed_worker_preserves_checkpoint_usage_and_step_budget() {
         Some(AgentEvent::TurnFailed { error }) if error.kind == "max_steps_exceeded"
     ));
     assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn worker_checkpoints_a_client_tool_and_resumes_after_its_result() {
+    struct ClientThenFinishProvider {
+        requests: Arc<std::sync::Mutex<Vec<ChatRequest>>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for ClientThenFinishProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("client-then-finish")
+        }
+
+        async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let mut requests = self.requests.lock().unwrap();
+            requests.push(req);
+            let events = if requests.len() == 1 {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "native_1".into(),
+                        name: "connect_folder".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: r#"{"hint":"Documents"}"#.into(),
+                    },
+                    ProviderEvent::Usage(Usage {
+                        input_tokens: 5,
+                        output_tokens: 2,
+                        ..Usage::default()
+                    }),
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta {
+                        text: "folder connected".into(),
+                    },
+                    ProviderEvent::Usage(Usage {
+                        input_tokens: 3,
+                        output_tokens: 4,
+                        ..Usage::default()
+                    }),
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            drop(requests);
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let inner: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let injected = Arc::new(PauseTerminalStore::new(
+        inner,
+        Arc::new(Notify::new()),
+        Arc::new(Notify::new()),
+    ));
+    injected.do_not_pause_terminal();
+    injected.fail_after_next_park_commit();
+    let store: Arc<dyn Store> = injected;
+    let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let mut tools = ToolRegistry::new();
+    tools.register_client(ToolSpec {
+        name: "connect_folder".into(),
+        description: "Ask the desktop to connect a folder".into(),
+        input_schema: serde_json::json!({"type": "object"}),
+    });
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(ClientThenFinishProvider {
+            requests: requests.clone(),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(tools),
+        retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    let router = app(state.clone());
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "connect documents").await,
+        StatusCode::ACCEPTED
+    );
+
+    let pending = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let pending = store.list_pending_client_tool_calls(chat.id).await.unwrap();
+            if let Some(call) = pending.into_iter().next() {
+                break call;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("worker should durably checkpoint the client tool");
+    let parked = store.get_turn_run(turn_id).await.unwrap().unwrap();
+    assert_eq!(parked.status, TurnRunStatus::WaitingForClient);
+    assert_eq!(parked.model_steps, 1);
+    assert_eq!(parked.usage.input_tokens, 5);
+    assert_eq!(parked.usage.output_tokens, 2);
+    assert_eq!(pending.name, "connect_folder");
+    assert_eq!(pending.execution, ToolCallExecution::Client);
+    assert_eq!(pending.arguments, serde_json::json!({"hint": "Documents"}));
+
+    resolve_parked_client_call(
+        &*store,
+        chat.id,
+        &ClientToolCallRequest {
+            id: pending.id,
+            chat_id: pending.chat_id,
+            turn_id: pending.turn_id,
+            provider_id: pending.provider_id.clone(),
+            name: pending.name.clone(),
+            arguments: pending.arguments.clone(),
+        },
+    )
+    .await;
+    state.turn_job_wake.notify_one();
+    let events = wait_for_turn(&store, chat.id).await;
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCompleted { usage, .. })
+            if usage.input_tokens == 8 && usage.output_tokens == 6
+    ));
+    {
+        let requests = requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[1].messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    openwave_core::ContentBlock::ToolUse { id, name, .. }
+                        if id == "native_1" && name == "connect_folder"
+                )
+            })
+        }));
+        assert!(requests[1].messages.iter().any(|message| {
+            message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    openwave_core::ContentBlock::ToolResult { tool_use_id, content, .. }
+                        if tool_use_id == "native_1" && content == "connected-root"
+                )
+            })
+        }));
+    }
+
+    let exhausted_dir = tempfile::tempdir().unwrap();
+    let exhausted_store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            exhausted_dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let (exhausted_retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let mut exhausted_tools = ToolRegistry::new();
+    exhausted_tools.register_client(ToolSpec {
+        name: "connect_folder".into(),
+        description: "Ask the desktop to connect a folder".into(),
+        input_schema: serde_json::json!({"type": "object"}),
+    });
+    let exhausted_state = AppState::new(
+        Config::desktop(exhausted_dir.path()),
+        exhausted_store.clone(),
+        Arc::new(FixedResolver(Arc::new(ClientThenFinishProvider {
+            requests: Arc::new(std::sync::Mutex::new(Vec::new())),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(exhausted_tools),
+        exhausted_retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            max_steps: 1,
+            ..AgentConfig::default()
+        },
+    );
+    let exhausted_token = exhausted_state.token.clone();
+    spawn_turn_worker(&exhausted_state);
+    let exhausted_router = app(exhausted_state);
+    let exhausted_bearer = format!("Bearer {exhausted_token}");
+    let exhausted_chat = make_chat(&exhausted_router, &exhausted_bearer).await;
+    let exhausted_turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(
+            &exhausted_router,
+            &exhausted_bearer,
+            exhausted_chat.id,
+            exhausted_turn_id,
+            "connect documents",
+        )
+        .await,
+        StatusCode::ACCEPTED
+    );
+    let exhausted_events = wait_for_turn(&exhausted_store, exhausted_chat.id).await;
+    assert!(matches!(
+        exhausted_events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnFailed { error }) if error.kind == "max_steps_exceeded"
+    ));
+    let exhausted_turn = exhausted_store
+        .get_turn_run(exhausted_turn_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(exhausted_turn.model_steps, 1);
+    assert_eq!(exhausted_turn.usage.input_tokens, 5);
+    assert_eq!(exhausted_turn.usage.output_tokens, 2);
+    assert!(exhausted_store
+        .list_pending_client_tool_calls(exhausted_chat.id)
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 #[tokio::test]

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -8,8 +8,9 @@ use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::StreamExt;
 use openwave_core::{
     Agent, AgentConfig, AgentError, AgentEvent, AgentTurnOutcome, ClaimedAgentEvent,
-    CompleteTurnRunOutcome, MessageId, RecordTurnFailureOutcome, Result, SequencedEvent, Store,
-    ToolRegistry, TurnFailureRetry, TurnId, TurnRun, TurnRunStatus,
+    CompleteTurnRunOutcome, MessageId, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
+    Result, SequencedEvent, Store, ToolRegistry, TurnCheckpointProgress, TurnFailureRetry, TurnId,
+    TurnRun, TurnRunStatus,
 };
 use tokio::sync::Notify;
 
@@ -46,6 +47,7 @@ impl Default for TurnWorkerConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TurnWorkerOutcome {
     Completed(TurnId),
+    WaitingForClient(TurnId),
     Cancelled(TurnId),
     Failed(TurnId),
     LeaseLost(TurnId),
@@ -339,6 +341,8 @@ impl TurnWorker {
                 .await;
         };
         let mut total_usage = turn.usage;
+        let mut checkpoint_usage = openwave_core::Usage::default();
+        let mut checkpoint_steps = 0_usize;
         if remaining_steps == 0 {
             return self
                 .record_failure(
@@ -363,11 +367,26 @@ impl TurnWorker {
                 )
                 .await;
         };
-        let Some(active) = self.signals.register(turn.chat_id, turn.id, lease_token) else {
-            return Err(AgentError::msg(format!(
-                "turn {} already has a conflicting local worker",
-                turn.id
-            )));
+        let active = loop {
+            if let Some(active) = self.signals.register(turn.chat_id, turn.id, lease_token) {
+                break active;
+            }
+            tokio::select! {
+                () = self.signals.wait_until_vacant(turn.chat_id) => {}
+                () = tokio::time::sleep(self.config.heartbeat) => {
+                    match self.renew_lease(&turn, lease_token).await {
+                        LeaseState::Running => {}
+                        LeaseState::Cancelling => {
+                            return self
+                                .acknowledge_cancellation(&turn, lease_token, total_usage)
+                                .await;
+                        }
+                        LeaseState::Lost => {
+                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                        }
+                    }
+                }
+            }
         };
         let cancel = active.cancel_token();
         match self.renew_lease(&turn, lease_token).await {
@@ -539,6 +558,7 @@ impl TurnWorker {
                     let usage = match &drive_result {
                         Ok(AgentTurnOutcome::Completed { usage, .. })
                         | Ok(AgentTurnOutcome::Cancelled { usage, .. })
+                        | Ok(AgentTurnOutcome::ClientToolCall { usage, .. })
                         | Ok(AgentTurnOutcome::Failed { usage, .. }) => *usage,
                         Err(_) => openwave_core::Usage::default(),
                     };
@@ -588,6 +608,28 @@ impl TurnWorker {
                                 .await;
                         }
                     };
+                    checkpoint_usage = match checked_usage_sum(checkpoint_usage, usage) {
+                        Ok(total) => total,
+                        Err(_) => {
+                            return self
+                                .record_failure(
+                                    &turn,
+                                    lease_token,
+                                    total_model_steps,
+                                    total_usage,
+                                    "usage_overflow",
+                                    "provider usage exceeded the supported checkpoint total",
+                                )
+                                .await;
+                        }
+                    };
+                    checkpoint_steps =
+                        checkpoint_steps.checked_add(model_steps).ok_or_else(|| {
+                            AgentError::msg(format!(
+                                "turn {} checkpoint model-step count overflowed",
+                                turn.id
+                            ))
+                        })?;
                     if output.content.contains('\0') {
                         return self
                             .record_failure(
@@ -610,8 +652,7 @@ impl TurnWorker {
                         usage: total_usage,
                         stop_reason,
                     };
-                    let mut continue_after_steer = false;
-                    loop {
+                    let continue_after_steer = loop {
                         match self
                             .store
                             .complete_turn_run_and_append_event(
@@ -635,8 +676,7 @@ impl TurnWorker {
                                 }
                                 CompleteTurnRunOutcome::SteerPending(_)
                                 | CompleteTurnRunOutcome::OutputSuperseded(_) => {
-                                    continue_after_steer = true;
-                                    break;
+                                    break true;
                                 }
                             },
                             Ok(None) => {
@@ -650,7 +690,7 @@ impl TurnWorker {
                                 // retry must supersede this output.
                                 match self.live_turn_state_retry(&turn, lease_token).await {
                                     LiveTurnState::Running => tokio::task::yield_now().await,
-                                    LiveTurnState::Cancelling => break,
+                                    LiveTurnState::Cancelling => break false,
                                     LiveTurnState::Lost => {
                                         return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
                                     }
@@ -674,14 +714,14 @@ impl TurnWorker {
                                         self.publish(turn.chat_id, event);
                                         return Ok(TurnWorkerOutcome::Completed(turn.id));
                                     }
-                                    ResolutionState::Cancelling => break,
+                                    ResolutionState::Cancelling => break false,
                                     ResolutionState::Lost => {
                                         return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
                                     }
                                 }
                             }
                         }
-                    }
+                    };
                     if continue_after_steer {
                         if remaining_steps == 0 {
                             drop(active);
@@ -740,6 +780,218 @@ impl TurnWorker {
                     return self
                         .acknowledge_cancellation(&turn, lease_token, total_usage)
                         .await;
+                }
+                Ok(AgentTurnOutcome::ClientToolCall {
+                    request,
+                    usage,
+                    steer_revision,
+                    model_steps,
+                }) => {
+                    if model_steps == 0 || model_steps > remaining_steps {
+                        return Err(AgentError::msg(format!(
+                            "turn {} returned an invalid model-step count {model_steps}",
+                            turn.id
+                        )));
+                    }
+                    remaining_steps -= model_steps;
+                    total_model_steps = checked_model_step_sum(total_model_steps, model_steps)?;
+                    total_usage = match checked_usage_sum(total_usage, usage) {
+                        Ok(total) => total,
+                        Err(_) => {
+                            return self
+                                .record_failure(
+                                    &turn,
+                                    lease_token,
+                                    total_model_steps,
+                                    total_usage,
+                                    "usage_overflow",
+                                    "provider usage exceeded the supported turn total",
+                                )
+                                .await;
+                        }
+                    };
+                    if remaining_steps == 0 {
+                        drop(active);
+                        return self
+                            .record_failure(
+                                &turn,
+                                lease_token,
+                                total_model_steps,
+                                total_usage,
+                                "max_steps_exceeded",
+                                "max steps per turn exceeded before client tool execution",
+                            )
+                            .await;
+                    }
+                    if request.chat_id != turn.chat_id
+                        || request.turn_id != turn.id
+                        || !request.is_well_formed()
+                        || self.tools.execution(&request.name)
+                            != Some(openwave_core::ToolCallExecution::Client)
+                    {
+                        drop(active);
+                        return self
+                            .record_failure(
+                                &turn,
+                                lease_token,
+                                total_model_steps,
+                                total_usage,
+                                "invalid_client_tool_call",
+                                "agent returned an invalid client tool checkpoint",
+                            )
+                            .await;
+                    }
+                    checkpoint_usage = match checked_usage_sum(checkpoint_usage, usage) {
+                        Ok(total) => total,
+                        Err(_) => {
+                            return self
+                                .record_failure(
+                                    &turn,
+                                    lease_token,
+                                    total_model_steps,
+                                    total_usage,
+                                    "usage_overflow",
+                                    "provider usage exceeded the supported checkpoint total",
+                                )
+                                .await;
+                        }
+                    };
+                    checkpoint_steps =
+                        checkpoint_steps.checked_add(model_steps).ok_or_else(|| {
+                            AgentError::msg(format!(
+                                "turn {} checkpoint model-step count overflowed",
+                                turn.id
+                            ))
+                        })?;
+                    let progress = TurnCheckpointProgress {
+                        model_steps: i32::try_from(checkpoint_steps).map_err(|_| {
+                            AgentError::msg(format!(
+                                "turn {} checkpoint model-step count is too large",
+                                turn.id
+                            ))
+                        })?,
+                        usage: checkpoint_usage,
+                    };
+                    let mut checkpoint_heartbeat = AbortOnDrop(tokio::spawn(
+                        self.clone()
+                            .heartbeat_lease(turn.clone(), lease_token, cancel.clone()),
+                    ));
+                    loop {
+                        let park_result = tokio::select! {
+                            result = self.store.park_turn_for_client_tool_call(
+                                turn.id,
+                                lease_token,
+                                steer_revision,
+                                progress,
+                                Utc::now(),
+                                &request,
+                            ) => result,
+                            result = &mut checkpoint_heartbeat.0 => {
+                                match result {
+                                    Ok(HeartbeatOutcome::Cancelling) => {
+                                        drop(active);
+                                        return self
+                                            .acknowledge_cancellation(
+                                                &turn,
+                                                lease_token,
+                                                total_usage,
+                                            )
+                                            .await;
+                                    }
+                                    Ok(HeartbeatOutcome::LeaseLost) | Err(_) => {
+                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    }
+                                }
+                            }
+                        };
+                        match park_result {
+                            Ok(Some(ParkTurnForClientCallOutcome::Parked { .. }))
+                            | Ok(Some(ParkTurnForClientCallOutcome::Existing { .. })) => {
+                                checkpoint_heartbeat.abort_and_wait().await;
+                                return Ok(TurnWorkerOutcome::WaitingForClient(turn.id));
+                            }
+                            Ok(Some(ParkTurnForClientCallOutcome::SteerPending(_)))
+                            | Ok(Some(ParkTurnForClientCallOutcome::OutputSuperseded(_))) => {
+                                break;
+                            }
+                            Ok(Some(ParkTurnForClientCallOutcome::IdentityConflict)) => {
+                                checkpoint_heartbeat.abort_and_wait().await;
+                                return self
+                                    .record_failure(
+                                        &turn,
+                                        lease_token,
+                                        total_model_steps,
+                                        total_usage,
+                                        "client_tool_identity_conflict",
+                                        "client tool call identity conflicts with its durable receipt",
+                                    )
+                                    .await;
+                            }
+                            Ok(None) => {
+                                match self.live_turn_state_retry(&turn, lease_token).await {
+                                    LiveTurnState::Running => tokio::task::yield_now().await,
+                                    LiveTurnState::Cancelling => {
+                                        checkpoint_heartbeat.abort_and_wait().await;
+                                        drop(active);
+                                        return self
+                                            .acknowledge_cancellation(
+                                                &turn,
+                                                lease_token,
+                                                total_usage,
+                                            )
+                                            .await;
+                                    }
+                                    LiveTurnState::Lost => {
+                                        checkpoint_heartbeat.abort_and_wait().await;
+                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    }
+                                }
+                            }
+                            Err(error) => {
+                                self.retry_after("client checkpoint", turn.id, &error).await;
+                            }
+                        }
+                    }
+                    checkpoint_heartbeat.abort_and_wait().await;
+                    if remaining_steps == 0 {
+                        drop(active);
+                        return self
+                            .record_failure(
+                                &turn,
+                                lease_token,
+                                total_model_steps,
+                                total_usage,
+                                "max_steps_exceeded",
+                                "max steps per turn exceeded while applying durable steering",
+                            )
+                            .await;
+                    }
+                    let mut continuation_heartbeat = AbortOnDrop(tokio::spawn(
+                        self.clone()
+                            .heartbeat_lease(turn.clone(), lease_token, cancel.clone()),
+                    ));
+                    match self
+                        .append_event(&turn, lease_token, ordinal, &AgentEvent::StreamInterrupted)
+                        .await?
+                    {
+                        EventAppend::Committed => {
+                            ordinal = ordinal.checked_add(1).ok_or_else(|| {
+                                AgentError::msg(format!("turn {} event ordinal exhausted", turn.id))
+                            })?;
+                        }
+                        EventAppend::Cancelling => {
+                            cancel.cancel();
+                            drop(active);
+                            return self
+                                .acknowledge_cancellation(&turn, lease_token, total_usage)
+                                .await;
+                        }
+                        EventAppend::LeaseLost => {
+                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                        }
+                    }
+                    continuation_heartbeat.abort_and_wait().await;
+                    continue;
                 }
                 Ok(AgentTurnOutcome::Cancelled { usage, .. }) => {
                     match checked_usage_sum(total_usage, usage) {

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -272,7 +272,9 @@ This will land in independently reviewable pieces:
    guard heartbeat, terminal resolution, and explicit expired-claim recovery.
    Authenticated per-chat pending/claim/heartbeat/resolve routes now expose that
    state machine without leaking tokens through polling. Atomic turn parking,
-   the folder request tool, and the desktop executor remain to be layered on it.
+   cumulative progress accounting, and the agent/worker handoff for a singular
+   client-owned call are now implemented. The folder request contract and desktop
+   executor remain to be layered on that boundary.
 8. Replace project/chat `workspace_dir` with persisted host-access context
    identity and connected-root APIs. This can update the pre-v1 baseline schema
    directly.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -147,7 +147,8 @@ tool-call records. It then loops for a bounded number of model steps:
 
 1. fit the transcript into the model's context window;
 2. call the selected provider and stream its output;
-3. durably accept each tool call's canonical name and arguments, then run it;
+3. either durably accept and run a server tool, or hand one client-owned call to
+   the turn worker for an atomic wait checkpoint;
 4. feed tool results back to the model;
 5. repeat until the model produces a final answer.
 
@@ -164,11 +165,13 @@ product boundary. The desktop can now connect, list, and revoke multiple folders
 through a native picker and capability-gated host-broker sidecar; it exposes only
 opaque root IDs and display names to the renderer. The next tool-routing slice
 will resolve file operations through those roots instead of the legacy workspace.
-See [Host access and connected folders](host-access.md). An agent may later ask
-the desktop to connect another folder, but the request only opens a native consent
-flow; it never grants a named path by itself. The model router supports Anthropic, OpenAI, and
-OpenAI-compatible endpoints. It fails closed: if no enabled provider with a
-usable credential can serve the selected model, no model request is sent.
+See [Host access and connected folders](host-access.md). The agent loop can now
+produce a durable client-wait checkpoint for a registered client-owned tool. The
+folder-request contract and desktop executor are the next layers: such a request
+will only open a native consent flow and will never grant a named path by itself.
+The model router supports Anthropic, OpenAI, and OpenAI-compatible endpoints. It
+fails closed: if no enabled provider with a usable credential can serve the
+selected model, no model request is sent.
 
 ### Tool calls are small state machines too
 
@@ -179,8 +182,13 @@ identity with different arguments is a conflict. A server tool then makes one
 terminal transition to `completed`, `failed`, or `cancelled`, and an exact retry
 recovers that result rather than overwriting it.
 
-The same record can describe work that must execute on a trusted client, such as
-a future native folder-picker request. Client work starts unclaimed and is
+The same record describes work that must execute on a trusted client, such as a
+native folder-picker request. The tool registry advertises these contracts to the
+model without installing a server-side executor. For now, the agent accepts only
+one such call at a model boundary, with no sibling call or assistant text, because
+the durable wait receipt represents one exact continuation. The worker atomically
+stores that call, its immutable wait receipt, provider usage, and consumed model
+steps before releasing its lease. Client work then starts unclaimed and is
 listed from durable storage for reconnect recovery. A client claims it with an
 executor identity and a fresh secret claim token; the store installs that token
 with the expiry. Heartbeat and completion require it, so an old callback from
@@ -582,8 +590,8 @@ The main next steps are:
 
 - replace raw chat/project workspace paths with broker-mediated, per-context
   connected roots while keeping OpenWave's private app data separate;
-- teach the agent to emit client-wait checkpoints, notify clients of durable
-  pending work, and run native folder requests in the desktop;
+- register the folder-request tool, notify the desktop of durable pending work,
+  and execute native folder requests through the picker and broker;
 - add resumable checkpoints and explicit idempotency policy around remaining
   server-side tool effects;
 - make approvals resumable rather than process-local;


### PR DESCRIPTION
## Summary

- advertise client-owned tool contracts without installing server executors
- atomically checkpoint one canonical client tool call and release the turn lease
- resume from durable client results with exact usage, step, steering, and cancellation handling
- document the trusted-client handoff and next folder-consent layer

## Validation

- `bw dev lint --rust --check --repo-root "$PWD"`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p openwave-core --all-features`
- `cargo test -p openwave-server --all-features`
