### PR TITLE
feat(server): expose native root attachment recovery

### DIFF
--- a/crates/openwave-core/src/db/ops/root_attachment/finish.rs
+++ b/crates/openwave-core/src/db/ops/root_attachment/finish.rs
@@ -68,12 +68,10 @@ pub(in crate::db) async fn finish_root_attachment_change(
         transaction.commit().await.map_err(store_err)?;
         return Ok(outcome);
     }
-    if finished_at < change.created_at {
-        transaction.rollback().await.map_err(store_err)?;
-        return Err(AgentError::Store(
-            "root attachment change finish time precedes creation".into(),
-        ));
-    }
+    // Creation time is immutable caller identity, while finish time is
+    // server-owned metadata. Clamp under the operation lock so clock skew or a
+    // wall-clock rollback cannot wedge this chat's single pending slot.
+    let finished_at = finished_at.max(change.created_at);
 
     if let RootAttachmentChangeTerminal::Completed {
         broker_currently_attached,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -836,7 +836,9 @@ pub trait Store: Send + Sync {
     /// Atomically finish one exact change under its stable executor.
     ///
     /// Exact terminal retries return `Existing`. Implementations apply the
-    /// final projection, terminal receipt, and result revision together.
+    /// final projection, terminal receipt, and result revision together. The
+    /// server-owned finish time is clamped to the immutable creation time under
+    /// the operation lock so wall-clock skew cannot wedge pending work.
     /// Adapters must first bind the broker receipt to this exact persisted
     /// operation; arbitrary transport failures are not durable broker failures.
     async fn finish_root_attachment_change(

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -1507,11 +1507,10 @@ impl Store for MemStore {
                 FinishRootAttachmentChangeOutcome::AlreadyTerminal(existing)
             });
         }
-        if finished_at < existing.created_at {
-            return Err(AgentError::Store(
-                "root attachment change finish time precedes creation".into(),
-            ));
-        }
+        // Match the database contract: caller creation time is immutable
+        // identity, while server-owned finish time is clamped under the lock so
+        // clock skew cannot leave the chat permanently busy.
+        let finished_at = finished_at.max(existing.created_at);
         let desired_attached = existing.action == RootAttachmentChangeAction::Attach;
         let broker_state_contradicts_terminal = match terminal {
             RootAttachmentChangeTerminal::Completed {

--- a/crates/openwave-core/src/storage/tests/root_attachment.rs
+++ b/crates/openwave-core/src/storage/tests/root_attachment.rs
@@ -271,7 +271,7 @@ fn mem_root_attachment_attach_projects_intent_and_rolls_back_failure() {
             retryable: false,
         },
     };
-    let finished_at = now + chrono::Duration::seconds(1);
+    let finished_at = now - chrono::Duration::seconds(1);
     assert_eq!(
         block_on(store.finish_root_attachment_change(
             request.id,
@@ -306,6 +306,7 @@ fn mem_root_attachment_attach_projects_intent_and_rolls_back_failure() {
         outcome => panic!("unexpected finish outcome: {outcome:?}"),
     };
     assert_eq!(failed.phase, RootAttachmentChangePhase::Failed);
+    assert_eq!(failed.finished_at, Some(now));
     assert_eq!(failed.result_revision, Some(2));
     assert_eq!(failed.projection_changed, Some(false));
     let rolled_back = block_on(store.get_chat(chat.id)).unwrap().unwrap();

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -178,7 +178,7 @@ impl ReceiptStore {
         Ok(store)
     }
 
-    pub(super) const fn executor_id(&self) -> Uuid {
+    pub(crate) const fn executor_id(&self) -> Uuid {
         self.executor_id
     }
 

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -47,6 +47,11 @@ impl HostAccess {
             .map_err(|_| "host access store was initialized more than once".to_owned())
     }
 
+    /// Stable private identity shared by native receipts and server recovery.
+    pub(crate) const fn client_executor_id(&self) -> Uuid {
+        self.receipts.executor_id()
+    }
+
     pub(crate) fn initialize_control_plane(
         &self,
         base_url: String,

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -121,9 +121,13 @@ async fn boot_server(
     info_tx: watch::Sender<Option<ServerInfo>>,
     data_dir: PathBuf,
 ) -> Result<(), String> {
-    let server = openwave_server::bind(Config::desktop(data_dir))
-        .await
-        .map_err(|e| e.to_string())?;
+    let client_executor_id = app.state::<host_access::HostAccess>().client_executor_id();
+    let server = openwave_server::bind_with_client_executor_id(
+        Config::desktop(data_dir),
+        client_executor_id,
+    )
+    .await
+    .map_err(|e| e.to_string())?;
     app.state::<host_access::HostAccess>()
         .initialize_store(server.store())?;
     let base_url = format!("http://{}", server.local_addr());

--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -67,6 +67,17 @@ impl ServerError {
         }
     }
 
+    /// A `409 Conflict` with a route-specific stable machine-readable kind.
+    pub(crate) fn conflict_kind(kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            info: AgentErrorInfo {
+                kind: kind.to_owned(),
+                message: message.into(),
+            },
+        }
+    }
+
     /// A `500 Internal Server Error` for an unexpected server-side failure that
     /// isn't an [`AgentError`] (e.g. a retrieval backend fault). Carries a stable
     /// `kind` so a client sees the same `{ kind, message }` shape as any error.

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -39,6 +39,7 @@ use axum::routing::{get, post};
 use axum::Router;
 use tokio::net::TcpListener;
 use tower_http::cors::{AllowOrigin, CorsLayer};
+use uuid::Uuid;
 
 use openwave_core::{
     request_folder_access_tool_spec, validate_request_folder_access_arguments, AgentConfig,
@@ -73,11 +74,28 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/chats/{id}/client-executions/{call_id}/resolve",
             post(routes::resolve_client_execution),
-        )
-        .route_layer(axum::middleware::from_fn_with_state(
-            state.clone(),
-            auth::require_client_executor_token,
-        ));
+        );
+    let client_executor_api = if state.root_attachment_routes_enabled {
+        client_executor_api
+            .route(
+                "/chats/{chat_id}/root-attachment-changes/{change_id}/begin",
+                post(routes::begin_root_attachment_change),
+            )
+            .route(
+                "/root-attachment-changes/pending",
+                get(routes::list_pending_root_attachment_changes),
+            )
+            .route(
+                "/root-attachment-changes/{change_id}/finish",
+                post(routes::finish_root_attachment_change),
+            )
+    } else {
+        client_executor_api
+    }
+    .route_layer(axum::middleware::from_fn_with_state(
+        state.clone(),
+        auth::require_client_executor_token,
+    ));
 
     let api = Router::new()
         .route(
@@ -282,7 +300,28 @@ impl Server {
 const DEFAULT_MODEL: &str = "claude-opus-4-8";
 
 /// Wire the store from `config` and bind the API to an ephemeral loopback port.
+///
+/// This generic embedding does not expose durable root-attachment mutations,
+/// because it has no restart-stable native executor identity.
 pub async fn bind(config: Config) -> Result<Server> {
+    bind_inner(config, None).await
+}
+
+/// Bind the API with a stable app-private native executor identity.
+///
+/// The desktop persists this identity outside renderer-visible state so pending
+/// attachment work remains recoverable across launches.
+pub async fn bind_with_client_executor_id(
+    config: Config,
+    client_executor_id: Uuid,
+) -> Result<Server> {
+    if client_executor_id.is_nil() {
+        return Err(AgentError::config("client executor id must not be nil"));
+    }
+    bind_inner(config, Some(client_executor_id)).await
+}
+
+async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<Server> {
     // Desktop live delivery, steer, and approvals are process-local. Until the
     // self-host control plane makes those paths durable, one process owns the
     // complete data directory and its worker set.
@@ -296,15 +335,27 @@ pub async fn bind(config: Config) -> Result<Server> {
     let embedder = resolve_embedder(&*store, &*secrets).await;
     let vector_store = connect_vector_store(&config, embedder.dimensions()).await?;
     let (retrieval, tools, agent_config) = agent_deps(embedder, vector_store);
-    let state = AppState::new(
-        config,
-        store,
-        resolver,
-        secrets,
-        tools,
-        retrieval,
-        agent_config,
-    );
+    let state = match client_executor_id {
+        Some(client_executor_id) => AppState::new_with_client_executor_id(
+            config,
+            store,
+            resolver,
+            secrets,
+            tools,
+            retrieval,
+            agent_config,
+            client_executor_id,
+        )?,
+        None => AppState::new(
+            config,
+            store,
+            resolver,
+            secrets,
+            tools,
+            retrieval,
+            agent_config,
+        ),
+    };
     let token = state.token.clone();
     let client_executor_token = state.client_executor_token.clone();
     let document_worker = document_worker::DocumentWorker::new(

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -26,8 +26,10 @@ use crate::state::AppState;
 
 mod client_execution;
 mod document;
+mod root_attachment;
 pub use client_execution::*;
 pub use document::*;
+pub use root_attachment::*;
 
 /// The store-settings key for the selected model.
 const MODEL_SETTING: &str = "model";

--- a/crates/openwave-server/src/routes/root_attachment.rs
+++ b/crates/openwave-server/src/routes/root_attachment.rs
@@ -1,0 +1,264 @@
+//! Native-only HTTP boundary for durable root-attachment reconciliation.
+//!
+//! These routes only begin, recover, and finish product-side state. Broker
+//! dispatch remains the trusted desktop reconciler's responsibility.
+
+use axum::extract::State;
+use chrono::{DateTime, Utc};
+use openwave_core::{
+    BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, ChatId,
+    FinishRootAttachmentChangeOutcome, HostRootId, RootAttachmentChange,
+    RootAttachmentChangeAction, RootAttachmentChangeFailure, RootAttachmentChangeId,
+    RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
+    RootAttachmentSubjectKind, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::ServerError;
+use crate::extract::{Json, Path, Query};
+use crate::state::AppState;
+
+const DEFAULT_PENDING_LIMIT: u64 = 64;
+
+/// Caller intent for one exact root-attachment change.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BeginRootAttachmentChangeBody {
+    pub root_id: HostRootId,
+    pub action: RootAttachmentChangeAction,
+    pub expected_attachment_revision: i64,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Terminal broker observation for one exact root-attachment change.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FinishRootAttachmentChangeBody {
+    pub terminal: RootAttachmentChangeTerminal,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PendingRootAttachmentChangesQuery {
+    pub limit: Option<u64>,
+}
+
+/// Whether a begin call committed work or recovered an exact retry.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BeginRootAttachmentChangeDisposition {
+    Begun,
+    Existing,
+}
+
+/// Whether a finish call committed work or recovered an exact retry.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishRootAttachmentChangeDisposition {
+    Finished,
+    Existing,
+}
+
+/// Native recovery view. The private executor identity is intentionally absent.
+#[derive(Debug, Serialize)]
+pub struct RootAttachmentChangeView {
+    pub id: RootAttachmentChangeId,
+    pub chat_id: ChatId,
+    pub root_id: HostRootId,
+    pub action: RootAttachmentChangeAction,
+    pub subject_kind: RootAttachmentSubjectKind,
+    pub subject_id: Uuid,
+    pub origin: Option<RootAttachmentOrigin>,
+    pub projection_position: Option<u32>,
+    pub projection_existed_before: bool,
+    pub expected_revision: i64,
+    pub before_revision: i64,
+    pub intent_revision: i64,
+    pub phase: RootAttachmentChangePhase,
+    pub result_revision: Option<i64>,
+    pub projection_changed: Option<bool>,
+    pub broker_changed: Option<bool>,
+    pub broker_currently_attached: Option<bool>,
+    pub failure: Option<RootAttachmentChangeFailure>,
+    pub created_at: DateTime<Utc>,
+    pub finished_at: Option<DateTime<Utc>>,
+}
+
+impl From<RootAttachmentChange> for RootAttachmentChangeView {
+    fn from(change: RootAttachmentChange) -> Self {
+        Self {
+            id: change.id,
+            chat_id: change.chat_id,
+            root_id: change.root_id,
+            action: change.action,
+            subject_kind: change.subject_kind,
+            subject_id: change.subject_id,
+            origin: change.origin,
+            projection_position: change.projection_position,
+            projection_existed_before: change.projection_existed_before,
+            expected_revision: change.expected_revision,
+            before_revision: change.before_revision,
+            intent_revision: change.intent_revision,
+            phase: change.phase,
+            result_revision: change.result_revision,
+            projection_changed: change.projection_changed,
+            broker_changed: change.broker_changed,
+            broker_currently_attached: change.broker_currently_attached,
+            failure: change.failure,
+            created_at: change.created_at,
+            finished_at: change.finished_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct BegunRootAttachmentChange {
+    pub disposition: BeginRootAttachmentChangeDisposition,
+    pub change: RootAttachmentChangeView,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FinishedRootAttachmentChange {
+    pub disposition: FinishRootAttachmentChangeDisposition,
+    pub change: RootAttachmentChangeView,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PendingRootAttachmentChanges {
+    pub changes: Vec<RootAttachmentChangeView>,
+}
+
+/// Begin or recover one exact product-side attachment intent.
+pub async fn begin_root_attachment_change(
+    State(state): State<AppState>,
+    Path((chat_id, change_id)): Path<(ChatId, RootAttachmentChangeId)>,
+    Json(body): Json<BeginRootAttachmentChangeBody>,
+) -> Result<Json<BegunRootAttachmentChange>, ServerError> {
+    if chat_id.as_uuid().is_nil() {
+        return Err(ServerError::bad_request("chat id must not be nil"));
+    }
+    let request = BeginRootAttachmentChange {
+        id: change_id,
+        chat_id,
+        executor_id: state.client_executor_id,
+        root_id: body.root_id,
+        action: body.action,
+        expected_attachment_revision: body.expected_attachment_revision,
+        created_at: body.created_at,
+    };
+    request.validate().map_err(ServerError::bad_request)?;
+
+    let (disposition, change) = match state.store.begin_root_attachment_change(&request).await? {
+        BeginRootAttachmentChangeOutcome::Begun(change) => {
+            (BeginRootAttachmentChangeDisposition::Begun, change)
+        }
+        BeginRootAttachmentChangeOutcome::Existing(change) => {
+            (BeginRootAttachmentChangeDisposition::Existing, change)
+        }
+        BeginRootAttachmentChangeOutcome::ChatNotFound => {
+            return Err(ServerError::not_found("conversation not found"));
+        }
+        BeginRootAttachmentChangeOutcome::IdentityConflict => {
+            return Err(ServerError::conflict_kind(
+                "root_attachment_identity_conflict",
+                "root attachment change identity is already in use",
+            ));
+        }
+        BeginRootAttachmentChangeOutcome::RevisionConflict { .. } => {
+            return Err(ServerError::conflict_kind(
+                "root_attachment_revision_conflict",
+                "root attachment projection changed before this request",
+            ));
+        }
+        BeginRootAttachmentChangeOutcome::CapacityExceeded => {
+            return Err(ServerError::conflict_kind(
+                "root_attachment_capacity_exceeded",
+                "root attachment projection is at capacity",
+            ));
+        }
+        BeginRootAttachmentChangeOutcome::RevisionExhausted => {
+            return Err(ServerError::conflict_kind(
+                "root_attachment_revision_exhausted",
+                "root attachment revision cannot advance",
+            ));
+        }
+        BeginRootAttachmentChangeOutcome::ChatBusy => {
+            return Err(ServerError::conflict_kind(
+                "root_attachment_chat_busy",
+                "a root attachment change is already in progress",
+            ));
+        }
+    };
+    Ok(Json(BegunRootAttachmentChange {
+        disposition,
+        change: change.into(),
+    }))
+}
+
+/// List awaiting work owned by this app-private native executor.
+pub async fn list_pending_root_attachment_changes(
+    State(state): State<AppState>,
+    Query(query): Query<PendingRootAttachmentChangesQuery>,
+) -> Result<Json<PendingRootAttachmentChanges>, ServerError> {
+    let limit = query.limit.unwrap_or(DEFAULT_PENDING_LIMIT);
+    if !(1..=MAX_PENDING_ROOT_ATTACHMENT_CHANGES).contains(&limit) {
+        return Err(ServerError::bad_request(format!(
+            "limit must be between 1 and {MAX_PENDING_ROOT_ATTACHMENT_CHANGES}",
+        )));
+    }
+    let changes = state
+        .store
+        .list_pending_root_attachment_changes(state.client_executor_id, limit)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    Ok(Json(PendingRootAttachmentChanges { changes }))
+}
+
+/// Finish or recover one exact product-side attachment change.
+pub async fn finish_root_attachment_change(
+    State(state): State<AppState>,
+    Path(change_id): Path<RootAttachmentChangeId>,
+    Json(body): Json<FinishRootAttachmentChangeBody>,
+) -> Result<Json<FinishedRootAttachmentChange>, ServerError> {
+    body.terminal.validate().map_err(ServerError::bad_request)?;
+    let (disposition, change) = match state
+        .store
+        .finish_root_attachment_change(
+            change_id,
+            state.client_executor_id,
+            &body.terminal,
+            Utc::now(),
+        )
+        .await?
+    {
+        FinishRootAttachmentChangeOutcome::Finished(change) => {
+            (FinishRootAttachmentChangeDisposition::Finished, change)
+        }
+        FinishRootAttachmentChangeOutcome::Existing(change) => {
+            (FinishRootAttachmentChangeDisposition::Existing, change)
+        }
+        FinishRootAttachmentChangeOutcome::NotFound
+        | FinishRootAttachmentChangeOutcome::ExecutorMismatch => {
+            return Err(ServerError::not_found("root attachment change not found"));
+        }
+        FinishRootAttachmentChangeOutcome::AlreadyTerminal(_) => {
+            return Err(ServerError::conflict_kind(
+                "root_attachment_already_terminal",
+                "root attachment change already has a different result",
+            ));
+        }
+        FinishRootAttachmentChangeOutcome::BrokerStateMismatch => {
+            return Err(ServerError::conflict_kind(
+                "root_attachment_broker_state_mismatch",
+                "broker state contradicts this attachment result",
+            ));
+        }
+    };
+    Ok(Json(FinishedRootAttachmentChange {
+        disposition,
+        change: change.into(),
+    }))
+}

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -57,6 +57,10 @@ pub struct AppState {
     pub token: Arc<str>,
     /// A second per-launch secret required for client-execution mutations.
     pub(crate) client_executor_token: Arc<str>,
+    /// Stable private identity owning native attachment reconciliation work.
+    pub(crate) client_executor_id: Uuid,
+    /// Whether this embedding supplied a restart-stable attachment executor.
+    pub(crate) root_attachment_routes_enabled: bool,
     /// Process-local cancel/steer handles for exact durably claimed attempts.
     pub active_turns: Arc<TurnGuard>,
     /// Live fan-out of turn events to connected WebSocket clients.
@@ -77,9 +81,40 @@ impl AppState {
         retrieval: Arc<Retriever>,
         agent_config: AgentConfig,
     ) -> Self {
+        let mut state = Self::new_with_client_executor_id(
+            config,
+            store,
+            resolver,
+            secrets,
+            tools,
+            retrieval,
+            agent_config,
+            Uuid::new_v4(),
+        )
+        .expect("a generated client executor id is non-nil");
+        state.root_attachment_routes_enabled = false;
+        state
+    }
+
+    /// Assemble state with a stable native executor identity supplied by an
+    /// app-private embedding boundary.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_client_executor_id(
+        config: Config,
+        store: Arc<dyn Store>,
+        resolver: Arc<dyn ProviderResolver>,
+        secrets: Arc<dyn SecretProvider>,
+        tools: Arc<ToolRegistry>,
+        retrieval: Arc<Retriever>,
+        agent_config: AgentConfig,
+        client_executor_id: Uuid,
+    ) -> Result<Self> {
+        if client_executor_id.is_nil() {
+            return Err(AgentError::config("client executor id must not be nil"));
+        }
         let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
         let blob_writes = Arc::new(BlobWriteGuard::new(config.data_dir.join("blob-locks")));
-        Self {
+        Ok(Self {
             config: Arc::new(config),
             store,
             blobs,
@@ -95,10 +130,12 @@ impl AppState {
             agent_config,
             token: Uuid::new_v4().to_string().into(),
             client_executor_token: mint_client_executor_token(),
+            client_executor_id,
+            root_attachment_routes_enabled: true,
             active_turns: Arc::new(TurnGuard::default()),
             events: Arc::new(EventBus::default()),
             approvals: Arc::new(ApprovalBroker::new()),
-        }
+        })
     }
 }
 

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -9,12 +9,13 @@ use axum::http::{header, Request, StatusCode};
 use futures::stream::{self, BoxStream, StreamExt};
 // Tests use the in-memory store; production wires LanceDB in `bind`.
 use openwave_core::{
-    AgentErrorInfo, AgentEvent, ApprovalClass, BlobStore, CallId, Chat, ChatId, ChatRequest,
-    ChatRootAttachment, ClientToolCallRequest, HostRootId, Message, ModelProvider,
-    ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent, ProviderId,
-    RootAttachmentOrigin, SecretProvider, SequencedEvent, StopReason, Tool, ToolCallExecution,
-    ToolCallRecord, ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput, ToolSpec,
-    TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
+    AgentErrorInfo, AgentEvent, ApprovalClass, BeginRootAttachmentChange, BlobStore, CallId, Chat,
+    ChatId, ChatRequest, ChatRootAttachment, ClientToolCallRequest, HostRootId, Message,
+    ModelProvider, ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent, ProviderId,
+    RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentOrigin, SecretProvider,
+    SequencedEvent, StopReason, Tool, ToolCallExecution, ToolCallRecord, ToolCallResolution,
+    ToolCallStatus, ToolCtx, ToolOutput, ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus,
+    TurnSteerId, Usage,
 };
 use openwave_retrieval::{
     Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
@@ -23,6 +24,8 @@ use resolver::ProviderResolver;
 use serde::de::DeserializeOwned;
 use tokio::sync::Notify;
 use tower::ServiceExt;
+
+mod root_attachment;
 
 /// A provider that answers with a one-line completion and no tool calls.
 struct FakeProvider;
@@ -2442,6 +2445,28 @@ async fn post_json(
                 .method("POST")
                 .uri(uri)
                 .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// POST a JSON body through the native-only client-executor boundary.
+async fn post_native_json(
+    router: &Router,
+    bearer: &str,
+    uri: &str,
+    body: serde_json::Value,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header(header::AUTHORIZATION, bearer)
                 .header(
                     crate::auth::CLIENT_EXECUTOR_HEADER,
                     crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
@@ -2625,7 +2650,7 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         .unwrap();
     assert_eq!(renderer_only.status(), StatusCode::UNAUTHORIZED);
 
-    let first = post_json(&router, &bearer, &claim_uri, claim_body.clone()).await;
+    let first = post_native_json(&router, &bearer, &claim_uri, claim_body.clone()).await;
     assert_eq!(first.status(), StatusCode::OK);
     let first: serde_json::Value = json_body(first).await;
     assert_eq!(first["disposition"], "claimed");
@@ -2634,13 +2659,13 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
 
     // A lost response can be retried with the stable secret token even though
     // the server calculates a fresh proposed expiry for the second request.
-    let retry = post_json(&router, &bearer, &claim_uri, claim_body).await;
+    let retry = post_native_json(&router, &bearer, &claim_uri, claim_body).await;
     assert_eq!(retry.status(), StatusCode::OK);
     let retry: serde_json::Value = json_body(retry).await;
     assert_eq!(retry["disposition"], "existing");
     assert_eq!(retry["lease_token"], lease_token.to_string());
 
-    let stolen = post_json(
+    let stolen = post_native_json(
         &router,
         &bearer,
         &claim_uri,
@@ -2669,7 +2694,7 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         "authoritative polling must never disclose the secret lease token"
     );
 
-    let wrong_chat_heartbeat = post_json(
+    let wrong_chat_heartbeat = post_native_json(
         &router,
         &bearer,
         &format!(
@@ -2682,7 +2707,7 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
     assert_eq!(wrong_chat_heartbeat.status(), StatusCode::CONFLICT);
 
     tokio::time::sleep(Duration::from_millis(2)).await;
-    let heartbeat = post_json(
+    let heartbeat = post_native_json(
         &router,
         &bearer,
         &format!("/chats/{}/client-executions/{}/heartbeat", chat.id, call.id),
@@ -2698,7 +2723,7 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         "lease_token": lease_token,
         "resolution": {"status": "completed", "result": "folder connected"},
     });
-    let wrong_chat_resolve = post_json(
+    let wrong_chat_resolve = post_native_json(
         &router,
         &bearer,
         &format!(
@@ -2709,7 +2734,7 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
     )
     .await;
     assert_eq!(wrong_chat_resolve.status(), StatusCode::CONFLICT);
-    let wrong_token = post_json(
+    let wrong_token = post_native_json(
         &router,
         &bearer,
         &resolve_uri,
@@ -2721,7 +2746,7 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
     .await;
     assert_eq!(wrong_token.status(), StatusCode::CONFLICT);
 
-    let resolved = post_json(&router, &bearer, &resolve_uri, resolution.clone()).await;
+    let resolved = post_native_json(&router, &bearer, &resolve_uri, resolution.clone()).await;
     assert_eq!(resolved.status(), StatusCode::OK);
     let resolved: serde_json::Value = json_body(resolved).await;
     assert_eq!(resolved["disposition"], "resolved");
@@ -2729,12 +2754,12 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
     // Resolution time is server-owned metadata, not part of the stable command
     // identity, so an ambiguous retry converges on token + terminal payload.
     tokio::time::sleep(Duration::from_millis(2)).await;
-    let retry = post_json(&router, &bearer, &resolve_uri, resolution).await;
+    let retry = post_native_json(&router, &bearer, &resolve_uri, resolution).await;
     assert_eq!(retry.status(), StatusCode::OK);
     let retry: serde_json::Value = json_body(retry).await;
     assert_eq!(retry["disposition"], "existing");
 
-    let conflicting = post_json(
+    let conflicting = post_native_json(
         &router,
         &bearer,
         &resolve_uri,
@@ -2803,7 +2828,7 @@ async fn client_resolution_publishes_cancellation_and_wakes_resumable_turns() {
         )
         .await
         .unwrap();
-    let resume_response = post_json(
+    let resume_response = post_native_json(
         &router,
         &bearer,
         &format!(
@@ -2872,7 +2897,7 @@ async fn client_resolution_publishes_cancellation_and_wakes_resumable_turns() {
         "lease_token": cancel_token,
         "resolution": {"status": "cancelled", "result": "cancelled by user"},
     });
-    let cancelled = post_json(&router, &bearer, &resolve_uri, body.clone()).await;
+    let cancelled = post_native_json(&router, &bearer, &resolve_uri, body.clone()).await;
     assert_eq!(cancelled.status(), StatusCode::OK);
     let first_live = tokio::time::timeout(Duration::from_secs(1), live.recv())
         .await
@@ -2880,7 +2905,7 @@ async fn client_resolution_publishes_cancellation_and_wakes_resumable_turns() {
         .unwrap();
     assert!(matches!(first_live.event, AgentEvent::TurnCancelled { .. }));
 
-    let retry = post_json(&router, &bearer, &resolve_uri, body).await;
+    let retry = post_native_json(&router, &bearer, &resolve_uri, body).await;
     assert_eq!(retry.status(), StatusCode::OK);
     let retry: serde_json::Value = json_body(retry).await;
     assert_eq!(retry["disposition"], "existing");
@@ -3272,7 +3297,7 @@ async fn client_execution_api_reconciles_a_known_result_after_exact_lease_expiry
     ));
     tokio::time::sleep(Duration::from_millis(5)).await;
 
-    let resolved = post_json(
+    let resolved = post_native_json(
         &router,
         &bearer,
         &format!("/chats/{}/client-executions/{}/resolve", chat.id, call.id),
@@ -3328,7 +3353,7 @@ async fn client_execution_api_validates_scope_identity_and_terminal_payloads() {
     };
     store.accept_tool_call(&call).await.unwrap();
     let claim_uri = format!("/chats/{}/client-executions/{}/claim", chat.id, call.id);
-    let nil = post_json(
+    let nil = post_native_json(
         &router,
         &bearer,
         &claim_uri,
@@ -3341,7 +3366,7 @@ async fn client_execution_api_validates_scope_identity_and_terminal_payloads() {
     assert_eq!(nil.status(), StatusCode::BAD_REQUEST);
 
     let lease_token = uuid::Uuid::new_v4();
-    let claimed = post_json(
+    let claimed = post_native_json(
         &router,
         &bearer,
         &claim_uri,
@@ -3353,7 +3378,7 @@ async fn client_execution_api_validates_scope_identity_and_terminal_payloads() {
     .await;
     assert_eq!(claimed.status(), StatusCode::OK);
 
-    let oversized = post_json(
+    let oversized = post_native_json(
         &router,
         &bearer,
         &format!("/chats/{}/client-executions/{}/resolve", chat.id, call.id),

--- a/crates/openwave-server/src/tests/root_attachment.rs
+++ b/crates/openwave-server/src/tests/root_attachment.rs
@@ -1,0 +1,527 @@
+use super::*;
+
+async fn test_app_with_executor_id(
+    executor_id: uuid::Uuid,
+) -> (Router, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new_with_client_executor_id(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig::default(),
+        executor_id,
+    )
+    .unwrap();
+    let token = state.token.clone();
+    (app(state), token, store, dir)
+}
+
+async fn get_native(router: &Router, bearer: &str, uri: &str) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .header(header::AUTHORIZATION, bearer)
+                .header(
+                    crate::auth::CLIENT_EXECUTOR_HEADER,
+                    crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn assert_conflict_kind(response: axum::response::Response, expected: &str) {
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let body: serde_json::Value = json_body(response).await;
+    assert_eq!(body["kind"], expected);
+}
+
+fn root_attachment_begin_body(
+    root_id: HostRootId,
+    action: RootAttachmentChangeAction,
+    revision: i64,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "root_id": root_id,
+        "action": action,
+        "expected_attachment_revision": revision,
+        "created_at": created_at,
+    })
+}
+
+#[tokio::test]
+async fn root_attachment_begin_is_native_private_and_exactly_idempotent() {
+    let executor_id = uuid::Uuid::new_v4();
+    let (router, token, store, _dir) = test_app_with_executor_id(executor_id).await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let change_id = RootAttachmentChangeId::new();
+    let root_id = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let uri = format!(
+        "/chats/{}/root-attachment-changes/{change_id}/begin",
+        chat.id
+    );
+    let body = root_attachment_begin_body(
+        root_id,
+        RootAttachmentChangeAction::Attach,
+        0,
+        chrono::Utc::now(),
+    );
+
+    let bearer_only = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&uri)
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(bearer_only.status(), StatusCode::UNAUTHORIZED);
+
+    let mut untrusted = body.clone();
+    untrusted["executor_id"] = serde_json::json!(uuid::Uuid::new_v4());
+    let response = post_native_json(&router, &bearer, &uri, untrusted).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let response = post_native_json(&router, &bearer, &uri, body.clone()).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let begun: serde_json::Value = json_body(response).await;
+    assert_eq!(begun["disposition"], "begun");
+    assert!(begun["change"].get("executor_id").is_none());
+    let persisted = store
+        .get_root_attachment_change(change_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(persisted.executor_id, executor_id);
+
+    let response = post_native_json(&router, &bearer, &uri, body.clone()).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let existing: serde_json::Value = json_body(response).await;
+    assert_eq!(existing["disposition"], "existing");
+
+    let changed = root_attachment_begin_body(
+        HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+        RootAttachmentChangeAction::Attach,
+        0,
+        body["created_at"].as_str().unwrap().parse().unwrap(),
+    );
+    let response = post_native_json(&router, &bearer, &uri, changed).await;
+    assert_conflict_kind(response, "root_attachment_identity_conflict").await;
+
+    let revision_chat = make_chat(&router, &bearer).await;
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/root-attachment-changes/{}/begin",
+            revision_chat.id,
+            RootAttachmentChangeId::new()
+        ),
+        root_attachment_begin_body(
+            HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            RootAttachmentChangeAction::Attach,
+            1,
+            chrono::Utc::now(),
+        ),
+    )
+    .await;
+    assert_conflict_kind(response, "root_attachment_revision_conflict").await;
+
+    let malformed = post_native_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/root-attachment-changes/not-a-uuid/begin",
+            chat.id
+        ),
+        body.clone(),
+    )
+    .await;
+    assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+    let nil_chat = post_native_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/root-attachment-changes/{}/begin",
+            uuid::Uuid::nil(),
+            RootAttachmentChangeId::new()
+        ),
+        body,
+    )
+    .await;
+    assert_eq!(nil_chat.status(), StatusCode::BAD_REQUEST);
+
+    let invalid_body = post_native_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/root-attachment-changes/{}/begin",
+            chat.id,
+            RootAttachmentChangeId::new()
+        ),
+        serde_json::json!({
+            "root_id": uuid::Uuid::nil(),
+            "action": "not_an_action",
+            "expected_attachment_revision": -1,
+            "created_at": "not-a-timestamp"
+        }),
+    )
+    .await;
+    assert_eq!(invalid_body.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn root_attachment_pending_is_bounded_scoped_and_non_disclosing() {
+    let executor_id = uuid::Uuid::new_v4();
+    let other_executor = uuid::Uuid::new_v4();
+    let (router, token, store, _dir) = test_app_with_executor_id(executor_id).await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let change_id = RootAttachmentChangeId::new();
+    let created_at = chrono::Utc::now();
+    let begin_uri = format!(
+        "/chats/{}/root-attachment-changes/{change_id}/begin",
+        chat.id
+    );
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &begin_uri,
+        root_attachment_begin_body(
+            HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            RootAttachmentChangeAction::Attach,
+            0,
+            created_at,
+        ),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let competing_id = RootAttachmentChangeId::new();
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/root-attachment-changes/{competing_id}/begin",
+            chat.id
+        ),
+        root_attachment_begin_body(
+            HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            RootAttachmentChangeAction::Attach,
+            1,
+            created_at + chrono::Duration::seconds(1),
+        ),
+    )
+    .await;
+    assert_conflict_kind(response, "root_attachment_chat_busy").await;
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/root-attachment-changes/{competing_id}/begin",
+            chat.id
+        ),
+        root_attachment_begin_body(
+            HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            RootAttachmentChangeAction::Attach,
+            1,
+            created_at + chrono::Duration::seconds(1),
+        ),
+    )
+    .await;
+    let conflict: serde_json::Value = json_body(response).await;
+    let conflict_text = conflict.to_string();
+    assert!(!conflict_text.contains(&change_id.to_string()));
+    assert!(!conflict_text.contains("current_attachment_revision"));
+
+    let other_chat = make_chat(&router, &bearer).await;
+    let other_id = RootAttachmentChangeId::new();
+    store
+        .begin_root_attachment_change(&BeginRootAttachmentChange {
+            id: other_id,
+            chat_id: other_chat.id,
+            executor_id: other_executor,
+            root_id: HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            action: RootAttachmentChangeAction::Attach,
+            expected_attachment_revision: 0,
+            created_at: created_at - chrono::Duration::seconds(1),
+        })
+        .await
+        .unwrap();
+
+    let earlier_chat = make_chat(&router, &bearer).await;
+    let earlier_id = RootAttachmentChangeId::new();
+    store
+        .begin_root_attachment_change(&BeginRootAttachmentChange {
+            id: earlier_id,
+            chat_id: earlier_chat.id,
+            executor_id,
+            root_id: HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            action: RootAttachmentChangeAction::Attach,
+            expected_attachment_revision: 0,
+            created_at: created_at - chrono::Duration::seconds(2),
+        })
+        .await
+        .unwrap();
+
+    let response = get_native(&router, &bearer, "/root-attachment-changes/pending").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let pending: serde_json::Value = json_body(response).await;
+    assert_eq!(pending["changes"].as_array().unwrap().len(), 2);
+    assert_eq!(pending["changes"][0]["id"], earlier_id.to_string());
+    assert_eq!(pending["changes"][1]["id"], change_id.to_string());
+    assert!(pending["changes"][0].get("executor_id").is_none());
+    assert!(!pending.to_string().contains(&other_id.to_string()));
+
+    for uri in [
+        "/root-attachment-changes/pending?limit=0",
+        "/root-attachment-changes/pending?limit=257",
+        "/root-attachment-changes/pending?unknown=1",
+    ] {
+        assert_eq!(
+            get_native(&router, &bearer, uri).await.status(),
+            StatusCode::BAD_REQUEST
+        );
+    }
+}
+
+#[tokio::test]
+async fn root_attachment_finish_is_exact_scoped_and_keeps_contradictions_pending() {
+    let executor_id = uuid::Uuid::new_v4();
+    let (router, token, store, _dir) = test_app_with_executor_id(executor_id).await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let change_id = RootAttachmentChangeId::new();
+    let begin_uri = format!(
+        "/chats/{}/root-attachment-changes/{change_id}/begin",
+        chat.id
+    );
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &begin_uri,
+        root_attachment_begin_body(
+            HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            RootAttachmentChangeAction::Attach,
+            0,
+            chrono::Utc::now(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let finish_uri = format!("/root-attachment-changes/{change_id}/finish");
+    let terminal = serde_json::json!({
+        "terminal": {
+            "status": "completed",
+            "broker_changed": true,
+            "broker_currently_attached": true
+        }
+    });
+    let response = post_native_json(&router, &bearer, &finish_uri, terminal.clone()).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let finished: serde_json::Value = json_body(response).await;
+    assert_eq!(finished["disposition"], "finished");
+    assert!(finished["change"].get("executor_id").is_none());
+    let response = post_native_json(&router, &bearer, &finish_uri, terminal).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let existing: serde_json::Value = json_body(response).await;
+    assert_eq!(existing["disposition"], "existing");
+
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &finish_uri,
+        serde_json::json!({
+            "terminal": {
+                "status": "completed",
+                "broker_changed": false,
+                "broker_currently_attached": true
+            }
+        }),
+    )
+    .await;
+    assert_conflict_kind(response, "root_attachment_already_terminal").await;
+
+    let other_chat = make_chat(&router, &bearer).await;
+    let other_id = RootAttachmentChangeId::new();
+    store
+        .begin_root_attachment_change(&BeginRootAttachmentChange {
+            id: other_id,
+            chat_id: other_chat.id,
+            executor_id: uuid::Uuid::new_v4(),
+            root_id: HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            action: RootAttachmentChangeAction::Attach,
+            expected_attachment_revision: 0,
+            created_at: chrono::Utc::now(),
+        })
+        .await
+        .unwrap();
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &format!("/root-attachment-changes/{other_id}/finish"),
+        serde_json::json!({
+            "terminal": {
+                "status": "completed",
+                "broker_changed": true,
+                "broker_currently_attached": true
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let contradictory_chat = make_chat(&router, &bearer).await;
+    let contradictory_id = RootAttachmentChangeId::new();
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/root-attachment-changes/{contradictory_id}/begin",
+            contradictory_chat.id
+        ),
+        root_attachment_begin_body(
+            HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            RootAttachmentChangeAction::Attach,
+            0,
+            chrono::Utc::now(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &format!("/root-attachment-changes/{contradictory_id}/finish"),
+        serde_json::json!({
+            "terminal": {
+                "status": "failed",
+                "broker_changed": true,
+                "broker_currently_attached": true,
+                "failure": {"code": "broker_error", "message": "failed", "retryable": true}
+            }
+        }),
+    )
+    .await;
+    assert_conflict_kind(response, "root_attachment_broker_state_mismatch").await;
+    let pending = store
+        .list_pending_root_attachment_changes(executor_id, 64)
+        .await
+        .unwrap();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].id, contradictory_id);
+
+    let malformed = post_native_json(
+        &router,
+        &bearer,
+        &format!("/root-attachment-changes/{contradictory_id}/finish"),
+        serde_json::json!({
+            "terminal": {
+                "status": "failed",
+                "failure": {"code": "", "message": "failed", "retryable": false}
+            }
+        }),
+    )
+    .await;
+    assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+    let nil = post_native_json(
+        &router,
+        &bearer,
+        "/root-attachment-changes/00000000-0000-0000-0000-000000000000/finish",
+        serde_json::json!({
+            "terminal": {
+                "status": "completed",
+                "broker_changed": false,
+                "broker_currently_attached": true
+            }
+        }),
+    )
+    .await;
+    assert_eq!(nil.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn future_creation_time_cannot_wedge_a_pending_change() {
+    let executor_id = uuid::Uuid::new_v4();
+    let (router, token, store, _dir) = test_app_with_executor_id(executor_id).await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let change_id = RootAttachmentChangeId::new();
+    let created_at = chrono::Utc::now() + chrono::Duration::days(1);
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/root-attachment-changes/{change_id}/begin",
+            chat.id
+        ),
+        root_attachment_begin_body(
+            HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+            RootAttachmentChangeAction::Attach,
+            0,
+            created_at,
+        ),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &format!("/root-attachment-changes/{change_id}/finish"),
+        serde_json::json!({
+            "terminal": {
+                "status": "completed",
+                "broker_changed": true,
+                "broker_currently_attached": true
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let finished = store
+        .get_root_attachment_change(change_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(finished.finished_at, Some(finished.created_at));
+    assert!(store
+        .list_pending_root_attachment_changes(executor_id, 64)
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn generic_embedding_does_not_mount_durable_attachment_routes() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let response = get_native(&router, &bearer, "/root-attachment-changes/pending").await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -42,9 +42,46 @@ revision. Project defaults are snapshotted into a new chat's exact attachment
 set; later project changes cannot silently widen that chat. These product rows
 are not grants: they contain no path, capability, consent, or display name, and
 host access still requires the broker's live attachment and authorization. The
-product store now has a durable attachment-change state machine, but the current
-native picker still updates broker state only. Native reconciliation and routes
-are the next slice, before any tool treats the projection as usable context.
+product store now has a durable attachment-change state machine and a
+native-only HTTP boundary for driving it, but the current picker still updates
+broker state directly. A native reconciler is the next slice, before any tool
+treats the projection as usable context.
+
+### Native attachment-change boundary
+
+The local control plane exposes three attachment-change routes to trusted native
+code:
+
+- `POST /chats/{chat_id}/root-attachment-changes/{change_id}/begin` records an
+  exact attach or detach intent against the caller's observed projection
+  revision.
+- `GET /root-attachment-changes/pending?limit=64` recovers awaiting work for
+  this desktop's stable private executor identity, oldest first.
+- `POST /root-attachment-changes/{change_id}/finish` records the broker's exact
+  terminal observation and commits the corresponding projection transition.
+
+These routes require both the ordinary bearer credential and the native
+client-executor credential. The server supplies the stable executor identity;
+it is never accepted from a body, returned in a response, included in server
+discovery, or exposed to the renderer. Begin and finish retries return stable
+`begun`/`existing` and `finished`/`existing` dispositions. A missing change and
+a change owned by another executor are both reported as not found, while busy
+and revision conflicts do not identify the pending operation.
+
+Conflict responses carry stable machine-readable `kind` values so the native
+reconciler never branches on prose: `root_attachment_identity_conflict`,
+`root_attachment_revision_conflict`, `root_attachment_capacity_exceeded`,
+`root_attachment_revision_exhausted`, `root_attachment_chat_busy`,
+`root_attachment_already_terminal`, or
+`root_attachment_broker_state_mismatch`. The generic server embedding does not
+mount these routes because it has no restart-stable native executor identity;
+the desktop supplies its private persisted identity before binding the server.
+Finish timestamps are clamped to immutable creation time under the store lock,
+so clock skew cannot strand a conversation's single pending operation.
+
+This boundary deliberately does not call the broker. Dispatch, unknown-receipt
+recovery, and retry policy belong to the forthcoming desktop reconciler, which
+will use these routes around the broker's idempotent attach/detach operations.
 
 ## The four layers
 


### PR DESCRIPTION
## Summary

- add native-only begin, bounded pending-recovery, and finish routes for durable root attachment changes
- derive attachment executor ownership from the desktop private receipt store and keep it out of renderer-visible state and API payloads
- expose stable conflict kinds, preserve exact retry behavior, and prevent clock skew from wedging pending work
- leave generic server embeddings without attachment mutation routes unless they supply a restart-stable executor identity
- document the HTTP boundary and the forthcoming broker reconciler responsibility

## Validation

- `cargo test -p openwave-server` (171 tests)
- `cargo test -p openwave-core root_attachment` (20 tests)
- post-rebase `cargo test -p openwave-server root_attachment --locked` (5 tests)
- desktop receipt-store tests (3 tests)
- strict clippy for core, server, and desktop
- `bw dev lint --rust --check`
- `cargo fmt --all -- --check`
- `git diff --check`