### PR TITLE
feat(core): model durable agent runs

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -326,6 +326,34 @@ pub mod message {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod agent_run {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "agent_run")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub chat_id: Uuid,
+        pub parent_id: Option<Uuid>,
+        pub parent_depth: Option<i16>,
+        pub spawn_call_id: Option<Uuid>,
+        pub execution: String,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub depth: i16,
+        pub status: String,
+        pub input: Option<String>,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod turn_run {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -1,8 +1,8 @@
 use sea_orm_migration::prelude::*;
 
 use super::{
-    BlobRetirementStatus, DocumentJobKind, DocumentJobStatus, DocumentProcessingStatus,
-    TurnClientWaitStatus, TurnRunStatus, TurnSteerStatus,
+    AgentRunExecution, AgentRunStatus, BlobRetirementStatus, DocumentJobKind, DocumentJobStatus,
+    DocumentProcessingStatus, TurnClientWaitStatus, TurnRunStatus, TurnSteerStatus,
 };
 
 pub struct Migrator;
@@ -17,7 +17,179 @@ impl MigratorTrait for Migrator {
             Box::new(AddChatModel),
             Box::new(AddToolCalls),
             Box::new(AddDocuments),
+            Box::new(AddAgentRuns),
         ]
+    }
+}
+
+struct AddAgentRuns;
+
+impl MigrationName for AddAgentRuns {
+    fn name(&self) -> &str {
+        "m0007_agent_runs"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddAgentRuns {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let foreground_status = Expr::col(AgentRun::Status).is_in([
+            AgentRunStatus::Active.as_str(),
+            AgentRunStatus::Completed.as_str(),
+            AgentRunStatus::Failed.as_str(),
+            AgentRunStatus::Cancelled.as_str(),
+        ]);
+        let sandbox_status = Expr::col(AgentRun::Status).is_in([
+            AgentRunStatus::Queued.as_str(),
+            AgentRunStatus::Running.as_str(),
+            AgentRunStatus::Waiting.as_str(),
+            AgentRunStatus::RetryWait.as_str(),
+            AgentRunStatus::Completed.as_str(),
+            AgentRunStatus::Failed.as_str(),
+            AgentRunStatus::Cancelled.as_str(),
+        ]);
+        let foreground_shape = Expr::col(AgentRun::Execution)
+            .eq(AgentRunExecution::Foreground.as_str())
+            .and(Expr::col(AgentRun::Depth).eq(0))
+            .and(Expr::col(AgentRun::ParentId).is_null())
+            .and(Expr::col(AgentRun::ParentDepth).is_null())
+            .and(Expr::col(AgentRun::SpawnCallId).is_null())
+            .and(Expr::col(AgentRun::Input).is_null())
+            .and(foreground_status);
+        let sandbox_shape = Expr::col(AgentRun::Execution)
+            .eq(AgentRunExecution::Sandbox.as_str())
+            .and(Expr::col(AgentRun::Depth).eq(i32::from(crate::model::AgentRun::MAX_DEPTH)))
+            .and(Expr::col(AgentRun::ParentId).is_not_null())
+            .and(Expr::col(AgentRun::ParentDepth).eq(0))
+            .and(Expr::col(AgentRun::SpawnCallId).is_not_null())
+            .and(Expr::col(AgentRun::Input).is_not_null())
+            .and(
+                Func::char_length(Expr::col(AgentRun::Input))
+                    .between(1, crate::model::AgentRun::MAX_INPUT_LEN as i32),
+            )
+            .and(sandbox_status);
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(AgentRun::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(AgentRun::Id).uuid().not_null())
+                    .col(ColumnDef::new(AgentRun::ChatId).uuid().not_null())
+                    .col(ColumnDef::new(AgentRun::ParentId).uuid())
+                    .col(ColumnDef::new(AgentRun::ParentDepth).small_integer())
+                    .col(ColumnDef::new(AgentRun::SpawnCallId).uuid())
+                    .col(
+                        ColumnDef::new(AgentRun::Execution)
+                            .string_len(16)
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(AgentRun::Depth).small_integer().not_null())
+                    .col(ColumnDef::new(AgentRun::Status).string_len(32).not_null())
+                    .col(ColumnDef::new(AgentRun::Input).text())
+                    .col(
+                        ColumnDef::new(AgentRun::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AgentRun::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .name("pk_agent_run")
+                            .col(AgentRun::Id)
+                            .col(AgentRun::ChatId)
+                            .col(AgentRun::Depth),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_agent_run_chat")
+                            .from(AgentRun::Table, AgentRun::ChatId)
+                            .to(Chat::Table, Chat::Id)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_agent_run_parent")
+                            .from_tbl(AgentRun::Table)
+                            .from_col(AgentRun::ParentId)
+                            .from_col(AgentRun::ChatId)
+                            .from_col(AgentRun::ParentDepth)
+                            .to_tbl(AgentRun::Table)
+                            .to_col(AgentRun::Id)
+                            .to_col(AgentRun::ChatId)
+                            .to_col(AgentRun::Depth)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .check(foreground_shape.or(sandbox_shape))
+                    .check(Expr::col(AgentRun::UpdatedAt).gte(Expr::col(AgentRun::CreatedAt)))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_agent_run_id")
+                    .table(AgentRun::Table)
+                    .col(AgentRun::Id)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_agent_run_spawn_call")
+                    .table(AgentRun::Table)
+                    .col(AgentRun::SpawnCallId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_agent_run_one_foreground")
+                    .table(AgentRun::Table)
+                    .col(AgentRun::ChatId)
+                    .unique()
+                    .and_where(
+                        Expr::col(AgentRun::Execution).eq(AgentRunExecution::Foreground.as_str()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_agent_run_parent")
+                    .table(AgentRun::Table)
+                    .col(AgentRun::ParentId)
+                    .col(AgentRun::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_agent_run_chat_history")
+                    .table(AgentRun::Table)
+                    .col(AgentRun::ChatId)
+                    .col(AgentRun::CreatedAt)
+                    .col(AgentRun::Id)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(AgentRun::Table).to_owned())
+            .await
     }
 }
 
@@ -2690,6 +2862,22 @@ enum Chat {
     Model,
     AttachmentRevision,
     CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum AgentRun {
+    Table,
+    Id,
+    ChatId,
+    ParentId,
+    ParentDepth,
+    SpawnCallId,
+    Execution,
+    Depth,
+    Status,
+    Input,
+    CreatedAt,
+    UpdatedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -21,23 +21,24 @@ use crate::event::{AgentEvent, SequencedEvent};
 #[cfg(test)]
 use crate::id::MessageId;
 use crate::id::{
-    CallId, ChatId, DocumentId, DocumentJobId, HostRootId, ProjectId, RootAttachmentChangeId,
-    TurnId, TurnSteerId,
+    AgentRunId, CallId, ChatId, DocumentId, DocumentJobId, HostRootId, ProjectId,
+    RootAttachmentChangeId, TurnId, TurnSteerId,
 };
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
-    validate_project_root_projection, BeginRootAttachmentChange, BlobRetirement,
-    BlobRetirementStatus, Chat, DocumentGeneration, DocumentJob, DocumentJobKind,
-    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
-    DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
-    DocumentUpsert, Message, Project, RootAttachmentChange, RootAttachmentChangeTerminal,
-    SourceRegion, ToolCallRecord, ToolCallResolution, TurnCheckpointProgress, TurnClientWaitStatus,
-    TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteerStatus, MAX_ROOT_ATTACHMENTS,
+    validate_project_root_projection, AgentRun, AgentRunExecution, AgentRunStatus,
+    BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration,
+    DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput,
+    DocumentProcessingStatus, DocumentRecord, DocumentScope, DocumentSourceBlob,
+    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project,
+    RootAttachmentChange, RootAttachmentChangeTerminal, SourceRegion, ToolCallRecord,
+    ToolCallResolution, TurnCheckpointProgress, TurnClientWaitStatus, TurnFailureRetry, TurnRun,
+    TurnRunStatus, TurnSteerStatus, MAX_ROOT_ATTACHMENTS,
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
-    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
+    AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
     BeginRootAttachmentChangeOutcome, ClaimClientToolCallOutcome, ClaimTurnRunOutcome,
     CompleteTurnRunOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
     EnsureDocumentParseJobOutcome, FinishRootAttachmentChangeOutcome,
@@ -1720,6 +1721,35 @@ impl Store for DbStore {
         limit: u64,
     ) -> Result<Vec<RootAttachmentChange>> {
         ops::root_attachment::list_pending_root_attachment_changes(self, executor_id, limit).await
+    }
+
+    async fn accept_agent_run(
+        &self,
+        id: AgentRunId,
+        chat_id: ChatId,
+        parent_id: Option<AgentRunId>,
+        spawn_call_id: Option<CallId>,
+        execution: AgentRunExecution,
+        input: Option<&str>,
+    ) -> Result<AcceptAgentRunOutcome> {
+        ops::agent_run::accept_agent_run(
+            self,
+            id,
+            chat_id,
+            parent_id,
+            spawn_call_id,
+            execution,
+            input,
+        )
+        .await
+    }
+
+    async fn get_agent_run(&self, id: AgentRunId) -> Result<Option<AgentRun>> {
+        ops::agent_run::get_agent_run(self, id).await
+    }
+
+    async fn list_agent_runs(&self, chat_id: ChatId) -> Result<Vec<AgentRun>> {
+        ops::agent_run::list_agent_runs(self, chat_id).await
     }
 
     async fn get_turn_run(&self, id: TurnId) -> Result<Option<TurnRun>> {

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1,0 +1,370 @@
+use chrono::Utc;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
+
+use crate::error::{AgentError, Result};
+use crate::id::{AgentRunId, CallId, ChatId};
+use crate::model::{AgentRun, AgentRunExecution, AgentRunStatus};
+use crate::storage::AcceptAgentRunOutcome;
+
+use super::super::{entities, store_err, DbStore};
+use super::{acquire_chat_write_lock, turn::canonical_db_timestamp};
+
+pub(in crate::db) async fn accept_agent_run(
+    store: &DbStore,
+    id: AgentRunId,
+    chat_id: ChatId,
+    parent_id: Option<AgentRunId>,
+    spawn_call_id: Option<CallId>,
+    execution: AgentRunExecution,
+    input: Option<&str>,
+) -> Result<AcceptAgentRunOutcome> {
+    validate_request(id, parent_id, spawn_call_id, execution, input)?;
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, chat_id).await? {
+        return Err(AgentError::Store(format!("chat {chat_id} does not exist")));
+    }
+
+    if let Some(existing) = find_by_id_on(&transaction, id).await? {
+        let outcome = existing_request_outcome(
+            existing,
+            chat_id,
+            parent_id,
+            spawn_call_id,
+            execution,
+            input,
+        )?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(outcome);
+    }
+    if let Some(spawn_call_id) = spawn_call_id {
+        if let Some(existing) = find_by_spawn_call_on(&transaction, spawn_call_id).await? {
+            let outcome = existing_request_outcome(
+                existing,
+                chat_id,
+                parent_id,
+                Some(spawn_call_id),
+                execution,
+                input,
+            )?;
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(outcome);
+        }
+    }
+
+    let (depth, status) = match execution {
+        AgentRunExecution::Foreground => {
+            if let Some(existing) = entities::agent_run::Entity::find()
+                .filter(entities::agent_run::Column::ChatId.eq(chat_id.0))
+                .filter(
+                    entities::agent_run::Column::Execution
+                        .eq(AgentRunExecution::Foreground.as_str()),
+                )
+                .one(&transaction)
+                .await
+                .map_err(store_err)?
+            {
+                let existing = agent_run_from_model(existing)?;
+                transaction.commit().await.map_err(store_err)?;
+                return Ok(AcceptAgentRunOutcome::ForegroundExists(existing));
+            }
+            (0_i16, AgentRunStatus::Active)
+        }
+        AgentRunExecution::Sandbox => {
+            let Some(parent_id) = parent_id else {
+                unreachable!("validated sandbox parent")
+            };
+            let parent = find_by_id_on(&transaction, parent_id).await?;
+            let available = parent.is_some_and(|parent| {
+                parent.chat_id == chat_id.0
+                    && parent.parent_id.is_none()
+                    && parent.depth == 0
+                    && parent.execution == AgentRunExecution::Foreground.as_str()
+                    && parent.status == AgentRunStatus::Active.as_str()
+            });
+            if !available {
+                transaction.commit().await.map_err(store_err)?;
+                return Ok(AcceptAgentRunOutcome::ParentUnavailable);
+            }
+            (i16::from(AgentRun::MAX_DEPTH), AgentRunStatus::Queued)
+        }
+    };
+
+    let now = canonical_db_timestamp(Utc::now())?;
+    let model = entities::agent_run::ActiveModel {
+        id: Set(id.0),
+        chat_id: Set(chat_id.0),
+        parent_id: Set(parent_id.map(|parent| parent.0)),
+        parent_depth: Set(parent_id.map(|_| 0)),
+        spawn_call_id: Set(spawn_call_id.map(|call| call.0)),
+        execution: Set(execution.as_str().into()),
+        depth: Set(depth),
+        status: Set(status.as_str().into()),
+        input: Set(input.map(ToOwned::to_owned)),
+        created_at: Set(now),
+        updated_at: Set(now),
+    };
+    let model = match model.insert(&transaction).await {
+        Ok(model) => model,
+        Err(error) => {
+            transaction.rollback().await.map_err(store_err)?;
+            if let Some(existing) = find_by_id_on(&store.conn, id).await? {
+                return existing_request_outcome(
+                    existing,
+                    chat_id,
+                    parent_id,
+                    spawn_call_id,
+                    execution,
+                    input,
+                );
+            }
+            if let Some(spawn_call_id) = spawn_call_id {
+                if let Some(existing) = find_by_spawn_call_on(&store.conn, spawn_call_id).await? {
+                    return existing_request_outcome(
+                        existing,
+                        chat_id,
+                        parent_id,
+                        Some(spawn_call_id),
+                        execution,
+                        input,
+                    );
+                }
+            }
+            if execution == AgentRunExecution::Foreground {
+                if let Some(existing) = find_foreground_on(&store.conn, chat_id).await? {
+                    return Ok(AcceptAgentRunOutcome::ForegroundExists(
+                        agent_run_from_model(existing)?,
+                    ));
+                }
+            }
+            return Err(store_err(error));
+        }
+    };
+    let run = agent_run_from_model(model)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(AcceptAgentRunOutcome::Accepted(run))
+}
+
+pub(in crate::db) async fn get_agent_run(
+    store: &DbStore,
+    id: AgentRunId,
+) -> Result<Option<AgentRun>> {
+    find_by_id_on(&store.conn, id)
+        .await?
+        .map(agent_run_from_model)
+        .transpose()
+}
+
+pub(in crate::db) async fn list_agent_runs(
+    store: &DbStore,
+    chat_id: ChatId,
+) -> Result<Vec<AgentRun>> {
+    entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::ChatId.eq(chat_id.0))
+        .order_by_asc(entities::agent_run::Column::CreatedAt)
+        .order_by_asc(entities::agent_run::Column::Id)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(agent_run_from_model)
+        .collect()
+}
+
+fn validate_request(
+    id: AgentRunId,
+    parent_id: Option<AgentRunId>,
+    spawn_call_id: Option<CallId>,
+    execution: AgentRunExecution,
+    input: Option<&str>,
+) -> Result<()> {
+    if id.0.is_nil() {
+        return Err(AgentError::Store("agent-run id must not be nil".into()));
+    }
+    match execution {
+        AgentRunExecution::Foreground
+            if parent_id.is_some() || spawn_call_id.is_some() || input.is_some() =>
+        {
+            Err(AgentError::Store(
+                "foreground agent runs cannot have a parent, spawn call, or delegated task".into(),
+            ))
+        }
+        AgentRunExecution::Sandbox if parent_id.is_none() || spawn_call_id.is_none() => {
+            Err(AgentError::Store(
+                "sandbox agent runs require a foreground parent and spawn-call identity".into(),
+            ))
+        }
+        AgentRunExecution::Sandbox => {
+            if parent_id.is_some_and(|parent| parent.0.is_nil())
+                || spawn_call_id.is_some_and(|call| call.0.is_nil())
+            {
+                return Err(AgentError::Store(
+                    "sandbox parent and spawn-call identities must not be nil".into(),
+                ));
+            }
+            let Some(input) = input else {
+                return Err(AgentError::Store(
+                    "sandbox agent runs require a delegated task".into(),
+                ));
+            };
+            let input_len = input.chars().count();
+            if input_len == 0 || input_len > AgentRun::MAX_INPUT_LEN {
+                return Err(AgentError::Store(format!(
+                    "sandbox agent-run task must contain 1..={} characters",
+                    AgentRun::MAX_INPUT_LEN
+                )));
+            }
+            Ok(())
+        }
+        AgentRunExecution::Foreground => Ok(()),
+    }
+}
+
+fn agent_run_from_model(model: entities::agent_run::Model) -> Result<AgentRun> {
+    let execution = match model.execution.as_str() {
+        "foreground" => AgentRunExecution::Foreground,
+        "sandbox" => AgentRunExecution::Sandbox,
+        value => {
+            return Err(AgentError::Store(format!(
+                "invalid agent-run execution {value}"
+            )))
+        }
+    };
+    let status = match model.status.as_str() {
+        "active" => AgentRunStatus::Active,
+        "queued" => AgentRunStatus::Queued,
+        "running" => AgentRunStatus::Running,
+        "waiting" => AgentRunStatus::Waiting,
+        "retry_wait" => AgentRunStatus::RetryWait,
+        "completed" => AgentRunStatus::Completed,
+        "failed" => AgentRunStatus::Failed,
+        "cancelled" => AgentRunStatus::Cancelled,
+        value => {
+            return Err(AgentError::Store(format!(
+                "invalid agent-run status {value}"
+            )))
+        }
+    };
+    validate_stored_shape(&model, execution, status)?;
+    Ok(AgentRun {
+        id: AgentRunId(model.id),
+        chat_id: ChatId(model.chat_id),
+        parent_id: model.parent_id.map(AgentRunId),
+        spawn_call_id: model.spawn_call_id.map(CallId),
+        execution,
+        depth: u8::try_from(model.depth)
+            .map_err(|_| AgentError::Store("invalid negative agent-run depth".into()))?,
+        status,
+        input: model.input,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+    })
+}
+
+async fn find_by_id_on<C>(conn: &C, id: AgentRunId) -> Result<Option<entities::agent_run::Model>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::Id.eq(id.0))
+        .one(conn)
+        .await
+        .map_err(store_err)
+}
+
+async fn find_by_spawn_call_on<C>(
+    conn: &C,
+    id: CallId,
+) -> Result<Option<entities::agent_run::Model>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::SpawnCallId.eq(id.0))
+        .one(conn)
+        .await
+        .map_err(store_err)
+}
+
+async fn find_foreground_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+) -> Result<Option<entities::agent_run::Model>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::ChatId.eq(chat_id.0))
+        .filter(entities::agent_run::Column::Execution.eq(AgentRunExecution::Foreground.as_str()))
+        .one(conn)
+        .await
+        .map_err(store_err)
+}
+
+fn existing_request_outcome(
+    existing: entities::agent_run::Model,
+    chat_id: ChatId,
+    parent_id: Option<AgentRunId>,
+    spawn_call_id: Option<CallId>,
+    execution: AgentRunExecution,
+    input: Option<&str>,
+) -> Result<AcceptAgentRunOutcome> {
+    let exact = existing.chat_id == chat_id.0
+        && existing.parent_id == parent_id.map(|parent| parent.0)
+        && existing.spawn_call_id == spawn_call_id.map(|call| call.0)
+        && existing.execution == execution.as_str()
+        && existing.input.as_deref() == input;
+    Ok(if exact {
+        AcceptAgentRunOutcome::Existing(agent_run_from_model(existing)?)
+    } else {
+        AcceptAgentRunOutcome::IdentityConflict
+    })
+}
+
+fn validate_stored_shape(
+    model: &entities::agent_run::Model,
+    execution: AgentRunExecution,
+    status: AgentRunStatus,
+) -> Result<()> {
+    if model.id.is_nil() || model.updated_at < model.created_at {
+        return Err(AgentError::Store(
+            "invalid persisted agent-run identity or timestamp".into(),
+        ));
+    }
+    let valid = match execution {
+        AgentRunExecution::Foreground => {
+            model.depth == 0
+                && model.parent_id.is_none()
+                && model.parent_depth.is_none()
+                && model.spawn_call_id.is_none()
+                && model.input.is_none()
+                && matches!(
+                    status,
+                    AgentRunStatus::Active
+                        | AgentRunStatus::Completed
+                        | AgentRunStatus::Failed
+                        | AgentRunStatus::Cancelled
+                )
+        }
+        AgentRunExecution::Sandbox => {
+            model.depth == i16::from(AgentRun::MAX_DEPTH)
+                && model.parent_id.is_some()
+                && model.parent_depth == Some(0)
+                && model.spawn_call_id.is_some_and(|call| !call.is_nil())
+                && model.input.as_ref().is_some_and(|input| {
+                    let len = input.chars().count();
+                    len > 0 && len <= AgentRun::MAX_INPUT_LEN
+                })
+                && status != AgentRunStatus::Active
+        }
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(AgentError::Store(
+            "invalid persisted agent-run shape".into(),
+        ))
+    }
+}

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -5,6 +5,7 @@ use crate::id::{CallId, ChatId, TurnId};
 
 use super::{entities, store_err};
 
