### PR TITLE
Execute sandbox agent runs

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -43,7 +43,7 @@ use crate::storage::{
     ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome, ClaimTurnRunOutcome,
     CompleteTurnRunOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
     DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
-    FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
+    FailAgentRunOutcome, FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
     JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForAgentRunInboxOutcome,
     ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
@@ -1828,6 +1828,18 @@ impl Store for DbStore {
         text: &str,
     ) -> Result<Option<SubmitAgentRunResultOutcome>> {
         ops::agent_run::submit_agent_run_result(self, id, lease_token, text).await
+    }
+
+    async fn fail_agent_run(
+        &self,
+        id: AgentRunId,
+        lease_token: uuid::Uuid,
+        error_code: &str,
+        error_detail: &str,
+        retry_delay: chrono::Duration,
+    ) -> Result<Option<FailAgentRunOutcome>> {
+        ops::agent_run::fail_agent_run(self, id, lease_token, error_code, error_detail, retry_delay)
+            .await
     }
 
     async fn list_agent_run_inbox(

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -12,7 +12,7 @@ use crate::model::{
 };
 use crate::storage::{
     AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, ClaimAgentRunInboxOutcome,
-    ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
+    ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome, FailAgentRunOutcome,
     FinishAgentRunCancellationOutcome, ParkTurnForAgentRunInboxOutcome,
     RequestAgentRunCancellationOutcome, SubmitAgentRunResultOutcome,
 };
@@ -951,6 +951,174 @@ pub(in crate::db) async fn finish_agent_run_cancellation(
         .and_then(agent_run_from_model)?;
     transaction.commit().await.map_err(store_err)?;
     Ok(Some(FinishAgentRunCancellationOutcome::Cancelled(updated)))
+}
+
+/// Resolve an exact live sandbox lease after a provider/executor failure.
+///
+/// Intermediate failures release only the current lease and remain replay-safe.
+/// The final attempt also writes the same immutable parent inbox receipt used
+/// by successful completion, but transitions the child to `failed`.
+pub(in crate::db) async fn fail_agent_run(
+    store: &DbStore,
+    id: AgentRunId,
+    lease_token: uuid::Uuid,
+    error_code: &str,
+    error_detail: &str,
+    retry_delay: chrono::Duration,
+) -> Result<Option<FailAgentRunOutcome>> {
+    if lease_token.is_nil()
+        || error_code.is_empty()
+        || error_code.chars().count() > AgentRun::MAX_ERROR_CODE_LEN
+        || error_detail.chars().count() > AgentRun::MAX_ERROR_DETAIL_LEN
+        || retry_delay <= chrono::Duration::zero()
+    {
+        return Err(AgentError::Store(
+            "invalid sandbox agent failure resolution".into(),
+        ));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
+    let Some(run) = find_by_id_on(&transaction, id).await? else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    // A completed final receipt lets an ambiguous retry recover exactly; a
+    // later different terminal outcome never overwrites it.
+    if let Some(result) = entities::agent_run_result::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let result = agent_run_result_from_model(result)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok((result.lease_token == lease_token
+            && run.status == AgentRunStatus::Failed.as_str())
+        .then_some(FailAgentRunOutcome::ExistingFailed(result)));
+    }
+    let valid = run.execution == AgentRunExecution::Sandbox.as_str()
+        && run.status == AgentRunStatus::Running.as_str()
+        && run.lease_token == Some(lease_token)
+        && run.lease_expires_at.is_some_and(|expiry| expiry > now)
+        && run.deadline_at.is_some_and(|deadline| deadline > now)
+        && run.updated_at <= now;
+    if !valid {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let terminal = run.attempt_count >= run.max_attempts;
+    let available_at = now.checked_add_signed(retry_delay).ok_or_else(|| {
+        AgentError::Store("agent-run retry delay overflows timestamp range".into())
+    })?;
+    let status = if terminal {
+        AgentRunStatus::Failed
+    } else {
+        AgentRunStatus::RetryWait
+    };
+    let mut update = entities::agent_run::Entity::update_many()
+        .col_expr(
+            entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(status.as_str()),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Some(error_code.to_owned())),
+        )
+        .col_expr(
+            entities::agent_run::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Some(error_detail.to_owned())),
+        )
+        .col_expr(
+            entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::agent_run::Column::Id.eq(id.0))
+        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Running.as_str()))
+        .filter(entities::agent_run::Column::LeaseToken.eq(lease_token))
+        .filter(entities::agent_run::Column::LeaseExpiresAt.eq(run.lease_expires_at))
+        .filter(entities::agent_run::Column::LeaseExpiresAt.gt(now))
+        .filter(entities::agent_run::Column::DeadlineAt.gt(now))
+        .filter(entities::agent_run::Column::UpdatedAt.eq(run.updated_at));
+    if terminal {
+        update = update.col_expr(
+            entities::agent_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        );
+    } else {
+        update = update.col_expr(
+            entities::agent_run::Column::AvailableAt,
+            sea_orm::sea_query::Expr::value(available_at),
+        );
+    }
+    if update
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?
+        .rows_affected
+        != 1
+    {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let updated = find_by_id_on(&transaction, id)
+        .await?
+        .expect("updated agent run exists");
+    if !terminal {
+        let updated = agent_run_from_model(updated)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(FailAgentRunOutcome::RetryScheduled(updated)));
+    }
+    let Some(parent_id) = run.parent_id.map(AgentRunId) else {
+        return Err(AgentError::Store("sandbox run missing parent".into()));
+    };
+    let text = format!("Sandbox task failed ({error_code}): {error_detail}");
+    entities::agent_run_result::ActiveModel {
+        agent_run_id: Set(id.0),
+        lease_token: Set(lease_token),
+        attempt_count: Set(run.attempt_count),
+        claim_count: Set(run.claim_count),
+        text: Set(text),
+        submitted_at: Set(now),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    entities::agent_run_inbox::ActiveModel {
+        child_run_id: Set(id.0),
+        parent_run_id: Set(parent_id.0),
+        chat_id: Set(run.chat_id),
+        parent_depth: Set(0),
+        result_lease_token: Set(lease_token),
+        result_attempt_count: Set(run.attempt_count),
+        result_claim_count: Set(run.claim_count),
+        status: Set(AgentRunInboxStatus::Pending.as_str().into()),
+        claim_count: Set(0),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        consumed_lease_token: Set(None),
+        consumed_at: Set(None),
+        delivered_at: Set(now),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    let result = entities::agent_run_result::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .expect("inserted result exists");
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(FailAgentRunOutcome::Failed(
+        agent_run_result_from_model(result)?,
+    )))
 }
 
 pub(in crate::db) async fn submit_agent_run_result(

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -93,7 +93,7 @@ pub use storage::{
     ClaimClientToolCallOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim,
     CompleteTurnRunOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
     DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
-    FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
+    FailAgentRunOutcome, FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
     JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkTurnForAgentRunInboxOutcome,
     ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -222,6 +222,21 @@ pub enum SubmitAgentRunResultOutcome {
     Existing(AgentRunResult),
 }
 
+/// Resolution of one exact sandbox execution failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FailAgentRunOutcome {
+    /// The leased attempt was released for a bounded retry.
+    RetryScheduled(AgentRun),
+    /// The leased attempt exhausted its budget and delivered a terminal failure
+    /// receipt to the parent inbox.
+    Failed(AgentRunResult),
+    /// An exact ambiguous retry recovered the already-recorded retry or final
+    /// failure transition.
+    ExistingRetry(AgentRun),
+    /// An exact ambiguous retry recovered the final failure receipt.
+    ExistingFailed(AgentRunResult),
+}
+
 /// Result of acquiring durable ownership of one exact parent inbox delivery.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClaimAgentRunInboxOutcome {
@@ -1123,6 +1138,20 @@ pub trait Store: Send + Sync {
         _lease_token: uuid::Uuid,
         _text: &str,
     ) -> Result<Option<SubmitAgentRunResultOutcome>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Fence one exact sandbox lease after an execution failure. Attempts below
+    /// the run budget become replay-safe retry work; the final attempt writes a
+    /// parent-visible terminal receipt in the same transaction as `failed`.
+    async fn fail_agent_run(
+        &self,
+        _id: AgentRunId,
+        _lease_token: uuid::Uuid,
+        _error_code: &str,
+        _error_detail: &str,
+        _retry_delay: chrono::Duration,
+    ) -> Result<Option<FailAgentRunOutcome>> {
         agent_run_storage_unavailable()
     }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -26,6 +26,7 @@ mod provider;
 mod providers;
 mod resolver;
 mod routes;
+mod sandbox_agent_run_worker;
 mod state;
 mod turn_worker;
 
@@ -219,6 +220,7 @@ pub struct Server {
     _document_auditor: AbortTask,
     _document_worker: AbortTask,
     _turn_worker: AbortTask,
+    _sandbox_agent_run_worker: AbortTask,
     _blob_retirement_worker: AbortTask,
     _blob_orphan_auditor: AbortTask,
     _instance_lock: InstanceLock,
@@ -400,6 +402,14 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
         Some(state.config.data_dir.join("scratch")),
         turn_worker::TurnWorkerConfig::default(),
     );
+    let sandbox_agent_run_worker = sandbox_agent_run_worker::SandboxAgentRunWorker::new(
+        state.store.clone(),
+        state.resolver.clone(),
+        state.agent_run_wake.clone(),
+        state.agent_config.clone(),
+        Some(state.config.data_dir.join("scratch")),
+        sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default(),
+    );
     let server_store = state.store.clone();
     let router = app(state);
 
@@ -413,6 +423,7 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
     let document_auditor = tokio::spawn(document_auditor.run());
     let document_worker = tokio::spawn(document_worker.run());
     let turn_worker = tokio::spawn(turn_worker.run());
+    let sandbox_agent_run_worker = tokio::spawn(sandbox_agent_run_worker.run());
     let blob_retirement_worker = tokio::spawn(blob_retirement_worker.run());
     let blob_orphan_auditor = tokio::spawn(blob_orphan_auditor.run());
 
@@ -426,6 +437,7 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
         _document_auditor: AbortTask(document_auditor),
         _document_worker: AbortTask(document_worker),
         _turn_worker: AbortTask(turn_worker),
+        _sandbox_agent_run_worker: AbortTask(sandbox_agent_run_worker),
         _blob_retirement_worker: AbortTask(blob_retirement_worker),
         _blob_orphan_auditor: AbortTask(blob_orphan_auditor),
         _instance_lock: instance_lock,

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -1,0 +1,913 @@
+//! Execution for durably claimed sandboxed agent runs.
+//!
+//! A sandbox run intentionally is not a second foreground turn. It receives
+//! only its immutable delegated task, uses one model completion with no tools,
+//! and returns bounded text through the fenced agent-run result transition.
+//! That keeps the first execution surface small while preserving the same
+//! claim, heartbeat, cancellation, and replay mechanics as other workers.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use openwave_core::{
+    AgentConfig, AgentError, AgentRun, AgentRunStatus, ChatMessage, ChatRequest,
+    FailAgentRunOutcome, ModelProvider, ProviderEvent, Result, Role, StopReason, Store,
+    SubmitAgentRunResultOutcome,
+};
+use tokio::sync::Notify;
+
+use crate::resolver::ProviderResolver;
+
+/// Fixed instruction set for the initial isolated executor.
+///
+/// Deliberately do not inherit the foreground system prompt: it may describe
+/// interactive tools or conversation-wide responsibilities that are outside a
+/// depth-one child run's authority.
+const SANDBOX_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below and return a concise, self-contained result for your parent agent. You have no tools, cannot access the conversation, filesystem, network, or other agents, and must not ask to create or call tools.";
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SandboxAgentRunWorkerConfig {
+    lease: Duration,
+    heartbeat: Duration,
+    idle_min: Duration,
+    idle_cap: Duration,
+    failure_delay: Duration,
+    max_concurrency: usize,
+    max_running_global: u32,
+    max_running_per_chat: u32,
+    #[cfg(test)]
+    suppress_resolver_heartbeats: bool,
+}
+
+impl Default for SandboxAgentRunWorkerConfig {
+    fn default() -> Self {
+        Self {
+            lease: Duration::from_secs(60),
+            heartbeat: Duration::from_secs(15),
+            idle_min: Duration::from_millis(250),
+            idle_cap: Duration::from_secs(5),
+            failure_delay: Duration::from_secs(1),
+            max_concurrency: 4,
+            max_running_global: 4,
+            max_running_per_chat: 2,
+            #[cfg(test)]
+            suppress_resolver_heartbeats: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SandboxAgentRunWorkerOutcome {
+    Idle,
+    Completed(openwave_core::AgentRunId),
+    RetryScheduled(openwave_core::AgentRunId),
+    Failed(openwave_core::AgentRunId),
+    Cancelled(openwave_core::AgentRunId),
+    LeaseLost(openwave_core::AgentRunId),
+}
+
+#[derive(Clone)]
+pub(crate) struct SandboxAgentRunWorker {
+    store: Arc<dyn Store>,
+    resolver: Arc<dyn ProviderResolver>,
+    wake: Arc<Notify>,
+    agent_config: AgentConfig,
+    /// Each run receives a directory under this private root. The initial
+    /// no-tools executor does not open it; retaining the boundary now means a
+    /// future sandbox-safe tool adapter must be given an exact per-run handle
+    /// rather than a chat or project path.
+    private_scratch_root: Option<PathBuf>,
+    config: SandboxAgentRunWorkerConfig,
+}
+
+impl SandboxAgentRunWorker {
+    pub(crate) fn new(
+        store: Arc<dyn Store>,
+        resolver: Arc<dyn ProviderResolver>,
+        wake: Arc<Notify>,
+        agent_config: AgentConfig,
+        private_scratch_root: Option<PathBuf>,
+        config: SandboxAgentRunWorkerConfig,
+    ) -> Self {
+        assert!(!config.lease.is_zero());
+        assert!(!config.heartbeat.is_zero());
+        assert!(config.heartbeat < config.lease);
+        assert!(config.max_concurrency > 0);
+        assert!(config.max_running_global > 0);
+        assert!(config.max_running_per_chat > 0);
+        Self {
+            store,
+            resolver,
+            wake,
+            agent_config,
+            private_scratch_root,
+            config,
+        }
+    }
+
+    pub(crate) async fn run(self) {
+        let mut lanes = tokio::task::JoinSet::new();
+        for _ in 0..self.config.max_concurrency {
+            lanes.spawn(self.clone().run_lane());
+        }
+        while let Some(result) = lanes.join_next().await {
+            if let Err(error) = result {
+                eprintln!("openwave: sandbox agent worker lane stopped: {error}");
+                tokio::time::sleep(self.config.failure_delay).await;
+            }
+            lanes.spawn(self.clone().run_lane());
+        }
+    }
+
+    async fn run_lane(self) {
+        let mut idle_delay = self.config.idle_min;
+        loop {
+            match self.run_once().await {
+                Ok(SandboxAgentRunWorkerOutcome::Idle) => {
+                    tokio::select! {
+                        _ = tokio::time::sleep(idle_delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
+                }
+                Ok(_) => idle_delay = self.config.idle_min,
+                Err(error) => {
+                    eprintln!("openwave: sandbox agent worker iteration failed: {error}");
+                    tokio::select! {
+                        _ = tokio::time::sleep(self.config.failure_delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                }
+            }
+        }
+    }
+
+    /// Claim and execute one sandbox run. It is exposed inside the server crate
+    /// so focused integration tests can exercise the real durable transitions
+    /// without starting permanent worker lanes.
+    pub(crate) async fn run_once(&self) -> Result<SandboxAgentRunWorkerOutcome> {
+        let lease_token = uuid::Uuid::new_v4();
+        let lease = chrono_duration(self.config.lease)?;
+        let Some(run) = self
+            .store
+            .claim_agent_run(
+                lease_token,
+                lease,
+                self.config.max_running_global,
+                self.config.max_running_per_chat,
+            )
+            .await?
+        else {
+            return Ok(SandboxAgentRunWorkerOutcome::Idle);
+        };
+        self.wake.notify_one();
+        self.process(run, lease_token).await
+    }
+
+    async fn process(
+        &self,
+        run: AgentRun,
+        lease_token: uuid::Uuid,
+    ) -> Result<SandboxAgentRunWorkerOutcome> {
+        if run.status != AgentRunStatus::Running || run.lease_token != Some(lease_token) {
+            return Err(AgentError::msg(format!(
+                "claimed sandbox agent run {} has an invalid execution identity",
+                run.id
+            )));
+        }
+        let task = run.input.clone().ok_or_else(|| {
+            AgentError::msg(format!(
+                "claimed sandbox agent run {} has no delegated task",
+                run.id
+            ))
+        })?;
+        self.prepare_private_scratch(run.id)?;
+
+        let request = sandbox_request(&self.agent_config, task);
+        let provider = match self.resolve_provider(run.id, lease_token).await? {
+            Ok(provider) => provider,
+            Err(outcome) => return Ok(outcome),
+        };
+        // Resolve may have waited on credentials or provider configuration.
+        // Extend and revalidate the exact live lease immediately before the
+        // provider can observe a request.
+        // Request a strictly later expiry so the storage heartbeat remains
+        // monotonic even when SQLite's clock reports the same instant as the
+        // claim. It is still the final DB-clock lease proof before egress.
+        let pre_egress_lease = self.config.lease.saturating_add(Duration::from_millis(1));
+        if !self
+            .store
+            .heartbeat_agent_run(run.id, lease_token, chrono_duration(pre_egress_lease)?)
+            .await?
+        {
+            return self
+                .acknowledge_cancellation_or_lease_loss(run.id, lease_token)
+                .await;
+        }
+        let mut completion = Box::pin(complete_sandbox_task(provider, request));
+        let mut heartbeat = tokio::time::interval(self.config.heartbeat);
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        heartbeat.tick().await;
+
+        loop {
+            tokio::select! {
+                result = &mut completion => match result {
+                    Ok(text) => return self.submit_result(run.id, lease_token, text).await,
+                    // No terminal failure transition exists yet. Keep the exact
+                    // lease alive only until its scheduler expiry; then the
+                    // durable claim state machine safely retries or exhausts
+                    // the bounded attempt budget. This avoids inventing an
+                    // unfenced failure path in the executor.
+                    Err(error) => return self.record_failure(run.id, lease_token, error).await,
+                },
+                _ = heartbeat.tick() => {
+                    if self
+                        .store
+                        .heartbeat_agent_run(run.id, lease_token, chrono_duration(self.config.lease)?)
+                        .await?
+                    {
+                        continue;
+                    }
+                    return self.acknowledge_cancellation_or_lease_loss(run.id, lease_token).await;
+                }
+            }
+        }
+    }
+
+    async fn resolve_provider(
+        &self,
+        id: openwave_core::AgentRunId,
+        lease_token: uuid::Uuid,
+    ) -> Result<std::result::Result<Arc<dyn ModelProvider>, SandboxAgentRunWorkerOutcome>> {
+        let resolver = self.resolver.resolve();
+        tokio::pin!(resolver);
+        #[cfg(test)]
+        if self.config.suppress_resolver_heartbeats {
+            return Ok(Ok(resolver.await));
+        }
+        let mut heartbeat = tokio::time::interval(self.config.heartbeat);
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        heartbeat.tick().await;
+        loop {
+            tokio::select! {
+                provider = &mut resolver => return Ok(Ok(provider)),
+                _ = heartbeat.tick() => {
+                    if !self.store.heartbeat_agent_run(id, lease_token, chrono_duration(self.config.lease)?).await? {
+                        return Ok(Err(self.acknowledge_cancellation_or_lease_loss(id, lease_token).await?));
+                    }
+                }
+            }
+        }
+    }
+
+    async fn record_failure(
+        &self,
+        id: openwave_core::AgentRunId,
+        lease_token: uuid::Uuid,
+        error: AgentError,
+    ) -> Result<SandboxAgentRunWorkerOutcome> {
+        let detail = error.to_string();
+        let detail = detail
+            .chars()
+            .take(openwave_core::AgentRun::MAX_ERROR_DETAIL_LEN)
+            .collect::<String>();
+        match self
+            .store
+            .fail_agent_run(
+                id,
+                lease_token,
+                "sandbox_execution_failed",
+                &detail,
+                chrono_duration(self.config.failure_delay)?,
+            )
+            .await?
+        {
+            Some(FailAgentRunOutcome::RetryScheduled(_))
+            | Some(FailAgentRunOutcome::ExistingRetry(_)) => {
+                Ok(SandboxAgentRunWorkerOutcome::RetryScheduled(id))
+            }
+            Some(FailAgentRunOutcome::Failed(_)) | Some(FailAgentRunOutcome::ExistingFailed(_)) => {
+                Ok(SandboxAgentRunWorkerOutcome::Failed(id))
+            }
+            None => {
+                self.acknowledge_cancellation_or_lease_loss(id, lease_token)
+                    .await
+            }
+        }
+    }
+
+    async fn submit_result(
+        &self,
+        id: openwave_core::AgentRunId,
+        lease_token: uuid::Uuid,
+        text: String,
+    ) -> Result<SandboxAgentRunWorkerOutcome> {
+        match self
+            .store
+            .submit_agent_run_result(id, lease_token, &text)
+            .await?
+        {
+            Some(SubmitAgentRunResultOutcome::Completed(_))
+            | Some(SubmitAgentRunResultOutcome::Existing(_)) => {
+                Ok(SandboxAgentRunWorkerOutcome::Completed(id))
+            }
+            None => {
+                self.acknowledge_cancellation_or_lease_loss(id, lease_token)
+                    .await
+            }
+        }
+    }
+
+    async fn acknowledge_cancellation_or_lease_loss(
+        &self,
+        id: openwave_core::AgentRunId,
+        lease_token: uuid::Uuid,
+    ) -> Result<SandboxAgentRunWorkerOutcome> {
+        let Some(run) = self.store.get_agent_run(id).await? else {
+            return Ok(SandboxAgentRunWorkerOutcome::LeaseLost(id));
+        };
+        if run.status == AgentRunStatus::Cancelling && run.lease_token == Some(lease_token) {
+            if self
+                .store
+                .finish_agent_run_cancellation(id, lease_token)
+                .await?
+                .is_some()
+            {
+                return Ok(SandboxAgentRunWorkerOutcome::Cancelled(id));
+            }
+        }
+        Ok(SandboxAgentRunWorkerOutcome::LeaseLost(id))
+    }
+
+    fn prepare_private_scratch(&self, id: openwave_core::AgentRunId) -> Result<()> {
+        let Some(root) = &self.private_scratch_root else {
+            return Ok(());
+        };
+        let path = root.join("sandbox-runs").join(id.to_string());
+        std::fs::create_dir_all(&path).map_err(|error| {
+            AgentError::Store(format!(
+                "failed to create private sandbox scratch {}: {error}",
+                path.display()
+            ))
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).map_err(
+                |error| {
+                    AgentError::Store(format!(
+                        "failed to secure private sandbox scratch {}: {error}",
+                        path.display()
+                    ))
+                },
+            )?;
+        }
+        Ok(())
+    }
+}
+
+fn sandbox_request(config: &AgentConfig, task: String) -> ChatRequest {
+    ChatRequest {
+        model: config.model.clone(),
+        system: Some(SANDBOX_SYSTEM_PROMPT.into()),
+        messages: vec![ChatMessage::text(Role::User, task)],
+        tools: vec![],
+        max_tokens: config.max_tokens,
+        temperature: config.temperature,
+    }
+}
+
+async fn complete_sandbox_task(
+    provider: Arc<dyn ModelProvider>,
+    request: ChatRequest,
+) -> Result<String> {
+    let mut stream = provider.stream(request).await?;
+    let mut text = String::new();
+    while let Some(event) = stream.next().await {
+        match event {
+            ProviderEvent::TextDelta { text: delta } => {
+                text.push_str(&delta);
+                if text.chars().count() > AgentRun::MAX_RESULT_LEN {
+                    return Err(AgentError::msg(format!(
+                        "sandbox agent output exceeds {} characters",
+                        AgentRun::MAX_RESULT_LEN
+                    )));
+                }
+            }
+            ProviderEvent::ToolCallStarted { .. } | ProviderEvent::ToolCallArgsDelta { .. } => {
+                return Err(AgentError::msg(
+                    "sandbox agent requested a tool on the no-tools execution surface",
+                ));
+            }
+            ProviderEvent::Stop { reason } => {
+                if matches!(reason, StopReason::ToolUse | StopReason::Cancelled) {
+                    return Err(AgentError::msg(
+                        "sandbox agent did not produce a final result",
+                    ));
+                }
+                if text.trim().is_empty() {
+                    return Err(AgentError::msg(
+                        "sandbox agent produced an empty final result",
+                    ));
+                }
+                return Ok(text);
+            }
+            ProviderEvent::ReasoningDelta { .. } | ProviderEvent::Usage(_) => {}
+            _ => {
+                return Err(AgentError::msg(
+                    "sandbox agent provider emitted an unsupported event",
+                ))
+            }
+        }
+    }
+    Err(AgentError::msg(
+        "sandbox agent provider stream ended without a stop event",
+    ))
+}
+
+fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {
+    chrono::Duration::from_std(duration)
+        .map_err(|error| AgentError::msg(format!("invalid sandbox-worker duration: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use futures::stream::{self, BoxStream};
+    use openwave_core::{
+        AcceptAgentRunOutcome, AgentRunExecution, CallId, Chat, ChatId, ChatRequest, DbStore,
+        ModelProvider, ProviderId, Role, Store,
+    };
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingProvider {
+        requests: Mutex<Vec<ChatRequest>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for RecordingProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("recording")
+        }
+
+        async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            self.requests.lock().unwrap().push(request);
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "done".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    struct FixedResolver(Arc<dyn ModelProvider>);
+
+    #[async_trait]
+    impl ProviderResolver for FixedResolver {
+        async fn resolve(&self) -> Arc<dyn ModelProvider> {
+            self.0.clone()
+        }
+    }
+
+    struct DelayedResolver {
+        entered: Arc<Notify>,
+        release: Arc<Notify>,
+        provider: Arc<dyn ModelProvider>,
+    }
+
+    #[async_trait]
+    impl ProviderResolver for DelayedResolver {
+        async fn resolve(&self) -> Arc<dyn ModelProvider> {
+            self.entered.notify_one();
+            self.release.notified().await;
+            self.provider.clone()
+        }
+    }
+
+    struct BlockingProvider {
+        started: Arc<Notify>,
+    }
+
+    struct FailingProvider;
+
+    #[async_trait]
+    impl ModelProvider for FailingProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("failing")
+        }
+        async fn stream(&self, _request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            Err(AgentError::msg("provider unavailable"))
+        }
+    }
+
+    #[async_trait]
+    impl ModelProvider for BlockingProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("blocking")
+        }
+
+        async fn stream(&self, _request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            self.started.notify_one();
+            Ok(stream::pending().boxed())
+        }
+    }
+
+    async fn fixture() -> (
+        SandboxAgentRunWorker,
+        Arc<dyn Store>,
+        Arc<RecordingProvider>,
+        Chat,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = sandbox_chat();
+        store.create_chat(&chat).await.unwrap();
+        let provider = Arc::new(RecordingProvider::default());
+        let worker = SandboxAgentRunWorker::new(
+            store.clone(),
+            Arc::new(FixedResolver(provider.clone())),
+            Arc::new(Notify::new()),
+            AgentConfig {
+                model: "sandbox-model".into(),
+                ..AgentConfig::default()
+            },
+            Some(dir.path().join("scratch")),
+            SandboxAgentRunWorkerConfig::default(),
+        );
+        (worker, store, provider, chat, dir)
+    }
+
+    #[tokio::test]
+    async fn completes_a_claimed_run_with_a_no_tools_private_request() {
+        let (worker, store, provider, chat, dir) = fixture().await;
+        let call = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
+        let parent = openwave_core::AgentRunId::foreground_for_chat(chat.id);
+        assert!(matches!(
+            store
+                .accept_agent_run(
+                    id,
+                    chat.id,
+                    Some(parent),
+                    Some(call),
+                    AgentRunExecution::Sandbox,
+                    Some("Investigate this in isolation."),
+                )
+                .await
+                .unwrap(),
+            AcceptAgentRunOutcome::Accepted(_)
+        ));
+
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::Completed(id)
+        );
+        let completed = store.get_agent_run(id).await.unwrap().unwrap();
+        assert_eq!(completed.status, AgentRunStatus::Completed);
+        assert_eq!(
+            store.list_agent_run_inbox(parent).await.unwrap()[0]
+                .result
+                .text,
+            "done"
+        );
+        let scratch = dir
+            .path()
+            .join("scratch")
+            .join("sandbox-runs")
+            .join(id.to_string());
+        assert!(scratch.is_dir());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                scratch.metadata().unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].tools.is_empty());
+        assert_eq!(
+            requests[0].messages,
+            vec![ChatMessage::text(
+                Role::User,
+                "Investigate this in isolation."
+            )]
+        );
+        assert_eq!(requests[0].system.as_deref(), Some(SANDBOX_SYSTEM_PROMPT));
+    }
+
+    #[tokio::test]
+    async fn acknowledges_cancellation_under_its_exact_live_lease() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = sandbox_chat();
+        store.create_chat(&chat).await.unwrap();
+        let call = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
+        assert!(matches!(
+            store
+                .accept_agent_run(
+                    id,
+                    chat.id,
+                    Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
+                    Some(call),
+                    AgentRunExecution::Sandbox,
+                    Some("Wait until cancelled."),
+                )
+                .await
+                .unwrap(),
+            AcceptAgentRunOutcome::Accepted(_)
+        ));
+        let started = Arc::new(Notify::new());
+        let worker = SandboxAgentRunWorker::new(
+            store.clone(),
+            Arc::new(FixedResolver(Arc::new(BlockingProvider {
+                started: started.clone(),
+            }))),
+            Arc::new(Notify::new()),
+            AgentConfig {
+                model: "sandbox-model".into(),
+                ..AgentConfig::default()
+            },
+            None,
+            SandboxAgentRunWorkerConfig {
+                heartbeat: Duration::from_millis(10),
+                ..SandboxAgentRunWorkerConfig::default()
+            },
+        );
+        let started_wait = started.notified();
+        let execution = tokio::spawn(async move { worker.run_once().await });
+        started_wait.await;
+        assert!(matches!(
+            store.request_agent_run_cancellation(id).await.unwrap(),
+            Some(openwave_core::RequestAgentRunCancellationOutcome::Requested(_))
+        ));
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), execution)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap(),
+            SandboxAgentRunWorkerOutcome::Cancelled(id)
+        );
+        assert_eq!(
+            store.get_agent_run(id).await.unwrap().unwrap().status,
+            AgentRunStatus::Cancelled
+        );
+    }
+
+    #[tokio::test]
+    async fn immediate_failures_release_capacity_then_deliver_a_terminal_parent_receipt() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = sandbox_chat();
+        store.create_chat(&chat).await.unwrap();
+        let store_for_child = store.clone();
+        let child = move |task: String| {
+            let store = store_for_child.clone();
+            async move {
+                let call = CallId::new();
+                let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
+                store
+                    .accept_agent_run(
+                        id,
+                        chat.id,
+                        Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
+                        Some(call),
+                        AgentRunExecution::Sandbox,
+                        Some(&task),
+                    )
+                    .await
+                    .unwrap();
+                id
+            }
+        };
+        let first = child("first".into()).await;
+        let worker = SandboxAgentRunWorker::new(
+            store.clone(),
+            Arc::new(FixedResolver(Arc::new(FailingProvider))),
+            Arc::new(Notify::new()),
+            AgentConfig {
+                model: "m".into(),
+                ..AgentConfig::default()
+            },
+            None,
+            SandboxAgentRunWorkerConfig {
+                failure_delay: Duration::from_secs(1),
+                max_concurrency: 1,
+                max_running_global: 1,
+                max_running_per_chat: 1,
+                ..SandboxAgentRunWorkerConfig::default()
+            },
+        );
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::RetryScheduled(first)
+        );
+        let first_state = store.get_agent_run(first).await.unwrap().unwrap();
+        assert_eq!(first_state.status, AgentRunStatus::RetryWait);
+        assert!(first_state.lease_token.is_none());
+        let second = child("second".into()).await;
+        // The retry-wait lease is gone, so another queued child can claim the
+        // only scheduler slot immediately.
+        let claimed = store
+            .claim_agent_run(uuid::Uuid::new_v4(), chrono::Duration::minutes(1), 1, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(claimed.id, second);
+        store.request_agent_run_cancellation(second).await.unwrap();
+        store
+            .finish_agent_run_cancellation(second, claimed.lease_token.unwrap())
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::RetryScheduled(first)
+        );
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::Failed(first)
+        );
+        let terminal = store.get_agent_run(first).await.unwrap().unwrap();
+        assert_eq!(terminal.status, AgentRunStatus::Failed);
+        let inbox = store
+            .list_agent_run_inbox(openwave_core::AgentRunId::foreground_for_chat(chat.id))
+            .await
+            .unwrap();
+        assert!(inbox.iter().any(|entry| entry.child_run_id == first
+            && entry.result.text.contains("sandbox_execution_failed")));
+    }
+
+    #[tokio::test]
+    async fn cancellation_while_resolving_prevents_the_provider_request() {
+        let (_unused, store, provider, chat, _dir) = fixture().await;
+        let call = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
+        store
+            .accept_agent_run(
+                id,
+                chat.id,
+                Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
+                Some(call),
+                AgentRunExecution::Sandbox,
+                Some("do not call provider"),
+            )
+            .await
+            .unwrap();
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let worker = SandboxAgentRunWorker::new(
+            store.clone(),
+            Arc::new(DelayedResolver {
+                entered: entered.clone(),
+                release: release.clone(),
+                provider: provider.clone(),
+            }),
+            Arc::new(Notify::new()),
+            AgentConfig {
+                model: "m".into(),
+                ..AgentConfig::default()
+            },
+            None,
+            SandboxAgentRunWorkerConfig {
+                heartbeat: Duration::from_millis(10),
+                ..SandboxAgentRunWorkerConfig::default()
+            },
+        );
+        let entered_wait = entered.notified();
+        let execution = tokio::spawn(async move { worker.run_once().await });
+        entered_wait.await;
+        store.request_agent_run_cancellation(id).await.unwrap();
+        release.notify_one();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), execution)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap(),
+            SandboxAgentRunWorkerOutcome::Cancelled(id)
+        );
+        assert!(provider.requests.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolver_delay_past_the_database_lease_prevents_provider_egress() {
+        let (_unused, store, provider, chat, _dir) = fixture().await;
+        let call = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
+        store
+            .accept_agent_run(
+                id,
+                chat.id,
+                Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
+                Some(call),
+                AgentRunExecution::Sandbox,
+                Some("do not call provider after expiry"),
+            )
+            .await
+            .unwrap();
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let worker = SandboxAgentRunWorker::new(
+            store,
+            Arc::new(DelayedResolver {
+                entered: entered.clone(),
+                release: release.clone(),
+                provider: provider.clone(),
+            }),
+            Arc::new(Notify::new()),
+            AgentConfig {
+                model: "m".into(),
+                ..AgentConfig::default()
+            },
+            None,
+            SandboxAgentRunWorkerConfig {
+                lease: Duration::from_secs(1),
+                heartbeat: Duration::from_millis(5),
+                suppress_resolver_heartbeats: true,
+                ..SandboxAgentRunWorkerConfig::default()
+            },
+        );
+        let entered_wait = entered.notified();
+        let execution = tokio::spawn(async move { worker.run_once().await });
+        entered_wait.await;
+        // With periodic resolver heartbeats deliberately held for this test,
+        // this expiry is fenced by the final DB-clock heartbeat immediately
+        // before `provider.stream`.
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        release.notify_one();
+        let outcome = tokio::time::timeout(Duration::from_secs(1), execution)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert!(
+            matches!(outcome, SandboxAgentRunWorkerOutcome::LeaseLost(_)),
+            "{outcome:?}"
+        );
+        assert!(provider.requests.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sandbox_request_does_not_inherit_foreground_system_or_tools() {
+        let request = sandbox_request(
+            &AgentConfig {
+                model: "m".into(),
+                system_prompt: Some("foreground only".into()),
+                ..AgentConfig::default()
+            },
+            "task".into(),
+        );
+        assert_eq!(request.system.as_deref(), Some(SANDBOX_SYSTEM_PROMPT));
+        assert!(request.tools.is_empty());
+    }
+
+    fn sandbox_chat() -> Chat {
+        Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: Some("sandbox".into()),
+            model: Some("model".into()),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: chrono::Utc::now(),
+        }
+    }
+}

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -45,6 +45,12 @@ pub struct AppState {
     pub(crate) document_job_wake: Arc<Notify>,
     /// Wakes the durable turn worker after acceptance or cancellation commits.
     pub(crate) turn_job_wake: Arc<Notify>,
+    /// Wakes the bounded sandbox-run worker after delegated work commits.
+    ///
+    /// The foreground spawn contract is still intentionally disabled in the
+    /// production registry; this signal makes its later enablement immediate
+    /// rather than relying on the worker's idle poll.
+    pub(crate) agent_run_wake: Arc<Notify>,
     /// Wakes the source-blob retirement worker after a reference drop commits.
     pub(crate) blob_retirement_wake: Arc<Notify>,
     /// Serializes the final publish transition with source replacement/deletion.
@@ -124,6 +130,7 @@ impl AppState {
             retrieval,
             document_job_wake: Arc::new(Notify::new()),
             turn_job_wake: Arc::new(Notify::new()),
+            agent_run_wake: Arc::new(Notify::new()),
             blob_retirement_wake: Arc::new(Notify::new()),
             document_writes: Arc::new(DocumentWriteGuard::default()),
             blob_writes,

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -62,24 +62,25 @@ spawn:
 2. The tool-call identity is stored as the child's unique spawn identity, so an
    ambiguous retry recovers the original run instead of creating a duplicate.
 3. A bounded scheduler claims the child with an exact renewable lease.
-4. The scheduler creates or restores its sandbox and advances the shared agent
-   loop.
-5. The child submits an immutable terminal result or the scheduler records a
-   durable terminal failure.
+4. The scheduler gives the child private scratch and advances its isolated
+   no-tools task loop.
+5. The child submits an immutable terminal result. Provider failures leave the
+   exact lease for the bounded scheduler retry/reap path; they do not create an
+   unfenced executor-side failure transition.
 6. The result, terminal child state, and immutable parent inbox entry commit
    together. A later wait transition may consume that entry and wake a parent.
 
 The bounded `spawn_sandbox_agent` contract and its foreground checkpoint wiring
-are prepared, but deliberately disabled in the production tool registry: no
-sandbox executor exists yet to claim and complete the accepted child. When that
-executor lands, this will be a wait-form tool: it accepts one bounded `task`,
-derives the child identity from that exact tool call, and commits the queued
-child, durable wait, and release of the exact foreground worker lease in one
-transaction. It will be advertised only to a claimed foreground turn; sandbox
-workers will never receive it, and the store independently enforces depth one.
-A later non-blocking spawn tool can let the foreground continue after spawning,
-but must earn the same checkpoint and replay rules. The prepared boundary never
-leaves a child behind when a stale lease or steer fences its checkpoint.
+are prepared, but deliberately disabled in the production tool registry. The
+server now runs the executor that can claim and complete a child, but the tool
+will not be advertised until the final wiring wakes that worker after an atomic
+foreground spawn checkpoint. It will be a wait-form tool: it accepts one
+bounded `task`, derives the child identity from that exact tool call, and
+commits the queued child, durable wait, and release of the exact foreground
+worker lease in one transaction. It is advertised only to a claimed foreground
+turn; sandbox workers never receive it, and the store independently enforces
+depth one. A later non-blocking spawn tool can let the foreground continue after
+spawning, but must earn the same checkpoint and replay rules.
 
 The wait also carries an immutable atomic-admission marker. Only that receipt
 allows a later retry to recover the combined transition; an older path that
@@ -223,12 +224,13 @@ The implementation is intentionally incremental:
 6. Persist shared model/tool step boundaries and side-effect receipts.
 7. Atomically join durable inbox consumption with a parent turn checkpoint and
    durable `resuming` wake signal. *(Shipped.)*
-8. Atomically accept a sandbox spawn and its parent checkpoint from the
-   foreground tool boundary. The bounded foreground-only
-   `spawn_sandbox_agent` contract is wired to this transition, but remains
-   disabled until the sandbox executor lands. *(Groundwork shipped.)*
-9. Route sandbox folder access through the host broker.
-10. Add desktop surfaces for queued, running, waiting, failed, and completed
+8. Run isolated one-shot sandbox tasks with no tools or shared conversation
+   context, over the durable lease/result boundary. *(Shipped.)*
+9. Enable the bounded foreground-only `spawn_sandbox_agent` contract, wake the
+   sandbox worker after its atomic checkpoint, and resume the parked turn from
+   the already-delivered inbox receipt.
+10. Route sandbox folder access through the host broker.
+11. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.
-11. Add richer context lifecycle, parallel-safe tool groups, and further
+12. Add richer context lifecycle, parallel-safe tool groups, and further
    orchestration only after these recovery boundaries are proven.


### PR DESCRIPTION
## Summary

- add a bounded, supervised sandbox agent-run worker with private per-run scratch
- execute one isolated, tool-free provider completion per claimed child
- fence egress, retry immediate failures durably, and deliver terminal outcomes to the parent inbox

## Validation

- cargo test -p openwave-core -p openwave-server --locked
- cargo test -p openwave-core --no-default-features --features postgres --test postgres_turn_state --no-run --locked
- bw dev lint --rust --check