### PR TITLE
feat(core): add durable root attachment changes

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -163,11 +163,19 @@ pub mod chat {
     pub enum Relation {
         #[sea_orm(has_many = "super::chat_root_attachment::Entity")]
         RootAttachment,
+        #[sea_orm(has_many = "super::root_attachment_change::Entity")]
+        RootAttachmentChange,
     }
 
     impl Related<super::chat_root_attachment::Entity> for Entity {
         fn to() -> RelationDef {
             Relation::RootAttachment.def()
+        }
+    }
+
+    impl Related<super::root_attachment_change::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::RootAttachmentChange.def()
         }
     }
 
@@ -230,6 +238,59 @@ pub mod chat_root_attachment {
             to = "super::chat::Column::Id",
             on_update = "NoAction",
             on_delete = "Cascade"
+        )]
+        Chat,
+    }
+
+    impl Related<super::chat::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Chat.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod root_attachment_change {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "root_attachment_change")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub chat_id: Uuid,
+        pub subject_kind: String,
+        pub subject_id: Uuid,
+        pub executor_id: Uuid,
+        pub root_id: Uuid,
+        pub action: String,
+        pub origin: Option<String>,
+        pub projection_position: Option<i32>,
+        pub projection_existed_before: bool,
+        pub expected_revision: i64,
+        pub before_revision: i64,
+        pub intent_revision: i64,
+        pub phase: String,
+        pub result_revision: Option<i64>,
+        pub projection_changed: Option<bool>,
+        pub broker_changed: Option<bool>,
+        pub broker_currently_attached: Option<bool>,
+        pub failure_code: Option<String>,
+        pub failure_message: Option<String>,
+        pub failure_retryable: Option<bool>,
+        pub created_at: DateTimeUtc,
+        pub finished_at: Option<DateTimeUtc>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(
+            belongs_to = "super::chat::Entity",
+            from = "Column::ChatId",
+            to = "super::chat::Column::Id",
+            on_update = "NoAction",
+            on_delete = "Restrict"
         )]
         Chat,
     }

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -1243,10 +1243,291 @@ impl MigrationTrait for AddProjects {
                     .to_owned(),
             )
             .await?;
+
+        let projection_metadata_present = Expr::col(RootAttachmentChange::ProjectionExistedBefore)
+            .eq(true)
+            .or(Expr::col(RootAttachmentChange::Action).eq("attach"));
+        let projection_metadata_absent = Expr::col(RootAttachmentChange::ProjectionExistedBefore)
+            .eq(false)
+            .and(Expr::col(RootAttachmentChange::Action).eq("detach"));
+        let awaiting_broker = Expr::col(RootAttachmentChange::Phase)
+            .eq("awaiting_broker")
+            .and(Expr::col(RootAttachmentChange::ResultRevision).is_null())
+            .and(Expr::col(RootAttachmentChange::ProjectionChanged).is_null())
+            .and(Expr::col(RootAttachmentChange::BrokerChanged).is_null())
+            .and(Expr::col(RootAttachmentChange::BrokerCurrentlyAttached).is_null())
+            .and(Expr::col(RootAttachmentChange::FailureCode).is_null())
+            .and(Expr::col(RootAttachmentChange::FailureMessage).is_null())
+            .and(Expr::col(RootAttachmentChange::FailureRetryable).is_null())
+            .and(Expr::col(RootAttachmentChange::FinishedAt).is_null());
+        let completed = Expr::col(RootAttachmentChange::Phase)
+            .eq("completed")
+            .and(Expr::col(RootAttachmentChange::ResultRevision).is_not_null())
+            .and(Expr::col(RootAttachmentChange::ProjectionChanged).is_not_null())
+            .and(Expr::col(RootAttachmentChange::BrokerChanged).is_not_null())
+            .and(Expr::col(RootAttachmentChange::BrokerCurrentlyAttached).is_not_null())
+            .and(Expr::col(RootAttachmentChange::FailureCode).is_null())
+            .and(Expr::col(RootAttachmentChange::FailureMessage).is_null())
+            .and(Expr::col(RootAttachmentChange::FailureRetryable).is_null())
+            .and(Expr::col(RootAttachmentChange::FinishedAt).is_not_null());
+        let failed = Expr::col(RootAttachmentChange::Phase)
+            .eq("failed")
+            .and(Expr::col(RootAttachmentChange::ResultRevision).is_not_null())
+            .and(Expr::col(RootAttachmentChange::ProjectionChanged).is_not_null())
+            .and(Expr::col(RootAttachmentChange::FailureCode).is_not_null())
+            .and(Expr::col(RootAttachmentChange::FailureMessage).is_not_null())
+            .and(Expr::col(RootAttachmentChange::FailureRetryable).is_not_null())
+            .and(Expr::col(RootAttachmentChange::FinishedAt).is_not_null());
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(RootAttachmentChange::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::ChatId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::SubjectKind)
+                            .string_len(24)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::SubjectId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::ExecutorId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::RootId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::Action)
+                            .string_len(16)
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(RootAttachmentChange::Origin).string_len(24))
+                    .col(ColumnDef::new(RootAttachmentChange::ProjectionPosition).integer())
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::ProjectionExistedBefore)
+                            .boolean()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::ExpectedRevision)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::BeforeRevision)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::IntentRevision)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::Phase)
+                            .string_len(24)
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(RootAttachmentChange::ResultRevision).big_integer())
+                    .col(ColumnDef::new(RootAttachmentChange::ProjectionChanged).boolean())
+                    .col(ColumnDef::new(RootAttachmentChange::BrokerChanged).boolean())
+                    .col(ColumnDef::new(RootAttachmentChange::BrokerCurrentlyAttached).boolean())
+                    .col(ColumnDef::new(RootAttachmentChange::FailureCode).string_len(64))
+                    .col(ColumnDef::new(RootAttachmentChange::FailureMessage).string_len(256))
+                    .col(ColumnDef::new(RootAttachmentChange::FailureRetryable).boolean())
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RootAttachmentChange::FinishedAt).timestamp_with_time_zone(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_root_attachment_change_chat")
+                            .from(RootAttachmentChange::Table, RootAttachmentChange::ChatId)
+                            .to(Chat::Table, Chat::Id)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .check(Expr::col(RootAttachmentChange::Id).ne(uuid::Uuid::nil()))
+                    .check(Expr::col(RootAttachmentChange::ChatId).ne(uuid::Uuid::nil()))
+                    .check(Expr::col(RootAttachmentChange::SubjectId).ne(uuid::Uuid::nil()))
+                    .check(Expr::col(RootAttachmentChange::ExecutorId).ne(uuid::Uuid::nil()))
+                    .check(Expr::col(RootAttachmentChange::RootId).ne(uuid::Uuid::nil()))
+                    .check(
+                        Expr::col(RootAttachmentChange::SubjectKind)
+                            .is_in(["project", "conversation"]),
+                    )
+                    .check(Expr::col(RootAttachmentChange::Action).is_in(["attach", "detach"]))
+                    .check(
+                        Expr::col(RootAttachmentChange::Origin)
+                            .is_null()
+                            .or(Expr::col(RootAttachmentChange::Origin)
+                                .is_in(["project_default", "conversation"])),
+                    )
+                    .check(
+                        projection_metadata_present
+                            .and(Expr::col(RootAttachmentChange::Origin).is_not_null())
+                            .and(Expr::col(RootAttachmentChange::ProjectionPosition).is_not_null())
+                            .or(projection_metadata_absent
+                                .and(Expr::col(RootAttachmentChange::Origin).is_null())
+                                .and(
+                                    Expr::col(RootAttachmentChange::ProjectionPosition).is_null(),
+                                )),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::ProjectionPosition)
+                            .is_null()
+                            .or(Expr::col(RootAttachmentChange::ProjectionPosition)
+                                .between(0, crate::model::MAX_ROOT_ATTACHMENTS as i32 - 1)),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::Action)
+                            .ne("attach")
+                            .or(Expr::col(RootAttachmentChange::ProjectionExistedBefore).eq(true))
+                            .or(Expr::col(RootAttachmentChange::Origin).eq("conversation")),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::ExpectedRevision)
+                            .between(0, crate::model::MAX_ATTACHMENT_REVISION),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::BeforeRevision)
+                            .between(0, crate::model::MAX_ATTACHMENT_REVISION),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::IntentRevision)
+                            .between(0, crate::model::MAX_ATTACHMENT_REVISION),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::ResultRevision)
+                            .is_null()
+                            .or(Expr::col(RootAttachmentChange::ResultRevision)
+                                .between(0, crate::model::MAX_ATTACHMENT_REVISION)),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::ExpectedRevision)
+                            .equals(RootAttachmentChange::BeforeRevision),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::IntentRevision)
+                            .equals(RootAttachmentChange::BeforeRevision)
+                            .or(Expr::col(RootAttachmentChange::IntentRevision)
+                                .eq(Expr::col(RootAttachmentChange::BeforeRevision).add(1))),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::Action)
+                            .ne("attach")
+                            .or(Expr::col(RootAttachmentChange::ProjectionExistedBefore).eq(true))
+                            .or(Expr::col(RootAttachmentChange::IntentRevision)
+                                .eq(Expr::col(RootAttachmentChange::BeforeRevision).add(1))),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::Action)
+                            .eq("attach")
+                            .and(Expr::col(RootAttachmentChange::ProjectionExistedBefore).eq(false))
+                            .or(Expr::col(RootAttachmentChange::IntentRevision)
+                                .equals(RootAttachmentChange::BeforeRevision)),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::Action)
+                            .ne("attach")
+                            .or(Expr::col(RootAttachmentChange::ProjectionExistedBefore).eq(true))
+                            .or(Expr::col(RootAttachmentChange::BeforeRevision)
+                                .lte(crate::model::MAX_ATTACHMENT_REVISION - 2)),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::Action)
+                            .ne("detach")
+                            .or(Expr::col(RootAttachmentChange::ProjectionExistedBefore).eq(false))
+                            .or(Expr::col(RootAttachmentChange::BeforeRevision)
+                                .lte(crate::model::MAX_ATTACHMENT_REVISION - 1)),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::FailureCode).is_null().or(
+                            Func::char_length(Expr::col(RootAttachmentChange::FailureCode))
+                                .between(1, 64),
+                        ),
+                    )
+                    .check(
+                        Expr::col(RootAttachmentChange::FailureMessage)
+                            .is_null()
+                            .or(
+                                Func::char_length(Expr::col(RootAttachmentChange::FailureMessage))
+                                    .between(1, 256),
+                            ),
+                    )
+                    .check(awaiting_broker.or(completed).or(failed))
+                    .check(
+                        Expr::col(RootAttachmentChange::FinishedAt)
+                            .is_null()
+                            .or(Expr::col(RootAttachmentChange::FinishedAt)
+                                .gte(Expr::col(RootAttachmentChange::CreatedAt))),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_root_attachment_change_one_awaiting")
+                    .table(RootAttachmentChange::Table)
+                    .col(RootAttachmentChange::ChatId)
+                    .unique()
+                    .and_where(Expr::col(RootAttachmentChange::Phase).eq("awaiting_broker"))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_root_attachment_change_pending_scan")
+                    .table(RootAttachmentChange::Table)
+                    .col(RootAttachmentChange::ExecutorId)
+                    .col(RootAttachmentChange::Phase)
+                    .col(RootAttachmentChange::CreatedAt)
+                    .col(RootAttachmentChange::Id)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_root_attachment_change_history")
+                    .table(RootAttachmentChange::Table)
+                    .col(RootAttachmentChange::ChatId)
+                    .col(RootAttachmentChange::CreatedAt)
+                    .col(RootAttachmentChange::Id)
+                    .to_owned(),
+            )
+            .await?;
         Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(RootAttachmentChange::Table).to_owned())
+            .await?;
         manager
             .drop_table(Table::drop().table(ChatRootAttachment::Table).to_owned())
             .await?;
@@ -2426,6 +2707,34 @@ enum ChatRootAttachment {
     RootId,
     Position,
     Origin,
+}
+
+#[derive(DeriveIden)]
+enum RootAttachmentChange {
+    Table,
+    Id,
+    ChatId,
+    SubjectKind,
+    SubjectId,
+    ExecutorId,
+    RootId,
+    Action,
+    Origin,
+    ProjectionPosition,
+    ProjectionExistedBefore,
+    ExpectedRevision,
+    BeforeRevision,
+    IntentRevision,
+    Phase,
+    ResultRevision,
+    ProjectionChanged,
+    BrokerChanged,
+    BrokerCurrentlyAttached,
+    FailureCode,
+    FailureMessage,
+    FailureRetryable,
+    CreatedAt,
+    FinishedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -21,27 +21,29 @@ use crate::event::{AgentEvent, SequencedEvent};
 #[cfg(test)]
 use crate::id::MessageId;
 use crate::id::{
-    CallId, ChatId, DocumentId, DocumentJobId, HostRootId, ProjectId, TurnId, TurnSteerId,
+    CallId, ChatId, DocumentId, DocumentJobId, HostRootId, ProjectId, RootAttachmentChangeId,
+    TurnId, TurnSteerId,
 };
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
-    validate_project_root_projection, BlobRetirement, BlobRetirementStatus, Chat,
-    DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
-    DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
-    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
-    Project, SourceRegion, ToolCallRecord, ToolCallResolution, TurnCheckpointProgress,
-    TurnClientWaitStatus, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteerStatus,
-    MAX_ROOT_ATTACHMENTS,
+    validate_project_root_projection, BeginRootAttachmentChange, BlobRetirement,
+    BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
+    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
+    DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
+    DocumentUpsert, Message, Project, RootAttachmentChange, RootAttachmentChangeTerminal,
+    SourceRegion, ToolCallRecord, ToolCallResolution, TurnCheckpointProgress, TurnClientWaitStatus,
+    TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteerStatus, MAX_ROOT_ATTACHMENTS,
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
-    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, ClaimClientToolCallOutcome,
-    ClaimTurnRunOutcome, CompleteTurnRunOutcome, DocumentIndexJobReason,
-    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
-    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledTurnOutcome,
-    JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
-    RequestTurnCancellationOutcome, ResolveToolCallOutcome, Store,
+    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
+    BeginRootAttachmentChangeOutcome, ClaimClientToolCallOutcome, ClaimTurnRunOutcome,
+    CompleteTurnRunOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
+    EnsureDocumentParseJobOutcome, FinishRootAttachmentChangeOutcome,
+    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
+    JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome,
+    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome, Store,
 };
 
 mod ops;
@@ -1679,6 +1681,45 @@ impl Store for DbStore {
 
     async fn list_chats(&self) -> Result<Vec<Chat>> {
         ops::conversation::list_chats(self).await
+    }
+
+    async fn begin_root_attachment_change(
+        &self,
+        request: &BeginRootAttachmentChange,
+    ) -> Result<BeginRootAttachmentChangeOutcome> {
+        ops::root_attachment::begin_root_attachment_change(self, request).await
+    }
+
+    async fn finish_root_attachment_change(
+        &self,
+        id: RootAttachmentChangeId,
+        executor_id: uuid::Uuid,
+        terminal: &RootAttachmentChangeTerminal,
+        finished_at: chrono::DateTime<Utc>,
+    ) -> Result<FinishRootAttachmentChangeOutcome> {
+        ops::root_attachment::finish_root_attachment_change(
+            self,
+            id,
+            executor_id,
+            terminal,
+            finished_at,
+        )
+        .await
+    }
+
+    async fn get_root_attachment_change(
+        &self,
+        id: RootAttachmentChangeId,
+    ) -> Result<Option<RootAttachmentChange>> {
+        ops::root_attachment::get_root_attachment_change(self, id).await
+    }
+
+    async fn list_pending_root_attachment_changes(
+        &self,
+        executor_id: uuid::Uuid,
+        limit: u64,
+    ) -> Result<Vec<RootAttachmentChange>> {
+        ops::root_attachment::list_pending_root_attachment_changes(self, executor_id, limit).await
     }
 
     async fn get_turn_run(&self, id: TurnId) -> Result<Option<TurnRun>> {

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -567,14 +567,14 @@ fn validate_chat_attachments(chat: &Chat, project_roots: &[HostRootId]) -> Resul
         .map_err(|message| AgentError::Store(message.into()))
 }
 
-fn attachment_origin_to_db(origin: RootAttachmentOrigin) -> &'static str {
+pub(in crate::db) fn attachment_origin_to_db(origin: RootAttachmentOrigin) -> &'static str {
     match origin {
         RootAttachmentOrigin::ProjectDefault => "project_default",
         RootAttachmentOrigin::Conversation => "conversation",
     }
 }
 