+pub(in crate::db) mod agent_run;
 pub(in crate::db) mod blob;
 pub(in crate::db) mod client_execution;
 pub(in crate::db) mod conversation;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -7,6 +7,7 @@ use crate::model::{
 use crate::storage::ApplyTurnSteerOutcome;
 use chrono::{DateTime, Utc};
 
+mod agent_run;
 mod root_attachment;
 mod turn_steer;
 

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -1,0 +1,344 @@
+use super::{sample_chat, temp_store};
+use crate::{
+    AcceptAgentRunOutcome, AgentRunExecution, AgentRunId, AgentRunStatus, CallId, ChatId, Store,
+};
+use sea_orm::{ActiveModelTrait, Set};
+
+#[tokio::test]
+async fn foreground_and_sandbox_runs_roundtrip_with_exact_idempotency() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+
+    let foreground_id = AgentRunId::new();
+    let foreground = match store
+        .accept_agent_run(
+            foreground_id,
+            chat.id,
+            None,
+            None,
+            AgentRunExecution::Foreground,
+            None,
+        )
+        .await
+        .unwrap()
+    {
+        AcceptAgentRunOutcome::Accepted(run) => run,
+        outcome => panic!("unexpected foreground outcome: {outcome:?}"),
+    };
+    assert_eq!(foreground.id, foreground_id);
+    assert_eq!(foreground.chat_id, chat.id);
+    assert_eq!(foreground.parent_id, None);
+    assert_eq!(foreground.depth, 0);
+    assert_eq!(foreground.execution, AgentRunExecution::Foreground);
+    assert_eq!(foreground.status, AgentRunStatus::Active);
+    assert_eq!(foreground.input, None);
+
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                foreground_id,
+                chat.id,
+                None,
+                None,
+                AgentRunExecution::Foreground,
+                None,
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::Existing(existing) if existing == foreground
+    ));
+
+    let sandbox_id = AgentRunId::new();
+    let spawn_call_id = CallId::new();
+    let sandbox = match store
+        .accept_agent_run(
+            sandbox_id,
+            chat.id,
+            Some(foreground_id),
+            Some(spawn_call_id),
+            AgentRunExecution::Sandbox,
+            Some("Inspect the selected documents"),
+        )
+        .await
+        .unwrap()
+    {
+        AcceptAgentRunOutcome::Accepted(run) => run,
+        outcome => panic!("unexpected sandbox outcome: {outcome:?}"),
+    };
+    assert_eq!(sandbox.parent_id, Some(foreground_id));
+    assert_eq!(sandbox.spawn_call_id, Some(spawn_call_id));
+    assert_eq!(sandbox.depth, 1);
+    assert_eq!(sandbox.execution, AgentRunExecution::Sandbox);
+    assert_eq!(sandbox.status, AgentRunStatus::Queued);
+    assert_eq!(
+        sandbox.input.as_deref(),
+        Some("Inspect the selected documents")
+    );
+
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                sandbox_id,
+                chat.id,
+                Some(foreground_id),
+                Some(spawn_call_id),
+                AgentRunExecution::Sandbox,
+                Some("Inspect the selected documents"),
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::Existing(existing) if existing == sandbox
+    ));
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                AgentRunId::new(),
+                chat.id,
+                Some(foreground_id),
+                Some(spawn_call_id),
+                AgentRunExecution::Sandbox,
+                Some("Inspect the selected documents"),
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::Existing(existing) if existing == sandbox
+    ));
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                AgentRunId::new(),
+                chat.id,
+                Some(foreground_id),
+                Some(spawn_call_id),
+                AgentRunExecution::Sandbox,
+                Some("Changed delegated task"),
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::IdentityConflict
+    ));
+    assert_eq!(
+        store.get_agent_run(sandbox_id).await.unwrap(),
+        Some(sandbox.clone())
+    );
+    let listed = store.list_agent_runs(chat.id).await.unwrap();
+    assert_eq!(listed.len(), 2);
+    assert!(listed.contains(&foreground));
+    assert!(listed.contains(&sandbox));
+}
+
+#[tokio::test]
+async fn agent_run_acceptance_enforces_one_foreground_and_depth_one_children() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let foreground_id = AgentRunId::new();
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                foreground_id,
+                chat.id,
+                None,
+                None,
+                AgentRunExecution::Foreground,
+                None,
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::Accepted(_)
+    ));
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                AgentRunId::new(),
+                chat.id,
+                None,
+                None,
+                AgentRunExecution::Foreground,
+                None,
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::ForegroundExists(existing) if existing.id == foreground_id
+    ));
+
+    let child_id = AgentRunId::new();
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                child_id,
+                chat.id,
+                Some(foreground_id),
+                Some(CallId::new()),
+                AgentRunExecution::Sandbox,
+                Some("first child"),
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::Accepted(_)
+    ));
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                AgentRunId::new(),
+                chat.id,
+                Some(child_id),
+                Some(CallId::new()),
+                AgentRunExecution::Sandbox,
+                Some("forbidden grandchild"),
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::ParentUnavailable
+    ));
+
+    let other_chat = sample_chat();
+    store.create_chat(&other_chat).await.unwrap();
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                AgentRunId::new(),
+                other_chat.id,
+                Some(foreground_id),
+                Some(CallId::new()),
+                AgentRunExecution::Sandbox,
+                Some("cross-chat child"),
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::ParentUnavailable
+    ));
+}
+
+#[tokio::test]
+async fn agent_run_acceptance_rejects_invalid_shapes_and_identity_reuse() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let foreground_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            foreground_id,
+            chat.id,
+            None,
+            None,
+            AgentRunExecution::Foreground,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(store
+        .accept_agent_run(
+            AgentRunId::new(),
+            chat.id,
+            Some(foreground_id),
+            None,
+            AgentRunExecution::Foreground,
+            None,
+        )
+        .await
+        .is_err());
+    assert!(store
+        .accept_agent_run(
+            AgentRunId::new(),
+            chat.id,
+            Some(foreground_id),
+            None,
+            AgentRunExecution::Sandbox,
+            Some("missing spawn identity"),
+        )
+        .await
+        .is_err());
+    assert!(store
+        .accept_agent_run(
+            AgentRunId::new(),
+            chat.id,
+            Some(foreground_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            None,
+        )
+        .await
+        .is_err());
+    assert!(store
+        .accept_agent_run(
+            AgentRunId::new(),
+            chat.id,
+            Some(foreground_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some(""),
+        )
+        .await
+        .is_err());
+    assert!(store
+        .accept_agent_run(
+            AgentRunId::from(uuid::Uuid::nil()),
+            chat.id,
+            Some(foreground_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("nil identity"),
+        )
+        .await
+        .is_err());
+
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                foreground_id,
+                chat.id,
+                Some(foreground_id),
+                Some(CallId::new()),
+                AgentRunExecution::Sandbox,
+                Some("different immutable request"),
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::IdentityConflict
+    ));
+    assert!(store
+        .list_agent_runs(ChatId::new())
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn agent_run_schema_rejects_cross_chat_parentage() {
+    let (_dir, store) = temp_store().await;
+    let parent_chat = sample_chat();
+    let child_chat = sample_chat();
+    store.create_chat(&parent_chat).await.unwrap();
+    store.create_chat(&child_chat).await.unwrap();
+    let parent_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            parent_id,
+            parent_chat.id,
+            None,
+            None,
+            AgentRunExecution::Foreground,
+            None,
+        )
+        .await
+        .unwrap();
+
+    let now = chrono::Utc::now();
+    let malformed = crate::db::entities::agent_run::ActiveModel {
+        id: Set(AgentRunId::new().0),
+        chat_id: Set(child_chat.id.0),
+        parent_id: Set(Some(parent_id.0)),
+        parent_depth: Set(Some(0)),
+        spawn_call_id: Set(Some(CallId::new().0)),
+        execution: Set(AgentRunExecution::Sandbox.as_str().into()),
+        depth: Set(1),
+        status: Set(AgentRunStatus::Queued.as_str().into()),
+        input: Set(Some("cross-chat raw insert".into())),
+        created_at: Set(now),
+        updated_at: Set(now),
+    };
+    assert!(malformed.insert(&store.conn).await.is_err());
+}

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -161,6 +161,10 @@ id_type!(
     /// Identifies a persistent conversation.
     ChatId
 );
+id_type!(
+    /// Identifies one durable foreground or sandboxed background agent run.
+    AgentRunId
+);
 
 /// Stable product and broker idempotency identity for one root-attachment change.
 ///

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -54,23 +54,23 @@ pub use db::DbStore;
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{
-    CallId, ChatId, DocumentId, DocumentJobId, HostRootId, HostRootIdError, MessageId, ProjectId,
-    RootAttachmentChangeId, RootAttachmentChangeIdError, StepId, TurnId, TurnSteerId,
+    AgentRunId, CallId, ChatId, DocumentId, DocumentJobId, HostRootId, HostRootIdError, MessageId,
+    ProjectId, RootAttachmentChangeId, RootAttachmentChangeIdError, StepId, TurnId, TurnSteerId,
 };
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
 pub use model::{
-    validate_source_regions, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus,
-    ByteSpan, Chat, ChatRootAttachment, ClientToolCallRequest, DocumentGeneration, DocumentJob,
-    DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput,
-    DocumentProcessingStatus, DocumentRecord, DocumentScope, DocumentSourceBlob,
-    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, Role,
-    RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
-    RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
-    RootAttachmentSubjectKind, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
-    ToolCallResolution, ToolCallStatus, TurnCheckpointProgress, TurnClientWait,
-    TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer,
-    TurnSteerStatus, MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
+    validate_source_regions, AgentRun, AgentRunExecution, AgentRunStatus,
+    BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, ByteSpan, Chat,
+    ChatRootAttachment, ClientToolCallRequest, DocumentGeneration, DocumentJob, DocumentJobKind,
+    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
+    DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
+    DocumentUpsert, Message, Project, Role, RootAttachmentChange, RootAttachmentChangeAction,
+    RootAttachmentChangeFailure, RootAttachmentChangePhase, RootAttachmentChangeTerminal,
+    RootAttachmentOrigin, RootAttachmentSubjectKind, SourceLocation, SourceRegion,
+    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress,
+    TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun,
+    TurnRunStatus, TurnSteer, TurnSteerStatus, MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
@@ -78,8 +78,8 @@ pub use provider::{
 };
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
-    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, ApplyTurnSteerOutcome,
-    BeginRootAttachmentChangeOutcome, BlobStore, ClaimClientToolCallOutcome,
+    AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
+    ApplyTurnSteerOutcome, BeginRootAttachmentChangeOutcome, BlobStore, ClaimClientToolCallOutcome,
     ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim, CompleteTurnRunOutcome,
     DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
     FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1079,6 +1079,106 @@ pub(crate) fn validate_chat_root_projection_against_project(
     Ok(())
 }
 
+/// One durable foreground or sandboxed background execution context.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRun {
+    /// Stable idempotency identity.
+    pub id: crate::id::AgentRunId,
+    /// Conversation that owns this run and its events.
+    pub chat_id: ChatId,
+    /// Foreground coordinator that owns this run. Always absent at depth zero.
+    pub parent_id: Option<crate::id::AgentRunId>,
+    /// Exact tool-call identity that requested a sandbox child.
+    pub spawn_call_id: Option<crate::id::CallId>,
+    /// Where and how the run executes.
+    pub execution: AgentRunExecution,
+    /// Explicit bounded hierarchy depth. OpenWave v1 permits only zero or one.
+    pub depth: u8,
+    /// Durable lifecycle state.
+    pub status: AgentRunStatus,
+    /// Exact delegated task for a sandbox run. Foreground runs have no task.
+    pub input: Option<String>,
+    /// When the run was durably accepted.
+    pub created_at: DateTime<Utc>,
+    /// When its durable state last changed.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl AgentRun {
+    /// Recursive agent spawning is deliberately excluded from the initial model.
+    pub const MAX_DEPTH: u8 = 1;
+    /// Maximum persisted delegated task length.
+    pub const MAX_INPUT_LEN: usize = 65_536;
+}
+
+/// Execution boundary for an [`AgentRun`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AgentRunExecution {
+    /// Conversation coordinator advanced by foreground turn work.
+    Foreground,
+    /// Isolated background work advanced by the sandbox scheduler.
+    Sandbox,
+}
+
+impl AgentRunExecution {
+    /// Stable database and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Foreground => "foreground",
+            Self::Sandbox => "sandbox",
+        }
+    }
+}
+
+/// Durable lifecycle of an [`AgentRun`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AgentRunStatus {
+    /// Foreground coordinator is available to own chat turns.
+    Active,
+    /// Sandboxed work was accepted and awaits a bounded scheduler slot.
+    Queued,
+    /// One exact scheduler lease currently owns the run.
+    Running,
+    /// The run checkpointed and released its worker for a durable dependency.
+    Waiting,
+    /// Replay-safe work awaits another scheduler claim.
+    RetryWait,
+    /// The run submitted its final result successfully.
+    Completed,
+    /// The run failed permanently or cannot be replayed safely.
+    Failed,
+    /// The run was cancelled and has quiesced.
+    Cancelled,
+}
+
+impl AgentRunStatus {
+    /// Stable database and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Waiting => "waiting",
+            Self::RetryWait => "retry_wait",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// Whether no worker may advance this run without a new explicit command.
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
 /// Durable execution state of one user turn.
 ///
 /// A turn is accepted once under its stable [`TurnId`], then claimed under an

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -21,16 +21,17 @@ use serde_json::Value;
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{
-    CallId, ChatId, DocumentId, DocumentJobId, ProjectId, RootAttachmentChangeId, TurnId,
-    TurnSteerId,
+    AgentRunId, CallId, ChatId, DocumentId, DocumentJobId, ProjectId, RootAttachmentChangeId,
+    TurnId, TurnSteerId,
 };
 use crate::model::{
-    BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, Chat, ClientToolCallRequest,
-    DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
-    DocumentParseOutput, DocumentRecord, DocumentScope, DocumentSourceUpsert,
-    DocumentSummaryRecord, DocumentUpsert, Message, Project, RootAttachmentChange,
-    RootAttachmentChangeTerminal, ToolCallRecord, ToolCallResolution, TurnCheckpointProgress,
-    TurnClientWait, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
+    AgentRun, AgentRunExecution, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus,
+    Chat, ClientToolCallRequest, DocumentGeneration, DocumentJob, DocumentJobKind,
+    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentRecord, DocumentScope,
+    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project,
+    RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord, ToolCallResolution,
+    TurnCheckpointProgress, TurnClientWait, TurnFailureReceipt, TurnFailureRetry, TurnRun,
+    TurnSteer,
 };
 use crate::provider::{StopReason, Usage};
 
@@ -144,6 +145,21 @@ pub enum AcceptTurnOutcome {
     IdentityConflict,
     /// Another nonterminal turn already owns the chat's single live slot.
     ChatBusy(TurnRun),
+}
+
+/// Result of atomically accepting one durable foreground or sandboxed agent run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AcceptAgentRunOutcome {
+    /// This call committed a new run.
+    Accepted(AgentRun),
+    /// The exact id and immutable request were already committed.
+    Existing(AgentRun),
+    /// The id was already committed for different immutable request data.
+    IdentityConflict,
+    /// A chat may have only one foreground coordinator.
+    ForegroundExists(AgentRun),
+    /// The requested sandbox parent is missing, cross-chat, or not foreground.
+    ParentUnavailable,
 }
 
 /// Result of atomically accepting one exact steering instruction.
