### PR TITLE
Resolve sandbox agent runs

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -402,6 +402,47 @@ pub mod agent_run_claim_lock {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod agent_run_result {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "agent_run_result")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub agent_run_id: Uuid,
+        pub lease_token: Uuid,
+        pub attempt_count: i32,
+        pub claim_count: i32,
+        pub text: String,
+        pub submitted_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod agent_run_cancellation {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "agent_run_cancellation")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub agent_run_id: Uuid,
+        pub lease_token: Uuid,
+        pub attempt_count: i32,
+        pub claim_count: i32,
+        pub cancelled_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod turn_run {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -401,6 +401,138 @@ async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr
     Ok(())
 }
 
+async fn create_agent_run_result_table(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(AgentRunResult::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(AgentRunResult::AgentRunId)
+                        .uuid()
+                        .not_null()
+                        .primary_key(),
+                )
+                .col(ColumnDef::new(AgentRunResult::LeaseToken).uuid().not_null())
+                .col(
+                    ColumnDef::new(AgentRunResult::AttemptCount)
+                        .integer()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunResult::ClaimCount)
+                        .integer()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(AgentRunResult::Text).text().not_null())
+                .col(
+                    ColumnDef::new(AgentRunResult::SubmittedAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_agent_run_result_run")
+                        .from(AgentRunResult::Table, AgentRunResult::AgentRunId)
+                        .to(AgentRun::Table, AgentRun::Id)
+                        .on_delete(ForeignKeyAction::Restrict),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_agent_run_result_claim")
+                        .from_tbl(AgentRunResult::Table)
+                        .from_col(AgentRunResult::LeaseToken)
+                        .from_col(AgentRunResult::AgentRunId)
+                        .from_col(AgentRunResult::AttemptCount)
+                        .from_col(AgentRunResult::ClaimCount)
+                        .to_tbl(AgentRunClaim::Table)
+                        .to_col(AgentRunClaim::Token)
+                        .to_col(AgentRunClaim::AgentRunId)
+                        .to_col(AgentRunClaim::AttemptCount)
+                        .to_col(AgentRunClaim::ClaimCount)
+                        .on_delete(ForeignKeyAction::Restrict),
+                )
+                .check(Expr::col(AgentRunResult::AttemptCount).gte(1))
+                .check(
+                    Expr::col(AgentRunResult::ClaimCount)
+                        .gte(Expr::col(AgentRunResult::AttemptCount)),
+                )
+                .check(
+                    Func::char_length(Expr::col(AgentRunResult::Text))
+                        .between(1, crate::model::AgentRun::MAX_RESULT_LEN as i32),
+                )
+                .to_owned(),
+        )
+        .await
+}
+
+async fn create_agent_run_cancellation_table(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(AgentRunCancellation::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(AgentRunCancellation::AgentRunId)
+                        .uuid()
+                        .not_null()
+                        .primary_key(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunCancellation::LeaseToken)
+                        .uuid()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunCancellation::AttemptCount)
+                        .integer()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunCancellation::ClaimCount)
+                        .integer()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunCancellation::CancelledAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_agent_run_cancellation_run")
+                        .from(
+                            AgentRunCancellation::Table,
+                            AgentRunCancellation::AgentRunId,
+                        )
+                        .to(AgentRun::Table, AgentRun::Id)
+                        .on_delete(ForeignKeyAction::Restrict),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_agent_run_cancellation_claim")
+                        .from_tbl(AgentRunCancellation::Table)
+                        .from_col(AgentRunCancellation::LeaseToken)
+                        .from_col(AgentRunCancellation::AgentRunId)
+                        .from_col(AgentRunCancellation::AttemptCount)
+                        .from_col(AgentRunCancellation::ClaimCount)
+                        .to_tbl(AgentRunClaim::Table)
+                        .to_col(AgentRunClaim::Token)
+                        .to_col(AgentRunClaim::AgentRunId)
+                        .to_col(AgentRunClaim::AttemptCount)
+                        .to_col(AgentRunClaim::ClaimCount)
+                        .on_delete(ForeignKeyAction::Restrict),
+                )
+                .check(Expr::col(AgentRunCancellation::AttemptCount).gte(1))
+                .check(
+                    Expr::col(AgentRunCancellation::ClaimCount)
+                        .gte(Expr::col(AgentRunCancellation::AttemptCount)),
+                )
+                .to_owned(),
+        )
+        .await
+}
+
 struct Init;
 
 impl MigrationName for Init {
@@ -475,6 +607,8 @@ impl MigrationTrait for Init {
             .await?;
 
         create_agent_run_table(manager).await?;
+        create_agent_run_result_table(manager).await?;
+        create_agent_run_cancellation_table(manager).await?;
 
         manager
             .create_table(
@@ -1358,6 +1492,12 @@ impl MigrationTrait for Init {
             .await?;
         manager
             .drop_table(Table::drop().table(TurnRun::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(AgentRunResult::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(AgentRunCancellation::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(AgentRun::Table).to_owned())
@@ -3146,6 +3286,27 @@ enum AgentRunClaim {
 enum AgentRunClaimLock {
     Table,
     Id,
+}
+
+#[derive(DeriveIden)]
+enum AgentRunResult {
+    Table,
+    AgentRunId,
+    LeaseToken,
+    AttemptCount,
+    ClaimCount,
+    Text,
+    SubmittedAt,
+}
+
+#[derive(DeriveIden)]
+enum AgentRunCancellation {
+    Table,
+    AgentRunId,
+    LeaseToken,
+    AttemptCount,
+    ClaimCount,
+    CancelledAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -41,10 +41,12 @@ use crate::storage::{
     AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
     BeginRootAttachmentChangeOutcome, ClaimClientToolCallOutcome, ClaimTurnRunOutcome,
     CompleteTurnRunOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
-    EnsureDocumentParseJobOutcome, FinishRootAttachmentChangeOutcome,
-    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
-    JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome,
-    RecordTurnFailureOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome, Store,
+    EnsureDocumentParseJobOutcome, FinishAgentRunCancellationOutcome,
+    FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
+    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledTurnOutcome,
+    JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
+    RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome,
+    Store, SubmitAgentRunResultOutcome,
 };
 
 mod ops;
@@ -1776,6 +1778,30 @@ impl Store for DbStore {
         lease_duration: chrono::Duration,
     ) -> Result<bool> {
         ops::agent_run::heartbeat_agent_run(self, id, lease_token, lease_duration).await
+    }
+
+    async fn request_agent_run_cancellation(
+        &self,
+        id: AgentRunId,
+    ) -> Result<Option<RequestAgentRunCancellationOutcome>> {
+        ops::agent_run::request_agent_run_cancellation(self, id).await
+    }
+
+    async fn finish_agent_run_cancellation(
+        &self,
+        id: AgentRunId,
+        lease_token: uuid::Uuid,
+    ) -> Result<Option<FinishAgentRunCancellationOutcome>> {
+        ops::agent_run::finish_agent_run_cancellation(self, id, lease_token).await
+    }
+
+    async fn submit_agent_run_result(
+        &self,
+        id: AgentRunId,
+        lease_token: uuid::Uuid,
+        text: &str,
+    ) -> Result<Option<SubmitAgentRunResultOutcome>> {
+        ops::agent_run::submit_agent_run_result(self, id, lease_token, text).await
     }
 
     async fn get_turn_run(&self, id: TurnId) -> Result<Option<TurnRun>> {

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -6,8 +6,11 @@ use sea_orm::{
 
 use crate::error::{AgentError, Result};
 use crate::id::{AgentRunId, CallId, ChatId};
-use crate::model::{AgentRun, AgentRunExecution, AgentRunStatus};
-use crate::storage::AcceptAgentRunOutcome;
+use crate::model::{AgentRun, AgentRunExecution, AgentRunResult, AgentRunStatus};
+use crate::storage::{
+    AcceptAgentRunOutcome, FinishAgentRunCancellationOutcome, RequestAgentRunCancellationOutcome,
+    SubmitAgentRunResultOutcome,
+};
 
 use super::super::{entities, store_err, DbStore};
 use super::{acquire_chat_write_lock, turn::canonical_db_timestamp};
@@ -474,7 +477,12 @@ pub(in crate::db) async fn heartbeat_agent_run(
             "agent-run heartbeat requires a non-nil token and positive duration".into(),
         ));
     }
-    let now = database_now(&store.conn).await?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    // Serialize lease extension with claim, cancellation, and terminal
+    // resolution. Otherwise a racing heartbeat could make a one-shot durable
+    // cancellation request lose its compare-and-swap.
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
     let lease_expires_at = now.checked_add_signed(lease_duration).ok_or_else(|| {
         AgentError::Store("agent-run lease duration overflows the database timestamp range".into())
     })?;
@@ -496,10 +504,352 @@ pub(in crate::db) async fn heartbeat_agent_run(
         .filter(entities::agent_run::Column::DeadlineAt.gt(now))
         .filter(entities::agent_run::Column::DeadlineAt.gte(lease_expires_at))
         .filter(entities::agent_run::Column::UpdatedAt.lte(now))
-        .exec(&store.conn)
+        .exec(&transaction)
         .await
         .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
     Ok(heartbeat.rows_affected == 1)
+}
+
+pub(in crate::db) async fn request_agent_run_cancellation(
+    store: &DbStore,
+    id: AgentRunId,
+) -> Result<Option<RequestAgentRunCancellationOutcome>> {
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
+    let Some(run) = find_by_id_on(&transaction, id).await? else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if run.execution != AgentRunExecution::Sandbox.as_str() {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let status = agent_run_status_from_db(&run.status)?;
+    let existing = match status {
+        AgentRunStatus::Cancelling | AgentRunStatus::Cancelled => Some(
+            RequestAgentRunCancellationOutcome::Existing(agent_run_from_model(run.clone())?),
+        ),
+        AgentRunStatus::Completed | AgentRunStatus::Failed => Some(
+            RequestAgentRunCancellationOutcome::AlreadyTerminal(agent_run_from_model(run.clone())?),
+        ),
+        AgentRunStatus::Queued | AgentRunStatus::Waiting | AgentRunStatus::RetryWait => None,
+        AgentRunStatus::Running | AgentRunStatus::Active => None,
+    };
+    if let Some(outcome) = existing {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(outcome));
+    }
+    if run.updated_at > now {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let immediate = status != AgentRunStatus::Running
+        || !run.lease_expires_at.is_some_and(|expiry| expiry > now)
+        || !run.deadline_at.is_some_and(|deadline| deadline > now);
+    let next_status = if immediate {
+        AgentRunStatus::Cancelled
+    } else {
+        AgentRunStatus::Cancelling
+    };
+    let mut update = entities::agent_run::Entity::update_many()
+        .col_expr(
+            entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(next_status.as_str()),
+        )
+        .col_expr(
+            entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::agent_run::Column::Id.eq(id.0))
+        .filter(entities::agent_run::Column::Status.eq(&run.status))
+        .filter(entities::agent_run::Column::AttemptCount.eq(run.attempt_count))
+        .filter(entities::agent_run::Column::ClaimCount.eq(run.claim_count))
+        .filter(entities::agent_run::Column::UpdatedAt.eq(run.updated_at))
+        .filter(entities::agent_run::Column::UpdatedAt.lte(now));
+    if immediate {
+        update = update
+            .col_expr(
+                entities::agent_run::Column::LeaseToken,
+                sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+            )
+            .col_expr(
+                entities::agent_run::Column::LeaseExpiresAt,
+                sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+            )
+            .col_expr(
+                entities::agent_run::Column::FinishedAt,
+                sea_orm::sea_query::Expr::value(Some(now)),
+            )
+            .col_expr(
+                entities::agent_run::Column::LastErrorCode,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            )
+            .col_expr(
+                entities::agent_run::Column::LastErrorDetail,
+                sea_orm::sea_query::Expr::value(Option::<String>::None),
+            );
+    } else {
+        update = update
+            .filter(entities::agent_run::Column::LeaseToken.eq(run.lease_token))
+            .filter(entities::agent_run::Column::LeaseExpiresAt.eq(run.lease_expires_at))
+            .filter(entities::agent_run::Column::LeaseExpiresAt.gt(now));
+    }
+    let updated = update.exec(&transaction).await.map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let updated = find_by_id_on(&transaction, id)
+        .await?
+        .ok_or_else(|| AgentError::Store(format!("cancelled agent run {id} disappeared")))
+        .and_then(agent_run_from_model)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(if immediate {
+        RequestAgentRunCancellationOutcome::Cancelled(updated)
+    } else {
+        RequestAgentRunCancellationOutcome::Requested(updated)
+    }))
+}
+
+pub(in crate::db) async fn finish_agent_run_cancellation(
+    store: &DbStore,
+    id: AgentRunId,
+    lease_token: uuid::Uuid,
+) -> Result<Option<FinishAgentRunCancellationOutcome>> {
+    if lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "agent-run cancellation requires a non-nil lease token".into(),
+        ));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
+    if let Some(receipt) = entities::agent_run_cancellation::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        if receipt.lease_token != lease_token {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(None);
+        }
+        let Some(run) = find_by_id_on(&transaction, id).await? else {
+            return Err(AgentError::Store(format!(
+                "agent-run cancellation receipt references missing run {id}"
+            )));
+        };
+        if run.status != AgentRunStatus::Cancelled.as_str()
+            || run.attempt_count != receipt.attempt_count
+            || run.claim_count != receipt.claim_count
+        {
+            return Err(AgentError::Store(format!(
+                "agent-run cancellation receipt does not match terminal run {id}"
+            )));
+        }
+        let run = agent_run_from_model(run)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(FinishAgentRunCancellationOutcome::Existing(run)));
+    }
+    let Some(claim) = entities::agent_run_claim::Entity::find_by_id(lease_token)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .filter(|claim| claim.agent_run_id == Some(id.0))
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let Some(run) = find_by_id_on(&transaction, id).await? else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if run.execution != AgentRunExecution::Sandbox.as_str()
+        || Some(run.attempt_count) != claim.attempt_count
+        || Some(run.claim_count) != claim.claim_count
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    if run.status != AgentRunStatus::Cancelling.as_str()
+        || run.lease_token != Some(lease_token)
+        || !run.lease_expires_at.is_some_and(|expiry| expiry > now)
+        || !run.deadline_at.is_some_and(|deadline| deadline > now)
+        || run.updated_at > now
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    entities::agent_run_cancellation::ActiveModel {
+        agent_run_id: Set(id.0),
+        lease_token: Set(lease_token),
+        attempt_count: Set(run.attempt_count),
+        claim_count: Set(run.claim_count),
+        cancelled_at: Set(now),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    let updated = entities::agent_run::Entity::update_many()
+        .col_expr(
+            entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunStatus::Cancelled.as_str()),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            entities::agent_run::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::agent_run::Column::Id.eq(id.0))
+        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Cancelling.as_str()))
+        .filter(entities::agent_run::Column::AttemptCount.eq(run.attempt_count))
+        .filter(entities::agent_run::Column::ClaimCount.eq(run.claim_count))
+        .filter(entities::agent_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::agent_run::Column::LeaseExpiresAt.eq(run.lease_expires_at))
+        .filter(entities::agent_run::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::agent_run::Column::DeadlineAt.gt(now))
+        .filter(entities::agent_run::Column::UpdatedAt.eq(run.updated_at))
+        .filter(entities::agent_run::Column::UpdatedAt.lte(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let updated = find_by_id_on(&transaction, id)
+        .await?
+        .ok_or_else(|| AgentError::Store(format!("cancelled agent run {id} disappeared")))
+        .and_then(agent_run_from_model)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(FinishAgentRunCancellationOutcome::Cancelled(updated)))
+}
+
+pub(in crate::db) async fn submit_agent_run_result(
+    store: &DbStore,
+    id: AgentRunId,
+    lease_token: uuid::Uuid,
+    text: &str,
+) -> Result<Option<SubmitAgentRunResultOutcome>> {
+    if lease_token.is_nil() || text.is_empty() || text.chars().count() > AgentRun::MAX_RESULT_LEN {
+        return Err(AgentError::Store(format!(
+            "agent-run result requires a non-nil lease token and 1..={} characters",
+            AgentRun::MAX_RESULT_LEN
+        )));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
+    if let Some(result) = entities::agent_run_result::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let result = agent_run_result_from_model(result)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok((result.lease_token == lease_token && result.text == text)
+            .then_some(SubmitAgentRunResultOutcome::Existing(result)));
+    }
+    let Some(run) = find_by_id_on(&transaction, id).await? else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if run.execution != AgentRunExecution::Sandbox.as_str()
+        || run.status != AgentRunStatus::Running.as_str()
+        || run.lease_token != Some(lease_token)
+        || !run.lease_expires_at.is_some_and(|expiry| expiry > now)
+        || !run.deadline_at.is_some_and(|deadline| deadline > now)
+        || run.updated_at > now
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    entities::agent_run_result::ActiveModel {
+        agent_run_id: Set(id.0),
+        lease_token: Set(lease_token),
+        attempt_count: Set(run.attempt_count),
+        claim_count: Set(run.claim_count),
+        text: Set(text.to_owned()),
+        submitted_at: Set(now),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    let updated = entities::agent_run::Entity::update_many()
+        .col_expr(
+            entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunStatus::Completed.as_str()),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            entities::agent_run::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::agent_run::Column::Id.eq(id.0))
+        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Running.as_str()))
+        .filter(entities::agent_run::Column::AttemptCount.eq(run.attempt_count))
+        .filter(entities::agent_run::Column::ClaimCount.eq(run.claim_count))
+        .filter(entities::agent_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::agent_run::Column::LeaseExpiresAt.eq(run.lease_expires_at))
+        .filter(entities::agent_run::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::agent_run::Column::DeadlineAt.gt(now))
+        .filter(entities::agent_run::Column::UpdatedAt.eq(run.updated_at))
+        .filter(entities::agent_run::Column::UpdatedAt.lte(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let result = entities::agent_run_result::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("completed agent run {id} is missing its result")))
+        .and_then(agent_run_result_from_model)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(SubmitAgentRunResultOutcome::Completed(result)))
 }
 
 fn validate_claim_request(
@@ -833,22 +1183,7 @@ fn agent_run_from_model(model: entities::agent_run::Model) -> Result<AgentRun> {
             )))
         }
     };
