### PR TITLE
Model pathless root attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5887,6 +5887,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "axum",
+ "cap-std",
  "chrono",
  "futures",
  "openwave-core",

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -73,12 +73,14 @@ async fn serve() -> Result<()> {
 
 /// Serve the built-in read-only filesystem tools over MCP stdio.
 async fn serve_mcp(workspace: PathBuf) -> Result<()> {
-    let ctx = ToolCtx::try_new(ChatId::new(), None, workspace.clone()).map_err(|error| {
-        AgentError::config(format!(
-            "could not open MCP workspace {}: {error}",
-            workspace.display()
-        ))
-    })?;
+    let ctx = ToolCtx::try_new_legacy_workspace(ChatId::new(), None, workspace.clone()).map_err(
+        |error| {
+            AgentError::config(format!(
+                "could not open MCP workspace {}: {error}",
+                workspace.display()
+            ))
+        },
+    )?;
 
     let tools = Arc::new(
         ToolRegistry::new()

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -45,7 +45,7 @@ use crate::storage::{
     AcceptToolCallOutcome, ApplyTurnSteerOutcome, JournaledTurnSteerOutcome,
     ResolveToolCallOutcome, Store,
 };
-use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
+use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
 
 /// A name-keyed registry of the tools available to the agent.
 #[derive(Default)]
@@ -184,6 +184,10 @@ pub struct AgentConfig {
     /// The model's context window in tokens. Used to compute the message budget
     /// for context reduction (default: 200 000).
     pub context_window: usize,
+    /// Exact runtime-only private scratch directory for legacy built-in file
+    /// tools. It is derived by the embedding server and never persisted in a
+    /// project or conversation.
+    pub tool_scratch: Option<ToolScratch>,
 }
 
 /// Default context window: 200k tokens (Claude Opus/Sonnet).
@@ -199,6 +203,7 @@ impl Default for AgentConfig {
             max_steps: 16,
             max_tool_result_bytes: DEFAULT_MAX_TOOL_RESULT_BYTES,
             context_window: DEFAULT_CONTEXT_WINDOW,
+            tool_scratch: None,
         }
     }
 }
@@ -1275,7 +1280,10 @@ impl Agent {
                 return ToolOutput::error("turn cancelled while awaiting approval");
             }
         }
