### PR TITLE
feat(host-broker): inspect registration receipts

### DIFF
--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -61,6 +61,7 @@ pub enum AuditError {
 #[serde(rename_all = "snake_case")]
 pub enum AuditOperation {
     RegisterRoot,
+    LookupRegisterRootReceipt,
     RevokeRoot,
     ListRoots,
     ListDirectory,

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -30,10 +30,11 @@ use crate::{
     },
     protocol::{
         ControlEnvelope, ControlRequest, ControlResponseEnvelope, ControlResult, DirectoryEntry,
-        EntryKind, ErrorCode, ErrorResponse, HelloResult, OperationEnvelope, OperationRequest,
+        EntryKind, ErrorCode, ErrorResponse, HelloResult, LookupRegisterRootReceiptRequest,
+        LookupRegisterRootReceiptResult, OperationEnvelope, OperationRequest,
         OperationResponseEnvelope, OperationResult, PathRequest, ReadFileResult,
-        RegisterRootRequest, RegisterRootResult, Response, ResponseEnvelope, RevokeRootRequest,
-        RevokeRootResult, RootSummary, PROTOCOL_VERSION,
+        RegisterRootReceipt, RegisterRootRequest, RegisterRootResult, Response, ResponseEnvelope,
+        RevokeRootRequest, RevokeRootResult, RootSummary, PROTOCOL_VERSION,
     },
     Capability, ConsentMethod, ConsentRecord, ExecutionContext, Grant, GrantError, GrantId,
     GrantSubject, OperationId, RelativePath, RootAttachment, RootId, RootPolicy, RootPolicyError,
@@ -199,6 +200,15 @@ impl ControlAudit {
                 operation: AuditOperation::RegisterRoot,
                 operation_id: request.operation_id,
                 target: AuditTarget::selected_folder(&request.path),
+            }),
+            ControlRequest::LookupRegisterRootReceipt(request) => Some(Self {
+                actor: AuditActor::Control {
+                    subject: request.subject,
+                    conversation_id: Some(request.conversation_id),
+                },
+                operation: AuditOperation::LookupRegisterRootReceipt,
+                operation_id: request.operation_id,
+                target: AuditTarget::Subject,
             }),
             ControlRequest::RevokeRoot(request) => Some(Self {
                 actor: AuditActor::Control {
@@ -371,6 +381,9 @@ impl Controller {
             ControlRequest::RegisterRoot(request) => {
                 self.register_root(request).map(ControlResult::RegisterRoot)
             }
+            ControlRequest::LookupRegisterRootReceipt(request) => self
+                .lookup_register_root_receipt(request)
+                .map(ControlResult::LookupRegisterRootReceipt),
             ControlRequest::RevokeRoot(request) => {
                 self.revoke_root(request).map(ControlResult::RevokeRoot)
             }
@@ -455,6 +468,62 @@ impl Controller {
             return Err(error_response(error));
         }
         outcome
+    }
+
+    fn lookup_register_root_receipt(
+        &self,
+        request: LookupRegisterRootReceiptRequest,
+    ) -> Result<LookupRegisterRootReceiptResult, ErrorResponse> {
+        if request.conversation_id.is_nil()
+            || (request.subject.kind() == SubjectKind::Conversation
+                && request.subject.id() != request.conversation_id)
+        {
+            return Err(error_response(BrokerError::SubjectConversationMismatch));
+        }
+        let state = self.lock_state().map_err(error_response)?;
+        if let Some(record) = state.mutations.get(&request.operation_id) {
+            match record {
+                MutationRecord::Register {
+                    request: registered,
+                    ..
+                } if registered.subject == request.subject
+                    && registered.conversation_id == request.conversation_id => {}
+                MutationRecord::Register { .. } | MutationRecord::Revoke { .. } => {
+                    return Err(error_response(BrokerError::OperationIdConflict));
+                }
+            }
+        }
+        let receipt = match state.mutations.get(&request.operation_id) {
+            None => RegisterRootReceipt::Unknown,
+            Some(MutationRecord::Register {
+                outcome: MutationOutcome::Pending,
+                ..
+            }) => RegisterRootReceipt::Pending,
+            Some(MutationRecord::Register {
+                request: registered,
+                outcome: MutationOutcome::Complete(Ok(result)),
+            }) => {
+                let root = result.root.clone();
+                if registration_is_connected(&state, registered, &root) {
+                    RegisterRootReceipt::Completed { root }
+                } else {
+                    RegisterRootReceipt::Disconnected { root }
+                }
+            }
+            Some(MutationRecord::Register {
+                outcome: MutationOutcome::Complete(Err(error)),
+                ..
+            }) => RegisterRootReceipt::Failed {
+                error: error.clone(),
+            },
+            Some(MutationRecord::Revoke { .. }) => {
+                unreachable!("non-registration operation was rejected above")
+            }
+        };
+        Ok(LookupRegisterRootReceiptResult {
+            operation_id: request.operation_id,
+            receipt,
+        })
     }
 
     fn prepare_registration(
@@ -854,6 +923,27 @@ enum Claim<T> {
     Complete(Result<T, ErrorResponse>),
 }
 
+fn registration_is_connected(
+    state: &State,
+    request: &RegisterFingerprint,
+    root: &RootSummary,
+) -> bool {
+    state.roots.get(&root.root_id).is_some_and(|registered| {
+        registered.owner == request.subject && registered.display_name == root.display_name
+    }) && state.attachments.iter().any(|attachment| {
+        attachment.conversation_id() == request.conversation_id
+            && attachment.root_id() == root.root_id
+    }) && state.grants.iter().any(|grant| {
+        grant.subject() == request.subject
+            && grant.capability() == Capability::ListRoots
+            && matches!(grant.scope(), Scope::Subject)
+    }) && state.grants.iter().any(|grant| {
+        grant.subject() == request.subject
+            && grant.capability() == Capability::ReadFiles
+            && matches!(grant.scope(), Scope::Root { root_id } if *root_id == root.root_id)
+    })
+}
+
 fn claim_register(
     state: &mut State,
     operation_id: OperationId,
@@ -1239,6 +1329,27 @@ mod tests {
         result
     }
 
+    fn lookup_register_receipt(
+        controller: &Controller,
+        operation_id: OperationId,
+        subject: GrantSubject,
+        conversation_id: Uuid,
+    ) -> Result<LookupRegisterRootReceiptResult, ErrorResponse> {
+        let result = unwrap_response(controller.handle(ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request: ControlRequest::LookupRegisterRootReceipt(LookupRegisterRootReceiptRequest {
+                operation_id,
+                subject,
+                conversation_id,
+            }),
+        }))?;
+        let ControlResult::LookupRegisterRootReceipt(result) = result else {
+            panic!("unexpected control result")
+        };
+        Ok(result)
+    }
+
     fn operate(
         operator: &Operator,
         context: ExecutionContext,
@@ -1343,6 +1454,161 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn registration_receipt_lookup_never_starts_or_resumes_a_mutation() {
+        let (temp, broker, path) = setup();
+        let controller = broker.controller();
+        let conversation_id = Uuid::new_v4();
+        let subject = GrantSubject::conversation(conversation_id).unwrap();
+        let unknown_id = OperationId::new();
+        assert_eq!(
+            lookup_register_receipt(&controller, unknown_id, subject, conversation_id).unwrap(),
+            LookupRegisterRootReceiptResult {
+                operation_id: unknown_id,
+                receipt: RegisterRootReceipt::Unknown,
+            }
+        );
+
+        let operation_id = OperationId::new();
+        broker.shared.state.lock().unwrap().mutations.insert(
+            operation_id,
+            MutationRecord::Register {
+                request: RegisterFingerprint {
+                    subject,
+                    conversation_id,
+                    path: path.clone(),
+                    consent_method: ConsentMethod::FolderPicker,
+                },
+                outcome: MutationOutcome::Pending,
+            },
+        );
+        assert_eq!(
+            lookup_register_receipt(&controller, operation_id, subject, conversation_id).unwrap(),
+            LookupRegisterRootReceiptResult {
+                operation_id,
+                receipt: RegisterRootReceipt::Pending,
+            }
+        );
+        let other_conversation = Uuid::new_v4();
+        assert!(matches!(
+            lookup_register_receipt(
+                &controller,
+                operation_id,
+                GrantSubject::conversation(other_conversation).unwrap(),
+                other_conversation,
+            ),
+            Err(ErrorResponse {
+                code: ErrorCode::OperationIdConflict,
+                ..
+            })
+        ));
+        let state = broker.shared.state.lock().unwrap();
+        assert!(state.roots.is_empty());
+        assert!(!state.active_mutations.contains(&operation_id));
+        drop(state);
+
+        let completed = register(&controller, subject, conversation_id, path, operation_id);
+        let completed_root = completed.root.clone();
+        assert_eq!(
+            lookup_register_receipt(&controller, operation_id, subject, conversation_id).unwrap(),
+            LookupRegisterRootReceiptResult {
+                operation_id,
+                receipt: RegisterRootReceipt::Completed {
+                    root: completed_root.clone(),
+                },
+            }
+        );
+        let revoke = unwrap_response(controller.handle(ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request: ControlRequest::RevokeRoot(RevokeRootRequest {
+                operation_id: OperationId::new(),
+                subject,
+                root_id: completed_root.root_id,
+            }),
+        }))
+        .unwrap();
+        assert_eq!(
+            revoke,
+            ControlResult::RevokeRoot(RevokeRootResult { revoked: true })
+        );
+        assert_eq!(
+            lookup_register_receipt(&controller, operation_id, subject, conversation_id).unwrap(),
+            LookupRegisterRootReceiptResult {
+                operation_id,
+                receipt: RegisterRootReceipt::Disconnected {
+                    root: completed_root,
+                },
+            }
+        );
+
+        let failed_id = OperationId::new();
+        let failure = unwrap_response(controller.handle(ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request: ControlRequest::RegisterRoot(RegisterRootRequest {
+                operation_id: failed_id,
+                subject,
+                conversation_id,
+                path: temp.path().join("sensitive"),
+                consent_method: ConsentMethod::FolderPicker,
+            }),
+        }))
+        .unwrap_err();
+        assert_eq!(
+            lookup_register_receipt(&controller, failed_id, subject, conversation_id).unwrap(),
+            LookupRegisterRootReceiptResult {
+                operation_id: failed_id,
+                receipt: RegisterRootReceipt::Failed { error: failure },
+            }
+        );
+
+        let revoke_id = OperationId::new();
+        broker.shared.state.lock().unwrap().mutations.insert(
+            revoke_id,
+            MutationRecord::Revoke {
+                request: RevokeFingerprint {
+                    subject,
+                    root_id: RootId::new(),
+                },
+                outcome: MutationOutcome::Pending,
+            },
+        );
+        assert!(matches!(
+            lookup_register_receipt(&controller, revoke_id, subject, conversation_id),
+            Err(ErrorResponse {
+                code: ErrorCode::OperationIdConflict,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn registration_receipt_lookup_is_a_de_sensitized_audited_control_read() {
+        let (_temp, broker, _path, audit) = audited_setup();
+        let conversation_id = Uuid::new_v4();
+        let subject = GrantSubject::conversation(conversation_id).unwrap();
+        let operation_id = OperationId::new();
+        lookup_register_receipt(&broker.controller(), operation_id, subject, conversation_id)
+            .unwrap();
+
+        let events = audit.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].operation,
+            AuditOperation::LookupRegisterRootReceipt
+        );
+        assert_eq!(events[0].operation_id, Some(operation_id));
+        assert_eq!(
+            events[0].actor,
+            AuditActor::Control {
+                subject,
+                conversation_id: Some(conversation_id),
+            }
+        );
+        assert_eq!(events[0].target, AuditTarget::Subject);
     }
 
     #[test]
@@ -1986,6 +2252,15 @@ mod tests {
         drop(broker);
 
         let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+        assert_eq!(
+            lookup_register_receipt(&broker.controller(), operation_id, subject, conversation,)
+                .unwrap(),
+            LookupRegisterRootReceiptResult {
+                operation_id,
+                receipt: RegisterRootReceipt::Pending,
+            }
+        );
+        assert!(broker.shared.state.lock().unwrap().roots.is_empty());
         let completed = register(
             &broker.controller(),
             subject,
@@ -2042,9 +2317,25 @@ mod tests {
                 ..
             })
         ));
+        assert!(matches!(
+            lookup_register_receipt(&broker.controller(), operation_id, subject, conversation,),
+            Err(ErrorResponse {
+                code: ErrorCode::Internal,
+                retryable: false,
+                ..
+            })
+        ));
         drop(broker);
 
         let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+        assert_eq!(
+            lookup_register_receipt(&broker.controller(), operation_id, subject, conversation,)
+                .unwrap(),
+            LookupRegisterRootReceiptResult {
+                operation_id,
+                receipt: RegisterRootReceipt::Pending,
+            }
+        );
         let completed = register(
             &broker.controller(),
             subject,

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -31,9 +31,10 @@ pub use id::{
 pub use path_policy::{RootPolicy, RootPolicyError, ValidatedRoot};
 pub use protocol::{
     ControlEnvelope, ControlRequest, ControlResponseEnvelope, ControlResult, DirectoryEntry,
-    EntryKind, ErrorCode, ErrorResponse, HelloResult, OperationEnvelope, OperationRequest,
-    OperationResponseEnvelope, OperationResult, PathRequest, ReadFileResult, RegisterRootRequest,
-    RegisterRootResult, Response, ResponseEnvelope, RevokeRootRequest, RevokeRootResult,
-    RootSummary, PROTOCOL_VERSION,
+    EntryKind, ErrorCode, ErrorResponse, HelloResult, LookupRegisterRootReceiptRequest,
+    LookupRegisterRootReceiptResult, OperationEnvelope, OperationRequest,
+    OperationResponseEnvelope, OperationResult, PathRequest, ReadFileResult, RegisterRootReceipt,
+    RegisterRootRequest, RegisterRootResult, Response, ResponseEnvelope, RevokeRootRequest,
+    RevokeRootResult, RootSummary, PROTOCOL_VERSION,
 };
 pub use relative_path::{RelativePath, RelativePathError};

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -13,8 +13,8 @@ use crate::{
     ConsentMethod, ExecutionContext, GrantSubject, OperationId, RelativePath, RequestId, RootId,
 };
 
-/// First public broker protocol. Bump this for incompatible wire changes.
-pub const PROTOCOL_VERSION: u32 = 1;
+/// Current pre-v1 broker protocol. Bump this for incompatible wire changes.
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Host-originated request envelope.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -54,6 +54,8 @@ pub enum ControlRequest {
     /// Register the exact folder returned by a native picker and attach it to
     /// the conversation that initiated the trusted interaction.
     RegisterRoot(RegisterRootRequest),
+    /// Inspect a durable registration receipt without retrying the mutation.
+    LookupRegisterRootReceipt(LookupRegisterRootReceiptRequest),
     /// Disconnect a root owned by the exact subject. Idempotent.
     RevokeRoot(RevokeRootRequest),
 }
@@ -69,6 +71,18 @@ pub struct RegisterRootRequest {
     pub conversation_id: Uuid,
     pub path: PathBuf,
     pub consent_method: ConsentMethod,
+}
+
+/// Strict payload for recovery-only registration receipt lookup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LookupRegisterRootReceiptRequest {
+    /// Exact idempotency identity of the prior registration attempt.
+    pub operation_id: OperationId,
+    /// Trusted authority identity expected on the original registration.
+    pub subject: GrantSubject,
+    /// Trusted conversation expected on the original registration.
+    pub conversation_id: Uuid,
 }
 
 /// Strict payload for an idempotent root revocation.
@@ -162,6 +176,7 @@ pub type OperationResponseEnvelope = ResponseEnvelope<OperationResult>;
 pub enum ControlResult {
     Hello(HelloResult),
     RegisterRoot(RegisterRootResult),
+    LookupRegisterRootReceipt(LookupRegisterRootReceiptResult),
     RevokeRoot(RevokeRootResult),
 }
 
@@ -196,6 +211,31 @@ pub struct RootSummary {
 #[serde(deny_unknown_fields)]
 pub struct RegisterRootResult {
     pub root: RootSummary,
+}
+
+/// Recovery-only view of one durable registration mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LookupRegisterRootReceiptResult {
+    pub operation_id: OperationId,
+    pub receipt: RegisterRootReceipt,
+}
+
+/// Durable state observed without starting or resuming registration work.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RegisterRootReceipt {
+    /// No mutation has used this operation identity.
+    Unknown,
+    /// A registration was durably claimed but has no known terminal outcome.
+    Pending,
+    /// Registration durably committed this safe root summary.
+    Completed { root: RootSummary },
+    /// Registration committed historically, but the root is no longer connected.
+    Disconnected { root: RootSummary },
+    /// Registration durably committed this transport-safe failure.
+    Failed { error: ErrorResponse },
 }
 
 /// Result of an idempotent root revocation.
@@ -260,7 +300,7 @@ mod tests {
     #[test]
     fn protocol_paths_cannot_bypass_relative_path_validation() {
         let encoded = format!(
-            r#"{{"protocol_version":1,"request_id":"{}","context":{{"conversation_id":"{}","project_id":null}},"request":{{"operation":"read_file","payload":{{"root_id":"{}","path":"../secret"}}}}}}"#,
+            r#"{{"protocol_version":2,"request_id":"{}","context":{{"conversation_id":"{}","project_id":null}},"request":{{"operation":"read_file","payload":{{"root_id":"{}","path":"../secret"}}}}}}"#,
             RequestId::new(),
             Uuid::new_v4(),
             RootId::new(),
@@ -271,7 +311,7 @@ mod tests {
     #[test]
     fn request_leaf_payloads_reject_unknown_fields() {
         let encoded = format!(
-            r#"{{"protocol_version":1,"request_id":"{}","context":{{"conversation_id":"{}","project_id":null}},"request":{{"operation":"read_file","payload":{{"root_id":"{}","path":"note.txt","unexpected":true}}}}}}"#,
+            r#"{{"protocol_version":2,"request_id":"{}","context":{{"conversation_id":"{}","project_id":null}},"request":{{"operation":"read_file","payload":{{"root_id":"{}","path":"note.txt","unexpected":true}}}}}}"#,
             RequestId::new(),
             Uuid::new_v4(),
             RootId::new(),
@@ -282,12 +322,12 @@ mod tests {
     #[test]
     fn request_variants_reject_unknown_sibling_fields() {
         let control = format!(
-            r#"{{"protocol_version":1,"request_id":"{}","request":{{"control":"hello","extra":true}}}}"#,
+            r#"{{"protocol_version":2,"request_id":"{}","request":{{"control":"hello","extra":true}}}}"#,
             RequestId::new()
         );
         assert!(serde_json::from_str::<ControlEnvelope>(&control).is_err());
         let operation = format!(
-            r#"{{"protocol_version":1,"request_id":"{}","context":{{"conversation_id":"{}","project_id":null}},"request":{{"operation":"list_roots","extra":true}}}}"#,
+            r#"{{"protocol_version":2,"request_id":"{}","context":{{"conversation_id":"{}","project_id":null}},"request":{{"operation":"list_roots","extra":true}}}}"#,
             RequestId::new(),
             Uuid::new_v4(),
         );
@@ -306,6 +346,17 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<ControlResult>(&encoded).unwrap(),
             control
+        );
+
+        let operation_id = OperationId::new();
+        let lookup = ControlResult::LookupRegisterRootReceipt(LookupRegisterRootReceiptResult {
+            operation_id,
+            receipt: RegisterRootReceipt::Pending,
+        });
+        let encoded = serde_json::to_string(&lookup).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ControlResult>(&encoded).unwrap(),
+            lookup
         );
 
         let operation = OperationResult::ReadFile(ReadFileResult {

--- a/crates/openwave-host-broker/src/sidecar.rs
+++ b/crates/openwave-host-broker/src/sidecar.rs
@@ -194,12 +194,12 @@ mod tests {
     #[test]
     fn request_union_rejects_unknown_top_level_fields() {
         let request = format!(
-            r#"{{"channel":"control","envelope":{{"protocol_version":1,"request_id":"{}","request":{{"control":"hello"}}}},"extra":true}}"#,
+            r#"{{"channel":"control","envelope":{{"protocol_version":2,"request_id":"{}","request":{{"control":"hello"}}}},"extra":true}}"#,
             RequestId::new()
         );
         assert!(serde_json::from_str::<SidecarRequest>(&request).is_err());
         let nested = format!(
-            r#"{{"channel":"control","envelope":{{"protocol_version":1,"request_id":"{}","request":{{"control":"hello","extra":true}}}}}}"#,
+            r#"{{"channel":"control","envelope":{{"protocol_version":2,"request_id":"{}","request":{{"control":"hello","extra":true}}}}}}"#,
             RequestId::new()
         );
         assert!(serde_json::from_str::<SidecarRequest>(&nested).is_err());

--- a/crates/openwave-host-broker/tests/sidecar.rs
+++ b/crates/openwave-host-broker/tests/sidecar.rs
@@ -6,8 +6,8 @@ use std::{
 
 use openwave_host_broker::{
     ConsentMethod, ControlEnvelope, ControlRequest, ExecutionContext, GrantSubject,
-    OperationEnvelope, OperationId, OperationRequest, RegisterRootRequest, RequestId,
-    RevokeRootRequest, RootId, PROTOCOL_VERSION,
+    LookupRegisterRootReceiptRequest, OperationEnvelope, OperationId, OperationRequest,
+    RegisterRootRequest, RequestId, RevokeRootRequest, RootId, PROTOCOL_VERSION,
 };
 use serde::Serialize;
 use tempfile::TempDir;
@@ -64,6 +64,7 @@ fn stdio_sidecar_persists_authority_and_audit_across_restart() {
     let conversation_id = Uuid::new_v4();
     let subject = GrantSubject::conversation(conversation_id).unwrap();
 
+    let registration_id = OperationId::new();
     let root_id = {
         let mut child = spawn(&temp, &home);
         let mut input = child.stdin.take().unwrap();
@@ -76,7 +77,7 @@ fn stdio_sidecar_persists_authority_and_audit_across_restart() {
                 protocol_version: PROTOCOL_VERSION,
                 request_id: RequestId::new(),
                 request: ControlRequest::RegisterRoot(RegisterRootRequest {
-                    operation_id: OperationId::new(),
+                    operation_id: registration_id,
                     subject,
                     conversation_id,
                     path: root.clone(),
@@ -102,6 +103,29 @@ fn stdio_sidecar_persists_authority_and_audit_across_restart() {
     let mut child = spawn(&temp, &home);
     let mut input = child.stdin.take().unwrap();
     let mut output = BufReader::new(child.stdout.take().unwrap());
+    let receipt = exchange(
+        &mut input,
+        &mut output,
+        "control",
+        &ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            request: ControlRequest::LookupRegisterRootReceipt(LookupRegisterRootReceiptRequest {
+                operation_id: registration_id,
+                subject,
+                conversation_id,
+            }),
+        },
+    );
+    assert_eq!(
+        receipt["envelope"]["response"]["payload"]["receipt"]["state"],
+        "completed"
+    );
+    assert_eq!(
+        receipt["envelope"]["response"]["payload"]["receipt"]["root"]["root_id"],
+        root_id
+    );
+    assert!(!receipt.to_string().contains(root.to_str().unwrap()));
     let response = exchange(
         &mut input,
         &mut output,

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -276,8 +276,14 @@ This will land in independently reviewable pieces:
    cumulative progress accounting, and the agent/worker handoff for a singular
    client-owned call are now implemented. The bounded `request_folder_access`
    contract is registered without a server executor; its capability list is
-   explicitly an untrusted proposal. The desktop pending-work executor remains
-   to be layered on that boundary.
+   explicitly an untrusted proposal. The broker exposes a de-sensitized,
+   read-only registration-receipt lookup for crash recovery; looking up an
+   operation can never start or resume it. This lets a restarted client resolve
+   a known, still-connected registration without replaying a mutation after
+   losing its client lease. Lookup is fenced by the original trusted subject and
+   conversation and reports a later disconnection separately from a usable
+   grant. The desktop pending-work executor remains to be layered on that
+   boundary.
 8. Replace project/chat `workspace_dir` with persisted host-access context
    identity and connected-root APIs. This can update the pre-v1 baseline schema
    directly.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -243,10 +243,16 @@ The persisted totals also let cancellation report work performed before the
 pause, including when cancellation wins before the resumed agent starts. This is
 the durable equivalent of pausing a function, doing native work elsewhere, and
 continuing from a known checkpoint.
-The remaining integration work is to have the agent emit this checkpoint for
-folder-access tools and to run those pending calls from the desktop. Notifications
-will be wake-up hints; the pending-work query remains authoritative after a
-restart or missed notification.
+The agent and worker now emit this checkpoint for the bounded
+`request_folder_access` contract. The remaining integration work is to run those
+pending calls from the desktop. Notifications will be wake-up hints; the
+pending-work query remains authoritative after a restart or missed notification.
+For crash recovery, the broker exposes a de-sensitized registration-receipt
+lookup keyed by the stable operation ID. That lookup never starts or resumes a
+mutation: a restarted client may reconcile a known committed result, but must
+not replay unknown native work after losing its client lease. The lookup is
+bound to the registration's trusted subject and conversation, and distinguishes
+a currently connected root from one that was disconnected after registration.
 
 ### 4. Events drive the live client
 


### PR DESCRIPTION
## Summary

- add an authority-bound, read-only lookup for durable folder-registration receipts
- distinguish unknown, pending, connected, disconnected, and failed outcomes without starting or resuming mutations
- expose the lookup through protocol v2 with de-sensitized audit coverage and restart-safe process tests

## Validation

- `bw dev lint --rust --check --repo-root "$PWD"`
- `cargo test -p openwave-host-broker --all-features`
- `cargo clippy -p openwave-host-broker --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `git diff --check`