### PR TITLE
Bind turns to foreground agent runs

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -363,6 +363,8 @@ pub mod turn_run {
         #[sea_orm(primary_key, auto_increment = false)]
         pub id: Uuid,
         pub chat_id: Uuid,
+        pub agent_run_id: Uuid,
+        pub agent_run_depth: i16,
         pub input_message_id: Uuid,
         pub output_message_id: Option<Uuid>,
         pub model: String,

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -17,180 +17,162 @@ impl MigratorTrait for Migrator {
             Box::new(AddChatModel),
             Box::new(AddToolCalls),
             Box::new(AddDocuments),
-            Box::new(AddAgentRuns),
         ]
     }
 }
 
-struct AddAgentRuns;
+async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let foreground_status = Expr::col(AgentRun::Status).is_in([
+        AgentRunStatus::Active.as_str(),
+        AgentRunStatus::Completed.as_str(),
+        AgentRunStatus::Failed.as_str(),
+        AgentRunStatus::Cancelled.as_str(),
+    ]);
+    let sandbox_status = Expr::col(AgentRun::Status).is_in([
+        AgentRunStatus::Queued.as_str(),
+        AgentRunStatus::Running.as_str(),
+        AgentRunStatus::Waiting.as_str(),
+        AgentRunStatus::RetryWait.as_str(),
+        AgentRunStatus::Completed.as_str(),
+        AgentRunStatus::Failed.as_str(),
+        AgentRunStatus::Cancelled.as_str(),
+    ]);
+    let foreground_shape = Expr::col(AgentRun::Execution)
+        .eq(AgentRunExecution::Foreground.as_str())
+        .and(Expr::col(AgentRun::Depth).eq(0))
+        .and(Expr::col(AgentRun::ParentId).is_null())
+        .and(Expr::col(AgentRun::ParentDepth).is_null())
+        .and(Expr::col(AgentRun::SpawnCallId).is_null())
+        .and(Expr::col(AgentRun::Input).is_null())
+        .and(foreground_status);
+    let sandbox_shape = Expr::col(AgentRun::Execution)
+        .eq(AgentRunExecution::Sandbox.as_str())
+        .and(Expr::col(AgentRun::Depth).eq(i32::from(crate::model::AgentRun::MAX_DEPTH)))
+        .and(Expr::col(AgentRun::ParentId).is_not_null())
+        .and(Expr::col(AgentRun::ParentDepth).eq(0))
+        .and(Expr::col(AgentRun::SpawnCallId).is_not_null())
+        .and(Expr::col(AgentRun::Input).is_not_null())
+        .and(
+            Func::char_length(Expr::col(AgentRun::Input))
+                .between(1, crate::model::AgentRun::MAX_INPUT_LEN as i32),
+        )
+        .and(sandbox_status);
 