-fn attachment_origin_from_db(value: &str) -> Result<RootAttachmentOrigin> {
+pub(in crate::db) fn attachment_origin_from_db(value: &str) -> Result<RootAttachmentOrigin> {
     match value {
         "project_default" => Ok(RootAttachmentOrigin::ProjectDefault),
         "conversation" => Ok(RootAttachmentOrigin::Conversation),

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -9,6 +9,7 @@ pub(in crate::db) mod blob;
 pub(in crate::db) mod client_execution;
 pub(in crate::db) mod conversation;
 pub(in crate::db) mod document;
+pub(in crate::db) mod root_attachment;
 pub(in crate::db) mod turn;
 
 /// Acquire the shared cross-backend write lock for one chat row.

--- a/crates/openwave-core/src/db/ops/root_attachment.rs
+++ b/crates/openwave-core/src/db/ops/root_attachment.rs
@@ -1,0 +1,987 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use sea_orm::sea_query::{Expr, OnConflict};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect, Set,
+    TransactionTrait, TryInsertResult,
+};
+use uuid::Uuid;
+
+use crate::error::{AgentError, Result};
+use crate::id::{ChatId, HostRootId, RootAttachmentChangeId};
+use crate::model::{
+    BeginRootAttachmentChange, RootAttachmentChange, RootAttachmentChangeAction,
+    RootAttachmentChangeFailure, RootAttachmentChangePhase, RootAttachmentChangeTerminal,
+    RootAttachmentOrigin, RootAttachmentSubjectKind, MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
+};
+use crate::storage::{
+    BeginRootAttachmentChangeOutcome, FinishRootAttachmentChangeOutcome,
+    MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+};
+
+use super::super::{entities, store_err, DbStore};
+use super::acquire_chat_write_lock;
+use super::conversation::{attachment_origin_from_db, attachment_origin_to_db};
+use super::turn::canonical_db_timestamp;
+
+pub(in crate::db) async fn begin_root_attachment_change(
+    store: &DbStore,
+    request: &BeginRootAttachmentChange,
+) -> Result<BeginRootAttachmentChangeOutcome> {
+    request
+        .validate()
+        .map_err(|message| AgentError::Store(message.into()))?;
+    let created_at = canonical_db_timestamp(request.created_at)?;
+
+    if let Some(existing) = find_change(store, request.id).await? {
+        return Ok(exact_begin_outcome(existing, request, created_at));
+    }
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, request.chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(BeginRootAttachmentChangeOutcome::ChatNotFound);
+    }
+
+    if let Some(existing) = find_change_on(&transaction, request.id).await? {
+        let outcome = exact_begin_outcome(existing, request, created_at);
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(outcome);
+    }
+
+    let chat = entities::chat::Entity::find_by_id(request.chat_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "chat {} disappeared while beginning root attachment change {}",
+                request.chat_id, request.id
+            ))
+        })?;
+    let projection =
+        load_projection(&transaction, request.chat_id, chat.attachment_revision).await?;
+
+    if let Some(busy) = entities::root_attachment_change::Entity::find()
+        .filter(entities::root_attachment_change::Column::ChatId.eq(request.chat_id.0))
+        .filter(
+            entities::root_attachment_change::Column::Phase
+                .eq(phase_to_db(RootAttachmentChangePhase::AwaitingBroker)),
+        )
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let busy = change_from_model(busy)?;
+        validate_change_subject_on(&transaction, &busy).await?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(BeginRootAttachmentChangeOutcome::ChatBusy);
+    }
+    if chat.attachment_revision != request.expected_attachment_revision {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(BeginRootAttachmentChangeOutcome::RevisionConflict {
+            current_attachment_revision: chat.attachment_revision,
+        });
+    }
+
+    let existing_position = projection
+        .iter()
+        .position(|row| row.root_id == *request.root_id.as_uuid());
+    let projection_existed_before = existing_position.is_some();
+    let (origin, projection_position) = match existing_position {
+        Some(position) => (
+            Some(attachment_origin_from_db(&projection[position].origin)?),
+            Some(u32::try_from(position).map_err(|_| {
+                AgentError::Store("root attachment projection position exceeds u32".into())
+            })?),
+        ),
+        None if request.action == RootAttachmentChangeAction::Attach => {
+            if projection.len() >= MAX_ROOT_ATTACHMENTS {
+                transaction.commit().await.map_err(store_err)?;
+                return Ok(BeginRootAttachmentChangeOutcome::CapacityExceeded);
+            }
+            (
+                Some(RootAttachmentOrigin::Conversation),
+                Some(u32::try_from(projection.len()).map_err(|_| {
+                    AgentError::Store("root attachment projection position exceeds u32".into())
+                })?),
+            )
+        }
+        None => (None, None),
+    };
+
+    let (subject_kind, subject_id) = derive_subject(request.chat_id, chat.project_id)?;
+    let advances_intent =
+        request.action == RootAttachmentChangeAction::Attach && !projection_existed_before;
+    let needs_terminal_revision = advances_intent
+        || (request.action == RootAttachmentChangeAction::Detach && projection_existed_before);
+    let required_headroom = i64::from(advances_intent) + i64::from(needs_terminal_revision);
+    let Some(max_begin_revision) = MAX_ATTACHMENT_REVISION.checked_sub(required_headroom) else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(BeginRootAttachmentChangeOutcome::RevisionExhausted);
+    };
+    if chat.attachment_revision > max_begin_revision {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(BeginRootAttachmentChangeOutcome::RevisionExhausted);
+    }
+    let intent_revision = chat.attachment_revision + i64::from(advances_intent);
+
+    let change = RootAttachmentChange {
+        id: request.id,
+        chat_id: request.chat_id,
+        executor_id: request.executor_id,
+        root_id: request.root_id,
+        action: request.action,
+        subject_kind,
+        subject_id,
+        origin,
+        projection_position,
+        projection_existed_before,
+        expected_revision: request.expected_attachment_revision,
+        before_revision: chat.attachment_revision,
+        intent_revision,
+        phase: RootAttachmentChangePhase::AwaitingBroker,
+        result_revision: None,
+        projection_changed: None,
+        broker_changed: None,
+        broker_currently_attached: None,
+        failure: None,
+        created_at,
+        finished_at: None,
+    };
+    change
+        .validate()
+        .map_err(|message| AgentError::Store(message.into()))?;
+
+    let inserted = entities::root_attachment_change::Entity::insert(change_active_model(&change))
+        .on_conflict(
+            OnConflict::column(entities::root_attachment_change::Column::Id)
+                .do_nothing()
+                .to_owned(),
+        )
+        .do_nothing()
+        .exec_without_returning(&transaction)
+        .await;
+    match inserted {
+        Ok(TryInsertResult::Inserted(1)) => {}
+        Ok(_) => {
+            transaction.rollback().await.map_err(store_err)?;
+            return recover_begin_insert_race(store, request, created_at).await;
+        }
+        Err(error) => {
+            transaction.rollback().await.map_err(store_err)?;
+            if let Some(outcome) = recover_begin_state(store, request, created_at).await? {
+                return Ok(outcome);
+            }
+            return Err(store_err(error));
+        }
+    }
+
+    if advances_intent {
+        entities::chat_root_attachment::ActiveModel {
+            chat_id: Set(request.chat_id.0),
+            root_id: Set(*request.root_id.as_uuid()),
+            position: Set(i32::try_from(projection.len()).map_err(|_| {
+                AgentError::Store("root attachment projection position exceeds i32".into())
+            })?),
+            origin: Set(attachment_origin_to_db(RootAttachmentOrigin::Conversation).into()),
+        }
+        .insert(&transaction)
+        .await
+        .map_err(store_err)?;
+        set_chat_revision(
+            &transaction,
+            request.chat_id,
+            chat.attachment_revision,
+            intent_revision,
+        )
+        .await?;
+    }
+
+    transaction.commit().await.map_err(store_err)?;
+    Ok(BeginRootAttachmentChangeOutcome::Begun(change))
+}
+
+pub(in crate::db) async fn finish_root_attachment_change(
+    store: &DbStore,
+    id: RootAttachmentChangeId,
+    executor_id: Uuid,
+    terminal: &RootAttachmentChangeTerminal,
+    finished_at: DateTime<Utc>,
+) -> Result<FinishRootAttachmentChangeOutcome> {
+    if executor_id.is_nil() {
+        return Err(AgentError::Store(
+            "root attachment change executor id must not be nil".into(),
+        ));
+    }
+    terminal
+        .validate()
+        .map_err(|message| AgentError::Store(message.into()))?;
+    let finished_at = canonical_db_timestamp(finished_at)?;
+    let Some(initial) = find_change(store, id).await? else {
+        return Ok(FinishRootAttachmentChangeOutcome::NotFound);
+    };
+    if initial.executor_id != executor_id {
+        return Ok(FinishRootAttachmentChangeOutcome::ExecutorMismatch);
+    }
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, initial.chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "root attachment change {id} references missing chat {}",
+            initial.chat_id
+        )));
+    }
+    let Some(mut change) = find_change_on(&transaction, id).await? else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "root attachment change {id} disappeared while locked"
+        )));
+    };
+    if change.executor_id != executor_id {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(FinishRootAttachmentChangeOutcome::ExecutorMismatch);
+    }
+    if change.phase != RootAttachmentChangePhase::AwaitingBroker {
+        let outcome = if terminal_matches(&change, terminal) {
+            FinishRootAttachmentChangeOutcome::Existing(change)
+        } else {
+            FinishRootAttachmentChangeOutcome::AlreadyTerminal(change)
+        };
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(outcome);
+    }
+    if finished_at < change.created_at {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(
+            "root attachment change finish time precedes creation".into(),
+        ));
+    }
+
+    if let RootAttachmentChangeTerminal::Completed {
+        broker_currently_attached,
+        ..
+    } = terminal
+    {
+        let desired = change.action == RootAttachmentChangeAction::Attach;
+        if *broker_currently_attached != desired {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(FinishRootAttachmentChangeOutcome::BrokerStateMismatch);
+        }
+    }
+    if let RootAttachmentChangeTerminal::Failed {
+        broker_currently_attached: Some(broker_currently_attached),
+        ..
+    } = terminal
+    {
+        let desired = change.action == RootAttachmentChangeAction::Attach;
+        if *broker_currently_attached == desired {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(FinishRootAttachmentChangeOutcome::BrokerStateMismatch);
+        }
+    }
+
+    let chat = entities::chat::Entity::find_by_id(change.chat_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!("chat {} disappeared while locked", change.chat_id))
+        })?;
+    if chat.attachment_revision != change.intent_revision {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "chat {} attachment revision changed while root attachment change {id} was pending",
+            change.chat_id
+        )));
+    }
+    let projection =
+        load_projection(&transaction, change.chat_id, chat.attachment_revision).await?;
+    validate_pending_projection(&change, &projection)?;
+
+    let completed = matches!(terminal, RootAttachmentChangeTerminal::Completed { .. });
+    let remove_projection = (completed
+        && change.action == RootAttachmentChangeAction::Detach
+        && change.projection_existed_before)
+        || (!completed
+            && change.action == RootAttachmentChangeAction::Attach
+            && !change.projection_existed_before);
+    let result_revision = if remove_projection {
+        let position = change.projection_position.ok_or_else(|| {
+            AgentError::Store(format!(
+                "root attachment change {id} has no projection position"
+            ))
+        })?;
+        remove_projection_row(
+            &transaction,
+            change.chat_id,
+            change.root_id,
+            position,
+            change.intent_revision,
+        )
+        .await?;
+        change.intent_revision.checked_add(1).ok_or_else(|| {
+            AgentError::Store(format!("root attachment change {id} exhausted revisions"))
+        })?
+    } else {
+        change.intent_revision
+    };
+
+    change.phase = if completed {
+        RootAttachmentChangePhase::Completed
+    } else {
+        RootAttachmentChangePhase::Failed
+    };
+    change.result_revision = Some(result_revision);
+    change.projection_changed =
+        Some(completed && change.projection_existed_before != desired_state(&change));
+    match terminal {
+        RootAttachmentChangeTerminal::Completed {
+            broker_changed,
+            broker_currently_attached,
+        } => {
+            change.broker_changed = Some(*broker_changed);
+            change.broker_currently_attached = Some(*broker_currently_attached);
+            change.failure = None;
+        }
+        RootAttachmentChangeTerminal::Failed {
+            broker_changed,
+            broker_currently_attached,
+            failure,
+        } => {
+            change.broker_changed = *broker_changed;
+            change.broker_currently_attached = *broker_currently_attached;
+            change.failure = Some(failure.clone());
+        }
+    }
+    change.finished_at = Some(finished_at);
+    change
+        .validate()
+        .map_err(|message| AgentError::Store(message.into()))?;
+    persist_terminal_change(&transaction, &change).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(FinishRootAttachmentChangeOutcome::Finished(change))
+}
+
+pub(in crate::db) async fn get_root_attachment_change(
+    store: &DbStore,
+    id: RootAttachmentChangeId,
+) -> Result<Option<RootAttachmentChange>> {
+    find_change(store, id).await
+}
+
+pub(in crate::db) async fn list_pending_root_attachment_changes(
+    store: &DbStore,
+    executor_id: Uuid,
+    limit: u64,
+) -> Result<Vec<RootAttachmentChange>> {
+    if executor_id.is_nil() {
+        return Err(AgentError::Store(
+            "root attachment change executor id must not be nil".into(),
+        ));
+    }
+    if !(1..=MAX_PENDING_ROOT_ATTACHMENT_CHANGES).contains(&limit) {
+        return Err(AgentError::Store(format!(
+            "pending root attachment change limit must be in 1..={MAX_PENDING_ROOT_ATTACHMENT_CHANGES}"
+        )));
+    }
+    let rows = entities::root_attachment_change::Entity::find()
+        .filter(entities::root_attachment_change::Column::ExecutorId.eq(executor_id))
+        .filter(
+            entities::root_attachment_change::Column::Phase
+                .eq(phase_to_db(RootAttachmentChangePhase::AwaitingBroker)),
+        )
+        .order_by_asc(entities::root_attachment_change::Column::CreatedAt)
+        .order_by_asc(entities::root_attachment_change::Column::Id)
+        .limit(limit)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    let mut changes = Vec::with_capacity(rows.len());
+    for row in rows {
+        changes.push(change_from_model(row)?);
+    }
+    if changes.is_empty() {
+        return Ok(changes);
+    }
+    let chat_ids = changes
+        .iter()
+        .map(|change| change.chat_id.0)
+        .collect::<Vec<_>>();
+    let chats = entities::chat::Entity::find()
+        .filter(entities::chat::Column::Id.is_in(chat_ids))
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(|chat| (chat.id, chat.project_id))
+        .collect::<HashMap<_, _>>();
+    for change in &changes {
+        let project_id = chats.get(&change.chat_id.0).ok_or_else(|| {
+            AgentError::Store(format!(
+                "root attachment change {} references missing chat {}",
+                change.id, change.chat_id
+            ))
+        })?;
+        validate_change_subject(change, *project_id)?;
+    }
+    Ok(changes)
+}
+
+async fn find_change(
+    store: &DbStore,
+    id: RootAttachmentChangeId,
+) -> Result<Option<RootAttachmentChange>> {
+    find_change_on(&store.conn, id).await
+}
+
+async fn find_change_on<C>(
+    conn: &C,
+    id: RootAttachmentChangeId,
+) -> Result<Option<RootAttachmentChange>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let change = entities::root_attachment_change::Entity::find_by_id(*id.as_uuid())
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .map(change_from_model)
+        .transpose()?;
+    if let Some(change) = &change {
+        validate_change_subject_on(conn, change).await?;
+    }
+    Ok(change)
+}
+
+fn exact_begin_outcome(
+    existing: RootAttachmentChange,
+    request: &BeginRootAttachmentChange,
+    created_at: DateTime<Utc>,
+) -> BeginRootAttachmentChangeOutcome {
+    if existing.chat_id == request.chat_id
+        && existing.executor_id == request.executor_id
+        && existing.root_id == request.root_id
+        && existing.action == request.action
+        && existing.expected_revision == request.expected_attachment_revision
+        && existing.created_at == created_at
+    {
+        BeginRootAttachmentChangeOutcome::Existing(existing)
+    } else {
+        BeginRootAttachmentChangeOutcome::IdentityConflict
+    }
+}
+
+async fn recover_begin_insert_race(
+    store: &DbStore,
+    request: &BeginRootAttachmentChange,
+    created_at: DateTime<Utc>,
+) -> Result<BeginRootAttachmentChangeOutcome> {
+    if let Some(outcome) = recover_begin_state(store, request, created_at).await? {
+        return Ok(outcome);
+    }
+    Err(AgentError::Store(format!(
+        "root attachment change {} insert was ignored without durable state",
+        request.id
+    )))
+}
+
+async fn recover_begin_state(
+    store: &DbStore,
+    request: &BeginRootAttachmentChange,
+    created_at: DateTime<Utc>,
+) -> Result<Option<BeginRootAttachmentChangeOutcome>> {
+    if let Some(existing) = find_change(store, request.id).await? {
+        return Ok(Some(exact_begin_outcome(existing, request, created_at)));
+    }
+    let busy = entities::root_attachment_change::Entity::find()
+        .filter(entities::root_attachment_change::Column::ChatId.eq(request.chat_id.0))
+        .filter(
+            entities::root_attachment_change::Column::Phase
+                .eq(phase_to_db(RootAttachmentChangePhase::AwaitingBroker)),
+        )
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(change_from_model)
+        .transpose()?;
+    if let Some(busy) = &busy {
+        validate_change_subject_on(&store.conn, busy).await?;
+    }
+    Ok(busy.map(|_| BeginRootAttachmentChangeOutcome::ChatBusy))
+}
+
+fn derive_subject(
+    chat_id: ChatId,
+    project_id: Option<Uuid>,
+) -> Result<(RootAttachmentSubjectKind, Uuid)> {
+    if let Some(project_id) = project_id {
+        if project_id.is_nil() {
+            return Err(AgentError::Store(format!(
+                "chat {chat_id} has a nil root attachment project subject"
+            )));
+        }
+        Ok((RootAttachmentSubjectKind::Project, project_id))
+    } else {
+        Ok((RootAttachmentSubjectKind::Conversation, *chat_id.as_uuid()))
+    }
+}
+
+async fn validate_change_subject_on<C>(conn: &C, change: &RootAttachmentChange) -> Result<()>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let chat = entities::chat::Entity::find_by_id(change.chat_id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "root attachment change {} references missing chat {}",
+                change.id, change.chat_id
+            ))
+        })?;
+    validate_change_subject(change, chat.project_id)
+}
+
+fn validate_change_subject(change: &RootAttachmentChange, project_id: Option<Uuid>) -> Result<()> {
+    let expected = derive_subject(change.chat_id, project_id)?;
+    if (change.subject_kind, change.subject_id) != expected {
+        return Err(AgentError::Store(format!(
+            "root attachment change {} has authority inconsistent with chat {}",
+            change.id, change.chat_id
+        )));
+    }
+    Ok(())
+}
+
+async fn load_projection<C>(
+    conn: &C,
+    chat_id: ChatId,
+    revision: i64,
+) -> Result<Vec<entities::chat_root_attachment::Model>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    if !(0..=MAX_ATTACHMENT_REVISION).contains(&revision) {
+        return Err(AgentError::Store(format!(
+            "chat {chat_id} has an invalid attachment revision"
+        )));
+    }
+    let rows = entities::chat_root_attachment::Entity::find()
+        .filter(entities::chat_root_attachment::Column::ChatId.eq(chat_id.0))
+        .order_by_asc(entities::chat_root_attachment::Column::Position)
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    if rows.len() > MAX_ROOT_ATTACHMENTS {
+        return Err(AgentError::Store(format!(
+            "chat {chat_id} exceeds the root attachment limit"
+        )));
+    }
+    for (expected, row) in rows.iter().enumerate() {
+        if row.chat_id != chat_id.0 || usize::try_from(row.position).ok() != Some(expected) {
+            return Err(AgentError::Store(format!(
+                "chat {chat_id} root attachment positions are invalid"
+            )));
+        }
+        HostRootId::from_uuid(row.root_id).map_err(|error| {
+            AgentError::Store(format!("chat {chat_id} has an invalid root id: {error}"))
+        })?;
+        attachment_origin_from_db(&row.origin)?;
+    }
+    if !rows.is_empty() && revision == 0 {
+        return Err(AgentError::Store(format!(
+            "chat {chat_id} has roots at attachment revision zero"
+        )));
+    }
+    Ok(rows)
+}
+
+fn validate_pending_projection(
+    change: &RootAttachmentChange,
+    projection: &[entities::chat_root_attachment::Model],
+) -> Result<()> {
+    let found = projection
+        .iter()
+        .position(|row| row.root_id == *change.root_id.as_uuid());
+    let expected_present =
+        change.projection_existed_before || change.action == RootAttachmentChangeAction::Attach;
+    if expected_present != found.is_some() {
+        return Err(AgentError::Store(format!(
+            "root attachment change {} pending projection is inconsistent",
+            change.id
+        )));
+    }
+    if let Some(position) = found {
+        let expected_position = change
+            .projection_position
+            .and_then(|value| usize::try_from(value).ok());
+        if expected_position != Some(position)
+            || change.origin != Some(attachment_origin_from_db(&projection[position].origin)?)
+        {
+            return Err(AgentError::Store(format!(
+                "root attachment change {} pending projection metadata changed",
+                change.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn set_chat_revision<C>(conn: &C, chat_id: ChatId, before: i64, after: i64) -> Result<()>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let updated = entities::chat::Entity::update_many()
+        .col_expr(
+            entities::chat::Column::AttachmentRevision,
+            Expr::value(after),
+        )
+        .filter(entities::chat::Column::Id.eq(chat_id.0))
+        .filter(entities::chat::Column::AttachmentRevision.eq(before))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "chat {chat_id} attachment revision changed while locked"
+        )));
+    }
+    Ok(())
+}
+
+async fn remove_projection_row<C>(
+    conn: &C,
+    chat_id: ChatId,
+    root_id: HostRootId,
+    position: u32,
+    before_revision: i64,
+) -> Result<()>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let position = i32::try_from(position)
+        .map_err(|_| AgentError::Store("root attachment position exceeds i32".into()))?;
+    let deleted = entities::chat_root_attachment::Entity::delete_many()
+        .filter(entities::chat_root_attachment::Column::ChatId.eq(chat_id.0))
+        .filter(entities::chat_root_attachment::Column::RootId.eq(*root_id.as_uuid()))
+        .filter(entities::chat_root_attachment::Column::Position.eq(position))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    if deleted.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "chat {chat_id} root attachment changed while locked"
+        )));
+    }
+    let trailing = entities::chat_root_attachment::Entity::find()
+        .filter(entities::chat_root_attachment::Column::ChatId.eq(chat_id.0))
+        .filter(entities::chat_root_attachment::Column::Position.gt(position))
+        .order_by_asc(entities::chat_root_attachment::Column::Position)
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    // Compact from the gap upward. Updating one exact row at a time avoids
+    // transient unique-position collisions on backends that check uniqueness
+    // row-by-row rather than at the end of a multi-row UPDATE.
+    for row in trailing {
+        let compacted = entities::chat_root_attachment::Entity::update_many()
+            .col_expr(
+                entities::chat_root_attachment::Column::Position,
+                Expr::value(row.position - 1),
+            )
+            .filter(entities::chat_root_attachment::Column::ChatId.eq(chat_id.0))
+            .filter(entities::chat_root_attachment::Column::RootId.eq(row.root_id))
+            .filter(entities::chat_root_attachment::Column::Position.eq(row.position))
+            .exec(conn)
+            .await
+            .map_err(store_err)?;
+        if compacted.rows_affected != 1 {
+            return Err(AgentError::Store(format!(
+                "chat {chat_id} root attachment positions changed while locked"
+            )));
+        }
+    }
+    set_chat_revision(conn, chat_id, before_revision, before_revision + 1).await
+}
+
+async fn persist_terminal_change<C>(conn: &C, change: &RootAttachmentChange) -> Result<()>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let updated = entities::root_attachment_change::Entity::update_many()
+        .col_expr(
+            entities::root_attachment_change::Column::Phase,
+            Expr::value(phase_to_db(change.phase)),
+        )
+        .col_expr(
+            entities::root_attachment_change::Column::ResultRevision,
+            Expr::value(change.result_revision),
+        )
+        .col_expr(
+            entities::root_attachment_change::Column::ProjectionChanged,
+            Expr::value(change.projection_changed),
+        )
+        .col_expr(
+            entities::root_attachment_change::Column::BrokerChanged,
+            Expr::value(change.broker_changed),
+        )
+        .col_expr(
+            entities::root_attachment_change::Column::BrokerCurrentlyAttached,
+            Expr::value(change.broker_currently_attached),
+        )
+        .col_expr(
+            entities::root_attachment_change::Column::FailureCode,
+            Expr::value(change.failure.as_ref().map(|failure| failure.code.clone())),
+        )
+        .col_expr(
+            entities::root_attachment_change::Column::FailureMessage,
+            Expr::value(
+                change
+                    .failure
+                    .as_ref()
+                    .map(|failure| failure.message.clone()),
+            ),
+        )
+        .col_expr(
+            entities::root_attachment_change::Column::FailureRetryable,
+            Expr::value(change.failure.as_ref().map(|failure| failure.retryable)),
+        )
+        .col_expr(
+            entities::root_attachment_change::Column::FinishedAt,
+            Expr::value(change.finished_at),
+        )
+        .filter(entities::root_attachment_change::Column::Id.eq(*change.id.as_uuid()))
+        .filter(
+            entities::root_attachment_change::Column::Phase
+                .eq(phase_to_db(RootAttachmentChangePhase::AwaitingBroker)),
+        )
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "root attachment change {} changed while locked",
+            change.id
+        )));
+    }
+    Ok(())
+}
+
+fn change_active_model(
+    change: &RootAttachmentChange,
+) -> entities::root_attachment_change::ActiveModel {
+    entities::root_attachment_change::ActiveModel {
+        id: Set(*change.id.as_uuid()),
+        chat_id: Set(change.chat_id.0),
+        subject_kind: Set(subject_kind_to_db(change.subject_kind).into()),
+        subject_id: Set(change.subject_id),
+        executor_id: Set(change.executor_id),
+        root_id: Set(*change.root_id.as_uuid()),
+        action: Set(action_to_db(change.action).into()),
+        origin: Set(change
+            .origin
+            .map(|origin| attachment_origin_to_db(origin).into())),
+        projection_position: Set(change
+            .projection_position
+            .map(i64::from)
+            .map(|position| i32::try_from(position).expect("bounded projection position"))),
+        projection_existed_before: Set(change.projection_existed_before),
+        expected_revision: Set(change.expected_revision),
+        before_revision: Set(change.before_revision),
+        intent_revision: Set(change.intent_revision),
+        phase: Set(phase_to_db(change.phase).into()),
+        result_revision: Set(change.result_revision),
+        projection_changed: Set(change.projection_changed),
+        broker_changed: Set(change.broker_changed),
+        broker_currently_attached: Set(change.broker_currently_attached),
+        failure_code: Set(change.failure.as_ref().map(|failure| failure.code.clone())),
+        failure_message: Set(change
+            .failure
+            .as_ref()
+            .map(|failure| failure.message.clone())),
+        failure_retryable: Set(change.failure.as_ref().map(|failure| failure.retryable)),
+        created_at: Set(change.created_at),
+        finished_at: Set(change.finished_at),
+    }
+}
+
+fn change_from_model(
+    model: entities::root_attachment_change::Model,
+) -> Result<RootAttachmentChange> {
+    let created_at = require_canonical_timestamp("created_at", model.id, model.created_at)?;
+    let finished_at = model
+        .finished_at
+        .map(|value| require_canonical_timestamp("finished_at", model.id, value))
+        .transpose()?;
+    let failure = match (
+        model.failure_code,
+        model.failure_message,
+        model.failure_retryable,
+    ) {
+        (None, None, None) => None,
+        (Some(code), Some(message), Some(retryable)) => Some(RootAttachmentChangeFailure {
+            code,
+            message,
+            retryable,
+        }),
+        _ => {
+            return Err(AgentError::Store(format!(
+                "root attachment change {} has partial failure fields",
+                model.id
+            )))
+        }
+    };
+    let change = RootAttachmentChange {
+        id: RootAttachmentChangeId::from_uuid(model.id).map_err(|error| {
+            AgentError::Store(format!("invalid root attachment change id: {error}"))
+        })?,
+        chat_id: ChatId(model.chat_id),
+        executor_id: model.executor_id,
+        root_id: HostRootId::from_uuid(model.root_id).map_err(|error| {
+            AgentError::Store(format!(
+                "root attachment change {} has invalid root id: {error}",
+                model.id
+            ))
+        })?,
+        action: action_from_db(&model.action)?,
+        subject_kind: subject_kind_from_db(&model.subject_kind)?,
+        subject_id: model.subject_id,
+        origin: model
+            .origin
+            .as_deref()
+            .map(attachment_origin_from_db)
+            .transpose()?,
+        projection_position: model
+            .projection_position
+            .map(|position| {
+                u32::try_from(position).map_err(|_| {
+                    AgentError::Store(format!(
+                        "root attachment change {} has an invalid projection position",
+                        model.id
+                    ))
+                })
+            })
+            .transpose()?,
+        projection_existed_before: model.projection_existed_before,
+        expected_revision: model.expected_revision,
+        before_revision: model.before_revision,
+        intent_revision: model.intent_revision,
+        phase: phase_from_db(&model.phase)?,
+        result_revision: model.result_revision,
+        projection_changed: model.projection_changed,
+        broker_changed: model.broker_changed,
+        broker_currently_attached: model.broker_currently_attached,
+        failure,
+        created_at,
+        finished_at,
+    };
+    change.validate().map_err(|message| {
+        AgentError::Store(format!(
+            "invalid root attachment change {}: {message}",
+            change.id
+        ))
+    })?;
+    Ok(change)
+}
+
+fn require_canonical_timestamp(
+    field: &str,
+    id: Uuid,
+    value: DateTime<Utc>,
+) -> Result<DateTime<Utc>> {
+    let canonical = canonical_db_timestamp(value)?;
+    if canonical != value {
+        return Err(AgentError::Store(format!(
+            "root attachment change {id} has noncanonical {field}"
+        )));
+    }
+    Ok(canonical)
+}
+
+fn terminal_matches(
+    change: &RootAttachmentChange,
+    terminal: &RootAttachmentChangeTerminal,
+) -> bool {
+    match terminal {
+        RootAttachmentChangeTerminal::Completed {
+            broker_changed,
+            broker_currently_attached,
+        } => {
+            change.phase == RootAttachmentChangePhase::Completed
+                && change.broker_changed == Some(*broker_changed)
+                && change.broker_currently_attached == Some(*broker_currently_attached)
+                && change.failure.is_none()
+        }
+        RootAttachmentChangeTerminal::Failed {
+            broker_changed,
+            broker_currently_attached,
+            failure,
+        } => {
+            change.phase == RootAttachmentChangePhase::Failed
+                && change.broker_changed == *broker_changed
+                && change.broker_currently_attached == *broker_currently_attached
+                && change.failure.as_ref() == Some(failure)
+        }
+    }
+}
+
+fn desired_state(change: &RootAttachmentChange) -> bool {
+    change.action == RootAttachmentChangeAction::Attach
+}
+
+fn action_to_db(action: RootAttachmentChangeAction) -> &'static str {
+    match action {
+        RootAttachmentChangeAction::Attach => "attach",
+        RootAttachmentChangeAction::Detach => "detach",
+    }
+}
+
+fn action_from_db(value: &str) -> Result<RootAttachmentChangeAction> {
+    match value {
+        "attach" => Ok(RootAttachmentChangeAction::Attach),
+        "detach" => Ok(RootAttachmentChangeAction::Detach),
+        other => Err(AgentError::Store(format!(
+            "unknown root attachment action: {other}"
+        ))),
+    }
+}
+
+fn subject_kind_to_db(kind: RootAttachmentSubjectKind) -> &'static str {
+    match kind {
+        RootAttachmentSubjectKind::Project => "project",
+        RootAttachmentSubjectKind::Conversation => "conversation",
+    }
+}
+
+fn subject_kind_from_db(value: &str) -> Result<RootAttachmentSubjectKind> {
+    match value {
+        "project" => Ok(RootAttachmentSubjectKind::Project),
+        "conversation" => Ok(RootAttachmentSubjectKind::Conversation),
+        other => Err(AgentError::Store(format!(
+            "unknown root attachment subject kind: {other}"
+        ))),
+    }
+}
+
+fn phase_to_db(phase: RootAttachmentChangePhase) -> &'static str {
+    match phase {
+        RootAttachmentChangePhase::AwaitingBroker => "awaiting_broker",
+        RootAttachmentChangePhase::Completed => "completed",
+        RootAttachmentChangePhase::Failed => "failed",
+    }
+}
+
+fn phase_from_db(value: &str) -> Result<RootAttachmentChangePhase> {
+    match value {
+        "awaiting_broker" => Ok(RootAttachmentChangePhase::AwaitingBroker),
+        "completed" => Ok(RootAttachmentChangePhase::Completed),
+        "failed" => Ok(RootAttachmentChangePhase::Failed),
+        other => Err(AgentError::Store(format!(
+            "unknown root attachment change phase: {other}"
+        ))),
+    }
+}

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -7,6 +7,7 @@ use crate::model::{
 use crate::storage::ApplyTurnSteerOutcome;
 use chrono::{DateTime, Utc};
 
+mod root_attachment;
 mod turn_steer;
 
 async fn temp_store() -> (tempfile::TempDir, DbStore) {

--- a/crates/openwave-core/src/db/tests/root_attachment.rs
+++ b/crates/openwave-core/src/db/tests/root_attachment.rs
@@ -1,0 +1,895 @@
+use super::*;
+use crate::id::RootAttachmentChangeId;
+use crate::model::{
+    BeginRootAttachmentChange, RootAttachmentChange, RootAttachmentChangeAction,
+    RootAttachmentChangeFailure, RootAttachmentChangePhase, RootAttachmentChangeTerminal,
+    RootAttachmentSubjectKind,
+};
+use crate::storage::{
+    BeginRootAttachmentChangeOutcome, FinishRootAttachmentChangeOutcome,
+    MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+};
+
+fn at(second: i64) -> DateTime<Utc> {
+    DateTime::<Utc>::from_timestamp(1_710_000_000 + second, 0).unwrap()
+}
+
+fn root_id() -> HostRootId {
+    HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap()
+}
+
+fn begin_request(
+    chat: &Chat,
+    executor_id: uuid::Uuid,
+    root_id: HostRootId,
+    action: RootAttachmentChangeAction,
+    expected_attachment_revision: i64,
+    second: i64,
+) -> BeginRootAttachmentChange {
+    BeginRootAttachmentChange {
+        id: RootAttachmentChangeId::new(),
+        chat_id: chat.id,
+        executor_id,
+        root_id,
+        action,
+        expected_attachment_revision,
+        created_at: at(second),
+    }
+}
+
+fn begun(outcome: BeginRootAttachmentChangeOutcome) -> RootAttachmentChange {
+    match outcome {
+        BeginRootAttachmentChangeOutcome::Begun(change) => change,
+        other => panic!("expected begun attachment change, got {other:?}"),
+    }
+}
+
+fn finished(outcome: FinishRootAttachmentChangeOutcome) -> RootAttachmentChange {
+    match outcome {
+        FinishRootAttachmentChangeOutcome::Finished(change) => change,
+        other => panic!("expected finished attachment change, got {other:?}"),
+    }
+}
+
+fn completed(attached: bool, changed: bool) -> RootAttachmentChangeTerminal {
+    RootAttachmentChangeTerminal::Completed {
+        broker_changed: changed,
+        broker_currently_attached: attached,
+    }
+}
+
+fn failed(code: &str) -> RootAttachmentChangeTerminal {
+    RootAttachmentChangeTerminal::Failed {
+        broker_changed: None,
+        broker_currently_attached: None,
+        failure: RootAttachmentChangeFailure {
+            code: code.into(),
+            message: format!("{code} failure"),
+            retryable: true,
+        },
+    }
+}
+
+#[tokio::test]
+async fn attach_intent_success_and_failure_rollback_are_atomic() {
+    let (_dir, store) = temp_store().await;
+    let executor = uuid::Uuid::new_v4();
+
+    let success_chat = sample_chat();
+    store.create_chat(&success_chat).await.unwrap();
+    let success_root = root_id();
+    let success_request = begin_request(
+        &success_chat,
+        executor,
+        success_root,
+        RootAttachmentChangeAction::Attach,
+        0,
+        0,
+    );
+    let pending = begun(
+        store
+            .begin_root_attachment_change(&success_request)
+            .await
+            .unwrap(),
+    );
+    assert_eq!(pending.phase, RootAttachmentChangePhase::AwaitingBroker);
+    assert_eq!(pending.before_revision, 0);
+    assert_eq!(pending.intent_revision, 1);
+    assert!(!pending.projection_existed_before);
+    assert_eq!(pending.origin, Some(RootAttachmentOrigin::Conversation));
+    assert_eq!(pending.projection_position, Some(0));
+    let intent_chat = store.get_chat(success_chat.id).await.unwrap().unwrap();
+    assert_eq!(intent_chat.attachment_revision, 1);
+    assert_eq!(
+        intent_chat.root_attachments,
+        vec![ChatRootAttachment {
+            root_id: success_root,
+            origin: RootAttachmentOrigin::Conversation,
+        }]
+    );
+
+    let completed_change = finished(
+        store
+            .finish_root_attachment_change(
+                success_request.id,
+                executor,
+                &completed(true, true),
+                at(1),
+            )
+            .await
+            .unwrap(),
+    );
+    assert_eq!(completed_change.phase, RootAttachmentChangePhase::Completed);
+    assert_eq!(completed_change.result_revision, Some(1));
+    assert_eq!(completed_change.projection_changed, Some(true));
+    assert_eq!(
+        store
+            .get_chat(success_chat.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .root_attachments,
+        intent_chat.root_attachments
+    );
+
+    let failure_chat = sample_chat();
+    store.create_chat(&failure_chat).await.unwrap();
+    let failure_root = root_id();
+    let failure_request = begin_request(
+        &failure_chat,
+        executor,
+        failure_root,
+        RootAttachmentChangeAction::Attach,
+        0,
+        2,
+    );
+    begun(
+        store
+            .begin_root_attachment_change(&failure_request)
+            .await
+            .unwrap(),
+    );
+    let failed_change = finished(
+        store
+            .finish_root_attachment_change(failure_request.id, executor, &failed("denied"), at(3))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(failed_change.phase, RootAttachmentChangePhase::Failed);
+    assert_eq!(failed_change.result_revision, Some(2));
+    assert_eq!(failed_change.projection_changed, Some(false));
+    let rolled_back = store.get_chat(failure_chat.id).await.unwrap().unwrap();
+    assert_eq!(rolled_back.attachment_revision, 2);
+    assert!(rolled_back.root_attachments.is_empty());
+}
+
+#[tokio::test]
+async fn detach_waits_for_broker_then_removes_or_preserves_and_compacts_positions() {
+    let (_dir, store) = temp_store().await;
+    let executor = uuid::Uuid::new_v4();
+    let roots = [root_id(), root_id(), root_id()];
+
+    let mut success_chat = sample_chat();
+    success_chat.attachment_revision = 7;
+    success_chat.root_attachments = roots
+        .iter()
+        .copied()
+        .map(|root_id| ChatRootAttachment {
+            root_id,
+            origin: RootAttachmentOrigin::Conversation,
+        })
+        .collect();
+    store.create_chat(&success_chat).await.unwrap();
+    let detach = begin_request(
+        &success_chat,
+        executor,
+        roots[1],
+        RootAttachmentChangeAction::Detach,
+        7,
+        0,
+    );
+    let pending = begun(store.begin_root_attachment_change(&detach).await.unwrap());
+    assert!(pending.projection_existed_before);
+    assert_eq!(pending.projection_position, Some(1));
+    assert_eq!(pending.intent_revision, 7);
+    assert_eq!(
+        store.get_chat(success_chat.id).await.unwrap().unwrap(),
+        success_chat
+    );
+
+    let completed_change = finished(
+        store
+            .finish_root_attachment_change(detach.id, executor, &completed(false, true), at(1))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(completed_change.result_revision, Some(8));
+    assert_eq!(completed_change.projection_changed, Some(true));
+    let detached = store.get_chat(success_chat.id).await.unwrap().unwrap();
+    assert_eq!(detached.attachment_revision, 8);
+    assert_eq!(
+        detached
+            .root_attachments
+            .iter()
+            .map(|attachment| attachment.root_id)
+            .collect::<Vec<_>>(),
+        vec![roots[0], roots[2]]
+    );
+
+    let mut failure_chat = sample_chat();
+    failure_chat.attachment_revision = 4;
+    failure_chat.root_attachments = vec![ChatRootAttachment {
+        root_id: roots[1],
+        origin: RootAttachmentOrigin::Conversation,
+    }];
+    store.create_chat(&failure_chat).await.unwrap();
+    let failed_detach = begin_request(
+        &failure_chat,
+        executor,
+        roots[1],
+        RootAttachmentChangeAction::Detach,
+        4,
+        2,
+    );
+    begun(
+        store
+            .begin_root_attachment_change(&failed_detach)
+            .await
+            .unwrap(),
+    );
+    let failed_change = finished(
+        store
+            .finish_root_attachment_change(
+                failed_detach.id,
+                executor,
+                &failed("broker_unavailable"),
+                at(3),
+            )
+            .await
+            .unwrap(),
+    );
+    assert_eq!(failed_change.phase, RootAttachmentChangePhase::Failed);
+    assert_eq!(failed_change.result_revision, Some(4));
+    assert_eq!(failed_change.projection_changed, Some(false));
+    assert_eq!(
+        store.get_chat(failure_chat.id).await.unwrap().unwrap(),
+        failure_chat
+    );
+}
+
+#[tokio::test]
+async fn begin_and_finish_retries_are_exact_and_conflicts_fail_closed() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let executor = uuid::Uuid::new_v4();
+    let request = begin_request(
+        &chat,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        0,
+    );
+    let begun_change = begun(store.begin_root_attachment_change(&request).await.unwrap());
+    assert_eq!(
+        store.begin_root_attachment_change(&request).await.unwrap(),
+        BeginRootAttachmentChangeOutcome::Existing(begun_change.clone())
+    );
+
+    let mut conflicting = request;
+    conflicting.root_id = root_id();
+    assert_eq!(
+        store
+            .begin_root_attachment_change(&conflicting)
+            .await
+            .unwrap(),
+        BeginRootAttachmentChangeOutcome::IdentityConflict
+    );
+
+    assert_eq!(
+        store
+            .finish_root_attachment_change(
+                request.id,
+                uuid::Uuid::new_v4(),
+                &completed(true, true),
+                at(1),
+            )
+            .await
+            .unwrap(),
+        FinishRootAttachmentChangeOutcome::ExecutorMismatch
+    );
+    assert_eq!(
+        store.get_root_attachment_change(request.id).await.unwrap(),
+        Some(begun_change)
+    );
+
+    let terminal = completed(true, true);
+    let completed_change = finished(
+        store
+            .finish_root_attachment_change(request.id, executor, &terminal, at(1))
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        store
+            .finish_root_attachment_change(request.id, executor, &terminal, at(2))
+            .await
+            .unwrap(),
+        FinishRootAttachmentChangeOutcome::Existing(completed_change.clone())
+    );
+    assert_eq!(completed_change.finished_at, Some(at(1)));
+    assert_eq!(
+        store
+            .finish_root_attachment_change(request.id, executor, &completed(true, false), at(1))
+            .await
+            .unwrap(),
+        FinishRootAttachmentChangeOutcome::AlreadyTerminal(completed_change)
+    );
+    assert_eq!(
+        store
+            .finish_root_attachment_change(
+                RootAttachmentChangeId::new(),
+                executor,
+                &terminal,
+                at(1),
+            )
+            .await
+            .unwrap(),
+        FinishRootAttachmentChangeOutcome::NotFound
+    );
+}
+
+#[tokio::test]
+async fn one_pending_change_owns_each_chat_and_stale_revisions_are_rejected() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let executor = uuid::Uuid::new_v4();
+
+    let stale = begin_request(
+        &chat,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        1,
+        0,
+    );
+    assert_eq!(
+        store.begin_root_attachment_change(&stale).await.unwrap(),
+        BeginRootAttachmentChangeOutcome::RevisionConflict {
+            current_attachment_revision: 0,
+        }
+    );
+
+    let first = begin_request(
+        &chat,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        1,
+    );
+    let first_change = begun(store.begin_root_attachment_change(&first).await.unwrap());
+    let second = begin_request(
+        &chat,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        1,
+        2,
+    );
+    assert_eq!(
+        store.begin_root_attachment_change(&second).await.unwrap(),
+        BeginRootAttachmentChangeOutcome::ChatBusy
+    );
+    assert_eq!(
+        store.get_root_attachment_change(first.id).await.unwrap(),
+        Some(first_change)
+    );
+}
+
+#[tokio::test]
+async fn concurrent_begins_serialize_to_one_pending_change() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let executor = uuid::Uuid::new_v4();
+    let requests = [
+        begin_request(
+            &chat,
+            executor,
+            root_id(),
+            RootAttachmentChangeAction::Attach,
+            0,
+            0,
+        ),
+        begin_request(
+            &chat,
+            executor,
+            root_id(),
+            RootAttachmentChangeAction::Attach,
+            0,
+            1,
+        ),
+    ];
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(requests.len()));
+    let tasks = requests.into_iter().map(|request| {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store.begin_root_attachment_change(&request).await
+        })
+    });
+    let outcomes = futures::future::join_all(tasks)
+        .await
+        .into_iter()
+        .map(|task| task.expect("concurrent begin task panicked"))
+        .collect::<Vec<_>>();
+
+    let outcomes = outcomes
+        .into_iter()
+        .map(|outcome| outcome.expect("concurrent begin leaked a database error"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, BeginRootAttachmentChangeOutcome::Begun(_)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, BeginRootAttachmentChangeOutcome::ChatBusy))
+            .count(),
+        1
+    );
+    assert_eq!(
+        store
+            .list_pending_root_attachment_changes(executor, 2)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn concurrent_exact_finishes_converge_on_one_terminal_change() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let executor = uuid::Uuid::new_v4();
+    let request = begin_request(
+        &chat,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        0,
+    );
+    begun(store.begin_root_attachment_change(&request).await.unwrap());
+
+    let terminal = completed(true, true);
+    let finished_at = [at(1), at(2)];
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(finished_at.len()));
+    let tasks = finished_at.into_iter().map(|finished_at| {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        let terminal = terminal.clone();
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .finish_root_attachment_change(request.id, executor, &terminal, finished_at)
+                .await
+        })
+    });
+    let outcomes = futures::future::join_all(tasks)
+        .await
+        .into_iter()
+        .map(|task| task.expect("concurrent finish task panicked"))
+        .collect::<Vec<_>>();
+
+    let outcomes = outcomes
+        .into_iter()
+        .map(|outcome| outcome.expect("concurrent finish leaked a database error"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, FinishRootAttachmentChangeOutcome::Finished(_)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, FinishRootAttachmentChangeOutcome::Existing(_)))
+            .count(),
+        1
+    );
+    let committed = outcomes.iter().find_map(|outcome| match outcome {
+        FinishRootAttachmentChangeOutcome::Finished(change)
+        | FinishRootAttachmentChangeOutcome::Existing(change) => Some(change),
+        _ => None,
+    });
+    assert!(outcomes.iter().all(|outcome| match outcome {
+        FinishRootAttachmentChangeOutcome::Finished(change)
+        | FinishRootAttachmentChangeOutcome::Existing(change) => Some(change) == committed,
+        _ => false,
+    }));
+}
+
+#[tokio::test]
+async fn subjects_are_derived_from_authoritative_chat_ownership() {
+    let (_dir, store) = temp_store().await;
+    let executor = uuid::Uuid::new_v4();
+
+    let standalone = sample_chat();
+    store.create_chat(&standalone).await.unwrap();
+    let standalone_request = begin_request(
+        &standalone,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        0,
+    );
+    let standalone_change = begun(
+        store
+            .begin_root_attachment_change(&standalone_request)
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        standalone_change.subject_kind,
+        RootAttachmentSubjectKind::Conversation
+    );
+    assert_eq!(standalone_change.subject_id, *standalone.id.as_uuid());
+
+    let project = sample_project();
+    store.create_project(&project).await.unwrap();
+    let mut project_chat = sample_chat();
+    project_chat.project_id = Some(project.id);
+    store.create_chat(&project_chat).await.unwrap();
+    let project_request = begin_request(
+        &project_chat,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        1,
+    );
+    let project_change = begun(
+        store
+            .begin_root_attachment_change(&project_request)
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        project_change.subject_kind,
+        RootAttachmentSubjectKind::Project
+    );
+    assert_eq!(project_change.subject_id, *project.id.as_uuid());
+}
+
+#[tokio::test]
+async fn contradictory_broker_success_leaves_the_change_awaiting() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let executor = uuid::Uuid::new_v4();
+    let request = begin_request(
+        &chat,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        0,
+    );
+    let pending = begun(store.begin_root_attachment_change(&request).await.unwrap());
+
+    assert_eq!(
+        store
+            .finish_root_attachment_change(request.id, executor, &completed(false, true), at(1),)
+            .await
+            .unwrap(),
+        FinishRootAttachmentChangeOutcome::BrokerStateMismatch
+    );
+    assert_eq!(
+        store.get_root_attachment_change(request.id).await.unwrap(),
+        Some(pending)
+    );
+    assert_eq!(
+        store
+            .list_pending_root_attachment_changes(executor, 1)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn contradictory_failed_broker_observation_leaves_the_change_awaiting() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let executor = uuid::Uuid::new_v4();
+    let request = begin_request(
+        &chat,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        0,
+    );
+    let pending = begun(store.begin_root_attachment_change(&request).await.unwrap());
+    let contradictory_failure = RootAttachmentChangeTerminal::Failed {
+        broker_changed: Some(true),
+        broker_currently_attached: Some(true),
+        failure: RootAttachmentChangeFailure {
+            code: "ambiguous_attach".into(),
+            message: "broker reports the root remains attached".into(),
+            retryable: true,
+        },
+    };
+
+    assert_eq!(
+        store
+            .finish_root_attachment_change(request.id, executor, &contradictory_failure, at(1),)
+            .await
+            .unwrap(),
+        FinishRootAttachmentChangeOutcome::BrokerStateMismatch
+    );
+    assert_eq!(
+        store.get_root_attachment_change(request.id).await.unwrap(),
+        Some(pending)
+    );
+}
+
+#[tokio::test]
+async fn pending_scan_is_bounded_filtered_and_oldest_first() {
+    let (_dir, store) = temp_store().await;
+    let executor = uuid::Uuid::new_v4();
+    let other_executor = uuid::Uuid::new_v4();
+    let mut expected = Vec::new();
+
+    for second in [30, 10, 20] {
+        let chat = sample_chat();
+        store.create_chat(&chat).await.unwrap();
+        let request = begin_request(
+            &chat,
+            executor,
+            root_id(),
+            RootAttachmentChangeAction::Attach,
+            0,
+            second,
+        );
+        expected.push(begun(
+            store.begin_root_attachment_change(&request).await.unwrap(),
+        ));
+    }
+    let other_chat = sample_chat();
+    store.create_chat(&other_chat).await.unwrap();
+    let other = begin_request(
+        &other_chat,
+        other_executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        0,
+    );
+    begun(store.begin_root_attachment_change(&other).await.unwrap());
+
+    expected.sort_by_key(|change| change.created_at);
+    assert_eq!(
+        store
+            .list_pending_root_attachment_changes(executor, 2)
+            .await
+            .unwrap(),
+        expected[..2]
+    );
+    assert!(store
+        .list_pending_root_attachment_changes(executor, 0)
+        .await
+        .is_err());
+    assert!(store
+        .list_pending_root_attachment_changes(executor, MAX_PENDING_ROOT_ATTACHMENT_CHANGES + 1)
+        .await
+        .is_err());
+    assert!(store
+        .list_pending_root_attachment_changes(uuid::Uuid::nil(), 1)
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn capacity_and_revision_headroom_are_reserved_before_begin() {
+    let (_dir, store) = temp_store().await;
+    let executor = uuid::Uuid::new_v4();
+
+    let mut full = sample_chat();
+    full.attachment_revision = 1;
+    full.root_attachments = (0..MAX_ROOT_ATTACHMENTS)
+        .map(|_| ChatRootAttachment {
+            root_id: root_id(),
+            origin: RootAttachmentOrigin::Conversation,
+        })
+        .collect();
+    store.create_chat(&full).await.unwrap();
+    let over_capacity = begin_request(
+        &full,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        1,
+        0,
+    );
+    assert_eq!(
+        store
+            .begin_root_attachment_change(&over_capacity)
+            .await
+            .unwrap(),
+        BeginRootAttachmentChangeOutcome::CapacityExceeded
+    );
+    assert_eq!(store.get_chat(full.id).await.unwrap(), Some(full));
+
+    let mut no_rollback_headroom = sample_chat();
+    no_rollback_headroom.attachment_revision = MAX_ATTACHMENT_REVISION - 1;
+    store.create_chat(&no_rollback_headroom).await.unwrap();
+    let attach = begin_request(
+        &no_rollback_headroom,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        MAX_ATTACHMENT_REVISION - 1,
+        1,
+    );
+    assert_eq!(
+        store.begin_root_attachment_change(&attach).await.unwrap(),
+        BeginRootAttachmentChangeOutcome::RevisionExhausted
+    );
+
+    let existing_root = root_id();
+    let mut no_detach_headroom = sample_chat();
+    no_detach_headroom.attachment_revision = MAX_ATTACHMENT_REVISION;
+    no_detach_headroom.root_attachments = vec![ChatRootAttachment {
+        root_id: existing_root,
+        origin: RootAttachmentOrigin::Conversation,
+    }];
+    store.create_chat(&no_detach_headroom).await.unwrap();
+    let detach = begin_request(
+        &no_detach_headroom,
+        executor,
+        existing_root,
+        RootAttachmentChangeAction::Detach,
+        MAX_ATTACHMENT_REVISION,
+        2,
+    );
+    assert_eq!(
+        store.begin_root_attachment_change(&detach).await.unwrap(),
+        BeginRootAttachmentChangeOutcome::RevisionExhausted
+    );
+}
+
+#[tokio::test]
+async fn awaiting_and_terminal_changes_survive_file_backed_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        dir.path().join("restart.db").display()
+    );
+    let executor = uuid::Uuid::new_v4();
+    let (pending_request, terminal_request, terminal_change) = {
+        let store = DbStore::connect(&url).await.unwrap();
+        let pending_chat = sample_chat();
+        store.create_chat(&pending_chat).await.unwrap();
+        let pending_request = begin_request(
+            &pending_chat,
+            executor,
+            root_id(),
+            RootAttachmentChangeAction::Attach,
+            0,
+            0,
+        );
+        begun(
+            store
+                .begin_root_attachment_change(&pending_request)
+                .await
+                .unwrap(),
+        );
+
+        let terminal_chat = sample_chat();
+        store.create_chat(&terminal_chat).await.unwrap();
+        let terminal_request = begin_request(
+            &terminal_chat,
+            executor,
+            root_id(),
+            RootAttachmentChangeAction::Attach,
+            0,
+            1,
+        );
+        begun(
+            store
+                .begin_root_attachment_change(&terminal_request)
+                .await
+                .unwrap(),
+        );
+        let terminal_change = finished(
+            store
+                .finish_root_attachment_change(
+                    terminal_request.id,
+                    executor,
+                    &completed(true, true),
+                    at(2),
+                )
+                .await
+                .unwrap(),
+        );
+        (pending_request, terminal_request, terminal_change)
+    };
+
+    let reopened = DbStore::connect(&url).await.unwrap();
+    assert_eq!(
+        reopened
+            .get_root_attachment_change(terminal_request.id)
+            .await
+            .unwrap(),
+        Some(terminal_change)
+    );
+    assert_eq!(
+        reopened
+            .list_pending_root_attachment_changes(executor, 10)
+            .await
+            .unwrap()
+            .iter()
+            .map(|change| change.id)
+            .collect::<Vec<_>>(),
+        vec![pending_request.id]
+    );
+}
+
+#[tokio::test]
+async fn persisted_subject_must_match_the_authoritative_chat() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let executor = uuid::Uuid::new_v4();
+    let request = begin_request(
+        &chat,
+        executor,
+        root_id(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        0,
+    );
+    begun(store.begin_root_attachment_change(&request).await.unwrap());
+
+    let updated = entities::root_attachment_change::Entity::update_many()
+        .col_expr(
+            entities::root_attachment_change::Column::SubjectKind,
+            sea_orm::sea_query::Expr::value("project"),
+        )
+        .col_expr(
+            entities::root_attachment_change::Column::SubjectId,
+            sea_orm::sea_query::Expr::value(uuid::Uuid::new_v4()),
+        )
+        .filter(entities::root_attachment_change::Column::Id.eq(*request.id.as_uuid()))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert_eq!(updated.rows_affected, 1);
+
+    assert!(store.get_root_attachment_change(request.id).await.is_err());
+    assert!(store
+        .list_pending_root_attachment_changes(executor, 10)
+        .await
+        .is_err());
+    assert!(store
+        .finish_root_attachment_change(request.id, executor, &completed(true, true), at(1))
+        .await
+        .is_err());
+}

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -161,6 +161,78 @@ id_type!(
     /// Identifies a persistent conversation.
     ChatId
 );
