### PR TITLE
Fence parent inbox continuation

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -457,6 +457,12 @@ pub mod agent_run_inbox {
         pub result_lease_token: Uuid,
         pub result_attempt_count: i32,
         pub result_claim_count: i32,
+        pub status: String,
+        pub claim_count: i32,
+        pub lease_token: Option<Uuid>,
+        pub lease_expires_at: Option<DateTimeUtc>,
+        pub consumed_lease_token: Option<Uuid>,
+        pub consumed_at: Option<DateTimeUtc>,
         pub delivered_at: DateTimeUtc,
     }
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -525,6 +525,28 @@ async fn create_agent_run_inbox_table(manager: &SchemaManager<'_>) -> Result<(),
                         .integer()
                         .not_null(),
                 )
+                .col(ColumnDef::new(AgentRunInbox::Status).string().not_null())
+                .col(
+                    ColumnDef::new(AgentRunInbox::ClaimCount)
+                        .integer()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(AgentRunInbox::LeaseToken).uuid().null())
+                .col(
+                    ColumnDef::new(AgentRunInbox::LeaseExpiresAt)
+                        .timestamp_with_time_zone()
+                        .null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunInbox::ConsumedLeaseToken)
+                        .uuid()
+                        .null(),
+                )
+                .col(
+                    ColumnDef::new(AgentRunInbox::ConsumedAt)
+                        .timestamp_with_time_zone()
+                        .null(),
+                )
                 .col(
                     ColumnDef::new(AgentRunInbox::DeliveredAt)
                         .timestamp_with_time_zone()
@@ -576,6 +598,31 @@ async fn create_agent_run_inbox_table(manager: &SchemaManager<'_>) -> Result<(),
                 .check(
                     Expr::col(AgentRunInbox::ResultClaimCount)
                         .gte(Expr::col(AgentRunInbox::ResultAttemptCount)),
+                )
+                .check(Expr::col(AgentRunInbox::Status).is_in(["pending", "claimed", "consumed"]))
+                .check(Expr::col(AgentRunInbox::ClaimCount).gte(0))
+                .check(
+                    Expr::col(AgentRunInbox::Status)
+                        .eq("pending")
+                        .and(Expr::col(AgentRunInbox::ClaimCount).eq(0))
+                        .and(Expr::col(AgentRunInbox::LeaseToken).is_null())
+                        .and(Expr::col(AgentRunInbox::LeaseExpiresAt).is_null())
+                        .and(Expr::col(AgentRunInbox::ConsumedLeaseToken).is_null())
+                        .and(Expr::col(AgentRunInbox::ConsumedAt).is_null())
+                        .or(Expr::col(AgentRunInbox::Status)
+                            .eq("claimed")
+                            .and(Expr::col(AgentRunInbox::ClaimCount).gte(1))
+                            .and(Expr::col(AgentRunInbox::LeaseToken).is_not_null())
+                            .and(Expr::col(AgentRunInbox::LeaseExpiresAt).is_not_null())
+                            .and(Expr::col(AgentRunInbox::ConsumedLeaseToken).is_null())
+                            .and(Expr::col(AgentRunInbox::ConsumedAt).is_null()))
+                        .or(Expr::col(AgentRunInbox::Status)
+                            .eq("consumed")
+                            .and(Expr::col(AgentRunInbox::ClaimCount).gte(1))
+                            .and(Expr::col(AgentRunInbox::LeaseToken).is_null())
+                            .and(Expr::col(AgentRunInbox::LeaseExpiresAt).is_null())
+                            .and(Expr::col(AgentRunInbox::ConsumedLeaseToken).is_not_null())
+                            .and(Expr::col(AgentRunInbox::ConsumedAt).is_not_null())),
                 )
                 .to_owned(),
         )
@@ -3439,6 +3486,12 @@ enum AgentRunInbox {
     ResultLeaseToken,
     ResultAttemptCount,
     ResultClaimCount,
+    Status,
+    ClaimCount,
+    LeaseToken,
+    LeaseExpiresAt,
+    ConsumedLeaseToken,
+    ConsumedAt,
     DeliveredAt,
 }
 

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -39,14 +39,14 @@ use crate::model::{
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
     AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
-    BeginRootAttachmentChangeOutcome, ClaimClientToolCallOutcome, ClaimTurnRunOutcome,
-    CompleteTurnRunOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
-    EnsureDocumentParseJobOutcome, FinishAgentRunCancellationOutcome,
-    FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
-    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledTurnOutcome,
-    JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
-    RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome,
-    Store, SubmitAgentRunResultOutcome,
+    BeginRootAttachmentChangeOutcome, ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome,
+    ClaimTurnRunOutcome, CompleteTurnRunOutcome, ConsumeAgentRunInboxOutcome,
+    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
+    FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
+    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
+    JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome,
+    RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome,
+    ResolveToolCallOutcome, Store, SubmitAgentRunResultOutcome,
 };
 
 mod ops;
@@ -1809,6 +1809,38 @@ impl Store for DbStore {
         parent_run_id: AgentRunId,
     ) -> Result<Vec<AgentRunInboxEntry>> {
         ops::agent_run::list_agent_run_inbox(self, parent_run_id).await
+    }
+
+    async fn claim_agent_run_inbox_entry(
+        &self,
+        parent_run_id: AgentRunId,
+        child_run_id: AgentRunId,
+        lease_token: uuid::Uuid,
+        lease_duration: chrono::Duration,
+    ) -> Result<Option<ClaimAgentRunInboxOutcome>> {
+        ops::agent_run::claim_agent_run_inbox_entry(
+            self,
+            parent_run_id,
+            child_run_id,
+            lease_token,
+            lease_duration,
+        )
+        .await
+    }
+
+    async fn consume_agent_run_inbox_entry(
+        &self,
+        parent_run_id: AgentRunId,
+        child_run_id: AgentRunId,
+        lease_token: uuid::Uuid,
+    ) -> Result<Option<ConsumeAgentRunInboxOutcome>> {
+        ops::agent_run::consume_agent_run_inbox_entry(
+            self,
+            parent_run_id,
+            child_run_id,
+            lease_token,
+        )
+        .await
     }
 
     async fn get_turn_run(&self, id: TurnId) -> Result<Option<TurnRun>> {

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -7,10 +7,12 @@ use sea_orm::{
 use crate::error::{AgentError, Result};
 use crate::id::{AgentRunId, CallId, ChatId};
 use crate::model::{
-    AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunResult, AgentRunStatus,
+    AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunInboxStatus, AgentRunResult,
+    AgentRunStatus,
 };
 use crate::storage::{
-    AcceptAgentRunOutcome, FinishAgentRunCancellationOutcome, RequestAgentRunCancellationOutcome,
+    AcceptAgentRunOutcome, ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxOutcome,
+    FinishAgentRunCancellationOutcome, RequestAgentRunCancellationOutcome,
     SubmitAgentRunResultOutcome,
 };
 
@@ -826,6 +828,12 @@ pub(in crate::db) async fn submit_agent_run_result(
         result_lease_token: Set(lease_token),
         result_attempt_count: Set(run.attempt_count),
         result_claim_count: Set(run.claim_count),
+        status: Set(AgentRunInboxStatus::Pending.as_str().into()),
+        claim_count: Set(0),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        consumed_lease_token: Set(None),
+        consumed_at: Set(None),
         delivered_at: Set(now),
     }
     .insert(&transaction)
@@ -900,19 +908,238 @@ pub(in crate::db) async fn list_agent_run_inbox(
         .map_err(store_err)?;
     let mut inbox = Vec::with_capacity(entries.len());
     for entry in entries {
-        let result = entities::agent_run_result::Entity::find_by_id(entry.child_run_id)
-            .one(&store.conn)
-            .await
-            .map_err(store_err)?
-            .ok_or_else(|| {
-                AgentError::Store(format!(
-                    "agent-run inbox child {} is missing its result receipt",
-                    entry.child_run_id
-                ))
-            })?;
-        inbox.push(agent_run_inbox_from_models(entry, result)?);
+        inbox.push(load_agent_run_inbox_entry_on(&store.conn, entry).await?);
     }
     Ok(inbox)
+}
+
+/// Claim one exact immutable delivery as the next parent continuation boundary.
+///
+/// The shared scheduler lock deliberately serializes this with sandbox claims:
+/// a continuation must observe one database-clock ordering, and an expired
+/// continuation owner must never race a replacement owner into consumption.
+pub(in crate::db) async fn claim_agent_run_inbox_entry(
+    store: &DbStore,
+    parent_run_id: AgentRunId,
+    child_run_id: AgentRunId,
+    lease_token: uuid::Uuid,
+    lease_duration: chrono::Duration,
+) -> Result<Option<ClaimAgentRunInboxOutcome>> {
+    validate_inbox_claim_request(lease_token, lease_duration)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
+    let lease_expires_at = now.checked_add_signed(lease_duration).ok_or_else(|| {
+        AgentError::Store(
+            "agent-run inbox lease duration overflows the database timestamp range".into(),
+        )
+    })?;
+    if !parent_is_active_on(&transaction, parent_run_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let Some(model) = find_agent_run_inbox_on(&transaction, parent_run_id, child_run_id).await?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let entry = load_agent_run_inbox_entry_on(&transaction, model.clone()).await?;
+    match entry.status {
+        AgentRunInboxStatus::Pending => {
+            let updated = entities::agent_run_inbox::Entity::update_many()
+                .col_expr(
+                    entities::agent_run_inbox::Column::Status,
+                    sea_orm::sea_query::Expr::value(AgentRunInboxStatus::Claimed.as_str()),
+                )
+                .col_expr(
+                    entities::agent_run_inbox::Column::ClaimCount,
+                    sea_orm::sea_query::Expr::value(1),
+                )
+                .col_expr(
+                    entities::agent_run_inbox::Column::LeaseToken,
+                    sea_orm::sea_query::Expr::value(Some(lease_token)),
+                )
+                .col_expr(
+                    entities::agent_run_inbox::Column::LeaseExpiresAt,
+                    sea_orm::sea_query::Expr::value(Some(lease_expires_at)),
+                )
+                .filter(entities::agent_run_inbox::Column::ChildRunId.eq(child_run_id.0))
+                .filter(entities::agent_run_inbox::Column::ParentRunId.eq(parent_run_id.0))
+                .filter(
+                    entities::agent_run_inbox::Column::Status
+                        .eq(AgentRunInboxStatus::Pending.as_str()),
+                )
+                .filter(entities::agent_run_inbox::Column::ClaimCount.eq(0))
+                .exec(&transaction)
+                .await
+                .map_err(store_err)?;
+            if updated.rows_affected != 1 {
+                transaction.rollback().await.map_err(store_err)?;
+                return Ok(None);
+            }
+            let claimed = load_agent_run_inbox_by_ids_on(&transaction, parent_run_id, child_run_id)
+                .await?
+                .ok_or_else(|| {
+                    AgentError::Store("claimed agent-run inbox entry disappeared".into())
+                })?;
+            transaction.commit().await.map_err(store_err)?;
+            Ok(Some(ClaimAgentRunInboxOutcome::Claimed(claimed)))
+        }
+        AgentRunInboxStatus::Claimed
+            if entry.lease_token == Some(lease_token)
+                && entry
+                    .lease_expires_at
+                    .is_some_and(|expires_at| expires_at > now) =>
+        {
+            transaction.commit().await.map_err(store_err)?;
+            Ok(Some(ClaimAgentRunInboxOutcome::Existing(entry)))
+        }
+        AgentRunInboxStatus::Claimed
+            if entry
+                .lease_expires_at
+                .is_some_and(|expires_at| expires_at <= now) =>
+        {
+            // A lease token is a capability for one continuation attempt, not
+            // a retry identity. Once it expires, its former owner must not
+            // revive itself into a new attempt; only a fresh token may reclaim
+            // the immutable delivery.
+            if entry.lease_token == Some(lease_token) {
+                transaction.commit().await.map_err(store_err)?;
+                return Ok(None);
+            }
+            let next_claim_count = entry
+                .claim_count
+                .checked_add(1)
+                .ok_or_else(|| AgentError::Store("agent-run inbox claim count exhausted".into()))?;
+            let updated = entities::agent_run_inbox::Entity::update_many()
+                .col_expr(
+                    entities::agent_run_inbox::Column::ClaimCount,
+                    sea_orm::sea_query::Expr::value(next_claim_count),
+                )
+                .col_expr(
+                    entities::agent_run_inbox::Column::LeaseToken,
+                    sea_orm::sea_query::Expr::value(Some(lease_token)),
+                )
+                .col_expr(
+                    entities::agent_run_inbox::Column::LeaseExpiresAt,
+                    sea_orm::sea_query::Expr::value(Some(lease_expires_at)),
+                )
+                .filter(entities::agent_run_inbox::Column::ChildRunId.eq(child_run_id.0))
+                .filter(entities::agent_run_inbox::Column::ParentRunId.eq(parent_run_id.0))
+                .filter(
+                    entities::agent_run_inbox::Column::Status
+                        .eq(AgentRunInboxStatus::Claimed.as_str()),
+                )
+                .filter(entities::agent_run_inbox::Column::ClaimCount.eq(entry.claim_count))
+                .filter(entities::agent_run_inbox::Column::LeaseToken.eq(entry.lease_token))
+                .filter(
+                    entities::agent_run_inbox::Column::LeaseExpiresAt.eq(entry.lease_expires_at),
+                )
+                .filter(entities::agent_run_inbox::Column::LeaseExpiresAt.lte(now))
+                .exec(&transaction)
+                .await
+                .map_err(store_err)?;
+            if updated.rows_affected != 1 {
+                transaction.rollback().await.map_err(store_err)?;
+                return Ok(None);
+            }
+            let claimed = load_agent_run_inbox_by_ids_on(&transaction, parent_run_id, child_run_id)
+                .await?
+                .ok_or_else(|| {
+                    AgentError::Store("reclaimed agent-run inbox entry disappeared".into())
+                })?;
+            transaction.commit().await.map_err(store_err)?;
+            Ok(Some(ClaimAgentRunInboxOutcome::Claimed(claimed)))
+        }
+        AgentRunInboxStatus::Claimed | AgentRunInboxStatus::Consumed => {
+            transaction.commit().await.map_err(store_err)?;
+            Ok(None)
+        }
+    }
+}
+
+/// Mark one exact inbox delivery consumed under its active continuation lease.
+///
+/// Consumption is the commit point for a future parent resume transition. The
+/// resulting receipt is retained so a worker can recover an ambiguous commit
+/// without re-consuming the child result.
+pub(in crate::db) async fn consume_agent_run_inbox_entry(
+    store: &DbStore,
+    parent_run_id: AgentRunId,
+    child_run_id: AgentRunId,
+    lease_token: uuid::Uuid,
+) -> Result<Option<ConsumeAgentRunInboxOutcome>> {
+    if lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "agent-run inbox consumption requires a non-nil lease token".into(),
+        ));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
+    if !parent_is_active_on(&transaction, parent_run_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let Some(model) = find_agent_run_inbox_on(&transaction, parent_run_id, child_run_id).await?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let entry = load_agent_run_inbox_entry_on(&transaction, model).await?;
+    if entry.status == AgentRunInboxStatus::Consumed {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok((entry.consumed_lease_token == Some(lease_token))
+            .then_some(ConsumeAgentRunInboxOutcome::Existing(entry)));
+    }
+    if entry.status != AgentRunInboxStatus::Claimed
+        || entry.lease_token != Some(lease_token)
+        || !entry
+            .lease_expires_at
+            .is_some_and(|expires_at| expires_at > now)
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let updated = entities::agent_run_inbox::Entity::update_many()
+        .col_expr(
+            entities::agent_run_inbox::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunInboxStatus::Consumed.as_str()),
+        )
+        .col_expr(
+            entities::agent_run_inbox::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::agent_run_inbox::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::agent_run_inbox::Column::ConsumedLeaseToken,
+            sea_orm::sea_query::Expr::value(Some(lease_token)),
+        )
+        .col_expr(
+            entities::agent_run_inbox::Column::ConsumedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .filter(entities::agent_run_inbox::Column::ChildRunId.eq(child_run_id.0))
+        .filter(entities::agent_run_inbox::Column::ParentRunId.eq(parent_run_id.0))
+        .filter(entities::agent_run_inbox::Column::Status.eq(AgentRunInboxStatus::Claimed.as_str()))
+        .filter(entities::agent_run_inbox::Column::LeaseToken.eq(lease_token))
+        .filter(entities::agent_run_inbox::Column::LeaseExpiresAt.eq(entry.lease_expires_at))
+        .filter(entities::agent_run_inbox::Column::LeaseExpiresAt.gt(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let consumed = load_agent_run_inbox_by_ids_on(&transaction, parent_run_id, child_run_id)
+        .await?
+        .ok_or_else(|| AgentError::Store("consumed agent-run inbox entry disappeared".into()))?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(ConsumeAgentRunInboxOutcome::Consumed(consumed)))
 }
 
 fn validate_claim_request(
@@ -934,6 +1161,18 @@ fn validate_claim_request(
             "agent-run concurrency limits must satisfy 1 <= per-chat <= global <= {}",
             AgentRun::MAX_CONCURRENCY_LIMIT
         )));
+    }
+    Ok(())
+}
+
+fn validate_inbox_claim_request(
+    lease_token: uuid::Uuid,
+    lease_duration: chrono::Duration,
+) -> Result<()> {
+    if lease_token.is_nil() || lease_duration <= chrono::Duration::zero() {
+        return Err(AgentError::Store(
+            "agent-run inbox claim requires a non-nil token and positive duration".into(),
+        ));
     }
     Ok(())
 }
@@ -1317,10 +1556,39 @@ fn agent_run_inbox_from_models(
     model: entities::agent_run_inbox::Model,
     result: entities::agent_run_result::Model,
 ) -> Result<AgentRunInboxEntry> {
+    let status = AgentRunInboxStatus::parse(&model.status).ok_or_else(|| {
+        AgentError::Store("invalid stored agent-run inbox continuation status".into())
+    })?;
+    let valid_continuation = match status {
+        AgentRunInboxStatus::Pending => {
+            model.claim_count == 0
+                && model.lease_token.is_none()
+                && model.lease_expires_at.is_none()
+                && model.consumed_lease_token.is_none()
+                && model.consumed_at.is_none()
+        }
+        AgentRunInboxStatus::Claimed => {
+            model.claim_count >= 1
+                && model.lease_token.is_some_and(|token| !token.is_nil())
+                && model.lease_expires_at.is_some()
+                && model.consumed_lease_token.is_none()
+                && model.consumed_at.is_none()
+        }
+        AgentRunInboxStatus::Consumed => {
+            model.claim_count >= 1
+                && model.lease_token.is_none()
+                && model.lease_expires_at.is_none()
+                && model
+                    .consumed_lease_token
+                    .is_some_and(|token| !token.is_nil())
+                && model.consumed_at.is_some()
+        }
+    };
     if model.parent_depth != 0
         || model.result_lease_token.is_nil()
         || model.result_attempt_count < 1
         || model.result_claim_count < model.result_attempt_count
+        || !valid_continuation
     {
         return Err(AgentError::Store(
             "invalid stored agent-run inbox entry".into(),
@@ -1341,8 +1609,75 @@ fn agent_run_inbox_from_models(
         child_run_id: AgentRunId(model.child_run_id),
         chat_id: ChatId(model.chat_id),
         result,
+        status,
+        claim_count: model.claim_count,
+        lease_token: model.lease_token,
+        lease_expires_at: model.lease_expires_at,
+        consumed_lease_token: model.consumed_lease_token,
+        consumed_at: model.consumed_at,
         delivered_at: model.delivered_at,
     })
+}
+
+async fn find_agent_run_inbox_on<C>(
+    conn: &C,
+    parent_run_id: AgentRunId,
+    child_run_id: AgentRunId,
+) -> Result<Option<entities::agent_run_inbox::Model>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    entities::agent_run_inbox::Entity::find_by_id(child_run_id.0)
+        .filter(entities::agent_run_inbox::Column::ParentRunId.eq(parent_run_id.0))
+        .one(conn)
+        .await
+        .map_err(store_err)
+}
+
+async fn load_agent_run_inbox_by_ids_on<C>(
+    conn: &C,
+    parent_run_id: AgentRunId,
+    child_run_id: AgentRunId,
+) -> Result<Option<AgentRunInboxEntry>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let Some(model) = find_agent_run_inbox_on(conn, parent_run_id, child_run_id).await? else {
+        return Ok(None);
+    };
+    load_agent_run_inbox_entry_on(conn, model).await.map(Some)
+}
+
+async fn load_agent_run_inbox_entry_on<C>(
+    conn: &C,
+    model: entities::agent_run_inbox::Model,
+) -> Result<AgentRunInboxEntry>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let result = entities::agent_run_result::Entity::find_by_id(model.child_run_id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "agent-run inbox child {} is missing its result receipt",
+                model.child_run_id
+            ))
+        })?;
+    agent_run_inbox_from_models(model, result)
+}
+
+async fn parent_is_active_on<C>(conn: &C, parent_run_id: AgentRunId) -> Result<bool>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let parent = find_by_id_on(conn, parent_run_id).await?;
+    Ok(parent.is_some_and(|parent| {
+        parent.depth == 0
+            && parent.execution == AgentRunExecution::Foreground.as_str()
+            && parent.status == AgentRunStatus::Active.as_str()
+    }))
 }
 
 async fn find_by_id_on<C>(conn: &C, id: AgentRunId) -> Result<Option<entities::agent_run::Model>>

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -1,6 +1,7 @@
 use super::{sample_chat, temp_store};
 use crate::{
-    AcceptAgentRunOutcome, AgentRun, AgentRunExecution, AgentRunId, AgentRunStatus, CallId, ChatId,
+    AcceptAgentRunOutcome, AgentRun, AgentRunExecution, AgentRunId, AgentRunInboxStatus,
+    AgentRunStatus, CallId, ChatId, ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxOutcome,
     DbStore, FinishAgentRunCancellationOutcome, RequestAgentRunCancellationOutcome, Store,
     SubmitAgentRunResultOutcome,
 };
