### PR TITLE
Show agent run status in desktop

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import {
   ApiClient,
+  type AgentRun,
   type Chat,
   type ModelInfo,
   type PendingFolderAccessRequest,
@@ -49,6 +50,9 @@ export default function App() {
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [messages, setMessages] = useState<Msg[]>([]);
+  const [agentRuns, setAgentRuns] = useState<AgentRun[]>([]);
+  const [agentRunsLoading, setAgentRunsLoading] = useState(false);
+  const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
   const [folderAccessRequests, setFolderAccessRequests] = useState<
     PendingFolderAccessRequest[]
   >([]);
@@ -71,6 +75,7 @@ export default function App() {
   const assistantBufRef = useRef("");
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const refreshFolderAccessRef = useRef<(() => void) | null>(null);
+  const refreshAgentRunsRef = useRef<(() => void) | null>(null);
   const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
   const visibleFolderCallIdsRef = useRef<Set<string>>(new Set());
 
@@ -154,6 +159,61 @@ export default function App() {
     const refresh = async () => {
       const seq = ++requestSeq;
       try {
+        const runs = await client.listAgentRuns(chat.id);
+        if (!cancelled && seq === requestSeq) {
+          setAgentRuns(runs);
+          setAgentRunsError(null);
+        }
+      } catch (err) {
+        if (!cancelled && seq === requestSeq) {
+          setAgentRunsError(String(err));
+        }
+      } finally {
+        if (!cancelled && seq === requestSeq) {
+          setAgentRunsLoading(false);
+        }
+      }
+    };
+
+    setAgentRuns([]);
+    setAgentRunsError(null);
+    setAgentRunsLoading(true);
+    refreshAgentRunsRef.current = () => void refresh();
+    void refresh();
+    return () => {
+      cancelled = true;
+      requestSeq += 1;
+      if (refreshAgentRunsRef.current) {
+        refreshAgentRunsRef.current = null;
+      }
+    };
+  }, [client, chat?.id]);
+
+  const hasActiveSandboxRun = agentRuns.some(
+    (run) =>
+      run.execution === "sandbox" &&
+      ["queued", "running", "cancelling", "waiting", "retry_wait"].includes(
+        run.status,
+      ),
+  );
+
+  useEffect(() => {
+    if (!hasActiveSandboxRun) return;
+    const interval = window.setInterval(
+      () => refreshAgentRunsRef.current?.(),
+      5_000,
+    );
+    return () => window.clearInterval(interval);
+  }, [hasActiveSandboxRun]);
+
+  useEffect(() => {
+    if (!client || !chat) return;
+    let cancelled = false;
+    let requestSeq = 0;
+
+    const refresh = async () => {
+      const seq = ++requestSeq;
+      try {
         const requests = await client.listPendingFolderAccessRequests(chat.id);
         if (!cancelled && seq === requestSeq) {
           setFolderAccessRequests(requests);
@@ -201,6 +261,7 @@ export default function App() {
     const event = framed.event;
 
     if (event.type === "turn_started") {
+      refreshAgentRunsRef.current?.();
       assistantBufRef.current = "";
       setBusy(true);
       setMessages((prev) => [
@@ -239,6 +300,7 @@ export default function App() {
     }
 
     if (event.type === "tool_call_started") {
+      refreshAgentRunsRef.current?.();
       if (event.name === "request_folder_access") {
         refreshFolderAccessRef.current?.();
       }
@@ -276,11 +338,13 @@ export default function App() {
 
     if (event.type === "turn_completed") {
       setBusy(false);
+      refreshAgentRunsRef.current?.();
       return;
     }
 
     if (event.type === "turn_cancelled") {
       setBusy(false);
+      refreshAgentRunsRef.current?.();
       setMessages((prev) => [
         ...prev,
         { id: nextId(), role: "system", text: "turn cancelled" },
@@ -290,6 +354,7 @@ export default function App() {
 
     if (event.type === "turn_failed") {
       setBusy(false);
+      refreshAgentRunsRef.current?.();
       setMessages((prev) => [
         ...prev,
         {
@@ -320,6 +385,7 @@ export default function App() {
     setBusy(true);
     try {
       await client.postMessage(chat.id, turnId, content);
+      refreshAgentRunsRef.current?.();
     } catch (err) {
       setBusy(false);
       setMessages((prev) => [
@@ -340,6 +406,8 @@ export default function App() {
       assistantBufRef.current = "";
       lastSeqRef.current = 0;
       setMessages([]);
+      setAgentRuns([]);
+      setAgentRunsError(null);
       setFolderAccessRequests([]);
       setFolderAccessErrors({});
       setDraft("");
@@ -591,6 +659,12 @@ export default function App() {
                 if (e.key === "Enter") e.currentTarget.blur();
               }}
             />
+            <AgentRunStatusSurface
+              runs={agentRuns}
+              loading={agentRunsLoading}
+              error={agentRunsError}
+              onRetry={() => refreshAgentRunsRef.current?.()}
+            />
           </div>
 
           <div className="messages" ref={scrollRef}>
@@ -688,6 +762,82 @@ export default function App() {
       </div>
     </div>
   );
+}
+
+function AgentRunStatusSurface({
+  runs,
+  loading,
+  error,
+  onRetry,
+}: {
+  runs: AgentRun[];
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  if (loading) {
+    return <div className="agent-runs-state">Loading agent state…</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="agent-runs-state is-error" title={error}>
+        Agent state unavailable
+        <button type="button" className="agent-runs-retry" onClick={onRetry}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (runs.length === 0) {
+    return <div className="agent-runs-state">No agent runs yet</div>;
+  }
+
+  const foreground = runs.find((run) => run.execution === "foreground");
+  const sandboxes = runs.filter((run) => run.execution === "sandbox");
+  return (
+    <div className="agent-runs" aria-label="Agent execution state">
+      <span className="agent-runs-label">Agents</span>
+      {foreground ? (
+        <AgentRunPill run={foreground} label="Conversation" />
+      ) : (
+        <span className="agent-run-empty">Conversation unavailable</span>
+      )}
+      {sandboxes.length === 0 ? (
+        <span className="agent-run-empty">No background work</span>
+      ) : (
+        sandboxes.map((run, index) => (
+          <AgentRunPill key={run.id} run={run} label={`Background ${index + 1}`} />
+        ))
+      )}
+    </div>
+  );
+}
+
+function AgentRunPill({ run, label }: { run: AgentRun; label: string }) {
+  const status = readableAgentRunStatus(run.status);
+  const detail = run.last_error_detail || run.last_error_code || undefined;
+  return (
+    <span
+      className={`agent-run-pill is-${run.status}`}
+      title={detail ? `${label}: ${status} — ${detail}` : `${label}: ${status}`}
+    >
+      <span>{label}</span>
+      <strong>{status}</strong>
+    </span>
+  );
+}
+
+function readableAgentRunStatus(status: AgentRun["status"]): string {
+  switch (status) {
+    case "retry_wait":
+      return "retrying";
+    case "cancelling":
+      return "stopping";
+    default:
+      return status;
+  }
 }
 
 function FoldersPanel({ chat }: { chat: Chat }) {

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -31,6 +31,29 @@ export type Chat = {
   created_at: string;
 };
 
+/** A durable foreground coordinator or sandboxed background run. */
+export type AgentRun = {
+  id: string;
+  parent_id: string | null;
+  execution: "foreground" | "sandbox";
+  status:
+    | "active"
+    | "queued"
+    | "running"
+    | "cancelling"
+    | "waiting"
+    | "retry_wait"
+    | "completed"
+    | "failed"
+    | "cancelled";
+  started_at: string | null;
+  finished_at: string | null;
+  last_error_code: string | null;
+  last_error_detail: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
 export type SequencedEvent = {
   seq: number;
   event: AgentEvent;
@@ -145,6 +168,12 @@ export class ApiClient {
       method: "PATCH",
       headers: this.headers(true),
       body: JSON.stringify({ model }),
+    });
+  }
+
+  listAgentRuns(chatId: string): Promise<AgentRun[]> {
+    return this.json(`/chats/${chatId}/agent-runs`, {
+      headers: this.headers(),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -282,6 +282,86 @@ button {
   font-size: 0.8rem;
 }
 
+.agent-runs,
+.agent-runs-state {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: auto;
+  font-size: 0.75rem;
+}
+
+.agent-runs-label {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.agent-run-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+  max-width: 15rem;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.19rem 0.45rem;
+  background: var(--bg-elevated);
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.agent-run-pill strong {
+  overflow: hidden;
+  color: var(--ink);
+  font-weight: 600;
+  text-overflow: ellipsis;
+}
+
+.agent-run-pill.is-active,
+.agent-run-pill.is-completed {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+}
+
+.agent-run-pill.is-queued,
+.agent-run-pill.is-running,
+.agent-run-pill.is-waiting,
+.agent-run-pill.is-retry_wait,
+.agent-run-pill.is-cancelling {
+  border-color: color-mix(in srgb, var(--ink) 24%, var(--line));
+  background: var(--sidebar-active);
+}
+
+.agent-run-pill.is-failed,
+.agent-run-pill.is-cancelled {
+  border-color: color-mix(in srgb, var(--danger) 38%, var(--line));
+}
+
+.agent-run-pill.is-failed strong,
+.agent-run-pill.is-cancelled strong,
+.agent-runs-state.is-error {
+  color: var(--danger);
+}
+
+.agent-run-empty,
+.agent-runs-state {
+  color: var(--muted);
+}
+
+.agent-runs-retry {
+  border: 0;
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  font-size: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
 .messages {
   overflow: auto;
   padding: 1.25rem clamp(1rem, 7vw, 7rem);
@@ -544,5 +624,11 @@ button {
 
   .conversation-header .status {
     display: none;
+  }
+
+  .agent-runs,
+  .agent-runs-state {
+    width: 100%;
+    margin-left: 0;
   }
 }


### PR DESCRIPTION
## Summary

- add typed renderer-safe agent-run status snapshots to the desktop client
- show foreground and background execution state in the conversation shell
- refresh from chat lifecycle events and poll only while sandbox work is active

## Validation

- pnpm --dir crates/openwave-desktop/ui build
- git diff --check