+
+/// Stable product and broker idempotency identity for one root-attachment change.
+///
+/// The same UUID is used when reconciling the change with the host broker. Nil
+/// is reserved so a missing operation identity cannot become durable work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct RootAttachmentChangeId(Uuid);
+
+impl RootAttachmentChangeId {
+    /// Generate a fresh change identity.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Build a change identity from a non-nil UUID.
+    pub fn from_uuid(uuid: Uuid) -> Result<Self, RootAttachmentChangeIdError> {
+        if uuid.is_nil() {
+            Err(RootAttachmentChangeIdError::Nil)
+        } else {
+            Ok(Self(uuid))
+        }
+    }
+
+    /// Borrow the UUID also used as the broker operation identity.
+    #[must_use]
+    pub const fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl Default for RootAttachmentChangeId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'de> Deserialize<'de> for RootAttachmentChangeId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let uuid = Uuid::deserialize(deserializer)?;
+        Self::from_uuid(uuid).map_err(serde::de::Error::custom)
+    }
+}
+
+impl std::fmt::Display for RootAttachmentChangeId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl std::str::FromStr for RootAttachmentChangeId {
+    type Err = RootAttachmentChangeIdError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::from_uuid(Uuid::parse_str(value)?)
+    }
+}
+
+/// Invalid durable root-attachment change identity.
+#[derive(Debug, Error)]
+pub enum RootAttachmentChangeIdError {
+    /// The value is not a UUID.
+    #[error("invalid root attachment change id: {0}")]
+    InvalidUuid(#[from] uuid::Error),
+    /// Nil is reserved and never identifies durable attachment work.
+    #[error("root attachment change id must not be nil")]
+    Nil,
+}
 id_type!(
     /// Identifies a persisted message within a chat.
     MessageId
@@ -214,6 +286,22 @@ mod tests {
         assert!(
             serde_json::from_str::<HostRootId>("\"00000000-0000-0000-0000-000000000000\"").is_err()
         );
+    }
+
+    #[test]
+    fn root_attachment_change_ids_reject_nil_and_roundtrip() {
+        let uuid = Uuid::new_v4();
+        let id = RootAttachmentChangeId::from_uuid(uuid).unwrap();
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(
+            serde_json::from_str::<RootAttachmentChangeId>(&json).unwrap(),
+            id
+        );
+        assert!(RootAttachmentChangeId::from_uuid(Uuid::nil()).is_err());
+        assert!(serde_json::from_str::<RootAttachmentChangeId>(
+            "\"00000000-0000-0000-0000-000000000000\""
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -55,19 +55,22 @@ pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{
     CallId, ChatId, DocumentId, DocumentJobId, HostRootId, HostRootIdError, MessageId, ProjectId,
-    StepId, TurnId, TurnSteerId,
+    RootAttachmentChangeId, RootAttachmentChangeIdError, StepId, TurnId, TurnSteerId,
 };
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
 pub use model::{
-    validate_source_regions, BlobRetirement, BlobRetirementStatus, ByteSpan, Chat,
-    ChatRootAttachment, ClientToolCallRequest, DocumentGeneration, DocumentJob, DocumentJobKind,
-    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
-    DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
-    DocumentUpsert, Message, Project, Role, RootAttachmentOrigin, SourceLocation, SourceRegion,
-    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress,
-    TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun,
-    TurnRunStatus, TurnSteer, TurnSteerStatus, MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
+    validate_source_regions, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus,
+    ByteSpan, Chat, ChatRootAttachment, ClientToolCallRequest, DocumentGeneration, DocumentJob,
+    DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput,
+    DocumentProcessingStatus, DocumentRecord, DocumentScope, DocumentSourceBlob,
+    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, Role,
+    RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
+    RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
+    RootAttachmentSubjectKind, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
+    ToolCallResolution, ToolCallStatus, TurnCheckpointProgress, TurnClientWait,
+    TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer,
+    TurnSteerStatus, MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
@@ -76,12 +79,14 @@ pub use provider::{
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
     AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, ApplyTurnSteerOutcome,
-    BlobStore, ClaimClientToolCallOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome,
-    ClientToolCallClaim, CompleteTurnRunOutcome, DocumentIndexJobReason,
-    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FinishTurnCancellationOutcome,
+    BeginRootAttachmentChangeOutcome, BlobStore, ClaimClientToolCallOutcome,
+    ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim, CompleteTurnRunOutcome,
+    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
+    FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
     HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledTurnOutcome,
     JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
     RequestTurnCancellationOutcome, ResolveToolCallOutcome, SecretProvider, Store,
+    MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -94,7 +94,8 @@ pub fn validate_source_regions(
 }
 
 use crate::id::{
-    CallId, ChatId, DocumentId, DocumentJobId, HostRootId, MessageId, ProjectId, TurnId,
+    CallId, ChatId, DocumentId, DocumentJobId, HostRootId, MessageId, ProjectId,
+    RootAttachmentChangeId, TurnId,
 };
 
 /// Maximum number of host roots projected onto one project or conversation.
@@ -128,6 +129,347 @@ pub struct ChatRootAttachment {
     pub root_id: HostRootId,
     /// Product-level provenance for ordering and future management UI.
     pub origin: RootAttachmentOrigin,
+}
+
+/// Desired broker and product state for one durable root-attachment change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RootAttachmentChangeAction {
+    /// Make the root available to this conversation.
+    Attach,
+    /// Remove the root only from this conversation.
+    Detach,
+}
+
+/// Product identity that owns the broker grant used by an attachment change.
+///
+/// This is derived by the store while the chat and its projection are locked;
+/// callers cannot choose it in [`BeginRootAttachmentChange`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RootAttachmentSubjectKind {
+    /// The root is owned by the chat's project.
+    Project,
+    /// The root is owned by this exact conversation.
+    Conversation,
+}
+
+/// Durable phase of a product-side attachment state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RootAttachmentChangePhase {
+    /// Product intent is durable and awaits broker reconciliation.
+    AwaitingBroker,
+    /// Broker reconciliation and the final product projection are durable.
+    Completed,
+    /// Broker reconciliation failed and the final product projection is durable.
+    Failed,
+}
+
+/// Bounded transport-safe failure retained by an attachment change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RootAttachmentChangeFailure {
+    /// Stable machine-readable failure category.
+    pub code: String,
+    /// Bounded diagnostic message safe to retain in product storage.
+    pub message: String,
+    /// Whether trusted native control may offer an explicit retry.
+    pub retryable: bool,
+}
+
+impl RootAttachmentChangeFailure {
+    /// Maximum UTF-8 bytes in a stable failure code.
+    pub const MAX_CODE_LEN: usize = 64;
+    /// Maximum UTF-8 bytes in a retained diagnostic message.
+    pub const MAX_MESSAGE_LEN: usize = 256;
+
+    /// Validate the bounded failure payload before persistence.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.code.is_empty() {
+            return Err("root attachment failure code must not be empty");
+        }
+        if self.code.len() > Self::MAX_CODE_LEN {
+            return Err("root attachment failure code exceeds the supported limit");
+        }
+        if self.code.contains('\0') {
+            return Err("root attachment failure code contains a null byte");
+        }
+        if self.message.is_empty() {
+            return Err("root attachment failure message must not be empty");
+        }
+        if self.message.len() > Self::MAX_MESSAGE_LEN {
+            return Err("root attachment failure message exceeds the supported limit");
+        }
+        if self.message.contains('\0') {
+            return Err("root attachment failure message contains a null byte");
+        }
+        Ok(())
+    }
+}
+
+/// Caller-controlled identity and intent for beginning one attachment change.
+///
+/// Subject ownership, projection provenance, and projection position are
+/// intentionally absent. The store derives them atomically from authoritative
+/// chat state rather than trusting a native or HTTP caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BeginRootAttachmentChange {
+    /// Stable idempotency identity, also used as the broker operation UUID.
+    pub id: RootAttachmentChangeId,
+    /// Conversation whose exact broker attachment changes.
+    pub chat_id: ChatId,
+    /// Stable native reconciler allowed to finish this work.
+    pub executor_id: Uuid,
+    /// Opaque root identity; possession grants no authority.
+    pub root_id: HostRootId,
+    /// Desired attachment state.
+    pub action: RootAttachmentChangeAction,
+    /// CAS fence observed by the caller.
+    pub expected_attachment_revision: i64,
+    /// Caller operation time retained at database microsecond precision as
+    /// immutable request identity.
+    pub created_at: DateTime<Utc>,
+}
+
+impl BeginRootAttachmentChange {
+    /// Validate caller-controlled fields before beginning durable work.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.chat_id.as_uuid().is_nil() {
+            return Err("root attachment change chat id must not be nil");
+        }
+        if self.executor_id.is_nil() {
+            return Err("root attachment change executor id must not be nil");
+        }
+        if !(0..=MAX_ATTACHMENT_REVISION).contains(&self.expected_attachment_revision) {
+            return Err("expected attachment revision is outside the supported range");
+        }
+        Ok(())
+    }
+}
+
+/// Exact broker observation supplied when finishing an attachment change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum RootAttachmentChangeTerminal {
+    /// The broker durably applied or recovered the exact requested mutation.
+    Completed {
+        /// Whether that broker operation changed its live attachment set.
+        broker_changed: bool,
+        /// Broker attachment state observed by the terminal receipt.
+        broker_currently_attached: bool,
+    },
+    /// The broker durably rejected or failed the exact requested mutation.
+    Failed {
+        /// Whether the failed broker operation reported changing live state.
+        broker_changed: Option<bool>,
+        /// Live attachment state when the broker could report it.
+        broker_currently_attached: Option<bool>,
+        /// Stable bounded failure retained for exact retries.
+        failure: RootAttachmentChangeFailure,
+    },
+}
+
+impl RootAttachmentChangeTerminal {
+    /// Validate bounded terminal data before persistence.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        match self {
+            Self::Completed { .. } => Ok(()),
+            Self::Failed { failure, .. } => failure.validate(),
+        }
+    }
+}
+
+/// Product-side durable state for one broker-backed attachment mutation.
+///
+/// The immutable subject and projection metadata are derived under the same
+/// store lock as `before_revision` and the intent projection. Flat
+/// optional terminal fields make exact state validation explicit at storage
+/// boundaries and map directly to relational columns.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RootAttachmentChange {
+    pub id: RootAttachmentChangeId,
+    pub chat_id: ChatId,
+    pub executor_id: Uuid,
+    pub root_id: HostRootId,
+    pub action: RootAttachmentChangeAction,
+    /// Broker grant subject derived from authoritative chat state.
+    pub subject_kind: RootAttachmentSubjectKind,
+    /// Project or conversation UUID paired with `subject_kind`.
+    pub subject_id: Uuid,
+    /// Projection provenance captured by the store, when the root existed.
+    pub origin: Option<RootAttachmentOrigin>,
+    /// Zero-based projection position captured by the store, when applicable.
+    pub projection_position: Option<u32>,
+    /// Whether the root appeared in the projection before this operation.
+    pub projection_existed_before: bool,
+    pub expected_revision: i64,
+    /// Authoritative revision observed when begin committed.
+    pub before_revision: i64,
+    /// Revision after begin durably projected the operation's intent.
+    pub intent_revision: i64,
+    pub phase: RootAttachmentChangePhase,
+    /// Final revision after completion or rollback; absent while awaiting broker.
+    pub result_revision: Option<i64>,
+    /// Whether the final projection differs from the projection before begin.
+    pub projection_changed: Option<bool>,
+    /// Historical broker mutation result, required for completed work and
+    /// retained for failed work when the broker could report it.
+    pub broker_changed: Option<bool>,
+    /// Terminal broker attachment observation, required for completed work and
+    /// retained for failed work when the broker could report it.
+    pub broker_currently_attached: Option<bool>,
+    /// Stable broker failure, present only for failed work.
+    pub failure: Option<RootAttachmentChangeFailure>,
+    pub created_at: DateTime<Utc>,
+    pub finished_at: Option<DateTime<Utc>>,
+}
+
+impl RootAttachmentChange {
+    /// Validate identity, revision, projection, and terminal-state invariants.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.chat_id.as_uuid().is_nil() {
+            return Err("root attachment change chat id must not be nil");
+        }
+        if self.executor_id.is_nil() {
+            return Err("root attachment change executor id must not be nil");
+        }
+        if self.subject_id.is_nil() {
+            return Err("root attachment change subject id must not be nil");
+        }
+        if self.subject_kind == RootAttachmentSubjectKind::Conversation
+            && self.subject_id != *self.chat_id.as_uuid()
+        {
+            return Err("conversation attachment subject must match the chat");
+        }
+        for revision in [
+            self.expected_revision,
+            self.before_revision,
+            self.intent_revision,
+        ] {
+            if !(0..=MAX_ATTACHMENT_REVISION).contains(&revision) {
+                return Err("root attachment change revision is outside the supported range");
+            }
+        }
+        if self
+            .result_revision
+            .is_some_and(|revision| !(0..=MAX_ATTACHMENT_REVISION).contains(&revision))
+        {
+            return Err("root attachment change result revision is outside the supported range");
+        }
+        if self.expected_revision != self.before_revision {
+            return Err("root attachment change began from an unexpected revision");
+        }
+        if self.projection_position.is_some() != self.origin.is_some() {
+            return Err("root attachment projection origin and position must appear together");
+        }
+        let projection_metadata_required =
+            self.projection_existed_before || self.action == RootAttachmentChangeAction::Attach;
+        if projection_metadata_required != self.origin.is_some() {
+            return Err("root attachment prior projection metadata is inconsistent");
+        }
+        if self.action == RootAttachmentChangeAction::Attach
+            && !self.projection_existed_before
+            && self.origin != Some(RootAttachmentOrigin::Conversation)
+        {
+            return Err("a newly attached root must use conversation provenance");
+        }
+        if self
+            .projection_position
+            .is_some_and(|position| position as usize >= MAX_ROOT_ATTACHMENTS)
+        {
+            return Err("root attachment projection position exceeds the supported limit");
+        }
+        let intent_advanced =
+            self.action == RootAttachmentChangeAction::Attach && !self.projection_existed_before;
+        let terminal_may_advance = intent_advanced
+            || (self.action == RootAttachmentChangeAction::Detach
+                && self.projection_existed_before);
+        let required_headroom = i64::from(intent_advanced) + i64::from(terminal_may_advance);
+        if self.before_revision > MAX_ATTACHMENT_REVISION - required_headroom {
+            return Err("root attachment change lacks reserved revision headroom");
+        }
+        let expected_intent_revision = self
+            .before_revision
+            .checked_add(i64::from(intent_advanced))
+            .ok_or("root attachment intent revision overflowed")?;
+        if self.intent_revision != expected_intent_revision {
+            return Err("root attachment intent revision is inconsistent");
+        }
+
+        match self.phase {
+            RootAttachmentChangePhase::AwaitingBroker => {
+                if self.result_revision.is_some()
+                    || self.projection_changed.is_some()
+                    || self.broker_changed.is_some()
+                    || self.broker_currently_attached.is_some()
+                    || self.failure.is_some()
+                    || self.finished_at.is_some()
+                {
+                    return Err("awaiting root attachment change has terminal fields");
+                }
+            }
+            RootAttachmentChangePhase::Completed => {
+                if self.result_revision.is_none()
+                    || self.projection_changed.is_none()
+                    || self.broker_changed.is_none()
+                    || self.broker_currently_attached.is_none()
+                    || self.failure.is_some()
+                    || self.finished_at.is_none()
+                {
+                    return Err("completed root attachment change has invalid terminal fields");
+                }
+            }
+            RootAttachmentChangePhase::Failed => {
+                if self.result_revision.is_none()
+                    || self.projection_changed.is_none()
+                    || self.failure.is_none()
+                    || self.finished_at.is_none()
+                {
+                    return Err("failed root attachment change has invalid terminal fields");
+                }
+                self.failure.as_ref().expect("checked above").validate()?;
+            }
+        }
+        if self
+            .finished_at
+            .is_some_and(|finished_at| finished_at < self.created_at)
+        {
+            return Err("root attachment change finish time precedes creation");
+        }
+        if self.phase != RootAttachmentChangePhase::AwaitingBroker {
+            let completed = self.phase == RootAttachmentChangePhase::Completed;
+            let terminal_removal = (completed
+                && self.action == RootAttachmentChangeAction::Detach
+                && self.projection_existed_before)
+                || (!completed && intent_advanced);
+            let expected_result_revision = self
+                .intent_revision
+                .checked_add(i64::from(terminal_removal))
+                .ok_or("root attachment result revision overflowed")?;
+            let desired_attached = self.action == RootAttachmentChangeAction::Attach;
+            let expected_projection_changed =
+                completed && self.projection_existed_before != desired_attached;
+            if self.result_revision != Some(expected_result_revision)
+                || self.projection_changed != Some(expected_projection_changed)
+            {
+                return Err("root attachment terminal projection metadata is inconsistent");
+            }
+            if completed && self.broker_currently_attached != Some(desired_attached) {
+                return Err("completed root attachment change contradicts broker state");
+            }
+            if !completed
+                && self
+                    .broker_currently_attached
+                    .is_some_and(|attached| attached == desired_attached)
+            {
+                return Err("failed root attachment change contradicts broker state");
+            }
+        }
+        Ok(())
+    }
 }
 
 /// An optional grouping of chats that share project context and a document