@@ -44,6 +45,43 @@ async fn force_expired_agent_deadline(store: &DbStore, id: AgentRunId) {
         .exec(&store.conn)
         .await
         .unwrap();
+}
+
+async fn submit_sandbox_result(
+    store: &DbStore,
+    chat_id: ChatId,
+    input: &str,
+    text: &str,
+) -> (AgentRunId, crate::AgentRunResult) {
+    let child_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            child_id,
+            chat_id,
+            Some(AgentRunId::foreground_for_chat(chat_id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some(input),
+        )
+        .await
+        .unwrap();
+    let lease_token = uuid::Uuid::new_v4();
+    let claimed = store
+        .claim_agent_run(lease_token, Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .expect("sandbox child should claim");
+    assert_eq!(claimed.id, child_id);
+    let result = match store
+        .submit_agent_run_result(child_id, lease_token, text)
+        .await
+        .unwrap()
+        .expect("sandbox child should complete")
+    {
+        SubmitAgentRunResultOutcome::Completed(result) => result,
+        outcome => panic!("unexpected result submission outcome: {outcome:?}"),
+    };
+    (child_id, result)
 }
 
 #[tokio::test]
@@ -538,6 +576,12 @@ async fn sandbox_result_submission_is_fenced_and_idempotent() {
             child_run_id: child_id,
             chat_id: chat.id,
             result: result.clone(),
+            status: AgentRunInboxStatus::Pending,
+            claim_count: 0,
+            lease_token: None,
+            lease_expires_at: None,
+            consumed_lease_token: None,
+            consumed_at: None,
             delivered_at: result.submitted_at,
         }]
     );
