### PR TITLE
ci: move full validation to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+  # During active single-maintainer development, PRs run only the change
+  # detector, secret scan, rustfmt, and aggregate gate. The expensive Rust
+  # lanes run on the merged main tip (and on explicit manual dispatch).
   pull_request:
+  workflow_dispatch:
 
 # Least privilege by default; fork PRs get read-only.
 permissions:
@@ -77,7 +81,7 @@ jobs:
   lint:
     name: clippy
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -125,7 +129,7 @@ jobs:
   build:
     name: build
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -171,7 +175,7 @@ jobs:
   desktop:
     name: desktop test
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -214,7 +218,7 @@ jobs:
   test:
     name: test
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -253,7 +257,7 @@ jobs:
   postgres:
     name: postgres state machine
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     services:
@@ -315,16 +319,25 @@ jobs:
           POSTGRES_RESULT: ${{ needs.postgres.result }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           RUST_CHANGED: ${{ needs.changes.outputs.rust }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           test "$CHANGES_RESULT" = success
           case "$RUST_CHANGED" in
             true)
               test "$FMT_RESULT" = success
-              test "$LINT_RESULT" = success
-              test "$BUILD_RESULT" = success
-              test "$DESKTOP_RESULT" = success
-              test "$TEST_RESULT" = success
-              test "$POSTGRES_RESULT" = success
+              if [[ "$EVENT_NAME" = pull_request ]]; then
+                test "$LINT_RESULT" = skipped
+                test "$BUILD_RESULT" = skipped
+                test "$DESKTOP_RESULT" = skipped
+                test "$TEST_RESULT" = skipped
+                test "$POSTGRES_RESULT" = skipped
+              else
+                test "$LINT_RESULT" = success
+                test "$BUILD_RESULT" = success
+                test "$DESKTOP_RESULT" = success
+                test "$TEST_RESULT" = success
+                test "$POSTGRES_RESULT" = success
+              fi
               ;;
             false)
               test "$FMT_RESULT" = skipped


### PR DESCRIPTION
## Summary

- keep change detection, secret scanning, rustfmt, and the required aggregate gate on pull requests
- run clippy, build, desktop tests, headless tests, and PostgreSQL validation on `main` instead of blocking each PR
- allow the full workflow to be started manually when pre-merge validation is useful

## Why

This keeps the current fast safety checks while removing repeated full-workspace compilation from the active single-maintainer merge loop. The merged main tip remains fully validated.

## Validation

- parsed `.github/workflows/ci.yml` as YAML
- verified pull-request, main, and no-Rust-change aggregate result paths
- `git diff --check`