@@ -1265,6 +1607,80 @@ mod tests {
         );
         assert!(TurnRunStatus::Completed.is_terminal());
         assert!(!TurnRunStatus::Running.is_terminal());
+    }
+
+    #[test]
+    fn root_attachment_change_validation_enforces_derived_and_terminal_shape() {
+        let chat_id = ChatId::new();
+        let mut change = RootAttachmentChange {
+            id: RootAttachmentChangeId::new(),
+            chat_id,
+            executor_id: Uuid::new_v4(),
+            root_id: HostRootId::from_uuid(Uuid::new_v4()).unwrap(),
+            action: RootAttachmentChangeAction::Attach,
+            subject_kind: RootAttachmentSubjectKind::Conversation,
+            subject_id: *chat_id.as_uuid(),
+            origin: Some(RootAttachmentOrigin::Conversation),
+            projection_position: Some(0),
+            projection_existed_before: false,
+            expected_revision: 0,
+            before_revision: 0,
+            intent_revision: 1,
+            phase: RootAttachmentChangePhase::AwaitingBroker,
+            result_revision: None,
+            projection_changed: None,
+            broker_changed: None,
+            broker_currently_attached: None,
+            failure: None,
+            created_at: Utc::now(),
+            finished_at: None,
+        };
+        assert_eq!(change.validate(), Ok(()));
+
+        change.subject_id = Uuid::new_v4();
+        assert!(change.validate().is_err());
+        change.subject_id = *chat_id.as_uuid();
+        change.intent_revision = 0;
+        assert!(change.validate().is_err());
+        change.intent_revision = 1;
+        change.expected_revision = MAX_ATTACHMENT_REVISION - 1;
+        change.before_revision = MAX_ATTACHMENT_REVISION - 1;
+        change.intent_revision = MAX_ATTACHMENT_REVISION;
+        assert!(change.validate().is_err());
+        change.expected_revision = 0;
+        change.before_revision = 0;
+        change.intent_revision = 1;
+        change.phase = RootAttachmentChangePhase::Completed;
+        assert!(change.validate().is_err());
+        change.result_revision = Some(1);
+        change.projection_changed = Some(true);
+        change.broker_changed = Some(true);
+        change.broker_currently_attached = Some(true);
+        change.finished_at = Some(change.created_at);
+        assert_eq!(change.validate(), Ok(()));
+        change.result_revision = Some(2);
+        assert!(change.validate().is_err());
+    }
+
+    #[test]
+    fn root_attachment_failure_is_bounded_by_utf8_bytes() {
+        let valid = RootAttachmentChangeFailure {
+            code: "broker_denied".into(),
+            message: "root attachment was denied".into(),
+            retryable: false,
+        };
+        assert_eq!(valid.validate(), Ok(()));
+
+        let mut contains_null = valid.clone();
+        contains_null.code.push('\0');
+        assert!(contains_null.validate().is_err());
+        contains_null = valid.clone();
+        contains_null.message.push('\0');
+        assert!(contains_null.validate().is_err());
+
+        let mut oversized = valid;
+        oversized.message = "é".repeat(RootAttachmentChangeFailure::MAX_MESSAGE_LEN / 2 + 1);
+        assert!(oversized.validate().is_err());
     }
 
     #[test]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -20,15 +20,22 @@ use serde_json::Value;
 
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{CallId, ChatId, DocumentId, DocumentJobId, ProjectId, TurnId, TurnSteerId};
+use crate::id::{
+    CallId, ChatId, DocumentId, DocumentJobId, ProjectId, RootAttachmentChangeId, TurnId,
+    TurnSteerId,
+};
 use crate::model::{
-    BlobRetirement, BlobRetirementStatus, Chat, ClientToolCallRequest, DocumentGeneration,
-    DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput,
-    DocumentRecord, DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert,
-    Message, Project, ToolCallRecord, ToolCallResolution, TurnCheckpointProgress, TurnClientWait,
-    TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
+    BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, Chat, ClientToolCallRequest,
+    DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
+    DocumentParseOutput, DocumentRecord, DocumentScope, DocumentSourceUpsert,
+    DocumentSummaryRecord, DocumentUpsert, Message, Project, RootAttachmentChange,
+    RootAttachmentChangeTerminal, ToolCallRecord, ToolCallResolution, TurnCheckpointProgress,
+    TurnClientWait, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
 };
 use crate::provider::{StopReason, Usage};