@@ -562,6 +606,165 @@ async fn sandbox_result_submission_is_fenced_and_idempotent() {
         .await
         .unwrap()
         .is_none());
+}
+
+#[tokio::test]
+async fn parent_inbox_consumption_is_fenced_and_idempotent() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let parent_id = AgentRunId::foreground_for_chat(chat.id);
+    let (child_id, result) = submit_sandbox_result(
+        &store,
+        chat.id,
+        "prepare a parent continuation",
+        "completed child result",
+    )
+    .await;
+
+    let token = uuid::Uuid::new_v4();
+    let claimed = match store
+        .claim_agent_run_inbox_entry(parent_id, child_id, token, Duration::minutes(1))
+        .await
+        .unwrap()
+        .expect("pending delivery should claim")
+    {
+        ClaimAgentRunInboxOutcome::Claimed(entry) => entry,
+        outcome => panic!("unexpected inbox claim outcome: {outcome:?}"),
+    };
+    assert_eq!(claimed.result, result);
+    assert_eq!(claimed.status, AgentRunInboxStatus::Claimed);
+    assert_eq!(claimed.claim_count, 1);
+    assert_eq!(claimed.lease_token, Some(token));
+    assert!(claimed.lease_expires_at.is_some());
+    assert_eq!(claimed.consumed_lease_token, None);
+    assert_eq!(claimed.consumed_at, None);
+
+    assert!(matches!(
+        store
+            .claim_agent_run_inbox_entry(parent_id, child_id, token, Duration::minutes(1))
+            .await
+            .unwrap(),
+        Some(ClaimAgentRunInboxOutcome::Existing(entry)) if entry == claimed
+    ));
+    let stale_token = uuid::Uuid::new_v4();
+    assert!(store
+        .claim_agent_run_inbox_entry(parent_id, child_id, stale_token, Duration::minutes(1))
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .consume_agent_run_inbox_entry(parent_id, child_id, stale_token)
+        .await
+        .unwrap()
+        .is_none());
+
+    let consumed = match store
+        .consume_agent_run_inbox_entry(parent_id, child_id, token)
+        .await
+        .unwrap()
+        .expect("live lease should consume")
+    {
+        ConsumeAgentRunInboxOutcome::Consumed(entry) => entry,
+        outcome => panic!("unexpected inbox consumption outcome: {outcome:?}"),
+    };
+    assert_eq!(consumed.status, AgentRunInboxStatus::Consumed);
+    assert_eq!(consumed.claim_count, 1);
+    assert_eq!(consumed.lease_token, None);
+    assert_eq!(consumed.lease_expires_at, None);
+    assert_eq!(consumed.consumed_lease_token, Some(token));
+    assert!(consumed.consumed_at.is_some());
+    assert!(matches!(
+        store
+            .consume_agent_run_inbox_entry(parent_id, child_id, token)
+            .await
+            .unwrap(),
+        Some(ConsumeAgentRunInboxOutcome::Existing(entry)) if entry == consumed
+    ));
+    assert!(store
+        .consume_agent_run_inbox_entry(parent_id, child_id, stale_token)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .claim_agent_run_inbox_entry(
+            parent_id,
+            child_id,
+            uuid::Uuid::new_v4(),
+            Duration::minutes(1)
+        )
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn expired_parent_inbox_lease_can_be_reclaimed_but_not_consumed_by_stale_owner() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let parent_id = AgentRunId::foreground_for_chat(chat.id);
+    let (child_id, _) = submit_sandbox_result(
+        &store,
+        chat.id,
+        "exercise recovery",
+        "recoverable child result",
+    )
+    .await;
+    let first_token = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run_inbox_entry(parent_id, child_id, first_token, Duration::minutes(1))
+        .await
+        .unwrap()
+        .expect("pending delivery should claim");
+    let expired_at = Utc::now() - Duration::minutes(5);
+    crate::db::entities::agent_run_inbox::Entity::update_many()
+        .col_expr(
+            crate::db::entities::agent_run_inbox::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Some(expired_at)),
+        )
+        .filter(crate::db::entities::agent_run_inbox::Column::ChildRunId.eq(child_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    assert!(store
+        .claim_agent_run_inbox_entry(parent_id, child_id, first_token, Duration::minutes(1))
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .consume_agent_run_inbox_entry(parent_id, child_id, first_token)
+        .await
+        .unwrap()
+        .is_none());
+
+    let replacement_token = uuid::Uuid::new_v4();
+    let reclaimed = match store
+        .claim_agent_run_inbox_entry(parent_id, child_id, replacement_token, Duration::minutes(1))
+        .await
+        .unwrap()
+        .expect("expired delivery should reclaim")
+    {
+        ClaimAgentRunInboxOutcome::Claimed(entry) => entry,
+        outcome => panic!("unexpected inbox claim outcome: {outcome:?}"),
+    };
+    assert_eq!(reclaimed.claim_count, 2);
+    assert_eq!(reclaimed.lease_token, Some(replacement_token));
+    assert!(store
+        .consume_agent_run_inbox_entry(parent_id, child_id, first_token)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(matches!(
+        store
+            .consume_agent_run_inbox_entry(parent_id, child_id, replacement_token)
+            .await
+            .unwrap(),
+        Some(ConsumeAgentRunInboxOutcome::Consumed(entry))
+            if entry.claim_count == 2
+                && entry.consumed_lease_token == Some(replacement_token)
+    ));
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -60,13 +60,13 @@ pub use id::{
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;
 pub use model::{
-    validate_source_regions, AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunResult,
-    AgentRunStatus, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, ByteSpan,
-    Chat, ChatRootAttachment, ClientToolCallRequest, DocumentGeneration, DocumentJob,
-    DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput,
-    DocumentProcessingStatus, DocumentRecord, DocumentScope, DocumentSourceBlob,
-    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, Project, Role,
-    RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
+    validate_source_regions, AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunInboxStatus,
+    AgentRunResult, AgentRunStatus, BeginRootAttachmentChange, BlobRetirement,
+    BlobRetirementStatus, ByteSpan, Chat, ChatRootAttachment, ClientToolCallRequest,
+    DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
+    DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
+    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
+    Project, Role, RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
     RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
     RootAttachmentSubjectKind, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
     ToolCallResolution, ToolCallStatus, TurnCheckpointProgress, TurnClientWait,
@@ -80,9 +80,10 @@ pub use provider::{
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
     AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
-    ApplyTurnSteerOutcome, BeginRootAttachmentChangeOutcome, BlobStore, ClaimClientToolCallOutcome,
-    ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim, CompleteTurnRunOutcome,
-    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
+    ApplyTurnSteerOutcome, BeginRootAttachmentChangeOutcome, BlobStore, ClaimAgentRunInboxOutcome,
+    ClaimClientToolCallOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim,
+    CompleteTurnRunOutcome, ConsumeAgentRunInboxOutcome, DocumentIndexJobReason,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
     FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
     JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1182,8 +1182,58 @@ pub struct AgentRunInboxEntry {
     pub chat_id: ChatId,
     /// Exact result receipt that was delivered.
     pub result: AgentRunResult,
+    /// Durable continuation state for this exact child result.
+    pub status: AgentRunInboxStatus,
+    /// Number of distinct continuation leases issued for this delivery.
+    pub claim_count: i32,
+    /// Exact live continuation lease, when a worker currently owns it.
+    pub lease_token: Option<Uuid>,
+    /// Database-clock expiry of the live continuation lease.
+    pub lease_expires_at: Option<DateTime<Utc>>,
+    /// Exact lease that durably consumed this delivery.
+    pub consumed_lease_token: Option<Uuid>,
+    /// Database time at which consumption committed.
+    pub consumed_at: Option<DateTime<Utc>>,
     /// Database time when the durable parent delivery committed.
     pub delivered_at: DateTime<Utc>,
+}
+
+/// Durable continuation lifecycle for one parent inbox delivery.
+///
+/// A delivery is immutable; only its fenced consumption state advances. A
+/// continuation lease may be reclaimed after expiry, while a consumed receipt
+/// remains available for an ambiguous exact retry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AgentRunInboxStatus {
+    /// The parent has not yet claimed this child result.
+    Pending,
+    /// One exact continuation lease owns this child result.
+    Claimed,
+    /// One exact continuation lease durably consumed this child result.
+    Consumed,
+}
+
+impl AgentRunInboxStatus {
+    /// Stable database and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::Claimed => "claimed",
+            Self::Consumed => "consumed",
+        }
+    }
+
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value {
+            "pending" => Some(Self::Pending),
+            "claimed" => Some(Self::Claimed),
+            "consumed" => Some(Self::Consumed),
+            _ => None,
+        }
+    }
 }
 
 /// Execution boundary for an [`AgentRun`].

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -193,6 +193,24 @@ pub enum SubmitAgentRunResultOutcome {
     Existing(AgentRunResult),
 }
 
+/// Result of acquiring durable ownership of one exact parent inbox delivery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimAgentRunInboxOutcome {
+    /// This call acquired the continuation lease.
+    Claimed(AgentRunInboxEntry),
+    /// The exact live lease was already acquired by this caller.
+    Existing(AgentRunInboxEntry),
+}
+
+/// Result of consuming one exact parent inbox delivery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConsumeAgentRunInboxOutcome {
+    /// This exact live continuation lease committed consumption.
+    Consumed(AgentRunInboxEntry),
+    /// This exact lease already committed consumption.
+    Existing(AgentRunInboxEntry),
+}
+
 /// Result of atomically accepting one exact steering instruction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AcceptTurnSteerOutcome {