-    let status = match model.status.as_str() {
-        "active" => AgentRunStatus::Active,
-        "queued" => AgentRunStatus::Queued,
-        "running" => AgentRunStatus::Running,
-        "cancelling" => AgentRunStatus::Cancelling,
-        "waiting" => AgentRunStatus::Waiting,
-        "retry_wait" => AgentRunStatus::RetryWait,
-        "completed" => AgentRunStatus::Completed,
-        "failed" => AgentRunStatus::Failed,
-        "cancelled" => AgentRunStatus::Cancelled,
-        value => {
-            return Err(AgentError::Store(format!(
-                "invalid agent-run status {value}"
-            )))
-        }
-    };
+    let status = agent_run_status_from_db(&model.status)?;
     validate_stored_shape(&model, execution, status)?;
     Ok(AgentRun {
         id: AgentRunId(model.id),
@@ -873,6 +1208,45 @@ fn agent_run_from_model(model: entities::agent_run::Model) -> Result<AgentRun> {
         last_error_detail: model.last_error_detail,
         created_at: model.created_at,
         updated_at: model.updated_at,
+    })
+}
+
+fn agent_run_status_from_db(value: &str) -> Result<AgentRunStatus> {
+    let status = match value {
+        "active" => AgentRunStatus::Active,
+        "queued" => AgentRunStatus::Queued,
+        "running" => AgentRunStatus::Running,
+        "cancelling" => AgentRunStatus::Cancelling,
+        "waiting" => AgentRunStatus::Waiting,
+        "retry_wait" => AgentRunStatus::RetryWait,
+        "completed" => AgentRunStatus::Completed,
+        "failed" => AgentRunStatus::Failed,
+        "cancelled" => AgentRunStatus::Cancelled,
+        value => {
+            return Err(AgentError::Store(format!(
+                "invalid agent-run status {value}"
+            )))
+        }
+    };
+    Ok(status)
+}
+
+fn agent_run_result_from_model(model: entities::agent_run_result::Model) -> Result<AgentRunResult> {
+    if model.lease_token.is_nil()
+        || model.attempt_count < 1
+        || model.claim_count < model.attempt_count
+        || model.text.is_empty()
+        || model.text.chars().count() > AgentRun::MAX_RESULT_LEN
+    {
+        return Err(AgentError::Store("invalid stored agent-run result".into()));
+    }
+    Ok(AgentRunResult {
+        agent_run_id: AgentRunId(model.agent_run_id),
+        lease_token: model.lease_token,
+        attempt_count: model.attempt_count,
+        claim_count: model.claim_count,
+        text: model.text,
+        submitted_at: model.submitted_at,
     })
 }
 

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -1,7 +1,8 @@
 use super::{sample_chat, temp_store};
 use crate::{
     AcceptAgentRunOutcome, AgentRun, AgentRunExecution, AgentRunId, AgentRunStatus, CallId, ChatId,
-    DbStore, Store,
+    DbStore, FinishAgentRunCancellationOutcome, RequestAgentRunCancellationOutcome, Store,
+    SubmitAgentRunResultOutcome,
 };
 use chrono::{Duration, Utc};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