@@ -369,6 +385,12 @@ fn document_storage_unavailable<T>() -> Result<T> {
 fn turn_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "durable turn storage is not implemented by this Store".into(),
+    ))
+}
+
+fn agent_run_storage_unavailable<T>() -> Result<T> {
+    Err(AgentError::Store(
+        "durable agent-run storage is not implemented by this Store".into(),
     ))
 }
 
@@ -869,6 +891,37 @@ pub trait Store: Send + Sync {
         _limit: u64,
     ) -> Result<Vec<RootAttachmentChange>> {
         root_attachment_storage_unavailable()
+    }
+
+    /// Atomically accept one foreground coordinator or sandboxed child run.
+    ///
+    /// `id` is the run's stable idempotency identity. Foreground runs require no
+    /// parent, spawn call, or input and become active immediately. Sandboxed
+    /// runs require a unique `spawn_call_id`, non-empty task, and active
+    /// depth-zero foreground parent in the same chat; they are accepted as
+    /// queued depth-one work. An exact spawn-call retry recovers the original
+    /// run even if the caller supplies a fresh run id. Recursive children are
+    /// rejected by construction.
+    async fn accept_agent_run(
+        &self,
+        _id: AgentRunId,
+        _chat_id: ChatId,
+        _parent_id: Option<AgentRunId>,
+        _spawn_call_id: Option<CallId>,
+        _execution: AgentRunExecution,
+        _input: Option<&str>,
+    ) -> Result<AcceptAgentRunOutcome> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Fetch one agent run by its exact idempotency identity.
+    async fn get_agent_run(&self, _id: AgentRunId) -> Result<Option<AgentRun>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// List a chat's runs in deterministic creation order.
+    async fn list_agent_runs(&self, _chat_id: ChatId) -> Result<Vec<AgentRun>> {
+        agent_run_storage_unavailable()
     }
 
     /// Fetch one durable turn by its exact idempotency identity.

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -4,16 +4,17 @@ use std::sync::Arc;
 
 use chrono::{Duration, Utc};
 use openwave_core::{
-    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentEvent,
-    ApplyTurnSteerOutcome, BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, CallId,
-    Chat, ChatId, ChatRootAttachment, ClaimClientToolCallOutcome, ClientToolCallRequest,
-    CompleteTurnRunOutcome, DbStore, FinishRootAttachmentChangeOutcome,
-    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, HostRootId, Message, MessageId,
-    ParkTurnForClientCallOutcome, Project, ProjectId, RecordTurnFailureOutcome,
-    RequestTurnCancellationOutcome, ResolveToolCallOutcome, Role, RootAttachmentChangeAction,
-    RootAttachmentChangeId, RootAttachmentChangeTerminal, RootAttachmentOrigin, StopReason, Store,
-    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress,
-    TurnFailureRetry, TurnId, TurnRunStatus, TurnSteerId, TurnSteerStatus, Usage,
+    AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
+    AgentEvent, AgentRunExecution, AgentRunId, AgentRunStatus, ApplyTurnSteerOutcome,
+    BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, CallId, Chat, ChatId,
+    ChatRootAttachment, ClaimClientToolCallOutcome, ClientToolCallRequest, CompleteTurnRunOutcome,
+    DbStore, FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
+    HeartbeatClientToolCallOutcome, HostRootId, Message, MessageId, ParkTurnForClientCallOutcome,
+    Project, ProjectId, RecordTurnFailureOutcome, RequestTurnCancellationOutcome,
+    ResolveToolCallOutcome, Role, RootAttachmentChangeAction, RootAttachmentChangeId,
+    RootAttachmentChangeTerminal, RootAttachmentOrigin, StopReason, Store, ToolCallExecution,
+    ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress, TurnFailureRetry,
+    TurnId, TurnRunStatus, TurnSteerId, TurnSteerStatus, Usage,
 };
 
 static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