@@ -1022,6 +1040,31 @@ pub trait Store: Send + Sync {
         &self,
         _parent_run_id: AgentRunId,
     ) -> Result<Vec<AgentRunInboxEntry>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Acquire an expiring, exact lease to advance one immutable parent inbox
+    /// delivery. Repeating the same live lease recovers its ownership; an
+    /// expired lease may be reclaimed by a different continuation worker.
+    async fn claim_agent_run_inbox_entry(
+        &self,
+        _parent_run_id: AgentRunId,
+        _child_run_id: AgentRunId,
+        _lease_token: uuid::Uuid,
+        _lease_duration: chrono::Duration,
+    ) -> Result<Option<ClaimAgentRunInboxOutcome>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Consume one exact inbox delivery under its live continuation lease.
+    /// An ambiguous exact retry recovers the consumed receipt, while a stale
+    /// lease cannot consume or overwrite a reclaimed delivery.
+    async fn consume_agent_run_inbox_entry(
+        &self,
+        _parent_run_id: AgentRunId,
+        _child_run_id: AgentRunId,
+        _lease_token: uuid::Uuid,
+    ) -> Result<Option<ConsumeAgentRunInboxOutcome>> {
         agent_run_storage_unavailable()
     }
 

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -140,7 +140,15 @@ The scheduler's ownership rules are deliberately strict:
 Final sandbox text is stored as an immutable receipt keyed by the child run and
 the exact lease segment that submitted it. The receipt, `completed` state, and
 one parent inbox entry commit together, so an ambiguous worker retry can recover
