### PR TITLE
Atomically spawn and park sandbox work

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -484,6 +484,7 @@ pub mod turn_agent_run_wait {
         pub turn_id: Uuid,
         pub chat_id: Uuid,
         pub park_lease_token: Uuid,
+        pub atomic_admission: bool,
         pub attempt_count: i32,
         pub claim_count: i32,
         pub model_steps: i32,

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -1424,6 +1424,12 @@ impl MigrationTrait for Init {
                             .not_null(),
                     )
                     .col(
+                        ColumnDef::new(TurnAgentRunWait::AtomicAdmission)
+                            .boolean()
+                            .not_null()
+                            .default(false),
+                    )
+                    .col(
                         ColumnDef::new(TurnAgentRunWait::AttemptCount)
                             .integer()
                             .not_null(),
@@ -3664,6 +3670,7 @@ enum TurnAgentRunWait {
     TurnId,
     ChatId,
     ParkLeaseToken,
+    AtomicAdmission,
     AttemptCount,
     ClaimCount,
     ModelSteps,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -38,16 +38,16 @@ use crate::model::{
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
-    AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
-    BeginRootAttachmentChangeOutcome, ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome,
-    ClaimTurnRunOutcome, CompleteTurnRunOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
-    ConsumeAgentRunInboxOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
-    EnsureDocumentParseJobOutcome, FinishAgentRunCancellationOutcome,
-    FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
-    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledTurnOutcome,
-    JournaledTurnSteerOutcome, ParkTurnForAgentRunInboxOutcome, ParkTurnForClientCallOutcome,
-    RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome,
-    ResolveToolCallOutcome, Store, SubmitAgentRunResultOutcome,
+    AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, AcceptToolCallOutcome,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, BeginRootAttachmentChangeOutcome,
+    ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome, ClaimTurnRunOutcome,
+    CompleteTurnRunOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
+    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
+    FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
+    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
+    JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForAgentRunInboxOutcome,
+    ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
+    RequestTurnCancellationOutcome, ResolveToolCallOutcome, Store, SubmitAgentRunResultOutcome,
 };
 
 mod ops;
@@ -1743,6 +1743,31 @@ impl Store for DbStore {
             spawn_call_id,
             execution,
             input,
+        )
+        .await
+    }
+
+    async fn accept_sandbox_agent_run_and_park_turn(
+        &self,
+        child_run_id: AgentRunId,
+        turn_id: TurnId,
+        spawn_call_id: CallId,
+        input: &str,
+        lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
+        progress: TurnCheckpointProgress,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<Option<AcceptSandboxAgentRunAndParkTurnOutcome>> {
+        ops::agent_run::accept_sandbox_agent_run_and_park_turn(
+            self,
+            child_run_id,
+            turn_id,
+            spawn_call_id,
+            input,
+            lease_token,
+            expected_steer_revision,
+            progress,
+            now,
         )
         .await
     }

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -5,19 +5,26 @@ use sea_orm::{
 };
 
 use crate::error::{AgentError, Result};
-use crate::id::{AgentRunId, CallId, ChatId};
+use crate::id::{AgentRunId, CallId, ChatId, TurnId};
 use crate::model::{
     AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunInboxStatus, AgentRunResult,
     AgentRunStatus,
 };
 use crate::storage::{
-    AcceptAgentRunOutcome, ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
-    ConsumeAgentRunInboxOutcome, FinishAgentRunCancellationOutcome,
+    AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, ClaimAgentRunInboxOutcome,
+    ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
+    FinishAgentRunCancellationOutcome, ParkTurnForAgentRunInboxOutcome,
     RequestAgentRunCancellationOutcome, SubmitAgentRunResultOutcome,
 };
 
 use super::super::{entities, store_err, DbStore};
-use super::{acquire_chat_write_lock, acquire_turn_write_lock, turn::canonical_db_timestamp};
+use super::{
+    acquire_chat_write_lock, acquire_turn_write_lock,
+    turn::{
+        canonical_db_timestamp, park_turn_for_agent_run_inbox_on,
+        validate_agent_run_inbox_park_request,
+    },
+};
 
 pub(in crate::db) async fn insert_foreground_agent_run_on<C>(
     conn: &C,
@@ -223,6 +230,202 @@ pub(in crate::db) async fn accept_agent_run(
     let run = agent_run_from_model(model)?;
     transaction.commit().await.map_err(store_err)?;
     Ok(AcceptAgentRunOutcome::Accepted(run))
+}
+
+/// Accept one sandbox child and park its exact foreground turn in the same
+/// transaction. The sandbox parent comes from the locked turn, which binds
+/// child hierarchy and checkpoint scope without trusting a caller-supplied
+/// parent id.
+pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
+    store: &DbStore,
+    child_run_id: AgentRunId,
+    turn_id: TurnId,
+    spawn_call_id: CallId,
+    input: &str,
+    lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
+    progress: crate::TurnCheckpointProgress,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<AcceptSandboxAgentRunAndParkTurnOutcome>> {
+    validate_agent_run_inbox_park_request(turn_id, child_run_id, lease_token, progress)?;
+    let now = canonical_db_timestamp(now)?;
+    let Some(scope) = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, ChatId(scope.chat_id)).await?
+        || !acquire_turn_write_lock(&transaction, turn_id).await?
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let turn = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .expect("locked turn exists");
+    let chat_id = ChatId(turn.chat_id);
+    let parent_id = AgentRunId(turn.agent_run_id);
+    validate_request(
+        child_run_id,
+        Some(parent_id),
+        Some(spawn_call_id),
+        AgentRunExecution::Sandbox,
+        Some(input),
+    )?;
+
+    let existing = match find_by_id_on(&transaction, child_run_id).await? {
+        Some(existing) => Some(existing),
+        None => find_by_spawn_call_on(&transaction, spawn_call_id).await?,
+    };
+    if let Some(existing) = existing {
+        let canonical_child_run_id = AgentRunId(existing.id);
+        let exact = matches!(
+            existing_request_outcome(
+                existing.clone(),
+                chat_id,
+                Some(parent_id),
+                Some(spawn_call_id),
+                AgentRunExecution::Sandbox,
+                Some(input),
+            )?,
+            AcceptAgentRunOutcome::Existing(_)
+        );
+        if !exact {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(
+                AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
+            ));
+        }
+        // A child accepted outside this operation must never be retrofitted
+        // into a foreground checkpoint. A committed checkpoint is the only
+        // durable proof that this is an exact retry of the combined action.
+        let atomic_wait =
+            entities::turn_agent_run_wait::Entity::find_by_id(canonical_child_run_id.0)
+                .one(&transaction)
+                .await
+                .map_err(store_err)?;
+        if !atomic_wait.is_some_and(|wait| wait.atomic_admission) {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(
+                AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
+            ));
+        }
+        let outcome = park_turn_for_agent_run_inbox_on(
+            &transaction,
+            turn_id,
+            canonical_child_run_id,
+            lease_token,
+            expected_steer_revision,
+            progress,
+            now,
+            true,
+        )
+        .await?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(match outcome {
+            Some(ParkTurnForAgentRunInboxOutcome::Existing { turn, wait }) => {
+                AcceptSandboxAgentRunAndParkTurnOutcome::Existing {
+                    child: agent_run_from_model(existing)?,
+                    turn,
+                    wait,
+                }
+            }
+            _ => AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
+        }));
+    }
+
+    let parent = find_by_id_on(&transaction, parent_id).await?;
+    let parent_available = parent.is_some_and(|parent| {
+        parent.chat_id == chat_id.0
+            && parent.parent_id.is_none()
+            && parent.depth == 0
+            && parent.execution == AgentRunExecution::Foreground.as_str()
+            && parent.status == AgentRunStatus::Active.as_str()
+    });
+    if !parent_available {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(
+            AcceptSandboxAgentRunAndParkTurnOutcome::ParentUnavailable,
+        ));
+    }
+
+    let created_at = database_now(&transaction).await?;
+    let model = entities::agent_run::ActiveModel {
+        id: Set(child_run_id.0),
+        chat_id: Set(chat_id.0),
+        parent_id: Set(Some(parent_id.0)),
+        parent_depth: Set(Some(0)),
+        spawn_call_id: Set(Some(spawn_call_id.0)),
+        execution: Set(AgentRunExecution::Sandbox.as_str().into()),
+        depth: Set(i16::from(AgentRun::MAX_DEPTH)),
+        status: Set(AgentRunStatus::Queued.as_str().into()),
+        input: Set(Some(input.into())),
+        attempt_count: Set(0),
+        max_attempts: Set(AgentRun::DEFAULT_MAX_ATTEMPTS),
+        claim_count: Set(0),
+        available_at: Set(created_at),
+        deadline_at: Set(Some(created_at + AgentRun::DEFAULT_MAX_DURATION)),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        started_at: Set(None),
+        finished_at: Set(None),
+        last_error_code: Set(None),
+        last_error_detail: Set(None),
+        created_at: Set(created_at),
+        updated_at: Set(created_at),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    let child = agent_run_from_model(model)?;
+
+    let outcome = park_turn_for_agent_run_inbox_on(
+        &transaction,
+        turn_id,
+        child_run_id,
+        lease_token,
+        expected_steer_revision,
+        progress,
+        now,
+        true,
+    )
+    .await?;
+    let Some(outcome) = outcome else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let outcome = match outcome {
+        ParkTurnForAgentRunInboxOutcome::Parked { turn, wait } => {
+            AcceptSandboxAgentRunAndParkTurnOutcome::Parked { child, turn, wait }
+        }
+        ParkTurnForAgentRunInboxOutcome::SteerPending(turn) => {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::SteerPending(
+                turn,
+            )));
+        }
+        ParkTurnForAgentRunInboxOutcome::OutputSuperseded(turn) => {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(Some(
+                AcceptSandboxAgentRunAndParkTurnOutcome::OutputSuperseded(turn),
+            ));
+        }
+        ParkTurnForAgentRunInboxOutcome::Existing { .. }
+        | ParkTurnForAgentRunInboxOutcome::IdentityConflict => {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(Some(
+                AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
+            ));
+        }
+    };
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(outcome))
 }
 
 pub(in crate::db) async fn get_agent_run(

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -27,7 +27,8 @@ mod resolution;
 mod steer;
 
 pub(in crate::db) use agent_run_wait::{
-    park_turn_for_agent_run_inbox, resume_turn_after_agent_run_inbox_consumption_on,
+    park_turn_for_agent_run_inbox, park_turn_for_agent_run_inbox_on,
+    resume_turn_after_agent_run_inbox_consumption_on, validate_agent_run_inbox_park_request,
 };
 pub(in crate::db) use client_wait::{
     advance_turn_after_client_resolution_on, park_turn_for_client_tool_call,

--- a/crates/openwave-core/src/db/ops/turn/agent_run_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/agent_run_wait.rs
@@ -24,7 +24,7 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
     progress: TurnCheckpointProgress,
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<ParkTurnForAgentRunInboxOutcome>> {
-    validate_request(turn_id, child_run_id, lease_token, progress)?;
+    validate_agent_run_inbox_park_request(turn_id, child_run_id, lease_token, progress)?;
     let now = canonical_db_timestamp(now)?;
     let Some(scope) = entities::turn_run::Entity::find_by_id(turn_id.0)
         .one(&store.conn)
@@ -41,13 +41,43 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
         return Ok(None);
     }
 
+    let outcome = park_turn_for_agent_run_inbox_on(
+        &transaction,
+        turn_id,
+        child_run_id,
+        lease_token,
+        expected_steer_revision,
+        progress,
+        now,
+        false,
+    )
+    .await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(outcome)
+}
+
+/// Checkpoint one foreground turn using a caller-owned transaction with the
+/// chat and turn write locks already held.
+pub(in crate::db) async fn park_turn_for_agent_run_inbox_on<C>(
+    conn: &C,
+    turn_id: TurnId,
+    child_run_id: AgentRunId,
+    lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
+    progress: TurnCheckpointProgress,
+    now: chrono::DateTime<Utc>,
+    atomic_admission: bool,
+) -> Result<Option<ParkTurnForAgentRunInboxOutcome>>
+where
+    C: ConnectionTrait,
+{
     if let Some(wait) = entities::turn_agent_run_wait::Entity::find_by_id(child_run_id.0)
-        .one(&transaction)
+        .one(conn)
         .await
         .map_err(store_err)?
     {
         let turn = entities::turn_run::Entity::find_by_id(wait.turn_id)
-            .one(&transaction)
+            .one(conn)
             .await
             .map_err(store_err)?
             .ok_or_else(|| {
@@ -68,12 +98,11 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
         } else {
             ParkTurnForAgentRunInboxOutcome::IdentityConflict
         };
-        transaction.commit().await.map_err(store_err)?;
         return Ok(Some(outcome));
     }
 
     let turn = entities::turn_run::Entity::find_by_id(turn_id.0)
-        .one(&transaction)
+        .one(conn)
         .await
         .map_err(store_err)?
         .expect("locked turn exists");
@@ -84,19 +113,17 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
             .is_none_or(|lease_expires_at| lease_expires_at <= now)
         || turn.updated_at > now
     {
-        transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
     let steer_pending = entities::turn_steer::Entity::find()
         .filter(entities::turn_steer::Column::TurnId.eq(turn_id.0))
         .filter(entities::turn_steer::Column::Status.eq(TurnSteerStatus::Pending.as_str()))
-        .one(&transaction)
+        .one(conn)
         .await
         .map_err(store_err)?
         .is_some();
     if steer_pending || turn.steer_revision != expected_steer_revision {
         let turn = turn_run_from_model(turn)?;
-        transaction.commit().await.map_err(store_err)?;
         return Ok(Some(if steer_pending {
             ParkTurnForAgentRunInboxOutcome::SteerPending(turn)
         } else {
@@ -105,7 +132,7 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
     }
     let child = entities::agent_run::Entity::find()
         .filter(entities::agent_run::Column::Id.eq(child_run_id.0))
-        .one(&transaction)
+        .one(conn)
         .await
         .map_err(store_err)?;
     let valid_child = child.is_some_and(|child| {
@@ -120,7 +147,6 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
             )
     });
     if !valid_child {
-        transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
     let totals = checked_checkpoint_totals(&turn, progress)?;
@@ -130,6 +156,7 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
         turn_id: Set(turn_id.0),
         chat_id: Set(turn.chat_id),
         park_lease_token: Set(lease_token),
+        atomic_admission: Set(atomic_admission),
         attempt_count: Set(turn.attempt_count),
         claim_count: Set(turn.claim_count),
         model_steps: Set(progress.model_steps),
@@ -141,7 +168,7 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
         parked_at: Set(now),
         closed_at: Set(None),
     }
-    .insert(&transaction)
+    .insert(conn)
     .await
     .map_err(store_err)?;
     let parked = entities::turn_run::Entity::update_many()
@@ -191,19 +218,17 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
         .filter(entities::turn_run::Column::SteerRevision.eq(expected_steer_revision))
         .filter(entities::turn_run::Column::UpdatedAt.eq(turn.updated_at))
         .filter(entities::turn_run::Column::UpdatedAt.lte(now))
-        .exec(&transaction)
+        .exec(conn)
         .await
         .map_err(store_err)?;
     if parked.rows_affected != 1 {
-        transaction.rollback().await.map_err(store_err)?;
         return Ok(None);
     }
     let parked_turn = entities::turn_run::Entity::find_by_id(turn_id.0)
-        .one(&transaction)
+        .one(conn)
         .await
         .map_err(store_err)?
         .ok_or_else(|| AgentError::Store(format!("parked turn {turn_id} disappeared")))?;
-    transaction.commit().await.map_err(store_err)?;
     Ok(Some(ParkTurnForAgentRunInboxOutcome::Parked {
         turn: turn_run_from_model(parked_turn)?,
         wait: wait_from_model(wait)?,
@@ -326,7 +351,7 @@ where
     turn_run_from_model(turn).map(Some)
 }
 
-fn validate_request(
+pub(in crate::db) fn validate_agent_run_inbox_park_request(
     turn_id: TurnId,
     child_run_id: AgentRunId,
     lease_token: uuid::Uuid,

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -1,11 +1,11 @@
 use super::{sample_chat, temp_store};
 use crate::{
-    AcceptAgentRunOutcome, AcceptTurnOutcome, AgentRun, AgentRunExecution, AgentRunId,
-    AgentRunInboxStatus, AgentRunStatus, CallId, ChatId, ClaimAgentRunInboxOutcome,
-    ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome, DbStore,
-    FinishAgentRunCancellationOutcome, ParkTurnForAgentRunInboxOutcome,
-    RequestAgentRunCancellationOutcome, Store, SubmitAgentRunResultOutcome, TurnCheckpointProgress,
-    TurnId, TurnRunStatus, Usage,
+    AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, AcceptTurnOutcome, AgentRun,
+    AgentRunExecution, AgentRunId, AgentRunInboxStatus, AgentRunStatus, CallId, ChatId,
+    ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
+    ConsumeAgentRunInboxOutcome, DbStore, FinishAgentRunCancellationOutcome,
+    ParkTurnForAgentRunInboxOutcome, RequestAgentRunCancellationOutcome, Store,
+    SubmitAgentRunResultOutcome, TurnCheckpointProgress, TurnId, TurnRunStatus, Usage,
 };
 use chrono::{Duration, Utc};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
@@ -133,6 +133,275 @@ async fn park_foreground_turn_on_child(
         ParkTurnForAgentRunInboxOutcome::Parked { turn, .. } => turn,
         outcome => panic!("unexpected child checkpoint outcome: {outcome:?}"),
     }
+}
+
+#[tokio::test]
+async fn sandbox_spawn_and_foreground_checkpoint_commit_as_one_exact_transition() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let queued = match store
+        .accept_turn(TurnId::new(), chat.id, "gpt-5", "delegate this atomically")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected turn acceptance: {outcome:?}"),
+    };
+    let lease_token = uuid::Uuid::new_v4();
+    let now = Utc::now();
+    let running = store
+        .claim_turn_run(lease_token, now, now + Duration::minutes(5))
+        .await
+        .unwrap()
+        .turn
+        .expect("foreground turn should claim");
+    assert_eq!(running.id, queued.id);
+    let child_run_id = AgentRunId::new();
+    let spawn_call_id = CallId::new();
+    let progress = TurnCheckpointProgress {
+        model_steps: 1,
+        usage: Usage {
+            input_tokens: 11,
+            output_tokens: 7,
+            cache_read_input_tokens: 3,
+            cache_creation_input_tokens: 2,
+        },
+    };
+    let parked = match store
+        .accept_sandbox_agent_run_and_park_turn(
+            child_run_id,
+            running.id,
+            spawn_call_id,
+            "research the question",
+            lease_token,
+            running.steer_revision,
+            progress,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .expect("live foreground turn should checkpoint")
+    {
+        AcceptSandboxAgentRunAndParkTurnOutcome::Parked { child, turn, wait } => {
+            (child, turn, wait)
+        }
+        outcome => panic!("unexpected combined spawn outcome: {outcome:?}"),
+    };
+    assert_eq!(parked.0.id, child_run_id);
+    assert_eq!(
+        parked.0.parent_id,
+        Some(AgentRunId::foreground_for_chat(chat.id))
+    );
+    assert_eq!(parked.0.status, AgentRunStatus::Queued);
+    assert_eq!(parked.1.status, TurnRunStatus::WaitingForAgentRun);
+    assert_eq!(parked.1.lease_token, None);
+    assert_eq!(parked.2.turn_id, running.id);
+    assert_eq!(
+        parked.2.parent_run_id,
+        AgentRunId::foreground_for_chat(chat.id)
+    );
+    assert_eq!(parked.2.progress, progress);
+
+    assert!(matches!(
+        store
+            .accept_sandbox_agent_run_and_park_turn(
+                child_run_id,
+                running.id,
+                spawn_call_id,
+                "research the question",
+                lease_token,
+                running.steer_revision,
+                progress,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(AcceptSandboxAgentRunAndParkTurnOutcome::Existing { child, turn, wait })
+            if child == parked.0 && turn == parked.1 && wait == parked.2
+    ));
+    assert!(matches!(
+        store
+            .accept_sandbox_agent_run_and_park_turn(
+                AgentRunId::new(),
+                running.id,
+                spawn_call_id,
+                "research the question",
+                lease_token,
+                running.steer_revision,
+                progress,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(AcceptSandboxAgentRunAndParkTurnOutcome::Existing { child, turn, wait })
+            if child == parked.0 && turn == parked.1 && wait == parked.2
+    ));
+    assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn sandbox_spawn_checkpoint_rolls_back_when_foreground_lease_or_steer_is_stale() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let queued = match store
+        .accept_turn(
+            TurnId::new(),
+            chat.id,
+            "gpt-5",
+            "do not enqueue a stale child",
+        )
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected turn acceptance: {outcome:?}"),
+    };
+    let lease_token = uuid::Uuid::new_v4();
+    let now = Utc::now();
+    let running = store
+        .claim_turn_run(lease_token, now, now + Duration::minutes(5))
+        .await
+        .unwrap()
+        .turn
+        .expect("foreground turn should claim");
+    assert_eq!(running.id, queued.id);
+    let progress = TurnCheckpointProgress {
+        model_steps: 1,
+        usage: Usage::default(),
+    };
+    let stale_child_id = AgentRunId::new();
+    assert!(store
+        .accept_sandbox_agent_run_and_park_turn(
+            stale_child_id,
+            running.id,
+            CallId::new(),
+            "this child must roll back",
+            uuid::Uuid::new_v4(),
+            running.steer_revision,
+            progress,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store.get_agent_run(stale_child_id).await.unwrap().is_none());
+
+    let superseded_child_id = AgentRunId::new();
+    assert!(matches!(
+        store
+            .accept_sandbox_agent_run_and_park_turn(
+                superseded_child_id,
+                running.id,
+                CallId::new(),
+                "this child must not survive a stale model output",
+                lease_token,
+                running.steer_revision + 1,
+                progress,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(AcceptSandboxAgentRunAndParkTurnOutcome::OutputSuperseded(turn))
+            if turn == running
+    ));
+    assert!(store
+        .get_agent_run(superseded_child_id)
+        .await
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        store.get_turn_run(running.id).await.unwrap(),
+        Some(running),
+        "a rolled-back spawn must preserve the exact live foreground claim"
+    );
+}
+
+#[tokio::test]
+async fn sandbox_spawn_checkpoint_never_retrofits_a_separately_accepted_child() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let queued = match store
+        .accept_turn(
+            TurnId::new(),
+            chat.id,
+            "gpt-5",
+            "keep admission and waits coupled",
+        )
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected turn acceptance: {outcome:?}"),
+    };
+    let lease_token = uuid::Uuid::new_v4();
+    let now = Utc::now();
+    let running = store
+        .claim_turn_run(lease_token, now, now + Duration::minutes(5))
+        .await
+        .unwrap()
+        .turn
+        .expect("foreground turn should claim");
+    assert_eq!(running.id, queued.id);
+    let child_run_id = AgentRunId::new();
+    let spawn_call_id = CallId::new();
+    store
+        .accept_agent_run(
+            child_run_id,
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(spawn_call_id),
+            AgentRunExecution::Sandbox,
+            Some("accepted by an older boundary"),
+        )
+        .await
+        .unwrap();
+    let progress = TurnCheckpointProgress {
+        model_steps: 1,
+        usage: Usage::default(),
+    };
+    let legacy_parked = match store
+        .park_turn_for_agent_run_inbox(
+            running.id,
+            child_run_id,
+            lease_token,
+            running.steer_revision,
+            progress,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .expect("legacy checkpoint should commit")
+    {
+        ParkTurnForAgentRunInboxOutcome::Parked { turn, wait } => (turn, wait),
+        outcome => panic!("unexpected legacy checkpoint outcome: {outcome:?}"),
+    };
+    assert_eq!(legacy_parked.0.status, TurnRunStatus::WaitingForAgentRun);
+    assert_eq!(legacy_parked.1.child_run_id, child_run_id);
+
+    assert!(matches!(
+        store
+            .accept_sandbox_agent_run_and_park_turn(
+                AgentRunId::new(),
+                running.id,
+                spawn_call_id,
+                "accepted by an older boundary",
+                lease_token,
+                running.steer_revision,
+                progress,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict)
+    ));
+    assert_eq!(
+        store.get_turn_run(running.id).await.unwrap(),
+        Some(legacy_parked.0)
+    );
+    assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 2);
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -80,8 +80,9 @@ pub use provider::{
 };
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
-    AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
-    ApplyTurnSteerOutcome, BeginRootAttachmentChangeOutcome, BlobStore, ClaimAgentRunInboxOutcome,
+    AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, AcceptToolCallOutcome,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, ApplyTurnSteerOutcome,
+    BeginRootAttachmentChangeOutcome, BlobStore, ClaimAgentRunInboxOutcome,
     ClaimClientToolCallOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim,
     CompleteTurnRunOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
     DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -162,6 +162,35 @@ pub enum AcceptAgentRunOutcome {
     ParentUnavailable,
 }
 
+/// Result of atomically accepting one sandbox child and checkpointing its
+/// owning foreground turn on that child's inbox delivery.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AcceptSandboxAgentRunAndParkTurnOutcome {
+    /// The child, immutable wait receipt, and foreground lease release
+    /// committed in one transaction.
+    Parked {
+        child: AgentRun,
+        turn: TurnRun,
+        wait: TurnAgentRunWait,
+    },
+    /// An exact retry recovered the same already-committed transition.
+    Existing {
+        child: AgentRun,
+        turn: TurnRun,
+        wait: TurnAgentRunWait,
+    },
+    /// The child id or spawn-call identity is bound to a different request,
+    /// or was accepted outside this atomic transition.
+    IdentityConflict,
+    /// The turn's foreground coordinator is no longer an eligible sandbox
+    /// parent.
+    ParentUnavailable,
+    /// A durable steer won the checkpoint race and must be applied first.
+    SteerPending(TurnRun),
+    /// The request came from provider output generated before an applied steer.
+    OutputSuperseded(TurnRun),
+}
+
 /// Result of requesting durable cancellation for one sandbox run.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RequestAgentRunCancellationOutcome {
@@ -1002,6 +1031,28 @@ pub trait Store: Send + Sync {
         _execution: AgentRunExecution,
         _input: Option<&str>,
     ) -> Result<AcceptAgentRunOutcome> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Atomically accept one depth-one sandbox child and release the exact
+    /// owning foreground turn claim into a matching child-result wait.
+    ///
+    /// The parent is derived from the turn rather than supplied by a caller,
+    /// so a sandbox run cannot be parked against a turn owned by another
+    /// coordinator. Exact retries recover the immutable child and checkpoint
+    /// receipt; a child accepted through any other path is never retrofitted
+    /// into this transition.
+    async fn accept_sandbox_agent_run_and_park_turn(
+        &self,
+        _child_run_id: AgentRunId,
+        _turn_id: TurnId,
+        _spawn_call_id: CallId,
+        _input: &str,
+        _lease_token: uuid::Uuid,
+        _expected_steer_revision: i64,
+        _progress: TurnCheckpointProgress,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<AcceptSandboxAgentRunAndParkTurnOutcome>> {
         agent_run_storage_unavailable()
     }
 

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -70,8 +70,16 @@ spawn:
    together. A later wait transition may consume that entry and wake a parent.
 
 The foreground agent may continue or finish its current turn after spawning a
-child. If it needs the result before proceeding, it parks on a durable wait and
-releases its worker instead of polling in memory.
+child. If it needs the result before proceeding, the spawn boundary commits the
+queued child, its unique spawn identity, the durable wait, and release of the
+exact foreground worker lease in one transaction. It never leaves a child
+behind when that checkpoint is fenced by a stale lease or steer. The turn then
+waits without polling in memory.
+
+The wait also carries an immutable atomic-admission marker. Only that receipt
+allows a later retry to recover the combined transition; an older path that
+accepted a child and parked a turn in separate commits is never mistaken for
+proof that both effects committed together.
 
 ## One continuation model
 
@@ -187,9 +195,10 @@ The agent hierarchy preserves the runtime's existing rules:
 6. Steering and cancellation are resolved at explicit boundaries.
 7. A final result, terminal run state, and immutable parent inbox entry are
    committed atomically. A foreground turn may checkpoint against one exact
-   inbox delivery; consuming that delivery under an exact expiring continuation
-   lease also wakes the checkpointed turn to `resuming`, with exact retry
-   recovery.
+   inbox delivery. When the child is spawned from a wait boundary, that
+   checkpoint commits with child admission and releases the foreground lease;
+   consuming the delivery under an exact expiring continuation lease also wakes
+   the checkpointed turn to `resuming`, with exact retry recovery.
 8. Clients recover from a durable snapshot plus ordered event replay.
 
 Until a tool satisfies the side-effect receipt contract, OpenWave continues to
@@ -210,7 +219,7 @@ The implementation is intentionally incremental:
 7. Atomically join durable inbox consumption with a parent turn checkpoint and
    durable `resuming` wake signal. *(Shipped.)*
 8. Atomically accept a sandbox spawn and its parent checkpoint from the
-   foreground tool boundary.
+   foreground tool boundary. *(Shipped.)*
 9. Route sandbox folder access through the host broker.
 10. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.


### PR DESCRIPTION
## Summary

- atomically accept a sandbox child and park its foreground turn on the matching result wait
- preserve exact lease, steering, accounting, hierarchy, and spawn-call idempotency fences
- distinguish combined admissions from legacy two-step state so retries never retrofit work

## Validation

- cargo test -p openwave-core --lib --locked
- cargo check -p openwave-core --no-default-features --features postgres --locked
- bw dev lint --rust --check