+
+/// Largest pending attachment-reconciliation page accepted by [`Store`].
+pub const MAX_PENDING_ROOT_ATTACHMENT_CHANGES: u64 = 256;
 
 /// Why maintenance determined that a document needs an index job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,6 +91,46 @@ pub enum EnsureDocumentParseJobOutcome {
     MissingDocument,
     /// The caller inspected an obsolete source generation.
     GenerationChanged(DocumentGeneration),
+}
+
+/// Result of atomically beginning one broker-backed root attachment change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BeginRootAttachmentChangeOutcome {
+    /// Intent and immutable derived metadata were committed by this call.
+    Begun(RootAttachmentChange),
+    /// This exact identity and caller request were already committed.
+    Existing(RootAttachmentChange),
+    /// The change identity was already used for different immutable request data.
+    IdentityConflict,
+    /// The conversation does not exist.
+    ChatNotFound,
+    /// The caller's attachment revision no longer matches authoritative state.
+    RevisionConflict { current_attachment_revision: i64 },
+    /// Adding the root would exceed the bounded conversation projection.
+    CapacityExceeded,
+    /// The required intent or rollback transition cannot advance the revision.
+    RevisionExhausted,
+    /// Another awaiting operation owns this chat's single mutation slot.
+    /// Pending operation details are available only through executor-scoped
+    /// recovery scans, never through a competing begin request.
+    ChatBusy,
+}
+
+/// Result of atomically finishing one exact root attachment change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FinishRootAttachmentChangeOutcome {
+    /// Terminal broker observation and final projection committed by this call.
+    Finished(RootAttachmentChange),
+    /// An exact ambiguous retry recovered the same terminal change.
+    Existing(RootAttachmentChange),
+    /// No change exists under this idempotency identity.
+    NotFound,
+    /// The stable executor does not own this change.
+    ExecutorMismatch,
+    /// The change was already terminal under a different terminal payload.
+    AlreadyTerminal(RootAttachmentChange),
+    /// A terminal broker observation contradicts success or rollback state.
+    BrokerStateMismatch,
 }
 
 /// Result of atomically accepting one exact client turn request.
