### PR TITLE
build(deps): keep Arrow aligned with LanceDB

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,16 @@ updates:
     commit-message:
       prefix: build
       include: scope
+    # LanceDB 0.31 exposes Arrow 58 types. Moving any one of these direct
+    # dependencies to Arrow 59 creates an incompatible duplicate type graph;
+    # advance them together when LanceDB adopts the next Arrow major.
+    ignore:
+      - dependency-name: arrow-array
+        versions: [">=59"]
+      - dependency-name: arrow-schema
+        versions: [">=59"]
+      - dependency-name: arrow-select
+        versions: [">=59"]
     groups:
       # Batch low-risk bumps into one PR to keep the queue quiet.
       cargo-minor-and-patch:


### PR DESCRIPTION
## Summary

- keep the direct Arrow crates on major 58 while LanceDB 0.31 exposes Arrow 58 types
- prevent incompatible one-at-a-time Arrow 59 update proposals
- leave the pin easy to remove when LanceDB advances its Arrow major

## Validation

- parsed `.github/dependabot.yml` as YAML
- `git diff --check`