@@ -486,6 +487,224 @@ async fn sandbox_claims_are_exact_reclaimable_and_heartbeatable() {
         .unwrap();
     assert!(store
         .claim_agent_run(exhausted_scan, Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn sandbox_result_submission_is_fenced_and_idempotent() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let child_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("return a concise result"),
+        )
+        .await
+        .unwrap();
+    let lease_token = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(lease_token, Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let result = match store
+        .submit_agent_run_result(child_id, lease_token, "finished analysis")
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        SubmitAgentRunResultOutcome::Completed(result) => result,
+        outcome => panic!("unexpected result submission outcome: {outcome:?}"),
+    };
+    assert_eq!(result.agent_run_id, child_id);
+    assert_eq!(result.lease_token, lease_token);
+    assert_eq!(result.text, "finished analysis");
+    let completed = store.get_agent_run(child_id).await.unwrap().unwrap();
+    assert_eq!(completed.status, AgentRunStatus::Completed);
+    assert_eq!(completed.lease_token, None);
+    assert!(completed.finished_at.is_some());
+    assert!(matches!(
+        store
+            .submit_agent_run_result(child_id, lease_token, "finished analysis")
+            .await
+            .unwrap(),
+        Some(SubmitAgentRunResultOutcome::Existing(existing)) if existing == result
+    ));
+    assert!(store
+        .submit_agent_run_result(child_id, uuid::Uuid::new_v4(), "finished analysis")
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .submit_agent_run_result(child_id, lease_token, "different result")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn sandbox_cancellation_fences_running_work_and_recovers_exact_acknowledgement() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let queued_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            queued_id,
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("cancel before claim"),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        store.request_agent_run_cancellation(queued_id).await.unwrap(),
+        Some(RequestAgentRunCancellationOutcome::Cancelled(run)) if run.status == AgentRunStatus::Cancelled
+    ));
+    assert!(matches!(
+        store.request_agent_run_cancellation(queued_id).await.unwrap(),
+        Some(RequestAgentRunCancellationOutcome::Existing(run)) if run.status == AgentRunStatus::Cancelled
+    ));
+    assert!(store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .is_none());
+
+    let running_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            running_id,
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("cancel while running"),
+        )
+        .await
+        .unwrap();
+    let lease_token = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(lease_token, Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        store
+            .request_agent_run_cancellation(running_id)
+            .await
+            .unwrap(),
+        Some(RequestAgentRunCancellationOutcome::Requested(run)) if run.status == AgentRunStatus::Cancelling
+    ));
+    assert!(store
+        .submit_agent_run_result(running_id, lease_token, "too late")
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .finish_agent_run_cancellation(running_id, uuid::Uuid::new_v4())
+        .await
+        .unwrap()
+        .is_none());
+    let cancelled = match store
+        .finish_agent_run_cancellation(running_id, lease_token)
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        FinishAgentRunCancellationOutcome::Cancelled(run) => run,
+        outcome => panic!("unexpected cancellation outcome: {outcome:?}"),
+    };
+    assert_eq!(cancelled.status, AgentRunStatus::Cancelled);
+    assert!(matches!(
+        store
+            .finish_agent_run_cancellation(running_id, lease_token)
+            .await
+            .unwrap(),
+        Some(FinishAgentRunCancellationOutcome::Existing(existing)) if existing == cancelled
+    ));
+}
+
+#[tokio::test]
+async fn expired_sandbox_cancellation_is_terminal_and_cannot_fake_worker_acknowledgement() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let parent_id = AgentRunId::foreground_for_chat(chat.id);
+
+    let expired_before_request = AgentRunId::new();
+    store
+        .accept_agent_run(
+            expired_before_request,
+            chat.id,
+            Some(parent_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("cancel after lease expiry"),
+        )
+        .await
+        .unwrap();
+    store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    force_expired_agent_lease(&store, expired_before_request).await;
+    assert!(matches!(
+        store
+            .request_agent_run_cancellation(expired_before_request)
+            .await
+            .unwrap(),
+        Some(RequestAgentRunCancellationOutcome::Cancelled(run))
+            if run.status == AgentRunStatus::Cancelled && run.lease_token.is_none()
+    ));
+    assert!(store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .is_none());
+
+    let expired_after_request = AgentRunId::new();
+    store
+        .accept_agent_run(
+            expired_after_request,
+            chat.id,
+            Some(parent_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("expire after cancellation request"),
+        )
+        .await
+        .unwrap();
+    let lease_token = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(lease_token, Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .request_agent_run_cancellation(expired_after_request)
+        .await
+        .unwrap();
+    force_expired_agent_lease(&store, expired_after_request).await;
+    assert!(store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .finish_agent_run_cancellation(expired_after_request, lease_token)
         .await
         .unwrap()
         .is_none());

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -60,7 +60,7 @@ pub use id::{
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
 pub use model::{
-    validate_source_regions, AgentRun, AgentRunExecution, AgentRunStatus,
+    validate_source_regions, AgentRun, AgentRunExecution, AgentRunResult, AgentRunStatus,
     BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, ByteSpan, Chat,
     ChatRootAttachment, ClientToolCallRequest, DocumentGeneration, DocumentJob, DocumentJobKind,
     DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
@@ -82,10 +82,11 @@ pub use storage::{
     ApplyTurnSteerOutcome, BeginRootAttachmentChangeOutcome, BlobStore, ClaimClientToolCallOutcome,
     ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim, CompleteTurnRunOutcome,
     DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
-    FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
-    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledTurnOutcome,
-    JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
-    RequestTurnCancellationOutcome, ResolveToolCallOutcome, SecretProvider, Store,
+    FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
+    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
+    JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome,
+    RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome,
+    ResolveToolCallOutcome, SecretProvider, Store, SubmitAgentRunResultOutcome,
     MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1143,6 +1143,29 @@ impl AgentRun {
     pub const MAX_ERROR_CODE_LEN: usize = 128;
     /// Maximum persisted diagnostic-detail length.
     pub const MAX_ERROR_DETAIL_LEN: usize = 4_096;
+    /// Maximum final text stored in an immutable sandbox result receipt.
+    pub const MAX_RESULT_LEN: usize = 65_536;
+}
+
+/// Immutable final text submitted by one exact sandbox worker lease.
+///
+/// This receipt is intentionally separate from [`AgentRun`]: clearing the live
+/// lease at terminal transition must not erase the proof needed to recover an
+/// ambiguous submission retry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRunResult {
+    /// The terminal sandbox run.
+    pub agent_run_id: crate::id::AgentRunId,
+    /// Exact worker lease that committed this result.
+    pub lease_token: Uuid,
+    /// Worker attempt that produced the result.
+    pub attempt_count: i32,
+    /// Exact claim segment that produced the result.
+    pub claim_count: i32,
+    /// Bounded final text returned to the parent in a later delivery slice.
+    pub text: String,
+    /// Database time at which the terminal submission committed.
+    pub submitted_at: DateTime<Utc>,
 }
 
 /// Execution boundary for an [`AgentRun`].

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -25,10 +25,10 @@ use crate::id::{
     TurnId, TurnSteerId,
 };
 use crate::model::{
-    AgentRun, AgentRunExecution, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus,
-    Chat, ClientToolCallRequest, DocumentGeneration, DocumentJob, DocumentJobKind,
-    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentRecord, DocumentScope,
-    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project,
+    AgentRun, AgentRunExecution, AgentRunResult, BeginRootAttachmentChange, BlobRetirement,
+    BlobRetirementStatus, Chat, ClientToolCallRequest, DocumentGeneration, DocumentJob,
+    DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentRecord,
+    DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project,
     RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord, ToolCallResolution,
     TurnCheckpointProgress, TurnClientWait, TurnFailureReceipt, TurnFailureRetry, TurnRun,
     TurnSteer,
@@ -160,6 +160,37 @@ pub enum AcceptAgentRunOutcome {
     ForegroundExists(AgentRun),
     /// The requested sandbox parent is missing, cross-chat, or not foreground.
     ParentUnavailable,
+}
+
+/// Result of requesting durable cancellation for one sandbox run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RequestAgentRunCancellationOutcome {
+    /// Unclaimed work was cancelled immediately.
+    Cancelled(AgentRun),
+    /// A live worker retained its lease and must acknowledge cancellation.
+    Requested(AgentRun),
+    /// The run was already cancelling or cancelled.
+    Existing(AgentRun),
+    /// A successful result or permanent failure already won.
+    AlreadyTerminal(AgentRun),
+}
+
+/// Result of a sandbox worker acknowledging cancellation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FinishAgentRunCancellationOutcome {
+    /// This exact live lease committed terminal cancellation.
+    Cancelled(AgentRun),
+    /// This exact lease already committed terminal cancellation.
+    Existing(AgentRun),
+}
+
+/// Result of a sandbox worker submitting final text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubmitAgentRunResultOutcome {
+    /// This exact live lease committed the immutable terminal result.
+    Completed(AgentRunResult),
+    /// The same lease and payload were already committed.
+    Existing(AgentRunResult),
 }
 
 /// Result of atomically accepting one exact steering instruction.
@@ -950,6 +981,37 @@ pub trait Store: Send + Sync {
         _lease_token: uuid::Uuid,
         _lease_duration: chrono::Duration,
     ) -> Result<bool> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Request cancellation using the database clock. Queued, waiting, and
+    /// retry-wait runs become terminal immediately; a running worker retains
+    /// its exact lease in `cancelling` until it acknowledges quiescence.
+    async fn request_agent_run_cancellation(
+        &self,
+        _id: AgentRunId,
+    ) -> Result<Option<RequestAgentRunCancellationOutcome>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Acknowledge cancellation with one exact live sandbox lease.
+    async fn finish_agent_run_cancellation(
+        &self,
+        _id: AgentRunId,
+        _lease_token: uuid::Uuid,
+    ) -> Result<Option<FinishAgentRunCancellationOutcome>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Atomically persist immutable final text and complete one exact live
+    /// sandbox lease. An exact ambiguous retry returns the original receipt;
+    /// stale, cancelled, or differently-payloaded submissions return `None`.
+    async fn submit_agent_run_result(
+        &self,
+        _id: AgentRunId,
+        _lease_token: uuid::Uuid,
+        _text: &str,
+    ) -> Result<Option<SubmitAgentRunResultOutcome>> {
         agent_run_storage_unavailable()
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -8,11 +8,12 @@ use openwave_core::{
     AgentEvent, AgentRunExecution, AgentRunId, AgentRunStatus, ApplyTurnSteerOutcome,
     BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, CallId, Chat, ChatId,
     ChatRootAttachment, ClaimClientToolCallOutcome, ClientToolCallRequest, CompleteTurnRunOutcome,
-    DbStore, FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
-    HeartbeatClientToolCallOutcome, HostRootId, Message, MessageId, ParkTurnForClientCallOutcome,
-    Project, ProjectId, RecordTurnFailureOutcome, RequestTurnCancellationOutcome,
-    ResolveToolCallOutcome, Role, RootAttachmentChangeAction, RootAttachmentChangeId,
-    RootAttachmentChangeTerminal, RootAttachmentOrigin, StopReason, Store, ToolCallExecution,
+    DbStore, FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
+    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, HostRootId, Message, MessageId,
+    ParkTurnForClientCallOutcome, Project, ProjectId, RecordTurnFailureOutcome,
+    RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome,
+    Role, RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentChangeTerminal,
+    RootAttachmentOrigin, StopReason, Store, SubmitAgentRunResultOutcome, ToolCallExecution,
     ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress, TurnFailureRetry,
     TurnId, TurnRunStatus, TurnSteerId, TurnSteerStatus, Usage,
 };
@@ -303,6 +304,120 @@ async fn postgres_sandbox_claim_uses_statement_time_after_scheduler_lock_wait() 
         ))
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn postgres_sandbox_terminal_transitions_are_exact_and_fenced() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let parent_id = AgentRunId::foreground_for_chat(chat.id);
+
+    let completed_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            completed_id,
+            chat.id,
+            Some(parent_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("postgres terminal result"),
+        )
+        .await
+        .unwrap();
+    let prioritizer = Database::connect(&url).await.unwrap();
+    prioritizer
+        .execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "UPDATE agent_run \
+                 SET created_at = TIMESTAMPTZ '2000-01-01 00:00:00+00', \
+                     available_at = TIMESTAMPTZ '2000-01-01 00:00:00+00', \
+                     updated_at = clock_timestamp() \
+                 WHERE id = '{}'",
+                completed_id.0
+            ),
+        ))
+        .await
+        .unwrap();
+    let completed_token = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(completed_token, Duration::minutes(1), 1_024, 1_024)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        store
+            .submit_agent_run_result(completed_id, completed_token, "postgres result")
+            .await
+            .unwrap(),
+        Some(SubmitAgentRunResultOutcome::Completed(result))
+            if result.agent_run_id == completed_id && result.text == "postgres result"
+    ));
+    assert!(matches!(
+        store
+            .submit_agent_run_result(completed_id, completed_token, "postgres result")
+            .await
+            .unwrap(),
+        Some(SubmitAgentRunResultOutcome::Existing(_))
+    ));
+
+    let cancelling_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            cancelling_id,
+            chat.id,
+            Some(parent_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("postgres cancellation"),
+        )
+        .await
+        .unwrap();
+    prioritizer
+        .execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "UPDATE agent_run \
+                 SET created_at = TIMESTAMPTZ '1999-01-01 00:00:00+00', \
+                     available_at = TIMESTAMPTZ '1999-01-01 00:00:00+00', \
+                     updated_at = clock_timestamp() \
+                 WHERE id = '{}'",
+                cancelling_id.0
+            ),
+        ))
+        .await
+        .unwrap();
+    let cancelling_token = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(cancelling_token, Duration::minutes(1), 1_024, 1_024)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        store
+            .request_agent_run_cancellation(cancelling_id)
+            .await
+            .unwrap(),
+        Some(RequestAgentRunCancellationOutcome::Requested(run))
+            if run.status == AgentRunStatus::Cancelling
+    ));
+    assert!(matches!(
+        store
+            .finish_agent_run_cancellation(cancelling_id, cancelling_token)
+            .await
+            .unwrap(),
+        Some(FinishAgentRunCancellationOutcome::Cancelled(run))
+            if run.status == AgentRunStatus::Cancelled
+    ));
 }
 
 #[tokio::test]

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -64,9 +64,10 @@ spawn:
 3. A bounded scheduler claims the child with an exact renewable lease.
 4. The scheduler creates or restores its sandbox and advances the shared agent
    loop.