@@ -322,6 +369,12 @@ fn document_storage_unavailable<T>() -> Result<T> {
 fn turn_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "durable turn storage is not implemented by this Store".into(),
+    ))
+}
+
+fn root_attachment_storage_unavailable<T>() -> Result<T> {
+    Err(AgentError::Store(
+        "durable root attachment storage is not implemented by this Store".into(),
     ))
 }
 
@@ -765,6 +818,56 @@ pub trait Store: Send + Sync {
     /// Set (or clear, with `None`) a chat's model override. A no-op if the chat
     /// doesn't exist.
     async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()>;
+
+    /// Atomically begin one exact broker-backed attachment change.
+    ///
+    /// Implementations validate `request`, lock authoritative chat/projection
+    /// state, derive broker subject and prior projection metadata, enforce one
+    /// awaiting change per chat, and durably project intent before returning.
+    /// Transport adapters must derive `executor_id` from authenticated native
+    /// control; it is not renderer-selected authorization.
+    async fn begin_root_attachment_change(
+        &self,
+        _request: &BeginRootAttachmentChange,
+    ) -> Result<BeginRootAttachmentChangeOutcome> {
+        root_attachment_storage_unavailable()
+    }
+
+    /// Atomically finish one exact change under its stable executor.
+    ///
+    /// Exact terminal retries return `Existing`. Implementations apply the
+    /// final projection, terminal receipt, and result revision together.
+    /// Adapters must first bind the broker receipt to this exact persisted
+    /// operation; arbitrary transport failures are not durable broker failures.
+    async fn finish_root_attachment_change(
+        &self,
+        _id: RootAttachmentChangeId,
+        _executor_id: uuid::Uuid,
+        _terminal: &RootAttachmentChangeTerminal,
+        _finished_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<FinishRootAttachmentChangeOutcome> {
+        root_attachment_storage_unavailable()
+    }
+
+    /// Fetch one attachment change by exact idempotency identity.
+    async fn get_root_attachment_change(
+        &self,
+        _id: RootAttachmentChangeId,
+    ) -> Result<Option<RootAttachmentChange>> {
+        root_attachment_storage_unavailable()
+    }
+
+    /// List up to `limit` awaiting changes owned by one stable native executor.
+    ///
+    /// `limit` must be in `1..=MAX_PENDING_ROOT_ATTACHMENT_CHANGES` and results
+    /// are returned in deterministic oldest-first order.
+    async fn list_pending_root_attachment_changes(
+        &self,
+        _executor_id: uuid::Uuid,
+        _limit: u64,
+    ) -> Result<Vec<RootAttachmentChange>> {
+        root_attachment_storage_unavailable()
+    }
 
     /// Fetch one durable turn by its exact idempotency identity.
     async fn get_turn_run(&self, _id: TurnId) -> Result<Option<TurnRun>> {

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -8,7 +8,9 @@ use super::*;
 use crate::model::{
     validate_chat_root_projection, validate_chat_root_projection_against_project,
     validate_project_root_projection, ChatRootAttachment, DocumentJobKind, DocumentJobStatus,
-    DocumentProcessingStatus, RootAttachmentOrigin, ToolCallExecution, ToolCallStatus,
+    DocumentProcessingStatus, RootAttachmentChangeAction, RootAttachmentChangeFailure,
+    RootAttachmentChangePhase, RootAttachmentOrigin, RootAttachmentSubjectKind, ToolCallExecution,
+    ToolCallStatus, MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
 };
 
 /// Minimal in-memory `Store` — proves the trait is object-safe and usable
@@ -27,6 +29,7 @@ struct MemStore {
     projects: Mutex<HashMap<ProjectId, Project>>,
     document_state: Mutex<MemDocumentState>,
     chats: Mutex<HashMap<ChatId, Chat>>,
+    root_attachment_changes: Mutex<HashMap<RootAttachmentChangeId, RootAttachmentChange>>,
     settings: Mutex<HashMap<String, Value>>,
     events: Mutex<Vec<(ChatId, SequencedEvent)>>,
     tool_calls: Mutex<HashMap<crate::id::CallId, ToolCallRecord>>,
@@ -147,6 +150,82 @@ fn reset_mem_document_job(
     job.last_error_code = None;
     job.last_error_detail = None;
     job.updated_at = now;
+}
+
+fn root_attachment_terminal_matches(
+    change: &RootAttachmentChange,
+    terminal: &RootAttachmentChangeTerminal,
+) -> bool {
+    match terminal {
+        RootAttachmentChangeTerminal::Completed {
+            broker_changed,
+            broker_currently_attached,
+        } => {
+            change.phase == RootAttachmentChangePhase::Completed
+                && change.broker_changed == Some(*broker_changed)
+                && change.broker_currently_attached == Some(*broker_currently_attached)
+                && change.failure.is_none()
+        }
+        RootAttachmentChangeTerminal::Failed {
+            broker_changed,
+            broker_currently_attached,
+            failure,
+        } => {
+            change.phase == RootAttachmentChangePhase::Failed
+                && change.broker_changed == *broker_changed
+                && change.broker_currently_attached == *broker_currently_attached
+                && change.failure.as_ref() == Some(failure)
+        }
+    }
+}
+
+fn canonical_root_attachment_timestamp(
+    timestamp: chrono::DateTime<chrono::Utc>,
+) -> Result<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::from_timestamp_micros(timestamp.timestamp_micros())
+        .ok_or_else(|| AgentError::Store("timestamp is outside the database range".into()))
+}
+
+fn remove_exact_attachment(chat: &mut Chat, change: &RootAttachmentChange) -> Result<()> {
+    let position = change
+        .projection_position
+        .ok_or_else(|| AgentError::Store("root attachment change is missing its position".into()))?
+        as usize;
+    if chat
+        .root_attachments
+        .get(position)
+        .is_none_or(|attachment| attachment.root_id != change.root_id)
+    {
+        return Err(AgentError::Store(
+            "root attachment change projection no longer matches its intent".into(),
+        ));
+    }
+    chat.root_attachments.remove(position);
+    Ok(())
+}
+
+fn validate_mem_pending_attachment(chat: &Chat, change: &RootAttachmentChange) -> Result<()> {
+    let found = chat
+        .root_attachments
+        .iter()
+        .position(|attachment| attachment.root_id == change.root_id);
+    let expected_present =
+        change.projection_existed_before || change.action == RootAttachmentChangeAction::Attach;
+    if found.is_some() != expected_present {
+        return Err(AgentError::Store(
+            "root attachment change pending projection is inconsistent".into(),
+        ));
+    }
+    if let Some(position) = found {
+        if change.projection_position.map(|position| position as usize) != Some(position)
+            || change.origin != Some(chat.root_attachments[position].origin)
+        {
+            return Err(AgentError::Store(
+                "root attachment change pending projection metadata changed".into(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -1262,6 +1341,289 @@ impl Store for MemStore {
         }
         Ok(())
     }
+    async fn begin_root_attachment_change(
+        &self,
+        request: &BeginRootAttachmentChange,
+    ) -> Result<BeginRootAttachmentChangeOutcome> {
+        request
+            .validate()
+            .map_err(|message| AgentError::Store(message.into()))?;
+        let created_at = canonical_root_attachment_timestamp(request.created_at)?;
+
+        let mut chats = self.chats.lock().unwrap();
+        let mut changes = self.root_attachment_changes.lock().unwrap();
+        if let Some(existing) = changes.get(&request.id) {
+            let exact = existing.chat_id == request.chat_id
+                && existing.executor_id == request.executor_id
+                && existing.root_id == request.root_id
+                && existing.action == request.action
+                && existing.expected_revision == request.expected_attachment_revision
+                && existing.created_at == created_at;
+            return Ok(if exact {
+                BeginRootAttachmentChangeOutcome::Existing(existing.clone())
+            } else {
+                BeginRootAttachmentChangeOutcome::IdentityConflict
+            });
+        }
+
+        let Some(chat) = chats.get_mut(&request.chat_id) else {
+            return Ok(BeginRootAttachmentChangeOutcome::ChatNotFound);
+        };
+        if changes.values().any(|change| {
+            change.chat_id == request.chat_id
+                && change.phase == RootAttachmentChangePhase::AwaitingBroker
+        }) {
+            return Ok(BeginRootAttachmentChangeOutcome::ChatBusy);
+        }
+        if chat.attachment_revision != request.expected_attachment_revision {
+            return Ok(BeginRootAttachmentChangeOutcome::RevisionConflict {
+                current_attachment_revision: chat.attachment_revision,
+            });
+        }
+
+        let before_revision = chat.attachment_revision;
+        let existing_position = chat
+            .root_attachments
+            .iter()
+            .position(|attachment| attachment.root_id == request.root_id);
+        let projection_existed_before = existing_position.is_some();
+        let (origin, projection_position) = if let Some(position) = existing_position {
+            (
+                Some(chat.root_attachments[position].origin),
+                Some(u32::try_from(position).expect("bounded attachment position")),
+            )
+        } else if request.action == RootAttachmentChangeAction::Attach {
+            if chat.root_attachments.len() == MAX_ROOT_ATTACHMENTS {
+                return Ok(BeginRootAttachmentChangeOutcome::CapacityExceeded);
+            }
+            (
+                Some(RootAttachmentOrigin::Conversation),
+                Some(
+                    u32::try_from(chat.root_attachments.len())
+                        .expect("bounded attachment position"),
+                ),
+            )
+        } else {
+            (None, None)
+        };
+
+        let revisions_required = match (request.action, projection_existed_before) {
+            // Reserve both the intent revision and a possible failure rollback.
+            (RootAttachmentChangeAction::Attach, false) => 2,
+            // Successful detach removes the projection only after broker success.
+            (RootAttachmentChangeAction::Detach, true) => 1,
+            _ => 0,
+        };
+        if before_revision > MAX_ATTACHMENT_REVISION - revisions_required {
+            return Ok(BeginRootAttachmentChangeOutcome::RevisionExhausted);
+        }
+
+        let (subject_kind, subject_id) = match chat.project_id {
+            Some(project_id) if project_id.as_uuid().is_nil() => {
+                return Err(AgentError::Store(format!(
+                    "chat {} has a nil root attachment project subject",
+                    request.chat_id
+                )));
+            }
+            Some(project_id) => (RootAttachmentSubjectKind::Project, *project_id.as_uuid()),
+            None => (
+                RootAttachmentSubjectKind::Conversation,
+                *request.chat_id.as_uuid(),
+            ),
+        };
+        let intent_revision =
+            if request.action == RootAttachmentChangeAction::Attach && !projection_existed_before {
+                chat.root_attachments.push(ChatRootAttachment {
+                    root_id: request.root_id,
+                    origin: RootAttachmentOrigin::Conversation,
+                });
+                chat.attachment_revision += 1;
+                chat.attachment_revision
+            } else {
+                before_revision
+            };
+        let change = RootAttachmentChange {
+            id: request.id,
+            chat_id: request.chat_id,
+            executor_id: request.executor_id,
+            root_id: request.root_id,
+            action: request.action,
+            subject_kind,
+            subject_id,
+            origin,
+            projection_position,
+            projection_existed_before,
+            expected_revision: request.expected_attachment_revision,
+            before_revision,
+            intent_revision,
+            phase: RootAttachmentChangePhase::AwaitingBroker,
+            result_revision: None,
+            projection_changed: None,
+            broker_changed: None,
+            broker_currently_attached: None,
+            failure: None,
+            created_at,
+            finished_at: None,
+        };
+        change
+            .validate()
+            .map_err(|message| AgentError::Store(message.into()))?;
+        changes.insert(change.id, change.clone());
+        Ok(BeginRootAttachmentChangeOutcome::Begun(change))
+    }
+
+    async fn finish_root_attachment_change(
+        &self,
+        id: RootAttachmentChangeId,
+        executor_id: uuid::Uuid,
+        terminal: &RootAttachmentChangeTerminal,
+        finished_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<FinishRootAttachmentChangeOutcome> {
+        if executor_id.is_nil() {
+            return Err(AgentError::Store(
+                "root attachment change executor id must not be nil".into(),
+            ));
+        }
+        terminal
+            .validate()
+            .map_err(|message| AgentError::Store(message.into()))?;
+        let finished_at = canonical_root_attachment_timestamp(finished_at)?;
+
+        let mut chats = self.chats.lock().unwrap();
+        let mut changes = self.root_attachment_changes.lock().unwrap();
+        let Some(existing) = changes.get(&id).cloned() else {
+            return Ok(FinishRootAttachmentChangeOutcome::NotFound);
+        };
+        if existing.executor_id != executor_id {
+            return Ok(FinishRootAttachmentChangeOutcome::ExecutorMismatch);
+        }
+        if existing.phase != RootAttachmentChangePhase::AwaitingBroker {
+            let exact = root_attachment_terminal_matches(&existing, terminal);
+            return Ok(if exact {
+                FinishRootAttachmentChangeOutcome::Existing(existing)
+            } else {
+                FinishRootAttachmentChangeOutcome::AlreadyTerminal(existing)
+            });
+        }
+        if finished_at < existing.created_at {
+            return Err(AgentError::Store(
+                "root attachment change finish time precedes creation".into(),
+            ));
+        }
+        let desired_attached = existing.action == RootAttachmentChangeAction::Attach;
+        let broker_state_contradicts_terminal = match terminal {
+            RootAttachmentChangeTerminal::Completed {
+                broker_currently_attached,
+                ..
+            } => *broker_currently_attached != desired_attached,
+            RootAttachmentChangeTerminal::Failed {
+                broker_currently_attached: Some(broker_currently_attached),
+                ..
+            } => *broker_currently_attached == desired_attached,
+            RootAttachmentChangeTerminal::Failed {
+                broker_currently_attached: None,
+                ..
+            } => false,
+        };
+        if broker_state_contradicts_terminal {
+            return Ok(FinishRootAttachmentChangeOutcome::BrokerStateMismatch);
+        }
+
+        let chat = chats.get_mut(&existing.chat_id).ok_or_else(|| {
+            AgentError::Store("root attachment change references a missing chat".into())
+        })?;
+        if chat.attachment_revision != existing.intent_revision {
+            return Err(AgentError::Store(
+                "root attachment change intent revision no longer matches its chat".into(),
+            ));
+        }
+        validate_mem_pending_attachment(chat, &existing)?;
+
+        let mut finished = existing.clone();
+        match terminal {
+            RootAttachmentChangeTerminal::Completed {
+                broker_changed,
+                broker_currently_attached,
+            } => {
+                let projection_changed = match existing.action {
+                    RootAttachmentChangeAction::Attach => !existing.projection_existed_before,
+                    RootAttachmentChangeAction::Detach if existing.projection_existed_before => {
+                        remove_exact_attachment(chat, &existing)?;
+                        chat.attachment_revision += 1;
+                        true
+                    }
+                    RootAttachmentChangeAction::Detach => false,
+                };
+                finished.phase = RootAttachmentChangePhase::Completed;
+                finished.result_revision = Some(chat.attachment_revision);
+                finished.projection_changed = Some(projection_changed);
+                finished.broker_changed = Some(*broker_changed);
+                finished.broker_currently_attached = Some(*broker_currently_attached);
+            }
+            RootAttachmentChangeTerminal::Failed {
+                broker_changed,
+                broker_currently_attached,
+                failure,
+            } => {
+                if existing.action == RootAttachmentChangeAction::Attach
+                    && !existing.projection_existed_before
+                {
+                    remove_exact_attachment(chat, &existing)?;
+                    chat.attachment_revision += 1;
+                }
+                finished.phase = RootAttachmentChangePhase::Failed;
+                finished.result_revision = Some(chat.attachment_revision);
+                finished.projection_changed = Some(false);
+                finished.broker_changed = *broker_changed;
+                finished.broker_currently_attached = *broker_currently_attached;
+                finished.failure = Some(failure.clone());
+            }
+        }
+        finished.finished_at = Some(finished_at);
+        finished
+            .validate()
+            .map_err(|message| AgentError::Store(message.into()))?;
+        changes.insert(id, finished.clone());
+        Ok(FinishRootAttachmentChangeOutcome::Finished(finished))
+    }
+
+    async fn get_root_attachment_change(
+        &self,
+        id: RootAttachmentChangeId,
+    ) -> Result<Option<RootAttachmentChange>> {
+        Ok(self
+            .root_attachment_changes
+            .lock()
+            .unwrap()
+            .get(&id)
+            .cloned())
+    }
+
+    async fn list_pending_root_attachment_changes(
+        &self,
+        executor_id: uuid::Uuid,
+        limit: u64,
+    ) -> Result<Vec<RootAttachmentChange>> {
+        if executor_id.is_nil() || !(1..=MAX_PENDING_ROOT_ATTACHMENT_CHANGES).contains(&limit) {
+            return Err(AgentError::Store(
+                "invalid pending root attachment change scan".into(),
+            ));
+        }
+        let mut pending: Vec<_> = self
+            .root_attachment_changes
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|change| {
+                change.executor_id == executor_id
+                    && change.phase == RootAttachmentChangePhase::AwaitingBroker
+            })
+            .cloned()
+            .collect();
+        pending.sort_by_key(|change| (change.created_at, *change.id.as_uuid()));
+        pending.truncate(limit.try_into().expect("validated pending scan limit"));
+        Ok(pending)
+    }
     async fn append_message(&self, _message: &Message) -> Result<()> {
         Ok(())
     }
@@ -1679,6 +2041,588 @@ fn store_is_object_safe_and_roundtrips() {
         .unwrap(),
         Some(DocumentJobStatus::RetryWait)
     );
+}
+
+fn mem_root_id() -> crate::id::HostRootId {
+    crate::id::HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap()
+}
+
+fn mem_attachment_chat(
+    project_id: Option<ProjectId>,
+    roots: Vec<ChatRootAttachment>,
+    attachment_revision: i64,
+) -> Chat {
+    Chat {
+        id: ChatId::new(),
+        project_id,
+        title: None,
+        model: None,
+        attachment_revision,
+        root_attachments: roots,
+        created_at: chrono::DateTime::<chrono::Utc>::from_timestamp(10, 0).unwrap(),
+    }
+}
+
+fn mem_attachment_request(
+    chat: &Chat,
+    executor_id: uuid::Uuid,
+    root_id: crate::id::HostRootId,
+    action: RootAttachmentChangeAction,
+    expected_attachment_revision: i64,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> BeginRootAttachmentChange {
+    BeginRootAttachmentChange {
+        id: RootAttachmentChangeId::new(),
+        chat_id: chat.id,
+        executor_id,
+        root_id,
+        action,
+        expected_attachment_revision,
+        created_at,
+    }
+}
+
+#[test]
+fn mem_root_attachment_begin_derives_authority_and_enforces_atomic_guards() {
+    let store = MemStore::default();
+    let executor_id = uuid::Uuid::new_v4();
+    let project_root = mem_root_id();
+    let project = Project {
+        id: ProjectId::new(),
+        title: None,
+        attachment_revision: 1,
+        root_attachments: vec![project_root],
+        created_at: chrono::Utc::now(),
+    };
+    block_on(store.create_project(&project)).unwrap();
+    let base = mem_attachment_chat(Some(project.id), Vec::new(), 0);
+    let chat = block_on(store.create_chat_with_project_defaults(&base)).unwrap();
+    let root_id = mem_root_id();
+    let now = chrono::DateTime::<chrono::Utc>::from_timestamp(20, 0).unwrap();
+    let request = mem_attachment_request(
+        &chat,
+        executor_id,
+        root_id,
+        RootAttachmentChangeAction::Attach,
+        1,
+        now,
+    );
+
+    let begun = match block_on(store.begin_root_attachment_change(&request)).unwrap() {
+        BeginRootAttachmentChangeOutcome::Begun(change) => change,
+        outcome => panic!("unexpected begin outcome: {outcome:?}"),
+    };
+    assert_eq!(begun.subject_kind, RootAttachmentSubjectKind::Project);
+    assert_eq!(begun.subject_id, *project.id.as_uuid());
+    assert_eq!(begun.before_revision, 1);
+    assert_eq!(begun.intent_revision, 2);
+    assert_eq!(begun.origin, Some(RootAttachmentOrigin::Conversation));
+    assert_eq!(begun.projection_position, Some(1));
+    assert!(!begun.projection_existed_before);
+    assert_eq!(
+        block_on(store.get_chat(chat.id))
+            .unwrap()
+            .unwrap()
+            .root_attachments,
+        vec![
+            ChatRootAttachment {
+                root_id: project_root,
+                origin: RootAttachmentOrigin::ProjectDefault,
+            },
+            ChatRootAttachment {
+                root_id,
+                origin: RootAttachmentOrigin::Conversation,
+            },
+        ]
+    );
+    assert_eq!(
+        block_on(store.begin_root_attachment_change(&request)).unwrap(),
+        BeginRootAttachmentChangeOutcome::Existing(begun.clone())
+    );
+    assert_eq!(
+        block_on(
+            store.begin_root_attachment_change(&BeginRootAttachmentChange {
+                created_at: request.created_at + chrono::Duration::nanoseconds(999),
+                ..request
+            })
+        )
+        .unwrap(),
+        BeginRootAttachmentChangeOutcome::Existing(begun.clone())
+    );
+    assert_eq!(
+        block_on(
+            store.begin_root_attachment_change(&BeginRootAttachmentChange {
+                root_id: mem_root_id(),
+                ..request
+            })
+        )
+        .unwrap(),
+        BeginRootAttachmentChangeOutcome::IdentityConflict
+    );
+
+    let busy = mem_attachment_request(
+        &chat,
+        executor_id,
+        mem_root_id(),
+        RootAttachmentChangeAction::Attach,
+        2,
+        now + chrono::Duration::seconds(1),
+    );
+    assert_eq!(
+        block_on(store.begin_root_attachment_change(&busy)).unwrap(),
+        BeginRootAttachmentChangeOutcome::ChatBusy
+    );
+
+    let standalone = mem_attachment_chat(None, Vec::new(), 4);
+    block_on(store.create_chat(&standalone)).unwrap();
+    let stale = mem_attachment_request(
+        &standalone,
+        executor_id,
+        mem_root_id(),
+        RootAttachmentChangeAction::Attach,
+        3,
+        now,
+    );
+    assert_eq!(
+        block_on(store.begin_root_attachment_change(&stale)).unwrap(),
+        BeginRootAttachmentChangeOutcome::RevisionConflict {
+            current_attachment_revision: 4
+        }
+    );
+
+    let full_roots: Vec<_> = (0..MAX_ROOT_ATTACHMENTS)
+        .map(|_| ChatRootAttachment {
+            root_id: mem_root_id(),
+            origin: RootAttachmentOrigin::Conversation,
+        })
+        .collect();
+    let full = mem_attachment_chat(None, full_roots, 1);
+    block_on(store.create_chat(&full)).unwrap();
+    let at_capacity = mem_attachment_request(
+        &full,
+        executor_id,
+        mem_root_id(),
+        RootAttachmentChangeAction::Attach,
+        1,
+        now,
+    );
+    assert_eq!(
+        block_on(store.begin_root_attachment_change(&at_capacity)).unwrap(),
+        BeginRootAttachmentChangeOutcome::CapacityExceeded
+    );
+
+    let exhausted = mem_attachment_chat(None, Vec::new(), MAX_ATTACHMENT_REVISION - 1);
+    block_on(store.create_chat(&exhausted)).unwrap();
+    let cannot_reserve_rollback = mem_attachment_request(
+        &exhausted,
+        executor_id,
+        mem_root_id(),
+        RootAttachmentChangeAction::Attach,
+        MAX_ATTACHMENT_REVISION - 1,
+        now,
+    );
+    assert_eq!(
+        block_on(store.begin_root_attachment_change(&cannot_reserve_rollback)).unwrap(),
+        BeginRootAttachmentChangeOutcome::RevisionExhausted
+    );
+
+    let existing_root = mem_root_id();
+    let detach_exhausted = mem_attachment_chat(
+        None,
+        vec![ChatRootAttachment {
+            root_id: existing_root,
+            origin: RootAttachmentOrigin::Conversation,
+        }],
+        MAX_ATTACHMENT_REVISION,
+    );
+    block_on(store.create_chat(&detach_exhausted)).unwrap();
+    let cannot_reserve_removal = mem_attachment_request(
+        &detach_exhausted,
+        executor_id,
+        existing_root,
+        RootAttachmentChangeAction::Detach,
+        MAX_ATTACHMENT_REVISION,
+        now,
+    );
+    assert_eq!(
+        block_on(store.begin_root_attachment_change(&cannot_reserve_removal)).unwrap(),
+        BeginRootAttachmentChangeOutcome::RevisionExhausted
+    );
+
+    let invalid_project_chat =
+        mem_attachment_chat(Some(ProjectId(uuid::Uuid::nil())), Vec::new(), 0);
+    store
+        .chats
+        .lock()
+        .unwrap()
+        .insert(invalid_project_chat.id, invalid_project_chat.clone());
+    let invalid_request = mem_attachment_request(
+        &invalid_project_chat,
+        executor_id,
+        mem_root_id(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        now,
+    );
+    assert!(block_on(store.begin_root_attachment_change(&invalid_request)).is_err());
+    assert_eq!(
+        block_on(store.get_chat(invalid_project_chat.id)).unwrap(),
+        Some(invalid_project_chat)
+    );
+    assert!(
+        block_on(store.get_root_attachment_change(invalid_request.id))
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn mem_root_attachment_attach_projects_intent_and_rolls_back_failure() {
+    let store = MemStore::default();
+    let executor_id = uuid::Uuid::new_v4();
+    let chat = mem_attachment_chat(None, Vec::new(), 0);
+    block_on(store.create_chat(&chat)).unwrap();
+    let root_id = mem_root_id();
+    let now = chrono::DateTime::<chrono::Utc>::from_timestamp(30, 0).unwrap();
+    let request = mem_attachment_request(
+        &chat,
+        executor_id,
+        root_id,
+        RootAttachmentChangeAction::Attach,
+        0,
+        now,
+    );
+    let awaiting = match block_on(store.begin_root_attachment_change(&request)).unwrap() {
+        BeginRootAttachmentChangeOutcome::Begun(change) => change,
+        outcome => panic!("unexpected begin outcome: {outcome:?}"),
+    };
+    assert_eq!(
+        awaiting.subject_kind,
+        RootAttachmentSubjectKind::Conversation
+    );
+    assert_eq!(awaiting.subject_id, *chat.id.as_uuid());
+    let intent_chat = block_on(store.get_chat(chat.id)).unwrap().unwrap();
+    assert_eq!(intent_chat.attachment_revision, 1);
+    assert_eq!(intent_chat.root_attachments.len(), 1);
+
+    let failure = RootAttachmentChangeTerminal::Failed {
+        broker_changed: Some(false),
+        broker_currently_attached: Some(false),
+        failure: RootAttachmentChangeFailure {
+            code: "denied".into(),
+            message: "host access was denied".into(),
+            retryable: false,
+        },
+    };
+    let finished_at = now + chrono::Duration::seconds(1);
+    assert_eq!(
+        block_on(store.finish_root_attachment_change(
+            request.id,
+            executor_id,
+            &RootAttachmentChangeTerminal::Failed {
+                broker_changed: Some(true),
+                broker_currently_attached: Some(true),
+                failure: RootAttachmentChangeFailure {
+                    code: "ambiguous".into(),
+                    message: "broker reports the requested state".into(),
+                    retryable: true,
+                },
+            },
+            finished_at,
+        ))
+        .unwrap(),
+        FinishRootAttachmentChangeOutcome::BrokerStateMismatch
+    );
+    assert_eq!(
+        block_on(store.get_root_attachment_change(request.id)).unwrap(),
+        Some(awaiting)
+    );
+    let failed = match block_on(store.finish_root_attachment_change(
+        request.id,
+        executor_id,
+        &failure,
+        finished_at,
+    ))
+    .unwrap()
+    {
+        FinishRootAttachmentChangeOutcome::Finished(change) => change,
+        outcome => panic!("unexpected finish outcome: {outcome:?}"),
+    };
+    assert_eq!(failed.phase, RootAttachmentChangePhase::Failed);
+    assert_eq!(failed.result_revision, Some(2));
+    assert_eq!(failed.projection_changed, Some(false));
+    let rolled_back = block_on(store.get_chat(chat.id)).unwrap().unwrap();
+    assert_eq!(rolled_back.attachment_revision, 2);
+    assert!(rolled_back.root_attachments.is_empty());
+    assert_eq!(
+        block_on(store.finish_root_attachment_change(
+            request.id,
+            executor_id,
+            &failure,
+            finished_at,
+        ))
+        .unwrap(),
+        FinishRootAttachmentChangeOutcome::Existing(failed.clone())
+    );
+    assert_eq!(
+        block_on(store.finish_root_attachment_change(
+            request.id,
+            executor_id,
+            &failure,
+            finished_at + chrono::Duration::seconds(1),
+        ))
+        .unwrap(),
+        FinishRootAttachmentChangeOutcome::Existing(failed)
+    );
+
+    let success_request = mem_attachment_request(
+        &rolled_back,
+        executor_id,
+        root_id,
+        RootAttachmentChangeAction::Attach,
+        2,
+        now + chrono::Duration::seconds(2),
+    );
+    block_on(store.begin_root_attachment_change(&success_request)).unwrap();
+    let success = RootAttachmentChangeTerminal::Completed {
+        broker_changed: true,
+        broker_currently_attached: true,
+    };
+    let completed = match block_on(store.finish_root_attachment_change(
+        success_request.id,
+        executor_id,
+        &success,
+        now + chrono::Duration::seconds(3),
+    ))
+    .unwrap()
+    {
+        FinishRootAttachmentChangeOutcome::Finished(change) => change,
+        outcome => panic!("unexpected finish outcome: {outcome:?}"),
+    };
+    assert_eq!(completed.phase, RootAttachmentChangePhase::Completed);
+    assert_eq!(completed.result_revision, Some(3));
+    assert_eq!(completed.projection_changed, Some(true));
+    assert_eq!(
+        block_on(store.get_root_attachment_change(success_request.id)).unwrap(),
+        Some(completed)
+    );
+}
+
+#[test]
+fn mem_root_attachment_detach_waits_for_broker_and_preserves_position() {
+    let store = MemStore::default();
+    let executor_id = uuid::Uuid::new_v4();
+    let roots = [mem_root_id(), mem_root_id(), mem_root_id()];
+    let chat = mem_attachment_chat(
+        None,
+        roots
+            .into_iter()
+            .map(|root_id| ChatRootAttachment {
+                root_id,
+                origin: RootAttachmentOrigin::Conversation,
+            })
+            .collect(),
+        1,
+    );
+    block_on(store.create_chat(&chat)).unwrap();
+    let now = chrono::DateTime::<chrono::Utc>::from_timestamp(40, 0).unwrap();
+    let request = mem_attachment_request(
+        &chat,
+        executor_id,
+        roots[1],
+        RootAttachmentChangeAction::Detach,
+        1,
+        now,
+    );
+    let awaiting = match block_on(store.begin_root_attachment_change(&request)).unwrap() {
+        BeginRootAttachmentChangeOutcome::Begun(change) => change,
+        outcome => panic!("unexpected begin outcome: {outcome:?}"),
+    };
+    assert_eq!(awaiting.intent_revision, 1);
+    assert_eq!(awaiting.projection_position, Some(1));
+    assert_eq!(
+        block_on(store.get_chat(chat.id))
+            .unwrap()
+            .unwrap()
+            .root_attachments,
+        chat.root_attachments
+    );
+    let completed = RootAttachmentChangeTerminal::Completed {
+        broker_changed: true,
+        broker_currently_attached: false,
+    };
+    assert_eq!(
+        block_on(store.finish_root_attachment_change(
+            request.id,
+            uuid::Uuid::new_v4(),
+            &completed,
+            now + chrono::Duration::seconds(1),
+        ))
+        .unwrap(),
+        FinishRootAttachmentChangeOutcome::ExecutorMismatch
+    );
+    assert_eq!(
+        block_on(store.finish_root_attachment_change(
+            request.id,
+            executor_id,
+            &RootAttachmentChangeTerminal::Completed {
+                broker_changed: false,
+                broker_currently_attached: true,
+            },
+            now + chrono::Duration::seconds(1),
+        ))
+        .unwrap(),
+        FinishRootAttachmentChangeOutcome::BrokerStateMismatch
+    );
+    let finished = match block_on(store.finish_root_attachment_change(
+        request.id,
+        executor_id,
+        &completed,
+        now + chrono::Duration::seconds(1),
+    ))
+    .unwrap()
+    {
+        FinishRootAttachmentChangeOutcome::Finished(change) => change,
+        outcome => panic!("unexpected finish outcome: {outcome:?}"),
+    };
+    assert_eq!(finished.result_revision, Some(2));
+    assert_eq!(finished.projection_changed, Some(true));
+    let detached = block_on(store.get_chat(chat.id)).unwrap().unwrap();
+    assert_eq!(detached.attachment_revision, 2);
+    assert_eq!(
+        detached
+            .root_attachments
+            .iter()
+            .map(|attachment| attachment.root_id)
+            .collect::<Vec<_>>(),
+        vec![roots[0], roots[2]]
+    );
+
+    let absent = mem_attachment_request(
+        &detached,
+        executor_id,
+        roots[1],
+        RootAttachmentChangeAction::Detach,
+        2,
+        now + chrono::Duration::seconds(2),
+    );
+    let absent_change = match block_on(store.begin_root_attachment_change(&absent)).unwrap() {
+        BeginRootAttachmentChangeOutcome::Begun(change) => change,
+        outcome => panic!("unexpected begin outcome: {outcome:?}"),
+    };
+    assert!(!absent_change.projection_existed_before);
+    assert_eq!(absent_change.origin, None);
+    let absent_finished = match block_on(store.finish_root_attachment_change(
+        absent.id,
+        executor_id,
+        &RootAttachmentChangeTerminal::Completed {
+            broker_changed: false,
+            broker_currently_attached: false,
+        },
+        now + chrono::Duration::seconds(3),
+    ))
+    .unwrap()
+    {
+        FinishRootAttachmentChangeOutcome::Finished(change) => change,
+        outcome => panic!("unexpected finish outcome: {outcome:?}"),
+    };
+    assert_eq!(absent_finished.result_revision, Some(2));
+    assert_eq!(absent_finished.projection_changed, Some(false));
+
+    let failure_chat = mem_attachment_chat(
+        None,
+        vec![ChatRootAttachment {
+            root_id: roots[1],
+            origin: RootAttachmentOrigin::Conversation,
+        }],
+        5,
+    );
+    block_on(store.create_chat(&failure_chat)).unwrap();
+    let failed_detach = mem_attachment_request(
+        &failure_chat,
+        executor_id,
+        roots[1],
+        RootAttachmentChangeAction::Detach,
+        5,
+        now + chrono::Duration::seconds(4),
+    );
+    block_on(store.begin_root_attachment_change(&failed_detach)).unwrap();
+    let failed = match block_on(store.finish_root_attachment_change(
+        failed_detach.id,
+        executor_id,
+        &RootAttachmentChangeTerminal::Failed {
+            broker_changed: None,
+            broker_currently_attached: None,
+            failure: RootAttachmentChangeFailure {
+                code: "unavailable".into(),
+                message: "broker was unavailable".into(),
+                retryable: true,
+            },
+        },
+        now + chrono::Duration::seconds(5),
+    ))
+    .unwrap()
+    {
+        FinishRootAttachmentChangeOutcome::Finished(change) => change,
+        outcome => panic!("unexpected finish outcome: {outcome:?}"),
+    };
+    assert_eq!(failed.result_revision, Some(5));
+    assert_eq!(failed.projection_changed, Some(false));
+    assert_eq!(
+        block_on(store.get_chat(failure_chat.id)).unwrap(),
+        Some(failure_chat)
+    );
+}
+
+#[test]
+fn mem_root_attachment_pending_scan_is_bounded_filtered_and_ordered() {
+    let store = MemStore::default();
+    let executor_id = uuid::Uuid::new_v4();
+    let other_executor_id = uuid::Uuid::new_v4();
+    let time = chrono::DateTime::<chrono::Utc>::from_timestamp(50, 0).unwrap();
+    let mut expected = Vec::new();
+    for (id, executor, created_at) in [
+        (1_u128, executor_id, time),
+        (3, executor_id, time + chrono::Duration::seconds(1)),
+        (2, executor_id, time),
+        (4, other_executor_id, time),
+    ] {
+        let chat = mem_attachment_chat(None, Vec::new(), 0);
+        block_on(store.create_chat(&chat)).unwrap();
+        let mut request = mem_attachment_request(
+            &chat,
+            executor,
+            mem_root_id(),
+            RootAttachmentChangeAction::Detach,
+            0,
+            created_at,
+        );
+        request.id = RootAttachmentChangeId::from_uuid(uuid::Uuid::from_u128(id)).unwrap();
+        let change = match block_on(store.begin_root_attachment_change(&request)).unwrap() {
+            BeginRootAttachmentChangeOutcome::Begun(change) => change,
+            outcome => panic!("unexpected begin outcome: {outcome:?}"),
+        };
+        if executor == executor_id {
+            expected.push(change);
+        }
+    }
+    expected.sort_by_key(|change| (change.created_at, *change.id.as_uuid()));
+
+    assert_eq!(
+        block_on(store.list_pending_root_attachment_changes(executor_id, 2)).unwrap(),
+        expected[..2]
+    );
+    assert_eq!(
+        block_on(store.list_pending_root_attachment_changes(executor_id, 3)).unwrap(),
+        expected
+    );
+    assert!(block_on(store.list_pending_root_attachment_changes(executor_id, 0)).is_err());
+    assert!(block_on(store.list_pending_root_attachment_changes(
+        executor_id,
+        MAX_PENDING_ROOT_ATTACHMENT_CHANGES + 1,
+    ))
+    .is_err());
+    assert!(block_on(store.list_pending_root_attachment_changes(uuid::Uuid::nil(), 1)).is_err());
 }
 
 #[test]

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -5,13 +5,15 @@ use std::sync::Arc;
 use chrono::{Duration, Utc};
 use openwave_core::{
     AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentEvent,
-    ApplyTurnSteerOutcome, CallId, Chat, ChatId, ClaimClientToolCallOutcome, ClientToolCallRequest,
-    CompleteTurnRunOutcome, DbStore, FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome,
-    HostRootId, Message, MessageId, ParkTurnForClientCallOutcome, Project, ProjectId,
-    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome, Role,
-    RootAttachmentOrigin, StopReason, Store, ToolCallExecution, ToolCallRecord, ToolCallResolution,
-    ToolCallStatus, TurnCheckpointProgress, TurnFailureRetry, TurnId, TurnRunStatus, TurnSteerId,
-    TurnSteerStatus, Usage,
+    ApplyTurnSteerOutcome, BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, CallId,
+    Chat, ChatId, ChatRootAttachment, ClaimClientToolCallOutcome, ClientToolCallRequest,
+    CompleteTurnRunOutcome, DbStore, FinishRootAttachmentChangeOutcome,
+    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, HostRootId, Message, MessageId,
+    ParkTurnForClientCallOutcome, Project, ProjectId, RecordTurnFailureOutcome,
+    RequestTurnCancellationOutcome, ResolveToolCallOutcome, Role, RootAttachmentChangeAction,
+    RootAttachmentChangeId, RootAttachmentChangeTerminal, RootAttachmentOrigin, StopReason, Store,
+    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress,
+    TurnFailureRetry, TurnId, TurnRunStatus, TurnSteerId, TurnSteerStatus, Usage,
 };
 
 static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
@@ -1225,5 +1227,301 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
                 .unwrap()
                 .len(),
         1
+    );
+}
+
+#[tokio::test]
+async fn postgres_root_attachment_begin_and_finish_have_one_concurrent_winner() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = Arc::new(DbStore::connect(&url).await.unwrap());
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let executor_id = uuid::Uuid::new_v4();
+    let created_at = chrono::DateTime::<Utc>::from_timestamp(1_810_000_000, 123_456_789).unwrap();
+    let canonical_created_at =
+        chrono::DateTime::<Utc>::from_timestamp_micros(created_at.timestamp_micros()).unwrap();
+    let requests = [
+        BeginRootAttachmentChange {
+            id: RootAttachmentChangeId::new(),
+            chat_id: chat.id,
+            executor_id,
+            root_id: HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            action: RootAttachmentChangeAction::Attach,
+            expected_attachment_revision: 0,
+            created_at,
+        },
+        BeginRootAttachmentChange {
+            id: RootAttachmentChangeId::new(),
+            chat_id: chat.id,
+            executor_id,
+            root_id: HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            action: RootAttachmentChangeAction::Attach,
+            expected_attachment_revision: 0,
+            created_at,
+        },
+    ];
+    let barrier = Arc::new(tokio::sync::Barrier::new(requests.len()));
+    let mut tasks = Vec::new();
+    for request in requests {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store.begin_root_attachment_change(&request).await.unwrap()
+        }));
+    }
+
+    let mut begun = None;
+    let mut busy = false;
+    for task in tasks {
+        match task.await.unwrap() {
+            BeginRootAttachmentChangeOutcome::Begun(change) => {
+                assert!(begun.replace(change).is_none(), "multiple begin winners");
+            }
+            BeginRootAttachmentChangeOutcome::ChatBusy => {
+                assert!(!busy, "multiple busy outcomes");
+                busy = true;
+            }
+            outcome => panic!("unexpected concurrent begin outcome: {outcome:?}"),
+        }
+    }
+    let begun = begun.expect("one attachment change began");
+    assert!(busy, "one concurrent begin was busy");
+    assert_eq!(begun.created_at, canonical_created_at);
+    let winning_request = requests
+        .into_iter()
+        .find(|request| request.id == begun.id)
+        .unwrap();
+    assert_eq!(
+        store
+            .begin_root_attachment_change(&winning_request)
+            .await
+            .unwrap(),
+        BeginRootAttachmentChangeOutcome::Existing(begun.clone())
+    );
+
+    let terminal = RootAttachmentChangeTerminal::Completed {
+        broker_changed: true,
+        broker_currently_attached: true,
+    };
+    let finished_at = [
+        chrono::DateTime::<Utc>::from_timestamp(1_810_000_001, 234_567_891).unwrap(),
+        chrono::DateTime::<Utc>::from_timestamp(1_810_000_002, 345_678_912).unwrap(),
+    ];
+    let canonical_finished_at = finished_at.map(|value| {
+        chrono::DateTime::<Utc>::from_timestamp_micros(value.timestamp_micros()).unwrap()
+    });
+    let barrier = Arc::new(tokio::sync::Barrier::new(finished_at.len()));
+    let mut tasks = Vec::new();
+    for value in finished_at {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        let terminal = terminal.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .finish_root_attachment_change(begun.id, executor_id, &terminal, value)
+                .await
+                .unwrap()
+        }));
+    }
+
+    let mut finished = None;
+    let mut existing = None;
+    for task in tasks {
+        match task.await.unwrap() {
+            FinishRootAttachmentChangeOutcome::Finished(change) => {
+                assert!(
+                    finished.replace(change).is_none(),
+                    "multiple finish winners"
+                );
+            }
+            FinishRootAttachmentChangeOutcome::Existing(change) => {
+                assert!(
+                    existing.replace(change).is_none(),
+                    "multiple recovered finishes"
+                );
+            }
+            outcome => panic!("unexpected concurrent finish outcome: {outcome:?}"),
+        }
+    }
+    let finished = finished.expect("one attachment change finished");
+    assert_eq!(existing, Some(finished.clone()));
+    assert!(canonical_finished_at.contains(&finished.finished_at.unwrap()));
+    assert_eq!(
+        store
+            .finish_root_attachment_change(
+                begun.id,
+                executor_id,
+                &terminal,
+                finished_at[0] + Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        FinishRootAttachmentChangeOutcome::Existing(finished.clone())
+    );
+    let projected = store.get_chat(chat.id).await.unwrap().unwrap();
+    assert_eq!(projected.attachment_revision, 1);
+    assert_eq!(
+        projected.root_attachments,
+        vec![ChatRootAttachment {
+            root_id: begun.root_id,
+            origin: RootAttachmentOrigin::Conversation,
+        }]
+    );
+}
+
+#[tokio::test]
+async fn postgres_root_attachment_operation_id_collision_has_no_loser_side_effect() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = Arc::new(DbStore::connect(&url).await.unwrap());
+    let chats = [sample_chat(), sample_chat()];
+    for chat in &chats {
+        store.create_chat(chat).await.unwrap();
+    }
+    let operation_id = RootAttachmentChangeId::new();
+    let executor_id = uuid::Uuid::new_v4();
+    let requests = chats.map(|chat| BeginRootAttachmentChange {
+        id: operation_id,
+        chat_id: chat.id,
+        executor_id,
+        root_id: HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+        action: RootAttachmentChangeAction::Attach,
+        expected_attachment_revision: 0,
+        created_at: chrono::DateTime::<Utc>::from_timestamp(1_810_000_005, 345_678_912).unwrap(),
+    });
+    let barrier = Arc::new(tokio::sync::Barrier::new(requests.len()));
+    let mut tasks = Vec::new();
+    for request in requests {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            let outcome = store.begin_root_attachment_change(&request).await.unwrap();
+            (request, outcome)
+        }));
+    }
+
+    let mut winner = None;
+    let mut loser = None;
+    for task in tasks {
+        let (request, outcome) = task.await.unwrap();
+        match outcome {
+            BeginRootAttachmentChangeOutcome::Begun(change) => {
+                assert_eq!(change.chat_id, request.chat_id);
+                assert_eq!(change.root_id, request.root_id);
+                assert!(winner.replace(request).is_none(), "multiple begin winners");
+            }
+            BeginRootAttachmentChangeOutcome::IdentityConflict => {
+                assert!(
+                    loser.replace(request).is_none(),
+                    "multiple identity conflicts"
+                );
+            }
+            outcome => panic!("unexpected operation ID collision outcome: {outcome:?}"),
+        }
+    }
+    let winner = winner.expect("one operation ID collision began");
+    let loser = loser.expect("one operation ID collision conflicted");
+
+    let winning_chat = store.get_chat(winner.chat_id).await.unwrap().unwrap();
+    assert_eq!(winning_chat.attachment_revision, 1);
+    assert_eq!(
+        winning_chat.root_attachments,
+        vec![ChatRootAttachment {
+            root_id: winner.root_id,
+            origin: RootAttachmentOrigin::Conversation,
+        }]
+    );
+    let losing_chat = store.get_chat(loser.chat_id).await.unwrap().unwrap();
+    assert_eq!(losing_chat.attachment_revision, 0);
+    assert!(losing_chat.root_attachments.is_empty());
+}
+
+#[tokio::test]
+async fn postgres_root_attachment_detach_compacts_the_ordered_projection() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let roots = [
+        HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+        HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+        HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+    ];
+    let mut chat = sample_chat();
+    chat.attachment_revision = 7;
+    chat.root_attachments = roots
+        .into_iter()
+        .map(|root_id| ChatRootAttachment {
+            root_id,
+            origin: RootAttachmentOrigin::Conversation,
+        })
+        .collect();
+    store.create_chat(&chat).await.unwrap();
+    let executor_id = uuid::Uuid::new_v4();
+    let request = BeginRootAttachmentChange {
+        id: RootAttachmentChangeId::new(),
+        chat_id: chat.id,
+        executor_id,
+        root_id: roots[1],
+        action: RootAttachmentChangeAction::Detach,
+        expected_attachment_revision: 7,
+        created_at: chrono::DateTime::<Utc>::from_timestamp(1_810_000_010, 456_789_123).unwrap(),
+    };
+    let pending = match store.begin_root_attachment_change(&request).await.unwrap() {
+        BeginRootAttachmentChangeOutcome::Begun(change) => change,
+        outcome => panic!("unexpected detach begin outcome: {outcome:?}"),
+    };
+    assert_eq!(pending.projection_position, Some(1));
+    assert_eq!(pending.intent_revision, 7);
+
+    let terminal = RootAttachmentChangeTerminal::Completed {
+        broker_changed: true,
+        broker_currently_attached: false,
+    };
+    let finished = match store
+        .finish_root_attachment_change(
+            request.id,
+            executor_id,
+            &terminal,
+            chrono::DateTime::<Utc>::from_timestamp(1_810_000_011, 567_891_234).unwrap(),
+        )
+        .await
+        .unwrap()
+    {
+        FinishRootAttachmentChangeOutcome::Finished(change) => change,
+        outcome => panic!("unexpected detach finish outcome: {outcome:?}"),
+    };
+    assert_eq!(finished.result_revision, Some(8));
+    assert_eq!(finished.projection_changed, Some(true));
+    let projected = store.get_chat(chat.id).await.unwrap().unwrap();
+    assert_eq!(projected.attachment_revision, 8);
+    assert_eq!(
+        projected
+            .root_attachments
+            .into_iter()
+            .map(|attachment| attachment.root_id)
+            .collect::<Vec<_>>(),
+        vec![roots[0], roots[2]]
     );
 }

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -42,9 +42,9 @@ revision. Project defaults are snapshotted into a new chat's exact attachment
 set; later project changes cannot silently widen that chat. These product rows
 are not grants: they contain no path, capability, consent, or display name, and
 host access still requires the broker's live attachment and authorization. The
