### PR TITLE
Add foreground sandbox spawn groundwork

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -27,12 +27,13 @@ use futures::StreamExt;
 use futures_timer::Delay;
 use serde_json::Value;
 
+use crate::agent_tools::{validate_spawn_sandbox_agent_arguments, SpawnSandboxAgentArgs};
 use crate::approval::{ApprovalDecision, ApprovalGate, ApprovalRequest, RefuseGate};
 use crate::cancel::CancelToken;
 use crate::context;
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{CallId, MessageId, TurnId};
+use crate::id::{AgentRunId, CallId, MessageId, TurnId};
 use crate::model::{
     Chat, Message, Role, ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus,
     TurnRunStatus,
@@ -58,6 +59,9 @@ enum RegisteredTool {
     Client {
         spec: ToolSpec,
         validate_arguments: Option<fn(&Value) -> bool>,
+    },
+    ForegroundSandboxSpawn {
+        spec: ToolSpec,
     },
 }
 
@@ -100,6 +104,21 @@ impl ToolRegistry {
         );
     }
 
+    /// Register the prepared foreground-only sandbox delegation contract.
+    ///
+    /// This integration seam is intentionally not enabled by the production
+    /// registry until a sandbox executor can claim and complete the child. A
+    /// claimed foreground worker must opt in before it is advertised, then
+    /// atomically parks its exact turn with durable child admission. Sandboxed
+    /// workers never opt in.
+    pub fn register_foreground_sandbox_spawn(&mut self) {
+        let spec = crate::spawn_sandbox_agent_tool_spec();
+        self.tools.insert(
+            spec.name.clone(),
+            RegisteredTool::ForegroundSandboxSpawn { spec },
+        );
+    }
+
     /// Builder-style [`register`](Self::register).
     #[must_use]
     pub fn with(mut self, tool: Box<dyn Tool>) -> Self {
@@ -112,27 +131,43 @@ impl ToolRegistry {
     pub fn get(&self, name: &str) -> Option<&dyn Tool> {
         match self.tools.get(name) {
             Some(RegisteredTool::Server(tool)) => Some(tool.as_ref()),
-            Some(RegisteredTool::Client { .. }) | None => None,
+            Some(RegisteredTool::Client { .. })
+            | Some(RegisteredTool::ForegroundSandboxSpawn { .. })
+            | None => None,
         }
     }
 
     /// Resolve the trusted execution surface for a registered tool name.
     #[must_use]
     pub fn execution(&self, name: &str) -> Option<ToolCallExecution> {
-        self.tools.get(name).map(|tool| match tool {
+        Some(match self.tools.get(name)? {
             RegisteredTool::Server(_) => ToolCallExecution::Server,
             RegisteredTool::Client { .. } => ToolCallExecution::Client,
+            RegisteredTool::ForegroundSandboxSpawn { .. } => return None,
         })
     }
 
     /// The specs of every registered tool, to advertise to the model.
     #[must_use]
     pub fn specs(&self) -> Vec<ToolSpec> {
+        self.specs_for_foreground(false)
+    }
+
+    /// The model-visible definitions for one execution surface.
+    ///
+    /// The foreground coordinator may opt into the sandbox control tool. All
+    /// other contexts receive the ordinary server/client tool set only.
+    #[must_use]
+    pub fn specs_for_foreground(&self, allow_sandbox_spawn: bool) -> Vec<ToolSpec> {
         self.tools
             .values()
-            .map(|tool| match tool {
-                RegisteredTool::Server(tool) => tool.spec(),
-                RegisteredTool::Client { spec, .. } => spec.clone(),
+            .filter_map(|tool| match tool {
+                RegisteredTool::Server(tool) => Some(tool.spec()),
+                RegisteredTool::Client { spec, .. } => Some(spec.clone()),
+                RegisteredTool::ForegroundSandboxSpawn { spec } if allow_sandbox_spawn => {
+                    Some(spec.clone())
+                }
+                RegisteredTool::ForegroundSandboxSpawn { .. } => None,
             })
             .collect()
     }
@@ -149,8 +184,32 @@ impl ToolRegistry {
                 validate_arguments: None,
                 ..
             }) => true,
-            Some(RegisteredTool::Server(_)) | None => false,
+            Some(RegisteredTool::Server(_))
+            | Some(RegisteredTool::ForegroundSandboxSpawn { .. })
+            | None => false,
         }
+    }
+
+    /// Whether `name` identifies the foreground-only sandbox control tool.
+    #[must_use]
+    pub fn is_foreground_sandbox_spawn(&self, name: &str) -> bool {
+        matches!(
+            self.tools.get(name),
+            Some(RegisteredTool::ForegroundSandboxSpawn { .. })
+        )
+    }
+
+    /// Parse and validate one foreground sandbox task.
+    #[must_use]
+    pub fn sandbox_spawn_task(&self, name: &str, arguments: &Value) -> Option<String> {
+        if !self.is_foreground_sandbox_spawn(name)
+            || !validate_spawn_sandbox_agent_arguments(arguments)
+        {
+            return None;
+        }
+        serde_json::from_value::<SpawnSandboxAgentArgs>(arguments.clone())
+            .ok()
+            .map(|arguments| arguments.task)
     }
 
     /// Whether no tools are registered.
@@ -246,6 +305,21 @@ pub enum AgentTurnOutcome {
         /// Model-call steps consumed in this agent invocation.
         model_steps: usize,
     },
+    /// The foreground model requested one durable sandbox child.
+    ///
+    /// The foreground worker validates this exact request and invokes
+    /// [`Store::accept_sandbox_agent_run_and_park_turn`] with its live lease,
+    /// steering epoch, and accumulated checkpoint totals.
+    SandboxAgentSpawn {
+        /// Canonical child identity and bounded task derived from the tool call.
+        request: SandboxAgentSpawnRequest,
+        /// Provider usage incurred in this agent invocation.
+        usage: Usage,
+        /// Durable steering epoch captured before the producing model call.
+        steer_revision: i64,
+        /// Model-call steps consumed in this agent invocation.
+        model_steps: usize,
+    },
     /// Execution failed after consuming provider work that must be retained.
     Failed {
         /// Stable terminal error payload for the durable failure event.
@@ -255,6 +329,29 @@ pub enum AgentTurnOutcome {
         /// Model-call steps consumed before the failure.
         model_steps: usize,
     },
+}
+
+/// One model proposal to create a durable depth-one sandbox child.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxAgentSpawnRequest {
+    /// Stable call identity emitted by the model stream.
+    pub call_id: CallId,
+    /// Deterministic sandbox child identity derived from [`Self::call_id`].
+    pub child_run_id: AgentRunId,
+    /// Bounded, self-contained child input.
+    pub task: String,
+}
+
+impl SandboxAgentSpawnRequest {
+    /// Whether the immutable identities and task agree with the core contract.
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        self.call_id.0 != uuid::Uuid::nil()
+            && self.child_run_id == AgentRunId::sandbox_for_spawn_call(self.call_id)
+            && validate_spawn_sandbox_agent_arguments(&serde_json::json!({
+                "task": self.task,
+            }))
+    }
 }
 
 #[derive(Debug, Default)]
@@ -364,6 +461,7 @@ pub struct Agent {
     cancel: CancelToken,
     steer: SteerInbox,
     durable_steer_lease: Option<uuid::Uuid>,
+    sandbox_spawns_enabled: bool,
 }
 
 /// A tool call accumulated from the provider stream.
@@ -394,6 +492,7 @@ impl Agent {
             cancel: CancelToken::new(),
             steer: SteerInbox::new(),
             durable_steer_lease: None,
+            sandbox_spawns_enabled: false,
         }
     }
 