-5. The child submits a terminal result or a durable failure.
-6. Completion is delivered to the parent's durable inbox and wakes an explicit
-   parent wait, if one exists.
+5. The child submits an immutable terminal result or the scheduler records a
+   durable terminal failure.
+6. A follow-on delivery transition writes that result to the parent's durable
+   inbox and wakes an explicit parent wait, if one exists.
 
 The foreground agent may continue or finish its current turn after spawning a
 child. If it needs the result before proceeding, it parks on a durable wait and
@@ -136,6 +137,17 @@ The scheduler's ownership rules are deliberately strict:
 - a worker's writes must carry its exact live lease token, so a reclaimed or
   expired worker cannot resume ownership.
 
+Final sandbox text is stored as an immutable receipt keyed by the child run and
+the exact lease segment that submitted it. The receipt and `completed` state
+commit together, so an ambiguous worker retry can recover its original result
+but cannot overwrite it. Queued, waiting, and retry-wait work cancels
+immediately; a running worker first enters `cancelling` and must acknowledge its
+exact live lease. That acknowledgement writes its own immutable receipt, so only
+the worker that actually committed terminal cancellation can recover an
+ambiguous retry. An expired running lease is cancelled immediately on request
+rather than reclaimed. Parent inbox delivery is intentionally the next
+transition, not a process-local notification.
+
 ## Reliability contract
 
 The agent hierarchy preserves the runtime's existing rules:
