### PR TITLE
Execute folder consent requests in the desktop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5801,9 +5801,11 @@ dependencies = [
 name = "openwave-desktop"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "openwave-core",
  "openwave-host-broker",
  "openwave-server",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -5811,9 +5813,11 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/openwave-core/src/client_tools.rs
+++ b/crates/openwave-core/src/client_tools.rs
@@ -58,6 +58,23 @@ pub struct RequestFolderAccessArgs {
     pub folder_hint: Option<RequestedFolderHint>,
 }
 
+/// Model-facing result returned after the trusted desktop handles consent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RequestFolderAccessResult {
+    /// The user selected a folder and the broker reports live read access.
+    Connected {
+        /// Opaque broker-local root identity, never a host path.
+        root_id: uuid::Uuid,
+        /// Bounded leaf name safe for display.
+        display_name: String,
+        /// Capabilities the trusted host actually granted.
+        capabilities: Vec<RequestedFolderCapability>,
+    },
+    /// The user declined or closed the picker; no access was granted.
+    Declined,
+}
+
 fn deserialize_optional_hint<'de, D>(
     deserializer: D,
 ) -> Result<Option<RequestedFolderHint>, D::Error>
@@ -181,5 +198,25 @@ mod tests {
             serde_json::json!(["reason", "requested_capabilities"])
         );
         assert!(spec.description.contains("grants no access"));
+    }
+
+    #[test]
+    fn folder_access_results_never_need_a_host_path() {
+        let result = RequestFolderAccessResult::Connected {
+            root_id: uuid::Uuid::new_v4(),
+            display_name: "Documents".into(),
+            capabilities: vec![RequestedFolderCapability::ReadFiles],
+        };
+        let encoded = serde_json::to_value(&result).unwrap();
+        assert_eq!(encoded["status"], "connected");
+        assert!(encoded.get("path").is_none());
+        assert_eq!(
+            serde_json::from_value::<RequestFolderAccessResult>(encoded).unwrap(),
+            result
+        );
+        assert_eq!(
+            serde_json::to_value(RequestFolderAccessResult::Declined).unwrap(),
+            serde_json::json!({ "status": "declined" })
+        );
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -45,8 +45,8 @@ pub use blob::FsBlobStore;
 pub use cancel::{CancelToken, Cancelled};
 pub use client_tools::{
     request_folder_access_tool_spec, validate_request_folder_access_arguments,
-    RequestFolderAccessArgs, RequestedFolderCapability, RequestedFolderHint,
-    MAX_FOLDER_ACCESS_REASON_CHARS, REQUEST_FOLDER_ACCESS_TOOL,
+    RequestFolderAccessArgs, RequestFolderAccessResult, RequestedFolderCapability,
+    RequestedFolderHint, MAX_FOLDER_ACCESS_REASON_CHARS, REQUEST_FOLDER_ACCESS_TOOL,
 };
 pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { workspace = true }
 openwave-core = { path = "../openwave-core", default-features = false }
 openwave-host-broker = { path = "../openwave-host-broker" }
 openwave-server = { path = "../openwave-server" }
+reqwest = { workspace = true }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
@@ -35,5 +36,12 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "process", "rt-multi-thread", "macros", "sync", "time"] }
 uuid = { workspace = true }
 
+[dev-dependencies]
+chrono = { workspace = true }
+tempfile = "3"
+
 [target.'cfg(any(target_os = "macos", target_os = "linux", windows))'.dependencies]
 tauri-plugin-single-instance = "2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }

--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -6,6 +6,16 @@ webview. The UI talks to that local API over HTTP + WebSocket (subprotocol auth)
 The native host also owns the folder picker and a private host-broker sidecar;
 the renderer receives opaque folder IDs and display names, never absolute paths.
 
+When an agent needs a folder outside the current context, the chat UI renders a
+bounded consent card from the local API's authoritative pending-work list. The
+user can decline or ask the native host to open a picker. Native code then owns
+the fenced claim, broker registration, and durable recovery receipt. A broker
+mutation is marked durably before its single bounded dispatch and is never
+replayed after an ambiguous response. Background and restart recovery only query
+its exact operation receipt and publish a known result. Native mutation routes
+require a second credential that is never exposed to the webview. Closing the
+picker is a normal decline, and paths remain confined to app-private native state.
+
 ## Prerequisites
 
 - Rust toolchain (`rust-toolchain.toml` at the repo root)

--- a/crates/openwave-desktop/src/broker.rs
+++ b/crates/openwave-desktop/src/broker.rs
@@ -20,7 +20,7 @@ use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader},
     process::{Child, ChildStdin, ChildStdout, Command},
     sync::{mpsc, oneshot},
-    time::timeout,
+    time::{timeout, timeout_at, Instant},
 };
 
 const SIDECAR_NAME: &str = "openwave-host-broker";
