### PR TITLE
Deliver sandbox results to parent inbox

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -443,6 +443,29 @@ pub mod agent_run_cancellation {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod agent_run_inbox {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "agent_run_inbox")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub child_run_id: Uuid,
+        pub parent_run_id: Uuid,
+        pub chat_id: Uuid,
+        pub parent_depth: i16,
+        pub result_lease_token: Uuid,
+        pub result_attempt_count: i32,
+        pub result_claim_count: i32,
+        pub delivered_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod turn_run {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -334,6 +334,18 @@ async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr
     manager
         .create_index(
             Index::create()
+                .name("idx_agent_run_id_parent_chat")
+                .table(AgentRun::Table)
+                .col(AgentRun::Id)
+                .col(AgentRun::ParentId)
+                .col(AgentRun::ChatId)
+                .unique()
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
                 .name("idx_agent_run_spawn_call")
                 .table(AgentRun::Table)
                 .col(AgentRun::SpawnCallId)
@@ -460,6 +472,110 @@ async fn create_agent_run_result_table(manager: &SchemaManager<'_>) -> Result<()
                 .check(
                     Func::char_length(Expr::col(AgentRunResult::Text))
                         .between(1, crate::model::AgentRun::MAX_RESULT_LEN as i32),
+                )
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_agent_run_result_identity")
+                .table(AgentRunResult::Table)
+                .col(AgentRunResult::AgentRunId)
+                .col(AgentRunResult::LeaseToken)
+                .col(AgentRunResult::AttemptCount)
+                .col(AgentRunResult::ClaimCount)
+                .unique()
+                .to_owned(),
+        )
+        .await
+}
+
+async fn create_agent_run_inbox_table(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(AgentRunInbox::Table)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(AgentRunInbox::ChildRunId)
+                        .uuid()
+                        .not_null()
+                        .primary_key(),
+                )
+                .col(ColumnDef::new(AgentRunInbox::ParentRunId).uuid().not_null())
+                .col(ColumnDef::new(AgentRunInbox::ChatId).uuid().not_null())
+                .col(
+                    ColumnDef::new(AgentRunInbox::ParentDepth)
+                        .small_integer()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunInbox::ResultLeaseToken)
+                        .uuid()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunInbox::ResultAttemptCount)
+                        .integer()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunInbox::ResultClaimCount)
+                        .integer()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunInbox::DeliveredAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_agent_run_inbox_child")
+                        .from_tbl(AgentRunInbox::Table)
+                        .from_col(AgentRunInbox::ChildRunId)
+                        .from_col(AgentRunInbox::ParentRunId)
+                        .from_col(AgentRunInbox::ChatId)
+                        .to_tbl(AgentRun::Table)
+                        .to_col(AgentRun::Id)
+                        .to_col(AgentRun::ParentId)
+                        .to_col(AgentRun::ChatId)
+                        .on_delete(ForeignKeyAction::Restrict),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_agent_run_inbox_parent")
+                        .from_tbl(AgentRunInbox::Table)
+                        .from_col(AgentRunInbox::ParentRunId)
+                        .from_col(AgentRunInbox::ChatId)
+                        .from_col(AgentRunInbox::ParentDepth)
+                        .to_tbl(AgentRun::Table)
+                        .to_col(AgentRun::Id)
+                        .to_col(AgentRun::ChatId)
+                        .to_col(AgentRun::Depth)
+                        .on_delete(ForeignKeyAction::Restrict),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_agent_run_inbox_result")
+                        .from_tbl(AgentRunInbox::Table)
+                        .from_col(AgentRunInbox::ChildRunId)
+                        .from_col(AgentRunInbox::ResultLeaseToken)
+                        .from_col(AgentRunInbox::ResultAttemptCount)
+                        .from_col(AgentRunInbox::ResultClaimCount)
+                        .to_tbl(AgentRunResult::Table)
+                        .to_col(AgentRunResult::AgentRunId)
+                        .to_col(AgentRunResult::LeaseToken)
+                        .to_col(AgentRunResult::AttemptCount)
+                        .to_col(AgentRunResult::ClaimCount)
+                        .on_delete(ForeignKeyAction::Restrict),
+                )
+                .check(Expr::col(AgentRunInbox::ParentDepth).eq(0))
+                .check(Expr::col(AgentRunInbox::ResultAttemptCount).gte(1))
+                .check(
+                    Expr::col(AgentRunInbox::ResultClaimCount)
+                        .gte(Expr::col(AgentRunInbox::ResultAttemptCount)),
                 )
                 .to_owned(),
         )