@@ -147,8 +159,9 @@ The agent hierarchy preserves the runtime's existing rules:
    receipt before it becomes safely retryable.
 5. Waits release workers and resume from committed checkpoints.
 6. Steering and cancellation are resolved at explicit boundaries.
-7. A final result, terminal run state, parent delivery, and terminal event are
-   committed atomically.
+7. A final result and terminal run state are committed atomically. Parent
+   delivery and the corresponding terminal event will join that transaction
+   when the durable inbox exists.
 8. Clients recover from a durable snapshot plus ordered event replay.
 
 Until a tool satisfies the side-effect receipt contract, OpenWave continues to
@@ -160,11 +173,14 @@ The implementation is intentionally incremental:
 
 1. Add the durable `AgentRun` hierarchy, atomic foreground ownership, and
    depth-one constraints. *(Shipped.)*
-2. Add the bounded sandbox scheduler and sandbox lifecycle.
-3. Add idempotent spawn, claim, heartbeat, cancellation, and completion.
-4. Generalize client execution into the shared continuation model.
-5. Persist shared model/tool step boundaries and side-effect receipts.
-6. Add wait, inbox, result-submission, and parent wake-up operations.
+2. Add the bounded sandbox scheduler and lease lifecycle. *(Shipped.)*
+3. Add idempotent cancellation and immutable fenced result submission.
+   *(Shipped.)*
+4. Add the parent inbox, atomic child-result delivery, and parent wake-up
+   operations.
+5. Generalize client execution into the shared continuation model.
+6. Persist shared model/tool step boundaries and side-effect receipts.
+7. Add waits that consume durable inbox receipts.
 7. Route sandbox folder access through the host broker.
 8. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.


### PR DESCRIPTION
## Summary

- add immutable fenced receipts for sandbox final results and cancellation acknowledgements
- make cancellation terminal at expired leases and serialize it with heartbeats
- atomically complete exact live sandbox leases without allowing stale overwrites
- add SQLite and PostgreSQL coverage for terminal state transitions

## Validation

- cargo test -p openwave-core --lib --locked
- OPENWAVE_POSTGRES_TEST_URL=… cargo test -p openwave-core --no-default-features --features postgres --test postgres_turn_state --locked
- bw dev lint --rust --check