@@ -32,6 +33,159 @@ fn sample_chat() -> Chat {
         root_attachments: Vec::new(),
         created_at: utc_now_at_postgres_precision(),
     }
+}
+
+#[tokio::test]
+async fn postgres_agent_runs_enforce_foreground_parentage_and_idempotency() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let foreground_id = AgentRunId::new();
+    let foreground = match store
+        .accept_agent_run(
+            foreground_id,
+            chat.id,
+            None,
+            None,
+            AgentRunExecution::Foreground,
+            None,
+        )
+        .await
+        .unwrap()
+    {
+        AcceptAgentRunOutcome::Accepted(run) => run,
+        outcome => panic!("unexpected foreground outcome: {outcome:?}"),
+    };
+    assert_eq!(foreground.depth, 0);
+    assert_eq!(foreground.status, AgentRunStatus::Active);
+
+    let child_id = AgentRunId::new();
+    let spawn_call_id = CallId::new();
+    let child = match store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(foreground_id),
+            Some(spawn_call_id),
+            AgentRunExecution::Sandbox,
+            Some("postgres child"),
+        )
+        .await
+        .unwrap()
+    {
+        AcceptAgentRunOutcome::Accepted(run) => run,
+        outcome => panic!("unexpected sandbox outcome: {outcome:?}"),
+    };
+    assert_eq!(child.depth, 1);
+    assert_eq!(child.status, AgentRunStatus::Queued);
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                child_id,
+                chat.id,
+                Some(foreground_id),
+                Some(spawn_call_id),
+                AgentRunExecution::Sandbox,
+                Some("postgres child"),
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::Existing(existing) if existing == child
+    ));
+    assert!(matches!(
+        store
+            .accept_agent_run(
+                AgentRunId::new(),
+                chat.id,
+                Some(child_id),
+                Some(CallId::new()),
+                AgentRunExecution::Sandbox,
+                Some("forbidden grandchild"),
+            )
+            .await
+            .unwrap(),
+        AcceptAgentRunOutcome::ParentUnavailable
+    ));
+}
+
+#[tokio::test]
+async fn postgres_agent_run_identity_collision_recovers_exactly_across_chats() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = Arc::new(DbStore::connect(&url).await.unwrap());
+    let first_chat = sample_chat();
+    let second_chat = sample_chat();
+    store.create_chat(&first_chat).await.unwrap();
+    store.create_chat(&second_chat).await.unwrap();
+    let first_parent = AgentRunId::new();
+    let second_parent = AgentRunId::new();
+    for (chat_id, parent_id) in [
+        (first_chat.id, first_parent),
+        (second_chat.id, second_parent),
+    ] {
+        assert!(matches!(
+            store
+                .accept_agent_run(
+                    parent_id,
+                    chat_id,
+                    None,
+                    None,
+                    AgentRunExecution::Foreground,
+                    None,
+                )
+                .await
+                .unwrap(),
+            AcceptAgentRunOutcome::Accepted(_)
+        ));
+    }
+
+    let collision_id = AgentRunId::new();
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let mut tasks = Vec::new();
+    for (chat_id, parent_id) in [
+        (first_chat.id, first_parent),
+        (second_chat.id, second_parent),
+    ] {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .accept_agent_run(
+                    collision_id,
+                    chat_id,
+                    Some(parent_id),
+                    Some(CallId::new()),
+                    AgentRunExecution::Sandbox,
+                    Some("colliding child"),
+                )
+                .await
+        }));
+    }
+    let mut accepted = 0;
+    let mut conflicted = 0;
+    for task in tasks {
+        match task.await.unwrap() {
+            Ok(AcceptAgentRunOutcome::Accepted(_)) => accepted += 1,
+            Ok(AcceptAgentRunOutcome::IdentityConflict) => conflicted += 1,
+            outcome => panic!("unexpected cross-chat collision outcome: {outcome:?}"),
+        }
+    }
+    assert_eq!((accepted, conflicted), (1, 1));
 }
 
 #[tokio::test]

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -53,8 +53,8 @@ Starting an agent is an asynchronous state transition, not an in-process task
 spawn:
 
 1. The foreground tool call atomically creates a queued child `AgentRun`.
-2. The tool-call identity is the child's idempotency identity, so an ambiguous
-   retry cannot create a duplicate agent.
+2. The tool-call identity is stored as the child's unique spawn identity, so an
+   ambiguous retry recovers the original run instead of creating a duplicate.
 3. A bounded scheduler claims the child with an exact renewable lease.
 4. The scheduler creates or restores its sandbox and advances the shared agent
    loop.
@@ -145,4 +145,3 @@ The implementation is intentionally incremental:
    background work.
 8. Add richer context lifecycle, parallel-safe tool groups, and further
    orchestration only after these recovery boundaries are proven.
-


### PR DESCRIPTION
## Summary
- add durable foreground and sandbox AgentRun identities and lifecycle vocabulary
- enforce one foreground coordinator and same-chat depth-one sandbox parentage
- recover exact retries by run ID and unique spawn-call identity across concurrent races
- add fail-closed persistence decoding plus SQLite and PostgreSQL state coverage

## Validation
- `cargo test -p openwave-core --lib --locked`
- `bw dev lint --rust --check`
- focused SQLite AgentRun tests
- focused PostgreSQL AgentRun tests against PostgreSQL 16
- adversarial state-machine review and clean re-review