### PR TITLE
Expose agent run state

### DIFF
--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -157,6 +157,7 @@ pub fn app(state: AppState) -> Router {
             "/chats/{id}",
             get(routes::get_chat).patch(routes::patch_chat),
         )
+        .route("/chats/{id}/agent-runs", get(routes::list_agent_runs))
         .route(
             "/settings/api-key",
             axum::routing::put(routes::put_api_key).delete(routes::delete_api_key),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -13,9 +13,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, ApprovalDecision, CallId, Chat, ChatId, Project,
-    ProjectId, RequestTurnCancellationOutcome, SecretProvider, SequencedEvent, Store, TurnId,
-    TurnSteer, TurnSteerId,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, ApprovalDecision, CallId, Chat, ChatId,
+    Project, ProjectId, RequestTurnCancellationOutcome, SecretProvider, SequencedEvent, Store,
+    TurnId, TurnSteer, TurnSteerId,
 };
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
@@ -386,6 +386,19 @@ pub async fn get_chat(
         .await?
         .map(Json)
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))
+}
+
+/// `GET /chats/{id}/agent-runs` — list foreground and sandbox execution state.
+pub async fn list_agent_runs(
+    State(state): State<AppState>,
+    Path(id): Path<ChatId>,
+) -> Result<Json<Vec<AgentRun>>, ServerError> {
+    state
+        .store
+        .get_chat(id)
+        .await?
+        .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
+    Ok(Json(state.store.list_agent_runs(id).await?))
 }
 
 /// Body of `POST /chats/{id}/messages`.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -5198,6 +5198,28 @@ async fn create_then_get_and_list() {
     };
     assert_eq!(fetched, created);
 
+    let agent_runs: Vec<openwave_core::AgentRun> = {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/chats/{}/agent-runs", created.id))
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        json_body(response).await
+    };
+    assert_eq!(agent_runs.len(), 1);
+    assert_eq!(agent_runs[0].chat_id, created.id);
+    assert_eq!(
+        agent_runs[0].id,
+        openwave_core::AgentRunId::foreground_for_chat(created.id)
+    );
+
     let listed: Vec<Chat> = {
         let response = router
             .oneshot(

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -149,6 +149,15 @@ ambiguous retry. An expired running lease is cancelled immediately on request
 rather than reclaimed. Parent inbox delivery is intentionally the next
 transition, not a process-local notification.
 
+## Observing execution
+
+The authenticated local API exposes `GET /chats/{id}/agent-runs` for a
+chat-scoped snapshot of its foreground coordinator and any sandbox children.
+It is a read model, not a scheduler control surface: clients use it to render
+queued, running, waiting, failed, and completed work, while workers continue to
+advance runs solely through fenced store transitions. A missing chat returns
+`404`, rather than revealing whether an unrelated run identifier exists.
+
 ## Reliability contract
 
 The agent hierarchy preserves the runtime's existing rules:
@@ -181,8 +190,8 @@ The implementation is intentionally incremental:
 5. Generalize client execution into the shared continuation model.
 6. Persist shared model/tool step boundaries and side-effect receipts.
 7. Add waits that consume durable inbox receipts and wake a parent.
-7. Route sandbox folder access through the host broker.
-8. Add desktop surfaces for queued, running, waiting, failed, and completed
+8. Route sandbox folder access through the host broker.
+9. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.
-9. Add richer context lifecycle, parallel-safe tool groups, and further
+10. Add richer context lifecycle, parallel-safe tool groups, and further
    orchestration only after these recovery boundaries are proven.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -626,8 +626,8 @@ cancellation, reconnectable event stream, and fail-closed provider routing.
 
 The main next steps are:
 
-- introduce a durable agent-run hierarchy with one foreground coordinator,
-  depth-one sandboxed background agents, and bounded global/per-chat scheduling;
+- connect the durable agent-run hierarchy, depth-one sandbox scheduler, and
+  parent inbox to the shared execution loop;
 - unify client execution, approvals, folder consent, user questions, resource
   waits, and child-agent waits as durable continuations that release workers;
 - persist model/tool step boundaries and side-effect receipts so sandbox and


### PR DESCRIPTION
## Summary

- add an authenticated chat-scoped agent-run read endpoint
- return the deterministic foreground coordinator alongside sandbox state
- document the snapshot boundary and cover it in the server route suite

## Validation

- cargo test -p openwave-server --lib --locked
- bw dev lint --rust --check