@@ -28,6 +28,7 @@ const HELLO_TIMEOUT: Duration = Duration::from_secs(5);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 const COMMAND_QUEUE_CAPACITY: usize = 32;
+pub(crate) const MUTATION_DISPATCH_WINDOW: Duration = Duration::from_secs(5);
 
 const MINIMAL_ENV_KEYS: &[&str] = &[
     "PATH",
@@ -73,9 +74,33 @@ impl BrokerClient {
         &self,
         request: ControlRequest,
     ) -> Result<ControlResult, BrokerClientError> {
+        self.send_control(request, true, None).await
+    }
+
+    /// Send one control frame without replaying an ambiguous native mutation.
+    pub(crate) async fn control_without_retry(
+        &self,
+        request: ControlRequest,
+        dispatch_deadline: Instant,
+    ) -> Result<ControlResult, BrokerClientError> {
+        self.send_control(request, false, Some(dispatch_deadline))
+            .await
+    }
+
+    async fn send_control(
+        &self,
+        request: ControlRequest,
+        retry: bool,
+        dispatch_deadline: Option<Instant>,
+    ) -> Result<ControlResult, BrokerClientError> {
         let (reply, result) = oneshot::channel();
         self.commands
-            .try_send(BrokerCommand::Control { request, reply })
+            .try_send(BrokerCommand::Control {
+                request,
+                retry,
+                dispatch_deadline,
+                reply,
+            })
             .map_err(map_admission_error)?;
         result.await.map_err(|_| BrokerClientError::Closed)?
     }
@@ -121,6 +146,8 @@ impl BrokerClient {
 enum BrokerCommand {
     Control {
         request: ControlRequest,
+        retry: bool,
+        dispatch_deadline: Option<Instant>,
         reply: oneshot::Sender<Result<ControlResult, BrokerClientError>>,
     },
     Operation {
@@ -150,8 +177,18 @@ impl BrokerWorker {
     async fn run(mut self, mut commands: mpsc::Receiver<BrokerCommand>) {
         while let Some(command) = commands.recv().await {
             match command {
-                BrokerCommand::Control { request, reply } => {
-                    let _ = reply.send(self.control(request).await);
+                BrokerCommand::Control {
+                    request,
+                    retry,
+                    dispatch_deadline,
+                    reply,
+                } => {
+                    let result = if retry {
+                        self.control(request).await
+                    } else {
+                        self.control_once(request, dispatch_deadline).await
+                    };
+                    let _ = reply.send(result);
                 }
                 BrokerCommand::Operation { envelope, reply } => {
                     let result = self
@@ -177,12 +214,12 @@ impl BrokerWorker {
         &mut self,
         request: ControlRequest,
     ) -> Result<ControlResult, BrokerClientError> {
-        let first = self.control_once(request.clone()).await;
+        let first = self.control_once(request.clone(), None).await;
         if first
             .as_ref()
             .is_err_and(BrokerClientError::retryable_control)
         {
-            return self.control_once(request).await;
+            return self.control_once(request, None).await;
         }
         first
     }
@@ -190,13 +227,17 @@ impl BrokerWorker {
     async fn control_once(
         &mut self,
         request: ControlRequest,
+        dispatch_deadline: Option<Instant>,
     ) -> Result<ControlResult, BrokerClientError> {
         let envelope = ControlEnvelope {
             protocol_version: PROTOCOL_VERSION,
             request_id: RequestId::new(),
             request,
         };
-        match self.exchange(SidecarRequest::Control(envelope)).await? {
+        match self
+            .exchange_before(SidecarRequest::Control(envelope), dispatch_deadline)
+            .await?
+        {
             ExchangeResult::Control(result) => Ok(result),
             ExchangeResult::Operation(_) => Err(BrokerClientError::Protocol),
         }
@@ -206,19 +247,38 @@ impl BrokerWorker {
         &mut self,
         request: SidecarRequest,
     ) -> Result<ExchangeResult, BrokerClientError> {
+        self.exchange_before(request, None).await
+    }
+
+    async fn exchange_before(
+        &mut self,
+        request: SidecarRequest,
+        dispatch_deadline: Option<Instant>,
+    ) -> Result<ExchangeResult, BrokerClientError> {
+        if dispatch_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Err(BrokerClientError::DispatchExpired);
+        }
         if self.session.is_none() {
             self.session = Some(Session::start(&self.app, &self.data_dir, &self.home_dir).await?);
         }
-        let result = timeout(
-            REQUEST_TIMEOUT,
-            self.session
-                .as_mut()
-                .expect("session initialized")
-                .exchange(request),
-        )
-        .await
-        .map_err(|_| BrokerClientError::Timeout)
-        .and_then(|result| result);
+        if dispatch_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+            return Err(BrokerClientError::DispatchExpired);
+        }
+        let exchange = self
+            .session
+            .as_mut()
+            .expect("session initialized")
+            .exchange(request);
+        let result = match dispatch_deadline {
+            Some(deadline) => timeout_at(deadline, exchange)
+                .await
+                .map_err(|_| BrokerClientError::DispatchExpired)
+                .and_then(|result| result),
+            None => timeout(REQUEST_TIMEOUT, exchange)
+                .await
+                .map_err(|_| BrokerClientError::Timeout)
+                .and_then(|result| result),
+        };
         if result
             .as_ref()
             .is_err_and(BrokerClientError::poisons_session)
@@ -445,6 +505,8 @@ pub(crate) enum BrokerClientError {
     Start,
     #[error("host broker is busy; try again")]
     Busy,
+    #[error("host broker mutation could not start before its authority deadline")]
+    DispatchExpired,
     #[error("host broker connection closed")]
     Closed,
     #[error("host broker request timed out")]

--- a/crates/openwave-desktop/src/client_execution.rs
+++ b/crates/openwave-desktop/src/client_execution.rs
@@ -1,0 +1,569 @@
+//! Native owner of durable client-executed folder consent.
+//!
+//! The renderer discovers canonical pending requests, but never receives the
+//! claim token, picker result, or broker control surface. This module keeps
+//! those values together and persists enough private state to recover an exact
+//! outcome after a desktop or transport failure.
+
+use std::path::PathBuf;
+
+use openwave_core::{
+    validate_request_folder_access_arguments, CallId, ChatId, RequestFolderAccessArgs,
+    RequestFolderAccessResult, RequestedFolderCapability, RequestedFolderHint, ToolCallExecution,
+    ToolCallRecord, ToolCallStatus, REQUEST_FOLDER_ACCESS_TOOL,
+};
+use openwave_host_broker::{
+    ConsentMethod, ControlRequest, ControlResult, LookupRegisterRootReceiptRequest, OperationId,
+    RegisterRootReceipt, RegisterRootRequest,
+};
+use serde::Deserialize;
+use tauri::{AppHandle, Manager, State};
+use uuid::Uuid;
+
+use crate::host_access::{pick_folder, AuthoritativeContext, HostAccess};
+
+mod control_plane;
+mod receipt_store;
+
+pub(crate) use control_plane::ControlPlaneClient;
+use control_plane::ControlPlaneError;
+pub(crate) use receipt_store::ReceiptStore;
+use receipt_store::{FolderAccessIntent, FolderAccessReceipt, RegistrationPhase, StoredResolution};
+
+const RECOVERY_IDLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+const RECOVERY_MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(30);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ExecutionMode {
+    Interactive,
+    Recovery,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum FolderAccessDecision {
+    Allow,
+    Decline,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ResolveFolderAccessRequest {
+    chat_id: Uuid,
+    call_id: Uuid,
+    decision: FolderAccessDecision,
+}
+
+#[tauri::command]
+pub(crate) async fn resolve_folder_access_request(
+    app: AppHandle,
+    state: State<'_, HostAccess>,
+    request: ResolveFolderAccessRequest,
+) -> Result<(), String> {
+    if request.chat_id.is_nil() || request.call_id.is_nil() {
+        return Err("invalid folder-access request identity".to_owned());
+    }
+    let _exclusive = state
+        .picker
+        .try_lock()
+        .map_err(|_| "another native folder request is already active".to_owned())?;
+    let chat_id = ChatId::from(request.chat_id);
+    let call_id = CallId::from(request.call_id);
+    if let Some(receipt) = state
+        .receipts
+        .load_all()
+        .map_err(private_receipt_error)?
+        .into_iter()
+        .find(|receipt| receipt.call_id == call_id)
+    {
+        if receipt.chat_id != chat_id {
+            return Err("folder-access recovery receipt has the wrong conversation".to_owned());
+        }
+        return execute_receipt(&state, receipt, ExecutionMode::Recovery).await;
+    }
+
+    let _ = state.context(request.chat_id).await?;
+    let client = control_plane(&state)?;
+    let pending = client.pending(chat_id).await.map_err(control_plane_error)?;
+    let call = pending
+        .into_iter()
+        .find(|call| call.id == call_id)
+        .ok_or_else(|| "folder-access request is no longer pending".to_owned())?;
+    let arguments = validate_canonical_call(&call, chat_id, call_id)?;
+    if call.client_executor_id.is_some() {
+        return Err("folder-access request is already being handled".to_owned());
+    }
+
+    let intent = match request.decision {
+        FolderAccessDecision::Decline => FolderAccessIntent::Decline,
+        FolderAccessDecision::Allow => {
+            let starting_directory = picker_start(
+                app.path().document_dir().ok(),
+                app.path().download_dir().ok(),
+                arguments.folder_hint,
+            );
+            match pick_folder(&app, starting_directory).await? {
+                Some(path) if path.is_absolute() => FolderAccessIntent::Selected { path },
+                Some(_) => return Err("the folder picker returned an invalid path".to_owned()),
+                None => FolderAccessIntent::Decline,
+            }
+        }
+    };
+    let receipt = FolderAccessReceipt::new(chat_id, call_id, state.receipts.executor_id(), intent);
+    state
+        .receipts
+        .save(&receipt)
+        .map_err(private_receipt_error)?;
+    execute_receipt(&state, receipt, ExecutionMode::Interactive).await
+}
+
+pub(crate) async fn recover_folder_access_receipts(app: AppHandle) {
+    let mut backoff = RECOVERY_IDLE_INTERVAL;
+    loop {
+        let had_failure = recover_folder_access_receipts_once(&app).await;
+        let delay = if had_failure {
+            let delay = backoff;
+            backoff = backoff.saturating_mul(2).min(RECOVERY_MAX_BACKOFF);
+            delay
+        } else {
+            backoff = RECOVERY_IDLE_INTERVAL;
+            RECOVERY_IDLE_INTERVAL
+        };
+        tokio::time::sleep(delay).await;
+    }
+}
+
+async fn recover_folder_access_receipts_once(app: &AppHandle) -> bool {
+    let state = app.state::<HostAccess>();
+    let receipts = match state.receipts.load_all() {
+        Ok(receipts) => receipts,
+        Err(error) => {
+            eprintln!("openwave-desktop: private client-execution recovery failed: {error}");
+            return true;
+        }
+    };
+    let _exclusive = state.picker.lock().await;
+    let mut had_failure = false;
+    for receipt in receipts {
+        if let Err(error) = execute_receipt(&state, receipt, ExecutionMode::Recovery).await {
+            eprintln!("openwave-desktop: client-execution recovery deferred: {error}");
+            had_failure = true;
+        }
+    }
+    had_failure
+}
+
+async fn execute_receipt(
+    state: &HostAccess,
+    mut receipt: FolderAccessReceipt,
+    mode: ExecutionMode,
+) -> Result<(), String> {
+    let context = state.context(receipt.chat_id.0).await?;
+    if let Some(resolution) = receipt.resolution.clone() {
+        return publish_resolution(state, &receipt, &resolution).await;
+    }
+
+    let client = control_plane(state)?;
+    let claim = match client
+        .claim(
+            receipt.chat_id,
+            receipt.call_id,
+            receipt.executor_id,
+            receipt.lease_token,
+        )
+        .await
+    {
+        Ok(claim) => claim,
+        Err(error) if error.is_conflict() => {
+            return recover_after_claim_conflict(state, receipt, context).await;
+        }
+        Err(error) => return Err(control_plane_error(error)),
+    };
+    if claim.lease_token != receipt.lease_token
+        || claim.call.client_executor_id != Some(receipt.executor_id)
+        || validate_canonical_call(&claim.call, receipt.chat_id, receipt.call_id).is_err()
+    {
+        return Err("local control plane returned a mismatched client claim".to_owned());
+    }
+
+    let resolution = match receipt.intent.clone() {
+        FolderAccessIntent::Decline => declined_resolution()?,
+        FolderAccessIntent::Selected { path } => {
+            if should_start_registration(mode, receipt.registration_phase) {
+                match client
+                    .heartbeat(receipt.chat_id, receipt.call_id, receipt.lease_token)
+                    .await
+                {
+                    Ok(()) => {
+                        let dispatch_deadline =
+                            tokio::time::Instant::now() + crate::broker::MUTATION_DISPATCH_WINDOW;
+                        receipt.registration_phase = RegistrationPhase::Attempted;
+                        state
+                            .receipts
+                            .save(&receipt)
+                            .map_err(private_receipt_error)?;
+                        register_selected_folder(state, &receipt, context, path, dispatch_deadline)
+                            .await?
+                    }
+                    Err(_) => recover_broker_outcome(state, &receipt, context).await?,
+                }
+            } else {
+                recover_broker_outcome(state, &receipt, context).await?
+            }
+        }
+    };
+    receipt.resolution = Some(resolution.clone());
+    state
+        .receipts
+        .save(&receipt)
+        .map_err(private_receipt_error)?;
+    publish_resolution(state, &receipt, &resolution).await
+}
+
+fn should_start_registration(mode: ExecutionMode, phase: RegistrationPhase) -> bool {
+    mode == ExecutionMode::Interactive && phase == RegistrationPhase::NotStarted
+}
+
+async fn recover_after_claim_conflict(
+    state: &HostAccess,
+    mut receipt: FolderAccessReceipt,
+    context: AuthoritativeContext,
+) -> Result<(), String> {
+    let client = control_plane(state)?;
+    let pending = client
+        .pending(receipt.chat_id)
+        .await
+        .map_err(control_plane_error)?;
+    let Some(call) = pending.into_iter().find(|call| call.id == receipt.call_id) else {
+        state
+            .receipts
+            .remove(receipt.call_id)
+            .map_err(private_receipt_error)?;
+        return Ok(());
+    };
+    validate_canonical_call(&call, receipt.chat_id, receipt.call_id)?;
+    if call.client_executor_id != Some(receipt.executor_id) {
+        if call.client_executor_id.is_none() {
+            return Err("folder-access claim could not be recovered yet".to_owned());
+        }
+        state
+            .receipts
+            .remove(receipt.call_id)
+            .map_err(private_receipt_error)?;
+        return Err("folder-access request is owned by another desktop".to_owned());
+    }
+
+    let resolution = match receipt.intent {
+        FolderAccessIntent::Decline => declined_resolution()?,
+        FolderAccessIntent::Selected { .. } => {
+            recover_broker_outcome(state, &receipt, context).await?
+        }
+    };
+    receipt.resolution = Some(resolution.clone());
+    state
+        .receipts
+        .save(&receipt)
+        .map_err(private_receipt_error)?;
+    publish_resolution(state, &receipt, &resolution).await
+}
+
+async fn register_selected_folder(
+    state: &HostAccess,
+    receipt: &FolderAccessReceipt,
+    context: AuthoritativeContext,
+    path: PathBuf,
+    dispatch_deadline: tokio::time::Instant,
+) -> Result<StoredResolution, String> {
+    let operation_id = OperationId::from_uuid(receipt.call_id.0)
+        .map_err(|_| "invalid folder-access operation identity".to_owned())?;
+    let first = state
+        .broker
+        .control_without_retry(
+            ControlRequest::RegisterRoot(RegisterRootRequest {
+                operation_id,
+                subject: context.subject,
+                conversation_id: context.chat_id,
+                path,
+                consent_method: ConsentMethod::FolderPicker,
+            }),
+            dispatch_deadline,
+        )
+        .await;
+    match first {
+        Ok(ControlResult::RegisterRoot(_)) | Err(_) => {
+            // The receipt query below is the authoritative post-effect check.
+            // It also catches a revocation that raced the response.
+        }
+        Ok(_) => return Err("host broker returned an unexpected response".to_owned()),
+    }
+    recover_broker_outcome(state, receipt, context).await
+}
+
+async fn recover_broker_outcome(
+    state: &HostAccess,
+    receipt: &FolderAccessReceipt,
+    context: AuthoritativeContext,
+) -> Result<StoredResolution, String> {
+    let operation_id = OperationId::from_uuid(receipt.call_id.0)
+        .map_err(|_| "invalid folder-access operation identity".to_owned())?;
+    let result = state
+        .broker
+        .control(ControlRequest::LookupRegisterRootReceipt(
+            LookupRegisterRootReceiptRequest {
+                operation_id,
+                subject: context.subject,
+                conversation_id: context.chat_id,
+            },
+        ))
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::LookupRegisterRootReceipt(result) = result else {
+        return Err("host broker returned an unexpected recovery response".to_owned());
+    };
+    if result.operation_id != operation_id {
+        return Err("host broker returned a mismatched recovery receipt".to_owned());
+    }
+    match result.receipt {
+        RegisterRootReceipt::Completed { root } => connected_resolution(root),
+        RegisterRootReceipt::Disconnected { .. } => Ok(failed_resolution(
+            "folder_access_disconnected",
+            "The selected folder is no longer connected.",
+            None,
+        )),
+        RegisterRootReceipt::Failed { error } => Ok(failed_resolution(
+            "folder_access_registration_failed",
+            "The selected folder could not be connected.",
+            Some(error.message),
+        )),
+        RegisterRootReceipt::Unknown | RegisterRootReceipt::Pending => Ok(failed_resolution(
+            "folder_access_outcome_unknown",
+            "Folder access was not granted because the native outcome could not be confirmed.",
+            None,
+        )),
+        _ => Ok(failed_resolution(
+            "folder_access_receipt_unsupported",
+            "Folder access was not granted because the native receipt was not understood.",
+            None,
+        )),
+    }
+}
+
+async fn publish_resolution(
+    state: &HostAccess,
+    receipt: &FolderAccessReceipt,
+    resolution: &StoredResolution,
+) -> Result<(), String> {
+    let client = control_plane(state)?;
+    match client
+        .resolve(
+            receipt.chat_id,
+            receipt.call_id,
+            receipt.lease_token,
+            resolution,
+        )
+        .await
+    {
+        Ok(()) => {
+            state
+                .receipts
+                .remove(receipt.call_id)
+                .map_err(private_receipt_error)?;
+            Ok(())
+        }
+        Err(error) if error.is_conflict() => {
+            let still_pending = client
+                .pending(receipt.chat_id)
+                .await
+                .map_err(control_plane_error)?
+                .into_iter()
+                .any(|call| call.id == receipt.call_id);
+            if still_pending {
+                Err("folder-access result no longer owns the pending request".to_owned())
+            } else {
+                state
+                    .receipts
+                    .remove(receipt.call_id)
+                    .map_err(private_receipt_error)?;
+                Ok(())
+            }
+        }
+        Err(error) => Err(control_plane_error(error)),
+    }
+}
+
+fn validate_canonical_call(
+    call: &ToolCallRecord,
+    chat_id: ChatId,
+    call_id: CallId,
+) -> Result<RequestFolderAccessArgs, String> {
+    if call.id != call_id
+        || call.chat_id != chat_id
+        || call.name != REQUEST_FOLDER_ACCESS_TOOL
+        || call.execution != ToolCallExecution::Client
+        || call.status != ToolCallStatus::Pending
+        || !validate_request_folder_access_arguments(&call.arguments)
+    {
+        return Err("local control plane returned an invalid folder-access request".to_owned());
+    }
+    serde_json::from_value(call.arguments.clone())
+        .map_err(|_| "local control plane returned invalid folder-access arguments".to_owned())
+}
+
+fn picker_start(
+    documents: Option<PathBuf>,
+    downloads: Option<PathBuf>,
+    hint: Option<RequestedFolderHint>,
+) -> Option<PathBuf> {
+    let candidate = match hint {
+        Some(RequestedFolderHint::Documents) => documents?,
+        Some(RequestedFolderHint::Downloads) => downloads?,
+        None | Some(_) => return None,
+    };
+    candidate.is_dir().then_some(candidate)
+}
+
+fn connected_resolution(
+    root: openwave_host_broker::RootSummary,
+) -> Result<StoredResolution, String> {
+    let result = RequestFolderAccessResult::Connected {
+        root_id: root.root_id.as_uuid(),
+        display_name: root.display_name,
+        capabilities: vec![RequestedFolderCapability::ReadFiles],
+    };
+    Ok(StoredResolution::Completed {
+        result: serde_json::to_string(&result)
+            .map_err(|_| "could not encode folder-access result".to_owned())?,
+    })
+}
+
+fn declined_resolution() -> Result<StoredResolution, String> {
+    Ok(StoredResolution::Completed {
+        result: serde_json::to_string(&RequestFolderAccessResult::Declined)
+            .map_err(|_| "could not encode folder-access result".to_owned())?,
+    })
+}
+
+fn failed_resolution(
+    error_code: &str,
+    message: &str,
+    error_detail: Option<String>,
+) -> StoredResolution {
+    StoredResolution::Failed {
+        result: serde_json::json!({ "status": "unavailable", "message": message }).to_string(),
+        error_code: error_code.to_owned(),
+        error_detail,
+    }
+}
+
+fn control_plane(state: &HostAccess) -> Result<&ControlPlaneClient, String> {
+    state
+        .control_plane
+        .get()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())
+}
+
+fn control_plane_error(error: ControlPlaneError) -> String {
+    error.to_string()
+}
+
+fn private_receipt_error(_error: std::io::Error) -> String {
+    "could not update private client-execution recovery state".to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_folder_request_rejects_identity_and_contract_changes() {
+        let chat_id = ChatId::new();
+        let call_id = CallId::new();
+        let mut call = ToolCallRecord {
+            id: call_id,
+            chat_id,
+            turn_id: openwave_core::TurnId::new(),
+            provider_id: "provider-call".into(),
+            name: REQUEST_FOLDER_ACCESS_TOOL.into(),
+            arguments: serde_json::json!({
+                "reason": "Read reports",
+                "requested_capabilities": ["read_files"],
+                "folder_hint": "documents"
+            }),
+            execution: ToolCallExecution::Client,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: chrono::Utc::now(),
+            resolved_at: None,
+        };
+        assert!(validate_canonical_call(&call, chat_id, call_id).is_ok());
+        call.arguments["path"] = serde_json::json!("/Users/example/Documents");
+        assert!(validate_canonical_call(&call, chat_id, call_id).is_err());
+        call.arguments = serde_json::json!({
+            "reason": "Read reports",
+            "requested_capabilities": ["read_files"]
+        });
+        assert!(validate_canonical_call(&call, ChatId::new(), call_id).is_err());
+    }
+
+    #[test]
+    fn picker_hints_never_become_model_supplied_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let documents = temp.path().join("Documents");
+        std::fs::create_dir(&documents).unwrap();
+        assert_eq!(
+            picker_start(
+                Some(documents.clone()),
+                None,
+                Some(RequestedFolderHint::Documents)
+            ),
+            Some(documents)
+        );
+        assert_eq!(
+            picker_start(None, None, Some(RequestedFolderHint::Downloads)),
+            None
+        );
+        assert_eq!(picker_start(None, None, None), None);
+    }
+
+    #[test]
+    fn terminal_results_are_typed_and_path_free() {
+        let connected = connected_resolution(openwave_host_broker::RootSummary {
+            root_id: openwave_host_broker::RootId::new(),
+            display_name: "Documents".into(),
+        })
+        .unwrap();
+        let StoredResolution::Completed { result } = connected else {
+            panic!("expected completed result")
+        };
+        assert!(result.contains("connected"));
+        assert!(!result.contains("/Users/"));
+        assert!(matches!(
+            declined_resolution().unwrap(),
+            StoredResolution::Completed { result } if result.contains("declined")
+        ));
+    }
+
+    #[test]
+    fn recovery_never_starts_or_replays_registration() {
+        assert!(should_start_registration(
+            ExecutionMode::Interactive,
+            RegistrationPhase::NotStarted
+        ));
+        assert!(!should_start_registration(
+            ExecutionMode::Interactive,
+            RegistrationPhase::Attempted
+        ));
+        assert!(!should_start_registration(
+            ExecutionMode::Recovery,
+            RegistrationPhase::NotStarted
+        ));
+        assert!(!should_start_registration(
+            ExecutionMode::Recovery,
+            RegistrationPhase::Attempted
+        ));
+    }
+}

--- a/crates/openwave-desktop/src/client_execution/control_plane.rs
+++ b/crates/openwave-desktop/src/client_execution/control_plane.rs
@@ -1,0 +1,292 @@
+//! Authenticated loopback client for the durable client-execution API.
+
+use openwave_core::{CallId, ChatId, ToolCallRecord};
+use reqwest::StatusCode;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+use super::receipt_store::StoredResolution;
+
+const MAX_EXACT_ATTEMPTS: usize = 3;
+const CLIENT_EXECUTOR_HEADER: &str = "x-openwave-client-executor";
+
+#[derive(Clone)]
+pub(crate) struct ControlPlaneClient {
+    base_url: String,
+    token: String,
+    executor_token: reqwest::header::HeaderValue,
+    http: reqwest::Client,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ControlPlaneError {
+    #[error("local control plane request failed")]
+    Transport,
+    #[error("local control plane rejected the request ({status}): {message}")]
+    Http { status: u16, message: String },
+    #[error("local control plane returned an invalid response")]
+    Protocol,
+}
+
+impl ControlPlaneError {
+    pub(super) fn is_conflict(&self) -> bool {
+        matches!(self, Self::Http { status, .. } if *status == StatusCode::CONFLICT.as_u16())
+    }
+}
+
+#[derive(Serialize)]
+struct ClaimRequest {
+    executor_id: Uuid,
+    lease_token: Uuid,
+}
+
+#[derive(Deserialize)]
+pub(super) struct ClaimedExecution {
+    pub(super) call: ToolCallRecord,
+    pub(super) lease_token: Uuid,
+}
+
+#[derive(Serialize)]
+struct HeartbeatRequest {
+    lease_token: Uuid,
+}
+
+#[derive(Serialize)]
+struct ResolveRequest<'a> {
+    lease_token: Uuid,
+    resolution: &'a StoredResolution,
+}
+
+impl ControlPlaneClient {
+    pub(crate) fn new(
+        base_url: String,
+        token: String,
+        executor_token: String,
+    ) -> Result<Self, ControlPlaneError> {
+        let base_url = base_url.trim_end_matches('/').to_owned();
+        let url = reqwest::Url::parse(&base_url).map_err(|_| ControlPlaneError::Protocol)?;
+        let loopback_host = url.host_str().is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || host
+                    .trim_start_matches('[')
+                    .trim_end_matches(']')
+                    .parse::<std::net::IpAddr>()
+                    .is_ok_and(|address| address.is_loopback())
+        });
+        if url.scheme() != "http"
+            || !loopback_host
+            || url.port().is_none()
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.path() != "/"
+            || url.query().is_some()
+            || url.fragment().is_some()
+            || token.is_empty()
+            || executor_token.is_empty()
+        {
+            return Err(ControlPlaneError::Protocol);
+        }
+        let mut executor_token =
+            reqwest::header::HeaderValue::from_bytes(executor_token.as_bytes())
+                .map_err(|_| ControlPlaneError::Protocol)?;
+        executor_token.set_sensitive(true);
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .map_err(|_| ControlPlaneError::Protocol)?;
+        Ok(Self {
+            base_url,
+            token,
+            executor_token,
+            http,
+        })
+    }
+
+    pub(super) async fn claim(
+        &self,
+        chat_id: ChatId,
+        call_id: CallId,
+        executor_id: Uuid,
+        lease_token: Uuid,
+    ) -> Result<ClaimedExecution, ControlPlaneError> {
+        self.post(
+            &format!("/chats/{chat_id}/client-executions/{call_id}/claim"),
+            &ClaimRequest {
+                executor_id,
+                lease_token,
+            },
+        )
+        .await
+    }
+
+    pub(super) async fn pending(
+        &self,
+        chat_id: ChatId,
+    ) -> Result<Vec<ToolCallRecord>, ControlPlaneError> {
+        self.get(&format!("/chats/{chat_id}/client-executions/pending"))
+            .await
+    }
+
+    pub(super) async fn heartbeat(
+        &self,
+        chat_id: ChatId,
+        call_id: CallId,
+        lease_token: Uuid,
+    ) -> Result<(), ControlPlaneError> {
+        let _: serde_json::Value = self
+            .post(
+                &format!("/chats/{chat_id}/client-executions/{call_id}/heartbeat"),
+                &HeartbeatRequest { lease_token },
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub(super) async fn resolve(
+        &self,
+        chat_id: ChatId,
+        call_id: CallId,
+        lease_token: Uuid,
+        resolution: &StoredResolution,
+    ) -> Result<(), ControlPlaneError> {
+        let _: serde_json::Value = self
+            .post(
+                &format!("/chats/{chat_id}/client-executions/{call_id}/resolve"),
+                &ResolveRequest {
+                    lease_token,
+                    resolution,
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn post<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &impl Serialize,
+    ) -> Result<T, ControlPlaneError> {
+        let mut last_error = ControlPlaneError::Transport;
+        for attempt in 0..MAX_EXACT_ATTEMPTS {
+            let response = match self
+                .http
+                .post(format!("{}{path}", self.base_url))
+                .bearer_auth(&self.token)
+                .header(CLIENT_EXECUTOR_HEADER, self.executor_token.clone())
+                .json(body)
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(_) => {
+                    last_error = ControlPlaneError::Transport;
+                    retry_pause(attempt).await;
+                    continue;
+                }
+            };
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                if response.status().is_server_error() && attempt + 1 < MAX_EXACT_ATTEMPTS {
+                    last_error = ControlPlaneError::Http {
+                        status,
+                        message: "request failed".to_owned(),
+                    };
+                    retry_pause(attempt).await;
+                    continue;
+                }
+                let message = response
+                    .json::<ErrorBody>()
+                    .await
+                    .map(|body| body.message)
+                    .unwrap_or_else(|_| "request failed".to_owned());
+                return Err(ControlPlaneError::Http { status, message });
+            }
+            match response.json().await {
+                Ok(body) => return Ok(body),
+                Err(_) => {
+                    last_error = ControlPlaneError::Protocol;
+                    retry_pause(attempt).await;
+                }
+            }
+        }
+        Err(last_error)
+    }
+
+    async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, ControlPlaneError> {
+        let mut last_error = ControlPlaneError::Transport;
+        for attempt in 0..MAX_EXACT_ATTEMPTS {
+            let response = match self
+                .http
+                .get(format!("{}{path}", self.base_url))
+                .bearer_auth(&self.token)
+                .send()
+                .await
+            {
+                Ok(response) => response,
+                Err(_) => {
+                    last_error = ControlPlaneError::Transport;
+                    retry_pause(attempt).await;
+                    continue;
+                }
+            };
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                if response.status().is_server_error() && attempt + 1 < MAX_EXACT_ATTEMPTS {
+                    last_error = ControlPlaneError::Http {
+                        status,
+                        message: "request failed".to_owned(),
+                    };
+                    retry_pause(attempt).await;
+                    continue;
+                }
+                let message = response
+                    .json::<ErrorBody>()
+                    .await
+                    .map(|body| body.message)
+                    .unwrap_or_else(|_| "request failed".to_owned());
+                return Err(ControlPlaneError::Http { status, message });
+            }
+            match response.json().await {
+                Ok(body) => return Ok(body),
+                Err(_) => {
+                    last_error = ControlPlaneError::Protocol;
+                    retry_pause(attempt).await;
+                }
+            }
+        }
+        Err(last_error)
+    }
+}
+
+async fn retry_pause(attempt: usize) {
+    if attempt + 1 < MAX_EXACT_ATTEMPTS {
+        tokio::time::sleep(std::time::Duration::from_millis(50 * (attempt as u64 + 1))).await;
+    }
+}
+
+#[derive(Deserialize)]
+struct ErrorBody {
+    message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_accepts_only_authenticated_loopback_http() {
+        let client = |url: &str, bearer: &str, executor: &str| {
+            ControlPlaneClient::new(url.into(), bearer.into(), executor.into())
+        };
+        assert!(client("http://127.0.0.1:1234", "token", "native").is_ok());
+        assert!(client("http://[::1]:1234", "token", "native").is_ok());
+        assert!(client("http://localhost:1234", "token", "native").is_ok());
+        assert!(client("http://127.1.2.3:1234", "token", "native").is_ok());
+        assert!(client("https://example.com", "token", "native").is_err());
+        assert!(client("http://127.0.0.1.example:1234", "token", "native").is_err());
+        assert!(client("http://127.0.0.1:1234/path", "token", "native").is_err());
+        assert!(client("http://127.0.0.1:1234", "", "native").is_err());
+        assert!(client("http://127.0.0.1:1234", "token", "").is_err());
+    }
+}

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -1,0 +1,465 @@
+//! App-private recovery receipts for native client execution.
+
+use std::{
+    fs::{self, File, OpenOptions, TryLockError},
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+};
+
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+use openwave_core::{CallId, ChatId};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const RECEIPT_VERSION: u32 = 1;
+const RECEIPT_DIRECTORY: &str = "client-executions";
+const EXECUTOR_FILE: &str = "executor-id";
+const MAX_EXECUTOR_BYTES: usize = 128;
+const MAX_RECEIPT_BYTES: usize = 64 * 1024;
+const MAX_RECEIPTS: usize = 1_024;
+
+pub(crate) struct ReceiptStore {
+    directory: PathBuf,
+    executor_id: Uuid,
+    _lock: File,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub(super) struct FolderAccessReceipt {
+    version: u32,
+    pub(super) chat_id: ChatId,
+    pub(super) call_id: CallId,
+    pub(super) executor_id: Uuid,
+    pub(super) lease_token: Uuid,
+    pub(super) intent: FolderAccessIntent,
+    pub(super) registration_phase: RegistrationPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) resolution: Option<StoredResolution>,
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+pub(super) enum FolderAccessIntent {
+    Decline,
+    Selected { path: PathBuf },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum RegistrationPhase {
+    NotStarted,
+    Attempted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub(super) enum StoredResolution {
+    Completed {
+        result: String,
+    },
+    Failed {
+        result: String,
+        error_code: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error_detail: Option<String>,
+    },
+}
+
+impl std::fmt::Debug for FolderAccessReceipt {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FolderAccessReceipt")
+            .field("version", &self.version)
+            .field("chat_id", &self.chat_id)
+            .field("call_id", &self.call_id)
+            .field("executor_id", &self.executor_id)
+            .field("lease_token", &"[redacted]")
+            .field("intent", &self.intent)
+            .field("registration_phase", &self.registration_phase)
+            .field("resolution", &self.resolution)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for FolderAccessIntent {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Decline => formatter.write_str("Decline"),
+            Self::Selected { .. } => formatter
+                .debug_struct("Selected")
+                .field("path", &"[redacted]")
+                .finish(),
+        }
+    }
+}
+
+impl FolderAccessReceipt {
+    pub(super) fn new(
+        chat_id: ChatId,
+        call_id: CallId,
+        executor_id: Uuid,
+        intent: FolderAccessIntent,
+    ) -> Self {
+        Self {
+            version: RECEIPT_VERSION,
+            chat_id,
+            call_id,
+            executor_id,
+            lease_token: Uuid::new_v4(),
+            intent,
+            registration_phase: RegistrationPhase::NotStarted,
+            resolution: None,
+        }
+    }
+
+    fn validate(&self) -> io::Result<()> {
+        if self.version != RECEIPT_VERSION
+            || self.chat_id.0.is_nil()
+            || self.call_id.0.is_nil()
+            || self.executor_id.is_nil()
+            || self.lease_token.is_nil()
+            || matches!(&self.intent, FolderAccessIntent::Selected { path } if !path.is_absolute())
+            || matches!(
+                (&self.intent, self.registration_phase),
+                (FolderAccessIntent::Decline, RegistrationPhase::Attempted)
+            )
+        {
+            return Err(invalid_data("invalid client-execution receipt"));
+        }
+        Ok(())
+    }
+}
+
+impl ReceiptStore {
+    pub(crate) fn open(data_dir: &Path) -> io::Result<Self> {
+        let directory = data_dir.join(RECEIPT_DIRECTORY);
+        match fs::symlink_metadata(&directory) {
+            Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
+            Ok(_) => {
+                return Err(invalid_data(
+                    "client-execution receipt directory is not a real directory",
+                ));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                fs::create_dir_all(&directory)?;
+            }
+            Err(error) => return Err(error),
+        }
+        let directory = fs::canonicalize(directory)?;
+        #[cfg(unix)]
+        fs::set_permissions(&directory, fs::Permissions::from_mode(0o700))?;
+
+        let mut lock_options = OpenOptions::new();
+        lock_options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        lock_options.mode(0o600);
+        let lock = lock_options.open(directory.join("receipts.lock"))?;
+        match lock.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "another desktop executor owns the receipt directory",
+                ));
+            }
+            Err(TryLockError::Error(error)) => return Err(error),
+        }
+
+        let executor_id = load_or_create_executor_id(&directory)?;
+        let store = Self {
+            directory,
+            executor_id,
+            _lock: lock,
+        };
+        store.load_all()?;
+        Ok(store)
+    }
+
+    pub(super) const fn executor_id(&self) -> Uuid {
+        self.executor_id
+    }
+
+    pub(super) fn save(&self, receipt: &FolderAccessReceipt) -> io::Result<()> {
+        receipt.validate()?;
+        let bytes = serde_json::to_vec(receipt).map_err(invalid_data)?;
+        if bytes.len() > MAX_RECEIPT_BYTES {
+            return Err(invalid_data("client-execution receipt is too large"));
+        }
+        write_atomically(&self.directory, &self.receipt_path(receipt.call_id), &bytes)
+    }
+
+    pub(super) fn remove(&self, call_id: CallId) -> io::Result<()> {
+        match fs::remove_file(self.receipt_path(call_id)) {
+            Ok(()) => sync_directory(&self.directory),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(super) fn load_all(&self) -> io::Result<Vec<FolderAccessReceipt>> {
+        let mut receipts = Vec::new();
+        for entry in fs::read_dir(&self.directory)? {
+            let entry = entry?;
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                return Err(invalid_data("invalid client-execution receipt name"));
+            };
+            if matches!(file_name, EXECUTOR_FILE | "receipts.lock") {
+                continue;
+            }
+            if file_name.starts_with('.') && file_name.ends_with(".tmp") {
+                fs::remove_file(entry.path())?;
+                continue;
+            }
+            if receipts.len() >= MAX_RECEIPTS {
+                return Err(invalid_data("too many pending client-execution receipts"));
+            }
+            let call_id = file_name
+                .strip_suffix(".json")
+                .ok_or_else(|| invalid_data("invalid client-execution receipt name"))?
+                .parse::<Uuid>()
+                .map(CallId::from)
+                .map_err(invalid_data)?;
+            validate_private_file(&entry.path(), MAX_RECEIPT_BYTES)?;
+            let mut bytes = Vec::new();
+            File::open(entry.path())?
+                .take((MAX_RECEIPT_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)?;
+            if bytes.len() > MAX_RECEIPT_BYTES {
+                return Err(invalid_data("client-execution receipt is too large"));
+            }
+            let receipt: FolderAccessReceipt =
+                serde_json::from_slice(&bytes).map_err(invalid_data)?;
+            receipt.validate()?;
+            if receipt.call_id != call_id {
+                return Err(invalid_data("client-execution receipt identity mismatch"));
+            }
+            receipts.push(receipt);
+        }
+        receipts.sort_by_key(|receipt| receipt.call_id.to_string());
+        Ok(receipts)
+    }
+
+    fn receipt_path(&self, call_id: CallId) -> PathBuf {
+        self.directory.join(format!("{call_id}.json"))
+    }
+}
+
+fn load_or_create_executor_id(directory: &Path) -> io::Result<Uuid> {
+    let path = directory.join(EXECUTOR_FILE);
+    match validate_private_file(&path, MAX_EXECUTOR_BYTES) {
+        Ok(()) => {
+            let mut value = String::new();
+            File::open(&path)?
+                .take((MAX_EXECUTOR_BYTES + 1) as u64)
+                .read_to_string(&mut value)?;
+            if value.len() > MAX_EXECUTOR_BYTES {
+                return Err(invalid_data("desktop executor id is too large"));
+            }
+            let id = Uuid::parse_str(value.trim()).map_err(invalid_data)?;
+            if id.is_nil() {
+                return Err(invalid_data("desktop executor id must not be nil"));
+            }
+            Ok(id)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            let id = Uuid::new_v4();
+            let mut options = OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            options.mode(0o600);
+            let mut file = options.open(&path)?;
+            writeln!(file, "{id}")?;
+            file.sync_all()?;
+            sync_directory(directory)?;
+            Ok(id)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn validate_private_file(path: &Path, max_bytes: usize) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err(invalid_data("private state is not a regular file"));
+    }
+    if metadata.len() > max_bytes as u64 {
+        return Err(invalid_data("private state is too large"));
+    }
+    #[cfg(unix)]
+    if metadata.permissions().mode() & 0o077 != 0 {
+        return Err(invalid_data("private state permissions are too broad"));
+    }
+    Ok(())
+}
+
+fn write_atomically(directory: &Path, destination: &Path, bytes: &[u8]) -> io::Result<()> {
+    let temporary = directory.join(format!(".{}.tmp", Uuid::new_v4()));
+    let result = (|| {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options.open(&temporary)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        drop(file);
+        replace_file(&temporary, destination)?;
+        sync_directory(directory)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(temporary);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    fs::rename(temporary, destination)
+}
+
+#[cfg(windows)]
+fn replace_file(temporary: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let temporary = temporary
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let destination = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let succeeded = unsafe {
+        MoveFileExW(
+            temporary.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if succeeded == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn replace_file(_temporary: &Path, _destination: &Path) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "atomic client-execution receipt replacement is unsupported on this platform",
+    ))
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+fn invalid_data(error: impl std::fmt::Display) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receipts_roundtrip_with_stable_executor_and_exact_resolution() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(temp.path()).unwrap();
+        let executor_id = store.executor_id();
+        let mut receipt = FolderAccessReceipt::new(
+            ChatId::new(),
+            CallId::new(),
+            executor_id,
+            FolderAccessIntent::Selected {
+                path: temp.path().join("Documents"),
+            },
+        );
+        store.save(&receipt).unwrap();
+        assert_eq!(store.load_all().unwrap(), vec![receipt.clone()]);
+        let debug = format!("{receipt:?}");
+        assert!(!debug.contains(&receipt.lease_token.to_string()));
+        assert!(!debug.contains(&temp.path().display().to_string()));
+
+        receipt.resolution = Some(StoredResolution::Completed {
+            result: r#"{"status":"connected"}"#.into(),
+        });
+        store.save(&receipt).unwrap();
+        assert_eq!(store.load_all().unwrap(), vec![receipt.clone()]);
+        store.remove(receipt.call_id).unwrap();
+        assert!(store.load_all().unwrap().is_empty());
+        drop(store);
+
+        let reopened = ReceiptStore::open(temp.path()).unwrap();
+        assert_eq!(reopened.executor_id(), executor_id);
+    }
+
+    #[test]
+    fn receipt_directory_is_exclusive_and_corruption_fails_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(temp.path()).unwrap();
+        assert!(matches!(
+            ReceiptStore::open(temp.path()),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock
+        ));
+        let receipt = FolderAccessReceipt::new(
+            ChatId::new(),
+            CallId::new(),
+            store.executor_id(),
+            FolderAccessIntent::Decline,
+        );
+        store.save(&receipt).unwrap();
+        std::fs::write(store.receipt_path(receipt.call_id), b"not json").unwrap();
+        assert!(store.load_all().is_err());
+
+        let mut invalid = FolderAccessReceipt::new(
+            ChatId::new(),
+            CallId::new(),
+            store.executor_id(),
+            FolderAccessIntent::Decline,
+        );
+        invalid.registration_phase = RegistrationPhase::Attempted;
+        assert!(store.save(&invalid).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executor_identity_and_receipt_symlinks_fail_closed() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let receipt_directory = temp.path().join(RECEIPT_DIRECTORY);
+        std::fs::create_dir(&receipt_directory).unwrap();
+        let outside = temp.path().join("outside");
+        std::fs::write(&outside, Uuid::new_v4().to_string()).unwrap();
+        symlink(&outside, receipt_directory.join(EXECUTOR_FILE)).unwrap();
+        assert!(ReceiptStore::open(temp.path()).is_err());
+
+        std::fs::remove_file(receipt_directory.join(EXECUTOR_FILE)).unwrap();
+        let store = ReceiptStore::open(temp.path()).unwrap();
+        let receipt = FolderAccessReceipt::new(
+            ChatId::new(),
+            CallId::new(),
+            store.executor_id(),
+            FolderAccessIntent::Decline,
+        );
+        symlink(&outside, store.receipt_path(receipt.call_id)).unwrap();
+        assert!(store.load_all().is_err());
+    }
+}

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -14,20 +14,31 @@ use tokio::sync::{oneshot, Mutex, OnceCell};
 use uuid::Uuid;
 
 use crate::broker::BrokerClient;
+use crate::client_execution::{ControlPlaneClient, ReceiptStore};
 
 pub(crate) struct HostAccess {
-    broker: BrokerClient,
-    picker: Mutex<()>,
+    pub(super) broker: BrokerClient,
+    pub(super) picker: Mutex<()>,
     store: OnceCell<std::sync::Arc<dyn Store>>,
+    pub(super) control_plane: OnceCell<ControlPlaneClient>,
+    pub(super) receipts: ReceiptStore,
 }
 
 impl HostAccess {
-    pub(crate) fn new(app: AppHandle, data_dir: PathBuf, home_dir: PathBuf) -> Self {
-        Self {
+    pub(crate) fn new(
+        app: AppHandle,
+        data_dir: PathBuf,
+        home_dir: PathBuf,
+    ) -> Result<Self, String> {
+        let receipts = ReceiptStore::open(&data_dir)
+            .map_err(|_| "could not open private client-execution receipts".to_owned())?;
+        Ok(Self {
             broker: BrokerClient::new(app, data_dir, home_dir),
             picker: Mutex::const_new(()),
             store: OnceCell::new(),
-        }
+            control_plane: OnceCell::new(),
+            receipts,
+        })
     }
 
     pub(crate) fn initialize_store(&self, store: std::sync::Arc<dyn Store>) -> Result<(), String> {
@@ -36,7 +47,20 @@ impl HostAccess {
             .map_err(|_| "host access store was initialized more than once".to_owned())
     }
 
-    async fn context(&self, chat_id: Uuid) -> Result<AuthoritativeContext, String> {
+    pub(crate) fn initialize_control_plane(
+        &self,
+        base_url: String,
+        token: String,
+        executor_token: String,
+    ) -> Result<(), String> {
+        let client = ControlPlaneClient::new(base_url, token, executor_token)
+            .map_err(|_| "could not initialize the local control plane".to_owned())?;
+        self.control_plane
+            .set(client)
+            .map_err(|_| "local control plane was initialized more than once".to_owned())
+    }
+
+    pub(super) async fn context(&self, chat_id: Uuid) -> Result<AuthoritativeContext, String> {
         if chat_id.is_nil() {
             return Err("invalid conversation id".to_owned());
         }
@@ -59,10 +83,10 @@ impl HostAccess {
 }
 
 #[derive(Clone, Copy)]
-struct AuthoritativeContext {
-    chat_id: Uuid,
-    execution: ExecutionContext,
-    subject: GrantSubject,
+pub(super) struct AuthoritativeContext {
+    pub(super) chat_id: Uuid,
+    pub(super) execution: ExecutionContext,
+    pub(super) subject: GrantSubject,
 }
 
 fn authoritative_context(
@@ -117,7 +141,7 @@ pub(crate) async fn connect_folder(
         .picker
         .try_lock()
         .map_err(|_| "a folder picker is already open".to_owned())?;
-    let path = pick_folder(&app).await?;
+    let path = pick_folder(&app, None).await?;
     let Some(path) = path else {
         return Ok(None);
     };
@@ -195,12 +219,18 @@ pub(crate) async fn disconnect_folder(
     Ok(result.revoked)
 }
 
-async fn pick_folder(app: &AppHandle) -> Result<Option<PathBuf>, String> {
+pub(super) async fn pick_folder(
+    app: &AppHandle,
+    starting_directory: Option<PathBuf>,
+) -> Result<Option<PathBuf>, String> {
     let (tx, rx) = oneshot::channel();
     let mut picker = app
         .dialog()
         .file()
         .set_title("Choose a folder OpenWave can read");
+    if let Some(starting_directory) = starting_directory {
+        picker = picker.set_directory(starting_directory);
+    }
     if let Some(window) = app.get_webview_window("main") {
         picker = picker.set_parent(&window);
     }

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -15,10 +15,11 @@ use tokio::sync::watch;
 use openwave_core::Config;
 
 mod broker;
+mod client_execution;
 mod host_access;
 
 /// Connection details the webview needs to reach the in-process API.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ServerInfo {
     /// Base URL, e.g. `http://127.0.0.1:54321`.
@@ -103,6 +104,7 @@ pub fn run() {
         .manage(state)
         .invoke_handler(tauri::generate_handler![
             server_info,
+            client_execution::resolve_folder_access_request,
             host_access::connect_folder,
             host_access::list_connected_folders,
             host_access::disconnect_folder
@@ -112,11 +114,8 @@ pub fn run() {
             let data = data_dir(&handle)?;
             let home = home_dir(&handle)?;
             let scratch = private_scratch(&data)?;
-            app.manage(host_access::HostAccess::new(
-                handle.clone(),
-                data.clone(),
-                home,
-            ));
+            let host_access = host_access::HostAccess::new(handle.clone(), data.clone(), home)?;
+            app.manage(host_access);
 
             tauri::async_runtime::spawn(async move {
                 if let Err(error) = boot_server(handle, info_tx, data, scratch).await {
@@ -146,11 +145,20 @@ async fn boot_server(
         .map_err(|e| e.to_string())?;
     app.state::<host_access::HostAccess>()
         .initialize_store(server.store())?;
+    let base_url = format!("http://{}", server.local_addr());
+    let token = server.token().to_string();
+    let executor_token = server.client_executor_token().to_string();
+    app.state::<host_access::HostAccess>()
+        .initialize_control_plane(base_url.clone(), token.clone(), executor_token)?;
     let info = ServerInfo {
-        base_url: format!("http://{}", server.local_addr()),
-        token: server.token().to_string(),
+        base_url,
+        token,
         scratch_dir: scratch_dir.display().to_string(),
     };
     let _ = info_tx.send(Some(info));
+    let recovery_app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        client_execution::recover_folder_access_receipts(recovery_app).await;
+    });
     server.serve().await.map_err(|e| e.to_string())
 }

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -3,6 +3,7 @@ import {
   ApiClient,
   type Chat,
   type ModelInfo,
+  type PendingFolderAccessRequest,
   type ProviderInfo,
   type ProviderKind,
   type SequencedEvent,
@@ -14,8 +15,11 @@ import {
   disconnectFolder,
   hasNativeHost,
   listConnectedFolders,
+  resolveFolderAccessRequest,
   type ConnectedFolder,
+  type FolderAccessDecision,
 } from "./host";
+import { FolderAccessCard } from "./FolderAccessCard";
 import { Logomark } from "./Logomark";
 
 type Msg =
@@ -45,6 +49,15 @@ export default function App() {
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [messages, setMessages] = useState<Msg[]>([]);
+  const [folderAccessRequests, setFolderAccessRequests] = useState<
+    PendingFolderAccessRequest[]
+  >([]);
+  const [resolvingFolderCalls, setResolvingFolderCalls] = useState<Set<string>>(
+    new Set(),
+  );
+  const [folderAccessErrors, setFolderAccessErrors] = useState<
+    Record<string, string>
+  >({});
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
   const [settingsPanel, setSettingsPanel] = useState<
@@ -55,6 +68,9 @@ export default function App() {
   const lastSeqRef = useRef(0);
   const assistantBufRef = useRef("");
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const refreshFolderAccessRef = useRef<(() => void) | null>(null);
+  const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
+  const visibleFolderCallIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     let cancelled = false;
@@ -118,8 +134,53 @@ export default function App() {
   }, [client, chat?.id]);
 
   useEffect(() => {
+    if (!client || !chat) return;
+    let cancelled = false;
+    let requestSeq = 0;
+
+    const refresh = async () => {
+      const seq = ++requestSeq;
+      try {
+        const requests = await client.listPendingFolderAccessRequests(chat.id);
+        if (!cancelled && seq === requestSeq) {
+          setFolderAccessRequests(requests);
+        }
+      } catch (err) {
+        if (!cancelled && seq === requestSeq) {
+          console.error("failed to refresh pending folder access", err);
+          setFolderAccessRequests([]);
+        }
+      }
+    };
+
+    refreshFolderAccessRef.current = () => void refresh();
+    void refresh();
+    const interval = window.setInterval(() => void refresh(), 10_000);
+    return () => {
+      cancelled = true;
+      requestSeq += 1;
+      window.clearInterval(interval);
+      if (refreshFolderAccessRef.current) {
+        refreshFolderAccessRef.current = null;
+      }
+      setFolderAccessRequests([]);
+    };
+  }, [client, chat?.id]);
+
+  useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
   }, [messages]);
+
+  useEffect(() => {
+    const next = new Set(folderAccessRequests.map((request) => request.callId));
+    const gainedRequest = [...next].some(
+      (callId) => !visibleFolderCallIdsRef.current.has(callId),
+    );
+    visibleFolderCallIdsRef.current = next;
+    if (gainedRequest) {
+      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+    }
+  }, [folderAccessRequests]);
 
   function handleEvent(framed: SequencedEvent) {
     if (framed.seq <= lastSeqRef.current) return;
@@ -165,6 +226,9 @@ export default function App() {
     }
 
     if (event.type === "tool_call_started") {
+      if (event.name === "request_folder_access") {
+        refreshFolderAccessRef.current?.();
+      }
       setMessages((prev) => [
         ...prev,
         {
@@ -268,6 +332,64 @@ export default function App() {
           : m,
       ),
     );
+  }
+
+  async function onFolderAccessDecision(
+    callId: string,
+    decision: FolderAccessDecision,
+  ) {
+    if (!chat || !hasNativeHost()) return;
+    if (resolvingFolderCallsRef.current.size > 0) return;
+    resolvingFolderCallsRef.current.add(callId);
+    setResolvingFolderCalls((calls) => new Set(calls).add(callId));
+    setFolderAccessErrors((errors) => {
+      const next = { ...errors };
+      delete next[callId];
+      return next;
+    });
+    try {
+      await resolveFolderAccessRequest(chat.id, callId, decision);
+    } catch (err) {
+      setFolderAccessErrors((errors) => ({
+        ...errors,
+        [callId]: String(err),
+      }));
+    } finally {
+      resolvingFolderCallsRef.current.delete(callId);
+      setResolvingFolderCalls((calls) => {
+        const next = new Set(calls);
+        next.delete(callId);
+        return next;
+      });
+      refreshFolderAccessRef.current?.();
+    }
+  }
+
+  async function onFolderAccessCancel(callId: string, turnId: string) {
+    if (!client || !chat || resolvingFolderCallsRef.current.size > 0) return;
+    resolvingFolderCallsRef.current.add(callId);
+    setResolvingFolderCalls((calls) => new Set(calls).add(callId));
+    setFolderAccessErrors((errors) => {
+      const next = { ...errors };
+      delete next[callId];
+      return next;
+    });
+    try {
+      await client.cancel(chat.id, turnId);
+    } catch (err) {
+      setFolderAccessErrors((errors) => ({
+        ...errors,
+        [callId]: String(err),
+      }));
+    } finally {
+      resolvingFolderCallsRef.current.delete(callId);
+      setResolvingFolderCalls((calls) => {
+        const next = new Set(calls);
+        next.delete(callId);
+        return next;
+      });
+      refreshFolderAccessRef.current?.();
+    }
   }
 
   if (bootError) {
@@ -376,7 +498,7 @@ export default function App() {
           </div>
 
           <div className="messages" ref={scrollRef}>
-            {messages.length === 0 && (
+            {messages.length === 0 && folderAccessRequests.length === 0 && (
               <div className="bubble system">
                 Configure a provider, pick a model, then send a message.
               </div>
@@ -413,6 +535,22 @@ export default function App() {
                 </div>
               );
             })}
+            {folderAccessRequests.map((request) => (
+              <FolderAccessCard
+                key={request.callId}
+                request={request}
+                nativeHost={hasNativeHost()}
+                nativeBusy={resolvingFolderCalls.size > 0}
+                working={resolvingFolderCalls.has(request.callId)}
+                error={folderAccessErrors[request.callId]}
+                onDecision={(decision) =>
+                  void onFolderAccessDecision(request.callId, decision)
+                }
+                onCancel={() =>
+                  void onFolderAccessCancel(request.callId, request.turnId)
+                }
+              />
+            ))}
           </div>
 
           <form

--- a/crates/openwave-desktop/ui/src/FolderAccessCard.tsx
+++ b/crates/openwave-desktop/ui/src/FolderAccessCard.tsx
@@ -1,0 +1,96 @@
+import type { PendingFolderAccessRequest } from "./api";
+import type { FolderAccessDecision } from "./host";
+
+export function FolderAccessCard({
+  request,
+  nativeHost,
+  nativeBusy,
+  working,
+  error,
+  onDecision,
+  onCancel,
+}: {
+  request: PendingFolderAccessRequest;
+  nativeHost: boolean;
+  nativeBusy: boolean;
+  working: boolean;
+  error: string | undefined;
+  onDecision: (decision: FolderAccessDecision) => void;
+  onCancel: () => void;
+}) {
+  const hint = request.folderHint
+    ? request.folderHint[0].toUpperCase() + request.folderHint.slice(1)
+    : null;
+  const actionable =
+    nativeHost && !nativeBusy && !request.claimedByDesktop && !working;
+
+  return (
+    <section
+      className="folder-consent"
+      aria-labelledby={`folder-${request.callId}`}
+      aria-busy={working}
+    >
+      <div className="folder-consent-heading">
+        <div>
+          <h2 id={`folder-${request.callId}`}>Folder access requested</h2>
+          <span className="status">read access</span>
+        </div>
+      </div>
+      <p className="folder-consent-reason">{request.reason}</p>
+      {hint && (
+        <p className="folder-consent-hint">
+          Suggested starting location: <strong>{hint}</strong>
+        </p>
+      )}
+      {working ? (
+        <p className="folder-consent-note" role="status" aria-live="polite">
+          Resolving the folder request…
+        </p>
+      ) : request.claimedByDesktop ? (
+        <p className="folder-consent-note" role="status" aria-live="polite">
+          This request is already being handled by the native desktop.
+        </p>
+      ) : !nativeHost ? (
+        <div>
+          <p className="folder-consent-note">
+            Folder consent is unavailable in browser-only mode. This desktop
+            cannot resolve a chat owned by the headless server.
+          </p>
+          <div className="folder-consent-actions">
+            <button type="button" className="btn" onClick={onCancel}>
+              Cancel turn
+            </button>
+          </div>
+        </div>
+      ) : nativeBusy ? (
+        <p className="folder-consent-note" role="status" aria-live="polite">
+          Finish the current folder request first.
+        </p>
+      ) : (
+        <div className="folder-consent-actions">
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={!actionable}
+            onClick={() => onDecision("allow")}
+          >
+            Allow
+          </button>
+          <button
+            type="button"
+            className="btn"
+            disabled={!actionable}
+            onClick={() => onDecision("decline")}
+          >
+            Decline
+          </button>
+        </div>
+      )}
+      {error && (
+        <p className="folder-consent-error" role="alert">
+          {error}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -53,6 +53,17 @@ export type AgentEvent =
   | { type: "turn_cancelled"; usage: unknown }
   | { type: "user_steered"; content: string };
 
+export type FolderAccessHint = "documents" | "downloads";
+
+/** A validated, pending request that the renderer may safely present. */
+export type PendingFolderAccessRequest = {
+  callId: string;
+  turnId: string;
+  reason: string;
+  folderHint: FolderAccessHint | null;
+  claimedByDesktop: boolean;
+};
+
 const WS_HANDSHAKE = "openwave-v1";
 const WS_TOKEN_PREFIX = "openwave-token.";
 
@@ -181,6 +192,25 @@ export class ApiClient {
     });
   }
 
+  async listPendingFolderAccessRequests(
+    chatId: string,
+  ): Promise<PendingFolderAccessRequest[]> {
+    const body = await this.json<unknown>(
+      `/chats/${chatId}/client-executions/pending`,
+      { headers: this.headers() },
+    );
+    if (!Array.isArray(body)) return [];
+
+    const requests = new Map<string, PendingFolderAccessRequest>();
+    for (const item of body) {
+      const request = parseFolderAccessRequest(item, chatId);
+      if (request && !requests.has(request.callId)) {
+        requests.set(request.callId, request);
+      }
+    }
+    return [...requests.values()];
+  }
+
   /** Open the chat event stream; auth via Sec-WebSocket-Protocol. */
   openEvents(chatId: string, after: number, onEvent: (e: SequencedEvent) => void): WebSocket {
     const url = `${this.baseUrl.replace(/^http/, "ws")}/chats/${chatId}/events?after=${after}`;
@@ -195,4 +225,67 @@ export class ApiClient {
     };
     return socket;
   }
+}
+
+function parseFolderAccessRequest(
+  value: unknown,
+  chatId: string,
+): PendingFolderAccessRequest | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.id !== "string" ||
+    value.id.length === 0 ||
+    typeof value.turn_id !== "string" ||
+    value.turn_id.length === 0 ||
+    value.chat_id !== chatId ||
+    value.name !== "request_folder_access" ||
+    value.execution !== "client" ||
+    value.status !== "pending" ||
+    !(value.client_executor_id === null ||
+      typeof value.client_executor_id === "string")
+  ) {
+    return null;
+  }
+
+  const args = value.arguments;
+  if (!isRecord(args)) return null;
+  const keys = Object.keys(args);
+  if (
+    keys.some(
+      (key) =>
+        key !== "reason" &&
+        key !== "requested_capabilities" &&
+        key !== "folder_hint",
+    ) ||
+    typeof args.reason !== "string" ||
+    args.reason.trim().length === 0 ||
+    [...args.reason].length > 500 ||
+    args.reason.includes("\0") ||
+    !Array.isArray(args.requested_capabilities) ||
+    args.requested_capabilities.length !== 1 ||
+    args.requested_capabilities[0] !== "read_files"
+  ) {
+    return null;
+  }
+
+  const folderHint = args.folder_hint;
+  if (
+    folderHint !== undefined &&
+    folderHint !== "documents" &&
+    folderHint !== "downloads"
+  ) {
+    return null;
+  }
+
+  return {
+    callId: value.id,
+    turnId: value.turn_id,
+    reason: args.reason,
+    folderHint: folderHint ?? null,
+    claimedByDesktop: value.client_executor_id !== null,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -6,6 +6,8 @@ export type ConnectedFolder = {
   displayName: string;
 };
 
+export type FolderAccessDecision = "allow" | "decline";
+
 export function hasNativeHost(): boolean {
   return isTauri();
 }
@@ -23,5 +25,15 @@ export function connectFolder(chat: Chat): Promise<ConnectedFolder | null> {
 export function disconnectFolder(chat: Chat, rootId: string): Promise<boolean> {
   return invoke("disconnect_folder", {
     request: { chatId: chat.id, rootId },
+  });
+}
+
+export function resolveFolderAccessRequest(
+  chatId: string,
+  callId: string,
+  decision: FolderAccessDecision,
+): Promise<void> {
+  return invoke("resolve_folder_access_request", {
+    request: { chatId, callId, decision },
   });
 }

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -194,6 +194,58 @@ button {
   background: oklch(0.97 0.01 25);
 }
 
+.folder-consent {
+  align-self: flex-start;
+  width: min(100%, 34rem);
+  border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--line));
+  border-radius: 10px;
+  padding: 0.85rem;
+  background: var(--bg-elevated);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--ink) 6%, transparent);
+}
+
+.folder-consent-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.folder-consent h2 {
+  margin: 0 0 0.1rem;
+  font-size: 0.95rem;
+}
+
+.folder-consent-reason {
+  margin: 0.75rem 0 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.folder-consent-hint,
+.folder-consent-note,
+.folder-consent-error {
+  margin: 0.55rem 0 0;
+  font-size: 0.82rem;
+}
+
+.folder-consent-hint,
+.folder-consent-note {
+  color: var(--muted);
+}
+
+.folder-consent-error {
+  color: var(--danger);
+  overflow-wrap: anywhere;
+}
+
+.folder-consent-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
 .composer {
   display: grid;
   grid-template-columns: 1fr auto;

--- a/crates/openwave-server/src/auth.rs
+++ b/crates/openwave-server/src/auth.rs
@@ -14,7 +14,7 @@
 use axum::extract::{Request, State};
 use axum::http::{
     header::{AUTHORIZATION, SEC_WEBSOCKET_PROTOCOL, UPGRADE},
-    HeaderMap, StatusCode,
+    HeaderMap, HeaderName, StatusCode,
 };
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
@@ -31,6 +31,10 @@ pub const WS_HANDSHAKE_SUBPROTOCOL: &str = "openwave-v1";
 /// subprotocol token-char sequence.
 pub const WS_TOKEN_SUBPROTOCOL_PREFIX: &str = "openwave-token.";
 
+/// Native-only credential header for claim, heartbeat, and resolve mutations.
+pub const CLIENT_EXECUTOR_HEADER: HeaderName =
+    HeaderName::from_static("x-openwave-client-executor");
+
 /// Reject requests without a valid bearer token — from
 /// `Authorization: Bearer <token>`, or (on WebSocket upgrades only)
 /// `Sec-WebSocket-Protocol: openwave-token.<token>`.
@@ -43,6 +47,26 @@ pub async fn require_token(
 
     match presented {
         Some(token) if constant_time_eq(token.as_bytes(), state.token.as_bytes()) => {
+            next.run(request).await
+        }
+        _ => StatusCode::UNAUTHORIZED.into_response(),
+    }
+}
+
+/// Require the second credential held only by the trusted native executor.
+pub async fn require_client_executor_token(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let presented = request
+        .headers()
+        .get(&CLIENT_EXECUTOR_HEADER)
+        .and_then(|value| value.to_str().ok());
+    match presented {
+        Some(token)
+            if constant_time_eq(token.as_bytes(), state.client_executor_token.as_bytes()) =>
+        {
             next.run(request).await
         }
         _ => StatusCode::UNAUTHORIZED.into_response(),

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -4,7 +4,8 @@
 //! one local API rather than linking the loop directly, so all surfaces share a
 //! single wiring of `Config`, `Store`, and (next slice) the agent. The server
 //! binds to an ephemeral **loopback** port and mints a per-launch **bearer
-//! token**: only the local process it was handed to can reach it.
+//! token**. Trusted client-execution mutations require a second per-launch
+//! credential that renderer-facing clients are never given.
 //!
 //! The surface runs turns end to end: the chat CRUD routes, `POST
 //! /chats/{id}/messages` to start a turn (one per chat at a time), and
@@ -60,6 +61,24 @@ const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
 pub fn app(state: AppState) -> Router {
     // `route_layer` applies the token check to matched API routes only, so an
     // unknown path still answers `404` (not `401`), and `/healthz` stays open.
+    let client_executor_api = Router::new()
+        .route(
+            "/chats/{id}/client-executions/{call_id}/claim",
+            post(routes::claim_client_execution),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/heartbeat",
+            post(routes::heartbeat_client_execution),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/resolve",
+            post(routes::resolve_client_execution),
+        )
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            auth::require_client_executor_token,
+        ));
+
     let api = Router::new()
         .route(
             "/settings",
@@ -132,22 +151,11 @@ pub fn app(state: AppState) -> Router {
             get(routes::list_pending_client_executions),
         )
         .route(
-            "/chats/{id}/client-executions/{call_id}/claim",
-            post(routes::claim_client_execution),
-        )
-        .route(
-            "/chats/{id}/client-executions/{call_id}/heartbeat",
-            post(routes::heartbeat_client_execution),
-        )
-        .route(
-            "/chats/{id}/client-executions/{call_id}/resolve",
-            post(routes::resolve_client_execution),
-        )
-        .route(
             "/chats/{id}/approvals/{call_id}",
             post(routes::post_approval),
         )
         .route("/chats/{id}/events", get(routes::chat_events))
+        .merge(client_executor_api)
         .route_layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::require_token,
@@ -185,6 +193,7 @@ async fn healthz() -> &'static str {
 pub struct Server {
     local_addr: SocketAddr,
     token: Arc<str>,
+    client_executor_token: Arc<str>,
     store: Arc<dyn Store>,
     listener: TcpListener,
     router: Router,
@@ -247,6 +256,11 @@ impl Server {
         &self.token
     }
 
+    /// The second per-launch credential for trusted client-execution mutations.
+    pub fn client_executor_token(&self) -> &str {
+        &self.client_executor_token
+    }
+
     /// The authoritative durable store used by this server instance.
     ///
     /// Native embedders use this to resolve renderer-supplied entity IDs back
@@ -292,6 +306,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         agent_config,
     );
     let token = state.token.clone();
+    let client_executor_token = state.client_executor_token.clone();
     let document_worker = document_worker::DocumentWorker::new(
         state.store.clone(),
         state.blobs.clone(),
@@ -351,6 +366,7 @@ pub async fn bind(config: Config) -> Result<Server> {
     Ok(Server {
         local_addr,
         token,
+        client_executor_token,
         store: server_store,
         listener,
         router,

--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -3,6 +3,8 @@
 //! Polling is authoritative; event streams are only a latency hint. A client
 //! generates a fresh secret lease token before claiming, then retains it across
 //! ambiguous HTTP responses and presents it for every heartbeat or resolution.
+//! Claim, heartbeat, and resolve also require the server's native-only executor
+//! credential; pending polling uses ordinary API authentication.
 
 use axum::extract::State;
 use serde::{Deserialize, Serialize};

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -55,6 +55,8 @@ pub struct AppState {
     pub agent_config: AgentConfig,
     /// The secret every request must present as `Authorization: Bearer <token>`.
     pub token: Arc<str>,
+    /// A second per-launch secret required for client-execution mutations.
+    pub(crate) client_executor_token: Arc<str>,
     /// Process-local cancel/steer handles for exact durably claimed attempts.
     pub active_turns: Arc<TurnGuard>,
     /// Live fan-out of turn events to connected WebSocket clients.
@@ -92,11 +94,23 @@ impl AppState {
             blob_writes,
             agent_config,
             token: Uuid::new_v4().to_string().into(),
+            client_executor_token: mint_client_executor_token(),
             active_turns: Arc::new(TurnGuard::default()),
             events: Arc::new(EventBus::default()),
             approvals: Arc::new(ApprovalBroker::new()),
         }
     }
+}
+
+#[cfg(test)]
+pub(crate) const TEST_CLIENT_EXECUTOR_TOKEN: &str = "test-native-client-executor";
+
+fn mint_client_executor_token() -> Arc<str> {
+    #[cfg(test)]
+    return TEST_CLIENT_EXECUTOR_TOKEN.into();
+
+    #[cfg(not(test))]
+    return Uuid::new_v4().to_string().into();
 }
 
 /// Cross-process exclusion for one content-addressed blob lifecycle.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -2439,6 +2439,10 @@ async fn post_json(
                 .method("POST")
                 .uri(uri)
                 .header(header::AUTHORIZATION, bearer)
+                .header(
+                    crate::auth::CLIENT_EXECUTOR_HEADER,
+                    crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
+                )
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(body.to_string()))
                 .unwrap(),
@@ -2603,6 +2607,21 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         "executor_id": executor_id,
         "lease_token": lease_token,
     });
+    let renderer_only = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&claim_uri)
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(claim_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(renderer_only.status(), StatusCode::UNAUTHORIZED);
+
     let first = post_json(&router, &bearer, &claim_uri, claim_body.clone()).await;
     assert_eq!(first.status(), StatusCode::OK);
     let first: serde_json::Value = json_body(first).await;

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -282,8 +282,14 @@ This will land in independently reviewable pieces:
    a known, still-connected registration without replaying a mutation after
    losing its client lease. Lookup is fenced by the original trusted subject and
    conversation and reports a later disconnection separately from a usable
-   grant. The desktop pending-work executor remains to be layered on that
-   boundary.
+   grant. The desktop now polls that authoritative pending-work boundary, shows
+   a bounded consent card, and keeps the picker, claim token, selected path, and
+   broker mutation inside the native process. App-private receipts preserve the
+   exact operation ID, claim token, intent, and terminal payload across a crash.
+   A pre-effect phase is synced before the one registration dispatch, and the
+   dispatch must begin inside a short post-heartbeat deadline. Recovery runs in
+   the background with bounded backoff; it may query the broker receipt and
+   publish a known result, but it never starts or replays registration.
 8. Replace project/chat `workspace_dir` with persisted host-access context
    identity and connected-root APIs. This can update the pre-v1 baseline schema
    directly.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -171,8 +171,12 @@ opaque root IDs and display names to the renderer. The next tool-routing slice
 will resolve file operations through those roots instead of the legacy workspace.
 See [Host access and connected folders](host-access.md). The agent loop can now
 produce a durable client-wait checkpoint for the registered folder-request
-contract. The desktop executor is the next layer: the request will only open a
-native consent flow and will never grant a named path by itself.
+contract. The desktop discovers those pending requests from durable state and
+shows a consent card. If the user allows it, only native code can open the
+folder picker, claim the request, and ask the broker to register the selected
+folder. The selected path never enters the renderer or product HTTP API. The
+secret claim token is never renderer-visible; native code sends it only through
+the separately credentialed loopback client-execution API.
 The model router supports Anthropic, OpenAI, and OpenAI-compatible endpoints. It
 fails closed: if no enabled provider with a usable credential can serve the
 selected model, no model request is sent.
@@ -208,7 +212,7 @@ authoritative abandonment without replaying the native action.
 ```text
                          +----success----> completed
 pending ----execute----->+----failure----> failed
-                         +----decline----> cancelled
+                         +----decline----> completed (typed `declined`)
 
 client execution adds: unclaimed ----claim/heartbeat----> leased
 ```
@@ -244,9 +248,27 @@ pause, including when cancellation wins before the resumed agent starts. This is
 the durable equivalent of pausing a function, doing native work elsewhere, and
 continuing from a known checkpoint.
 The agent and worker now emit this checkpoint for the bounded
-`request_folder_access` contract. The remaining integration work is to run those
-pending calls from the desktop. Notifications will be wake-up hints; the
-pending-work query remains authoritative after a restart or missed notification.
+`request_folder_access` contract. The desktop runs those pending calls through a
+native consent state machine. Notifications are wake-up hints; an immediate
+query and periodic polling of pending work remain authoritative after a restart
+or missed notification. The picker opens before the claim, so the client does
+not hold a lease while the user is deciding. Once a choice exists, an app-private
+receipt binds the conversation, call, stable executor, fresh claim token, and
+intent. The call ID is also the broker registration operation ID.
+
+The native executor retries only exact, idempotent control-plane operations.
+Claim, heartbeat, and resolve also require a second per-launch native credential
+that is never given to the renderer. Immediately before broker admission, the
+executor syncs a durable pre-effect phase. The broker registration is then
+queued once with a short dispatch deadline inside the renewed lease. After a
+response, disconnect, or crash, the executor asks the broker for the registration
+receipt and records the de-sensitized terminal payload before resolving the
+client call. A background reconciler retries read-only lookup and exact result
+publication with bounded backoff. On restart it can publish a stored payload or
+reconcile a known broker outcome; it never starts registration from a recovery
+receipt. Declining or closing the picker completes the call with a typed
+`declined` result rather than treating consent as an execution error.
+
 For crash recovery, the broker exposes a de-sensitized registration-receipt
 lookup keyed by the stable operation ID. That lookup never starts or resumes a
 mutation: a restarted client may reconcile a known committed result, but must


### PR DESCRIPTION
## Summary

- render authoritative folder-consent requests and keep folder selection, claiming, and path authority inside the native desktop host
- persist fenced execution receipts and recover one-shot broker registrations without replaying mutations
- require a native-only executor credential for client-execution mutations while keeping typed results path-free
- add browser cancellation, accessibility states, and host-access documentation for the completed flow

## Testing

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `bw dev lint --rust --check --repo-root "$PWD"`
- `pnpm --dir crates/openwave-desktop/ui build`
- `git diff --check`
