### PR TITLE
Lease sandbox agent runs

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -344,8 +344,56 @@ pub mod agent_run {
         pub depth: i16,
         pub status: String,
         pub input: Option<String>,
+        pub attempt_count: i32,
+        pub max_attempts: i32,
+        pub claim_count: i32,
+        pub available_at: DateTimeUtc,
+        pub deadline_at: Option<DateTimeUtc>,
+        pub lease_token: Option<Uuid>,
+        pub lease_expires_at: Option<DateTimeUtc>,
+        pub started_at: Option<DateTimeUtc>,
+        pub finished_at: Option<DateTimeUtc>,
+        pub last_error_code: Option<String>,
+        pub last_error_detail: Option<String>,
         pub created_at: DateTimeUtc,
         pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod agent_run_claim {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "agent_run_claim")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub token: Uuid,
+        pub agent_run_id: Option<Uuid>,
+        pub attempt_count: Option<i32>,
+        pub claim_count: Option<i32>,
+        pub claimed_at: DateTimeUtc,
+        pub lease_expires_at: Option<DateTimeUtc>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod agent_run_claim_lock {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "agent_run_claim_lock")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: i32,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -22,6 +22,99 @@ impl MigratorTrait for Migrator {
 }
 
 async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(AgentRunClaimLock::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(AgentRunClaimLock::Id)
+                        .integer()
+                        .not_null()
+                        .primary_key(),
+                )
+                .check(Expr::col(AgentRunClaimLock::Id).eq(1))
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .get_connection()
+        .execute_unprepared(
+            "INSERT INTO agent_run_claim_lock (id) VALUES (1) ON CONFLICT DO NOTHING",
+        )
+        .await?;
+
+    manager
+        .create_table(
+            Table::create()
+                .table(AgentRunClaim::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(AgentRunClaim::Token)
+                        .uuid()
+                        .not_null()
+                        .primary_key(),
+                )
+                .col(ColumnDef::new(AgentRunClaim::AgentRunId).uuid())
+                .col(ColumnDef::new(AgentRunClaim::AttemptCount).integer())
+                .col(ColumnDef::new(AgentRunClaim::ClaimCount).integer())
+                .col(
+                    ColumnDef::new(AgentRunClaim::ClaimedAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(AgentRunClaim::LeaseExpiresAt).timestamp_with_time_zone())
+                .check(
+                    Expr::col(AgentRunClaim::AgentRunId)
+                        .is_null()
+                        .and(Expr::col(AgentRunClaim::AttemptCount).is_null())
+                        .and(Expr::col(AgentRunClaim::ClaimCount).is_null())
+                        .and(Expr::col(AgentRunClaim::LeaseExpiresAt).is_null())
+                        .or(Expr::col(AgentRunClaim::AgentRunId)
+                            .is_not_null()
+                            .and(Expr::col(AgentRunClaim::AttemptCount).is_not_null())
+                            .and(Expr::col(AgentRunClaim::AttemptCount).gte(1))
+                            .and(
+                                Expr::col(AgentRunClaim::ClaimCount).is_not_null().and(
+                                    Expr::col(AgentRunClaim::ClaimCount)
+                                        .gte(Expr::col(AgentRunClaim::AttemptCount)),
+                                ),
+                            )
+                            .and(
+                                Expr::col(AgentRunClaim::LeaseExpiresAt).is_not_null().and(
+                                    Expr::col(AgentRunClaim::LeaseExpiresAt)
+                                        .gt(Expr::col(AgentRunClaim::ClaimedAt)),
+                                ),
+                            )),
+                )
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_agent_run_claim_identity")
+                .table(AgentRunClaim::Table)
+                .col(AgentRunClaim::Token)
+                .col(AgentRunClaim::AgentRunId)
+                .col(AgentRunClaim::AttemptCount)
+                .col(AgentRunClaim::ClaimCount)
+                .unique()
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_agent_run_claim_count")
+                .table(AgentRunClaim::Table)
+                .col(AgentRunClaim::AgentRunId)
+                .col(AgentRunClaim::ClaimCount)
+                .unique()
+                .to_owned(),
+        )
+        .await?;
+
     let foreground_status = Expr::col(AgentRun::Status).is_in([
         AgentRunStatus::Active.as_str(),
         AgentRunStatus::Completed.as_str(),
@@ -31,6 +124,7 @@ async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr
     let sandbox_status = Expr::col(AgentRun::Status).is_in([
         AgentRunStatus::Queued.as_str(),
         AgentRunStatus::Running.as_str(),
+        AgentRunStatus::Cancelling.as_str(),
         AgentRunStatus::Waiting.as_str(),
         AgentRunStatus::RetryWait.as_str(),
         AgentRunStatus::Completed.as_str(),
@@ -44,6 +138,12 @@ async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr
         .and(Expr::col(AgentRun::ParentDepth).is_null())
         .and(Expr::col(AgentRun::SpawnCallId).is_null())
         .and(Expr::col(AgentRun::Input).is_null())
+        .and(Expr::col(AgentRun::AttemptCount).eq(0))
+        .and(Expr::col(AgentRun::MaxAttempts).eq(0))
+        .and(Expr::col(AgentRun::ClaimCount).eq(0))
+        .and(Expr::col(AgentRun::AvailableAt).eq(Expr::col(AgentRun::CreatedAt)))
+        .and(Expr::col(AgentRun::DeadlineAt).is_null())
+        .and(Expr::col(AgentRun::StartedAt).is_null())
         .and(foreground_status);
     let sandbox_shape = Expr::col(AgentRun::Execution)
         .eq(AgentRunExecution::Sandbox.as_str())
@@ -52,11 +152,69 @@ async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr
         .and(Expr::col(AgentRun::ParentDepth).eq(0))
         .and(Expr::col(AgentRun::SpawnCallId).is_not_null())
         .and(Expr::col(AgentRun::Input).is_not_null())
+        .and(Expr::col(AgentRun::MaxAttempts).gte(1))
+        .and(Expr::col(AgentRun::AttemptCount).gte(0))
+        .and(Expr::col(AgentRun::AttemptCount).lte(Expr::col(AgentRun::MaxAttempts)))
+        .and(Expr::col(AgentRun::ClaimCount).gte(Expr::col(AgentRun::AttemptCount)))
+        .and(Expr::col(AgentRun::AvailableAt).gte(Expr::col(AgentRun::CreatedAt)))
+        .and(Expr::col(AgentRun::DeadlineAt).gt(Expr::col(AgentRun::CreatedAt)))
         .and(
             Func::char_length(Expr::col(AgentRun::Input))
                 .between(1, crate::model::AgentRun::MAX_INPUT_LEN as i32),
         )
         .and(sandbox_status);
+    let active_lease = Expr::col(AgentRun::Status)
+        .is_in([
+            AgentRunStatus::Running.as_str(),
+            AgentRunStatus::Cancelling.as_str(),
+        ])
+        .and(Expr::col(AgentRun::LeaseToken).is_not_null())
+        .and(Expr::col(AgentRun::LeaseExpiresAt).is_not_null())
+        .and(Expr::col(AgentRun::AttemptCount).gte(1))
+        .and(Expr::col(AgentRun::StartedAt).is_not_null());
+    let no_lease = Expr::col(AgentRun::Status)
+        .is_not_in([
+            AgentRunStatus::Running.as_str(),
+            AgentRunStatus::Cancelling.as_str(),
+        ])
+        .and(Expr::col(AgentRun::LeaseToken).is_null())
+        .and(Expr::col(AgentRun::LeaseExpiresAt).is_null());
+    let terminal_finished = Expr::col(AgentRun::Status)
+        .is_in([
+            AgentRunStatus::Completed.as_str(),
+            AgentRunStatus::Failed.as_str(),
+            AgentRunStatus::Cancelled.as_str(),
+        ])
+        .and(Expr::col(AgentRun::FinishedAt).is_not_null());
+    let nonterminal_unfinished = Expr::col(AgentRun::Status)
+        .is_in([
+            AgentRunStatus::Active.as_str(),
+            AgentRunStatus::Queued.as_str(),
+            AgentRunStatus::Running.as_str(),
+            AgentRunStatus::Cancelling.as_str(),
+            AgentRunStatus::Waiting.as_str(),
+            AgentRunStatus::RetryWait.as_str(),
+        ])
+        .and(Expr::col(AgentRun::FinishedAt).is_null());
+    let failure_has_error = Expr::col(AgentRun::Status)
+        .is_in([
+            AgentRunStatus::RetryWait.as_str(),
+            AgentRunStatus::Failed.as_str(),
+        ])
+        .and(Expr::col(AgentRun::LastErrorCode).is_not_null());
+    let success_has_no_error = Expr::col(AgentRun::Status)
+        .is_not_in([
+            AgentRunStatus::RetryWait.as_str(),
+            AgentRunStatus::Failed.as_str(),
+        ])
+        .and(Expr::col(AgentRun::LastErrorCode).is_null())
+        .and(Expr::col(AgentRun::LastErrorDetail).is_null());
+    let queued_pristine = Expr::col(AgentRun::Status)
+        .ne(AgentRunStatus::Queued.as_str())
+        .or(Expr::col(AgentRun::AttemptCount)
+            .eq(0)
+            .and(Expr::col(AgentRun::ClaimCount).eq(0))
+            .and(Expr::col(AgentRun::StartedAt).is_null()));
 
     manager
         .create_table(
@@ -76,6 +234,27 @@ async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr
                 .col(ColumnDef::new(AgentRun::Depth).small_integer().not_null())
                 .col(ColumnDef::new(AgentRun::Status).string_len(32).not_null())
                 .col(ColumnDef::new(AgentRun::Input).text())
+                .col(ColumnDef::new(AgentRun::AttemptCount).integer().not_null())
+                .col(ColumnDef::new(AgentRun::MaxAttempts).integer().not_null())
+                .col(ColumnDef::new(AgentRun::ClaimCount).integer().not_null())
+                .col(
+                    ColumnDef::new(AgentRun::AvailableAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(AgentRun::DeadlineAt).timestamp_with_time_zone())
+                .col(ColumnDef::new(AgentRun::LeaseToken).uuid())
+                .col(ColumnDef::new(AgentRun::LeaseExpiresAt).timestamp_with_time_zone())
+                .col(ColumnDef::new(AgentRun::StartedAt).timestamp_with_time_zone())
+                .col(ColumnDef::new(AgentRun::FinishedAt).timestamp_with_time_zone())
+                .col(
+                    ColumnDef::new(AgentRun::LastErrorCode)
+                        .string_len(crate::model::AgentRun::MAX_ERROR_CODE_LEN as u32),
+                )
+                .col(
+                    ColumnDef::new(AgentRun::LastErrorDetail)
+                        .string_len(crate::model::AgentRun::MAX_ERROR_DETAIL_LEN as u32),
+                )
                 .col(
                     ColumnDef::new(AgentRun::CreatedAt)
                         .timestamp_with_time_zone()
@@ -113,7 +292,31 @@ async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr
                         .to_col(AgentRun::Depth)
                         .on_delete(ForeignKeyAction::Restrict),
                 )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_agent_run_live_claim")
+                        .from_tbl(AgentRun::Table)
+                        .from_col(AgentRun::LeaseToken)
+                        .from_col(AgentRun::Id)
+                        .from_col(AgentRun::AttemptCount)
+                        .from_col(AgentRun::ClaimCount)
+                        .to_tbl(AgentRunClaim::Table)
+                        .to_col(AgentRunClaim::Token)
+                        .to_col(AgentRunClaim::AgentRunId)
+                        .to_col(AgentRunClaim::AttemptCount)
+                        .to_col(AgentRunClaim::ClaimCount)
+                        .on_delete(ForeignKeyAction::Restrict),
+                )
                 .check(foreground_shape.or(sandbox_shape))
+                .check(active_lease.or(no_lease))
+                .check(terminal_finished.or(nonterminal_unfinished))
+                .check(failure_has_error.or(success_has_no_error))
+                .check(queued_pristine)
+                .check(
+                    Expr::col(AgentRun::LastErrorDetail)
+                        .is_null()
+                        .or(Expr::col(AgentRun::LastErrorCode).is_not_null()),
+                )
                 .check(Expr::col(AgentRun::UpdatedAt).gte(Expr::col(AgentRun::CreatedAt)))
                 .to_owned(),
         )
@@ -169,6 +372,29 @@ async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr
                 .col(AgentRun::ChatId)
                 .col(AgentRun::CreatedAt)
                 .col(AgentRun::Id)
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_agent_run_claimable")
+                .table(AgentRun::Table)
+                .col(AgentRun::Status)
+                .col(AgentRun::AvailableAt)
+                .col(AgentRun::CreatedAt)
+                .col(AgentRun::Id)
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_agent_run_live_by_chat")
+                .table(AgentRun::Table)
+                .col(AgentRun::Status)
+                .col(AgentRun::ChatId)
+                .col(AgentRun::LeaseExpiresAt)
                 .to_owned(),
         )
         .await?;
@@ -1135,6 +1361,12 @@ impl MigrationTrait for Init {
             .await?;
         manager
             .drop_table(Table::drop().table(AgentRun::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(AgentRunClaim::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(AgentRunClaimLock::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(Setting::Table).to_owned())
@@ -2884,8 +3116,36 @@ enum AgentRun {
     Depth,
     Status,
     Input,
+    AttemptCount,
+    MaxAttempts,
+    ClaimCount,
+    AvailableAt,
+    DeadlineAt,
+    LeaseToken,
+    LeaseExpiresAt,
+    StartedAt,
+    FinishedAt,
+    LastErrorCode,
+    LastErrorDetail,
     CreatedAt,
     UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+enum AgentRunClaim {
+    Table,
+    Token,
+    AgentRunId,
+    AttemptCount,
+    ClaimCount,
+    ClaimedAt,
+    LeaseExpiresAt,
+}
+
+#[derive(DeriveIden)]
+enum AgentRunClaimLock {
+    Table,
+    Id,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1752,6 +1752,32 @@ impl Store for DbStore {
         ops::agent_run::list_agent_runs(self, chat_id).await
     }
 
+    async fn claim_agent_run(
+        &self,
+        lease_token: uuid::Uuid,
+        lease_duration: chrono::Duration,
+        max_running_global: u32,
+        max_running_per_chat: u32,
+    ) -> Result<Option<AgentRun>> {
+        ops::agent_run::claim_agent_run(
+            self,
+            lease_token,
+            lease_duration,
+            max_running_global,
+            max_running_per_chat,
+        )
+        .await
+    }
+
+    async fn heartbeat_agent_run(
+        &self,
+        id: AgentRunId,
+        lease_token: uuid::Uuid,
+        lease_duration: chrono::Duration,
+    ) -> Result<bool> {
+        ops::agent_run::heartbeat_agent_run(self, id, lease_token, lease_duration).await
+    }
+
     async fn get_turn_run(&self, id: TurnId) -> Result<Option<TurnRun>> {
         ops::turn::get_turn_run(self, id).await
     }

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, DatabaseBackend, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, Set, Statement, TransactionTrait,
 };
 
 use crate::error::{AgentError, Result};
@@ -31,6 +32,17 @@ where
         depth: Set(0),
         status: Set(AgentRunStatus::Active.as_str().into()),
         input: Set(None),
+        attempt_count: Set(0),
+        max_attempts: Set(0),
+        claim_count: Set(0),
+        available_at: Set(created_at),
+        deadline_at: Set(None),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        started_at: Set(None),
+        finished_at: Set(None),
+        last_error_code: Set(None),
+        last_error_detail: Set(None),
         created_at: Set(created_at),
         updated_at: Set(created_at),
     }
@@ -134,7 +146,7 @@ pub(in crate::db) async fn accept_agent_run(
         }
     };
 
-    let now = canonical_db_timestamp(Utc::now())?;
+    let now = database_now(&transaction).await?;
     let model = entities::agent_run::ActiveModel {
         id: Set(id.0),
         chat_id: Set(chat_id.0),
@@ -145,6 +157,23 @@ pub(in crate::db) async fn accept_agent_run(
         depth: Set(depth),
         status: Set(status.as_str().into()),
         input: Set(input.map(ToOwned::to_owned)),
+        attempt_count: Set(0),
+        max_attempts: Set(match execution {
+            AgentRunExecution::Foreground => 0,
+            AgentRunExecution::Sandbox => AgentRun::DEFAULT_MAX_ATTEMPTS,
+        }),
+        claim_count: Set(0),
+        available_at: Set(now),
+        deadline_at: Set(match execution {
+            AgentRunExecution::Foreground => None,
+            AgentRunExecution::Sandbox => Some(now + AgentRun::DEFAULT_MAX_DURATION),
+        }),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        started_at: Set(None),
+        finished_at: Set(None),
+        last_error_code: Set(None),
+        last_error_detail: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
     };
@@ -197,6 +226,536 @@ pub(in crate::db) async fn get_agent_run(
         .await?
         .map(agent_run_from_model)
         .transpose()
+}
+
+pub(in crate::db) async fn claim_agent_run(
+    store: &DbStore,
+    lease_token: uuid::Uuid,
+    lease_duration: chrono::Duration,
+    max_running_global: u32,
+    max_running_per_chat: u32,
+) -> Result<Option<AgentRun>> {
+    validate_claim_request(
+        lease_token,
+        lease_duration,
+        max_running_global,
+        max_running_per_chat,
+    )?;
+
+    loop {
+        let transaction = store.conn.begin().await.map_err(store_err)?;
+        acquire_agent_run_claim_lock(&transaction).await?;
+        let now = database_now(&transaction).await?;
+        let lease_expires_at = now.checked_add_signed(lease_duration).ok_or_else(|| {
+            AgentError::Store(
+                "agent-run lease duration overflows the database timestamp range".into(),
+            )
+        })?;
+
+        if let Some(receipt) = entities::agent_run_claim::Entity::find_by_id(lease_token)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+        {
+            let Some(agent_run_id) = receipt.agent_run_id else {
+                transaction.commit().await.map_err(store_err)?;
+                return Ok(None);
+            };
+            let existing = find_by_id_on(&transaction, AgentRunId(agent_run_id))
+                .await?
+                .filter(|run| {
+                    run.execution == AgentRunExecution::Sandbox.as_str()
+                        && matches!(run.status.as_str(), "running" | "cancelling")
+                        && Some(run.attempt_count) == receipt.attempt_count
+                        && Some(run.claim_count) == receipt.claim_count
+                        && run.lease_token == Some(lease_token)
+                        && run.lease_expires_at.is_some_and(|expiry| expiry > now)
+                        && run.deadline_at.is_some_and(|deadline| deadline > now)
+                })
+                .map(agent_run_from_model)
+                .transpose()?;
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(existing);
+        }
+
+        if let Some(expired) = find_expired_deadline_on(&transaction, now).await? {
+            let updated = fail_candidate_on(
+                &transaction,
+                &expired,
+                now,
+                "deadline_exceeded",
+                "sandbox agent exceeded its wall-clock deadline",
+            )
+            .await?;
+            if !updated {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+            transaction.commit().await.map_err(store_err)?;
+            continue;
+        }
+
+        // Reaping does not consume a scheduler slot. Do it before capacity
+        // admission so an expired cancellation or exhausted worker cannot be
+        // stranded indefinitely behind unrelated live work.
+        if let Some(expired) = find_expired_lease_reaper_on(&transaction, now).await? {
+            let (error_code, error_detail) =
+                if expired.status == AgentRunStatus::Cancelling.as_str() {
+                    (
+                        "cancelled",
+                        "sandbox agent lease expired while cancellation was pending",
+                    )
+                } else {
+                    (
+                        "lease_expired",
+                        "sandbox agent exhausted its attempt budget after lease expiry",
+                    )
+                };
+            let updated =
+                fail_candidate_on(&transaction, &expired, now, error_code, error_detail).await?;
+            if !updated {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+            transaction.commit().await.map_err(store_err)?;
+            continue;
+        }
+
+        let live = entities::agent_run::Entity::find()
+            .filter(entities::agent_run::Column::Execution.eq(AgentRunExecution::Sandbox.as_str()))
+            .filter(entities::agent_run::Column::Status.is_in([
+                AgentRunStatus::Running.as_str(),
+                AgentRunStatus::Cancelling.as_str(),
+            ]))
+            .filter(entities::agent_run::Column::LeaseExpiresAt.gt(now))
+            .all(&transaction)
+            .await
+            .map_err(store_err)?;
+        if live.len() >= max_running_global as usize {
+            record_empty_claim_scan_on(&transaction, lease_token, now).await?;
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(None);
+        }
+        let mut live_by_chat = std::collections::HashMap::<uuid::Uuid, usize>::new();
+        for run in live {
+            *live_by_chat.entry(run.chat_id).or_default() += 1;
+        }
+
+        let Some(candidate) =
+            find_claim_candidate_on(&transaction, now, max_running_per_chat, &live_by_chat).await?
+        else {
+            record_empty_claim_scan_on(&transaction, lease_token, now).await?;
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(None);
+        };
+
+        let attempt_count = candidate.attempt_count.checked_add(1).ok_or_else(|| {
+            AgentError::Store(format!("agent run {} attempt count overflow", candidate.id))
+        })?;
+        let claim_count = candidate.claim_count.checked_add(1).ok_or_else(|| {
+            AgentError::Store(format!("agent run {} claim count overflow", candidate.id))
+        })?;
+        let effective_lease_expires_at = candidate
+            .deadline_at
+            .ok_or_else(|| AgentError::Store("sandbox agent run is missing its deadline".into()))?
+            .min(lease_expires_at);
+        entities::agent_run_claim::ActiveModel {
+            token: Set(lease_token),
+            agent_run_id: Set(Some(candidate.id)),
+            attempt_count: Set(Some(attempt_count)),
+            claim_count: Set(Some(claim_count)),
+            claimed_at: Set(now),
+            lease_expires_at: Set(Some(effective_lease_expires_at)),
+        }
+        .insert(&transaction)
+        .await
+        .map_err(store_err)?;
+
+        let reclaiming = candidate.status == AgentRunStatus::Running.as_str();
+        let claim = entities::agent_run::Entity::update_many()
+            .col_expr(
+                entities::agent_run::Column::Status,
+                sea_orm::sea_query::Expr::value(AgentRunStatus::Running.as_str()),
+            )
+            .col_expr(
+                entities::agent_run::Column::AttemptCount,
+                sea_orm::sea_query::Expr::value(attempt_count),
+            )
+            .col_expr(
+                entities::agent_run::Column::ClaimCount,
+                sea_orm::sea_query::Expr::value(claim_count),
+            )
+            .col_expr(
+                entities::agent_run::Column::LeaseToken,
+                sea_orm::sea_query::Expr::value(Some(lease_token)),
+            )
+            .col_expr(
+                entities::agent_run::Column::LeaseExpiresAt,
+                sea_orm::sea_query::Expr::value(Some(effective_lease_expires_at)),
+            )
+            .col_expr(
+                entities::agent_run::Column::StartedAt,
+                sea_orm::sea_query::Expr::value(Some(candidate.started_at.unwrap_or(now))),
+            )
+            .col_expr(
+                entities::agent_run::Column::LastErrorCode,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entities::agent_run::Column::LastErrorDetail,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entities::agent_run::Column::UpdatedAt,
+                sea_orm::sea_query::Expr::value(now),
+            )
+            .filter(entities::agent_run::Column::Id.eq(candidate.id))
+            .filter(entities::agent_run::Column::Status.eq(&candidate.status))
+            .filter(entities::agent_run::Column::AttemptCount.eq(candidate.attempt_count))
+            .filter(entities::agent_run::Column::ClaimCount.eq(candidate.claim_count))
+            .filter(entities::agent_run::Column::UpdatedAt.eq(candidate.updated_at))
+            .filter(entities::agent_run::Column::UpdatedAt.lte(now))
+            .filter(entities::agent_run::Column::DeadlineAt.gt(now));
+        let claim = if reclaiming {
+            claim
+                .filter(entities::agent_run::Column::LeaseToken.eq(candidate.lease_token))
+                .filter(entities::agent_run::Column::LeaseExpiresAt.eq(candidate.lease_expires_at))
+                .filter(entities::agent_run::Column::LeaseExpiresAt.lte(now))
+        } else {
+            claim
+                .filter(entities::agent_run::Column::LeaseToken.is_null())
+                .filter(entities::agent_run::Column::LeaseExpiresAt.is_null())
+                .filter(entities::agent_run::Column::AvailableAt.lte(now))
+        };
+        let claimed = claim.exec(&transaction).await.map_err(store_err)?;
+        if claimed.rows_affected != 1 {
+            transaction.rollback().await.map_err(store_err)?;
+            continue;
+        }
+        let claimed = find_by_id_on(&transaction, AgentRunId(candidate.id))
+            .await?
+            .ok_or_else(|| AgentError::Store("claimed agent run disappeared".into()))?;
+        let claimed = agent_run_from_model(claimed)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(claimed));
+    }
+}
+
+async fn record_empty_claim_scan_on<C>(
+    conn: &C,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+) -> Result<()>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    entities::agent_run_claim::ActiveModel {
+        token: Set(lease_token),
+        agent_run_id: Set(None),
+        attempt_count: Set(None),
+        claim_count: Set(None),
+        claimed_at: Set(now),
+        lease_expires_at: Set(None),
+    }
+    .insert(conn)
+    .await
+    .map_err(store_err)?;
+    Ok(())
+}
+
+pub(in crate::db) async fn heartbeat_agent_run(
+    store: &DbStore,
+    id: AgentRunId,
+    lease_token: uuid::Uuid,
+    lease_duration: chrono::Duration,
+) -> Result<bool> {
+    if lease_token.is_nil() || lease_duration <= chrono::Duration::zero() {
+        return Err(AgentError::Store(
+            "agent-run heartbeat requires a non-nil token and positive duration".into(),
+        ));
+    }
+    let now = database_now(&store.conn).await?;
+    let lease_expires_at = now.checked_add_signed(lease_duration).ok_or_else(|| {
+        AgentError::Store("agent-run lease duration overflows the database timestamp range".into())
+    })?;
+    let heartbeat = entities::agent_run::Entity::update_many()
+        .col_expr(
+            entities::agent_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Some(lease_expires_at)),
+        )
+        .col_expr(
+            entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::agent_run::Column::Id.eq(id.0))
+        .filter(entities::agent_run::Column::Execution.eq(AgentRunExecution::Sandbox.as_str()))
+        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Running.as_str()))
+        .filter(entities::agent_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::agent_run::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::agent_run::Column::LeaseExpiresAt.lt(lease_expires_at))
+        .filter(entities::agent_run::Column::DeadlineAt.gt(now))
+        .filter(entities::agent_run::Column::DeadlineAt.gte(lease_expires_at))
+        .filter(entities::agent_run::Column::UpdatedAt.lte(now))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(heartbeat.rows_affected == 1)
+}
+
+fn validate_claim_request(
+    lease_token: uuid::Uuid,
+    lease_duration: chrono::Duration,
+    max_running_global: u32,
+    max_running_per_chat: u32,
+) -> Result<()> {
+    if lease_token.is_nil() || lease_duration <= chrono::Duration::zero() {
+        return Err(AgentError::Store(
+            "agent-run claim requires a non-nil token and positive duration".into(),
+        ));
+    }
+    if !(1..=AgentRun::MAX_CONCURRENCY_LIMIT).contains(&max_running_global)
+        || !(1..=AgentRun::MAX_CONCURRENCY_LIMIT).contains(&max_running_per_chat)
+        || max_running_per_chat > max_running_global
+    {
+        return Err(AgentError::Store(format!(
+            "agent-run concurrency limits must satisfy 1 <= per-chat <= global <= {}",
+            AgentRun::MAX_CONCURRENCY_LIMIT
+        )));
+    }
+    Ok(())
+}
+
+async fn database_now<C>(conn: &C) -> Result<chrono::DateTime<Utc>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let backend = conn.get_database_backend();
+    // PostgreSQL's CURRENT_TIMESTAMP is fixed at transaction start. Claimers
+    // can wait on the scheduler lock, so use its statement-time clock there;
+    // SQLite's CURRENT_TIMESTAMP already has the desired statement semantics.
+    let clock_sql = match backend {
+        DatabaseBackend::Postgres => "SELECT clock_timestamp() AS now",
+        _ => "SELECT CURRENT_TIMESTAMP AS now",
+    };
+    let statement = Statement::from_string(backend, clock_sql);
+    let row = conn
+        .query_one(statement)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store("database clock query returned no row".into()))?;
+    let now = row
+        .try_get::<chrono::DateTime<Utc>>("", "now")
+        .map_err(store_err)?;
+    canonical_db_timestamp(now)
+}
+
+async fn acquire_agent_run_claim_lock<C>(conn: &C) -> Result<()>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let locked = entities::agent_run_claim_lock::Entity::update_many()
+        .col_expr(
+            entities::agent_run_claim_lock::Column::Id,
+            sea_orm::sea_query::Expr::col(entities::agent_run_claim_lock::Column::Id).into(),
+        )
+        .filter(entities::agent_run_claim_lock::Column::Id.eq(1))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    if locked.rows_affected != 1 {
+        return Err(AgentError::Store(
+            "durable agent-run claim lock is missing".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn find_expired_deadline_on<C>(
+    conn: &C,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<entities::agent_run::Model>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::Execution.eq(AgentRunExecution::Sandbox.as_str()))
+        .filter(entities::agent_run::Column::Status.is_in([
+            AgentRunStatus::Queued.as_str(),
+            AgentRunStatus::Running.as_str(),
+            AgentRunStatus::Cancelling.as_str(),
+            AgentRunStatus::Waiting.as_str(),
+            AgentRunStatus::RetryWait.as_str(),
+        ]))
+        .filter(entities::agent_run::Column::DeadlineAt.lte(now))
+        .filter(entities::agent_run::Column::UpdatedAt.lte(now))
+        .order_by_asc(entities::agent_run::Column::DeadlineAt)
+        .order_by_asc(entities::agent_run::Column::CreatedAt)
+        .order_by_asc(entities::agent_run::Column::Id)
+        .one(conn)
+        .await
+        .map_err(store_err)
+}
+
+async fn find_claim_candidate_on<C>(
+    conn: &C,
+    now: chrono::DateTime<Utc>,
+    max_running_per_chat: u32,
+    live_by_chat: &std::collections::HashMap<uuid::Uuid, usize>,
+) -> Result<Option<entities::agent_run::Model>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    const PAGE_SIZE: u64 = 64;
+    let mut offset = 0;
+    loop {
+        let page = entities::agent_run::Entity::find()
+            .filter(entities::agent_run::Column::Execution.eq(AgentRunExecution::Sandbox.as_str()))
+            .filter(
+                sea_orm::Condition::any()
+                    .add(
+                        sea_orm::Condition::all()
+                            .add(entities::agent_run::Column::Status.is_in([
+                                AgentRunStatus::Queued.as_str(),
+                                AgentRunStatus::RetryWait.as_str(),
+                            ]))
+                            .add(entities::agent_run::Column::AvailableAt.lte(now)),
+                    )
+                    .add(
+                        sea_orm::Condition::all()
+                            .add(
+                                entities::agent_run::Column::Status
+                                    .is_in([AgentRunStatus::Running.as_str()]),
+                            )
+                            .add(entities::agent_run::Column::LeaseExpiresAt.lte(now)),
+                    ),
+            )
+            .filter(entities::agent_run::Column::UpdatedAt.lte(now))
+            .filter(entities::agent_run::Column::DeadlineAt.gt(now))
+            .order_by_asc(entities::agent_run::Column::AvailableAt)
+            .order_by_asc(entities::agent_run::Column::CreatedAt)
+            .order_by_asc(entities::agent_run::Column::Id)
+            .offset(offset)
+            .limit(PAGE_SIZE)
+            .all(conn)
+            .await
+            .map_err(store_err)?;
+        if page.is_empty() {
+            return Ok(None);
+        }
+        let page_len = page.len();
+        if let Some(candidate) = page.into_iter().find(|candidate| {
+            live_by_chat.get(&candidate.chat_id).copied().unwrap_or(0)
+                < max_running_per_chat as usize
+        }) {
+            return Ok(Some(candidate));
+        }
+        if page_len < PAGE_SIZE as usize {
+            return Ok(None);
+        }
+        offset += PAGE_SIZE;
+    }
+}
+
+async fn find_expired_lease_reaper_on<C>(
+    conn: &C,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<entities::agent_run::Model>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::Execution.eq(AgentRunExecution::Sandbox.as_str()))
+        .filter(
+            sea_orm::Condition::any()
+                .add(entities::agent_run::Column::Status.eq(AgentRunStatus::Cancelling.as_str()))
+                .add(
+                    sea_orm::Condition::all()
+                        .add(
+                            entities::agent_run::Column::Status
+                                .eq(AgentRunStatus::Running.as_str()),
+                        )
+                        .add(
+                            sea_orm::sea_query::Expr::col(
+                                entities::agent_run::Column::AttemptCount,
+                            )
+                            .gte(sea_orm::sea_query::Expr::col(
+                                entities::agent_run::Column::MaxAttempts,
+                            )),
+                        ),
+                ),
+        )
+        .filter(entities::agent_run::Column::LeaseExpiresAt.lte(now))
+        .filter(entities::agent_run::Column::UpdatedAt.lte(now))
+        .order_by_asc(entities::agent_run::Column::LeaseExpiresAt)
+        .order_by_asc(entities::agent_run::Column::CreatedAt)
+        .order_by_asc(entities::agent_run::Column::Id)
+        .one(conn)
+        .await
+        .map_err(store_err)
+}
+
+async fn fail_candidate_on<C>(
+    conn: &C,
+    candidate: &entities::agent_run::Model,
+    now: chrono::DateTime<Utc>,
+    error_code: &str,
+    error_detail: &str,
+) -> Result<bool>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let cancelling = candidate.status == AgentRunStatus::Cancelling.as_str();
+    let terminal_status = if cancelling {
+        AgentRunStatus::Cancelled
+    } else {
+        AgentRunStatus::Failed
+    };
+    let update = entities::agent_run::Entity::update_many()
+        .col_expr(
+            entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(terminal_status.as_str()),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            entities::agent_run::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value((!cancelling).then(|| error_code.to_owned())),
+        )
+        .col_expr(
+            entities::agent_run::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value((!cancelling).then(|| error_detail.to_owned())),
+        )
+        .col_expr(
+            entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::agent_run::Column::Id.eq(candidate.id))
+        .filter(entities::agent_run::Column::Status.eq(candidate.status.clone()))
+        .filter(entities::agent_run::Column::AttemptCount.eq(candidate.attempt_count))
+        .filter(entities::agent_run::Column::ClaimCount.eq(candidate.claim_count))
+        .filter(entities::agent_run::Column::UpdatedAt.eq(candidate.updated_at))
+        .filter(entities::agent_run::Column::UpdatedAt.lte(now));
+    let update = if candidate.lease_token.is_some() {
+        update
+            .filter(entities::agent_run::Column::LeaseToken.eq(candidate.lease_token))
+            .filter(entities::agent_run::Column::LeaseExpiresAt.eq(candidate.lease_expires_at))
+    } else {
+        update
+            .filter(entities::agent_run::Column::LeaseToken.is_null())
+            .filter(entities::agent_run::Column::LeaseExpiresAt.is_null())
+    };
+    let updated = update.exec(conn).await.map_err(store_err)?;
+    Ok(updated.rows_affected == 1)
 }
 
 pub(in crate::db) async fn list_agent_runs(
@@ -278,6 +837,7 @@ fn agent_run_from_model(model: entities::agent_run::Model) -> Result<AgentRun> {
         "active" => AgentRunStatus::Active,
         "queued" => AgentRunStatus::Queued,
         "running" => AgentRunStatus::Running,
+        "cancelling" => AgentRunStatus::Cancelling,
         "waiting" => AgentRunStatus::Waiting,
         "retry_wait" => AgentRunStatus::RetryWait,
         "completed" => AgentRunStatus::Completed,
@@ -300,6 +860,17 @@ fn agent_run_from_model(model: entities::agent_run::Model) -> Result<AgentRun> {
             .map_err(|_| AgentError::Store("invalid negative agent-run depth".into()))?,
         status,
         input: model.input,
+        attempt_count: model.attempt_count,
+        max_attempts: model.max_attempts,
+        claim_count: model.claim_count,
+        available_at: model.available_at,
+        deadline_at: model.deadline_at,
+        lease_token: model.lease_token,
+        lease_expires_at: model.lease_expires_at,
+        started_at: model.started_at,
+        finished_at: model.finished_at,
+        last_error_code: model.last_error_code,
+        last_error_detail: model.last_error_detail,
         created_at: model.created_at,
         updated_at: model.updated_at,
     })
@@ -382,6 +953,14 @@ fn validate_stored_shape(
                 && model.parent_depth.is_none()
                 && model.spawn_call_id.is_none()
                 && model.input.is_none()
+                && model.attempt_count == 0
+                && model.max_attempts == 0
+                && model.claim_count == 0
+                && model.available_at == model.created_at
+                && model.deadline_at.is_none()
+                && model.lease_token.is_none()
+                && model.lease_expires_at.is_none()
+                && model.started_at.is_none()
                 && matches!(
                     status,
                     AgentRunStatus::Active
@@ -399,6 +978,14 @@ fn validate_stored_shape(
                     let len = input.chars().count();
                     len > 0 && len <= AgentRun::MAX_INPUT_LEN
                 })
+                && model.max_attempts >= 1
+                && model.attempt_count >= 0
+                && model.attempt_count <= model.max_attempts
+                && model.claim_count >= model.attempt_count
+                && model.available_at >= model.created_at
+                && model
+                    .deadline_at
+                    .is_some_and(|deadline| deadline > model.created_at)
                 && status != AgentRunStatus::Active
         }
     };

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5424,6 +5424,10 @@ async fn turn_acceptance_is_atomic_idempotent_and_chat_scoped() {
             entities::agent_run::Column::Status,
             sea_orm::sea_query::Expr::value(AgentRunStatus::Completed.as_str()),
         )
+        .col_expr(
+            entities::agent_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(accepted.updated_at)),
+        )
         .filter(entities::agent_run::Column::Id.eq(accepted.agent_run_id.0))
         .exec(&store.conn)
         .await

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -1,8 +1,49 @@
 use super::{sample_chat, temp_store};
 use crate::{
-    AcceptAgentRunOutcome, AgentRunExecution, AgentRunId, AgentRunStatus, CallId, ChatId, Store,
+    AcceptAgentRunOutcome, AgentRun, AgentRunExecution, AgentRunId, AgentRunStatus, CallId, ChatId,
+    DbStore, Store,
 };
-use sea_orm::{ActiveModelTrait, Set};
+use chrono::{Duration, Utc};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+
+async fn force_expired_agent_lease(store: &DbStore, id: AgentRunId) {
+    let past = Utc::now() - Duration::minutes(5);
+    crate::db::entities::agent_run::Entity::update_many()
+        .col_expr(
+            crate::db::entities::agent_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Some(past)),
+        )
+        .filter(crate::db::entities::agent_run::Column::Id.eq(id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+}
+
+async fn force_expired_agent_deadline(store: &DbStore, id: AgentRunId) {
+    let deadline = Utc::now() - Duration::minutes(5);
+    let created_at = deadline - Duration::hours(1);
+    crate::db::entities::agent_run::Entity::update_many()
+        .col_expr(
+            crate::db::entities::agent_run::Column::CreatedAt,
+            sea_orm::sea_query::Expr::value(created_at),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(created_at),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::DeadlineAt,
+            sea_orm::sea_query::Expr::value(Some(deadline)),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(deadline),
+        )
+        .filter(crate::db::entities::agent_run::Column::Id.eq(id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+}
 
 #[tokio::test]
 async fn foreground_and_sandbox_runs_roundtrip_with_exact_idempotency() {
@@ -23,6 +64,10 @@ async fn foreground_and_sandbox_runs_roundtrip_with_exact_idempotency() {
     assert_eq!(foreground.execution, AgentRunExecution::Foreground);
     assert_eq!(foreground.status, AgentRunStatus::Active);
     assert_eq!(foreground.input, None);
+    assert_eq!(foreground.attempt_count, 0);
+    assert_eq!(foreground.max_attempts, 0);
+    assert_eq!(foreground.claim_count, 0);
+    assert_eq!(foreground.deadline_at, None);
 
     assert!(matches!(
         store
@@ -61,6 +106,13 @@ async fn foreground_and_sandbox_runs_roundtrip_with_exact_idempotency() {
     assert_eq!(sandbox.depth, 1);
     assert_eq!(sandbox.execution, AgentRunExecution::Sandbox);
     assert_eq!(sandbox.status, AgentRunStatus::Queued);
+    assert_eq!(sandbox.attempt_count, 0);
+    assert_eq!(
+        sandbox.max_attempts,
+        crate::model::AgentRun::DEFAULT_MAX_ATTEMPTS
+    );
+    assert_eq!(sandbox.claim_count, 0);
+    assert!(sandbox.deadline_at.is_some());
     assert_eq!(
         sandbox.input.as_deref(),
         Some("Inspect the selected documents")
@@ -291,8 +343,343 @@ async fn agent_run_schema_rejects_cross_chat_parentage() {
         depth: Set(1),
         status: Set(AgentRunStatus::Queued.as_str().into()),
         input: Set(Some("cross-chat raw insert".into())),
+        attempt_count: Set(0),
+        max_attempts: Set(crate::model::AgentRun::DEFAULT_MAX_ATTEMPTS),
+        claim_count: Set(0),
+        available_at: Set(now),
+        deadline_at: Set(Some(now + crate::model::AgentRun::DEFAULT_MAX_DURATION)),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        started_at: Set(None),
+        finished_at: Set(None),
+        last_error_code: Set(None),
+        last_error_detail: Set(None),
         created_at: Set(now),
         updated_at: Set(now),
     };
     assert!(malformed.insert(&store.conn).await.is_err());
+
+    let partial_claim = crate::db::entities::agent_run_claim::ActiveModel {
+        token: Set(uuid::Uuid::new_v4()),
+        agent_run_id: Set(Some(AgentRunId::new().0)),
+        attempt_count: Set(None),
+        claim_count: Set(None),
+        claimed_at: Set(now),
+        lease_expires_at: Set(None),
+    };
+    assert!(partial_claim.insert(&store.conn).await.is_err());
+}
+
+#[tokio::test]
+async fn sandbox_claims_are_exact_reclaimable_and_heartbeatable() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let foreground_id = AgentRunId::foreground_for_chat(chat.id);
+    let child_id = AgentRunId::new();
+    let _child = match store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(foreground_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("claim and heartbeat"),
+        )
+        .await
+        .unwrap()
+    {
+        AcceptAgentRunOutcome::Accepted(run) => run,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+
+    let first_token = uuid::Uuid::new_v4();
+    let first = store
+        .claim_agent_run(first_token, Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.id, child_id);
+    assert_eq!(first.status, AgentRunStatus::Running);
+    assert_eq!(first.attempt_count, 1);
+    assert_eq!(first.claim_count, 1);
+    assert_eq!(first.lease_token, Some(first_token));
+    assert!(first.lease_expires_at.is_some());
+    assert_eq!(
+        store
+            .claim_agent_run(first_token, Duration::minutes(1), 2, 1)
+            .await
+            .unwrap(),
+        Some(first.clone())
+    );
+
+    assert!(!store
+        .heartbeat_agent_run(child_id, uuid::Uuid::new_v4(), Duration::minutes(1))
+        .await
+        .unwrap());
+    assert!(store
+        .heartbeat_agent_run(child_id, first_token, Duration::minutes(2))
+        .await
+        .unwrap());
+    assert!(!store
+        .heartbeat_agent_run(child_id, first_token, Duration::minutes(2))
+        .await
+        .unwrap());
+    assert!(!store
+        .heartbeat_agent_run(
+            child_id,
+            first_token,
+            AgentRun::DEFAULT_MAX_DURATION + Duration::seconds(1),
+        )
+        .await
+        .unwrap());
+
+    force_expired_agent_lease(&store, child_id).await;
+    let second_token = uuid::Uuid::new_v4();
+    let second = store
+        .claim_agent_run(second_token, Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(second.id, child_id);
+    assert_eq!(second.attempt_count, 2);
+    assert_eq!(second.claim_count, 2);
+    assert_eq!(second.lease_token, Some(second_token));
+    assert!(!store
+        .heartbeat_agent_run(child_id, first_token, Duration::minutes(1))
+        .await
+        .unwrap());
+
+    force_expired_agent_lease(&store, child_id).await;
+    let third_token = uuid::Uuid::new_v4();
+    let third = store
+        .claim_agent_run(third_token, Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(third.attempt_count, 3);
+
+    force_expired_agent_lease(&store, child_id).await;
+    let exhausted_scan = uuid::Uuid::new_v4();
+    assert!(store
+        .claim_agent_run(exhausted_scan, Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .is_none());
+    let failed = store.get_agent_run(child_id).await.unwrap().unwrap();
+    assert_eq!(failed.status, AgentRunStatus::Failed);
+    assert_eq!(failed.last_error_code.as_deref(), Some("lease_expired"));
+    assert!(failed.finished_at.is_some());
+
+    let later_chat = sample_chat();
+    store.create_chat(&later_chat).await.unwrap();
+    store
+        .accept_agent_run(
+            AgentRunId::new(),
+            later_chat.id,
+            Some(AgentRunId::foreground_for_chat(later_chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("later work"),
+        )
+        .await
+        .unwrap();
+    assert!(store
+        .claim_agent_run(exhausted_scan, Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn sandbox_claims_enforce_global_and_per_chat_limits() {
+    let (_dir, store) = temp_store().await;
+    let first_chat = sample_chat();
+    let second_chat = sample_chat();
+    store.create_chat(&first_chat).await.unwrap();
+    store.create_chat(&second_chat).await.unwrap();
+    let mut accepted = Vec::new();
+    for (chat_id, task) in [
+        (first_chat.id, "first-a"),
+        (first_chat.id, "first-b"),
+        (second_chat.id, "second-a"),
+    ] {
+        let run = match store
+            .accept_agent_run(
+                AgentRunId::new(),
+                chat_id,
+                Some(AgentRunId::foreground_for_chat(chat_id)),
+                Some(CallId::new()),
+                AgentRunExecution::Sandbox,
+                Some(task),
+            )
+            .await
+            .unwrap()
+        {
+            AcceptAgentRunOutcome::Accepted(run) => run,
+            outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+        };
+        accepted.push(run);
+    }
+
+    let first = store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    let second = store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_ne!(first.chat_id, second.chat_id);
+    assert!(store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn sandbox_claim_terminalizes_expired_deadlines() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let child_id = AgentRunId::new();
+    let child = match store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("deadline"),
+        )
+        .await
+        .unwrap()
+    {
+        AcceptAgentRunOutcome::Accepted(run) => run,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    force_expired_agent_deadline(&store, child.id).await;
+    assert!(store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .is_none());
+    let failed = store.get_agent_run(child_id).await.unwrap().unwrap();
+    assert_eq!(failed.status, AgentRunStatus::Failed);
+    assert_eq!(failed.last_error_code.as_deref(), Some("deadline_exceeded"));
+}
+
+#[tokio::test]
+async fn expired_cancelling_sandbox_run_is_reaped_and_releases_capacity() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    let other_chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    store.create_chat(&other_chat).await.unwrap();
+    let child_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("cancellation reaper"),
+        )
+        .await
+        .unwrap();
+    store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    let other_child_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            other_child_id,
+            other_chat.id,
+            Some(AgentRunId::foreground_for_chat(other_chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("capacity-consuming live worker"),
+        )
+        .await
+        .unwrap();
+    let other = store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(other.id, other_child_id);
+    crate::db::entities::agent_run::Entity::update_many()
+        .col_expr(
+            crate::db::entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunStatus::Cancelling.as_str()),
+        )
+        .filter(crate::db::entities::agent_run::Column::Id.eq(child_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    force_expired_agent_lease(&store, child_id).await;
+
+    assert!(store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .is_none());
+    let cancelled = store.get_agent_run(child_id).await.unwrap().unwrap();
+    assert_eq!(cancelled.status, AgentRunStatus::Cancelled);
+    assert!(cancelled.finished_at.is_some());
+    assert_eq!(cancelled.lease_token, None);
+}
+
+#[tokio::test]
+async fn concurrent_sandbox_claimers_respect_both_limits() {
+    let (_dir, store) = temp_store().await;
+    let first_chat = sample_chat();
+    let second_chat = sample_chat();
+    store.create_chat(&first_chat).await.unwrap();
+    store.create_chat(&second_chat).await.unwrap();
+    for chat_id in [first_chat.id, first_chat.id, second_chat.id, second_chat.id] {
+        let _accepted = match store
+            .accept_agent_run(
+                AgentRunId::new(),
+                chat_id,
+                Some(AgentRunId::foreground_for_chat(chat_id)),
+                Some(CallId::new()),
+                AgentRunExecution::Sandbox,
+                Some("concurrent claim"),
+            )
+            .await
+            .unwrap()
+        {
+            AcceptAgentRunOutcome::Accepted(run) => run,
+            outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+        };
+    }
+
+    let store = std::sync::Arc::new(store);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
+                .await
+                .unwrap()
+        }));
+    }
+    let claimed = futures::future::join_all(tasks)
+        .await
+        .into_iter()
+        .filter_map(|result| result.unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(claimed.len(), 2);
+    assert_ne!(claimed[0].chat_id, claimed[1].chat_id);
 }

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1098,6 +1098,30 @@ pub struct AgentRun {
     pub status: AgentRunStatus,
     /// Exact delegated task for a sandbox run. Foreground runs have no task.
     pub input: Option<String>,
+    /// Failure attempts already started. Reclaiming an expired lease starts a
+    /// new attempt; later continuation resumptions will not.
+    pub attempt_count: i32,
+    /// Maximum failure attempts permitted for this run.
+    pub max_attempts: i32,
+    /// Exact worker lease segments issued over the run's lifetime.
+    pub claim_count: i32,
+    /// Earliest time queued or retry-wait work may be claimed.
+    pub available_at: DateTime<Utc>,
+    /// Absolute wall-clock limit for sandbox work. Foreground coordinators do
+    /// not carry a scheduler deadline.
+    pub deadline_at: Option<DateTime<Utc>>,
+    /// Exact worker claim identity while running or cancelling.
+    pub lease_token: Option<Uuid>,
+    /// When the current worker claim becomes stale.
+    pub lease_expires_at: Option<DateTime<Utc>>,
+    /// When the first worker claim began.
+    pub started_at: Option<DateTime<Utc>>,
+    /// When the run entered a terminal state.
+    pub finished_at: Option<DateTime<Utc>>,
+    /// Stable machine-readable failure category.
+    pub last_error_code: Option<String>,
+    /// Bounded diagnostic detail for local operators.
+    pub last_error_detail: Option<String>,
     /// When the run was durably accepted.
     pub created_at: DateTime<Utc>,
     /// When its durable state last changed.
@@ -1109,6 +1133,16 @@ impl AgentRun {
     pub const MAX_DEPTH: u8 = 1;
     /// Maximum persisted delegated task length.
     pub const MAX_INPUT_LEN: usize = 65_536;
+    /// Default failure-attempt budget for sandboxed work.
+    pub const DEFAULT_MAX_ATTEMPTS: i32 = 3;
+    /// Default wall-clock budget for one sandbox run.
+    pub const DEFAULT_MAX_DURATION: chrono::Duration = chrono::Duration::hours(1);
+    /// Largest accepted scheduler concurrency bound.
+    pub const MAX_CONCURRENCY_LIMIT: u32 = 1_024;
+    /// Maximum stable failure-category length.
+    pub const MAX_ERROR_CODE_LEN: usize = 128;
+    /// Maximum persisted diagnostic-detail length.
+    pub const MAX_ERROR_DETAIL_LEN: usize = 4_096;
 }
 
 /// Execution boundary for an [`AgentRun`].
@@ -1144,6 +1178,8 @@ pub enum AgentRunStatus {
     Queued,
     /// One exact scheduler lease currently owns the run.
     Running,
+    /// Cancellation was requested while an exact worker lease remained live.
+    Cancelling,
     /// The run checkpointed and released its worker for a durable dependency.
     Waiting,
     /// Replay-safe work awaits another scheduler claim.
@@ -1164,6 +1200,7 @@ impl AgentRunStatus {
             Self::Active => "active",
             Self::Queued => "queued",
             Self::Running => "running",
+            Self::Cancelling => "cancelling",
             Self::Waiting => "waiting",
             Self::RetryWait => "retry_wait",
             Self::Completed => "completed",

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -924,6 +924,35 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// Atomically claim the oldest due sandbox run under exact bounded lease
+    /// ownership.
+    ///
+    /// The global scheduler lock makes global and per-chat concurrency limits
+    /// race-safe across processes. Expired leases are reclaimed only while the
+    /// attempt budget remains; exhausted attempts and wall-clock deadlines are
+    /// terminalized before scanning continues. Reusing `lease_token` recovers
+    /// only its original still-live claim and can never claim different work.
+    async fn claim_agent_run(
+        &self,
+        _lease_token: uuid::Uuid,
+        _lease_duration: chrono::Duration,
+        _max_running_global: u32,
+        _max_running_per_chat: u32,
+    ) -> Result<Option<AgentRun>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Monotonically extend one exact live sandbox lease without resurrecting
+    /// expiry or crossing the run's absolute deadline.
+    async fn heartbeat_agent_run(
+        &self,
+        _id: AgentRunId,
+        _lease_token: uuid::Uuid,
+        _lease_duration: chrono::Duration,
+    ) -> Result<bool> {
+        agent_run_storage_unavailable()
+    }
+
     /// Fetch one durable turn by its exact idempotency identity.
     async fn get_turn_run(&self, _id: TurnId) -> Result<Option<TurnRun>> {
         turn_storage_unavailable()

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "postgres")]
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration as StdDuration};
 
 use chrono::{Duration, Utc};
 use openwave_core::{
@@ -16,6 +16,7 @@ use openwave_core::{
     ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress, TurnFailureRetry,
     TurnId, TurnRunStatus, TurnSteerId, TurnSteerStatus, Usage,
 };
+use sea_orm::{ConnectionTrait, Database, DatabaseBackend, Statement, TransactionTrait};
 
 static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
@@ -116,7 +117,7 @@ async fn postgres_agent_run_identity_collision_recovers_exactly_across_chats() {
         }
         Err(_) => return,
     };
-    let store = Arc::new(DbStore::connect(&url).await.unwrap());
+    let store = DbStore::connect(&url).await.unwrap();
     let first_chat = sample_chat();
     let second_chat = sample_chat();
     store.create_chat(&first_chat).await.unwrap();
@@ -157,6 +158,151 @@ async fn postgres_agent_run_identity_collision_recovers_exactly_across_chats() {
         }
     }
     assert_eq!((accepted, conflicted), (1, 1));
+}
+
+#[tokio::test]
+async fn postgres_concurrent_sandbox_claims_respect_global_and_per_chat_limits() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = Arc::new(DbStore::connect(&url).await.unwrap());
+    let first_chat = sample_chat();
+    let second_chat = sample_chat();
+    store.create_chat(&first_chat).await.unwrap();
+    store.create_chat(&second_chat).await.unwrap();
+    for chat_id in [first_chat.id, first_chat.id, second_chat.id, second_chat.id] {
+        let _accepted = match store
+            .accept_agent_run(
+                AgentRunId::new(),
+                chat_id,
+                Some(AgentRunId::foreground_for_chat(chat_id)),
+                Some(CallId::new()),
+                AgentRunExecution::Sandbox,
+                Some("postgres concurrent claim"),
+            )
+            .await
+            .unwrap()
+        {
+            AcceptAgentRunOutcome::Accepted(run) => run,
+            outcome => panic!("unexpected sandbox outcome: {outcome:?}"),
+        };
+    }
+    let barrier = Arc::new(tokio::sync::Barrier::new(8));
+    let mut claimers = Vec::new();
+    for _ in 0..8 {
+        claimers.push(DbStore::connect(&url).await.unwrap());
+    }
+    let mut tasks = Vec::new();
+    for store in claimers {
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
+                .await
+                .unwrap()
+        }));
+    }
+    let claimed = futures::future::join_all(tasks)
+        .await
+        .into_iter()
+        .filter_map(|result| result.unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(claimed.len(), 2);
+    assert_ne!(claimed[0].chat_id, claimed[1].chat_id);
+}
+
+#[tokio::test]
+async fn postgres_sandbox_claim_uses_statement_time_after_scheduler_lock_wait() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let child_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("scheduler lock clock regression"),
+        )
+        .await
+        .unwrap();
+
+    let blocker = Database::connect(&url).await.unwrap();
+    blocker
+        .execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "UPDATE agent_run \
+                 SET created_at = TIMESTAMPTZ '2000-01-01 00:00:00+00', \
+                     available_at = TIMESTAMPTZ '2000-01-01 00:00:00+00', \
+                     updated_at = clock_timestamp() \
+                 WHERE id = '{}'",
+                child_id.0
+            ),
+        ))
+        .await
+        .unwrap();
+    let transaction = blocker.begin().await.unwrap();
+    transaction
+        .execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "UPDATE agent_run_claim_lock SET id = id WHERE id = 1",
+        ))
+        .await
+        .unwrap();
+
+    let claimant = DbStore::connect(&url).await.unwrap();
+    let claim = tokio::spawn(async move {
+        claimant
+            .claim_agent_run(
+                uuid::Uuid::new_v4(),
+                Duration::milliseconds(100),
+                1_024,
+                1_024,
+            )
+            .await
+            .unwrap()
+            .unwrap()
+    });
+    // Give the claimant time to begin its transaction and block on the row.
+    // The wait is deliberately longer than the requested lease duration.
+    tokio::time::sleep(StdDuration::from_millis(500)).await;
+    transaction.commit().await.unwrap();
+
+    let claimed = claim.await.unwrap();
+    assert_eq!(claimed.id, child_id);
+    assert!(claimed.lease_expires_at.unwrap() > Utc::now());
+    // The integration suite shares an isolated database, so leave no live
+    // scheduler capacity behind for its independent concurrency cases.
+    blocker
+        .execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "UPDATE agent_run \
+                 SET status = 'completed', lease_token = NULL, lease_expires_at = NULL, \
+                     finished_at = clock_timestamp(), updated_at = clock_timestamp() \
+                 WHERE id = '{}'",
+                child_id.0
+            ),
+        ))
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -119,6 +119,23 @@ waiting agent does not consume a running slot. Cancellation of a foreground run
 also cancels its owned queued or running children in the initial model; detached
 agents are intentionally deferred.
 
+The scheduler's ownership rules are deliberately strict:
+
+- a singleton durable scheduler lock makes global and per-chat running caps
+  atomic across local processes;
+- scheduler ownership uses the database clock rather than a worker-supplied
+  timestamp, so a skewed local process cannot steal a live lease;
+- every claim has a unique receipt, including an empty scan, so retrying a
+  claim token can recover only its original running lease or its original
+  no-work result;
+- a running lease has a monotonically extendable expiry and never outlives the
+  run's absolute wall-clock deadline;
+- an expired lease starts a new attempt only while budget remains; exhausted
+  attempts and deadlines become durable terminal failures, while an expired
+  cancellation fence becomes `cancelled` and releases capacity;
+- a worker's writes must carry its exact live lease token, so a reclaimed or
+  expired worker cannot resume ownership.
+
 ## Reliability contract
 
 The agent hierarchy preserves the runtime's existing rules:


### PR DESCRIPTION
## Summary

- add durable sandbox attempt, deadline, lease, and claim-receipt state
- enforce global and per-chat scheduler limits under a database lock
- reclaim stale work safely, including expired cancellation fences
- cover SQLite concurrency plus PostgreSQL lock-wait clock behavior

## Validation

- cargo test -p openwave-core --lib --locked
- OPENWAVE_POSTGRES_TEST_URL=… cargo test -p openwave-core --no-default-features --features postgres --test postgres_turn_state --locked
- bw dev lint --rust --check