### PR TITLE
feat(core): register folder access consent tool

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -55,7 +55,10 @@ pub struct ToolRegistry {
 
 enum RegisteredTool {
     Server(Box<dyn Tool>),
-    Client(ToolSpec),
+    Client {
+        spec: ToolSpec,
+        validate_arguments: Option<fn(&Value) -> bool>,
+    },
 }
 
 impl ToolRegistry {
@@ -73,8 +76,28 @@ impl ToolRegistry {
 
     /// Register a client-owned tool contract with no server-side executor.
     pub fn register_client(&mut self, spec: ToolSpec) {
-        self.tools
-            .insert(spec.name.clone(), RegisteredTool::Client(spec));
+        self.tools.insert(
+            spec.name.clone(),
+            RegisteredTool::Client {
+                spec,
+                validate_arguments: None,
+            },
+        );
+    }
+
+    /// Register a client-owned contract with payload validation at checkpoint time.
+    pub fn register_validated_client(
+        &mut self,
+        spec: ToolSpec,
+        validate_arguments: fn(&Value) -> bool,
+    ) {
+        self.tools.insert(
+            spec.name.clone(),
+            RegisteredTool::Client {
+                spec,
+                validate_arguments: Some(validate_arguments),
+            },
+        );
     }
 
     /// Builder-style [`register`](Self::register).
@@ -89,7 +112,7 @@ impl ToolRegistry {
     pub fn get(&self, name: &str) -> Option<&dyn Tool> {
         match self.tools.get(name) {
             Some(RegisteredTool::Server(tool)) => Some(tool.as_ref()),
-            Some(RegisteredTool::Client(_)) | None => None,
+            Some(RegisteredTool::Client { .. }) | None => None,
         }
     }
 
@@ -98,7 +121,7 @@ impl ToolRegistry {
     pub fn execution(&self, name: &str) -> Option<ToolCallExecution> {
         self.tools.get(name).map(|tool| match tool {
             RegisteredTool::Server(_) => ToolCallExecution::Server,
-            RegisteredTool::Client(_) => ToolCallExecution::Client,
+            RegisteredTool::Client { .. } => ToolCallExecution::Client,
         })
     }
 
@@ -109,9 +132,25 @@ impl ToolRegistry {
             .values()
             .map(|tool| match tool {
                 RegisteredTool::Server(tool) => tool.spec(),
-                RegisteredTool::Client(spec) => spec.clone(),
+                RegisteredTool::Client { spec, .. } => spec.clone(),
             })
             .collect()
+    }
+
+    /// Validate canonical arguments against a registered client-owned contract.
+    #[must_use]
+    pub fn client_arguments_are_valid(&self, name: &str, arguments: &Value) -> bool {
+        match self.tools.get(name) {
+            Some(RegisteredTool::Client {
+                validate_arguments: Some(validate),
+                ..
+            }) => validate(arguments),
+            Some(RegisteredTool::Client {
+                validate_arguments: None,
+                ..
+            }) => true,
+            Some(RegisteredTool::Server(_)) | None => false,
+        }
     }
 
     /// Whether no tools are registered.
@@ -693,7 +732,11 @@ impl Agent {
                     name: call.name.clone(),
                     arguments,
                 };
-                if !request.is_well_formed() {
+                if !request.is_well_formed()
+                    || !self
+                        .tools
+                        .client_arguments_are_valid(&request.name, &request.arguments)
+                {
                     events.send(AgentEvent::StreamInterrupted);
                     transcript.push(ChatMessage {
                         role: Role::User,
@@ -1519,6 +1562,8 @@ mod tests {
 
     struct ClientToolProvider {
         assistant_text: bool,
+        name: &'static str,
+        arguments: &'static str,
     }
 
     struct ContextRecordingTool {
@@ -1601,11 +1646,11 @@ mod tests {
                 ProviderEvent::ToolCallStarted {
                     index: 0,
                     id: "native_1".into(),
-                    name: "connect_folder".into(),
+                    name: self.name.into(),
                 },
                 ProviderEvent::ToolCallArgsDelta {
                     index: 0,
-                    fragment: r#"{"hint":"Documents"}"#.into(),
+                    fragment: self.arguments.into(),
                 },
                 ProviderEvent::Usage(Usage {
                     input_tokens: 5,
@@ -1680,6 +1725,8 @@ mod tests {
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
                 assistant_text: false,
+                name: "connect_folder",
+                arguments: r#"{"hint":"Documents"}"#,
             }),
             Arc::new(registry),
             store.clone(),
@@ -1719,6 +1766,41 @@ mod tests {
             event,
             AgentEvent::ToolCallStarted { name, .. } if name == "connect_folder"
         )));
+
+        let mut validated_registry = ToolRegistry::new();
+        validated_registry.register_validated_client(
+            crate::request_folder_access_tool_spec(),
+            crate::validate_request_folder_access_arguments,
+        );
+        let invalid_agent = Agent::new(
+            Arc::new(ClientToolProvider {
+                assistant_text: false,
+                name: crate::REQUEST_FOLDER_ACCESS_TOOL,
+                arguments: r#"{"reason":"Read reports","requested_capabilities":["write_files"],"path":"/Users/example/Documents"}"#,
+            }),
+            Arc::new(validated_registry),
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                max_steps: 1,
+                ..AgentConfig::default()
+            },
+        )
+        .with_durable_steer(lease_token);
+        let (invalid_tx, _invalid_rx) = unbounded();
+        let invalid_outcome = invalid_agent
+            .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &invalid_tx)
+            .await
+            .unwrap();
+        assert!(matches!(
+            invalid_outcome,
+            AgentTurnOutcome::Failed {
+                error,
+                model_steps: 1,
+                ..
+            } if error.kind == "max_steps_exceeded"
+        ));
+        assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -1766,6 +1848,8 @@ mod tests {
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
                 assistant_text: true,
+                name: "connect_folder",
+                arguments: r#"{"hint":"Documents"}"#,
             }),
             Arc::new(registry),
             store.clone(),

--- a/crates/openwave-core/src/client_tools.rs
+++ b/crates/openwave-core/src/client_tools.rs
@@ -1,0 +1,185 @@
+//! Shared contracts for work that must execute on a trusted client.
+//!
+//! These types describe model proposals, not authority. A desktop or other
+//! trusted client must still validate the payload, obtain explicit user
+//! consent, and derive the actual host-broker grant itself.
+
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+
+use crate::ToolSpec;
+
+/// Stable tool name for asking the user to connect another folder.
+pub const REQUEST_FOLDER_ACCESS_TOOL: &str = "request_folder_access";
+
+/// Maximum user-facing explanation length advertised to the model.
+pub const MAX_FOLDER_ACCESS_REASON_CHARS: usize = 500;
+
+/// One untrusted capability proposal attached to a folder-access request.
+///
+/// The trusted host derives the granted capabilities after consent; it must not
+/// copy this list directly into a grant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RequestedFolderCapability {
+    /// List directories and read files below the selected folder.
+    ReadFiles,
+}
+
+/// Non-authoritative, well-known starting location for the native picker.
+///
+/// This is deliberately not a free-form path. The trusted desktop decides how
+/// (or whether) to map it to a local picker location.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RequestedFolderHint {
+    /// Start the picker near the user's documents folder when supported.
+    Documents,
+    /// Start the picker near the user's downloads folder when supported.
+    Downloads,
+}
+
+/// Canonical arguments for [`REQUEST_FOLDER_ACCESS_TOOL`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RequestFolderAccessArgs {
+    /// Short explanation shown to the user before any picker opens.
+    pub reason: String,
+    /// Capabilities the model believes it needs; these are proposals only.
+    pub requested_capabilities: Vec<RequestedFolderCapability>,
+    /// Optional non-authoritative well-known picker hint.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_hint"
+    )]
+    pub folder_hint: Option<RequestedFolderHint>,
+}
+
+fn deserialize_optional_hint<'de, D>(
+    deserializer: D,
+) -> Result<Option<RequestedFolderHint>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    RequestedFolderHint::deserialize(deserializer).map(Some)
+}
+
+impl RequestFolderAccessArgs {
+    /// Whether a trusted client may safely present this proposal to the user.
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        !self.reason.trim().is_empty()
+            && self.reason.chars().count() <= MAX_FOLDER_ACCESS_REASON_CHARS
+            && !self.reason.contains('\0')
+            && self.requested_capabilities == [RequestedFolderCapability::ReadFiles]
+    }
+}
+
+/// Validate one canonical JSON payload before it crosses the trusted-client boundary.
+#[must_use]
+pub fn validate_request_folder_access_arguments(arguments: &Value) -> bool {
+    serde_json::from_value::<RequestFolderAccessArgs>(arguments.clone())
+        .is_ok_and(|arguments| arguments.is_well_formed())
+}
+
+/// Tool contract advertised by the local control plane.
+#[must_use]
+pub fn request_folder_access_tool_spec() -> ToolSpec {
+    ToolSpec {
+        name: REQUEST_FOLDER_ACCESS_TOOL.into(),
+        description: "Ask the user to connect another folder through a native consent flow. This request grants no access by itself. Provide a short reason, the read capability proposal, and optionally a label such as Documents or Downloads; never provide an absolute path.".into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": MAX_FOLDER_ACCESS_REASON_CHARS,
+                    "description": "Why access is needed, shown to the user."
+                },
+                "requested_capabilities": {
+                    "type": "array",
+                    "description": "Untrusted capability proposals; the host derives any actual grant.",
+                    "items": { "enum": ["read_files"] },
+                    "minItems": 1,
+                    "maxItems": 1,
+                    "uniqueItems": true
+                },
+                "folder_hint": {
+                    "enum": ["documents", "downloads"],
+                    "description": "Optional well-known picker hint, never an absolute path."
+                }
+            },
+            "required": ["reason", "requested_capabilities"],
+            "additionalProperties": false
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folder_access_contract_is_bounded_and_denies_unknown_fields() {
+        let args: RequestFolderAccessArgs = serde_json::from_value(serde_json::json!({
+            "reason": "Read the reports needed for this project",
+            "requested_capabilities": ["read_files"],
+            "folder_hint": "documents"
+        }))
+        .unwrap();
+        assert!(args.is_well_formed());
+        assert!(validate_request_folder_access_arguments(
+            &serde_json::to_value(&args).unwrap()
+        ));
+        assert!(
+            serde_json::from_value::<RequestFolderAccessArgs>(serde_json::json!({
+                "reason": "Read reports",
+                "requested_capabilities": ["read_files"],
+                "path": "/Users/example/Documents"
+            }))
+            .is_err()
+        );
+
+        let mut invalid = args.clone();
+        invalid.reason = " ".into();
+        assert!(!invalid.is_well_formed());
+        invalid = args.clone();
+        invalid.requested_capabilities.clear();
+        assert!(!invalid.is_well_formed());
+        invalid = args;
+        invalid.reason = format!("{}x", " ".repeat(MAX_FOLDER_ACCESS_REASON_CHARS));
+        assert!(!invalid.is_well_formed());
+        assert!(
+            serde_json::from_value::<RequestFolderAccessArgs>(serde_json::json!({
+                "reason": "Read reports",
+                "requested_capabilities": ["read_files"],
+                "folder_hint": "/Users/example/Documents"
+            }))
+            .is_err()
+        );
+        assert!(
+            serde_json::from_value::<RequestFolderAccessArgs>(serde_json::json!({
+                "reason": "Read reports",
+                "requested_capabilities": ["read_files"],
+                "folder_hint": null
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn folder_access_spec_marks_every_proposal_as_non_authoritative() {
+        let spec = request_folder_access_tool_spec();
+        assert_eq!(spec.name, REQUEST_FOLDER_ACCESS_TOOL);
+        assert_eq!(spec.input_schema["additionalProperties"], false);
+        assert_eq!(
+            spec.input_schema["required"],
+            serde_json::json!(["reason", "requested_capabilities"])
+        );
+        assert!(spec.description.contains("grants no access"));
+    }
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod approval;
 #[cfg(feature = "blob-fs")]
 pub mod blob;
 pub mod cancel;
+pub mod client_tools;
 pub mod config;
 pub mod context;
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
@@ -42,6 +43,11 @@ pub use approval::{
 #[cfg(feature = "blob-fs")]
 pub use blob::FsBlobStore;
 pub use cancel::{CancelToken, Cancelled};
+pub use client_tools::{
+    request_folder_access_tool_spec, validate_request_folder_access_arguments,
+    RequestFolderAccessArgs, RequestedFolderCapability, RequestedFolderHint,
+    MAX_FOLDER_ACCESS_REASON_CHARS, REQUEST_FOLDER_ACCESS_TOOL,
+};
 pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub use db::DbStore;

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -40,8 +40,9 @@ use tokio::net::TcpListener;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 
 use openwave_core::{
-    AgentConfig, AgentError, Config, DbStore, KeychainSecretProvider, ListDir, Profile, ReadFile,
-    Result, SecretProvider, Store, ToolRegistry, WriteFile,
+    request_folder_access_tool_spec, validate_request_folder_access_arguments, AgentConfig,
+    AgentError, Config, DbStore, KeychainSecretProvider, ListDir, Profile, ReadFile, Result,
+    SecretProvider, Store, ToolRegistry, WriteFile,
 };
 use openwave_retrieval::{
     Embedder, HashEmbedder, LanceVectorStore, OpenAiEmbedder, ParserRegistry, PlainTextParser,
@@ -373,13 +374,16 @@ fn agent_deps(
     store: Arc<dyn VectorStore>,
 ) -> (Arc<Retriever>, Arc<ToolRegistry>, AgentConfig) {
     let (retrieval, search) = build_retrieval(embedder, store);
-    let tools = Arc::new(
-        ToolRegistry::new()
-            .with(Box::new(ReadFile))
-            .with(Box::new(ListDir))
-            .with(Box::new(WriteFile))
-            .with(search),
+    let mut tools = ToolRegistry::new()
+        .with(Box::new(ReadFile))
+        .with(Box::new(ListDir))
+        .with(Box::new(WriteFile))
+        .with(search);
+    tools.register_validated_client(
+        request_folder_access_tool_spec(),
+        validate_request_folder_access_arguments,
     );
+    let tools = Arc::new(tools);
     let model = std::env::var("OPENWAVE_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string());
     let agent_config = AgentConfig {
         model,

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -4821,7 +4821,7 @@ async fn root_search_never_returns_project_owned_vectors() {
 }
 
 #[test]
-fn agent_deps_registers_the_search_tool_alongside_the_file_tools() {
+fn agent_deps_registers_server_tools_and_the_folder_consent_contract() {
     let (_retrieval, tools, _config) = agent_deps(
         Arc::new(HashEmbedder::default()),
         Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
@@ -4835,6 +4835,35 @@ fn agent_deps_registers_the_search_tool_alongside_the_file_tools() {
         names.iter().any(|n| n == "read_file"),
         "file tools still present"
     );
+    assert_eq!(
+        tools.execution(openwave_core::REQUEST_FOLDER_ACCESS_TOOL),
+        Some(ToolCallExecution::Client)
+    );
+    assert!(tools
+        .get(openwave_core::REQUEST_FOLDER_ACCESS_TOOL)
+        .is_none());
+    let spec = tools
+        .specs()
+        .into_iter()
+        .find(|spec| spec.name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL)
+        .expect("folder consent tool is advertised");
+    assert_eq!(spec, openwave_core::request_folder_access_tool_spec());
+    assert!(tools.client_arguments_are_valid(
+        openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
+        &serde_json::json!({
+            "reason": "Read the reports needed for this project",
+            "requested_capabilities": ["read_files"],
+            "folder_hint": "documents"
+        })
+    ));
+    assert!(!tools.client_arguments_are_valid(
+        openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
+        &serde_json::json!({
+            "reason": "Read reports",
+            "requested_capabilities": ["write_files"],
+            "path": "/Users/example/Documents"
+        })
+    ));
 }
 
 #[tokio::test]

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -104,6 +104,19 @@ async fn drain_committed_events(
     }
 }
 
+fn client_checkpoint_is_valid(
+    tools: &ToolRegistry,
+    chat_id: openwave_core::ChatId,
+    turn_id: TurnId,
+    request: &openwave_core::ClientToolCallRequest,
+) -> bool {
+    request.chat_id == chat_id
+        && request.turn_id == turn_id
+        && request.is_well_formed()
+        && tools.client_arguments_are_valid(&request.name, &request.arguments)
+        && tools.execution(&request.name) == Some(openwave_core::ToolCallExecution::Client)
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum LeaseState {
     Running,
@@ -823,12 +836,12 @@ impl TurnWorker {
                             )
                             .await;
                     }
-                    if request.chat_id != turn.chat_id
-                        || request.turn_id != turn.id
-                        || !request.is_well_formed()
-                        || self.tools.execution(&request.name)
-                            != Some(openwave_core::ToolCallExecution::Client)
-                    {
+                    if !client_checkpoint_is_valid(
+                        self.tools.as_ref(),
+                        turn.chat_id,
+                        turn.id,
+                        &request,
+                    ) {
                         drop(active);
                         return self
                             .record_failure(
@@ -1532,5 +1545,40 @@ mod committed_event_drain_tests {
             },
         )
         .is_err());
+    }
+
+    #[test]
+    fn client_checkpoint_fence_rejects_invalid_payloads_before_parking() {
+        let mut tools = ToolRegistry::new();
+        tools.register_validated_client(
+            openwave_core::request_folder_access_tool_spec(),
+            openwave_core::validate_request_folder_access_arguments,
+        );
+        let chat_id = openwave_core::ChatId::new();
+        let turn_id = TurnId::new();
+        let mut request = openwave_core::ClientToolCallRequest {
+            id: openwave_core::CallId::new(),
+            chat_id,
+            turn_id,
+            provider_id: "provider-call-1".into(),
+            name: openwave_core::REQUEST_FOLDER_ACCESS_TOOL.into(),
+            arguments: serde_json::json!({
+                "reason": "Read the reports needed for this project",
+                "requested_capabilities": ["read_files"],
+                "folder_hint": "documents"
+            }),
+        };
+        assert!(client_checkpoint_is_valid(
+            &tools, chat_id, turn_id, &request
+        ));
+
+        request.arguments = serde_json::json!({
+            "reason": "Read reports",
+            "requested_capabilities": ["write_files"],
+            "path": "/Users/example/Documents"
+        });
+        assert!(!client_checkpoint_is_valid(
+            &tools, chat_id, turn_id, &request
+        ));
     }
 }

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -134,7 +134,8 @@ two-step product workflow, not a privileged broker operation:
 
 1. The agent records an access request with a stable identity, a user-readable
    reason, untrusted proposals for the capabilities it needs, and an optional
-   folder hint such as `Documents`, `Downloads`, or a project name.
+   well-known folder hint for `Documents` or `Downloads`. The contract does not
+   accept free-form labels or paths.
 2. The desktop renders a request card. Only after the user accepts that card does
    it open a native folder picker. A hint may choose the picker's starting
    location, but it confers no authority. Durable coalescing and rate limits keep
@@ -273,8 +274,10 @@ This will land in independently reviewable pieces:
    Authenticated per-chat pending/claim/heartbeat/resolve routes now expose that
    state machine without leaking tokens through polling. Atomic turn parking,
    cumulative progress accounting, and the agent/worker handoff for a singular
-   client-owned call are now implemented. The folder request contract and desktop
-   executor remain to be layered on that boundary.
+   client-owned call are now implemented. The bounded `request_folder_access`
+   contract is registered without a server executor; its capability list is
+   explicitly an untrusted proposal. The desktop pending-work executor remains
+   to be layered on that boundary.
 8. Replace project/chat `workspace_dir` with persisted host-access context
    identity and connected-root APIs. This can update the pre-v1 baseline schema
    directly.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -157,7 +157,11 @@ The built-in server registry currently contains:
 - `read_file` and `list_dir`, which are read-only;
 - `write_file`, which is workspace-confined and runs without a prompt;
 - `search`, which queries the indexed corpus and requires approval only when its
-  embedder, store, or reranker can send data outside the machine.
+  embedder, store, or reranker can send data outside the machine;
+- `request_folder_access`, a client-owned consent proposal with a bounded
+  user-facing reason, one read capability proposal, and an optional well-known
+  picker hint for Documents or Downloads. It has no server executor and grants
+  nothing.
 
 Today these file tools still operate inside one directly opened workspace
 directory stored on the chat. That temporary tool path is not the intended
@@ -166,9 +170,9 @@ through a native picker and capability-gated host-broker sidecar; it exposes onl
 opaque root IDs and display names to the renderer. The next tool-routing slice
 will resolve file operations through those roots instead of the legacy workspace.
 See [Host access and connected folders](host-access.md). The agent loop can now
-produce a durable client-wait checkpoint for a registered client-owned tool. The
-folder-request contract and desktop executor are the next layers: such a request
-will only open a native consent flow and will never grant a named path by itself.
+produce a durable client-wait checkpoint for the registered folder-request
+contract. The desktop executor is the next layer: the request will only open a
+native consent flow and will never grant a named path by itself.
 The model router supports Anthropic, OpenAI, and OpenAI-compatible endpoints. It
 fails closed: if no enabled provider with a usable credential can serve the
 selected model, no model request is sent.
@@ -590,8 +594,8 @@ The main next steps are:
 
 - replace raw chat/project workspace paths with broker-mediated, per-context
   connected roots while keeping OpenWave's private app data separate;
-- register the folder-request tool, notify the desktop of durable pending work,
-  and execute native folder requests through the picker and broker;
+- notify the desktop of durable pending folder requests and execute them through
+  the picker and broker;
 - add resumable checkpoints and explicit idempotency policy around remaining
   server-side tool effects;
 - make approvals resumable rather than process-local;


### PR DESCRIPTION
## Summary

- add a bounded, typed `request_folder_access` proposal contract with no server-side executor
- validate client-owned arguments in both the agent loop and the worker before durable checkpointing
- register the production contract and document that picker hints and capability requests confer no authority

## Validation

- `bw dev lint --rust --check --repo-root "$PWD"`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p openwave-core --all-features` (228 library tests + 2 PostgreSQL tests)
- `cargo test -p openwave-server --all-features agent_deps_registers_server_tools_and_the_folder_consent_contract`
- `cargo test -p openwave-server --all-features client_checkpoint_fence_rejects_invalid_payloads_before_parking`
- full server suite: 159 passed; the pre-existing timeout-sensitive `committed_steer_event_recovers_when_cancellation_wins_ambiguous_response` test timed out and passed immediately in isolation