### PR TITLE
Redact agent run snapshots

### DIFF
--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -13,9 +13,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, ApprovalDecision, CallId, Chat, ChatId,
-    Project, ProjectId, RequestTurnCancellationOutcome, SecretProvider, SequencedEvent, Store,
-    TurnId, TurnSteer, TurnSteerId,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunExecution, AgentRunStatus,
+    ApprovalDecision, CallId, Chat, ChatId, Project, ProjectId, RequestTurnCancellationOutcome,
+    SecretProvider, SequencedEvent, Store, TurnId, TurnSteer, TurnSteerId,
 };
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
@@ -388,17 +388,60 @@ pub async fn get_chat(
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))
 }
 
-/// `GET /chats/{id}/agent-runs` — list foreground and sandbox execution state.
+/// Renderer-safe state for one agent run.
+///
+/// Worker lease tokens, delegated inputs, scheduling budgets, and other
+/// executor-facing fields intentionally remain inside the server/store boundary.
+#[derive(Debug, Serialize)]
+pub struct AgentRunSnapshot {
+    pub id: openwave_core::AgentRunId,
+    pub parent_id: Option<openwave_core::AgentRunId>,
+    pub execution: AgentRunExecution,
+    pub status: AgentRunStatus,
+    pub started_at: Option<chrono::DateTime<Utc>>,
+    pub finished_at: Option<chrono::DateTime<Utc>>,
+    pub last_error_code: Option<String>,
+    pub last_error_detail: Option<String>,
+    pub created_at: chrono::DateTime<Utc>,
+    pub updated_at: chrono::DateTime<Utc>,
+}
+
+impl From<AgentRun> for AgentRunSnapshot {
+    fn from(run: AgentRun) -> Self {
+        Self {
+            id: run.id,
+            parent_id: run.parent_id,
+            execution: run.execution,
+            status: run.status,
+            started_at: run.started_at,
+            finished_at: run.finished_at,
+            last_error_code: run.last_error_code,
+            last_error_detail: run.last_error_detail,
+            created_at: run.created_at,
+            updated_at: run.updated_at,
+        }
+    }
+}
+
+/// `GET /chats/{id}/agent-runs` — list renderer-safe execution state.
 pub async fn list_agent_runs(
     State(state): State<AppState>,
     Path(id): Path<ChatId>,
-) -> Result<Json<Vec<AgentRun>>, ServerError> {
+) -> Result<Json<Vec<AgentRunSnapshot>>, ServerError> {
     state
         .store
         .get_chat(id)
         .await?
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
-    Ok(Json(state.store.list_agent_runs(id).await?))
+    Ok(Json(
+        state
+            .store
+            .list_agent_runs(id)
+            .await?
+            .into_iter()
+            .map(AgentRunSnapshot::from)
+            .collect(),
+    ))
 }
 
 /// Body of `POST /chats/{id}/messages`.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -5198,7 +5198,7 @@ async fn create_then_get_and_list() {
     };
     assert_eq!(fetched, created);
 
-    let agent_runs: Vec<openwave_core::AgentRun> = {
+    let agent_runs: Vec<serde_json::Value> = {
         let response = router
             .clone()
             .oneshot(
@@ -5214,11 +5214,17 @@ async fn create_then_get_and_list() {
         json_body(response).await
     };
     assert_eq!(agent_runs.len(), 1);
-    assert_eq!(agent_runs[0].chat_id, created.id);
     assert_eq!(
-        agent_runs[0].id,
-        openwave_core::AgentRunId::foreground_for_chat(created.id)
+        agent_runs[0].get("id"),
+        Some(&serde_json::Value::String(
+            openwave_core::AgentRunId::foreground_for_chat(created.id).to_string()
+        ))
     );
+    let snapshot = agent_runs[0].as_object().unwrap();
+    assert!(snapshot.get("lease_token").is_none());
+    assert!(snapshot.get("lease_expires_at").is_none());
+    assert!(snapshot.get("input").is_none());
+    assert!(snapshot.get("chat_id").is_none());
 
     let listed: Vec<Chat> = {
         let response = router

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -157,6 +157,8 @@ It is a read model, not a scheduler control surface: clients use it to render
 queued, running, waiting, failed, and completed work, while workers continue to
 advance runs solely through fenced store transitions. A missing chat returns
 `404`, rather than revealing whether an unrelated run identifier exists.
+The response is deliberately renderer-safe: worker lease tokens, delegated
+input, and scheduler bookkeeping never cross this API boundary.
 
 ## Reliability contract
 


### PR DESCRIPTION
## Summary

- return a renderer-safe agent-run snapshot instead of the worker record
- keep lease tokens, delegated inputs, and scheduler bookkeeping inside the server boundary
- verify the status route never serializes worker capabilities

## Validation

- cargo test -p openwave-server --lib --locked
- bw dev lint --rust --check