@@ -425,6 +524,20 @@ impl Agent {
     pub fn with_durable_steer(mut self, lease_token: uuid::Uuid) -> Self {
         self.durable_steer_lease = Some(lease_token);
         self
+    }
+
+    /// Advertise and accept the foreground-only sandbox delegation tool.
+    ///
+    /// This is intentionally opt-in: sandbox workers must not set it, keeping
+    /// the v1 hierarchy at a single child depth.
+    #[must_use]
+    pub fn with_foreground_sandbox_spawns(mut self) -> Self {
+        self.sandbox_spawns_enabled = true;
+        self
+    }
+
+    fn sandbox_spawns_active(&self) -> bool {
+        self.sandbox_spawns_enabled && self.durable_steer_lease.is_some()
     }
 
     /// Run one turn: submit `user_input`, drive the loop to a final answer,
@@ -591,7 +704,9 @@ impl Agent {
                     model: self.config.model.clone(),
                     system: self.config.system_prompt.clone(),
                     messages: fitted,
-                    tools: self.tools.specs(),
+                    tools: self
+                        .tools
+                        .specs_for_foreground(self.sandbox_spawns_active()),
                     max_tokens: self.config.max_tokens,
                     temperature: self.config.temperature,
                 };
@@ -756,6 +871,67 @@ impl Agent {
                 })?;
                 return Ok(AgentTurnOutcome::ClientToolCall {
                     request,
+                    usage: total_usage,
+                    steer_revision,
+                    model_steps: step + 1,
+                });
+            }
+
+            let sandbox_spawns = calls
+                .iter()
+                .filter(|call| {
+                    self.sandbox_spawns_active()
+                        && self.tools.is_foreground_sandbox_spawn(&call.name)
+                })
+                .collect::<Vec<_>>();
+            if !sandbox_spawns.is_empty() {
+                if calls.len() != 1 || sandbox_spawns.len() != 1 || !text.is_empty() {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text {
+                            text: "A sandbox delegation must be requested alone, without assistant text or sibling tool calls. Retry the request in that form.".into(),
+                        }],
+                    });
+                    continue;
+                }
+                let call = sandbox_spawns[0];
+                let Some(arguments) = parse_client_args(&call.args) else {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text {
+                            text: "The sandbox task arguments were not valid JSON. Retry with one complete task value.".into(),
+                        }],
+                    });
+                    continue;
+                };
+                let Some(task) = self.tools.sandbox_spawn_task(&call.name, &arguments) else {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text {
+                            text: "The sandbox task must be one non-empty, bounded `task` field with no extra properties. Retry with that exact shape.".into(),
+                        }],
+                    });
+                    continue;
+                };
+                let Some(steer_revision) = generation_steer_revision else {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage {
+                        role: Role::User,
+                        content: vec![ContentBlock::Text {
+                            text: "Sandbox delegation is available only from a durably claimed foreground turn. Continue without delegating.".into(),
+                        }],
+                    });
+                    continue;
+                };
+                return Ok(AgentTurnOutcome::SandboxAgentSpawn {
+                    request: SandboxAgentSpawnRequest {
+                        call_id: call.call_id,
+                        child_run_id: AgentRunId::sandbox_for_spawn_call(call.call_id),
+                        task,
+                    },
                     usage: total_usage,
                     steer_revision,
                     model_steps: step + 1,
@@ -1815,6 +1991,99 @@ mod tests {
             } if error.kind == "max_steps_exceeded"
         ));
         assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn claimed_foreground_agent_returns_one_bounded_sandbox_checkpoint() {
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "fake", "research this")
+            .await
+            .unwrap();
+        let lease_token = uuid::Uuid::new_v4();
+        let claimed_at = Utc::now();
+        store
+            .claim_turn_run(
+                lease_token,
+                claimed_at,
+                claimed_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap();
+
+        let mut registry = ToolRegistry::new();
+        registry.register_foreground_sandbox_spawn();
+        assert!(registry.specs().is_empty());
+        assert_eq!(
+            registry.specs_for_foreground(true)[0].name,
+            crate::SPAWN_SANDBOX_AGENT_TOOL
+        );
+        let agent = Agent::new(
+            Arc::new(ClientToolProvider {
+                assistant_text: false,
+                name: crate::SPAWN_SANDBOX_AGENT_TOOL,
+                arguments: r#"{"task":"Research the error handling options."}"#,
+            }),
+            Arc::new(registry),
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        )
+        .with_durable_steer(lease_token)
+        .with_foreground_sandbox_spawns();
+        let (tx, rx) = unbounded();
+        let outcome = agent
+            .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
+            .await
+            .unwrap();
+        drop(tx);
+        let events = emitted_events(rx.collect().await);
+        let AgentTurnOutcome::SandboxAgentSpawn {
+            request,
+            usage,
+            steer_revision,
+            model_steps,
+        } = outcome
+        else {
+            panic!("foreground agent should return a sandbox checkpoint");
+        };
+        assert_eq!(request.task, "Research the error handling options.");
+        assert_eq!(
+            request.child_run_id,
+            AgentRunId::sandbox_for_spawn_call(request.call_id)
+        );
+        assert!(request.is_well_formed());
+        assert_eq!(usage.input_tokens, 5);
+        assert_eq!(usage.output_tokens, 2);
+        assert_eq!(steer_revision, 0);
+        assert_eq!(model_steps, 1);
+        assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::ToolCallStarted { name, .. }
+                if name == crate::SPAWN_SANDBOX_AGENT_TOOL
+        )));
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -1,0 +1,111 @@
+//! Model-facing contracts for durable agent orchestration.
+//!
+//! These are prepared control-flow proposals, not generic server-executed
+//! tools. The foreground turn worker owns the corresponding durable transition
+//! so the model can never bypass its lease, steer, or accounting fences. The
+//! production registry deliberately keeps this definition disabled until a
+//! sandbox executor can claim and complete the child.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::model::AgentRun;
+use crate::tool::ToolSpec;
+
+/// Stable name for the foreground-only sandbox delegation tool.
+pub const SPAWN_SANDBOX_AGENT_TOOL: &str = "spawn_sandbox_agent";
+
+/// Maximum task length in Unicode scalar values advertised to a model.
+///
+/// The persisted byte limit remains [`AgentRun::MAX_INPUT_LEN`]; this lower
+/// character cap ensures even four-byte UTF-8 input fits that durable bound.
+pub const MAX_SANDBOX_AGENT_TASK_CHARS: usize = 16_000;
+
+/// Canonical model proposal for one isolated sandbox task.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpawnSandboxAgentArgs {
+    /// A self-contained task for the isolated child. It cannot spawn children.
+    pub task: String,
+}
+
+impl SpawnSandboxAgentArgs {
+    /// Whether this proposal fits the durable sandbox-run contract.
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        !self.task.trim().is_empty()
+            && !self.task.contains('\0')
+            && self.task.chars().count() <= MAX_SANDBOX_AGENT_TASK_CHARS
+            && self.task.len() <= AgentRun::MAX_INPUT_LEN
+    }
+}
+
+/// Validate one canonical model payload before the foreground worker parks.
+#[must_use]
+pub fn validate_spawn_sandbox_agent_arguments(arguments: &Value) -> bool {
+    serde_json::from_value::<SpawnSandboxAgentArgs>(arguments.clone())
+        .is_ok_and(|arguments| arguments.is_well_formed())
+}
+
+/// Foreground-only model tool contract for delegating one bounded task.
+///
+/// The worker derives the durable child identity from the model tool call and
+/// atomically parks the foreground turn. Sandboxed agents never receive this
+/// definition, so the v1 hierarchy cannot recurse past depth one.
+#[must_use]
+pub fn spawn_sandbox_agent_tool_spec() -> ToolSpec {
+    ToolSpec {
+        name: SPAWN_SANDBOX_AGENT_TOOL.into(),
+        description: "Delegate one self-contained task to an isolated background agent. The conversation will pause until that agent returns. Use this only when independent work is useful; do not ask it to spawn more agents.".into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": MAX_SANDBOX_AGENT_TASK_CHARS,
+                    "description": "A concise, self-contained task for one isolated background agent."
+                }
+            },
+            "required": ["task"],
+            "additionalProperties": false
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_spawn_contract_is_strict_and_bounded() {
+        let valid = serde_json::json!({"task": "Research the error handling approach."});
+        assert!(validate_spawn_sandbox_agent_arguments(&valid));
+        assert!(!validate_spawn_sandbox_agent_arguments(
+            &serde_json::json!({
+                "task": "",
+            })
+        ));
+        assert!(!validate_spawn_sandbox_agent_arguments(
+            &serde_json::json!({
+                "task": "Research this.",
+                "priority": "high",
+            })
+        ));
+        assert!(!validate_spawn_sandbox_agent_arguments(
+            &serde_json::json!({
+                "task": format!("{}x", "a".repeat(MAX_SANDBOX_AGENT_TASK_CHARS)),
+            })
+        ));
+    }
+
+    #[test]
+    fn sandbox_spawn_spec_describes_a_single_bounded_task() {
+        let spec = spawn_sandbox_agent_tool_spec();
+        assert_eq!(spec.name, SPAWN_SANDBOX_AGENT_TOOL);
+        assert_eq!(spec.input_schema["additionalProperties"], false);
+        assert_eq!(spec.input_schema["required"], serde_json::json!(["task"]));
+        assert_eq!(spec.input_schema["properties"]["task"]["maxLength"], 16_000);
+        assert!(spec.description.contains("do not ask it to spawn"));
+    }
+}

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -169,6 +169,9 @@ id_type!(
 impl AgentRunId {
     /// Namespace for the one foreground coordinator derived for each chat.
     const FOREGROUND_NAMESPACE: Uuid = Uuid::from_u128(0x38fd_6a64_b02f_4e91_a60c_7173_9af0_5b21);
+    /// Namespace for a sandbox child derived from its exact model tool call.
+    const SANDBOX_SPAWN_NAMESPACE: Uuid =
+        Uuid::from_u128(0xb4b6_2a8f_6f85_4e0e_9e53_443a_4e69_a217);
 
     /// Derive the stable foreground coordinator identity for a chat.
     #[must_use]
@@ -176,6 +179,15 @@ impl AgentRunId {
         Self(Uuid::new_v5(
             &Self::FOREGROUND_NAMESPACE,
             chat_id.as_uuid().as_bytes(),
+        ))
+    }
+
+    /// Derive the stable child identity for one exact model tool call.
+    #[must_use]
+    pub fn sandbox_for_spawn_call(call_id: CallId) -> Self {
+        Self(Uuid::new_v5(
+            &Self::SANDBOX_SPAWN_NAMESPACE,
+            call_id.as_uuid().as_bytes(),
         ))
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -14,6 +14,7 @@
 //! contract).
 
 pub mod agent;
+pub mod agent_tools;
 pub mod approval;
 #[cfg(feature = "blob-fs")]
 pub mod blob;
@@ -36,7 +37,13 @@ pub mod tool;
 #[cfg(feature = "tools")]
 pub mod tools;
 
-pub use agent::{Agent, AgentConfig, AgentTurnOutcome, ClaimedAgentEvent, ToolRegistry};
+pub use agent::{
+    Agent, AgentConfig, AgentTurnOutcome, ClaimedAgentEvent, SandboxAgentSpawnRequest, ToolRegistry,
+};
+pub use agent_tools::{
+    spawn_sandbox_agent_tool_spec, validate_spawn_sandbox_agent_arguments, SpawnSandboxAgentArgs,
+    MAX_SANDBOX_AGENT_TASK_CHARS, SPAWN_SANDBOX_AGENT_TOOL,
+};
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalRequest, AutoApproveGate, RefuseGate,
 };

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -4868,7 +4868,7 @@ async fn root_search_never_returns_project_owned_vectors() {
 }
 
 #[test]
-fn agent_deps_registers_server_tools_and_the_folder_consent_contract() {
+fn agent_deps_registers_server_tools_and_the_folder_consent_contract_without_sandbox_spawn() {
     let (_retrieval, tools, _config) = agent_deps(
         Arc::new(HashEmbedder::default()),
         Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
@@ -4881,6 +4881,19 @@ fn agent_deps_registers_server_tools_and_the_folder_consent_contract() {
     assert!(
         names.iter().any(|n| n == "read_file"),
         "file tools still present"
+    );
+    assert!(
+        !names
+            .iter()
+            .any(|name| name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL),
+        "production registry must not advertise sandbox spawning before an executor exists"
+    );
+    assert!(
+        !tools
+            .specs_for_foreground(true)
+            .iter()
+            .any(|spec| spec.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL),
+        "ordinary claimed foreground turns must not expose the disabled sandbox tool"
     );
     assert_eq!(
         tools.execution(openwave_core::REQUEST_FOLDER_ACCESS_TOOL),

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -15,10 +15,11 @@ use chrono::Utc;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::StreamExt;
 use openwave_core::{
-    Agent, AgentConfig, AgentError, AgentEvent, AgentTurnOutcome, ClaimedAgentEvent,
-    CompleteTurnRunOutcome, MessageId, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
-    Result, SequencedEvent, Store, ToolRegistry, ToolScratch, TurnCheckpointProgress,
-    TurnFailureRetry, TurnId, TurnRun, TurnRunStatus,
+    AcceptSandboxAgentRunAndParkTurnOutcome, Agent, AgentConfig, AgentError, AgentEvent,
+    AgentTurnOutcome, ClaimedAgentEvent, CompleteTurnRunOutcome, MessageId,
+    ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, Result, SandboxAgentSpawnRequest,
+    SequencedEvent, Store, ToolRegistry, ToolScratch, TurnCheckpointProgress, TurnFailureRetry,
+    TurnId, TurnRun, TurnRunStatus, SPAWN_SANDBOX_AGENT_TOOL,
 };
 use tokio::sync::Notify;
 
@@ -56,6 +57,7 @@ impl Default for TurnWorkerConfig {
 pub(crate) enum TurnWorkerOutcome {
     Completed(TurnId),
     WaitingForClient(TurnId),
+    WaitingForAgentRun(TurnId),
     Cancelled(TurnId),
     Failed(TurnId),
     LeaseLost(TurnId),
@@ -124,6 +126,20 @@ fn client_checkpoint_is_valid(
         && request.is_well_formed()
         && tools.client_arguments_are_valid(&request.name, &request.arguments)
         && tools.execution(&request.name) == Some(openwave_core::ToolCallExecution::Client)
+}
+
+fn sandbox_spawn_checkpoint_is_valid(
+    tools: &ToolRegistry,
+    request: &SandboxAgentSpawnRequest,
+) -> bool {
+    request.is_well_formed()
+        && tools.is_foreground_sandbox_spawn(SPAWN_SANDBOX_AGENT_TOOL)
+        && tools
+            .sandbox_spawn_task(
+                SPAWN_SANDBOX_AGENT_TOOL,
+                &serde_json::json!({"task": request.task}),
+            )
+            .is_some_and(|task| task == request.task)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -465,7 +481,8 @@ impl TurnWorker {
                 .with_approvals(self.approvals.clone())
                 .with_cancel(cancel.clone())
                 .with_steer(steer.clone())
-                .with_durable_steer(lease_token);
+                .with_durable_steer(lease_token)
+                .with_foreground_sandbox_spawns();
             let chat = chat.clone();
             let (events_tx, mut events_rx) = unbounded();
             let mut drive = AbortOnDrop(tokio::spawn(async move {
@@ -595,6 +612,7 @@ impl TurnWorker {
                         Ok(AgentTurnOutcome::Completed { usage, .. })
                         | Ok(AgentTurnOutcome::Cancelled { usage, .. })
                         | Ok(AgentTurnOutcome::ClientToolCall { usage, .. })
+                        | Ok(AgentTurnOutcome::SandboxAgentSpawn { usage, .. })
                         | Ok(AgentTurnOutcome::Failed { usage, .. }) => *usage,
                         Err(_) => openwave_core::Usage::default(),
                     };
@@ -985,6 +1003,225 @@ impl TurnWorker {
                             }
                             Err(error) => {
                                 self.retry_after("client checkpoint", turn.id, &error).await;
+                            }
+                        }
+                    }
+                    checkpoint_heartbeat.abort_and_wait().await;
+                    if remaining_steps == 0 {
+                        drop(active);
+                        return self
+                            .record_failure(
+                                &turn,
+                                lease_token,
+                                total_model_steps,
+                                total_usage,
+                                "max_steps_exceeded",
+                                "max steps per turn exceeded while applying durable steering",
+                            )
+                            .await;
+                    }
+                    let mut continuation_heartbeat = AbortOnDrop(tokio::spawn(
+                        self.clone()
+                            .heartbeat_lease(turn.clone(), lease_token, cancel.clone()),
+                    ));
+                    match self
+                        .append_event(&turn, lease_token, ordinal, &AgentEvent::StreamInterrupted)
+                        .await?
+                    {
+                        EventAppend::Committed => {
+                            ordinal = ordinal.checked_add(1).ok_or_else(|| {
+                                AgentError::msg(format!("turn {} event ordinal exhausted", turn.id))
+                            })?;
+                        }
+                        EventAppend::Cancelling => {
+                            cancel.cancel();
+                            drop(active);
+                            return self
+                                .acknowledge_cancellation(&turn, lease_token, total_usage)
+                                .await;
+                        }
+                        EventAppend::LeaseLost => {
+                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                        }
+                    }
+                    continuation_heartbeat.abort_and_wait().await;
+                    continue;
+                }
+                Ok(AgentTurnOutcome::SandboxAgentSpawn {
+                    request,
+                    usage,
+                    steer_revision,
+                    model_steps,
+                }) => {
+                    if model_steps == 0 || model_steps > remaining_steps {
+                        return Err(AgentError::msg(format!(
+                            "turn {} returned an invalid model-step count {model_steps}",
+                            turn.id
+                        )));
+                    }
+                    remaining_steps -= model_steps;
+                    total_model_steps = checked_model_step_sum(total_model_steps, model_steps)?;
+                    total_usage = match checked_usage_sum(total_usage, usage) {
+                        Ok(total) => total,
+                        Err(_) => {
+                            return self
+                                .record_failure(
+                                    &turn,
+                                    lease_token,
+                                    total_model_steps,
+                                    total_usage,
+                                    "usage_overflow",
+                                    "provider usage exceeded the supported turn total",
+                                )
+                                .await;
+                        }
+                    };
+                    if remaining_steps == 0 {
+                        drop(active);
+                        return self
+                            .record_failure(
+                                &turn,
+                                lease_token,
+                                total_model_steps,
+                                total_usage,
+                                "max_steps_exceeded",
+                                "max steps per turn exceeded before sandbox delegation",
+                            )
+                            .await;
+                    }
+                    if !sandbox_spawn_checkpoint_is_valid(self.tools.as_ref(), &request) {
+                        drop(active);
+                        return self
+                            .record_failure(
+                                &turn,
+                                lease_token,
+                                total_model_steps,
+                                total_usage,
+                                "invalid_sandbox_agent_spawn",
+                                "agent returned an invalid sandbox delegation checkpoint",
+                            )
+                            .await;
+                    }
+                    checkpoint_usage = match checked_usage_sum(checkpoint_usage, usage) {
+                        Ok(total) => total,
+                        Err(_) => {
+                            return self
+                                .record_failure(
+                                    &turn,
+                                    lease_token,
+                                    total_model_steps,
+                                    total_usage,
+                                    "usage_overflow",
+                                    "provider usage exceeded the supported checkpoint total",
+                                )
+                                .await;
+                        }
+                    };
+                    checkpoint_steps =
+                        checkpoint_steps.checked_add(model_steps).ok_or_else(|| {
+                            AgentError::msg(format!(
+                                "turn {} checkpoint model-step count overflowed",
+                                turn.id
+                            ))
+                        })?;
+                    let progress = TurnCheckpointProgress {
+                        model_steps: i32::try_from(checkpoint_steps).map_err(|_| {
+                            AgentError::msg(format!(
+                                "turn {} checkpoint model-step count is too large",
+                                turn.id
+                            ))
+                        })?,
+                        usage: checkpoint_usage,
+                    };
+                    let mut checkpoint_heartbeat = AbortOnDrop(tokio::spawn(
+                        self.clone()
+                            .heartbeat_lease(turn.clone(), lease_token, cancel.clone()),
+                    ));
+                    loop {
+                        let park_result = tokio::select! {
+                            result = self.store.accept_sandbox_agent_run_and_park_turn(
+                                request.child_run_id,
+                                turn.id,
+                                request.call_id,
+                                &request.task,
+                                lease_token,
+                                steer_revision,
+                                progress,
+                                Utc::now(),
+                            ) => result,
+                            result = &mut checkpoint_heartbeat.0 => {
+                                match result {
+                                    Ok(HeartbeatOutcome::Cancelling) => {
+                                        drop(active);
+                                        return self
+                                            .acknowledge_cancellation(
+                                                &turn,
+                                                lease_token,
+                                                total_usage,
+                                            )
+                                            .await;
+                                    }
+                                    Ok(HeartbeatOutcome::LeaseLost) | Err(_) => {
+                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    }
+                                }
+                            }
+                        };
+                        match park_result {
+                            Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::Parked {
+                                ..
+                            }))
+                            | Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::Existing {
+                                ..
+                            })) => {
+                                checkpoint_heartbeat.abort_and_wait().await;
+                                return Ok(TurnWorkerOutcome::WaitingForAgentRun(turn.id));
+                            }
+                            Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::SteerPending(_)))
+                            | Ok(Some(
+                                AcceptSandboxAgentRunAndParkTurnOutcome::OutputSuperseded(_),
+                            )) => {
+                                break;
+                            }
+                            Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict))
+                            | Ok(Some(
+                                AcceptSandboxAgentRunAndParkTurnOutcome::ParentUnavailable,
+                            )) => {
+                                checkpoint_heartbeat.abort_and_wait().await;
+                                return self
+                                    .record_failure(
+                                        &turn,
+                                        lease_token,
+                                        total_model_steps,
+                                        total_usage,
+                                        "sandbox_agent_spawn_identity_conflict",
+                                        "sandbox delegation conflicts with its durable receipt",
+                                    )
+                                    .await;
+                            }
+                            Ok(None) => {
+                                match self.live_turn_state_retry(&turn, lease_token).await {
+                                    LiveTurnState::Running => tokio::task::yield_now().await,
+                                    LiveTurnState::Cancelling => {
+                                        checkpoint_heartbeat.abort_and_wait().await;
+                                        drop(active);
+                                        return self
+                                            .acknowledge_cancellation(
+                                                &turn,
+                                                lease_token,
+                                                total_usage,
+                                            )
+                                            .await;
+                                    }
+                                    LiveTurnState::Lost => {
+                                        checkpoint_heartbeat.abort_and_wait().await;
+                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    }
+                                }
+                            }
+                            Err(error) => {
+                                self.retry_after("sandbox delegation checkpoint", turn.id, &error)
+                                    .await;
                             }
                         }
                     }
@@ -1751,5 +1988,30 @@ mod committed_event_drain_tests {
         assert!(!client_checkpoint_is_valid(
             &tools, chat_id, turn_id, &request
         ));
+    }
+
+    #[test]
+    fn sandbox_spawn_checkpoint_fence_requires_the_registered_foreground_contract() {
+        let mut tools = ToolRegistry::new();
+        tools.register_foreground_sandbox_spawn();
+        let call_id = openwave_core::CallId::new();
+        let request = SandboxAgentSpawnRequest {
+            call_id,
+            child_run_id: openwave_core::AgentRunId::sandbox_for_spawn_call(call_id),
+            task: "Research the error handling options.".into(),
+        };
+        assert!(sandbox_spawn_checkpoint_is_valid(&tools, &request));
+
+        let invalid_task = SandboxAgentSpawnRequest {
+            task: " ".into(),
+            ..request.clone()
+        };
+        assert!(!sandbox_spawn_checkpoint_is_valid(&tools, &invalid_task));
+
+        let forged_child = SandboxAgentSpawnRequest {
+            child_run_id: openwave_core::AgentRunId::new(),
+            ..request
+        };
+        assert!(!sandbox_spawn_checkpoint_is_valid(&tools, &forged_child));
     }
 }

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -69,12 +69,17 @@ spawn:
 6. The result, terminal child state, and immutable parent inbox entry commit
    together. A later wait transition may consume that entry and wake a parent.
 
-The foreground agent may continue or finish its current turn after spawning a
-child. If it needs the result before proceeding, the spawn boundary commits the
-queued child, its unique spawn identity, the durable wait, and release of the
-exact foreground worker lease in one transaction. It never leaves a child
-behind when that checkpoint is fenced by a stale lease or steer. The turn then
-waits without polling in memory.
+The bounded `spawn_sandbox_agent` contract and its foreground checkpoint wiring
+are prepared, but deliberately disabled in the production tool registry: no
+sandbox executor exists yet to claim and complete the accepted child. When that
+executor lands, this will be a wait-form tool: it accepts one bounded `task`,
+derives the child identity from that exact tool call, and commits the queued
+child, durable wait, and release of the exact foreground worker lease in one
+transaction. It will be advertised only to a claimed foreground turn; sandbox
+workers will never receive it, and the store independently enforces depth one.
+A later non-blocking spawn tool can let the foreground continue after spawning,
+but must earn the same checkpoint and replay rules. The prepared boundary never
+leaves a child behind when a stale lease or steer fences its checkpoint.
 
 The wait also carries an immutable atomic-admission marker. Only that receipt
 allows a later retry to recover the combined transition; an older path that
@@ -219,7 +224,9 @@ The implementation is intentionally incremental:
 7. Atomically join durable inbox consumption with a parent turn checkpoint and
    durable `resuming` wake signal. *(Shipped.)*
 8. Atomically accept a sandbox spawn and its parent checkpoint from the
-   foreground tool boundary. *(Shipped.)*
+   foreground tool boundary. The bounded foreground-only
+   `spawn_sandbox_agent` contract is wired to this transition, but remains
+   disabled until the sandbox executor lands. *(Groundwork shipped.)*
 9. Route sandbox folder access through the host broker.
 10. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -56,6 +56,11 @@ The foreground coordinator needs tools for:
 - spawning, inspecting, messaging, waiting for, cancelling, and reviewing
   depth-one sandbox agents.
 
+`spawn_sandbox_agent` has a prepared bounded contract and durable foreground
+checkpoint path, but is intentionally disabled in the production registry
+until a sandbox executor exists. Enabling it earlier would park a foreground
+chat with no worker able to complete the child.
+
 A background sandbox starts with a deliberately smaller surface:
 
 - confined command execution;
@@ -126,4 +131,3 @@ Every new tool should answer these questions before it is registered:
 
 Until an effect has an idempotency or reconciliation contract, OpenWave fails
 conservatively after an ambiguous execution instead of replaying it.
-


### PR DESCRIPTION
## Summary

- add a strict, typed foreground sandbox-spawn checkpoint contract
- derive child identity from the model call and preserve the worker-owned atomic park transition
- keep the production tool registry disabled until a sandbox executor is available

## Validation

- cargo test -p openwave-core --lib --locked
- cargo test -p openwave-server --lib --locked
- bw dev lint --rust --check