-its original result but cannot overwrite or double-deliver it. Queued, waiting,
+its original result but cannot overwrite or double-deliver it. Each inbox entry
+then advances through its own fenced continuation state machine:
+`pending -> claimed -> consumed`. A parent continuation claims one exact child
+result with a database-clock lease, and only that live lease can consume it.
+An expired claim can be reclaimed; a consumed entry retains the exact consuming
+lease as an immutable receipt, so an ambiguous consume retry recovers the same
+boundary without processing the child result twice. This is intentionally
+separate from model/tool execution: a later slice will atomically combine
+consumption with the parent turn checkpoint and wake event. Queued, waiting,
 and retry-wait work cancels
 immediately; a running worker first enters `cancelling` and must acknowledge its
 exact live lease. That acknowledgement writes its own immutable receipt, so only
@@ -170,8 +178,10 @@ The agent hierarchy preserves the runtime's existing rules:
 5. Waits release workers and resume from committed checkpoints.
 6. Steering and cancellation are resolved at explicit boundaries.
 7. A final result, terminal run state, and immutable parent inbox entry are
-   committed atomically. Wait consumption and the corresponding terminal event
-   will join a later continuation transition.
+   committed atomically. The inbox entry itself is consumed only under an exact
+   expiring continuation lease, and preserves its consumed receipt for retry
+   recovery. The corresponding parent checkpoint and wake event will join a
+   later continuation transition.
 8. Clients recover from a durable snapshot plus ordered event replay.
 
 Until a tool satisfies the side-effect receipt contract, OpenWave continues to
@@ -189,7 +199,8 @@ The implementation is intentionally incremental:
 4. Add the parent inbox and atomic child-result delivery. *(Shipped.)*
 5. Generalize client execution into the shared continuation model.
 6. Persist shared model/tool step boundaries and side-effect receipts.
-7. Add waits that consume durable inbox receipts and wake a parent.
+7. Atomically join durable inbox consumption with a parent wait/checkpoint and
+   wake event.
 8. Route sandbox folder access through the host broker.
 9. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.


### PR DESCRIPTION
## Summary

- model each parent inbox delivery as a durable pending, claimed, and consumed continuation
- fence claim and consumption with expiring database-clock leases and exact retry receipts
- reject an expired worker token from reclaiming its own continuation lease

## Validation

- cargo test -p openwave-core --features sqlite --lib --locked
- cargo check -p openwave-core --no-default-features --features postgres --locked
- bw dev lint --rust --check