@@ -609,6 +725,7 @@ impl MigrationTrait for Init {
         create_agent_run_table(manager).await?;
         create_agent_run_result_table(manager).await?;
         create_agent_run_cancellation_table(manager).await?;
+        create_agent_run_inbox_table(manager).await?;
 
         manager
             .create_table(
@@ -1492,6 +1609,9 @@ impl MigrationTrait for Init {
             .await?;
         manager
             .drop_table(Table::drop().table(TurnRun::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(AgentRunInbox::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(AgentRunResult::Table).to_owned())
@@ -3307,6 +3427,19 @@ enum AgentRunCancellation {
     AttemptCount,
     ClaimCount,
     CancelledAt,
+}
+
+#[derive(DeriveIden)]
+enum AgentRunInbox {
+    Table,
+    ChildRunId,
+    ParentRunId,
+    ChatId,
+    ParentDepth,
+    ResultLeaseToken,
+    ResultAttemptCount,
+    ResultClaimCount,
+    DeliveredAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -27,12 +27,12 @@ use crate::id::{
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
-    validate_project_root_projection, AgentRun, AgentRunExecution, AgentRunStatus,
-    BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, Chat, DocumentGeneration,
-    DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput,
-    DocumentProcessingStatus, DocumentRecord, DocumentScope, DocumentSourceBlob,
-    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project,
-    RootAttachmentChange, RootAttachmentChangeTerminal, SourceRegion, ToolCallRecord,
+    validate_project_root_projection, AgentRun, AgentRunExecution, AgentRunInboxEntry,
+    AgentRunStatus, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, Chat,
+    DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
+    DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
+    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
+    Project, RootAttachmentChange, RootAttachmentChangeTerminal, SourceRegion, ToolCallRecord,
     ToolCallResolution, TurnCheckpointProgress, TurnClientWaitStatus, TurnFailureRetry, TurnRun,
     TurnRunStatus, TurnSteerStatus, MAX_ROOT_ATTACHMENTS,
 };
@@ -1802,6 +1802,13 @@ impl Store for DbStore {
         text: &str,
     ) -> Result<Option<SubmitAgentRunResultOutcome>> {
         ops::agent_run::submit_agent_run_result(self, id, lease_token, text).await
+    }
+
+    async fn list_agent_run_inbox(
+        &self,
+        parent_run_id: AgentRunId,
+    ) -> Result<Vec<AgentRunInboxEntry>> {
+        ops::agent_run::list_agent_run_inbox(self, parent_run_id).await
     }
 
     async fn get_turn_run(&self, id: TurnId) -> Result<Option<TurnRun>> {

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -6,7 +6,9 @@ use sea_orm::{
 
 use crate::error::{AgentError, Result};
 use crate::id::{AgentRunId, CallId, ChatId};
-use crate::model::{AgentRun, AgentRunExecution, AgentRunResult, AgentRunStatus};
+use crate::model::{
+    AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunResult, AgentRunStatus,
+};
 use crate::storage::{
     AcceptAgentRunOutcome, FinishAgentRunCancellationOutcome, RequestAgentRunCancellationOutcome,
     SubmitAgentRunResultOutcome,
@@ -785,6 +787,26 @@ pub(in crate::db) async fn submit_agent_run_result(
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
+    let Some(parent_id) = run.parent_id.map(AgentRunId) else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "sandbox agent run {id} is missing its parent"
+        )));
+    };
+    let Some(parent) = find_by_id_on(&transaction, parent_id).await? else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "sandbox agent run {id} references missing parent {parent_id}"
+        )));
+    };
+    if parent.chat_id != run.chat_id
+        || parent.depth != 0
+        || parent.execution != AgentRunExecution::Foreground.as_str()
+        || parent.status != AgentRunStatus::Active.as_str()
+    {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
     entities::agent_run_result::ActiveModel {
         agent_run_id: Set(id.0),
         lease_token: Set(lease_token),
@@ -792,6 +814,19 @@ pub(in crate::db) async fn submit_agent_run_result(
         claim_count: Set(run.claim_count),
         text: Set(text.to_owned()),
         submitted_at: Set(now),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    entities::agent_run_inbox::ActiveModel {
+        child_run_id: Set(id.0),
+        parent_run_id: Set(parent_id.0),
+        chat_id: Set(run.chat_id),
+        parent_depth: Set(0),
+        result_lease_token: Set(lease_token),
+        result_attempt_count: Set(run.attempt_count),
+        result_claim_count: Set(run.claim_count),
+        delivered_at: Set(now),
     }
     .insert(&transaction)
     .await
@@ -850,6 +885,34 @@ pub(in crate::db) async fn submit_agent_run_result(
         .and_then(agent_run_result_from_model)?;
     transaction.commit().await.map_err(store_err)?;
     Ok(Some(SubmitAgentRunResultOutcome::Completed(result)))
+}
+
+pub(in crate::db) async fn list_agent_run_inbox(
+    store: &DbStore,
+    parent_run_id: AgentRunId,
+) -> Result<Vec<AgentRunInboxEntry>> {
+    let entries = entities::agent_run_inbox::Entity::find()
+        .filter(entities::agent_run_inbox::Column::ParentRunId.eq(parent_run_id.0))
+        .order_by_asc(entities::agent_run_inbox::Column::DeliveredAt)
+        .order_by_asc(entities::agent_run_inbox::Column::ChildRunId)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    let mut inbox = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let result = entities::agent_run_result::Entity::find_by_id(entry.child_run_id)
+            .one(&store.conn)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| {
+                AgentError::Store(format!(
+                    "agent-run inbox child {} is missing its result receipt",
+                    entry.child_run_id
+                ))
+            })?;
+        inbox.push(agent_run_inbox_from_models(entry, result)?);
+    }
+    Ok(inbox)
 }
 
 fn validate_claim_request(
@@ -1247,6 +1310,38 @@ fn agent_run_result_from_model(model: entities::agent_run_result::Model) -> Resu
         claim_count: model.claim_count,
         text: model.text,
         submitted_at: model.submitted_at,
+    })
+}
+
+fn agent_run_inbox_from_models(
+    model: entities::agent_run_inbox::Model,
+    result: entities::agent_run_result::Model,
+) -> Result<AgentRunInboxEntry> {
+    if model.parent_depth != 0
+        || model.result_lease_token.is_nil()
+        || model.result_attempt_count < 1
+        || model.result_claim_count < model.result_attempt_count
+    {
+        return Err(AgentError::Store(
+            "invalid stored agent-run inbox entry".into(),
+        ));
+    }
+    let result = agent_run_result_from_model(result)?;
+    if result.agent_run_id != AgentRunId(model.child_run_id)
+        || result.lease_token != model.result_lease_token
+        || result.attempt_count != model.result_attempt_count
+        || result.claim_count != model.result_claim_count
+    {
+        return Err(AgentError::Store(
+            "agent-run inbox does not match its result receipt".into(),
+        ));
+    }
+    Ok(AgentRunInboxEntry {
+        parent_run_id: AgentRunId(model.parent_run_id),
+        child_run_id: AgentRunId(model.child_run_id),
+        chat_id: ChatId(model.chat_id),
+        result,
+        delivered_at: model.delivered_at,
     })
 }
 

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -528,6 +528,19 @@ async fn sandbox_result_submission_is_fenced_and_idempotent() {
     assert_eq!(result.agent_run_id, child_id);
     assert_eq!(result.lease_token, lease_token);
     assert_eq!(result.text, "finished analysis");
+    assert_eq!(
+        store
+            .list_agent_run_inbox(AgentRunId::foreground_for_chat(chat.id))
+            .await
+            .unwrap(),
+        vec![crate::AgentRunInboxEntry {
+            parent_run_id: AgentRunId::foreground_for_chat(chat.id),
+            child_run_id: child_id,
+            chat_id: chat.id,
+            result: result.clone(),
+            delivered_at: result.submitted_at,
+        }]
+    );
     let completed = store.get_agent_run(child_id).await.unwrap().unwrap();
     assert_eq!(completed.status, AgentRunStatus::Completed);
     assert_eq!(completed.lease_token, None);
@@ -708,6 +721,80 @@ async fn expired_sandbox_cancellation_is_terminal_and_cannot_fake_worker_acknowl
         .await
         .unwrap()
         .is_none());
+}
+
+#[tokio::test]
+async fn unavailable_parent_rejects_result_without_holding_the_scheduler_lock() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    let other_chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    store.create_chat(&other_chat).await.unwrap();
+    let child_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("parent may finish first"),
+        )
+        .await
+        .unwrap();
+    let lease_token = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(lease_token, Duration::minutes(1), 2, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    let other_child_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            other_child_id,
+            other_chat.id,
+            Some(AgentRunId::foreground_for_chat(other_chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("scheduler remains usable"),
+        )
+        .await
+        .unwrap();
+    let now = Utc::now();
+    crate::db::entities::agent_run::Entity::update_many()
+        .col_expr(
+            crate::db::entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunStatus::Completed.as_str()),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(
+            crate::db::entities::agent_run::Column::Id
+                .eq(AgentRunId::foreground_for_chat(chat.id).0),
+        )
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert!(store
+        .submit_agent_run_result(child_id, lease_token, "orphaned result")
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        store
+            .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        other_child_id
+    );
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -60,17 +60,18 @@ pub use id::{
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
 pub use model::{
-    validate_source_regions, AgentRun, AgentRunExecution, AgentRunResult, AgentRunStatus,
-    BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, ByteSpan, Chat,
-    ChatRootAttachment, ClientToolCallRequest, DocumentGeneration, DocumentJob, DocumentJobKind,
-    DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus,
-    DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord,
-    DocumentUpsert, Message, Project, Role, RootAttachmentChange, RootAttachmentChangeAction,
-    RootAttachmentChangeFailure, RootAttachmentChangePhase, RootAttachmentChangeTerminal,
-    RootAttachmentOrigin, RootAttachmentSubjectKind, SourceLocation, SourceRegion,
-    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress,
-    TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun,
-    TurnRunStatus, TurnSteer, TurnSteerStatus, MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
+    validate_source_regions, AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunResult,
+    AgentRunStatus, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, ByteSpan,
+    Chat, ChatRootAttachment, ClientToolCallRequest, DocumentGeneration, DocumentJob,
+    DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput,
+    DocumentProcessingStatus, DocumentRecord, DocumentScope, DocumentSourceBlob,
+    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, Role,
+    RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
+    RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
+    RootAttachmentSubjectKind, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
+    ToolCallResolution, ToolCallStatus, TurnCheckpointProgress, TurnClientWait,
+    TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer,
+    TurnSteerStatus, MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1168,6 +1168,24 @@ pub struct AgentRunResult {
     pub submitted_at: DateTime<Utc>,
 }
 
+/// One immutable result delivered from a sandbox child to its foreground parent.
+///
+/// Delivery is written in the same transaction as the child's terminal result;
+/// waking or consuming a parent continuation is deliberately a later concern.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRunInboxEntry {
+    /// Foreground coordinator that owns this child result.
+    pub parent_run_id: crate::id::AgentRunId,
+    /// Completed sandbox child. One child has exactly one inbox entry.
+    pub child_run_id: crate::id::AgentRunId,
+    /// Chat shared by parent and child.
+    pub chat_id: ChatId,
+    /// Exact result receipt that was delivered.
+    pub result: AgentRunResult,
+    /// Database time when the durable parent delivery committed.
+    pub delivered_at: DateTime<Utc>,
+}
+
 /// Execution boundary for an [`AgentRun`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -25,13 +25,13 @@ use crate::id::{
     TurnId, TurnSteerId,
 };
 use crate::model::{
-    AgentRun, AgentRunExecution, AgentRunResult, BeginRootAttachmentChange, BlobRetirement,
-    BlobRetirementStatus, Chat, ClientToolCallRequest, DocumentGeneration, DocumentJob,
-    DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput, DocumentRecord,
-    DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project,
-    RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord, ToolCallResolution,
-    TurnCheckpointProgress, TurnClientWait, TurnFailureReceipt, TurnFailureRetry, TurnRun,
-    TurnSteer,
+    AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunResult, BeginRootAttachmentChange,
+    BlobRetirement, BlobRetirementStatus, Chat, ClientToolCallRequest, DocumentGeneration,
+    DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput,
+    DocumentRecord, DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert,
+    Message, Project, RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord,
+    ToolCallResolution, TurnCheckpointProgress, TurnClientWait, TurnFailureReceipt,
+    TurnFailureRetry, TurnRun, TurnSteer,
 };
 use crate::provider::{StopReason, Usage};
 
@@ -1012,6 +1012,16 @@ pub trait Store: Send + Sync {
         _lease_token: uuid::Uuid,
         _text: &str,
     ) -> Result<Option<SubmitAgentRunResultOutcome>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// List immutable child results delivered to one foreground coordinator.
+    /// Consuming or waking a parent continuation is intentionally a separate
+    /// state-machine transition.
+    async fn list_agent_run_inbox(
+        &self,
+        _parent_run_id: AgentRunId,
+    ) -> Result<Vec<AgentRunInboxEntry>> {
         agent_run_storage_unavailable()
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -362,6 +362,11 @@ async fn postgres_sandbox_terminal_transitions_are_exact_and_fenced() {
         Some(SubmitAgentRunResultOutcome::Completed(result))
             if result.agent_run_id == completed_id && result.text == "postgres result"
     ));
+    let inbox = store.list_agent_run_inbox(parent_id).await.unwrap();
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].parent_run_id, parent_id);
+    assert_eq!(inbox[0].child_run_id, completed_id);
+    assert_eq!(inbox[0].result.text, "postgres result");
     assert!(matches!(
         store
             .submit_agent_run_result(completed_id, completed_token, "postgres result")

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -66,8 +66,8 @@ spawn:
    loop.
 5. The child submits an immutable terminal result or the scheduler records a
    durable terminal failure.
-6. A follow-on delivery transition writes that result to the parent's durable
-   inbox and wakes an explicit parent wait, if one exists.
+6. The result, terminal child state, and immutable parent inbox entry commit
+   together. A later wait transition may consume that entry and wake a parent.
 
 The foreground agent may continue or finish its current turn after spawning a
 child. If it needs the result before proceeding, it parks on a durable wait and
@@ -138,9 +138,10 @@ The scheduler's ownership rules are deliberately strict:
   expired worker cannot resume ownership.
 
 Final sandbox text is stored as an immutable receipt keyed by the child run and
-the exact lease segment that submitted it. The receipt and `completed` state
-commit together, so an ambiguous worker retry can recover its original result
-but cannot overwrite it. Queued, waiting, and retry-wait work cancels
+the exact lease segment that submitted it. The receipt, `completed` state, and
+one parent inbox entry commit together, so an ambiguous worker retry can recover
+its original result but cannot overwrite or double-deliver it. Queued, waiting,
+and retry-wait work cancels
 immediately; a running worker first enters `cancelling` and must acknowledge its
 exact live lease. That acknowledgement writes its own immutable receipt, so only
 the worker that actually committed terminal cancellation can recover an
@@ -159,9 +160,9 @@ The agent hierarchy preserves the runtime's existing rules:
    receipt before it becomes safely retryable.
 5. Waits release workers and resume from committed checkpoints.
 6. Steering and cancellation are resolved at explicit boundaries.
-7. A final result and terminal run state are committed atomically. Parent
-   delivery and the corresponding terminal event will join that transaction
-   when the durable inbox exists.
+7. A final result, terminal run state, and immutable parent inbox entry are
+   committed atomically. Wait consumption and the corresponding terminal event
+   will join a later continuation transition.
 8. Clients recover from a durable snapshot plus ordered event replay.
 
 Until a tool satisfies the side-effect receipt contract, OpenWave continues to
@@ -176,11 +177,10 @@ The implementation is intentionally incremental:
 2. Add the bounded sandbox scheduler and lease lifecycle. *(Shipped.)*
 3. Add idempotent cancellation and immutable fenced result submission.
    *(Shipped.)*
-4. Add the parent inbox, atomic child-result delivery, and parent wake-up
-   operations.
+4. Add the parent inbox and atomic child-result delivery. *(Shipped.)*
 5. Generalize client execution into the shared continuation model.
 6. Persist shared model/tool step boundaries and side-effect receipts.
-7. Add waits that consume durable inbox receipts.
+7. Add waits that consume durable inbox receipts and wake a parent.
 7. Route sandbox folder access through the host broker.
 8. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.


### PR DESCRIPTION
## Summary

- atomically write immutable parent inbox entries alongside sandbox result completion
- reference and revalidate result receipts instead of duplicating result payloads
- enforce parent/child/result relationships with cross-database foreign keys
- add SQLite and PostgreSQL coverage for inbox delivery

## Validation

- cargo test -p openwave-core --lib --locked
- OPENWAVE_POSTGRES_TEST_URL=… cargo test -p openwave-core --no-default-features --features postgres --test postgres_turn_state --locked
- bw dev lint --rust --check