-current native picker still updates broker state only; synchronizing those
-connections into this product projection is the next native CAS/reconciliation
-slice, before any tool treats the projection as usable context.
+product store now has a durable attachment-change state machine, but the current
+native picker still updates broker state only. Native reconciliation and routes
+are the next slice, before any tool treats the projection as usable context.
 
 ## The four layers
 
@@ -138,6 +138,30 @@ receipt lets a recovering native client distinguish unknown, completed, and
 failed work without starting or replaying the mutation. Attachment changes are
 computed and published in one durable state replacement, so they do not expose
 a recoverable intermediate phase.
+
+The product database coordinates its side of the operation separately. It
+stores an `awaiting_broker` change before native code talks to the broker, then
+finishes it as `completed` or `failed` from an exact broker receipt. Only one
+change may wait for the broker per conversation. Attach records product intent
+first and rolls it back if the broker fails; detach leaves the root visible until
+the broker confirms it is detached. The final projection and terminal receipt
+commit together. A crash therefore leaves durable work that a native reconciler
+can resume instead of an ambiguous half-update.
+
+The store derives the broker subject from the locked chat: project chats use the
+project subject, while standalone chats use the conversation subject. Callers
+provide only the stable operation ID, chat, executor, root, action, expected
+revision, and creation time. They cannot choose a project, path, projection
+position, or provenance.
+
+The native reconciler must derive its stable executor identity from its private
+authenticated session; renderer input cannot choose or learn that identity. It
+must also bind a broker receipt back to the persisted operation ID, subject,
+conversation, root, and action before constructing a product terminal result.
+An unknown attachment receipt may dispatch the exact fingerprinted mutation. A
+matching completed or durable failed receipt may finish the product change. A
+contradictory receipt returns `BrokerStateMismatch`, leaves the change pending,
+and must be escalated rather than converted into an ordinary failure.
 
 The host-access context and the conversation's attached-root set are supplied by
 trusted conversation execution state, not by model-generated tool arguments.