-        let ctx = ToolCtx::new(chat.id, chat.project_id, chat.workspace_dir.clone());
+        let ctx = self.config.tool_scratch.as_ref().map_or_else(
+            || ToolCtx::without_private_scratch(chat.id, chat.project_id),
+            |scratch| ToolCtx::with_private_scratch(chat.id, chat.project_id, scratch.clone()),
+        );
         let mut output = match tool.execute(&ctx, parse_args(&call.args)).await {
             Ok(output) => output,
             Err(err) => ToolOutput::error(err.to_string()),
@@ -1531,6 +1539,12 @@ mod tests {
     use crate::provider::ProviderId;
     use crate::tools::ReadFile;
 
+    fn tool_scratch(path: &std::path::Path) -> ToolScratch {
+        ToolScratch::from_dir(
+            cap_std::fs::Dir::open_ambient_dir(path, cap_std::ambient_authority()).unwrap(),
+        )
+    }
+
     fn emitted_events(emissions: Vec<ClaimedAgentEvent>) -> Vec<AgentEvent> {
         emissions
             .into_iter()
@@ -1675,7 +1689,6 @@ mod tests {
 
     #[tokio::test]
     async fn claimed_agent_returns_a_client_tool_checkpoint_without_executing_it() {
-        let workspace = tempfile::tempdir().unwrap();
         let db = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -1690,7 +1703,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -1805,7 +1819,6 @@ mod tests {
 
     #[tokio::test]
     async fn claimed_agent_retries_a_mixed_client_call_then_preserves_exhausted_usage() {
-        let workspace = tempfile::tempdir().unwrap();
         let db = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -1820,7 +1833,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -1899,7 +1913,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -1913,6 +1928,7 @@ mod tests {
             store.clone(),
             AgentConfig {
                 model: "fake".into(),
+                tool_scratch: Some(tool_scratch(workspace.path())),
                 ..Default::default()
             },
         );
@@ -1981,7 +1997,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -2012,6 +2029,7 @@ mod tests {
             store.clone(),
             AgentConfig {
                 model: "fake".into(),
+                tool_scratch: Some(tool_scratch(workspace.path())),
                 ..Default::default()
             },
         );
@@ -2357,7 +2375,6 @@ mod tests {
 
     #[tokio::test]
     async fn tool_context_inherits_the_chats_project_scope() {
-        let workspace = tempfile::tempdir().unwrap();
         let db = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -2370,7 +2387,8 @@ mod tests {
         let project = Project {
             id: ProjectId::new(),
             title: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_project(&project).await.unwrap();
@@ -2379,7 +2397,8 @@ mod tests {
             project_id: Some(project.id),
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -2422,7 +2441,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -2485,7 +2505,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -2558,7 +2579,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -2572,6 +2594,7 @@ mod tests {
             AgentConfig {
                 model: "fake".into(),
                 max_tool_result_bytes: 100,
+                tool_scratch: Some(tool_scratch(workspace.path())),
                 ..Default::default()
             },
         );
@@ -2658,7 +2681,6 @@ mod tests {
     async fn sensitive_tool_parks_until_approved() {
         use crate::approval::AutoApproveGate;
 
-        let workspace = tempfile::tempdir().unwrap();
         let db = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -2673,7 +2695,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -2774,7 +2797,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -3254,7 +3278,6 @@ mod tests {
 
     #[tokio::test]
     async fn sensitive_tool_is_refused_without_a_gate() {
-        let workspace = tempfile::tempdir().unwrap();
         let db = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -3269,7 +3292,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -3478,7 +3502,8 @@ mod tests {
             project_id: None,
             title: None,
             model: None,
-            workspace_dir: workspace.path().to_path_buf(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
@@ -3492,6 +3517,7 @@ mod tests {
             store.clone(),
             AgentConfig {
                 model: "fake".into(),
+                tool_scratch: Some(tool_scratch(workspace.path())),
                 ..Default::default()
             },
         );

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -125,12 +125,21 @@ pub mod project {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
         pub title: Option<String>,
-        pub workspace_dir: String,
+        pub attachment_revision: i64,
         pub created_at: DateTimeUtc,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
-    pub enum Relation {}
+    pub enum Relation {
+        #[sea_orm(has_many = "super::project_root_attachment::Entity")]
+        RootAttachment,
+    }
+
+    impl Related<super::project_root_attachment::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::RootAttachment.def()
+        }
+    }
 
     impl ActiveModelBehavior for ActiveModel {}
 }
@@ -146,12 +155,90 @@ pub mod chat {
         pub project_id: Option<Uuid>,
         pub title: Option<String>,
         pub model: Option<String>,
-        pub workspace_dir: String,
+        pub attachment_revision: i64,
         pub created_at: DateTimeUtc,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
-    pub enum Relation {}
+    pub enum Relation {
+        #[sea_orm(has_many = "super::chat_root_attachment::Entity")]
+        RootAttachment,
+    }
+
+    impl Related<super::chat_root_attachment::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::RootAttachment.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod project_root_attachment {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "project_root_attachment")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub project_id: Uuid,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub root_id: Uuid,
+        pub position: i32,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(
+            belongs_to = "super::project::Entity",
+            from = "Column::ProjectId",
+            to = "super::project::Column::Id",
+            on_update = "NoAction",
+            on_delete = "Cascade"
+        )]
+        Project,
+    }
+
+    impl Related<super::project::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Project.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod chat_root_attachment {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "chat_root_attachment")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub chat_id: Uuid,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub root_id: Uuid,
+        pub position: i32,
+        pub origin: String,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(
+            belongs_to = "super::chat::Entity",
+            from = "Column::ChatId",
+            to = "super::chat::Column::Id",
+            on_update = "NoAction",
+            on_delete = "Cascade"
+        )]
+        Chat,
+    }
+
+    impl Related<super::chat::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Chat.def()
+        }
+    }
 
     impl ActiveModelBehavior for ActiveModel {}
 }

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -35,15 +35,60 @@ impl MigrationTrait for Init {
         manager
             .create_table(
                 Table::create()
+                    .table(Project::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Project::Id).uuid().not_null().primary_key())
+                    .col(ColumnDef::new(Project::Title).text())
+                    .col(
+                        ColumnDef::new(Project::AttachmentRevision)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(Project::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .check(Expr::col(Project::AttachmentRevision).gte(0))
+                    .check(
+                        Expr::col(Project::AttachmentRevision)
+                            .lte(crate::model::MAX_ATTACHMENT_REVISION),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
                     .table(Chat::Table)
                     .if_not_exists()
                     .col(ColumnDef::new(Chat::Id).uuid().not_null().primary_key())
+                    .col(ColumnDef::new(Chat::ProjectId).uuid())
                     .col(ColumnDef::new(Chat::Title).text())
-                    .col(ColumnDef::new(Chat::WorkspaceDir).text().not_null())
+                    .col(
+                        ColumnDef::new(Chat::AttachmentRevision)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
                     .col(
                         ColumnDef::new(Chat::CreatedAt)
                             .timestamp_with_time_zone()
                             .not_null(),
+                    )
+                    .check(Expr::col(Chat::AttachmentRevision).gte(0))
+                    .check(
+                        Expr::col(Chat::AttachmentRevision)
+                            .lte(crate::model::MAX_ATTACHMENT_REVISION),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_chat_project")
+                            .from(Chat::Table, Chat::ProjectId)
+                            .to(Project::Table, Project::Id)
+                            .on_delete(ForeignKeyAction::Restrict),
                     )
                     .to_owned(),
             )
@@ -929,6 +974,9 @@ impl MigrationTrait for Init {
         manager
             .drop_table(Table::drop().table(Chat::Table).to_owned())
             .await?;
+        manager
+            .drop_table(Table::drop().table(Project::Table).to_owned())
+            .await?;
         Ok(())
     }
 }
@@ -1074,7 +1122,7 @@ impl MigrationTrait for AddEventJournal {
     }
 }
 
-/// Adds the `project` table and the optional `chat.project_id` link.
+/// Adds ordered host-root projection rows for projects and chats.
 struct AddProjects;
 
 impl MigrationName for AddProjects {
@@ -1089,28 +1137,109 @@ impl MigrationTrait for AddProjects {
         manager
             .create_table(
                 Table::create()
-                    .table(Project::Table)
+                    .table(ProjectRootAttachment::Table)
                     .if_not_exists()
-                    .col(ColumnDef::new(Project::Id).uuid().not_null().primary_key())
-                    .col(ColumnDef::new(Project::Title).text())
-                    .col(ColumnDef::new(Project::WorkspaceDir).text().not_null())
                     .col(
-                        ColumnDef::new(Project::CreatedAt)
-                            .timestamp_with_time_zone()
+                        ColumnDef::new(ProjectRootAttachment::ProjectId)
+                            .uuid()
                             .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ProjectRootAttachment::RootId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ProjectRootAttachment::Position)
+                            .integer()
+                            .not_null(),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .col(ProjectRootAttachment::ProjectId)
+                            .col(ProjectRootAttachment::RootId),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_project_root_attachment_project")
+                            .from(
+                                ProjectRootAttachment::Table,
+                                ProjectRootAttachment::ProjectId,
+                            )
+                            .to(Project::Table, Project::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .check(Expr::col(ProjectRootAttachment::RootId).ne(uuid::Uuid::nil()))
+                    .check(Expr::col(ProjectRootAttachment::Position).gte(0))
+                    .check(
+                        Expr::col(ProjectRootAttachment::Position)
+                            .lt(crate::model::MAX_ROOT_ATTACHMENTS as i32),
                     )
                     .to_owned(),
             )
             .await?;
-
-        // A nullable link, no DB-level foreign key: SQLite can't add an FK to
-        // an existing table, so membership is validated at the API edge (the
-        // server checks the project exists before creating the chat).
         manager
-            .alter_table(
-                Table::alter()
-                    .table(Chat::Table)
-                    .add_column(ColumnDef::new(Chat::ProjectId).uuid())
+            .create_index(
+                Index::create()
+                    .name("idx_project_root_attachment_position")
+                    .table(ProjectRootAttachment::Table)
+                    .col(ProjectRootAttachment::ProjectId)
+                    .col(ProjectRootAttachment::Position)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(ChatRootAttachment::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(ChatRootAttachment::ChatId).uuid().not_null())
+                    .col(ColumnDef::new(ChatRootAttachment::RootId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(ChatRootAttachment::Position)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ChatRootAttachment::Origin)
+                            .string_len(24)
+                            .not_null(),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .col(ChatRootAttachment::ChatId)
+                            .col(ChatRootAttachment::RootId),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_chat_root_attachment_chat")
+                            .from(ChatRootAttachment::Table, ChatRootAttachment::ChatId)
+                            .to(Chat::Table, Chat::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .check(Expr::col(ChatRootAttachment::RootId).ne(uuid::Uuid::nil()))
+                    .check(Expr::col(ChatRootAttachment::Position).gte(0))
+                    .check(
+                        Expr::col(ChatRootAttachment::Position)
+                            .lt(crate::model::MAX_ROOT_ATTACHMENTS as i32),
+                    )
+                    .check(
+                        Expr::col(ChatRootAttachment::Origin)
+                            .is_in(["project_default", "conversation"]),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_chat_root_attachment_position")
+                    .table(ChatRootAttachment::Table)
+                    .col(ChatRootAttachment::ChatId)
+                    .col(ChatRootAttachment::Position)
+                    .unique()
                     .to_owned(),
             )
             .await?;
@@ -1119,15 +1248,10 @@ impl MigrationTrait for AddProjects {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .alter_table(
-                Table::alter()
-                    .table(Chat::Table)
-                    .drop_column(Chat::ProjectId)
-                    .to_owned(),
-            )
+            .drop_table(Table::drop().table(ChatRootAttachment::Table).to_owned())
             .await?;
         manager
-            .drop_table(Table::drop().table(Project::Table).to_owned())
+            .drop_table(Table::drop().table(ProjectRootAttachment::Table).to_owned())
             .await?;
         Ok(())
     }
@@ -2195,7 +2319,7 @@ enum Project {
     Table,
     Id,
     Title,
-    WorkspaceDir,
+    AttachmentRevision,
     CreatedAt,
 }
 
@@ -2283,8 +2407,25 @@ enum Chat {
     ProjectId,
     Title,
     Model,
-    WorkspaceDir,
+    AttachmentRevision,
     CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum ProjectRootAttachment {
+    Table,
+    ProjectId,
+    RootId,
+    Position,
+}
+
+#[derive(DeriveIden)]
+enum ChatRootAttachment {
+    Table,
+    ChatId,
+    RootId,
+    Position,
+    Origin,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -6,8 +6,6 @@
 //! so nothing is stringly-encoded by hand. Enabled by the `sqlite` feature (which
 //! compiles in the SQLite driver).
 
-use std::path::PathBuf;
-
 use async_trait::async_trait;
 use chrono::Utc;
 use sea_orm::sea_query::OnConflict;
@@ -22,16 +20,19 @@ use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 #[cfg(test)]
 use crate::id::MessageId;
-use crate::id::{CallId, ChatId, DocumentId, DocumentJobId, ProjectId, TurnId, TurnSteerId};
+use crate::id::{
+    CallId, ChatId, DocumentId, DocumentJobId, HostRootId, ProjectId, TurnId, TurnSteerId,
+};
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
-    BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
-    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
-    DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
-    DocumentUpsert, Message, Project, SourceRegion, ToolCallRecord, ToolCallResolution,
-    TurnCheckpointProgress, TurnClientWaitStatus, TurnFailureRetry, TurnRun, TurnRunStatus,
-    TurnSteerStatus,
+    validate_project_root_projection, BlobRetirement, BlobRetirementStatus, Chat,
+    DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
+    DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
+    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
+    Project, SourceRegion, ToolCallRecord, ToolCallResolution, TurnCheckpointProgress,
+    TurnClientWaitStatus, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteerStatus,
+    MAX_ROOT_ATTACHMENTS,
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
@@ -99,35 +100,61 @@ impl DbStore {
 #[async_trait]
 impl Store for DbStore {
     async fn create_project(&self, project: &Project) -> Result<()> {
+        validate_project_attachments(project)?;
+        let transaction = self.conn.begin().await.map_err(store_err)?;
         entities::project::ActiveModel {
             id: Set(project.id.0),
             title: Set(project.title.clone()),
-            workspace_dir: Set(project.workspace_dir.to_string_lossy().into_owned()),
+            attachment_revision: Set(project.attachment_revision),
             created_at: Set(project.created_at),
         }
-        .insert(&self.conn)
+        .insert(&transaction)
         .await
         .map_err(store_err)?;
+        for (position, root_id) in project.root_attachments.iter().copied().enumerate() {
+            entities::project_root_attachment::ActiveModel {
+                project_id: Set(project.id.0),
+                root_id: Set(*root_id.as_uuid()),
+                position: Set(i32::try_from(position)
+                    .map_err(|_| AgentError::Store("project root position exceeds i32".into()))?),
+            }
+            .insert(&transaction)
+            .await
+            .map_err(store_err)?;
+        }
+        transaction.commit().await.map_err(store_err)?;
         Ok(())
     }
 
     async fn get_project(&self, id: ProjectId) -> Result<Option<Project>> {
-        Ok(entities::project::Entity::find_by_id(id.0)
-            .one(&self.conn)
+        let mut rows = entities::project::Entity::find_by_id(id.0)
+            .find_with_related(entities::project_root_attachment::Entity)
+            .order_by_asc(entities::project_root_attachment::Column::Position)
+            .all(&self.conn)
             .await
-            .map_err(store_err)?
-            .map(project_from_model))
+            .map_err(store_err)?;
+        rows.pop()
+            .map(|(model, roots)| project_from_models(model, roots))
+            .transpose()
     }
 
     async fn list_projects(&self) -> Result<Vec<Project>> {
-        Ok(entities::project::Entity::find()
-            .order_by_desc(entities::project::Column::CreatedAt)
+        let mut projects = entities::project::Entity::find()
+            .find_with_related(entities::project_root_attachment::Entity)
+            .order_by_asc(entities::project_root_attachment::Column::Position)
             .all(&self.conn)
             .await
             .map_err(store_err)?
             .into_iter()
-            .map(project_from_model)
-            .collect())
+            .map(|(model, roots)| project_from_models(model, roots))
+            .collect::<Result<Vec<_>>>()?;
+        projects.sort_by(|left, right| {
+            right
+                .created_at
+                .cmp(&left.created_at)
+                .then_with(|| right.id.0.cmp(&left.id.0))
+        });
+        Ok(projects)
     }
 
     async fn create_document(&self, document: &DocumentRecord) -> Result<()> {
@@ -1638,6 +1665,10 @@ impl Store for DbStore {
         ops::conversation::create_chat(self, chat).await
     }
 
+    async fn create_chat_with_project_defaults(&self, chat: &Chat) -> Result<Chat> {
+        ops::conversation::create_chat_with_project_defaults(self, chat).await
+    }
+
     async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()> {
         ops::conversation::set_chat_model(self, id, model).await
     }
@@ -2705,13 +2736,50 @@ where
     Ok(())
 }
 
-fn project_from_model(model: entities::project::Model) -> Project {
-    Project {
+pub(in crate::db) fn project_from_models(
+    model: entities::project::Model,
+    roots: Vec<entities::project_root_attachment::Model>,
+) -> Result<Project> {
+    let root_attachments = hydrate_project_root_attachments(ProjectId(model.id), roots)?;
+    let project = Project {
         id: ProjectId(model.id),
         title: model.title,
-        workspace_dir: PathBuf::from(model.workspace_dir),
+        attachment_revision: model.attachment_revision,
+        root_attachments,
         created_at: model.created_at,
+    };
+    validate_project_attachments(&project)?;
+    Ok(project)
+}
+
+fn hydrate_project_root_attachments(
+    project_id: ProjectId,
+    rows: Vec<entities::project_root_attachment::Model>,
+) -> Result<Vec<HostRootId>> {
+    if rows.len() > MAX_ROOT_ATTACHMENTS {
+        return Err(AgentError::Store(format!(
+            "project {project_id} exceeds the root attachment limit"
+        )));
     }
+    rows.into_iter()
+        .enumerate()
+        .map(|(expected, row)| {
+            if usize::try_from(row.position).ok() != Some(expected) {
+                return Err(AgentError::Store(format!(
+                    "project {project_id} root positions are not contiguous"
+                )));
+            }
+            HostRootId::from_uuid(row.root_id).map_err(|error| {
+                AgentError::Store(format!(
+                    "project {project_id} has an invalid root id: {error}"
+                ))
+            })
+        })
+        .collect()
+}
+
+fn validate_project_attachments(project: &Project) -> Result<()> {
+    validate_project_root_projection(project).map_err(|message| AgentError::Store(message.into()))
 }
 
 fn validate_document_source_regions(text: &str, regions: &[SourceRegion]) -> Result<()> {

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use chrono::Utc;
 use sea_orm::sea_query::OnConflict;
 use sea_orm::{
@@ -9,10 +7,14 @@ use sea_orm::{
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{ChatId, MessageId, ProjectId, TurnId};
-use crate::model::{Chat, Message, Role, ToolCallRecord, TurnRunStatus};
+use crate::id::{ChatId, HostRootId, MessageId, ProjectId, TurnId};
+use crate::model::{
+    validate_chat_root_projection, validate_chat_root_projection_against_project, Chat,
+    ChatRootAttachment, Message, Role, RootAttachmentOrigin, ToolCallRecord, TurnRunStatus,
+    MAX_ROOT_ATTACHMENTS,
+};
 
-use super::super::{entities, store_err, DbStore};
+use super::super::{entities, project_from_models, store_err, DbStore};
 use super::turn::canonical_db_timestamp;
 use super::{acquire_chat_write_lock, acquire_turn_write_lock};
 
@@ -90,17 +92,91 @@ where
 }
 
 pub(in crate::db) async fn create_chat(store: &DbStore, chat: &Chat) -> Result<()> {
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let project_roots = load_chat_project_roots(&transaction, chat.project_id).await?;
+    validate_chat_attachments(chat, &project_roots)?;
+    insert_chat_on(&transaction, chat).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(())
+}
+
+pub(in crate::db) async fn create_chat_with_project_defaults(
+    store: &DbStore,
+    base: &Chat,
+) -> Result<Chat> {
+    if base.attachment_revision != 0 || !base.root_attachments.is_empty() {
+        return Err(AgentError::Store(
+            "chat project defaults must be derived from an empty revision-zero projection".into(),
+        ));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let project_roots = load_chat_project_roots(&transaction, base.project_id).await?;
+    let mut chat = base.clone();
+    chat.root_attachments = project_roots
+        .into_iter()
+        .map(|root_id| ChatRootAttachment {
+            root_id,
+            origin: RootAttachmentOrigin::ProjectDefault,
+        })
+        .collect();
+    if !chat.root_attachments.is_empty() {
+        chat.attachment_revision = 1;
+    }
+    validate_chat_root_projection(&chat).map_err(|message| AgentError::Store(message.into()))?;
+    insert_chat_on(&transaction, &chat).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(chat)
+}
+
+async fn load_chat_project_roots<C>(
+    conn: &C,
+    project_id: Option<ProjectId>,
+) -> Result<Vec<HostRootId>>
+where
+    C: ConnectionTrait,
+{
+    let Some(project_id) = project_id else {
+        return Ok(Vec::new());
+    };
+    let mut rows = entities::project::Entity::find_by_id(project_id.0)
+        .find_with_related(entities::project_root_attachment::Entity)
+        .order_by_asc(entities::project_root_attachment::Column::Position)
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    let (model, roots) = rows
+        .pop()
+        .ok_or_else(|| AgentError::Store(format!("chat project {project_id} does not exist")))?;
+    Ok(project_from_models(model, roots)?.root_attachments)
+}
+
+async fn insert_chat_on<C>(conn: &C, chat: &Chat) -> Result<()>
+where
+    C: ConnectionTrait,
+{
     entities::chat::ActiveModel {
         id: Set(chat.id.0),
         project_id: Set(chat.project_id.map(|p| p.0)),
         title: Set(chat.title.clone()),
         model: Set(chat.model.clone()),
-        workspace_dir: Set(chat.workspace_dir.to_string_lossy().into_owned()),
+        attachment_revision: Set(chat.attachment_revision),
         created_at: Set(chat.created_at),
     }
-    .insert(&store.conn)
+    .insert(conn)
     .await
     .map_err(store_err)?;
+    for (position, attachment) in chat.root_attachments.iter().copied().enumerate() {
+        entities::chat_root_attachment::ActiveModel {
+            chat_id: Set(chat.id.0),
+            root_id: Set(*attachment.root_id.as_uuid()),
+            position: Set(i32::try_from(position)
+                .map_err(|_| AgentError::Store("chat root position exceeds i32".into()))?),
+            origin: Set(attachment_origin_to_db(attachment.origin).to_owned()),
+        }
+        .insert(conn)
+        .await
+        .map_err(store_err)?;
+    }
     Ok(())
 }
 
@@ -122,22 +198,34 @@ pub(in crate::db) async fn set_chat_model(
 }
 
 pub(in crate::db) async fn get_chat(store: &DbStore, id: ChatId) -> Result<Option<Chat>> {
-    Ok(entities::chat::Entity::find_by_id(id.0)
-        .one(&store.conn)
+    let mut rows = entities::chat::Entity::find_by_id(id.0)
+        .find_with_related(entities::chat_root_attachment::Entity)
+        .order_by_asc(entities::chat_root_attachment::Column::Position)
+        .all(&store.conn)
         .await
-        .map_err(store_err)?
-        .map(chat_from_model))
+        .map_err(store_err)?;
+    rows.pop()
+        .map(|(model, roots)| chat_from_models(model, roots))
+        .transpose()
 }
 
 pub(in crate::db) async fn list_chats(store: &DbStore) -> Result<Vec<Chat>> {
-    Ok(entities::chat::Entity::find()
-        .order_by_desc(entities::chat::Column::CreatedAt)
+    let mut chats = entities::chat::Entity::find()
+        .find_with_related(entities::chat_root_attachment::Entity)
+        .order_by_asc(entities::chat_root_attachment::Column::Position)
         .all(&store.conn)
         .await
         .map_err(store_err)?
         .into_iter()
-        .map(chat_from_model)
-        .collect())
+        .map(|(model, roots)| chat_from_models(model, roots))
+        .collect::<Result<Vec<_>>>()?;
+    chats.sort_by(|left, right| {
+        right
+            .created_at
+            .cmp(&left.created_at)
+            .then_with(|| right.id.0.cmp(&left.id.0))
+    });
+    Ok(chats)
 }
 
 pub(in crate::db) async fn append_message(store: &DbStore, message: &Message) -> Result<()> {
@@ -433,14 +521,66 @@ pub(in crate::db) async fn list_events(
         .collect()
 }
 
-fn chat_from_model(model: entities::chat::Model) -> Chat {
-    Chat {
+fn chat_from_models(
+    model: entities::chat::Model,
+    rows: Vec<entities::chat_root_attachment::Model>,
+) -> Result<Chat> {
+    if rows.len() > MAX_ROOT_ATTACHMENTS {
+        return Err(AgentError::Store(format!(
+            "chat {} exceeds the root attachment limit",
+            model.id
+        )));
+    }
+    let root_attachments = rows
+        .into_iter()
+        .enumerate()
+        .map(|(expected, row)| {
+            if usize::try_from(row.position).ok() != Some(expected) {
+                return Err(AgentError::Store(format!(
+                    "chat {} root positions are not contiguous",
+                    model.id
+                )));
+            }
+            Ok(ChatRootAttachment {
+                root_id: HostRootId::from_uuid(row.root_id).map_err(|error| {
+                    AgentError::Store(format!("chat {} has an invalid root id: {error}", model.id))
+                })?,
+                origin: attachment_origin_from_db(&row.origin)?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let chat = Chat {
         id: ChatId(model.id),
         project_id: model.project_id.map(ProjectId),
         title: model.title,
         model: model.model,
-        workspace_dir: PathBuf::from(model.workspace_dir),
+        attachment_revision: model.attachment_revision,
+        root_attachments,
         created_at: model.created_at,
+    };
+    validate_chat_root_projection(&chat).map_err(|message| AgentError::Store(message.into()))?;
+    Ok(chat)
+}
+
+fn validate_chat_attachments(chat: &Chat, project_roots: &[HostRootId]) -> Result<()> {
+    validate_chat_root_projection_against_project(chat, project_roots)
+        .map_err(|message| AgentError::Store(message.into()))
+}
+
+fn attachment_origin_to_db(origin: RootAttachmentOrigin) -> &'static str {
+    match origin {
+        RootAttachmentOrigin::ProjectDefault => "project_default",
+        RootAttachmentOrigin::Conversation => "conversation",
+    }
+}
+
+fn attachment_origin_from_db(value: &str) -> Result<RootAttachmentOrigin> {
+    match value {
+        "project_default" => Ok(RootAttachmentOrigin::ProjectDefault),
+        "conversation" => Ok(RootAttachmentOrigin::Conversation),
+        other => Err(AgentError::Store(format!(
+            "unknown chat root attachment origin: {other}"
+        ))),
     }
 }
 

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::model::{
-    ByteSpan, DocumentParseOutput, DocumentSourceBlob, DocumentSourceUpsert, SourceLocation,
-    ToolCallExecution, ToolCallResolution, ToolCallStatus,
+    ByteSpan, ChatRootAttachment, DocumentParseOutput, DocumentSourceBlob, DocumentSourceUpsert,
+    RootAttachmentOrigin, SourceLocation, ToolCallExecution, ToolCallResolution, ToolCallStatus,
+    MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
 };
 use crate::storage::ApplyTurnSteerOutcome;
 use chrono::{DateTime, Utc};
@@ -21,7 +22,8 @@ fn sample_chat() -> Chat {
         project_id: None,
         title: Some("hello".into()),
         model: None,
-        workspace_dir: PathBuf::from("/tmp/ws"),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
         created_at: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
     }
 }
@@ -42,7 +44,8 @@ fn sample_project() -> Project {
     Project {
         id: ProjectId::new(),
         title: Some("proj".into()),
-        workspace_dir: PathBuf::from("/tmp/proj"),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
         created_at: DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
     }
 }
@@ -130,6 +133,269 @@ async fn projects_roundtrip_and_a_chat_can_belong_to_one() {
     };
     assert_eq!(listed_link(in_project.id), Some(project.id));
     assert_eq!(listed_link(loose.id), None);
+}
+
+#[tokio::test]
+async fn ordered_root_projections_roundtrip_and_project_defaults_are_snapshotted() {
+    let (_dir, store) = temp_store().await;
+    let root_a = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let root_b = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let root_c = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let mut project = sample_project();
+    project.attachment_revision = 7;
+    project.root_attachments = vec![root_b, root_a];
+    store.create_project(&project).await.unwrap();
+    assert_eq!(
+        store.get_project(project.id).await.unwrap(),
+        Some(project.clone())
+    );
+
+    let mut chat = sample_chat();
+    chat.project_id = Some(project.id);
+    chat.attachment_revision = 1;
+    chat.root_attachments = vec![
+        ChatRootAttachment {
+            root_id: root_b,
+            origin: RootAttachmentOrigin::ProjectDefault,
+        },
+        ChatRootAttachment {
+            root_id: root_a,
+            origin: RootAttachmentOrigin::ProjectDefault,
+        },
+        ChatRootAttachment {
+            root_id: root_c,
+            origin: RootAttachmentOrigin::Conversation,
+        },
+    ];
+    store.create_chat(&chat).await.unwrap();
+    assert_eq!(store.get_chat(chat.id).await.unwrap(), Some(chat));
+}
+
+#[tokio::test]
+async fn root_projection_validation_fails_closed() {
+    let (_dir, store) = temp_store().await;
+    let root = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+
+    let mut duplicate_project = sample_project();
+    duplicate_project.root_attachments = vec![root, root];
+    assert!(store.create_project(&duplicate_project).await.is_err());
+
+    let mut oversized_project = sample_project();
+    oversized_project.root_attachments = (0..=MAX_ROOT_ATTACHMENTS)
+        .map(|_| HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap())
+        .collect();
+    assert!(store.create_project(&oversized_project).await.is_err());
+
+    let project_root = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let mut project = sample_project();
+    project.attachment_revision = 1;
+    project.root_attachments = vec![project_root];
+    store.create_project(&project).await.unwrap();
+
+    let mut stale_snapshot = sample_chat();
+    stale_snapshot.project_id = Some(project.id);
+    stale_snapshot.attachment_revision = 1;
+    stale_snapshot.root_attachments = vec![ChatRootAttachment {
+        root_id: root,
+        origin: RootAttachmentOrigin::ProjectDefault,
+    }];
+    assert!(store.create_chat(&stale_snapshot).await.is_err());
+    assert!(store.get_chat(stale_snapshot.id).await.unwrap().is_none());
+
+    let mut standalone = sample_chat();
+    standalone.attachment_revision = 1;
+    standalone.root_attachments = vec![ChatRootAttachment {
+        root_id: root,
+        origin: RootAttachmentOrigin::ProjectDefault,
+    }];
+    assert!(store.create_chat(&standalone).await.is_err());
+
+    let mut zero_revision = sample_chat();
+    zero_revision.root_attachments = vec![ChatRootAttachment {
+        root_id: root,
+        origin: RootAttachmentOrigin::Conversation,
+    }];
+    assert!(store.create_chat(&zero_revision).await.is_err());
+
+    let mut orphan = sample_chat();
+    orphan.project_id = Some(ProjectId::new());
+    assert!(store.create_chat(&orphan).await.is_err());
+    assert!(store.get_chat(orphan.id).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn corrupted_root_projection_rows_fail_closed_on_read() {
+    let (_dir, store) = temp_store().await;
+    let standalone = sample_chat();
+    store.create_chat(&standalone).await.unwrap();
+    entities::chat::Entity::update_many()
+        .col_expr(
+            entities::chat::Column::AttachmentRevision,
+            sea_orm::sea_query::Expr::value(1_i64),
+        )
+        .filter(entities::chat::Column::Id.eq(standalone.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    entities::chat_root_attachment::ActiveModel {
+        chat_id: Set(standalone.id.0),
+        root_id: Set(uuid::Uuid::new_v4()),
+        position: Set(0),
+        origin: Set("project_default".into()),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    assert!(store.get_chat(standalone.id).await.is_err());
+
+    let gapped = sample_chat();
+    store.create_chat(&gapped).await.unwrap();
+    entities::chat::Entity::update_many()
+        .col_expr(
+            entities::chat::Column::AttachmentRevision,
+            sea_orm::sea_query::Expr::value(1_i64),
+        )
+        .filter(entities::chat::Column::Id.eq(gapped.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    entities::chat_root_attachment::ActiveModel {
+        chat_id: Set(gapped.id.0),
+        root_id: Set(uuid::Uuid::new_v4()),
+        position: Set(1),
+        origin: Set("conversation".into()),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    assert!(store.get_chat(gapped.id).await.is_err());
+
+    let project = sample_project();
+    store.create_project(&project).await.unwrap();
+    let mut mixed = sample_chat();
+    mixed.project_id = Some(project.id);
+    store.create_chat(&mixed).await.unwrap();
+    entities::chat::Entity::update_many()
+        .col_expr(
+            entities::chat::Column::AttachmentRevision,
+            sea_orm::sea_query::Expr::value(2_i64),
+        )
+        .filter(entities::chat::Column::Id.eq(mixed.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    for (position, origin) in [(0, "conversation"), (1, "project_default")] {
+        entities::chat_root_attachment::ActiveModel {
+            chat_id: Set(mixed.id.0),
+            root_id: Set(uuid::Uuid::new_v4()),
+            position: Set(position),
+            origin: Set(origin.into()),
+        }
+        .insert(&store.conn)
+        .await
+        .unwrap();
+    }
+    assert!(store.get_chat(mixed.id).await.is_err());
+
+    let corrupted_project = sample_project();
+    store.create_project(&corrupted_project).await.unwrap();
+    entities::project_root_attachment::ActiveModel {
+        project_id: Set(corrupted_project.id.0),
+        root_id: Set(uuid::Uuid::new_v4()),
+        position: Set(0),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    assert!(store.get_project(corrupted_project.id).await.is_err());
+    let mut base = sample_chat();
+    base.project_id = Some(corrupted_project.id);
+    assert!(store
+        .create_chat_with_project_defaults(&base)
+        .await
+        .is_err());
+    assert!(store.get_chat(base.id).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn project_membership_fk_and_attachment_insertions_are_atomic() {
+    let (_dir, store) = temp_store().await;
+    let orphan = entities::chat::ActiveModel {
+        id: Set(uuid::Uuid::new_v4()),
+        project_id: Set(Some(uuid::Uuid::new_v4())),
+        title: Set(None),
+        model: Set(None),
+        attachment_revision: Set(0),
+        created_at: Set(Utc::now()),
+    };
+    assert!(orphan.insert(&store.conn).await.is_err());
+
+    let project = sample_project();
+    store.create_project(&project).await.unwrap();
+    let mut chat = sample_chat();
+    chat.project_id = Some(project.id);
+    store.create_chat(&chat).await.unwrap();
+    assert!(entities::project::Entity::delete_by_id(project.id.0)
+        .exec(&store.conn)
+        .await
+        .is_err());
+
+    let mut max_revision = sample_project();
+    max_revision.attachment_revision = MAX_ATTACHMENT_REVISION;
+    store.create_project(&max_revision).await.unwrap();
+    let mut excessive_revision = sample_project();
+    excessive_revision.attachment_revision = MAX_ATTACHMENT_REVISION + 1;
+    assert!(store.create_project(&excessive_revision).await.is_err());
+    let direct_excessive = entities::project::ActiveModel {
+        id: Set(uuid::Uuid::new_v4()),
+        title: Set(None),
+        attachment_revision: Set(MAX_ATTACHMENT_REVISION + 1),
+        created_at: Set(Utc::now()),
+    };
+    assert!(direct_excessive.insert(&store.conn).await.is_err());
+
+    let root = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let mut rooted_project = sample_project();
+    rooted_project.attachment_revision = 1;
+    rooted_project.root_attachments = vec![root];
+    store.create_project(&rooted_project).await.unwrap();
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_chat_root_insert
+             BEFORE INSERT ON chat_root_attachment
+             BEGIN SELECT RAISE(FAIL, 'forced chat root failure'); END;",
+        )
+        .await
+        .unwrap();
+    let mut rejected_chat = sample_chat();
+    rejected_chat.project_id = Some(rooted_project.id);
+    assert!(store
+        .create_chat_with_project_defaults(&rejected_chat)
+        .await
+        .is_err());
+    assert!(store.get_chat(rejected_chat.id).await.unwrap().is_none());
+    store
+        .conn
+        .execute_unprepared("DROP TRIGGER fail_chat_root_insert")
+        .await
+        .unwrap();
+
+    store
+        .conn
+        .execute_unprepared(
+            "CREATE TRIGGER fail_project_root_insert
+             BEFORE INSERT ON project_root_attachment
+             BEGIN SELECT RAISE(FAIL, 'forced project root failure'); END;",
+        )
+        .await
+        .unwrap();
+    let root = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let mut rejected = sample_project();
+    rejected.attachment_revision = 1;
+    rejected.root_attachments = vec![root];
+    assert!(store.create_project(&rejected).await.is_err());
+    assert!(store.get_project(rejected.id).await.unwrap().is_none());
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -6,6 +6,7 @@
 //! `Store` they are indistinguishable from a plain UUID.
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use uuid::Uuid;
 
 /// Declares a UUID-backed identifier newtype with the common impls.
@@ -62,6 +63,67 @@ id_type!(
     /// Identifies a project: an optional grouping a chat may belong to.
     ProjectId
 );
+
+/// Opaque identifier for a folder registered with a host broker.
+///
+/// This is product projection data, not authority: possession of an id never
+/// grants access to the corresponding host path. The broker independently
+/// validates live attachments, consent, capabilities, and revocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct HostRootId(Uuid);
+
+impl HostRootId {
+    /// Build a root id from its non-nil wire UUID.
+    pub fn from_uuid(uuid: Uuid) -> Result<Self, HostRootIdError> {
+        if uuid.is_nil() {
+            Err(HostRootIdError::Nil)
+        } else {
+            Ok(Self(uuid))
+        }
+    }
+
+    /// Borrow the underlying UUID.
+    #[must_use]
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for HostRootId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let uuid = Uuid::deserialize(deserializer)?;
+        Self::from_uuid(uuid).map_err(serde::de::Error::custom)
+    }
+}
+
+impl std::fmt::Display for HostRootId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl std::str::FromStr for HostRootId {
+    type Err = HostRootIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::from_uuid(Uuid::parse_str(value)?)
+    }
+}
+
+/// Invalid opaque host-root identity.
+#[derive(Debug, Error)]
+pub enum HostRootIdError {
+    /// The value is not a UUID.
+    #[error("invalid host root id: {0}")]
+    InvalidUuid(#[from] uuid::Error),
+    /// Nil is reserved and never identifies a broker root.
+    #[error("host root id must not be nil")]
+    Nil,
+}
 id_type!(
     /// Identifies an authoritative source document.
     ///
@@ -96,7 +158,7 @@ impl DocumentId {
     }
 }
 id_type!(
-    /// Identifies a persistent conversation (owns a workspace directory).
+    /// Identifies a persistent conversation.
     ChatId
 );
 id_type!(
@@ -140,6 +202,18 @@ mod tests {
         // Transparent: serializes as the bare quoted UUID, no wrapper.
         assert_eq!(json, format!("\"{id}\""));
         assert_eq!(serde_json::from_str::<ChatId>(&json).unwrap(), id);
+    }
+
+    #[test]
+    fn host_root_ids_reject_nil_and_roundtrip() {
+        let uuid = Uuid::new_v4();
+        let id = HostRootId::from_uuid(uuid).unwrap();
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(serde_json::from_str::<HostRootId>(&json).unwrap(), id);
+        assert!(HostRootId::from_uuid(Uuid::nil()).is_err());
+        assert!(
+            serde_json::from_str::<HostRootId>("\"00000000-0000-0000-0000-000000000000\"").is_err()
+        );
     }
 
     #[test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -54,19 +54,20 @@ pub use db::DbStore;
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{
-    CallId, ChatId, DocumentId, DocumentJobId, MessageId, ProjectId, StepId, TurnId, TurnSteerId,
+    CallId, ChatId, DocumentId, DocumentJobId, HostRootId, HostRootIdError, MessageId, ProjectId,
+    StepId, TurnId, TurnSteerId,
 };
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
 pub use model::{
     validate_source_regions, BlobRetirement, BlobRetirementStatus, ByteSpan, Chat,
-    ClientToolCallRequest, DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus,
-    DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus, DocumentRecord,
-    DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert,
-    Message, Project, Role, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
-    ToolCallResolution, ToolCallStatus, TurnCheckpointProgress, TurnClientWait,
-    TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer,
-    TurnSteerStatus,
+    ChatRootAttachment, ClientToolCallRequest, DocumentGeneration, DocumentJob, DocumentJobKind,
+    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
+    DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
+    DocumentUpsert, Message, Project, Role, RootAttachmentOrigin, SourceLocation, SourceRegion,
+    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress,
+    TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun,
+    TurnRunStatus, TurnSteer, TurnSteerStatus, MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
@@ -82,6 +83,6 @@ pub use storage::{
     JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
     RequestTurnCancellationOutcome, ResolveToolCallOutcome, SecretProvider, Store,
 };
-pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
+pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
 #[cfg(feature = "tools")]
 pub use tools::{ListDir, ReadFile, WriteFile};

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1,12 +1,11 @@
 //! The persisted conversation model.
 //!
 //! Mirrors the conversation tables of `Store` schema v1. A
-//! [`Chat`] is a durable conversation that owns a workspace directory; a
+//! [`Chat`] is a durable conversation with an ordered, pathless host-root
+//! projection; a
 //! [`TurnRun`] is one durably scheduled agent turn, and a [`Message`] is one
 //! user input or assistant answer within it. Steps remain runtime concepts of
 //! the agent loop.
-
-use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -94,9 +93,44 @@ pub fn validate_source_regions(
     Ok(())
 }
 
-use crate::id::{CallId, ChatId, DocumentId, DocumentJobId, MessageId, ProjectId, TurnId};
+use crate::id::{
+    CallId, ChatId, DocumentId, DocumentJobId, HostRootId, MessageId, ProjectId, TurnId,
+};
 
-/// An optional grouping of chats that share a workspace and (later) a document
+/// Maximum number of host roots projected onto one project or conversation.
+///
+/// The host broker separately bounds and authorizes its live registry. This
+/// product-side limit keeps API responses, turn snapshots, and future CAS
+/// replacements predictably small.
+pub const MAX_ROOT_ATTACHMENTS: usize = 32;
+
+/// Largest attachment revision represented exactly by every supported client.
+///
+/// JSON numbers become JavaScript `number` values in the desktop renderer, so
+/// revisions stay within the integer-safe range instead of silently losing CAS
+/// precision at the product boundary.
+pub const MAX_ATTACHMENT_REVISION: i64 = 9_007_199_254_740_991;
+
+/// Why a root appears in one conversation's exact ordered projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RootAttachmentOrigin {
+    /// Snapshotted from project defaults when the conversation was created.
+    ProjectDefault,
+    /// Added specifically to this conversation by trusted native control.
+    Conversation,
+}
+
+/// One pathless root in a conversation's exact ordered projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChatRootAttachment {
+    /// Opaque broker root identity. This value grants no authority by itself.
+    pub root_id: HostRootId,
+    /// Product-level provenance for ordering and future management UI.
+    pub origin: RootAttachmentOrigin,
+}
+
+/// An optional grouping of chats that share project context and a document
 /// corpus. A chat may belong to a project or stand alone — unlike some designs
 /// that make a project mandatory, OpenWave keeps loose, projectless chats.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -105,8 +139,11 @@ pub struct Project {
     pub id: ProjectId,
     /// Human-facing title.
     pub title: Option<String>,
-    /// Absolute path to the project's workspace/corpus root.
-    pub workspace_dir: PathBuf,
+    /// CAS revision of the ordered root projection.
+    pub attachment_revision: i64,
+    /// Ordered opaque root defaults for conversations created in this project.
+    /// These ids are product state, never host authorization.
+    pub root_attachments: Vec<HostRootId>,
     /// When the project was created.
     pub created_at: DateTime<Utc>,
 }
@@ -594,7 +631,7 @@ pub enum Role {
     Tool,
 }
 
-/// A persistent conversation. Owns a workspace directory the agent operates in.
+/// A persistent conversation with an exact, ordered host-root projection.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Chat {
     /// Stable identifier.
@@ -605,10 +642,99 @@ pub struct Chat {
     pub title: Option<String>,
     /// The model this chat runs against, or `None` to use the configured default.
     pub model: Option<String>,
-    /// Absolute path to this chat's workspace directory.
-    pub workspace_dir: PathBuf,
+    /// CAS revision of this conversation's exact root projection.
+    pub attachment_revision: i64,
+    /// Ordered opaque roots available for future broker-backed operations.
+    /// Live broker authorization remains mandatory and may revoke access at any
+    /// time, regardless of this projection.
+    pub root_attachments: Vec<ChatRootAttachment>,
     /// When the chat was created.
     pub created_at: DateTime<Utc>,
+}
+
+pub(crate) fn validate_project_root_projection(project: &Project) -> Result<(), &'static str> {
+    if !(0..=MAX_ATTACHMENT_REVISION).contains(&project.attachment_revision) {
+        return Err("project attachment revision is outside the supported range");
+    }
+    if project.root_attachments.len() > MAX_ROOT_ATTACHMENTS {
+        return Err("project root attachment count exceeds the supported limit");
+    }
+    if !project.root_attachments.is_empty() && project.attachment_revision == 0 {
+        return Err("a nonempty project root projection must have a positive revision");
+    }
+    let unique = project
+        .root_attachments
+        .iter()
+        .copied()
+        .collect::<std::collections::HashSet<_>>();
+    if unique.len() != project.root_attachments.len() {
+        return Err("project root attachments must be unique");
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_chat_root_projection(chat: &Chat) -> Result<(), &'static str> {
+    if !(0..=MAX_ATTACHMENT_REVISION).contains(&chat.attachment_revision) {
+        return Err("chat attachment revision is outside the supported range");
+    }
+    if chat.root_attachments.len() > MAX_ROOT_ATTACHMENTS {
+        return Err("chat root attachment count exceeds the supported limit");
+    }
+    if !chat.root_attachments.is_empty() && chat.attachment_revision == 0 {
+        return Err("a nonempty chat root projection must have a positive revision");
+    }
+    let unique = chat
+        .root_attachments
+        .iter()
+        .map(|attachment| attachment.root_id)
+        .collect::<std::collections::HashSet<_>>();
+    if unique.len() != chat.root_attachments.len() {
+        return Err("chat root attachments must be unique");
+    }
+    if chat.project_id.is_none()
+        && chat
+            .root_attachments
+            .iter()
+            .any(|attachment| attachment.origin == RootAttachmentOrigin::ProjectDefault)
+    {
+        return Err("a standalone chat cannot contain project-default roots");
+    }
+    let mut conversation_root_seen = false;
+    for attachment in &chat.root_attachments {
+        match attachment.origin {
+            RootAttachmentOrigin::ProjectDefault if conversation_root_seen => {
+                return Err("project-default roots must precede conversation roots");
+            }
+            RootAttachmentOrigin::Conversation => conversation_root_seen = true,
+            RootAttachmentOrigin::ProjectDefault => {}
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_chat_root_projection_against_project(
+    chat: &Chat,
+    project_roots: &[HostRootId],
+) -> Result<(), &'static str> {
+    validate_chat_root_projection(chat)?;
+    if chat.project_id.is_none() && !project_roots.is_empty() {
+        return Err("a standalone chat cannot snapshot project roots");
+    }
+    if chat.root_attachments.len() < project_roots.len() {
+        return Err("chat is missing project root defaults");
+    }
+    for (expected, actual) in project_roots.iter().zip(&chat.root_attachments) {
+        if actual.root_id != *expected || actual.origin != RootAttachmentOrigin::ProjectDefault {
+            return Err("chat project root snapshot does not match current project defaults");
+        }
+    }
+    if chat.root_attachments[project_roots.len()..]
+        .iter()
+        .any(|attachment| attachment.origin != RootAttachmentOrigin::Conversation)
+    {
+        return Err("chat-specific roots must follow project defaults");
+    }
+    Ok(())
 }
 
 /// Durable execution state of one user turn.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -744,12 +744,17 @@ pub trait Store: Send + Sync {
 
     /// Persist a new chat.
     ///
-    /// A chat's `project_id`, when set, is not checked against an existing
-    /// project here — there is no database foreign key on the link (SQLite can't
-    /// add one to an existing table). Callers that accept a `project_id` from
-    /// outside must verify the project exists first (the server does so at its
-    /// API edge) to avoid persisting a dangling reference.
+    /// The ordered projection must be valid. When `project_id` is set, the
+    /// project must exist and the leading `project_default` roots must exactly
+    /// snapshot its current ordered defaults. The insertion is atomic.
     async fn create_chat(&self, chat: &Chat) -> Result<()>;
+
+    /// Persist a new chat while atomically deriving its project-default roots.
+    ///
+    /// `chat` must carry revision zero and an empty projection. Implementations
+    /// resolve the current project inside the same atomic operation that inserts
+    /// the chat, returning the exact persisted snapshot.
+    async fn create_chat_with_project_defaults(&self, chat: &Chat) -> Result<Chat>;
 
     /// Fetch a chat by id, or `None` if it doesn't exist.
     async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>>;

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -6,7 +6,9 @@ use futures::executor::block_on;
 
 use super::*;
 use crate::model::{
-    DocumentJobKind, DocumentJobStatus, DocumentProcessingStatus, ToolCallExecution, ToolCallStatus,
+    validate_chat_root_projection, validate_chat_root_projection_against_project,
+    validate_project_root_projection, ChatRootAttachment, DocumentJobKind, DocumentJobStatus,
+    DocumentProcessingStatus, RootAttachmentOrigin, ToolCallExecution, ToolCallStatus,
 };
 
 /// Minimal in-memory `Store` — proves the trait is object-safe and usable
@@ -150,10 +152,13 @@ fn reset_mem_document_job(
 #[async_trait]
 impl Store for MemStore {
     async fn create_project(&self, project: &Project) -> Result<()> {
-        self.projects
-            .lock()
-            .unwrap()
-            .insert(project.id, project.clone());
+        validate_project_root_projection(project)
+            .map_err(|message| AgentError::Store(message.into()))?;
+        let mut projects = self.projects.lock().unwrap();
+        if projects.contains_key(&project.id) {
+            return Err(AgentError::Store("project already exists".into()));
+        }
+        projects.insert(project.id, project.clone());
         Ok(())
     }
     async fn get_project(&self, id: ProjectId) -> Result<Option<Project>> {
@@ -1192,8 +1197,58 @@ impl Store for MemStore {
         Ok(true)
     }
     async fn create_chat(&self, chat: &Chat) -> Result<()> {
-        self.chats.lock().unwrap().insert(chat.id, chat.clone());
+        validate_chat_root_projection(chat).map_err(|message| AgentError::Store(message.into()))?;
+        let projects = self.projects.lock().unwrap();
+        let project_roots = match chat.project_id {
+            Some(project_id) => projects
+                .get(&project_id)
+                .ok_or_else(|| AgentError::Store("chat project does not exist".into()))?
+                .root_attachments
+                .as_slice(),
+            None => &[],
+        };
+        validate_chat_root_projection_against_project(chat, project_roots)
+            .map_err(|message| AgentError::Store(message.into()))?;
+        let mut chats = self.chats.lock().unwrap();
+        if chats.contains_key(&chat.id) {
+            return Err(AgentError::Store("chat already exists".into()));
+        }
+        chats.insert(chat.id, chat.clone());
         Ok(())
+    }
+    async fn create_chat_with_project_defaults(&self, base: &Chat) -> Result<Chat> {
+        if base.attachment_revision != 0 || !base.root_attachments.is_empty() {
+            return Err(AgentError::Store(
+                "chat project defaults must start from an empty revision-zero projection".into(),
+            ));
+        }
+        let projects = self.projects.lock().unwrap();
+        let mut chat = base.clone();
+        if let Some(project_id) = chat.project_id {
+            let project = projects
+                .get(&project_id)
+                .ok_or_else(|| AgentError::Store("chat project does not exist".into()))?;
+            chat.root_attachments = project
+                .root_attachments
+                .iter()
+                .copied()
+                .map(|root_id| ChatRootAttachment {
+                    root_id,
+                    origin: RootAttachmentOrigin::ProjectDefault,
+                })
+                .collect();
+            if !chat.root_attachments.is_empty() {
+                chat.attachment_revision = 1;
+            }
+        }
+        validate_chat_root_projection(&chat)
+            .map_err(|message| AgentError::Store(message.into()))?;
+        let mut chats = self.chats.lock().unwrap();
+        if chats.contains_key(&chat.id) {
+            return Err(AgentError::Store("chat already exists".into()));
+        }
+        chats.insert(chat.id, chat.clone());
+        Ok(chat)
     }
     async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
         Ok(self.chats.lock().unwrap().get(&id).cloned())
@@ -1524,7 +1579,8 @@ fn store_is_object_safe_and_roundtrips() {
         project_id: None,
         title: None,
         model: None,
-        workspace_dir: "/tmp/ws".into(),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
         created_at: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap(),
     };
     block_on(store.create_chat(&chat)).unwrap();
@@ -1631,12 +1687,14 @@ fn mem_store_rejects_moving_a_live_document_between_corpora() {
     let project_a = Project {
         id: ProjectId::new(),
         title: None,
-        workspace_dir: "/tmp/a".into(),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
         created_at: chrono::Utc::now(),
     };
     let project_b = Project {
         id: ProjectId::new(),
-        workspace_dir: "/tmp/b".into(),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
         ..project_a.clone()
     };
     block_on(store.create_project(&project_a)).unwrap();

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -21,6 +21,36 @@ use serde_json::Value;
 use crate::error::Result;
 use crate::id::{ChatId, ProjectId};
 
+/// A pinned runtime-only directory capability for legacy private-scratch tools.
+///
+/// It carries no host path and grants access only to the already-open directory
+/// handle supplied by the embedding runtime.
+#[derive(Clone)]
+pub struct ToolScratch {
+    #[cfg(feature = "tools")]
+    workspace: Arc<Dir>,
+}
+
+impl std::fmt::Debug for ToolScratch {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ToolScratch")
+            .field("available", &cfg!(feature = "tools"))
+            .finish_non_exhaustive()
+    }
+}
+
+impl ToolScratch {
+    /// Wrap an already-open exact directory capability.
+    #[cfg(feature = "tools")]
+    #[must_use]
+    pub fn from_dir(workspace: Dir) -> Self {
+        Self {
+            workspace: Arc::new(workspace),
+        }
+    }
+}
+
 /// The approval policy class a tool declares for itself.
 ///
 /// Policy maps class → auto-approve / ask / deny. In v1: `ReadOnly` and
@@ -105,9 +135,6 @@ pub struct ToolCtx {
     pub chat_id: ChatId,
     /// Project corpus inherited from the chat, or `None` for a loose chat.
     pub project_id: Option<ProjectId>,
-    /// Absolute path to the chat's workspace directory. Workspace-class
-    /// tools stay within it without prompting.
-    pub workspace_dir: PathBuf,
     #[cfg(feature = "tools")]
     workspace: WorkspaceAccess,
 }
@@ -125,30 +152,33 @@ impl std::fmt::Debug for ToolCtx {
             .debug_struct("ToolCtx")
             .field("chat_id", &self.chat_id)
             .field("project_id", &self.project_id)
-            .field("workspace_dir", &self.workspace_dir)
+            .field("private_scratch_available", &self.scratch_available())
             .finish_non_exhaustive()
     }
 }
 
 impl ToolCtx {
-    /// Build an execution context and pin the workspace to an open directory
-    /// capability. A missing workspace remains a model-facing tool error rather
-    /// than preventing unrelated tools from running.
-    pub fn new(chat_id: ChatId, project_id: Option<ProjectId>, workspace_dir: PathBuf) -> Self {
-        match Self::try_new(chat_id, project_id, workspace_dir.clone()) {
+    /// Build a legacy CLI/MCP context by opening an explicit workspace path.
+    ///
+    /// Product turns must use a pinned [`ToolScratch`] supplied by their runtime.
+    pub fn new_legacy_workspace(
+        chat_id: ChatId,
+        project_id: Option<ProjectId>,
+        workspace_dir: PathBuf,
+    ) -> Self {
+        match Self::try_new_legacy_workspace(chat_id, project_id, workspace_dir) {
             Ok(ctx) => ctx,
             Err(_error) => Self {
                 chat_id,
                 project_id,
-                workspace_dir,
                 #[cfg(feature = "tools")]
                 workspace: WorkspaceAccess::Unavailable(_error.to_string().into()),
             },
         }
     }
 
-    /// Build an execution context, failing if its workspace cannot be pinned.
-    pub fn try_new(
+    /// Build a legacy CLI/MCP context, failing if its path cannot be pinned.
+    pub fn try_new_legacy_workspace(
         chat_id: ChatId,
         project_id: Option<ProjectId>,
         workspace_dir: PathBuf,
@@ -158,10 +188,49 @@ impl ToolCtx {
         Ok(Self {
             chat_id,
             project_id,
-            workspace_dir,
             #[cfg(feature = "tools")]
             workspace: WorkspaceAccess::Open(Arc::new(workspace)),
         })
+    }
+
+    /// Build a product execution context from an exact pinned scratch handle.
+    #[must_use]
+    pub fn with_private_scratch(
+        chat_id: ChatId,
+        project_id: Option<ProjectId>,
+        scratch: ToolScratch,
+    ) -> Self {
+        Self {
+            chat_id,
+            project_id,
+            #[cfg(feature = "tools")]
+            workspace: WorkspaceAccess::Open(scratch.workspace),
+        }
+    }
+
+    /// Build a context with no direct filesystem scratch available.
+    ///
+    /// Non-filesystem tools remain usable; a legacy filesystem tool fails
+    /// closed instead of resolving an absent path against the process CWD.
+    #[must_use]
+    pub fn without_private_scratch(chat_id: ChatId, project_id: Option<ProjectId>) -> Self {
+        Self {
+            chat_id,
+            project_id,
+            #[cfg(feature = "tools")]
+            workspace: WorkspaceAccess::Unavailable("private scratch is unavailable".into()),
+        }
+    }
+
+    fn scratch_available(&self) -> bool {
+        #[cfg(feature = "tools")]
+        {
+            matches!(&self.workspace, WorkspaceAccess::Open(_))
+        }
+        #[cfg(not(feature = "tools"))]
+        {
+            false
+        }
     }
 
     #[cfg(feature = "tools")]
@@ -169,7 +238,7 @@ impl ToolCtx {
         match &self.workspace {
             WorkspaceAccess::Open(workspace) => Ok(Arc::clone(workspace)),
             WorkspaceAccess::Unavailable(error) => {
-                Err(format!("workspace directory unavailable: {error}"))
+                Err(format!("private scratch unavailable: {error}"))
             }
         }
     }

--- a/crates/openwave-core/src/tools.rs
+++ b/crates/openwave-core/src/tools.rs
@@ -1,7 +1,7 @@
 //! Built-in filesystem tools: `read_file`, `list_dir`, `write_file`.
 //!
 //! These are the M0 Workspace-class tools. Every path is resolved **relative to
-//! the chat's workspace directory** and may not escape it (no absolute paths,
+//! the chat's private scratch directory** and may not escape it (no absolute paths,
 //! no `..`). Filesystem operations are relative to a pinned directory
 //! capability, so symlinks and path replacement cannot escape it. Failures the
 //! model should see and react to (missing file, bad path)
@@ -32,7 +32,7 @@ const MAX_LIST_DIR_ENTRIES: usize = 4_096;
 fn workspace_relative(rel: &str) -> std::result::Result<PathBuf, String> {
     let path = Path::new(rel);
     if path.is_absolute() {
-        return Err(format!("path must be relative to the workspace: {rel}"));
+        return Err(format!("path must be relative to private scratch: {rel}"));
     }
     for component in path.components() {
         match component {
@@ -40,7 +40,7 @@ fn workspace_relative(rel: &str) -> std::result::Result<PathBuf, String> {
                 return Err(format!("path may not contain `..`: {rel}"));
             }
             Component::Prefix(_) | Component::RootDir => {
-                return Err(format!("path must be relative to the workspace: {rel}"));
+                return Err(format!("path must be relative to private scratch: {rel}"));
             }
             _ => {}
         }
@@ -180,11 +180,12 @@ impl Tool for ReadFile {
     fn spec(&self) -> ToolSpec {
         ToolSpec {
             name: "read_file".into(),
-            description: "Read a UTF-8 text file, relative to the workspace directory.".into(),
+            description: "Read a UTF-8 text file, relative to the private scratch directory."
+                .into(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Workspace-relative file path." }
+                    "path": { "type": "string", "description": "Private-scratch-relative file path." }
                 },
                 "required": ["path"]
             }),
@@ -223,7 +224,7 @@ impl Tool for ReadFile {
     }
 }
 
-/// `list_dir` — list the entries of a workspace directory.
+/// `list_dir` — list the entries of a private scratch directory.
 pub struct ListDir;
 
 #[derive(Deserialize)]
@@ -237,11 +238,12 @@ impl Tool for ListDir {
     fn spec(&self) -> ToolSpec {
         ToolSpec {
             name: "list_dir".into(),
-            description: "List the entries of a workspace directory (defaults to the root).".into(),
+            description: "List the entries of a private scratch directory (defaults to the root)."
+                .into(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Workspace-relative directory (optional)." }
+                    "path": { "type": "string", "description": "Private-scratch-relative directory (optional)." }
                 }
             }),
         }
@@ -276,8 +278,8 @@ impl Tool for ListDir {
     }
 }
 
-/// `write_file` — write a UTF-8 text file into the workspace (creating parent
-/// directories). Workspace-class: auto-approved inside the workspace.
+/// `write_file` — write a UTF-8 text file into private scratch (creating parent
+/// directories). Workspace-class: auto-approved inside private scratch.
 pub struct WriteFile;
 
 #[derive(Deserialize)]
@@ -291,13 +293,13 @@ impl Tool for WriteFile {
     fn spec(&self) -> ToolSpec {
         ToolSpec {
             name: "write_file".into(),
-            description: "Write a UTF-8 text file into the workspace, creating parent \
+            description: "Write a UTF-8 text file into private scratch, creating parent \
                           directories. Overwrites an existing file."
                 .into(),
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Workspace-relative file path." },
+                    "path": { "type": "string", "description": "Private-scratch-relative file path." },
                     "content": { "type": "string", "description": "File contents to write." }
                 },
                 "required": ["path", "content"]
@@ -349,7 +351,26 @@ mod tests {
     use crate::id::ChatId;
 
     fn ctx(dir: &std::path::Path) -> ToolCtx {
-        ToolCtx::try_new(ChatId::new(), None, dir.to_path_buf()).unwrap()
+        ToolCtx::try_new_legacy_workspace(ChatId::new(), None, dir.to_path_buf()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn every_file_tool_fails_closed_without_private_scratch() {
+        let ctx = ToolCtx::without_private_scratch(ChatId::new(), None);
+
+        let read = ReadFile
+            .execute(&ctx, json!({"path": "note.txt"}))
+            .await
+            .unwrap();
+        let list = ListDir.execute(&ctx, json!({})).await.unwrap();
+        let write = WriteFile
+            .execute(&ctx, json!({"path": "note.txt", "content": "nope"}))
+            .await
+            .unwrap();
+
+        assert!(read.is_error);
+        assert!(list.is_error);
+        assert!(write.is_error);
     }
 
     #[tokio::test]

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -16,6 +16,10 @@ use openwave_core::{
 
 static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+fn utc_now_at_postgres_precision() -> chrono::DateTime<Utc> {
+    chrono::DateTime::<Utc>::from_timestamp_micros(Utc::now().timestamp_micros()).unwrap()
+}
+
 fn sample_chat() -> Chat {
     Chat {
         id: ChatId::new(),
@@ -24,7 +28,7 @@ fn sample_chat() -> Chat {
         model: None,
         attachment_revision: 0,
         root_attachments: Vec::new(),
-        created_at: Utc::now(),
+        created_at: utc_now_at_postgres_precision(),
     }
 }
 
@@ -46,7 +50,7 @@ async fn postgres_ordered_root_projection_roundtrips_and_snapshots_atomically() 
         title: Some("postgres roots".into()),
         attachment_revision: 1,
         root_attachments: vec![root_b, root_a],
-        created_at: Utc::now(),
+        created_at: utc_now_at_postgres_precision(),
     };
     store.create_project(&project).await.unwrap();
     assert_eq!(

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "postgres")]
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::{Duration, Utc};
@@ -8,10 +7,11 @@ use openwave_core::{
     AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentEvent,
     ApplyTurnSteerOutcome, CallId, Chat, ChatId, ClaimClientToolCallOutcome, ClientToolCallRequest,
     CompleteTurnRunOutcome, DbStore, FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome,
-    Message, MessageId, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
-    RequestTurnCancellationOutcome, ResolveToolCallOutcome, Role, StopReason, Store,
-    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress,
-    TurnFailureRetry, TurnId, TurnRunStatus, TurnSteerId, TurnSteerStatus, Usage,
+    HostRootId, Message, MessageId, ParkTurnForClientCallOutcome, Project, ProjectId,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome, Role,
+    RootAttachmentOrigin, StopReason, Store, ToolCallExecution, ToolCallRecord, ToolCallResolution,
+    ToolCallStatus, TurnCheckpointProgress, TurnFailureRetry, TurnId, TurnRunStatus, TurnSteerId,
+    TurnSteerStatus, Usage,
 };
 
 static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
@@ -22,9 +22,56 @@ fn sample_chat() -> Chat {
         project_id: None,
         title: None,
         model: None,
-        workspace_dir: PathBuf::from("/tmp/openwave-postgres-test"),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
         created_at: Utc::now(),
     }
+}
+
+#[tokio::test]
+async fn postgres_ordered_root_projection_roundtrips_and_snapshots_atomically() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let root_b = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let root_a = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let project = Project {
+        id: ProjectId::new(),
+        title: Some("postgres roots".into()),
+        attachment_revision: 1,
+        root_attachments: vec![root_b, root_a],
+        created_at: Utc::now(),
+    };
+    store.create_project(&project).await.unwrap();
+    assert_eq!(
+        store.get_project(project.id).await.unwrap(),
+        Some(project.clone())
+    );
+
+    let mut base = sample_chat();
+    base.project_id = Some(project.id);
+    let chat = store
+        .create_chat_with_project_defaults(&base)
+        .await
+        .unwrap();
+    assert_eq!(chat.attachment_revision, 1);
+    assert_eq!(
+        chat.root_attachments
+            .iter()
+            .map(|attachment| (attachment.root_id, attachment.origin))
+            .collect::<Vec<_>>(),
+        vec![
+            (root_b, RootAttachmentOrigin::ProjectDefault),
+            (root_a, RootAttachmentOrigin::ProjectDefault),
+        ]
+    );
+    assert_eq!(store.get_chat(chat.id).await.unwrap(), Some(chat));
 }
 
 #[tokio::test]

--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -56,8 +56,7 @@ cargo run -p openwave-cli -- serve
 
 # terminal 2
 cp ui/.env.example ui/.env.local
-# edit ui/.env.local: VITE_OPENWAVE_URL, VITE_OPENWAVE_TOKEN,
-# and an explicit absolute VITE_OPENWAVE_SCRATCH on the machine running serve
+# edit ui/.env.local: VITE_OPENWAVE_URL and VITE_OPENWAVE_TOKEN
 
 pnpm --dir ui install
 pnpm --dir ui dev

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -26,9 +26,6 @@ pub struct ServerInfo {
     pub base_url: String,
     /// Per-launch bearer token.
     pub token: String,
-    /// App-private scratch path used by legacy direct file tools until they are
-    /// routed through the host broker.
-    pub scratch_dir: String,
 }
 
 struct AppState {
@@ -69,20 +66,6 @@ fn home_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         .map_err(|e| format!("resolve home dir: {e}"))
 }
 
-/// Private scratch for the current desktop profile. This is operational app
-/// data, not a connected user folder and never appears in a native picker.
-fn private_scratch(data_dir: &std::path::Path) -> Result<PathBuf, String> {
-    let scratch = data_dir.join("scratch");
-    std::fs::create_dir_all(&scratch).map_err(|e| format!("create private scratch: {e}"))?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&scratch, std::fs::Permissions::from_mode(0o700))
-            .map_err(|e| format!("restrict private scratch: {e}"))?;
-    }
-    Ok(scratch)
-}
-
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let (info_tx, info_rx) = watch::channel(None);
@@ -113,12 +96,11 @@ pub fn run() {
             let handle = app.handle().clone();
             let data = data_dir(&handle)?;
             let home = home_dir(&handle)?;
-            let scratch = private_scratch(&data)?;
             let host_access = host_access::HostAccess::new(handle.clone(), data.clone(), home)?;
             app.manage(host_access);
 
             tauri::async_runtime::spawn(async move {
-                if let Err(error) = boot_server(handle, info_tx, data, scratch).await {
+                if let Err(error) = boot_server(handle, info_tx, data).await {
                     eprintln!("openwave-desktop: {error}");
                 }
             });
@@ -138,7 +120,6 @@ async fn boot_server(
     app: tauri::AppHandle,
     info_tx: watch::Sender<Option<ServerInfo>>,
     data_dir: PathBuf,
-    scratch_dir: PathBuf,
 ) -> Result<(), String> {
     let server = openwave_server::bind(Config::desktop(data_dir))
         .await
@@ -150,11 +131,7 @@ async fn boot_server(
     let executor_token = server.client_executor_token().to_string();
     app.state::<host_access::HostAccess>()
         .initialize_control_plane(base_url.clone(), token.clone(), executor_token)?;
-    let info = ServerInfo {
-        base_url,
-        token,
-        scratch_dir: scratch_dir.display().to_string(),
-    };
+    let info = ServerInfo { base_url, token };
     let _ = info_tx.send(Some(info));
     let recovery_app = app.clone();
     tauri::async_runtime::spawn(async move {

--- a/crates/openwave-desktop/ui/.env.example
+++ b/crates/openwave-desktop/ui/.env.example
@@ -6,5 +6,3 @@
 #
 VITE_OPENWAVE_URL=http://127.0.0.1:PORT
 VITE_OPENWAVE_TOKEN=paste-token-here
-# Explicit app-private scratch on the machine running `openwave serve`.
-VITE_OPENWAVE_SCRATCH=/tmp/openwave-private-scratch

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -102,10 +102,7 @@ export default function App() {
         if (cancelled) return;
         setModels(catalog.models);
         setProviders(providerList.providers);
-        const created = await client.createChat(
-          info.scratchDir,
-          catalog.models[0]?.id,
-        );
+        const created = await client.createChat(catalog.models[0]?.id);
         if (cancelled) return;
         setChat(created);
         setStatus(`chat ${created.id.slice(0, 8)}…`);
@@ -492,9 +489,6 @@ export default function App() {
                 if (e.key === "Enter") e.currentTarget.blur();
               }}
             />
-            <span title={chat.workspace_dir}>
-              private scratch · {shortPath(chat.workspace_dir)}
-            </span>
           </div>
 
           <div className="messages" ref={scrollRef}>
@@ -592,12 +586,6 @@ export default function App() {
       </div>
     </div>
   );
-}
-
-function shortPath(path: string): string {
-  const parts = path.split(/[/\\]/).filter(Boolean);
-  if (parts.length <= 2) return path;
-  return `…/${parts.slice(-2).join("/")}`;
 }
 
 function FoldersPanel({ chat }: { chat: Chat }) {

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -2,7 +2,6 @@
 export type ServerInfo = {
   baseUrl: string;
   token: string;
-  scratchDir: string;
 };
 
 export type ProviderKind = "anthropic" | "openai" | "openai_compatible";
@@ -23,7 +22,11 @@ export type Chat = {
   id: string;
   title: string | null;
   model: string | null;
-  workspace_dir: string;
+  attachment_revision: number;
+  root_attachments: Array<{
+    root_id: string;
+    origin: "project_default" | "conversation";
+  }>;
   project_id: string | null;
   created_at: string;
 };
@@ -129,16 +132,11 @@ export class ApiClient {
     return this.json("/models", { headers: this.headers() });
   }
 
-  createChat(scratchDir: string, model?: string): Promise<Chat> {
+  createChat(model?: string): Promise<Chat> {
     return this.json("/chats", {
       method: "POST",
       headers: this.headers(true),
-      body: JSON.stringify({
-        // Temporary server field: this now points only at app-private scratch.
-        // Connected user folders are broker capabilities, not chat workspaces.
-        workspace_dir: scratchDir,
-        model: model || undefined,
-      }),
+      body: JSON.stringify({ model: model || undefined }),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/boot.ts
+++ b/crates/openwave-desktop/ui/src/boot.ts
@@ -6,8 +6,8 @@ import type { ServerInfo } from "./api";
  *
  * - Inside Tauri: `server_info` from the host (in-process server).
  * - In a plain browser (`pnpm --dir ui dev`): `VITE_OPENWAVE_URL` +
- *   `VITE_OPENWAVE_TOKEN` + explicit `VITE_OPENWAVE_SCRATCH`, so the same
- *   React app can be exercised against `openwave serve`.
+ *   `VITE_OPENWAVE_TOKEN`, so the same React app can be exercised against
+ *   `openwave serve`. The server derives private scratch itself.
  */
 export async function resolveServerInfo(): Promise<ServerInfo> {
   if (isTauri()) {
@@ -18,8 +18,7 @@ export async function resolveServerInfo(): Promise<ServerInfo> {
   if (fromEnv) return fromEnv;
 
   throw new Error(
-    "Set VITE_OPENWAVE_URL, VITE_OPENWAVE_TOKEN, and VITE_OPENWAVE_SCRATCH " +
-      "(for `openwave serve`) " +
+    "Set VITE_OPENWAVE_URL and VITE_OPENWAVE_TOKEN (for `openwave serve`) " +
       "to run the UI in a browser, or launch via `cargo tauri dev`.",
   );
 }
@@ -29,12 +28,8 @@ function envServerInfo(): ServerInfo | null {
   const token = import.meta.env.VITE_OPENWAVE_TOKEN?.trim();
   if (!baseUrl || !token) return null;
 
-  const scratchDir = import.meta.env.VITE_OPENWAVE_SCRATCH?.trim();
-  if (!scratchDir) return null;
-
   return {
     baseUrl: baseUrl.replace(/\/$/, ""),
     token,
-    scratchDir,
   };
 }

--- a/crates/openwave-desktop/ui/src/vite-env.d.ts
+++ b/crates/openwave-desktop/ui/src/vite-env.d.ts
@@ -3,7 +3,6 @@
 interface ImportMetaEnv {
   readonly VITE_OPENWAVE_URL?: string;
   readonly VITE_OPENWAVE_TOKEN?: string;
-  readonly VITE_OPENWAVE_SCRATCH?: string;
 }
 
 interface ImportMeta {

--- a/crates/openwave-mcp/src/lib.rs
+++ b/crates/openwave-mcp/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! # fn demo() -> std::io::Result<()> {
 //! let tools = Arc::new(ToolRegistry::new());
-//! let ctx = ToolCtx::try_new(ChatId::new(), None, ".".into())?;
+//! let ctx = ToolCtx::try_new_legacy_workspace(ChatId::new(), None, ".".into())?;
 //! let server = McpServer::new(tools, ctx);
 //! // then: `openwave_mcp::serve_stdio(server).await` inside an async runtime.
 //! # let _ = server;

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -317,7 +317,7 @@ mod tests {
     }
 
     fn server_with(tools: ToolRegistry) -> McpServer {
-        let ctx = ToolCtx::new(ChatId::new(), None, PathBuf::from("/tmp/ws"));
+        let ctx = ToolCtx::new_legacy_workspace(ChatId::new(), None, PathBuf::from("/tmp/ws"));
         McpServer::new(Arc::new(tools), ctx)
     }
 

--- a/crates/openwave-mcp/src/stdio.rs
+++ b/crates/openwave-mcp/src/stdio.rs
@@ -77,7 +77,7 @@ mod tests {
     use openwave_core::{ChatId, ToolCtx, ToolRegistry};
 
     fn empty_server() -> McpServer {
-        let ctx = ToolCtx::new(ChatId::new(), None, PathBuf::from("/tmp/ws"));
+        let ctx = ToolCtx::new_legacy_workspace(ChatId::new(), None, PathBuf::from("/tmp/ws"));
         McpServer::new(Arc::new(ToolRegistry::new()), ctx)
     }
 

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -261,7 +261,7 @@ mod tests {
     }
 
     fn ctx_for(project_id: Option<ProjectId>) -> ToolCtx {
-        ToolCtx::new(ChatId::new(), project_id, PathBuf::from("/tmp/unused"))
+        ToolCtx::new_legacy_workspace(ChatId::new(), project_id, PathBuf::from("/tmp/unused"))
     }
 
     struct SpyVectorStore {

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 sha2 = { workspace = true }
+cap-std = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }

--- a/crates/openwave-server/src/document_worker.rs
+++ b/crates/openwave-server/src/document_worker.rs
@@ -1204,7 +1204,8 @@ mod tests {
                 .create_project(&Project {
                     id: project_id,
                     title: None,
-                    workspace_dir: std::path::PathBuf::from(format!("/{project_id}")),
+                    attachment_revision: 0,
+                    root_attachments: Vec::new(),
                     created_at: Utc::now(),
                 })
                 .await

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -345,6 +345,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
         state.agent_config.clone(),
+        Some(state.config.data_dir.join("scratch")),
         turn_worker::TurnWorkerConfig::default(),
     );
     let server_store = state.store.clone();

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -4,8 +4,6 @@
 //! submodule; settings, providers, projects, chats, and event streaming remain
 //! here.
 
-use std::path::PathBuf;
-
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -249,9 +247,8 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCata
 
 /// Body of `POST /projects`.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateProject {
-    /// Absolute path to the project's workspace/corpus root.
-    pub workspace_dir: PathBuf,
     /// Optional human-facing title.
     #[serde(default)]
     pub title: Option<String>,
@@ -262,16 +259,11 @@ pub async fn create_project(
     State(state): State<AppState>,
     Json(body): Json<CreateProject>,
 ) -> Result<impl IntoResponse, ServerError> {
-    if !body.workspace_dir.is_absolute() {
-        return Err(ServerError::bad_request(format!(
-            "workspace_dir must be an absolute path, got {:?}",
-            body.workspace_dir
-        )));
-    }
     let project = Project {
         id: ProjectId::new(),
         title: body.title,
-        workspace_dir: body.workspace_dir,
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
         created_at: Utc::now(),
     };
     state.store.create_project(&project).await?;
@@ -300,9 +292,8 @@ pub async fn get_project(
 
 /// Body of `POST /chats`.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateChat {
-    /// Absolute path to the workspace directory the agent operates in.
-    pub workspace_dir: PathBuf,
     /// Optional human-facing title.
     #[serde(default)]
     pub title: Option<String>,
@@ -319,24 +310,15 @@ pub async fn create_chat(
     State(state): State<AppState>,
     Json(body): Json<CreateChat>,
 ) -> Result<impl IntoResponse, ServerError> {
-    // The workspace path must be absolute: a relative one is resolved against
-    // the server process's CWD only later (when a tool canonicalizes it), so the
-    // same chat would map to different directories across restarts or launch
-    // dirs. Reject it here rather than persist an ambiguous path.
-    if !body.workspace_dir.is_absolute() {
-        return Err(ServerError::bad_request(format!(
-            "workspace_dir must be an absolute path, got {:?}",
-            body.workspace_dir
-        )));
-    }
-    // Membership is validated here (the store has no DB-level foreign key): a
-    // chat can't reference a project that doesn't exist.
-    if let Some(project_id) = body.project_id {
-        if state.store.get_project(project_id).await?.is_none() {
-            return Err(ServerError::bad_request(format!(
-                "project {project_id} not found"
-            )));
+    // Return a product-facing 400 for an unknown project. The Store and schema
+    // independently enforce the same membership invariant inside insertion.
+    match body.project_id {
+        Some(project_id) => {
+            state.store.get_project(project_id).await?.ok_or_else(|| {
+                ServerError::bad_request(format!("project {project_id} not found"))
+            })?;
         }
+        None => {}
     }
     if body.model.as_deref().is_some_and(str::is_empty) {
         return Err(ServerError::bad_request("model must not be empty"));
@@ -346,10 +328,11 @@ pub async fn create_chat(
         project_id: body.project_id,
         title: body.title,
         model: body.model,
-        workspace_dir: body.workspace_dir,
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
         created_at: Utc::now(),
     };
-    state.store.create_chat(&chat).await?;
+    let chat = state.store.create_chat_with_project_defaults(&chat).await?;
     Ok((StatusCode::CREATED, Json(chat)))
 }
 
@@ -357,6 +340,7 @@ pub async fn create_chat(
 /// leaves the model unchanged, `null` clears it (fall back to the default), and a
 /// value sets it.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ChatUpdate {
     #[serde(default, deserialize_with = "double_option")]
     pub model: Option<Option<String>>,

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -312,13 +312,12 @@ pub async fn create_chat(
 ) -> Result<impl IntoResponse, ServerError> {
     // Return a product-facing 400 for an unknown project. The Store and schema
     // independently enforce the same membership invariant inside insertion.
-    match body.project_id {
-        Some(project_id) => {
-            state.store.get_project(project_id).await?.ok_or_else(|| {
-                ServerError::bad_request(format!("project {project_id} not found"))
-            })?;
-        }
-        None => {}
+    if let Some(project_id) = body.project_id {
+        state
+            .store
+            .get_project(project_id)
+            .await?
+            .ok_or_else(|| ServerError::bad_request(format!("project {project_id} not found")))?;
     }
     if body.model.as_deref().is_some_and(str::is_empty) {
         return Err(ServerError::bad_request("model must not be empty"));

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -10,10 +10,11 @@ use futures::stream::{self, BoxStream, StreamExt};
 // Tests use the in-memory store; production wires LanceDB in `bind`.
 use openwave_core::{
     AgentErrorInfo, AgentEvent, ApprovalClass, BlobStore, CallId, Chat, ChatId, ChatRequest,
-    ClientToolCallRequest, Message, ModelProvider, ParkTurnForClientCallOutcome, Project,
-    ProjectId, ProviderEvent, ProviderId, SecretProvider, SequencedEvent, StopReason, Tool,
-    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput,
-    ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
+    ChatRootAttachment, ClientToolCallRequest, HostRootId, Message, ModelProvider,
+    ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent, ProviderId,
+    RootAttachmentOrigin, SecretProvider, SequencedEvent, StopReason, Tool, ToolCallExecution,
+    ToolCallRecord, ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput, ToolSpec,
+    TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
 };
 use openwave_retrieval::{
     Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
@@ -636,6 +637,9 @@ impl Store for PauseTerminalStore {
     }
     async fn create_chat(&self, chat: &Chat) -> Result<()> {
         self.inner.create_chat(chat).await
+    }
+    async fn create_chat_with_project_defaults(&self, chat: &Chat) -> Result<Chat> {
+        self.inner.create_chat_with_project_defaults(chat).await
     }
     async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
         self.inner.get_chat(id).await
@@ -1280,6 +1284,7 @@ fn spawn_turn_worker_with_config(state: &AppState, config: turn_worker::TurnWork
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
         state.agent_config.clone(),
+        None,
         config,
     );
     tokio::spawn(worker.run());
@@ -1343,9 +1348,7 @@ async fn make_chat(router: &Router, bearer: &str) -> Chat {
                 .uri("/chats")
                 .header(header::AUTHORIZATION, bearer)
                 .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(
-                    serde_json::json!({"workspace_dir": "/tmp/ws"}).to_string(),
-                ))
+                .body(Body::from(serde_json::json!({}).to_string()))
                 .unwrap(),
         )
         .await
@@ -5137,9 +5140,7 @@ async fn create_then_get_and_list() {
                     .uri("/chats")
                     .header(header::AUTHORIZATION, &bearer)
                     .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(
-                        serde_json::json!({"workspace_dir": "/tmp/ws", "title": "hi"}).to_string(),
-                    ))
+                    .body(Body::from(serde_json::json!({"title": "hi"}).to_string()))
                     .unwrap(),
             )
             .await
@@ -5148,6 +5149,12 @@ async fn create_then_get_and_list() {
         json_body(response).await
     };
     assert_eq!(created.title.as_deref(), Some("hi"));
+    assert_eq!(created.attachment_revision, 0);
+    assert!(created.root_attachments.is_empty());
+    assert!(serde_json::to_value(&created)
+        .unwrap()
+        .get("workspace_dir")
+        .is_none());
 
     let fetched: Chat = {
         let response = router
@@ -5193,9 +5200,7 @@ async fn make_project(router: &Router, bearer: &str) -> Project {
                 .uri("/projects")
                 .header(header::AUTHORIZATION, bearer)
                 .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(
-                    serde_json::json!({"workspace_dir": "/tmp/proj", "title": "p"}).to_string(),
-                ))
+                .body(Body::from(serde_json::json!({"title": "p"}).to_string()))
                 .unwrap(),
         )
         .await
@@ -5210,6 +5215,12 @@ async fn project_create_get_and_list() {
     let bearer = format!("Bearer {token}");
     let created = make_project(&router, &bearer).await;
     assert_eq!(created.title.as_deref(), Some("p"));
+    assert_eq!(created.attachment_revision, 0);
+    assert!(created.root_attachments.is_empty());
+    assert!(serde_json::to_value(&created)
+        .unwrap()
+        .get("workspace_dir")
+        .is_none());
 
     let fetched: Project = {
         let response = router
@@ -5259,8 +5270,7 @@ async fn chat_can_be_filed_under_a_project() {
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({"workspace_dir": "/tmp/ws", "project_id": project.id})
-                        .to_string(),
+                    serde_json::json!({"project_id": project.id}).to_string(),
                 ))
                 .unwrap(),
         )
@@ -5269,6 +5279,53 @@ async fn chat_can_be_filed_under_a_project() {
     assert_eq!(response.status(), StatusCode::CREATED);
     let chat: Chat = json_body(response).await;
     assert_eq!(chat.project_id, Some(project.id));
+}
+
+#[tokio::test]
+async fn project_chat_snapshots_ordered_opaque_root_defaults() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let root_b = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let root_a = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let project = Project {
+        id: ProjectId::new(),
+        title: Some("pathless".into()),
+        attachment_revision: 3,
+        root_attachments: vec![root_b, root_a],
+        created_at: chrono::Utc::now(),
+    };
+    store.create_project(&project).await.unwrap();
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chats")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"project_id": project.id}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let chat: Chat = json_body(response).await;
+    assert_eq!(chat.attachment_revision, 1);
+    assert_eq!(
+        chat.root_attachments,
+        vec![
+            ChatRootAttachment {
+                root_id: root_b,
+                origin: RootAttachmentOrigin::ProjectDefault,
+            },
+            ChatRootAttachment {
+                root_id: root_a,
+                origin: RootAttachmentOrigin::ProjectDefault,
+            },
+        ]
+    );
 }
 
 #[tokio::test]
@@ -5282,8 +5339,7 @@ async fn chat_referencing_an_unknown_project_is_rejected() {
                 .header(header::AUTHORIZATION, format!("Bearer {token}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({"workspace_dir": "/tmp/ws", "project_id": ProjectId::new()})
-                        .to_string(),
+                    serde_json::json!({"project_id": ProjectId::new()}).to_string(),
                 ))
                 .unwrap(),
         )
@@ -5325,8 +5381,7 @@ async fn chat_created_with_a_model() {
                 .header(header::AUTHORIZATION, format!("Bearer {token}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({"workspace_dir": "/tmp/ws", "model": "claude-x"})
-                        .to_string(),
+                    serde_json::json!({"model": "claude-x"}).to_string(),
                 ))
                 .unwrap(),
         )
@@ -5347,9 +5402,7 @@ async fn chat_created_with_empty_model_is_rejected() {
                 .uri("/chats")
                 .header(header::AUTHORIZATION, format!("Bearer {token}"))
                 .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(
-                    serde_json::json!({"workspace_dir": "/tmp/ws", "model": ""}).to_string(),
-                ))
+                .body(Body::from(serde_json::json!({"model": ""}).to_string()))
                 .unwrap(),
         )
         .await
@@ -5417,6 +5470,24 @@ async fn patch_chat_rejects_empty_model_and_unknown_chat() {
 
     let empty = patch_chat(&router, &bearer, chat.id, serde_json::json!({"model": ""})).await;
     assert_eq!(empty.status(), StatusCode::BAD_REQUEST);
+
+    let legacy_path = patch_chat(
+        &router,
+        &bearer,
+        chat.id,
+        serde_json::json!({"workspace_dir": "/tmp/legacy"}),
+    )
+    .await;
+    assert_eq!(legacy_path.status(), StatusCode::BAD_REQUEST);
+
+    let forged_roots = patch_chat(
+        &router,
+        &bearer,
+        chat.id,
+        serde_json::json!({"root_attachments": []}),
+    )
+    .await;
+    assert_eq!(forged_roots.status(), StatusCode::BAD_REQUEST);
 
     let missing = patch_chat(
         &router,
@@ -6047,7 +6118,7 @@ async fn configured_model_is_used_for_the_turn() {
 }
 
 #[tokio::test]
-async fn relative_workspace_dir_is_rejected() {
+async fn workspace_dir_is_not_an_accepted_product_field() {
     let (router, token, _store, _dir) = test_app().await;
     let response = router
         .oneshot(
@@ -6057,7 +6128,7 @@ async fn relative_workspace_dir_is_rejected() {
                 .header(header::AUTHORIZATION, format!("Bearer {token}"))
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({"workspace_dir": "relative/dir"}).to_string(),
+                    serde_json::json!({"workspace_dir": "/tmp/legacy"}).to_string(),
                 ))
                 .unwrap(),
         )
@@ -6121,7 +6192,8 @@ async fn worker_drains_a_turn_queued_before_startup() {
         project_id: None,
         title: None,
         model: None,
-        workspace_dir: std::path::PathBuf::from("/tmp/ws"),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
         created_at: chrono::Utc::now(),
     };
     store.create_chat(&chat).await.unwrap();
@@ -6521,6 +6593,7 @@ async fn worker_renews_a_near_expiry_ambiguous_claim_before_execution() {
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
         state.agent_config.clone(),
+        None,
         turn_worker::TurnWorkerConfig {
             lease: Duration::from_millis(600),
             heartbeat: Duration::from_millis(200),
@@ -6614,6 +6687,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
         state.agent_config.clone(),
+        None,
         turn_worker::TurnWorkerConfig {
             lease: Duration::from_millis(250),
             heartbeat: Duration::from_millis(50),
@@ -7369,7 +7443,7 @@ async fn malformed_requests_get_json_errors_not_plaintext() {
                 .method("POST")
                 .uri("/chats")
                 .header(header::AUTHORIZATION, &bearer)
-                .body(Body::from(r#"{"workspace_dir":"/tmp/ws"}"#))
+                .body(Body::from(r#"{}"#))
                 .unwrap(),
         )
         .await
@@ -7493,7 +7567,7 @@ async fn make_chat_http(client: &reqwest::Client, addr: SocketAddr, token: &str)
     client
         .post(format!("http://{addr}/chats"))
         .bearer_auth(token)
-        .json(&serde_json::json!({"workspace_dir": "/tmp/ws"}))
+        .json(&serde_json::json!({}))
         .send()
         .await
         .unwrap()

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -1,16 +1,24 @@
 //! Supervised execution for durably claimed chat turns.
 
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt as StdDirBuilderExt, PermissionsExt};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, DirBuilder};
+#[cfg(unix)]
+use cap_std::fs::{DirBuilderExt as CapDirBuilderExt, PermissionsExt as CapPermissionsExt};
 use chrono::Utc;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::StreamExt;
 use openwave_core::{
     Agent, AgentConfig, AgentError, AgentEvent, AgentTurnOutcome, ClaimedAgentEvent,
     CompleteTurnRunOutcome, MessageId, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
-    Result, SequencedEvent, Store, ToolRegistry, TurnCheckpointProgress, TurnFailureRetry, TurnId,
-    TurnRun, TurnRunStatus,
+    Result, SequencedEvent, Store, ToolRegistry, ToolScratch, TurnCheckpointProgress,
+    TurnFailureRetry, TurnId, TurnRun, TurnRunStatus,
 };
 use tokio::sync::Notify;
 
@@ -63,6 +71,7 @@ pub(crate) struct TurnWorker {
     signals: Arc<TurnGuard>,
     wake: Arc<Notify>,
     agent_config: AgentConfig,
+    private_scratch_root: Option<PathBuf>,
     config: TurnWorkerConfig,
 }
 
@@ -209,6 +218,7 @@ impl TurnWorker {
         signals: Arc<TurnGuard>,
         wake: Arc<Notify>,
         agent_config: AgentConfig,
+        private_scratch_root: Option<PathBuf>,
         config: TurnWorkerConfig,
     ) -> Self {
         assert!(!config.lease.is_zero());
@@ -225,6 +235,7 @@ impl TurnWorker {
             signals,
             wake,
             agent_config,
+            private_scratch_root,
             config,
         }
     }
@@ -436,6 +447,18 @@ impl TurnWorker {
             let mut config = self.agent_config.clone();
             config.model = turn.model.clone();
             config.max_steps = remaining_steps;
+            config.tool_scratch = self.private_scratch_root.as_deref().and_then(|root| {
+                match private_chat_scratch(root, chat.id) {
+                    Ok(scratch) => Some(scratch),
+                    Err(error) => {
+                        eprintln!(
+                            "openwave: private scratch unavailable for chat {}: {}",
+                            chat.id, error
+                        );
+                        None
+                    }
+                }
+            });
             let provider = self.resolver.resolve().await;
             let steer = active.steer_inbox();
             let agent = Agent::new(provider, self.tools.clone(), self.store.clone(), config)
@@ -1440,6 +1463,63 @@ impl TurnWorker {
     }
 }
 
+/// Derive and create one chat's runtime-only scratch under the private server
+/// data directory. Product records and API responses never receive this path.
+fn private_chat_scratch(
+    root: &Path,
+    chat_id: openwave_core::ChatId,
+) -> std::io::Result<ToolScratch> {
+    let mut root_builder = fs::DirBuilder::new();
+    root_builder.recursive(true);
+    #[cfg(unix)]
+    root_builder.mode(0o700);
+    root_builder.create(root)?;
+    let root_meta = fs::symlink_metadata(root)?;
+    if !root_meta.is_dir() || root_meta.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "private scratch root is not a regular directory",
+        ));
+    }
+    #[cfg(unix)]
+    fs::set_permissions(root, fs::Permissions::from_mode(0o700))?;
+    let root_dir = Dir::open_ambient_dir(root, ambient_authority())?;
+    #[cfg(unix)]
+    {
+        let opened = root_dir.dir_metadata()?;
+        if std::os::unix::fs::MetadataExt::dev(&root_meta) != cap_std::fs::MetadataExt::dev(&opened)
+            || std::os::unix::fs::MetadataExt::ino(&root_meta)
+                != cap_std::fs::MetadataExt::ino(&opened)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "private scratch root changed while it was being pinned",
+            ));
+        }
+    }
+    let chat_name = chat_id.to_string();
+    match root_dir.symlink_metadata(&chat_name) {
+        Ok(metadata) if !metadata.is_dir() || metadata.file_type().is_symlink() => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "private chat scratch is not a regular directory",
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let mut builder = DirBuilder::new();
+            #[cfg(unix)]
+            builder.mode(0o700);
+            root_dir.create_dir_with(&chat_name, &builder)?;
+        }
+        Err(error) => return Err(error),
+    }
+    #[cfg(unix)]
+    root_dir.set_permissions(&chat_name, cap_std::fs::Permissions::from_mode(0o700))?;
+    let chat_dir = root_dir.open_dir(&chat_name)?;
+    Ok(ToolScratch::from_dir(chat_dir))
+}
+
 fn checked_usage_sum(
     total: openwave_core::Usage,
     delta: openwave_core::Usage,
@@ -1473,6 +1553,97 @@ fn log_turn_result(result: std::result::Result<Result<TurnWorkerOutcome>, tokio:
 #[cfg(test)]
 mod committed_event_drain_tests {
     use super::*;
+
+    #[test]
+    fn private_scratch_is_isolated_per_chat() {
+        let root = tempfile::tempdir().unwrap();
+        let first_chat = openwave_core::ChatId::new();
+        let second_chat = openwave_core::ChatId::new();
+
+        let _first = private_chat_scratch(root.path(), first_chat).unwrap();
+        let _second = private_chat_scratch(root.path(), second_chat).unwrap();
+        let first = root.path().join(first_chat.to_string());
+        let second = root.path().join(second_chat.to_string());
+
+        assert_ne!(first, second);
+        assert_eq!(first.parent(), second.parent());
+        assert!(first.is_dir());
+        assert!(second.is_dir());
+
+        #[cfg(unix)]
+        {
+            assert_eq!(
+                fs::metadata(&first).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(&second).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_scratch_rejects_a_symlinked_chat_directory() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let chat_id = openwave_core::ChatId::new();
+        symlink(outside.path(), root.path().join(chat_id.to_string())).unwrap();
+
+        let error = private_chat_scratch(root.path(), chat_id).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_scratch_rejects_a_symlinked_root() {
+        use std::os::unix::fs::symlink;
+
+        let parent = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root = parent.path().join("scratch");
+        symlink(outside.path(), &root).unwrap();
+
+        let error = private_chat_scratch(&root, openwave_core::ChatId::new()).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pinned_private_scratch_survives_path_replacement_without_escaping() {
+        use openwave_core::{Tool, ToolCtx, WriteFile};
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let chat_id = openwave_core::ChatId::new();
+        let original = root.path().join(chat_id.to_string());
+        let moved = root.path().join("pinned");
+        let scratch = private_chat_scratch(root.path(), chat_id).unwrap();
+        fs::rename(&original, &moved).unwrap();
+        symlink(outside.path(), &original).unwrap();
+        let ctx = ToolCtx::with_private_scratch(chat_id, None, scratch);
+
+        let output = WriteFile
+            .execute(
+                &ctx,
+                serde_json::json!({"path": "note.txt", "content": "pinned"}),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error);
+        assert_eq!(
+            fs::read_to_string(moved.join("note.txt")).unwrap(),
+            "pinned"
+        );
+        assert!(!outside.path().join("note.txt").exists());
+    }
 
     #[tokio::test]
     async fn lease_loss_drain_discards_pending_and_publishes_committed_events() {

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -37,9 +37,14 @@ In practical terms:
   such as Documents or Downloads. The request can explain why and suggest where
   to open the picker, but only the folder the user actually selects is granted.
 
-The current `workspace_dir` fields on projects and chats do not express this
-model. They are temporary pre-alpha implementation details and will be replaced
-rather than preserved as a compatibility layer.
+Projects and chats now persist only ordered opaque root IDs plus an attachment
+revision. Project defaults are snapshotted into a new chat's exact attachment
+set; later project changes cannot silently widen that chat. These product rows
+are not grants: they contain no path, capability, consent, or display name, and
+host access still requires the broker's live attachment and authorization. The
+current native picker still updates broker state only; synchronizing those
+connections into this product projection is the next native CAS/reconciliation
+slice, before any tool treats the projection as usable context.
 
 ## The four layers
 
@@ -290,9 +295,11 @@ This will land in independently reviewable pieces:
    dispatch must begin inside a short post-heartbeat deadline. Recovery runs in
    the background with bounded backoff; it may query the broker receipt and
    publish a known result, but it never starts or replays registration.
-8. Replace project/chat `workspace_dir` with persisted host-access context
-   identity and connected-root APIs. This can update the pre-v1 baseline schema
-   directly.
+8. **Pathless baseline complete:** project/chat `workspace_dir` is gone. The
+   pre-v1 schema stores bounded ordered opaque root projections and revisions,
+   while runtime-only legacy scratch is derived under private server data and
+   never returned by the product API. Native-only attachment mutation and
+   reconciliation APIs remain a separate slice.
 9. Route built-in file tools through the operation interface and remove direct
    ambient host-directory opening from `ToolCtx`.
 10. Port bounded imports, writes, approvals, and confined command execution as

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -155,7 +155,8 @@ tool-call records. It then loops for a bounded number of model steps:
 The built-in server registry currently contains:
 
 - `read_file` and `list_dir`, which are read-only;
-- `write_file`, which is workspace-confined and runs without a prompt;
+- `write_file`, which is confined to private per-chat scratch and runs without a
+  prompt;
 - `search`, which queries the indexed corpus and requires approval only when its
   embedder, store, or reranker can send data outside the machine;
 - `request_folder_access`, a client-owned consent proposal with a bounded
@@ -163,12 +164,13 @@ The built-in server registry currently contains:
   picker hint for Documents or Downloads. It has no server executor and grants
   nothing.
 
-Today these file tools still operate inside one directly opened workspace
-directory stored on the chat. That temporary tool path is not the intended
-product boundary. The desktop can now connect, list, and revoke multiple folders
+Today these file tools still operate inside a server-derived, pinned per-chat
+scratch capability. Its path is neither persisted on the chat nor returned by
+the product API. The desktop can connect, list, and revoke multiple folders
 through a native picker and capability-gated host-broker sidecar; it exposes only
-opaque root IDs and display names to the renderer. The next tool-routing slice
-will resolve file operations through those roots instead of the legacy workspace.
+opaque root IDs and display names to the renderer. The next native CAS slice will
+synchronize broker connections into the product's pathless root projection, and
+the following tool-routing slice will resolve operations through those roots.
 See [Host access and connected folders](host-access.md). The agent loop can now
 produce a durable client-wait checkpoint for the registered folder-request
 contract. The desktop discovers those pending requests from durable state and
@@ -389,7 +391,7 @@ result rather than applying the instruction twice.
 
 ## What happens when a document is added
 
-A project does not automatically crawl its workspace. Documents enter the
+A project does not automatically crawl its connected roots. Documents enter the
 system through an explicit HTTP upload. A source URI is identity and provenance;
 OpenWave does not fetch that URI itself.
 
@@ -525,8 +527,11 @@ loose chat on each launch and supports provider setup, model selection, basic
 chat streaming, approval prompts, and native connected-folder pick/list/revoke.
 OpenWave's operational scratch stays in private app storage; user-selected paths
 cross only the native host-to-broker control boundary, while the renderer sees
-opaque folder summaries. Built-in agent file tools still use the temporary
-private scratch path and are not yet routed through those connected roots. The
+opaque folder summaries. Projects and chats store only ordered opaque root IDs
+and attachment revisions—never host paths or grants. Built-in agent file tools
+still use a server-derived per-chat private scratch directory and are not yet
+routed through connected roots; that scratch path is neither persisted nor
+returned to the renderer. The
 UI does not yet provide a chat picker, history reconstruction, projects,
 document ingestion, document search, cancel, or steer controls, even though much
 of that backend API already exists.
@@ -620,10 +625,10 @@ cancellation, reconnectable event stream, and fail-closed provider routing.
 
 The main next steps are:
 
-- replace raw chat/project workspace paths with broker-mediated, per-context
-  connected roots while keeping OpenWave's private app data separate;
-- notify the desktop of durable pending folder requests and execute them through
-  the picker and broker;
+- synchronize native picker connections into the pathless project/conversation
+  root projection with exact CAS and broker reconciliation;
+- route built-in file tools through explicit broker roots while keeping private
+  per-chat scratch separate;
 - add resumable checkpoints and explicit idempotency policy around remaining
   server-side tool effects;
 - make approvals resumable rather than process-local;


### PR DESCRIPTION
## Summary

- replace persisted project and chat paths with bounded, ordered opaque root projections and CAS-safe revisions
- snapshot project defaults atomically when creating a chat, with baseline foreign keys and fail-closed storage validation
- derive legacy per-chat scratch privately on the server and pass it to tools as a pinned directory capability
- remove scratch paths from the desktop/API contract and document the native reconciliation follow-up

## Validation

- `cargo test -p openwave-core --all-features`
- `cargo test --workspace --all-features --no-run`
- focused server API, projection, and private-scratch tests
- `pnpm --dir crates/openwave-desktop/ui build`
- `bw dev lint --rust --check --repo-root "$PWD"`
- `cargo fmt --all --check`
