### PR TITLE
Wake foreground turns from child results

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -472,6 +472,36 @@ pub mod agent_run_inbox {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod turn_agent_run_wait {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "turn_agent_run_wait")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub child_run_id: Uuid,
+        pub parent_run_id: Uuid,
+        pub turn_id: Uuid,
+        pub chat_id: Uuid,
+        pub park_lease_token: Uuid,
+        pub attempt_count: i32,
+        pub claim_count: i32,
+        pub model_steps: i32,
+        pub input_tokens: i64,
+        pub output_tokens: i64,
+        pub cache_read_input_tokens: i64,
+        pub cache_creation_input_tokens: i64,
+        pub status: String,
+        pub parked_at: DateTimeUtc,
+        pub closed_at: Option<DateTimeUtc>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod turn_run {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -2,7 +2,8 @@ use sea_orm_migration::prelude::*;
 
 use super::{
     AgentRunExecution, AgentRunStatus, BlobRetirementStatus, DocumentJobKind, DocumentJobStatus,
-    DocumentProcessingStatus, TurnClientWaitStatus, TurnRunStatus, TurnSteerStatus,
+    DocumentProcessingStatus, TurnAgentRunWaitStatus, TurnClientWaitStatus, TurnRunStatus,
+    TurnSteerStatus,
 };
 
 pub struct Migrator;
@@ -958,6 +959,7 @@ impl MigrationTrait for Init {
             TurnRunStatus::Running.as_str(),
             TurnRunStatus::Cancelling.as_str(),
             TurnRunStatus::WaitingForClient.as_str(),
+            TurnRunStatus::WaitingForAgentRun.as_str(),
             TurnRunStatus::CancellingClient.as_str(),
             TurnRunStatus::Resuming.as_str(),
             TurnRunStatus::RetryWait.as_str(),
@@ -996,6 +998,7 @@ impl MigrationTrait for Init {
                 TurnRunStatus::Running.as_str(),
                 TurnRunStatus::Cancelling.as_str(),
                 TurnRunStatus::WaitingForClient.as_str(),
+                TurnRunStatus::WaitingForAgentRun.as_str(),
                 TurnRunStatus::CancellingClient.as_str(),
                 TurnRunStatus::Resuming.as_str(),
                 TurnRunStatus::RetryWait.as_str(),
@@ -1018,9 +1021,10 @@ impl MigrationTrait for Init {
             .and(Expr::col(TurnRun::AttemptCount).gte(1))
             .and(Expr::col(TurnRun::AttemptCount).lt(Expr::col(TurnRun::MaxAttempts)))
             .and(Expr::col(TurnRun::StartedAt).is_not_null());
-        let client_checkpoint_attempt = Expr::col(TurnRun::Status)
+        let continuation_checkpoint_attempt = Expr::col(TurnRun::Status)
             .is_in([
                 TurnRunStatus::WaitingForClient.as_str(),
+                TurnRunStatus::WaitingForAgentRun.as_str(),
                 TurnRunStatus::CancellingClient.as_str(),
                 TurnRunStatus::Resuming.as_str(),
             ])
@@ -1056,6 +1060,7 @@ impl MigrationTrait for Init {
                 TurnRunStatus::Running.as_str(),
                 TurnRunStatus::Cancelling.as_str(),
                 TurnRunStatus::WaitingForClient.as_str(),
+                TurnRunStatus::WaitingForAgentRun.as_str(),
                 TurnRunStatus::CancellingClient.as_str(),
                 TurnRunStatus::Resuming.as_str(),
                 TurnRunStatus::Completed.as_str(),
@@ -1262,7 +1267,7 @@ impl MigrationTrait for Init {
                     .check(
                         queued_attempt
                             .or(leased_attempt)
-                            .or(client_checkpoint_attempt)
+                            .or(continuation_checkpoint_attempt)
                             .or(retryable_attempt)
                             .or(resolved_attempt)
                             .or(cancelled_attempt),
@@ -1345,6 +1350,7 @@ impl MigrationTrait for Init {
                         TurnRunStatus::Running.as_str(),
                         TurnRunStatus::Cancelling.as_str(),
                         TurnRunStatus::WaitingForClient.as_str(),
+                        TurnRunStatus::WaitingForAgentRun.as_str(),
                         TurnRunStatus::CancellingClient.as_str(),
                         TurnRunStatus::Resuming.as_str(),
                         TurnRunStatus::RetryWait.as_str(),
@@ -1390,6 +1396,158 @@ impl MigrationTrait for Init {
                     .table(TurnRun::Table)
                     .col(TurnRun::ChatId)
                     .col(TurnRun::CreatedAt)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(TurnAgentRunWait::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::ChildRunId)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::ParentRunId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(TurnAgentRunWait::TurnId).uuid().not_null())
+                    .col(ColumnDef::new(TurnAgentRunWait::ChatId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::ParkLeaseToken)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::AttemptCount)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::ClaimCount)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::ModelSteps)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::InputTokens)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::OutputTokens)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::CacheReadInputTokens)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::CacheCreationInputTokens)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(TurnAgentRunWait::Status).text().not_null())
+                    .col(
+                        ColumnDef::new(TurnAgentRunWait::ParkedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(TurnAgentRunWait::ClosedAt).timestamp_with_time_zone())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_agent_run_wait_turn")
+                            .from_tbl(TurnAgentRunWait::Table)
+                            .from_col(TurnAgentRunWait::TurnId)
+                            .to_tbl(TurnRun::Table)
+                            .to_col(TurnRun::Id)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_agent_run_wait_child")
+                            .from_tbl(TurnAgentRunWait::Table)
+                            .from_col(TurnAgentRunWait::ChildRunId)
+                            .from_col(TurnAgentRunWait::ParentRunId)
+                            .from_col(TurnAgentRunWait::ChatId)
+                            .to_tbl(AgentRun::Table)
+                            .to_col(AgentRun::Id)
+                            .to_col(AgentRun::ParentId)
+                            .to_col(AgentRun::ChatId)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_agent_run_wait_claim")
+                            .from_tbl(TurnAgentRunWait::Table)
+                            .from_col(TurnAgentRunWait::ParkLeaseToken)
+                            .from_col(TurnAgentRunWait::TurnId)
+                            .from_col(TurnAgentRunWait::AttemptCount)
+                            .from_col(TurnAgentRunWait::ClaimCount)
+                            .to_tbl(TurnClaim::Table)
+                            .to_col(TurnClaim::Token)
+                            .to_col(TurnClaim::TurnId)
+                            .to_col(TurnClaim::AttemptCount)
+                            .to_col(TurnClaim::ClaimCount)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .check(Expr::col(TurnAgentRunWait::Status).is_in([
+                        TurnAgentRunWaitStatus::Waiting.as_str(),
+                        TurnAgentRunWaitStatus::Resumed.as_str(),
+                        TurnAgentRunWaitStatus::Cancelled.as_str(),
+                    ]))
+                    .check(
+                        Expr::col(TurnAgentRunWait::Status)
+                            .eq(TurnAgentRunWaitStatus::Waiting.as_str())
+                            .and(Expr::col(TurnAgentRunWait::ClosedAt).is_null())
+                            .or(Expr::col(TurnAgentRunWait::Status)
+                                .ne(TurnAgentRunWaitStatus::Waiting.as_str())
+                                .and(Expr::col(TurnAgentRunWait::ClosedAt).is_not_null())),
+                    )
+                    .check(Expr::col(TurnAgentRunWait::AttemptCount).gte(1))
+                    .check(
+                        Expr::col(TurnAgentRunWait::ClaimCount)
+                            .gte(Expr::col(TurnAgentRunWait::AttemptCount)),
+                    )
+                    .check(
+                        Expr::col(TurnAgentRunWait::ModelSteps)
+                            .gt(0)
+                            .and(Expr::col(TurnAgentRunWait::InputTokens).gte(0))
+                            .and(Expr::col(TurnAgentRunWait::OutputTokens).gte(0))
+                            .and(Expr::col(TurnAgentRunWait::CacheReadInputTokens).gte(0))
+                            .and(Expr::col(TurnAgentRunWait::CacheCreationInputTokens).gte(0)),
+                    )
+                    .check(
+                        Expr::col(TurnAgentRunWait::ClosedAt)
+                            .is_null()
+                            .or(Expr::col(TurnAgentRunWait::ClosedAt)
+                                .gte(Expr::col(TurnAgentRunWait::ParkedAt))),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_agent_run_wait_one_open")
+                    .table(TurnAgentRunWait::Table)
+                    .col(TurnAgentRunWait::TurnId)
+                    .unique()
+                    .and_where(
+                        Expr::col(TurnAgentRunWait::Status)
+                            .eq(TurnAgentRunWaitStatus::Waiting.as_str()),
+                    )
                     .to_owned(),
             )
             .await?;
@@ -1653,6 +1811,9 @@ impl MigrationTrait for Init {
             .await?;
         manager
             .drop_table(Table::drop().table(TurnFailure::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(TurnAgentRunWait::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(TurnRun::Table).to_owned())
@@ -3493,6 +3654,26 @@ enum AgentRunInbox {
     ConsumedLeaseToken,
     ConsumedAt,
     DeliveredAt,
+}
+
+#[derive(DeriveIden)]
+enum TurnAgentRunWait {
+    Table,
+    ChildRunId,
+    ParentRunId,
+    TurnId,
+    ChatId,
+    ParkLeaseToken,
+    AttemptCount,
+    ClaimCount,
+    ModelSteps,
+    InputTokens,
+    OutputTokens,
+    CacheReadInputTokens,
+    CacheCreationInputTokens,
+    Status,
+    ParkedAt,
+    ClosedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -33,18 +33,19 @@ use crate::model::{
     DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
     DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
     Project, RootAttachmentChange, RootAttachmentChangeTerminal, SourceRegion, ToolCallRecord,
-    ToolCallResolution, TurnCheckpointProgress, TurnClientWaitStatus, TurnFailureRetry, TurnRun,
-    TurnRunStatus, TurnSteerStatus, MAX_ROOT_ATTACHMENTS,
+    ToolCallResolution, TurnAgentRunWaitStatus, TurnCheckpointProgress, TurnClientWaitStatus,
+    TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteerStatus, MAX_ROOT_ATTACHMENTS,
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
     AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
     BeginRootAttachmentChangeOutcome, ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome,
-    ClaimTurnRunOutcome, CompleteTurnRunOutcome, ConsumeAgentRunInboxOutcome,
-    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
-    FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
-    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
-    JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome,
+    ClaimTurnRunOutcome, CompleteTurnRunOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
+    ConsumeAgentRunInboxOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
+    EnsureDocumentParseJobOutcome, FinishAgentRunCancellationOutcome,
+    FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
+    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledTurnOutcome,
+    JournaledTurnSteerOutcome, ParkTurnForAgentRunInboxOutcome, ParkTurnForClientCallOutcome,
     RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome,
     ResolveToolCallOutcome, Store, SubmitAgentRunResultOutcome,
 };
@@ -1843,6 +1844,21 @@ impl Store for DbStore {
         .await
     }
 
+    async fn consume_agent_run_inbox_entry_and_resume_turn(
+        &self,
+        parent_run_id: AgentRunId,
+        child_run_id: AgentRunId,
+        lease_token: uuid::Uuid,
+    ) -> Result<Option<ConsumeAgentRunInboxAndResumeTurnOutcome>> {
+        ops::agent_run::consume_agent_run_inbox_entry_and_resume_turn(
+            self,
+            parent_run_id,
+            child_run_id,
+            lease_token,
+        )
+        .await
+    }
+
     async fn get_turn_run(&self, id: TurnId) -> Result<Option<TurnRun>> {
         ops::turn::get_turn_run(self, id).await
     }
@@ -2059,6 +2075,27 @@ impl Store for DbStore {
             progress,
             now,
             call,
+        )
+        .await
+    }
+
+    async fn park_turn_for_agent_run_inbox(
+        &self,
+        turn_id: TurnId,
+        child_run_id: AgentRunId,
+        lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
+        progress: TurnCheckpointProgress,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<Option<ParkTurnForAgentRunInboxOutcome>> {
+        ops::turn::park_turn_for_agent_run_inbox(
+            self,
+            turn_id,
+            child_run_id,
+            lease_token,
+            expected_steer_revision,
+            progress,
+            now,
         )
         .await
     }

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -11,13 +11,13 @@ use crate::model::{
     AgentRunStatus,
 };
 use crate::storage::{
-    AcceptAgentRunOutcome, ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxOutcome,
-    FinishAgentRunCancellationOutcome, RequestAgentRunCancellationOutcome,
-    SubmitAgentRunResultOutcome,
+    AcceptAgentRunOutcome, ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
+    ConsumeAgentRunInboxOutcome, FinishAgentRunCancellationOutcome,
+    RequestAgentRunCancellationOutcome, SubmitAgentRunResultOutcome,
 };
 
 use super::super::{entities, store_err, DbStore};
-use super::{acquire_chat_write_lock, turn::canonical_db_timestamp};
+use super::{acquire_chat_write_lock, acquire_turn_write_lock, turn::canonical_db_timestamp};
 
 pub(in crate::db) async fn insert_foreground_agent_run_on<C>(
     conn: &C,
@@ -943,6 +943,14 @@ pub(in crate::db) async fn claim_agent_run_inbox_entry(
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     };
+    // A completed child may arrive before its foreground worker reaches the
+    // checkpoint boundary. Keep that delivery pending until the exact waiting
+    // turn exists: otherwise a continuation lease could expire or be consumed
+    // before there is a durable parent state to wake.
+    if !parent_turn_checkpoint_is_waiting_on(&transaction, parent_run_id, child_run_id).await? {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
     let entry = load_agent_run_inbox_entry_on(&transaction, model.clone()).await?;
     match entry.status {
         AgentRunInboxStatus::Pending => {
@@ -1069,6 +1077,32 @@ pub(in crate::db) async fn consume_agent_run_inbox_entry(
     child_run_id: AgentRunId,
     lease_token: uuid::Uuid,
 ) -> Result<Option<ConsumeAgentRunInboxOutcome>> {
+    Ok(consume_agent_run_inbox_entry_and_resume_turn(
+        store,
+        parent_run_id,
+        child_run_id,
+        lease_token,
+    )
+    .await?
+    .map(|outcome| match outcome {
+        ConsumeAgentRunInboxAndResumeTurnOutcome::Resumed { inbox, .. } => {
+            ConsumeAgentRunInboxOutcome::Consumed(inbox)
+        }
+        ConsumeAgentRunInboxAndResumeTurnOutcome::Existing { inbox, .. } => {
+            ConsumeAgentRunInboxOutcome::Existing(inbox)
+        }
+    }))
+}
+
+/// Consume one exact child result and queue its foreground turn to resume in
+/// the same transaction. The turn's durable `resuming` state is the wake
+/// signal; callers can restart after commit and use ordinary turn claiming.
+pub(in crate::db) async fn consume_agent_run_inbox_entry_and_resume_turn(
+    store: &DbStore,
+    parent_run_id: AgentRunId,
+    child_run_id: AgentRunId,
+    lease_token: uuid::Uuid,
+) -> Result<Option<ConsumeAgentRunInboxAndResumeTurnOutcome>> {
     if lease_token.is_nil() {
         return Err(AgentError::Store(
             "agent-run inbox consumption requires a non-nil lease token".into(),
@@ -1088,9 +1122,24 @@ pub(in crate::db) async fn consume_agent_run_inbox_entry(
     };
     let entry = load_agent_run_inbox_entry_on(&transaction, model).await?;
     if entry.status == AgentRunInboxStatus::Consumed {
+        let turn = if entry.consumed_lease_token == Some(lease_token) {
+            super::turn::resume_turn_after_agent_run_inbox_consumption_on(
+                &transaction,
+                parent_run_id,
+                child_run_id,
+                now,
+            )
+            .await?
+        } else {
+            None
+        };
         transaction.commit().await.map_err(store_err)?;
-        return Ok((entry.consumed_lease_token == Some(lease_token))
-            .then_some(ConsumeAgentRunInboxOutcome::Existing(entry)));
+        return Ok(
+            turn.map(|turn| ConsumeAgentRunInboxAndResumeTurnOutcome::Existing {
+                inbox: entry,
+                turn,
+            }),
+        );
     }
     if entry.status != AgentRunInboxStatus::Claimed
         || entry.lease_token != Some(lease_token)
@@ -1101,6 +1150,17 @@ pub(in crate::db) async fn consume_agent_run_inbox_entry(
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
+    let Some(turn) = super::turn::resume_turn_after_agent_run_inbox_consumption_on(
+        &transaction,
+        parent_run_id,
+        child_run_id,
+        now,
+    )
+    .await?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
     let updated = entities::agent_run_inbox::Entity::update_many()
         .col_expr(
             entities::agent_run_inbox::Column::Status,
@@ -1135,11 +1195,14 @@ pub(in crate::db) async fn consume_agent_run_inbox_entry(
         transaction.rollback().await.map_err(store_err)?;
         return Ok(None);
     }
-    let consumed = load_agent_run_inbox_by_ids_on(&transaction, parent_run_id, child_run_id)
+    let inbox = load_agent_run_inbox_by_ids_on(&transaction, parent_run_id, child_run_id)
         .await?
         .ok_or_else(|| AgentError::Store("consumed agent-run inbox entry disappeared".into()))?;
     transaction.commit().await.map_err(store_err)?;
-    Ok(Some(ConsumeAgentRunInboxOutcome::Consumed(consumed)))
+    Ok(Some(ConsumeAgentRunInboxAndResumeTurnOutcome::Resumed {
+        inbox,
+        turn,
+    }))
 }
 
 fn validate_claim_request(
@@ -1678,6 +1741,51 @@ where
             && parent.execution == AgentRunExecution::Foreground.as_str()
             && parent.status == AgentRunStatus::Active.as_str()
     }))
+}
+
+/// Confirm the parent has durably yielded the foreground turn that this exact
+/// child result will wake. Holding the turn lock through the inbox claim keeps
+/// cancellation or another wake from leaving a live continuation lease with no
+/// checkpoint to consume.
+async fn parent_turn_checkpoint_is_waiting_on<C>(
+    conn: &C,
+    parent_run_id: AgentRunId,
+    child_run_id: AgentRunId,
+) -> Result<bool>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let Some(wait) = entities::turn_agent_run_wait::Entity::find_by_id(child_run_id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(false);
+    };
+    if wait.parent_run_id != parent_run_id.0
+        || wait.status != crate::model::TurnAgentRunWaitStatus::Waiting.as_str()
+        || wait.closed_at.is_some()
+    {
+        return Ok(false);
+    }
+    let turn_id = crate::TurnId(wait.turn_id);
+    if !acquire_turn_write_lock(conn, turn_id).await? {
+        return Err(AgentError::Store(format!(
+            "agent-run checkpoint for child {child_run_id} references missing turn {turn_id}"
+        )));
+    }
+    let turn = entities::turn_run::Entity::find_by_id(wait.turn_id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .expect("locked agent-run checkpoint turn exists");
+    Ok(turn.chat_id == wait.chat_id
+        && turn.agent_run_id == parent_run_id.0
+        && turn.status == crate::TurnRunStatus::WaitingForAgentRun.as_str()
+        && turn.attempt_count == wait.attempt_count
+        && turn.claim_count == wait.claim_count
+        && turn.lease_token.is_none()
+        && turn.lease_expires_at.is_none())
 }
 
 async fn find_by_id_on<C>(conn: &C, id: AgentRunId) -> Result<Option<entities::agent_run::Model>>

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -21,10 +21,14 @@ use super::{
     },
 };
 
+mod agent_run_wait;
 mod client_wait;
 mod resolution;
 mod steer;
 
+pub(in crate::db) use agent_run_wait::{
+    park_turn_for_agent_run_inbox, resume_turn_after_agent_run_inbox_consumption_on,
+};
 pub(in crate::db) use client_wait::{
     advance_turn_after_client_resolution_on, park_turn_for_client_tool_call,
     recover_turn_after_client_resolution_on,
@@ -820,6 +824,7 @@ where
             TurnRunStatus::Running.as_str(),
             TurnRunStatus::Cancelling.as_str(),
             TurnRunStatus::WaitingForClient.as_str(),
+            TurnRunStatus::WaitingForAgentRun.as_str(),
             TurnRunStatus::CancellingClient.as_str(),
             TurnRunStatus::Resuming.as_str(),
             TurnRunStatus::RetryWait.as_str(),
@@ -926,6 +931,7 @@ fn turn_run_status_from_db(text: &str) -> Result<TurnRunStatus> {
         "running" => Ok(TurnRunStatus::Running),
         "cancelling" => Ok(TurnRunStatus::Cancelling),
         "waiting_for_client" => Ok(TurnRunStatus::WaitingForClient),
+        "waiting_for_agent_run" => Ok(TurnRunStatus::WaitingForAgentRun),
         "cancelling_client" => Ok(TurnRunStatus::CancellingClient),
         "resuming" => Ok(TurnRunStatus::Resuming),
         "retry_wait" => Ok(TurnRunStatus::RetryWait),

--- a/crates/openwave-core/src/db/ops/turn/agent_run_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/agent_run_wait.rs
@@ -1,0 +1,451 @@
+use chrono::Utc;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set, TransactionTrait,
+};
+
+use crate::error::{AgentError, Result};
+use crate::model::{
+    AgentRunExecution, AgentRunStatus, TurnAgentRunWait, TurnAgentRunWaitStatus,
+    TurnCheckpointProgress, TurnRunStatus, TurnSteerStatus,
+};
+use crate::storage::ParkTurnForAgentRunInboxOutcome;
+use crate::{AgentRunId, TurnId, TurnRun};
+
+use super::super::super::{entities, store_err, DbStore};
+use super::super::{acquire_chat_write_lock, acquire_turn_write_lock};
+use super::{canonical_db_timestamp, turn_run_from_model};
+
+pub(in crate::db) async fn park_turn_for_agent_run_inbox(
+    store: &DbStore,
+    turn_id: TurnId,
+    child_run_id: AgentRunId,
+    lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
+    progress: TurnCheckpointProgress,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<ParkTurnForAgentRunInboxOutcome>> {
+    validate_request(turn_id, child_run_id, lease_token, progress)?;
+    let now = canonical_db_timestamp(now)?;
+    let Some(scope) = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, crate::ChatId(scope.chat_id)).await?
+        || !acquire_turn_write_lock(&transaction, turn_id).await?
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    if let Some(wait) = entities::turn_agent_run_wait::Entity::find_by_id(child_run_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let turn = entities::turn_run::Entity::find_by_id(wait.turn_id)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| {
+                AgentError::Store(format!(
+                    "agent-run checkpoint for child {child_run_id} is missing its turn"
+                ))
+            })?;
+        let exact = wait.turn_id == turn_id.0
+            && wait.parent_run_id == turn.agent_run_id
+            && wait.chat_id == turn.chat_id
+            && wait.park_lease_token == lease_token
+            && progress_from_wait_model(&wait)? == progress;
+        let outcome = if exact {
+            ParkTurnForAgentRunInboxOutcome::Existing {
+                turn: turn_run_from_model(turn)?,
+                wait: wait_from_model(wait)?,
+            }
+        } else {
+            ParkTurnForAgentRunInboxOutcome::IdentityConflict
+        };
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(outcome));
+    }
+
+    let turn = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .expect("locked turn exists");
+    if turn.status != TurnRunStatus::Running.as_str()
+        || turn.lease_token != Some(lease_token)
+        || turn
+            .lease_expires_at
+            .is_none_or(|lease_expires_at| lease_expires_at <= now)
+        || turn.updated_at > now
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let steer_pending = entities::turn_steer::Entity::find()
+        .filter(entities::turn_steer::Column::TurnId.eq(turn_id.0))
+        .filter(entities::turn_steer::Column::Status.eq(TurnSteerStatus::Pending.as_str()))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .is_some();
+    if steer_pending || turn.steer_revision != expected_steer_revision {
+        let turn = turn_run_from_model(turn)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(if steer_pending {
+            ParkTurnForAgentRunInboxOutcome::SteerPending(turn)
+        } else {
+            ParkTurnForAgentRunInboxOutcome::OutputSuperseded(turn)
+        }));
+    }
+    let child = entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::Id.eq(child_run_id.0))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?;
+    let valid_child = child.is_some_and(|child| {
+        child.chat_id == turn.chat_id
+            && child.parent_id == Some(turn.agent_run_id)
+            && child.depth == 1
+            && child.execution == AgentRunExecution::Sandbox.as_str()
+            && !matches!(
+                child.status.as_str(),
+                status if status == AgentRunStatus::Failed.as_str()
+                    || status == AgentRunStatus::Cancelled.as_str()
+            )
+    });
+    if !valid_child {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let totals = checked_checkpoint_totals(&turn, progress)?;
+    let wait = entities::turn_agent_run_wait::ActiveModel {
+        child_run_id: Set(child_run_id.0),
+        parent_run_id: Set(turn.agent_run_id),
+        turn_id: Set(turn_id.0),
+        chat_id: Set(turn.chat_id),
+        park_lease_token: Set(lease_token),
+        attempt_count: Set(turn.attempt_count),
+        claim_count: Set(turn.claim_count),
+        model_steps: Set(progress.model_steps),
+        input_tokens: Set(i64::from(progress.usage.input_tokens)),
+        output_tokens: Set(i64::from(progress.usage.output_tokens)),
+        cache_read_input_tokens: Set(i64::from(progress.usage.cache_read_input_tokens)),
+        cache_creation_input_tokens: Set(i64::from(progress.usage.cache_creation_input_tokens)),
+        status: Set(TurnAgentRunWaitStatus::Waiting.as_str().into()),
+        parked_at: Set(now),
+        closed_at: Set(None),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    let parked = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnRunStatus::WaitingForAgentRun.as_str()),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::turn_run::Column::ModelSteps,
+            sea_orm::sea_query::Expr::value(totals.model_steps),
+        )
+        .col_expr(
+            entities::turn_run::Column::InputTokens,
+            sea_orm::sea_query::Expr::value(totals.input_tokens),
+        )
+        .col_expr(
+            entities::turn_run::Column::OutputTokens,
+            sea_orm::sea_query::Expr::value(totals.output_tokens),
+        )
+        .col_expr(
+            entities::turn_run::Column::CacheReadInputTokens,
+            sea_orm::sea_query::Expr::value(totals.cache_read_input_tokens),
+        )
+        .col_expr(
+            entities::turn_run::Column::CacheCreationInputTokens,
+            sea_orm::sea_query::Expr::value(totals.cache_creation_input_tokens),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
+        .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
+        .filter(entities::turn_run::Column::AttemptCount.eq(turn.attempt_count))
+        .filter(entities::turn_run::Column::ClaimCount.eq(turn.claim_count))
+        .filter(entities::turn_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.eq(turn.lease_expires_at))
+        .filter(entities::turn_run::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::turn_run::Column::SteerRevision.eq(expected_steer_revision))
+        .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at))
+        .filter(entities::turn_run::Column::UpdatedAt.lte(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if parked.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let parked_turn = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("parked turn {turn_id} disappeared")))?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(ParkTurnForAgentRunInboxOutcome::Parked {
+        turn: turn_run_from_model(parked_turn)?,
+        wait: wait_from_model(wait)?,
+    }))
+}
+
+/// Close a matching foreground checkpoint and make its turn claimable again.
+/// The caller owns the encompassing transaction and only invokes this after it
+/// has verified the exact live child-inbox continuation lease.
+pub(in crate::db) async fn resume_turn_after_agent_run_inbox_consumption_on<C>(
+    conn: &C,
+    parent_run_id: AgentRunId,
+    child_run_id: AgentRunId,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<TurnRun>>
+where
+    C: ConnectionTrait,
+{
+    let Some(wait) = entities::turn_agent_run_wait::Entity::find_by_id(child_run_id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+    if wait.parent_run_id != parent_run_id.0 {
+        return Ok(None);
+    }
+    let turn_id = TurnId(wait.turn_id);
+    if !acquire_turn_write_lock(conn, turn_id).await? {
+        return Err(AgentError::Store(format!(
+            "agent-run checkpoint for child {child_run_id} references missing turn {turn_id}"
+        )));
+    }
+    let turn = entities::turn_run::Entity::find_by_id(wait.turn_id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .expect("locked checkpoint turn exists");
+    if wait.status == TurnAgentRunWaitStatus::Resumed.as_str() {
+        let valid = turn.chat_id == wait.chat_id
+            && turn.agent_run_id == wait.parent_run_id
+            && turn.status == TurnRunStatus::Resuming.as_str()
+            && turn.attempt_count == wait.attempt_count
+            && turn.claim_count == wait.claim_count
+            && turn.lease_token.is_none()
+            && turn.lease_expires_at.is_none()
+            && wait.closed_at.is_some();
+        return valid.then(|| turn_run_from_model(turn)).transpose();
+    }
+    if wait.status != TurnAgentRunWaitStatus::Waiting.as_str()
+        || turn.chat_id != wait.chat_id
+        || turn.agent_run_id != wait.parent_run_id
+        || turn.status != TurnRunStatus::WaitingForAgentRun.as_str()
+        || turn.attempt_count != wait.attempt_count
+        || turn.claim_count != wait.claim_count
+        || turn.lease_token.is_some()
+        || turn.lease_expires_at.is_some()
+    {
+        return Ok(None);
+    }
+    // SQLite's statement clock is second-granularity while a foreground
+    // checkpoint preserves microseconds. Never let that representation detail
+    // make a later durable wake appear to precede its own checkpoint.
+    let transition_at = std::cmp::max(now, wait.parked_at);
+    let closed = entities::turn_agent_run_wait::Entity::update_many()
+        .col_expr(
+            entities::turn_agent_run_wait::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnAgentRunWaitStatus::Resumed.as_str()),
+        )
+        .col_expr(
+            entities::turn_agent_run_wait::Column::ClosedAt,
+            sea_orm::sea_query::Expr::value(Some(transition_at)),
+        )
+        .filter(entities::turn_agent_run_wait::Column::ChildRunId.eq(child_run_id.0))
+        .filter(
+            entities::turn_agent_run_wait::Column::Status
+                .eq(TurnAgentRunWaitStatus::Waiting.as_str()),
+        )
+        .filter(entities::turn_agent_run_wait::Column::ClosedAt.is_null())
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    if closed.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "agent-run checkpoint for child {child_run_id} changed while resuming"
+        )));
+    }
+    let resumed = entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::Status,
+            sea_orm::sea_query::Expr::value(TurnRunStatus::Resuming.as_str()),
+        )
+        .col_expr(
+            entities::turn_run::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(transition_at),
+        )
+        .col_expr(
+            entities::turn_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(transition_at),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn.id))
+        .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::WaitingForAgentRun.as_str()))
+        .filter(entities::turn_run::Column::AttemptCount.eq(turn.attempt_count))
+        .filter(entities::turn_run::Column::ClaimCount.eq(turn.claim_count))
+        .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    if resumed.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "agent-run checkpoint for child {child_run_id} lost its turn wake"
+        )));
+    }
+    let turn = entities::turn_run::Entity::find_by_id(turn.id)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| AgentError::Store(format!("resumed turn {turn_id} disappeared")))?;
+    turn_run_from_model(turn).map(Some)
+}
+
+fn validate_request(
+    turn_id: TurnId,
+    child_run_id: AgentRunId,
+    lease_token: uuid::Uuid,
+    progress: TurnCheckpointProgress,
+) -> Result<()> {
+    if turn_id.0.is_nil()
+        || child_run_id.0.is_nil()
+        || lease_token.is_nil()
+        || progress.model_steps <= 0
+    {
+        return Err(AgentError::Store(
+            "invalid sandbox-child turn checkpoint request".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn checked_checkpoint_totals(
+    turn: &entities::turn_run::Model,
+    progress: TurnCheckpointProgress,
+) -> Result<CheckpointTotals> {
+    let model_steps = turn
+        .model_steps
+        .checked_add(progress.model_steps)
+        .filter(|total| *total >= 0)
+        .ok_or_else(|| AgentError::Store("turn model-step checkpoint overflowed".into()))?;
+    Ok(CheckpointTotals {
+        model_steps,
+        input_tokens: checked_token_total("input", turn.input_tokens, progress.usage.input_tokens)?,
+        output_tokens: checked_token_total(
+            "output",
+            turn.output_tokens,
+            progress.usage.output_tokens,
+        )?,
+        cache_read_input_tokens: checked_token_total(
+            "cache-read input",
+            turn.cache_read_input_tokens,
+            progress.usage.cache_read_input_tokens,
+        )?,
+        cache_creation_input_tokens: checked_token_total(
+            "cache-creation input",
+            turn.cache_creation_input_tokens,
+            progress.usage.cache_creation_input_tokens,
+        )?,
+    })
+}
+
+struct CheckpointTotals {
+    model_steps: i32,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_input_tokens: i64,
+    cache_creation_input_tokens: i64,
+}
+
+fn checked_token_total(field: &str, current: i64, delta: u32) -> Result<i64> {
+    current
+        .checked_add(i64::from(delta))
+        .filter(|total| u32::try_from(*total).is_ok())
+        .ok_or_else(|| AgentError::Store(format!("turn {field} accounting overflowed")))
+}
+
+fn progress_from_wait_model(
+    wait: &entities::turn_agent_run_wait::Model,
+) -> Result<TurnCheckpointProgress> {
+    fn token(value: i64, field: &str) -> Result<u32> {
+        u32::try_from(value).map_err(|_| {
+            AgentError::Store(format!(
+                "agent-run checkpoint {field} token count is invalid"
+            ))
+        })
+    }
+    Ok(TurnCheckpointProgress {
+        model_steps: wait.model_steps,
+        usage: crate::Usage {
+            input_tokens: token(wait.input_tokens, "input")?,
+            output_tokens: token(wait.output_tokens, "output")?,
+            cache_read_input_tokens: token(wait.cache_read_input_tokens, "cache-read input")?,
+            cache_creation_input_tokens: token(
+                wait.cache_creation_input_tokens,
+                "cache-creation input",
+            )?,
+        },
+    })
+}
+
+pub(in crate::db) fn wait_from_model(
+    wait: entities::turn_agent_run_wait::Model,
+) -> Result<TurnAgentRunWait> {
+    let status = match wait.status.as_str() {
+        "waiting" => TurnAgentRunWaitStatus::Waiting,
+        "resumed" => TurnAgentRunWaitStatus::Resumed,
+        "cancelled" => TurnAgentRunWaitStatus::Cancelled,
+        _ => {
+            return Err(AgentError::Store(
+                "invalid agent-run checkpoint status".into(),
+            ))
+        }
+    };
+    if wait.attempt_count < 1
+        || wait.claim_count < wait.attempt_count
+        || wait.model_steps <= 0
+        || (status == TurnAgentRunWaitStatus::Waiting) != wait.closed_at.is_none()
+    {
+        return Err(AgentError::Store(
+            "invalid stored agent-run checkpoint".into(),
+        ));
+    }
+    Ok(TurnAgentRunWait {
+        child_run_id: AgentRunId(wait.child_run_id),
+        parent_run_id: AgentRunId(wait.parent_run_id),
+        turn_id: TurnId(wait.turn_id),
+        chat_id: crate::ChatId(wait.chat_id),
+        park_lease_token: wait.park_lease_token,
+        attempt_count: wait.attempt_count,
+        claim_count: wait.claim_count,
+        progress: progress_from_wait_model(&wait)?,
+        status,
+        parked_at: wait.parked_at,
+        closed_at: wait.closed_at,
+    })
+}

--- a/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
@@ -78,6 +78,7 @@ async fn request_turn_cancellation_inner(
         TurnRunStatus::Queued
         | TurnRunStatus::Running
         | TurnRunStatus::WaitingForClient
+        | TurnRunStatus::WaitingForAgentRun
         | TurnRunStatus::Resuming
         | TurnRunStatus::RetryWait => {}
     }
@@ -130,6 +131,54 @@ async fn request_turn_cancellation_inner(
         }
         if call.client_executor_id.is_none() {
             cancel_unclaimed_call = Some((wait, call));
+        }
+    }
+
+    if status == TurnRunStatus::WaitingForAgentRun {
+        let wait = entities::turn_agent_run_wait::Entity::find()
+            .filter(entities::turn_agent_run_wait::Column::TurnId.eq(id.0))
+            .filter(
+                entities::turn_agent_run_wait::Column::Status
+                    .eq(crate::model::TurnAgentRunWaitStatus::Waiting.as_str()),
+            )
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| {
+                AgentError::Store(format!("waiting turn {id} is missing its child receipt"))
+            })?;
+        if wait.chat_id != turn.chat_id
+            || wait.parent_run_id != turn.agent_run_id
+            || wait.attempt_count != turn.attempt_count
+            || wait.claim_count != turn.claim_count
+        {
+            return Err(AgentError::Store(format!(
+                "waiting turn {id} has a mismatched child receipt"
+            )));
+        }
+        let closed = entities::turn_agent_run_wait::Entity::update_many()
+            .col_expr(
+                entities::turn_agent_run_wait::Column::Status,
+                sea_orm::sea_query::Expr::value(
+                    crate::model::TurnAgentRunWaitStatus::Cancelled.as_str(),
+                ),
+            )
+            .col_expr(
+                entities::turn_agent_run_wait::Column::ClosedAt,
+                sea_orm::sea_query::Expr::value(Some(now)),
+            )
+            .filter(entities::turn_agent_run_wait::Column::ChildRunId.eq(wait.child_run_id))
+            .filter(
+                entities::turn_agent_run_wait::Column::Status
+                    .eq(crate::model::TurnAgentRunWaitStatus::Waiting.as_str()),
+            )
+            .filter(entities::turn_agent_run_wait::Column::ClosedAt.is_null())
+            .exec(&transaction)
+            .await
+            .map_err(store_err)?;
+        if closed.rows_affected != 1 {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(None);
         }
     }
 

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -87,6 +87,7 @@ pub(in crate::db) async fn accept_turn_steer(
             TurnRunStatus::Queued
                 | TurnRunStatus::Running
                 | TurnRunStatus::WaitingForClient
+                | TurnRunStatus::WaitingForAgentRun
                 | TurnRunStatus::Resuming
                 | TurnRunStatus::RetryWait
         )

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -1,9 +1,11 @@
 use super::{sample_chat, temp_store};
 use crate::{
-    AcceptAgentRunOutcome, AgentRun, AgentRunExecution, AgentRunId, AgentRunInboxStatus,
-    AgentRunStatus, CallId, ChatId, ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxOutcome,
-    DbStore, FinishAgentRunCancellationOutcome, RequestAgentRunCancellationOutcome, Store,
-    SubmitAgentRunResultOutcome,
+    AcceptAgentRunOutcome, AcceptTurnOutcome, AgentRun, AgentRunExecution, AgentRunId,
+    AgentRunInboxStatus, AgentRunStatus, CallId, ChatId, ClaimAgentRunInboxOutcome,
+    ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome, DbStore,
+    FinishAgentRunCancellationOutcome, ParkTurnForAgentRunInboxOutcome,
+    RequestAgentRunCancellationOutcome, Store, SubmitAgentRunResultOutcome, TurnCheckpointProgress,
+    TurnId, TurnRunStatus, Usage,
 };
 use chrono::{Duration, Utc};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
@@ -82,6 +84,55 @@ async fn submit_sandbox_result(
         outcome => panic!("unexpected result submission outcome: {outcome:?}"),
     };
     (child_id, result)
+}
+
+async fn park_foreground_turn_on_child(
+    store: &DbStore,
+    chat_id: ChatId,
+    child_run_id: AgentRunId,
+) -> crate::TurnRun {
+    let queued = match store
+        .accept_turn(TurnId::new(), chat_id, "gpt-5", "wait for the child")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected turn acceptance: {outcome:?}"),
+    };
+    let lease_token = uuid::Uuid::new_v4();
+    let now = Utc::now();
+    let running = store
+        .claim_turn_run(lease_token, now, now + Duration::minutes(5))
+        .await
+        .unwrap()
+        .turn
+        .expect("foreground turn should claim");
+    assert_eq!(running.id, queued.id);
+    let progress = TurnCheckpointProgress {
+        model_steps: 1,
+        usage: Usage {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+        },
+    };
+    match store
+        .park_turn_for_agent_run_inbox(
+            running.id,
+            child_run_id,
+            lease_token,
+            running.steer_revision,
+            progress,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .expect("foreground turn should park")
+    {
+        ParkTurnForAgentRunInboxOutcome::Parked { turn, .. } => turn,
+        outcome => panic!("unexpected child checkpoint outcome: {outcome:?}"),
+    }
 }
 
 #[tokio::test]
@@ -622,6 +673,26 @@ async fn parent_inbox_consumption_is_fenced_and_idempotent() {
     )
     .await;
 
+    // A child can finish before the parent reaches the tool boundary. The
+    // delivery stays pending until that exact foreground checkpoint exists.
+    let early_lease = uuid::Uuid::new_v4();
+    assert!(store
+        .claim_agent_run_inbox_entry(parent_id, child_id, early_lease, Duration::minutes(1))
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .consume_agent_run_inbox_entry_and_resume_turn(parent_id, child_id, early_lease)
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        store.list_agent_run_inbox(parent_id).await.unwrap()[0].status,
+        AgentRunInboxStatus::Pending
+    );
+    let parked = park_foreground_turn_on_child(&store, chat.id, child_id).await;
+    assert_eq!(parked.status, TurnRunStatus::WaitingForAgentRun);
+
     let token = uuid::Uuid::new_v4();
     let claimed = match store
         .claim_agent_run_inbox_entry(parent_id, child_id, token, Duration::minutes(1))
@@ -699,6 +770,139 @@ async fn parent_inbox_consumption_is_fenced_and_idempotent() {
 }
 
 #[tokio::test]
+async fn child_inbox_consumption_atomically_wakes_a_parked_foreground_turn() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let parent_id = AgentRunId::foreground_for_chat(chat.id);
+    let queued = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "delegate the research")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected turn acceptance: {outcome:?}"),
+    };
+    let turn_lease = uuid::Uuid::new_v4();
+    let now = Utc::now();
+    let running = store
+        .claim_turn_run(turn_lease, now, now + Duration::minutes(5))
+        .await
+        .unwrap()
+        .turn
+        .expect("foreground turn should claim");
+    assert_eq!(running.id, queued.id);
+    let child_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(parent_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("research the question"),
+        )
+        .await
+        .unwrap();
+    let progress = TurnCheckpointProgress {
+        model_steps: 1,
+        usage: Usage {
+            input_tokens: 11,
+            output_tokens: 7,
+            cache_read_input_tokens: 3,
+            cache_creation_input_tokens: 2,
+        },
+    };
+    let parked = match store
+        .park_turn_for_agent_run_inbox(
+            running.id,
+            child_id,
+            turn_lease,
+            running.steer_revision,
+            progress,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .expect("running turn should checkpoint")
+    {
+        ParkTurnForAgentRunInboxOutcome::Parked { turn, wait } => (turn, wait),
+        outcome => panic!("unexpected child checkpoint outcome: {outcome:?}"),
+    };
+    assert_eq!(parked.0.status, TurnRunStatus::WaitingForAgentRun);
+    assert_eq!(parked.1.child_run_id, child_id);
+    assert_eq!(parked.1.parent_run_id, parent_id);
+    assert_eq!(parked.1.progress, progress);
+
+    let child_lease = uuid::Uuid::new_v4();
+    let claimed_child = store
+        .claim_agent_run(child_lease, Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .expect("sandbox child should claim");
+    assert_eq!(claimed_child.id, child_id);
+    store
+        .submit_agent_run_result(child_id, child_lease, "research complete")
+        .await
+        .unwrap()
+        .expect("sandbox result should deliver");
+    let continuation_lease = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run_inbox_entry(
+            parent_id,
+            child_id,
+            continuation_lease,
+            Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .expect("delivered child result should claim");
+    let resumed = match store
+        .consume_agent_run_inbox_entry_and_resume_turn(parent_id, child_id, continuation_lease)
+        .await
+        .unwrap()
+        .expect("claimed child result should wake its parent turn")
+    {
+        ConsumeAgentRunInboxAndResumeTurnOutcome::Resumed { inbox, turn } => (inbox, turn),
+        outcome => panic!("unexpected inbox wake outcome: {outcome:?}"),
+    };
+    assert_eq!(resumed.0.status, AgentRunInboxStatus::Consumed);
+    assert_eq!(resumed.0.consumed_lease_token, Some(continuation_lease));
+    assert_eq!(resumed.1.status, TurnRunStatus::Resuming);
+    assert_eq!(resumed.1.attempt_count, running.attempt_count);
+    assert_eq!(resumed.1.claim_count, running.claim_count);
+    assert_eq!(resumed.1.model_steps, progress.model_steps);
+    assert_eq!(resumed.1.usage, progress.usage);
+    assert!(matches!(
+        store
+            .consume_agent_run_inbox_entry_and_resume_turn(parent_id, child_id, continuation_lease)
+            .await
+            .unwrap(),
+        Some(ConsumeAgentRunInboxAndResumeTurnOutcome::Existing { inbox, turn })
+            if inbox == resumed.0 && turn == resumed.1
+    ));
+    assert!(store
+        .consume_agent_run_inbox_entry_and_resume_turn(parent_id, child_id, uuid::Uuid::new_v4())
+        .await
+        .unwrap()
+        .is_none());
+
+    let resumed_lease = uuid::Uuid::new_v4();
+    let resumed_claim = store
+        .claim_turn_run(resumed_lease, Utc::now(), Utc::now() + Duration::minutes(5))
+        .await
+        .unwrap()
+        .turn
+        .expect("durable wake should make the turn claimable");
+    assert_eq!(resumed_claim.id, running.id);
+    assert_eq!(resumed_claim.status, TurnRunStatus::Running);
+    assert_eq!(resumed_claim.attempt_count, running.attempt_count);
+    assert_eq!(resumed_claim.claim_count, running.claim_count + 1);
+    assert_eq!(resumed_claim.model_steps, progress.model_steps);
+    assert_eq!(resumed_claim.usage, progress.usage);
+}
+
+#[tokio::test]
 async fn expired_parent_inbox_lease_can_be_reclaimed_but_not_consumed_by_stale_owner() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
@@ -711,6 +915,7 @@ async fn expired_parent_inbox_lease_can_be_reclaimed_but_not_consumed_by_stale_o
         "recoverable child result",
     )
     .await;
+    park_foreground_turn_on_child(&store, chat.id, child_id).await;
     let first_token = uuid::Uuid::new_v4();
     store
         .claim_agent_run_inbox_entry(parent_id, child_id, first_token, Duration::minutes(1))

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -69,9 +69,10 @@ pub use model::{
     Project, Role, RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
     RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
     RootAttachmentSubjectKind, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
-    ToolCallResolution, ToolCallStatus, TurnCheckpointProgress, TurnClientWait,
-    TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer,
-    TurnSteerStatus, MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
+    ToolCallResolution, ToolCallStatus, TurnAgentRunWait, TurnAgentRunWaitStatus,
+    TurnCheckpointProgress, TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt,
+    TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus, MAX_ATTACHMENT_REVISION,
+    MAX_ROOT_ATTACHMENTS,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
@@ -82,14 +83,14 @@ pub use storage::{
     AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
     ApplyTurnSteerOutcome, BeginRootAttachmentChangeOutcome, BlobStore, ClaimAgentRunInboxOutcome,
     ClaimClientToolCallOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim,
-    CompleteTurnRunOutcome, ConsumeAgentRunInboxOutcome, DocumentIndexJobReason,
-    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
+    CompleteTurnRunOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
+    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
     FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
-    JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForClientCallOutcome,
-    RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome,
-    ResolveToolCallOutcome, SecretProvider, Store, SubmitAgentRunResultOutcome,
-    MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+    JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForAgentRunInboxOutcome,
+    ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
+    RequestTurnCancellationOutcome, ResolveToolCallOutcome, SecretProvider, Store,
+    SubmitAgentRunResultOutcome, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1399,6 +1399,9 @@ pub enum TurnRunStatus {
     /// The worker checkpointed safely and released its lease while one exact
     /// durable client call executes on the host.
     WaitingForClient,
+    /// The worker checkpointed safely and released its lease while one exact
+    /// sandbox child result is awaited in the foreground inbox.
+    WaitingForAgentRun,
     /// Cancellation was requested after the client call may have started. The
     /// chat stays occupied until that exact call reports a terminal result.
     CancellingClient,
@@ -1424,6 +1427,7 @@ impl TurnRunStatus {
             Self::Running => "running",
             Self::Cancelling => "cancelling",
             Self::WaitingForClient => "waiting_for_client",
+            Self::WaitingForAgentRun => "waiting_for_agent_run",
             Self::CancellingClient => "cancelling_client",
             Self::Resuming => "resuming",
             Self::RetryWait => "retry_wait",
@@ -1437,6 +1441,63 @@ impl TurnRunStatus {
     #[must_use]
     pub const fn is_terminal(self) -> bool {
         matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
+/// Durable checkpoint linking one foreground turn to an exact sandbox child.
+///
+/// The checkpoint records the worker lease segment that parked the turn and
+/// the progress already committed before it yielded. Once the child's inbox
+/// delivery is consumed under an exact continuation lease, this row becomes
+/// the durable proof that the turn was moved to [`TurnRunStatus::Resuming`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnAgentRunWait {
+    /// Sandboxed child whose immutable result unblocks this checkpoint.
+    pub child_run_id: crate::id::AgentRunId,
+    /// Foreground coordinator shared by the child and turn.
+    pub parent_run_id: crate::id::AgentRunId,
+    /// Foreground turn parked at this continuation boundary.
+    pub turn_id: TurnId,
+    /// Conversation shared by the child and turn.
+    pub chat_id: ChatId,
+    /// Exact worker lease that created the checkpoint.
+    pub park_lease_token: Uuid,
+    /// Failure attempt containing the checkpoint.
+    pub attempt_count: i32,
+    /// Exact lease-segment ordinal containing the checkpoint.
+    pub claim_count: i32,
+    /// Progress committed before releasing the turn worker.
+    pub progress: TurnCheckpointProgress,
+    /// Durable lifecycle of this child-result checkpoint.
+    pub status: TurnAgentRunWaitStatus,
+    /// Database time at which the checkpoint committed.
+    pub parked_at: DateTime<Utc>,
+    /// Database time at which the inbox delivery woke the turn, if any.
+    pub closed_at: Option<DateTime<Utc>>,
+}
+
+/// Durable lifecycle of a [`TurnAgentRunWait`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TurnAgentRunWaitStatus {
+    /// The foreground turn is durably parked awaiting the child result.
+    Waiting,
+    /// The exact child inbox delivery was consumed and woke the turn.
+    Resumed,
+    /// The turn was cancelled before the child result could wake it.
+    Cancelled,
+}
+
+impl TurnAgentRunWaitStatus {
+    /// Stable database and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Waiting => "waiting",
+            Self::Resumed => "resumed",
+            Self::Cancelled => "cancelled",
+        }
     }
 }
 

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -30,8 +30,8 @@ use crate::model::{
     DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor, DocumentParseOutput,
     DocumentRecord, DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert,
     Message, Project, RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord,
-    ToolCallResolution, TurnCheckpointProgress, TurnClientWait, TurnFailureReceipt,
-    TurnFailureRetry, TurnRun, TurnSteer,
+    ToolCallResolution, TurnAgentRunWait, TurnCheckpointProgress, TurnClientWait,
+    TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
 };
 use crate::provider::{StopReason, Usage};
 
@@ -211,6 +211,27 @@ pub enum ConsumeAgentRunInboxOutcome {
     Existing(AgentRunInboxEntry),
 }
 
+/// Result of atomically consuming a child inbox delivery and waking its parked
+/// foreground turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConsumeAgentRunInboxAndResumeTurnOutcome {
+    /// The exact continuation lease consumed the delivery and queued the turn
+    /// for a fresh foreground worker claim.
+    Resumed {
+        /// Immutable inbox receipt now marked consumed.
+        inbox: AgentRunInboxEntry,
+        /// Foreground turn now durably ready to resume.
+        turn: TurnRun,
+    },
+    /// An ambiguous retry recovered the exact prior consumption and wake.
+    Existing {
+        /// Immutable inbox receipt consumed by this lease.
+        inbox: AgentRunInboxEntry,
+        /// Foreground turn already durably ready to resume.
+        turn: TurnRun,
+    },
+}
+
 /// Result of atomically accepting one exact steering instruction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AcceptTurnSteerOutcome {
@@ -373,6 +394,27 @@ pub enum ParkTurnForClientCallOutcome {
         wait: TurnClientWait,
     },
     /// The call identity already names a different immutable request.
+    IdentityConflict,
+    /// A durable steer won the checkpoint race and must be applied first.
+    SteerPending(TurnRun),
+    /// The request came from provider output generated before an applied steer.
+    OutputSuperseded(TurnRun),
+}
+
+/// Result of checkpointing a foreground turn while it awaits one sandbox child.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParkTurnForAgentRunInboxOutcome {
+    /// The immutable wait receipt and foreground lease release committed together.
+    Parked {
+        turn: TurnRun,
+        wait: TurnAgentRunWait,
+    },
+    /// An exact retry recovered the previously committed checkpoint.
+    Existing {
+        turn: TurnRun,
+        wait: TurnAgentRunWait,
+    },
+    /// The child delivery identity is already bound to another checkpoint.
     IdentityConflict,
     /// A durable steer won the checkpoint race and must be applied first.
     SteerPending(TurnRun),
@@ -1068,6 +1110,19 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// Atomically consume one exact child result and wake the foreground turn
+    /// that checkpointed on it. The durable turn transition is the wake signal;
+    /// callers may use ordinary turn claiming after this commit and never rely
+    /// on a process-local notification.
+    async fn consume_agent_run_inbox_entry_and_resume_turn(
+        &self,
+        _parent_run_id: AgentRunId,
+        _child_run_id: AgentRunId,
+        _lease_token: uuid::Uuid,
+    ) -> Result<Option<ConsumeAgentRunInboxAndResumeTurnOutcome>> {
+        agent_run_storage_unavailable()
+    }
+
     /// Fetch one durable turn by its exact idempotency identity.
     async fn get_turn_run(&self, _id: TurnId) -> Result<Option<TurnRun>> {
         turn_storage_unavailable()
@@ -1348,6 +1403,21 @@ pub trait Store: Send + Sync {
         _now: chrono::DateTime<chrono::Utc>,
         _call: &ClientToolCallRequest,
     ) -> Result<Option<ParkTurnForClientCallOutcome>> {
+        turn_storage_unavailable()
+    }
+
+    /// Persist a foreground turn checkpoint while it awaits one exact sandbox
+    /// child result. The live worker lease is released in the same transaction,
+    /// and its committed progress becomes the baseline for the resumed worker.
+    async fn park_turn_for_agent_run_inbox(
+        &self,
+        _turn_id: TurnId,
+        _child_run_id: AgentRunId,
+        _lease_token: uuid::Uuid,
+        _expected_steer_revision: i64,
+        _progress: TurnCheckpointProgress,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<ParkTurnForAgentRunInboxOutcome>> {
         turn_storage_unavailable()
     }
 

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -143,12 +143,18 @@ one parent inbox entry commit together, so an ambiguous worker retry can recover
 its original result but cannot overwrite or double-deliver it. Each inbox entry
 then advances through its own fenced continuation state machine:
 `pending -> claimed -> consumed`. A parent continuation claims one exact child
-result with a database-clock lease, and only that live lease can consume it.
+result only after the matching foreground checkpoint has committed, with a
+database-clock lease, and only that live lease can consume it. A result that
+arrives first remains pending; it is never leased merely because a process saw
+it before the parent reached its durable boundary.
 An expired claim can be reclaimed; a consumed entry retains the exact consuming
 lease as an immutable receipt, so an ambiguous consume retry recovers the same
-boundary without processing the child result twice. This is intentionally
-separate from model/tool execution: a later slice will atomically combine
-consumption with the parent turn checkpoint and wake event. Queued, waiting,
+boundary without processing the child result twice. A foreground worker can
+checkpoint its exact turn against a known child, releasing its turn lease and
+preserving model progress. Consumption then closes that checkpoint and moves
+the turn to `resuming` in the same transaction. `resuming` is the durable wake
+signal: any worker can claim it after restart, without relying on an in-memory
+notification. Queued, waiting,
 and retry-wait work cancels
 immediately; a running worker first enters `cancelling` and must acknowledge its
 exact live lease. That acknowledgement writes its own immutable receipt, so only
@@ -180,10 +186,10 @@ The agent hierarchy preserves the runtime's existing rules:
 5. Waits release workers and resume from committed checkpoints.
 6. Steering and cancellation are resolved at explicit boundaries.
 7. A final result, terminal run state, and immutable parent inbox entry are
-   committed atomically. The inbox entry itself is consumed only under an exact
-   expiring continuation lease, and preserves its consumed receipt for retry
-   recovery. The corresponding parent checkpoint and wake event will join a
-   later continuation transition.
+   committed atomically. A foreground turn may checkpoint against one exact
+   inbox delivery; consuming that delivery under an exact expiring continuation
+   lease also wakes the checkpointed turn to `resuming`, with exact retry
+   recovery.
 8. Clients recover from a durable snapshot plus ordered event replay.
 
 Until a tool satisfies the side-effect receipt contract, OpenWave continues to
@@ -201,10 +207,12 @@ The implementation is intentionally incremental:
 4. Add the parent inbox and atomic child-result delivery. *(Shipped.)*
 5. Generalize client execution into the shared continuation model.
 6. Persist shared model/tool step boundaries and side-effect receipts.
-7. Atomically join durable inbox consumption with a parent wait/checkpoint and
-   wake event.
-8. Route sandbox folder access through the host broker.
-9. Add desktop surfaces for queued, running, waiting, failed, and completed
+7. Atomically join durable inbox consumption with a parent turn checkpoint and
+   durable `resuming` wake signal. *(Shipped.)*
+8. Atomically accept a sandbox spawn and its parent checkpoint from the
+   foreground tool boundary.
+9. Route sandbox folder access through the host broker.
+10. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.
-10. Add richer context lifecycle, parallel-safe tool groups, and further
+11. Add richer context lifecycle, parallel-safe tool groups, and further
    orchestration only after these recovery boundaries are proven.


### PR DESCRIPTION
## Summary

- add a durable foreground turn checkpoint for an exact sandbox child result
- atomically consume the fenced inbox delivery, close the checkpoint, and make the turn resumable
- keep early child delivery pending until a matching foreground wait exists

## Validation

- cargo test -p openwave-core --features sqlite --lib --locked
- cargo check -p openwave-core --no-default-features --features postgres --locked
- bw dev lint --rust --check