-impl MigrationName for AddAgentRuns {
-    fn name(&self) -> &str {
-        "m0007_agent_runs"
-    }
-}
-
-#[async_trait::async_trait]
-impl MigrationTrait for AddAgentRuns {
-    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        let foreground_status = Expr::col(AgentRun::Status).is_in([
-            AgentRunStatus::Active.as_str(),
-            AgentRunStatus::Completed.as_str(),
-            AgentRunStatus::Failed.as_str(),
-            AgentRunStatus::Cancelled.as_str(),
-        ]);
-        let sandbox_status = Expr::col(AgentRun::Status).is_in([
-            AgentRunStatus::Queued.as_str(),
-            AgentRunStatus::Running.as_str(),
-            AgentRunStatus::Waiting.as_str(),
-            AgentRunStatus::RetryWait.as_str(),
-            AgentRunStatus::Completed.as_str(),
-            AgentRunStatus::Failed.as_str(),
-            AgentRunStatus::Cancelled.as_str(),
-        ]);
-        let foreground_shape = Expr::col(AgentRun::Execution)
-            .eq(AgentRunExecution::Foreground.as_str())
-            .and(Expr::col(AgentRun::Depth).eq(0))
-            .and(Expr::col(AgentRun::ParentId).is_null())
-            .and(Expr::col(AgentRun::ParentDepth).is_null())
-            .and(Expr::col(AgentRun::SpawnCallId).is_null())
-            .and(Expr::col(AgentRun::Input).is_null())
-            .and(foreground_status);
-        let sandbox_shape = Expr::col(AgentRun::Execution)
-            .eq(AgentRunExecution::Sandbox.as_str())
-            .and(Expr::col(AgentRun::Depth).eq(i32::from(crate::model::AgentRun::MAX_DEPTH)))
-            .and(Expr::col(AgentRun::ParentId).is_not_null())
-            .and(Expr::col(AgentRun::ParentDepth).eq(0))
-            .and(Expr::col(AgentRun::SpawnCallId).is_not_null())
-            .and(Expr::col(AgentRun::Input).is_not_null())
-            .and(
-                Func::char_length(Expr::col(AgentRun::Input))
-                    .between(1, crate::model::AgentRun::MAX_INPUT_LEN as i32),
-            )
-            .and(sandbox_status);
-
-        manager
-            .create_table(
-                Table::create()
-                    .table(AgentRun::Table)
-                    .if_not_exists()
-                    .col(ColumnDef::new(AgentRun::Id).uuid().not_null())
-                    .col(ColumnDef::new(AgentRun::ChatId).uuid().not_null())
-                    .col(ColumnDef::new(AgentRun::ParentId).uuid())
-                    .col(ColumnDef::new(AgentRun::ParentDepth).small_integer())
-                    .col(ColumnDef::new(AgentRun::SpawnCallId).uuid())
-                    .col(
-                        ColumnDef::new(AgentRun::Execution)
-                            .string_len(16)
-                            .not_null(),
-                    )
-                    .col(ColumnDef::new(AgentRun::Depth).small_integer().not_null())
-                    .col(ColumnDef::new(AgentRun::Status).string_len(32).not_null())
-                    .col(ColumnDef::new(AgentRun::Input).text())
-                    .col(
-                        ColumnDef::new(AgentRun::CreatedAt)
-                            .timestamp_with_time_zone()
-                            .not_null(),
-                    )
-                    .col(
-                        ColumnDef::new(AgentRun::UpdatedAt)
-                            .timestamp_with_time_zone()
-                            .not_null(),
-                    )
-                    .primary_key(
-                        Index::create()
-                            .name("pk_agent_run")
-                            .col(AgentRun::Id)
-                            .col(AgentRun::ChatId)
-                            .col(AgentRun::Depth),
-                    )
-                    .foreign_key(
-                        ForeignKey::create()
-                            .name("fk_agent_run_chat")
-                            .from(AgentRun::Table, AgentRun::ChatId)
-                            .to(Chat::Table, Chat::Id)
-                            .on_delete(ForeignKeyAction::Restrict),
-                    )
-                    .foreign_key(
-                        ForeignKey::create()
-                            .name("fk_agent_run_parent")
-                            .from_tbl(AgentRun::Table)
-                            .from_col(AgentRun::ParentId)
-                            .from_col(AgentRun::ChatId)
-                            .from_col(AgentRun::ParentDepth)
-                            .to_tbl(AgentRun::Table)
-                            .to_col(AgentRun::Id)
-                            .to_col(AgentRun::ChatId)
-                            .to_col(AgentRun::Depth)
-                            .on_delete(ForeignKeyAction::Restrict),
-                    )
-                    .check(foreground_shape.or(sandbox_shape))
-                    .check(Expr::col(AgentRun::UpdatedAt).gte(Expr::col(AgentRun::CreatedAt)))
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_agent_run_id")
-                    .table(AgentRun::Table)
-                    .col(AgentRun::Id)
-                    .unique()
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_agent_run_spawn_call")
-                    .table(AgentRun::Table)
-                    .col(AgentRun::SpawnCallId)
-                    .unique()
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_agent_run_one_foreground")
-                    .table(AgentRun::Table)
-                    .col(AgentRun::ChatId)
-                    .unique()
-                    .and_where(
-                        Expr::col(AgentRun::Execution).eq(AgentRunExecution::Foreground.as_str()),
-                    )
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_agent_run_parent")
-                    .table(AgentRun::Table)
-                    .col(AgentRun::ParentId)
-                    .col(AgentRun::CreatedAt)
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_agent_run_chat_history")
-                    .table(AgentRun::Table)
-                    .col(AgentRun::ChatId)
-                    .col(AgentRun::CreatedAt)
-                    .col(AgentRun::Id)
-                    .to_owned(),
-            )
-            .await?;
-        Ok(())
-    }
-
-    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
-        manager
-            .drop_table(Table::drop().table(AgentRun::Table).to_owned())
-            .await
-    }
+    manager
+        .create_table(
+            Table::create()
+                .table(AgentRun::Table)
+                .if_not_exists()
+                .col(ColumnDef::new(AgentRun::Id).uuid().not_null())
+                .col(ColumnDef::new(AgentRun::ChatId).uuid().not_null())
+                .col(ColumnDef::new(AgentRun::ParentId).uuid())
+                .col(ColumnDef::new(AgentRun::ParentDepth).small_integer())
+                .col(ColumnDef::new(AgentRun::SpawnCallId).uuid())
+                .col(
+                    ColumnDef::new(AgentRun::Execution)
+                        .string_len(16)
+                        .not_null(),
+                )
+                .col(ColumnDef::new(AgentRun::Depth).small_integer().not_null())
+                .col(ColumnDef::new(AgentRun::Status).string_len(32).not_null())
+                .col(ColumnDef::new(AgentRun::Input).text())
+                .col(
+                    ColumnDef::new(AgentRun::CreatedAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRun::UpdatedAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .primary_key(
+                    Index::create()
+                        .name("pk_agent_run")
+                        .col(AgentRun::Id)
+                        .col(AgentRun::ChatId)
+                        .col(AgentRun::Depth),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_agent_run_chat")
+                        .from(AgentRun::Table, AgentRun::ChatId)
+                        .to(Chat::Table, Chat::Id)
+                        .on_delete(ForeignKeyAction::Restrict),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_agent_run_parent")
+                        .from_tbl(AgentRun::Table)
+                        .from_col(AgentRun::ParentId)
+                        .from_col(AgentRun::ChatId)
+                        .from_col(AgentRun::ParentDepth)
+                        .to_tbl(AgentRun::Table)
+                        .to_col(AgentRun::Id)
+                        .to_col(AgentRun::ChatId)
+                        .to_col(AgentRun::Depth)
+                        .on_delete(ForeignKeyAction::Restrict),
+                )
+                .check(foreground_shape.or(sandbox_shape))
+                .check(Expr::col(AgentRun::UpdatedAt).gte(Expr::col(AgentRun::CreatedAt)))
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_agent_run_id")
+                .table(AgentRun::Table)
+                .col(AgentRun::Id)
+                .unique()
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_agent_run_spawn_call")
+                .table(AgentRun::Table)
+                .col(AgentRun::SpawnCallId)
+                .unique()
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_agent_run_one_foreground")
+                .table(AgentRun::Table)
+                .col(AgentRun::ChatId)
+                .unique()
+                .and_where(
+                    Expr::col(AgentRun::Execution).eq(AgentRunExecution::Foreground.as_str()),
+                )
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_agent_run_parent")
+                .table(AgentRun::Table)
+                .col(AgentRun::ParentId)
+                .col(AgentRun::CreatedAt)
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_agent_run_chat_history")
+                .table(AgentRun::Table)
+                .col(AgentRun::ChatId)
+                .col(AgentRun::CreatedAt)
+                .col(AgentRun::Id)
+                .to_owned(),
+        )
+        .await?;
+    Ok(())
 }
 
 struct Init;
@@ -265,6 +247,8 @@ impl MigrationTrait for Init {
                     .to_owned(),
             )
             .await?;
+
+        create_agent_run_table(manager).await?;
 
         manager
             .create_table(
@@ -569,6 +553,13 @@ impl MigrationTrait for Init {
                     .if_not_exists()
                     .col(ColumnDef::new(TurnRun::Id).uuid().not_null().primary_key())
                     .col(ColumnDef::new(TurnRun::ChatId).uuid().not_null())
+                    .col(ColumnDef::new(TurnRun::AgentRunId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(TurnRun::AgentRunDepth)
+                            .small_integer()
+                            .not_null()
+                            .default(0),
+                    )
                     .col(ColumnDef::new(TurnRun::InputMessageId).uuid().not_null())
                     .col(ColumnDef::new(TurnRun::OutputMessageId).uuid())
                     .col(
@@ -673,6 +664,19 @@ impl MigrationTrait for Init {
                     )
                     .foreign_key(
                         ForeignKey::create()
+                            .name("fk_turn_run_foreground_agent")
+                            .from_tbl(TurnRun::Table)
+                            .from_col(TurnRun::AgentRunId)
+                            .from_col(TurnRun::ChatId)
+                            .from_col(TurnRun::AgentRunDepth)
+                            .to_tbl(AgentRun::Table)
+                            .to_col(AgentRun::Id)
+                            .to_col(AgentRun::ChatId)
+                            .to_col(AgentRun::Depth)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
                             .name("fk_turn_run_input_message")
                             .from_tbl(TurnRun::Table)
                             .from_col(TurnRun::InputMessageId)
@@ -716,6 +720,7 @@ impl MigrationTrait for Init {
                         Func::char_length(Expr::col(TurnRun::Model))
                             .between(1, crate::model::TurnRun::MAX_MODEL_LEN as i32),
                     )
+                    .check(Expr::col(TurnRun::AgentRunDepth).eq(0))
                     .check(valid_turn_status)
                     .check(
                         Expr::col(TurnRun::AttemptCount)
@@ -1127,6 +1132,9 @@ impl MigrationTrait for Init {
             .await?;
         manager
             .drop_table(Table::drop().table(TurnRun::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(AgentRun::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(Setting::Table).to_owned())
@@ -2951,6 +2959,8 @@ enum TurnRun {
     Table,
     Id,
     ChatId,
+    AgentRunId,
+    AgentRunDepth,
     InputMessageId,
     OutputMessageId,
     Model,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -11,6 +11,48 @@ use crate::storage::AcceptAgentRunOutcome;
 use super::super::{entities, store_err, DbStore};
 use super::{acquire_chat_write_lock, turn::canonical_db_timestamp};
 
+pub(in crate::db) async fn insert_foreground_agent_run_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+    created_at: chrono::DateTime<Utc>,
+) -> Result<AgentRunId>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let id = AgentRunId::foreground_for_chat(chat_id);
+    let created_at = canonical_db_timestamp(created_at)?;
+    entities::agent_run::ActiveModel {
+        id: Set(id.0),
+        chat_id: Set(chat_id.0),
+        parent_id: Set(None),
+        parent_depth: Set(None),
+        spawn_call_id: Set(None),
+        execution: Set(AgentRunExecution::Foreground.as_str().into()),
+        depth: Set(0),
+        status: Set(AgentRunStatus::Active.as_str().into()),
+        input: Set(None),
+        created_at: Set(created_at),
+        updated_at: Set(created_at),
+    }
+    .insert(conn)
+    .await
+    .map_err(store_err)?;
+    Ok(id)
+}
+
+pub(in crate::db) async fn find_foreground_agent_run_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+) -> Result<Option<AgentRun>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    find_foreground_on(conn, chat_id)
+        .await?
+        .map(agent_run_from_model)
+        .transpose()
+}
+
 pub(in crate::db) async fn accept_agent_run(
     store: &DbStore,
     id: AgentRunId,

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -16,7 +16,9 @@ use crate::model::{
 
 use super::super::{entities, project_from_models, store_err, DbStore};
 use super::turn::canonical_db_timestamp;
-use super::{acquire_chat_write_lock, acquire_turn_write_lock};
+use super::{
+    acquire_chat_write_lock, acquire_turn_write_lock, agent_run::insert_foreground_agent_run_on,
+};
 
 pub(in crate::db) const MESSAGE_IDENTITY_OWNER_MESSAGE: &str = "message";
 pub(in crate::db) const MESSAGE_IDENTITY_OWNER_STEER: &str = "turn_steer";
@@ -96,6 +98,7 @@ pub(in crate::db) async fn create_chat(store: &DbStore, chat: &Chat) -> Result<(
     let project_roots = load_chat_project_roots(&transaction, chat.project_id).await?;
     validate_chat_attachments(chat, &project_roots)?;
     insert_chat_on(&transaction, chat).await?;
+    insert_foreground_agent_run_on(&transaction, chat.id, chat.created_at).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(())
 }
@@ -124,6 +127,7 @@ pub(in crate::db) async fn create_chat_with_project_defaults(
     }
     validate_chat_root_projection(&chat).map_err(|message| AgentError::Store(message.into()))?;
     insert_chat_on(&transaction, &chat).await?;
+    insert_foreground_agent_run_on(&transaction, chat.id, chat.created_at).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(chat)
 }

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -6,14 +6,15 @@ use sea_orm::{
 
 use crate::error::{AgentError, AgentErrorInfo, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{ChatId, MessageId, TurnId};
-use crate::model::{TurnRun, TurnRunStatus};
+use crate::id::{AgentRunId, ChatId, MessageId, TurnId};
+use crate::model::{AgentRunStatus, TurnRun, TurnRunStatus};
 use crate::provider::Usage;
 use crate::storage::{AcceptTurnOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome};
 
 use super::super::{entities, store_err, DbStore};
 use super::{
     acquire_chat_write_lock,
+    agent_run::find_foreground_agent_run_on,
     conversation::{
         append_event_on, next_message_seq_on, reserve_message_identity_on,
         MESSAGE_IDENTITY_OWNER_MESSAGE,
@@ -105,16 +106,32 @@ pub(in crate::db) async fn accept_turn(
     if !acquire_chat_write_lock(&transaction, chat_id).await? {
         return Err(AgentError::Store(format!("chat {chat_id} does not exist")));
     }
+    let foreground = find_foreground_agent_run_on(&transaction, chat_id)
+        .await?
+        .ok_or_else(|| AgentError::Store(format!("chat {chat_id} has no foreground agent run")))?;
 
     if let Some(existing) = entities::turn_run::Entity::find_by_id(id.0)
         .one(&transaction)
         .await
         .map_err(store_err)?
     {
-        let existing =
-            exact_accepted_turn_on(&transaction, existing, chat_id, model, content).await?;
+        let existing = exact_accepted_turn_on(
+            &transaction,
+            existing,
+            chat_id,
+            foreground.id,
+            model,
+            content,
+        )
+        .await?;
         transaction.commit().await.map_err(store_err)?;
         return Ok(existing);
+    }
+
+    if foreground.status != AgentRunStatus::Active {
+        return Err(AgentError::Store(format!(
+            "chat {chat_id} foreground agent run is not active"
+        )));
     }
 
     if let Some(active) = find_active_turn_on(&transaction, chat_id).await? {
@@ -156,6 +173,8 @@ pub(in crate::db) async fn accept_turn(
     let run = entities::turn_run::ActiveModel {
         id: Set(id.0),
         chat_id: Set(chat_id.0),
+        agent_run_id: Set(foreground.id.0),
+        agent_run_depth: Set(0),
         input_message_id: Set(input_message_id.0),
         output_message_id: Set(None),
         model: Set(model.into()),
@@ -189,8 +208,15 @@ pub(in crate::db) async fn accept_turn(
                 .await
                 .map_err(store_err)?
             {
-                return exact_accepted_turn_on(&store.conn, existing, chat_id, model, content)
-                    .await;
+                return exact_accepted_turn_on(
+                    &store.conn,
+                    existing,
+                    chat_id,
+                    foreground.id,
+                    model,
+                    content,
+                )
+                .await;
             }
             if let Some(active) = find_active_turn_on(&store.conn, chat_id).await? {
                 return Ok(AcceptTurnOutcome::ChatBusy(turn_run_from_model(active)?));
@@ -807,6 +833,7 @@ async fn exact_accepted_turn_on<C>(
     conn: &C,
     existing: entities::turn_run::Model,
     chat_id: ChatId,
+    agent_run_id: AgentRunId,
     model: &str,
     content: &str,
 ) -> Result<AcceptTurnOutcome>
@@ -832,8 +859,11 @@ where
             TurnId(existing.id)
         )));
     }
-    let exact =
-        existing.chat_id == chat_id.0 && existing.model == model && message.content == content;
+    let exact = existing.chat_id == chat_id.0
+        && existing.agent_run_id == agent_run_id.0
+        && existing.agent_run_depth == 0
+        && existing.model == model
+        && message.content == content;
     Ok(if exact {
         AcceptTurnOutcome::Existing(turn_run_from_model(existing)?)
     } else {
@@ -846,6 +876,7 @@ fn turn_run_from_model(model: entities::turn_run::Model) -> Result<TurnRun> {
     Ok(TurnRun {
         id: TurnId(model.id),
         chat_id: ChatId(model.chat_id),
+        agent_run_id: AgentRunId(model.agent_run_id),
         input_message_id: MessageId(model.input_message_id),
         output_message_id: model.output_message_id.map(MessageId),
         model: model.model,

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4886,6 +4886,8 @@ async fn make_queued_turn(
     entities::turn_run::ActiveModel {
         id: Set(turn_id.0),
         chat_id: Set(chat_id.0),
+        agent_run_id: Set(crate::id::AgentRunId::foreground_for_chat(chat_id).0),
+        agent_run_depth: Set(0),
         input_message_id: Set(input_message_id.0),
         output_message_id: Set(None),
         model: Set(model.into()),
@@ -4926,6 +4928,10 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
     let stored = store.get_turn_run(TurnId(first.id)).await.unwrap().unwrap();
     assert_eq!(stored.id, TurnId(first.id));
     assert_eq!(stored.chat_id, chat.id);
+    assert_eq!(
+        stored.agent_run_id,
+        crate::id::AgentRunId::foreground_for_chat(chat.id)
+    );
     assert_eq!(stored.model, "claude-sonnet-4-5");
     assert_eq!(stored.status, TurnRunStatus::Queued);
     assert_eq!(stored.model_steps, 0);
@@ -4992,6 +4998,11 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
 
     let invalid_chat = sample_chat();
     store.create_chat(&invalid_chat).await.unwrap();
+
+    let mut cross_chat_coordinator = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
+    cross_chat_coordinator.agent_run_id =
+        Set(crate::id::AgentRunId::foreground_for_chat(chat.id).0);
+    assert!(cross_chat_coordinator.insert(&store.conn).await.is_err());
 
     let mut negative_accounting = make_queued_turn(&store, invalid_chat.id, "gpt-5", now).await;
     negative_accounting.input_tokens = Set(-1);
@@ -5408,6 +5419,26 @@ async fn turn_acceptance_is_atomic_idempotent_and_chat_scoped() {
     assert!(store.list_turn_runs(other.id).await.unwrap().is_empty());
     assert!(store.list_messages(other.id).await.unwrap().is_empty());
 
+    entities::agent_run::Entity::update_many()
+        .col_expr(
+            entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunStatus::Completed.as_str()),
+        )
+        .filter(entities::agent_run::Column::Id.eq(accepted.agent_run_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert!(matches!(
+        store
+            .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::Existing(turn) if turn == accepted
+    ));
+    assert!(store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "new work")
+        .await
+        .is_err());
     entities::message::Entity::update_many()
         .col_expr(
             entities::message::Column::Role,

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -10,22 +10,12 @@ async fn foreground_and_sandbox_runs_roundtrip_with_exact_idempotency() {
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
 
-    let foreground_id = AgentRunId::new();
-    let foreground = match store
-        .accept_agent_run(
-            foreground_id,
-            chat.id,
-            None,
-            None,
-            AgentRunExecution::Foreground,
-            None,
-        )
+    let foreground_id = AgentRunId::foreground_for_chat(chat.id);
+    let foreground = store
+        .get_agent_run(foreground_id)
         .await
         .unwrap()
-    {
-        AcceptAgentRunOutcome::Accepted(run) => run,
-        outcome => panic!("unexpected foreground outcome: {outcome:?}"),
-    };
+        .expect("chat creation should create its foreground agent run");
     assert_eq!(foreground.id, foreground_id);
     assert_eq!(foreground.chat_id, chat.id);
     assert_eq!(foreground.parent_id, None);
@@ -133,21 +123,7 @@ async fn agent_run_acceptance_enforces_one_foreground_and_depth_one_children() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let foreground_id = AgentRunId::new();
-    assert!(matches!(
-        store
-            .accept_agent_run(
-                foreground_id,
-                chat.id,
-                None,
-                None,
-                AgentRunExecution::Foreground,
-                None,
-            )
-            .await
-            .unwrap(),
-        AcceptAgentRunOutcome::Accepted(_)
-    ));
+    let foreground_id = AgentRunId::foreground_for_chat(chat.id);
     assert!(matches!(
         store
             .accept_agent_run(
@@ -216,18 +192,7 @@ async fn agent_run_acceptance_rejects_invalid_shapes_and_identity_reuse() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let foreground_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            foreground_id,
-            chat.id,
-            None,
-            None,
-            AgentRunExecution::Foreground,
-            None,
-        )
-        .await
-        .unwrap();
+    let foreground_id = AgentRunId::foreground_for_chat(chat.id);
 
     assert!(store
         .accept_agent_run(
@@ -313,18 +278,7 @@ async fn agent_run_schema_rejects_cross_chat_parentage() {
     let child_chat = sample_chat();
     store.create_chat(&parent_chat).await.unwrap();
     store.create_chat(&child_chat).await.unwrap();
-    let parent_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            parent_id,
-            parent_chat.id,
-            None,
-            None,
-            AgentRunExecution::Foreground,
-            None,
-        )
-        .await
-        .unwrap();
+    let parent_id = AgentRunId::foreground_for_chat(parent_chat.id);
 
     let now = chrono::Utc::now();
     let malformed = crate::db::entities::agent_run::ActiveModel {

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -166,6 +166,20 @@ id_type!(
     AgentRunId
 );
 
+impl AgentRunId {
+    /// Namespace for the one foreground coordinator derived for each chat.
+    const FOREGROUND_NAMESPACE: Uuid = Uuid::from_u128(0x38fd_6a64_b02f_4e91_a60c_7173_9af0_5b21);
+
+    /// Derive the stable foreground coordinator identity for a chat.
+    #[must_use]
+    pub fn foreground_for_chat(chat_id: ChatId) -> Self {
+        Self(Uuid::new_v5(
+            &Self::FOREGROUND_NAMESPACE,
+            chat_id.as_uuid().as_bytes(),
+        ))
+    }
+}
+
 /// Stable product and broker idempotency identity for one root-attachment change.
 ///
 /// The same UUID is used when reconciling the change with the host broker. Nil
@@ -267,6 +281,20 @@ mod tests {
         let chat = ChatId::new();
         let turn = TurnId::new();
         assert_ne!(chat.0, turn.0);
+    }
+
+    #[test]
+    fn foreground_agent_run_ids_are_stable_and_chat_scoped() {
+        let first_chat = ChatId::new();
+        let second_chat = ChatId::new();
+        assert_eq!(
+            AgentRunId::foreground_for_chat(first_chat),
+            AgentRunId::foreground_for_chat(first_chat)
+        );
+        assert_ne!(
+            AgentRunId::foreground_for_chat(first_chat),
+            AgentRunId::foreground_for_chat(second_chat)
+        );
     }
 
     #[test]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -94,7 +94,7 @@ pub fn validate_source_regions(
 }
 
 use crate::id::{
-    CallId, ChatId, DocumentId, DocumentJobId, HostRootId, MessageId, ProjectId,
+    AgentRunId, CallId, ChatId, DocumentId, DocumentJobId, HostRootId, MessageId, ProjectId,
     RootAttachmentChangeId, TurnId,
 };
 
@@ -1191,6 +1191,8 @@ pub struct TurnRun {
     pub id: TurnId,
     /// Conversation this turn belongs to.
     pub chat_id: ChatId,
+    /// Foreground coordinator that owns this conversation segment.
+    pub agent_run_id: AgentRunId,
     /// Exact persisted user message that supplied this turn's initial input.
     pub input_message_id: MessageId,
     /// Exact designated terminal assistant message committed with successful

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -48,22 +48,12 @@ async fn postgres_agent_runs_enforce_foreground_parentage_and_idempotency() {
     let store = DbStore::connect(&url).await.unwrap();
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let foreground_id = AgentRunId::new();
-    let foreground = match store
-        .accept_agent_run(
-            foreground_id,
-            chat.id,
-            None,
-            None,
-            AgentRunExecution::Foreground,
-            None,
-        )
+    let foreground_id = AgentRunId::foreground_for_chat(chat.id);
+    let foreground = store
+        .get_agent_run(foreground_id)
         .await
         .unwrap()
-    {
-        AcceptAgentRunOutcome::Accepted(run) => run,
-        outcome => panic!("unexpected foreground outcome: {outcome:?}"),
-    };
+        .expect("chat creation should create its foreground agent run");
     assert_eq!(foreground.depth, 0);
     assert_eq!(foreground.status, AgentRunStatus::Active);
 
@@ -131,27 +121,8 @@ async fn postgres_agent_run_identity_collision_recovers_exactly_across_chats() {
     let second_chat = sample_chat();
     store.create_chat(&first_chat).await.unwrap();
     store.create_chat(&second_chat).await.unwrap();
-    let first_parent = AgentRunId::new();
-    let second_parent = AgentRunId::new();
-    for (chat_id, parent_id) in [
-        (first_chat.id, first_parent),
-        (second_chat.id, second_parent),
-    ] {
-        assert!(matches!(
-            store
-                .accept_agent_run(
-                    parent_id,
-                    chat_id,
-                    None,
-                    None,
-                    AgentRunExecution::Foreground,
-                    None,
-                )
-                .await
-                .unwrap(),
-            AcceptAgentRunOutcome::Accepted(_)
-        ));
-    }
+    let first_parent = AgentRunId::foreground_for_chat(first_chat.id);
+    let second_parent = AgentRunId::foreground_for_chat(second_chat.id);
 
     let collision_id = AgentRunId::new();
     let barrier = Arc::new(tokio::sync::Barrier::new(2));

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -31,6 +31,12 @@ conversation segment inside that context. Model steps, tool calls, waits, and
 receipts are resumable work beneath the run rather than independent ad-hoc
 tasks.
 
+Chat creation and foreground-run creation are one atomic database operation.
+The foreground identity is derived from the chat identity, so retries and every
+process agree on the same coordinator without a lookup race. Turn acceptance
+stores a database-enforced reference to that exact depth-zero run; a turn can
+never be admitted under another chat's coordinator or a background child.
+
 Foreground and background agents use the same loop mechanics: durable
 acceptance, exact claim ownership, model and tool checkpoints, steering,
 cancellation, ordered events, and fenced completion. Their product contracts
@@ -135,13 +141,15 @@ fail conservatively after an ambiguous execution rather than replay it.
 
 The implementation is intentionally incremental:
 
-1. Add the durable `AgentRun` hierarchy and depth-one constraints.
-2. Generalize client execution into the shared continuation model.
-3. Persist model/tool step boundaries and side-effect receipts.
-4. Add the bounded sandbox scheduler and sandbox lifecycle.
-5. Add idempotent spawn, wait, cancel, inbox, and result-submission operations.
-6. Route sandbox folder access through the host broker.
-7. Add desktop surfaces for queued, running, waiting, failed, and completed
+1. Add the durable `AgentRun` hierarchy, atomic foreground ownership, and
+   depth-one constraints. *(Shipped.)*
+2. Add the bounded sandbox scheduler and sandbox lifecycle.
+3. Add idempotent spawn, claim, heartbeat, cancellation, and completion.
+4. Generalize client execution into the shared continuation model.
+5. Persist shared model/tool step boundaries and side-effect receipts.
+6. Add wait, inbox, result-submission, and parent wake-up operations.
+7. Route sandbox folder access through the host broker.
+8. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.
-8. Add richer context lifecycle, parallel-safe tool groups, and further
+9. Add richer context lifecycle, parallel-safe tool groups, and further
    orchestration only after these recovery boundaries are proven.


### PR DESCRIPTION
## Summary
- create each chat's deterministic foreground agent run atomically with the chat
- bind every accepted turn to that exact depth-zero coordinator with a composite database foreign key
- fold the agent-run schema into the pre-v1 baseline migration and document the execution ownership model

## Validation
- `cargo test -p openwave-core --lib --locked` (260 passed)
- PostgreSQL 16 `postgres_turn_state` integration suite (8 passed)
- `bw dev lint --rust --check`
- adversarial durability and schema review