@@ -312,8 +336,8 @@ This will land in independently reviewable pieces:
    while runtime-only legacy scratch is derived under private server data and
    never returned by the product API. The broker now supports exact,
    idempotent per-conversation attach/detach plus read-only recovery receipts.
-   The durable product-side attachment operation and native reconciliation loop
-   remain separate slices.
+   The durable product-side attachment operation is now implemented in core.
+   Native routes and the reconciliation loop remain separate slices.
 9. Route built-in file tools through the operation interface and remove direct
    ambient host-directory opening from `ToolCtx`.
 10. Port bounded imports, writes, approvals, and confined command execution as

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -168,9 +168,10 @@ Today these file tools still operate inside a server-derived, pinned per-chat
 scratch capability. Its path is neither persisted on the chat nor returned by
 the product API. The desktop can connect, list, and revoke multiple folders
 through a native picker and capability-gated host-broker sidecar; it exposes only
-opaque root IDs and display names to the renderer. The next native CAS slice will
-synchronize broker connections into the product's pathless root projection, and
-the following tool-routing slice will resolve operations through those roots.
+opaque root IDs and display names to the renderer. The next native slice will
+synchronize broker connections through core's durable attachment-change state
+machine, and the following tool-routing slice will resolve operations through
+those roots.
 See [Host access and connected folders](host-access.md). The agent loop can now
 produce a durable client-wait checkpoint for the registered folder-request
 contract. The desktop discovers those pending requests from durable state and


### PR DESCRIPTION
## Summary

- add a durable product-side state machine for exact broker-backed root attach and detach changes
- derive project or conversation authority under the chat lock, fence completion by executor, and keep one pending mutation per chat
- commit attach intent before broker work, defer detach projection changes until success, and atomically persist completion or rollback receipts
- fold strict relational state into the pre-v1 schema with SQLite and PostgreSQL concurrency coverage
- document the native reconciliation contract and authority boundary

## Validation

- cargo test -p openwave-core --all-features
- cargo clippy -p openwave-core --all-targets --all-features --locked -- -D warnings
- bw dev lint --rust --check
- PostgreSQL 17 attachment concurrency, idempotency, and projection-compaction tests
- cargo fmt --all -- --check
- git diff --check