### PR TITLE
Enable sandbox agent delegation

### DIFF
--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -600,7 +600,12 @@ async fn create_agent_run_inbox_table(manager: &SchemaManager<'_>) -> Result<(),
                     Expr::col(AgentRunInbox::ResultClaimCount)
                         .gte(Expr::col(AgentRunInbox::ResultAttemptCount)),
                 )
-                .check(Expr::col(AgentRunInbox::Status).is_in(["pending", "claimed", "consumed"]))
+                .check(Expr::col(AgentRunInbox::Status).is_in([
+                    "pending",
+                    "claimed",
+                    "consumed",
+                    "cancelled",
+                ]))
                 .check(Expr::col(AgentRunInbox::ClaimCount).gte(0))
                 .check(
                     Expr::col(AgentRunInbox::Status)
@@ -623,7 +628,13 @@ async fn create_agent_run_inbox_table(manager: &SchemaManager<'_>) -> Result<(),
                             .and(Expr::col(AgentRunInbox::LeaseToken).is_null())
                             .and(Expr::col(AgentRunInbox::LeaseExpiresAt).is_null())
                             .and(Expr::col(AgentRunInbox::ConsumedLeaseToken).is_not_null())
-                            .and(Expr::col(AgentRunInbox::ConsumedAt).is_not_null())),
+                            .and(Expr::col(AgentRunInbox::ConsumedAt).is_not_null()))
+                        .or(Expr::col(AgentRunInbox::Status)
+                            .eq("cancelled")
+                            .and(Expr::col(AgentRunInbox::LeaseToken).is_null())
+                            .and(Expr::col(AgentRunInbox::LeaseExpiresAt).is_null())
+                            .and(Expr::col(AgentRunInbox::ConsumedLeaseToken).is_null())
+                            .and(Expr::col(AgentRunInbox::ConsumedAt).is_null())),
                 )
                 .to_owned(),
         )

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1849,6 +1849,10 @@ impl Store for DbStore {
         ops::agent_run::list_agent_run_inbox(self, parent_run_id).await
     }
 
+    async fn list_agent_run_inbox_candidates(&self, limit: u64) -> Result<Vec<AgentRunInboxEntry>> {
+        ops::agent_run::list_agent_run_inbox_candidates(self, limit).await
+    }
+
     async fn claim_agent_run_inbox_entry(
         &self,
         parent_run_id: AgentRunId,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -5,10 +5,10 @@ use sea_orm::{
 };
 
 use crate::error::{AgentError, Result};
-use crate::id::{AgentRunId, CallId, ChatId, TurnId};
+use crate::id::{AgentRunId, CallId, ChatId, MessageId, TurnId};
 use crate::model::{
     AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunInboxStatus, AgentRunResult,
-    AgentRunStatus,
+    AgentRunStatus, TurnRun,
 };
 use crate::storage::{
     AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, ClaimAgentRunInboxOutcome,
@@ -20,6 +20,9 @@ use crate::storage::{
 use super::super::{entities, store_err, DbStore};
 use super::{
     acquire_chat_write_lock, acquire_turn_write_lock,
+    conversation::{
+        next_message_seq_on, reserve_message_identity_on, MESSAGE_IDENTITY_OWNER_MESSAGE,
+    },
     turn::{
         canonical_db_timestamp, park_turn_for_agent_run_inbox_on,
         validate_agent_run_inbox_park_request,
@@ -821,6 +824,146 @@ pub(in crate::db) async fn request_agent_run_cancellation(
     }))
 }
 
+/// Fence-cascade a cancelled foreground checkpoint to its owned sandbox child.
+///
+/// This runs under the parent turn's chat/turn transaction.  It deliberately
+/// uses the child row's exact lifecycle fields as a CAS rather than taking the
+/// global sandbox scheduler lock: a concurrent claim either loses its queued
+/// predicate or becomes `cancelling`, and can never produce a second result.
+pub(in crate::db) async fn cancel_sandbox_child_for_parked_turn_on<C>(
+    conn: &C,
+    parent_run_id: AgentRunId,
+    child_run_id: AgentRunId,
+    chat_id: ChatId,
+    now: chrono::DateTime<Utc>,
+) -> Result<bool>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let Some(child) = find_by_id_on(conn, child_run_id).await? else {
+        return Err(AgentError::Store(format!(
+            "waiting turn references missing sandbox child {child_run_id}"
+        )));
+    };
+    if child.chat_id != chat_id.0
+        || child.parent_id != Some(parent_run_id.0)
+        || child.execution != AgentRunExecution::Sandbox.as_str()
+        || child.depth != 1
+    {
+        return Err(AgentError::Store(format!(
+            "waiting turn child {child_run_id} is not owned by its foreground parent"
+        )));
+    }
+    let status = agent_run_status_from_db(&child.status)?;
+    match status {
+        AgentRunStatus::Cancelled | AgentRunStatus::Cancelling => return Ok(true),
+        AgentRunStatus::Completed | AgentRunStatus::Failed => {
+            let retired = entities::agent_run_inbox::Entity::update_many()
+                .col_expr(
+                    entities::agent_run_inbox::Column::Status,
+                    sea_orm::sea_query::Expr::value(AgentRunInboxStatus::Cancelled.as_str()),
+                )
+                .col_expr(
+                    entities::agent_run_inbox::Column::LeaseToken,
+                    sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+                )
+                .col_expr(
+                    entities::agent_run_inbox::Column::LeaseExpiresAt,
+                    sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+                )
+                .filter(entities::agent_run_inbox::Column::ChildRunId.eq(child_run_id.0))
+                .filter(entities::agent_run_inbox::Column::ParentRunId.eq(parent_run_id.0))
+                .filter(
+                    Condition::any()
+                        .add(
+                            entities::agent_run_inbox::Column::Status
+                                .eq(AgentRunInboxStatus::Pending.as_str()),
+                        )
+                        .add(
+                            entities::agent_run_inbox::Column::Status
+                                .eq(AgentRunInboxStatus::Claimed.as_str()),
+                        ),
+                )
+                .exec(conn)
+                .await
+                .map_err(store_err)?;
+            if retired.rows_affected == 1 {
+                return Ok(true);
+            }
+            let inbox = find_agent_run_inbox_on(conn, parent_run_id, child_run_id).await?;
+            return match inbox
+                .as_ref()
+                .and_then(|entry| AgentRunInboxStatus::parse(&entry.status))
+            {
+                Some(AgentRunInboxStatus::Cancelled) => Ok(true),
+                Some(AgentRunInboxStatus::Consumed) => Err(AgentError::Store(format!(
+                    "waiting turn has already-consumed child delivery {child_run_id}"
+                ))),
+                Some(_) => Ok(false),
+                None => Err(AgentError::Store(format!(
+                    "terminal sandbox child {child_run_id} is missing its inbox delivery"
+                ))),
+            };
+        }
+        AgentRunStatus::Active => {
+            return Err(AgentError::Store(format!(
+                "waiting turn child {child_run_id} unexpectedly has foreground status"
+            )));
+        }
+        AgentRunStatus::Queued
+        | AgentRunStatus::Waiting
+        | AgentRunStatus::RetryWait
+        | AgentRunStatus::Running => {}
+    }
+    if child.updated_at > now {
+        return Ok(false);
+    }
+    let immediate = status != AgentRunStatus::Running
+        || !child.lease_expires_at.is_some_and(|expiry| expiry > now)
+        || !child.deadline_at.is_some_and(|deadline| deadline > now);
+    let next = if immediate {
+        AgentRunStatus::Cancelled
+    } else {
+        AgentRunStatus::Cancelling
+    };
+    let mut update = entities::agent_run::Entity::update_many()
+        .col_expr(
+            entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(next.as_str()),
+        )
+        .col_expr(
+            entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::agent_run::Column::Id.eq(child_run_id.0))
+        .filter(entities::agent_run::Column::Status.eq(status.as_str()))
+        .filter(entities::agent_run::Column::AttemptCount.eq(child.attempt_count))
+        .filter(entities::agent_run::Column::ClaimCount.eq(child.claim_count))
+        .filter(entities::agent_run::Column::UpdatedAt.eq(child.updated_at))
+        .filter(entities::agent_run::Column::UpdatedAt.lte(now));
+    if immediate {
+        update = update
+            .col_expr(
+                entities::agent_run::Column::LeaseToken,
+                sea_orm::sea_query::Expr::value(Option::<uuid::Uuid>::None),
+            )
+            .col_expr(
+                entities::agent_run::Column::LeaseExpiresAt,
+                sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
+            )
+            .col_expr(
+                entities::agent_run::Column::FinishedAt,
+                sea_orm::sea_query::Expr::value(Some(now)),
+            );
+    } else {
+        update = update
+            .filter(entities::agent_run::Column::LeaseToken.eq(child.lease_token))
+            .filter(entities::agent_run::Column::LeaseExpiresAt.eq(child.lease_expires_at))
+            .filter(entities::agent_run::Column::LeaseExpiresAt.gt(now));
+    }
+    Ok(update.exec(conn).await.map_err(store_err)?.rows_affected == 1)
+}
+
 pub(in crate::db) async fn finish_agent_run_cancellation(
     store: &DbStore,
     id: AgentRunId,
@@ -1297,6 +1440,145 @@ pub(in crate::db) async fn list_agent_run_inbox_candidates(
         return Ok(Vec::new());
     }
     let now = database_now(&store.conn).await?;
+    // Do not let an old result for a completed or cancelled parent consume the
+    // bounded recovery scan.  The worker still rechecks this relationship when
+    // claiming, but filtering it here gives a live parked turn a fair chance to
+    // run even if historical inbox receipts remain in the database.
+    let waiting_checkpoint = sea_orm::sea_query::Query::select()
+        .expr(sea_orm::sea_query::Expr::value(1))
+        .from(entities::turn_agent_run_wait::Entity)
+        .inner_join(
+            entities::turn_run::Entity,
+            sea_orm::sea_query::Expr::col((
+                entities::turn_agent_run_wait::Entity,
+                entities::turn_agent_run_wait::Column::TurnId,
+            ))
+            .equals((entities::turn_run::Entity, entities::turn_run::Column::Id)),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_agent_run_wait::Entity,
+                entities::turn_agent_run_wait::Column::Status,
+            ))
+            .eq(crate::model::TurnAgentRunWaitStatus::Waiting.as_str()),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_agent_run_wait::Entity,
+                entities::turn_agent_run_wait::Column::ClosedAt,
+            ))
+            .is_null(),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_run::Entity,
+                entities::turn_run::Column::Status,
+            ))
+            .eq(crate::model::TurnRunStatus::WaitingForAgentRun.as_str()),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_agent_run_wait::Entity,
+                entities::turn_agent_run_wait::Column::ChildRunId,
+            ))
+            .equals((
+                entities::agent_run_inbox::Entity,
+                entities::agent_run_inbox::Column::ChildRunId,
+            )),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_agent_run_wait::Entity,
+                entities::turn_agent_run_wait::Column::ParentRunId,
+            ))
+            .equals((
+                entities::agent_run_inbox::Entity,
+                entities::agent_run_inbox::Column::ParentRunId,
+            )),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_agent_run_wait::Entity,
+                entities::turn_agent_run_wait::Column::ChatId,
+            ))
+            .equals((
+                entities::agent_run_inbox::Entity,
+                entities::agent_run_inbox::Column::ChatId,
+            )),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_run::Entity,
+                entities::turn_run::Column::ChatId,
+            ))
+            .equals((
+                entities::turn_agent_run_wait::Entity,
+                entities::turn_agent_run_wait::Column::ChatId,
+            )),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_run::Entity,
+                entities::turn_run::Column::AgentRunId,
+            ))
+            .equals((
+                entities::turn_agent_run_wait::Entity,
+                entities::turn_agent_run_wait::Column::ParentRunId,
+            )),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_run::Entity,
+                entities::turn_run::Column::AttemptCount,
+            ))
+            .equals((
+                entities::turn_agent_run_wait::Entity,
+                entities::turn_agent_run_wait::Column::AttemptCount,
+            )),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_run::Entity,
+                entities::turn_run::Column::ClaimCount,
+            ))
+            .equals((
+                entities::turn_agent_run_wait::Entity,
+                entities::turn_agent_run_wait::Column::ClaimCount,
+            )),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_run::Entity,
+                entities::turn_run::Column::LeaseToken,
+            ))
+            .is_null(),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::turn_run::Entity,
+                entities::turn_run::Column::LeaseExpiresAt,
+            ))
+            .is_null(),
+        )
+        .to_owned();
+    let active_parents = sea_orm::sea_query::Query::select()
+        .column((entities::agent_run::Entity, entities::agent_run::Column::Id))
+        .from(entities::agent_run::Entity)
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::agent_run::Entity,
+                entities::agent_run::Column::Status,
+            ))
+            .eq(AgentRunStatus::Active.as_str()),
+        )
+        .and_where(
+            sea_orm::sea_query::Expr::col((
+                entities::agent_run::Entity,
+                entities::agent_run::Column::Execution,
+            ))
+            .eq(AgentRunExecution::Foreground.as_str()),
+        )
+        .to_owned();
     let entries = entities::agent_run_inbox::Entity::find()
         .filter(
             Condition::any()
@@ -1313,6 +1595,8 @@ pub(in crate::db) async fn list_agent_run_inbox_candidates(
                         .add(entities::agent_run_inbox::Column::LeaseExpiresAt.lte(now)),
                 ),
         )
+        .filter(sea_orm::sea_query::Expr::exists(waiting_checkpoint))
+        .filter(entities::agent_run_inbox::Column::ParentRunId.in_subquery(active_parents))
         .order_by_asc(entities::agent_run_inbox::Column::DeliveredAt)
         .order_by_asc(entities::agent_run_inbox::Column::ChildRunId)
         .limit(limit)
@@ -1472,7 +1756,9 @@ pub(in crate::db) async fn claim_agent_run_inbox_entry(
             transaction.commit().await.map_err(store_err)?;
             Ok(Some(ClaimAgentRunInboxOutcome::Claimed(claimed)))
         }
-        AgentRunInboxStatus::Claimed | AgentRunInboxStatus::Consumed => {
+        AgentRunInboxStatus::Claimed
+        | AgentRunInboxStatus::Consumed
+        | AgentRunInboxStatus::Cancelled => {
             transaction.commit().await.map_err(store_err)?;
             Ok(None)
         }
@@ -1546,6 +1832,9 @@ pub(in crate::db) async fn consume_agent_run_inbox_entry_and_resume_turn(
         } else {
             None
         };
+        if let Some(turn) = turn.as_ref() {
+            ensure_sandbox_result_message_on(&transaction, &entry, turn, now, false).await?;
+        }
         transaction.commit().await.map_err(store_err)?;
         return Ok(
             turn.map(|turn| ConsumeAgentRunInboxAndResumeTurnOutcome::Existing {
@@ -1574,6 +1863,7 @@ pub(in crate::db) async fn consume_agent_run_inbox_entry_and_resume_turn(
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     };
+    ensure_sandbox_result_message_on(&transaction, &entry, &turn, now, true).await?;
     let updated = entities::agent_run_inbox::Entity::update_many()
         .col_expr(
             entities::agent_run_inbox::Column::Status,
@@ -2059,6 +2349,12 @@ fn agent_run_inbox_from_models(
                     .is_some_and(|token| !token.is_nil())
                 && model.consumed_at.is_some()
         }
+        AgentRunInboxStatus::Cancelled => {
+            model.lease_token.is_none()
+                && model.lease_expires_at.is_none()
+                && model.consumed_lease_token.is_none()
+                && model.consumed_at.is_none()
+        }
     };
     if model.parent_depth != 0
         || model.result_lease_token.is_nil()
@@ -2154,6 +2450,105 @@ where
             && parent.execution == AgentRunExecution::Foreground.as_str()
             && parent.status == AgentRunStatus::Active.as_str()
     }))
+}
+
+/// Persist the exact terminal child result into the foreground transcript at
+/// the same durable boundary that consumes its inbox receipt.  A deterministic
+/// message id makes an ambiguous commit retry safe without relying on worker
+/// memory: the next foreground provider request rebuilds this message from the
+/// ordinary transcript after any restart.
+async fn ensure_sandbox_result_message_on<C>(
+    conn: &C,
+    entry: &AgentRunInboxEntry,
+    turn: &TurnRun,
+    now: chrono::DateTime<Utc>,
+    insert_if_missing: bool,
+) -> Result<()>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let child = find_by_id_on(conn, entry.child_run_id)
+        .await?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "agent-run inbox child {} disappeared before transcript delivery",
+                entry.child_run_id
+            ))
+        })?;
+    if child.chat_id != entry.chat_id.0
+        || child.parent_id != Some(entry.parent_run_id.0)
+        || child.execution != AgentRunExecution::Sandbox.as_str()
+        || child.depth != 1
+    {
+        return Err(AgentError::Store(format!(
+            "agent-run inbox child {} does not match its durable parent delivery",
+            entry.child_run_id
+        )));
+    }
+    let disposition = match agent_run_status_from_db(&child.status)? {
+        AgentRunStatus::Completed => "completed",
+        AgentRunStatus::Failed => "failed",
+        status => {
+            return Err(AgentError::Store(format!(
+                "agent-run inbox child {} is not terminal ({})",
+                entry.child_run_id,
+                status.as_str()
+            )));
+        }
+    };
+    let message_id = MessageId::sandbox_result_for_child(entry.child_run_id);
+    let content = format!(
+        "Sandbox agent {disposition}. Its exact final result follows:\n{}",
+        entry.result.text
+    );
+    let existing = entities::message::Entity::find_by_id(message_id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?;
+    if let Some(existing) = existing {
+        if existing.chat_id == entry.chat_id.0
+            && existing.turn_id == turn.id.0
+            && existing.role == "system"
+            && existing.content == content
+        {
+            return Ok(());
+        }
+        return Err(AgentError::Store(format!(
+            "sandbox result message identity {message_id} is already bound to different content"
+        )));
+    }
+    if !insert_if_missing {
+        return Err(AgentError::Store(format!(
+            "consumed agent-run inbox entry for child {} is missing its transcript result",
+            entry.child_run_id
+        )));
+    }
+    if !reserve_message_identity_on(
+        conn,
+        message_id,
+        entry.chat_id,
+        turn.id,
+        MESSAGE_IDENTITY_OWNER_MESSAGE,
+    )
+    .await?
+    {
+        return Err(AgentError::Store(format!(
+            "sandbox result message identity {message_id} was reserved without a message"
+        )));
+    }
+    entities::message::ActiveModel {
+        id: Set(message_id.0),
+        chat_id: Set(entry.chat_id.0),
+        turn_id: Set(turn.id.0),
+        seq: Set(next_message_seq_on(conn, entry.chat_id).await?),
+        role: Set("system".to_owned()),
+        content: Set(content),
+        created_at: Set(now),
+    }
+    .insert(conn)
+    .await
+    .map_err(store_err)?;
+    Ok(())
 }
 
 /// Confirm the parent has durably yielded the foreground turn that this exact

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseBackend, EntityTrait, QueryFilter, QueryOrder,
-    QuerySelect, Set, Statement, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, Condition, DatabaseBackend, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
 };
 
 use crate::error::{AgentError, Result};
@@ -1274,6 +1274,48 @@ pub(in crate::db) async fn list_agent_run_inbox(
         .filter(entities::agent_run_inbox::Column::ParentRunId.eq(parent_run_id.0))
         .order_by_asc(entities::agent_run_inbox::Column::DeliveredAt)
         .order_by_asc(entities::agent_run_inbox::Column::ChildRunId)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    let mut inbox = Vec::with_capacity(entries.len());
+    for entry in entries {
+        inbox.push(load_agent_run_inbox_entry_on(&store.conn, entry).await?);
+    }
+    Ok(inbox)
+}
+
+/// Find deliveries that need a foreground continuation attempt.
+///
+/// Selection is deliberately only a bounded recovery hint. The exact claim
+/// below serializes ownership against every other worker and rechecks the
+/// parent checkpoint with the database clock.
+pub(in crate::db) async fn list_agent_run_inbox_candidates(
+    store: &DbStore,
+    limit: u64,
+) -> Result<Vec<AgentRunInboxEntry>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let now = database_now(&store.conn).await?;
+    let entries = entities::agent_run_inbox::Entity::find()
+        .filter(
+            Condition::any()
+                .add(
+                    entities::agent_run_inbox::Column::Status
+                        .eq(AgentRunInboxStatus::Pending.as_str()),
+                )
+                .add(
+                    Condition::all()
+                        .add(
+                            entities::agent_run_inbox::Column::Status
+                                .eq(AgentRunInboxStatus::Claimed.as_str()),
+                        )
+                        .add(entities::agent_run_inbox::Column::LeaseExpiresAt.lte(now)),
+                ),
+        )
+        .order_by_asc(entities::agent_run_inbox::Column::DeliveredAt)
+        .order_by_asc(entities::agent_run_inbox::Column::ChildRunId)
+        .limit(limit)
         .all(&store.conn)
         .await
         .map_err(store_err)?;

--- a/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
@@ -156,6 +156,18 @@ async fn request_turn_cancellation_inner(
                 "waiting turn {id} has a mismatched child receipt"
             )));
         }
+        if !super::super::super::agent_run::cancel_sandbox_child_for_parked_turn_on(
+            &transaction,
+            crate::AgentRunId(wait.parent_run_id),
+            crate::AgentRunId(wait.child_run_id),
+            ChatId(turn.chat_id),
+            now,
+        )
+        .await?
+        {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(None);
+        }
         let closed = entities::turn_agent_run_wait::Entity::update_many()
             .col_expr(
                 entities::turn_agent_run_wait::Column::Status,

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -3,8 +3,8 @@ use crate::{
     AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, AcceptTurnOutcome, AgentRun,
     AgentRunExecution, AgentRunId, AgentRunInboxStatus, AgentRunStatus, CallId, ChatId,
     ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
-    ConsumeAgentRunInboxOutcome, DbStore, FinishAgentRunCancellationOutcome,
-    ParkTurnForAgentRunInboxOutcome, RequestAgentRunCancellationOutcome, Store,
+    ConsumeAgentRunInboxOutcome, DbStore, FinishAgentRunCancellationOutcome, MessageId,
+    ParkTurnForAgentRunInboxOutcome, RequestAgentRunCancellationOutcome, Role, Store,
     SubmitAgentRunResultOutcome, TurnCheckpointProgress, TurnId, TurnRunStatus, Usage,
 };
 use chrono::{Duration, Utc};
@@ -1142,6 +1142,14 @@ async fn child_inbox_consumption_atomically_wakes_a_parked_foreground_turn() {
     assert_eq!(resumed.1.claim_count, running.claim_count);
     assert_eq!(resumed.1.model_steps, progress.model_steps);
     assert_eq!(resumed.1.usage, progress.usage);
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert!(messages.iter().any(|message| {
+        message.id == MessageId::sandbox_result_for_child(child_id)
+            && message.turn_id == running.id
+            && message.role == Role::System
+            && message.content
+                == "Sandbox agent completed. Its exact final result follows:\nresearch complete"
+    }));
     assert!(matches!(
         store
             .consume_agent_run_inbox_entry_and_resume_turn(parent_id, child_id, continuation_lease)
@@ -1169,6 +1177,223 @@ async fn child_inbox_consumption_atomically_wakes_a_parked_foreground_turn() {
     assert_eq!(resumed_claim.claim_count, running.claim_count + 1);
     assert_eq!(resumed_claim.model_steps, progress.model_steps);
     assert_eq!(resumed_claim.usage, progress.usage);
+}
+
+#[tokio::test]
+async fn parked_parent_cancellation_retires_a_delivered_child_without_an_orphan_wake() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+
+    let child_id = AgentRunId::new();
+    let parent_id = AgentRunId::foreground_for_chat(chat.id);
+    store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(parent_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("finish before the parent is cancelled"),
+        )
+        .await
+        .unwrap();
+    let parked = park_foreground_turn_on_child(&store, chat.id, child_id).await;
+    let child_lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(child_lease, Duration::minutes(1), 4, 2)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        child_id
+    );
+    store
+        .submit_agent_run_result(child_id, child_lease, "terminal child result")
+        .await
+        .unwrap()
+        .expect("child result should be delivered before cancellation");
+
+    assert!(matches!(
+        store.request_turn_cancellation(parked.id, Utc::now()).await.unwrap(),
+        Some(crate::RequestTurnCancellationOutcome::Cancelled(turn))
+            if turn.status == TurnRunStatus::Cancelled
+    ));
+    let inbox = store.list_agent_run_inbox(parent_id).await.unwrap();
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].status, AgentRunInboxStatus::Cancelled);
+    assert!(store
+        .list_agent_run_inbox_candidates(16)
+        .await
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        store
+            .list_agent_runs(chat.id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|run| run.id == child_id)
+            .unwrap()
+            .status,
+        AgentRunStatus::Completed,
+        "an already-terminal child remains auditable, but its delivery is fenced"
+    );
+}
+
+#[tokio::test]
+async fn parked_parent_cancellation_cascades_to_an_unclaimed_sandbox_child() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+
+    let child_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("this work should be fenced before it starts"),
+        )
+        .await
+        .unwrap();
+    let parked = park_foreground_turn_on_child(&store, chat.id, child_id).await;
+    assert!(matches!(
+        store
+            .request_turn_cancellation(parked.id, Utc::now())
+            .await
+            .unwrap(),
+        Some(crate::RequestTurnCancellationOutcome::Cancelled(_))
+    ));
+    let child = store
+        .list_agent_runs(chat.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|run| run.id == child_id)
+        .unwrap();
+    assert_eq!(child.status, AgentRunStatus::Cancelled);
+    assert!(store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 4, 2)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .list_agent_run_inbox(AgentRunId::foreground_for_chat(chat.id))
+        .await
+        .unwrap()
+        .is_empty());
+}
+
+#[tokio::test]
+async fn failed_child_result_is_persisted_in_the_resumed_parent_transcript() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let child_id = AgentRunId::new();
+    let parent_id = AgentRunId::foreground_for_chat(chat.id);
+    store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(parent_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("this task will fail"),
+        )
+        .await
+        .unwrap();
+    crate::db::entities::agent_run::Entity::update_many()
+        .col_expr(
+            crate::db::entities::agent_run::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(1),
+        )
+        .filter(crate::db::entities::agent_run::Column::Id.eq(child_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    let parked = park_foreground_turn_on_child(&store, chat.id, child_id).await;
+    let child_lease = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(child_lease, Duration::minutes(1), 4, 2)
+        .await
+        .unwrap()
+        .expect("child should claim");
+    assert!(matches!(
+        store
+            .fail_agent_run(
+                child_id,
+                child_lease,
+                "sandbox_execution_failed",
+                "provider failed",
+                Duration::seconds(1),
+            )
+            .await
+            .unwrap(),
+        Some(crate::FailAgentRunOutcome::Failed(_))
+    ));
+    let continuation_lease = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run_inbox_entry(
+            parent_id,
+            child_id,
+            continuation_lease,
+            Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .expect("failed result should claim for the parked parent");
+    store
+        .consume_agent_run_inbox_entry_and_resume_turn(parent_id, child_id, continuation_lease)
+        .await
+        .unwrap()
+        .expect("failed result should resume the parked parent");
+    assert!(store.list_messages(chat.id).await.unwrap().iter().any(|message| {
+        message.id == MessageId::sandbox_result_for_child(child_id)
+            && message.turn_id == parked.id
+            && message.role == Role::System
+            && message.content
+                == "Sandbox agent failed. Its exact final result follows:\nSandbox task failed (sandbox_execution_failed): provider failed"
+    }));
+}
+
+#[tokio::test]
+async fn live_parent_inbox_candidates_skip_sixteen_obsolete_deliveries() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+
+    for index in 0..16 {
+        submit_sandbox_result(
+            &store,
+            chat.id,
+            &format!("obsolete task {index}"),
+            &format!("obsolete result {index}"),
+        )
+        .await;
+    }
+    let (live_child, _) = submit_sandbox_result(
+        &store,
+        chat.id,
+        "the live delegated task",
+        "the live result",
+    )
+    .await;
+    let parked = park_foreground_turn_on_child(&store, chat.id, live_child).await;
+    assert_eq!(parked.status, TurnRunStatus::WaitingForAgentRun);
+
+    let candidates = store.list_agent_run_inbox_candidates(16).await.unwrap();
+    assert_eq!(
+        candidates
+            .iter()
+            .map(|entry| entry.child_run_id)
+            .collect::<Vec<_>>(),
+        vec![live_child],
+        "obsolete entries must not starve the bounded recovery scan"
+    );
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -267,6 +267,22 @@ id_type!(
     /// Identifies a persisted message within a chat.
     MessageId
 );
+
+impl MessageId {
+    /// Namespace for the transcript message carrying one exact sandbox child
+    /// result into its foreground parent.
+    const SANDBOX_RESULT_NAMESPACE: Uuid =
+        Uuid::from_u128(0xa6e4_7b83_9c19_470f_9b2d_b8d4_0f4d_55ac);
+
+    /// Derive the one idempotent transcript identity for a sandbox child.
+    #[must_use]
+    pub fn sandbox_result_for_child(child_id: AgentRunId) -> Self {
+        Self(Uuid::new_v5(
+            &Self::SANDBOX_RESULT_NAMESPACE,
+            child_id.as_uuid().as_bytes(),
+        ))
+    }
+}
 id_type!(
     /// Identifies one turn: a single user input through to the final answer.
     TurnId

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1213,6 +1213,8 @@ pub enum AgentRunInboxStatus {
     Claimed,
     /// One exact continuation lease durably consumed this child result.
     Consumed,
+    /// The parent turn was cancelled before this delivery could resume it.
+    Cancelled,
 }
 
 impl AgentRunInboxStatus {
@@ -1223,6 +1225,7 @@ impl AgentRunInboxStatus {
             Self::Pending => "pending",
             Self::Claimed => "claimed",
             Self::Consumed => "consumed",
+            Self::Cancelled => "cancelled",
         }
     }
 
@@ -1231,6 +1234,7 @@ impl AgentRunInboxStatus {
             "pending" => Some(Self::Pending),
             "claimed" => Some(Self::Claimed),
             "consumed" => Some(Self::Consumed),
+            "cancelled" => Some(Self::Cancelled),
             _ => None,
         }
     }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1165,6 +1165,16 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// List a bounded set of parent deliveries that may need durable
+    /// continuation work. This is an advisory scan: an exact claim remains the
+    /// authority for both pending delivery and expired-lease recovery.
+    async fn list_agent_run_inbox_candidates(
+        &self,
+        _limit: u64,
+    ) -> Result<Vec<AgentRunInboxEntry>> {
+        agent_run_storage_unavailable()
+    }
+
     /// Acquire an expiring, exact lease to advance one immutable parent inbox
     /// delivery. Repeating the same live lease recovers its ownership; an
     /// expired lease may be reclaimed by a different continuation worker.

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -398,6 +398,7 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
         state.events.clone(),
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
+        state.agent_run_wake.clone(),
         state.agent_config.clone(),
         Some(state.config.data_dir.join("scratch")),
         turn_worker::TurnWorkerConfig::default(),
@@ -406,6 +407,7 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
         state.store.clone(),
         state.resolver.clone(),
         state.agent_run_wake.clone(),
+        state.turn_job_wake.clone(),
         state.agent_config.clone(),
         Some(state.config.data_dir.join("scratch")),
         sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default(),
@@ -464,6 +466,10 @@ fn agent_deps(
         request_folder_access_tool_spec(),
         validate_request_folder_access_arguments,
     );
+    // The foreground worker parks atomically with child acceptance, and the
+    // bounded sandbox worker is started from the same state below. Sandboxed
+    // requests deliberately never receive this foreground-only definition.
+    tools.register_foreground_sandbox_spawn();
     let tools = Arc::new(tools);
     let model = std::env::var("OPENWAVE_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string());
     let agent_config = AgentConfig {

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -683,6 +683,10 @@ pub async fn post_cancel(
     }
     state.active_turns.cancel(id, body.turn_id);
     state.turn_job_wake.notify_one();
+    // A parked-parent cancellation can fence a queued or running sandbox
+    // child. Wake its worker promptly; durable claims remain the source of
+    // truth if this notification is lost.
+    state.agent_run_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
 }
 

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -12,7 +12,8 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use openwave_core::{
-    AgentConfig, AgentError, AgentRun, AgentRunStatus, ChatMessage, ChatRequest,
+    AgentConfig, AgentError, AgentRun, AgentRunInboxEntry, AgentRunStatus, ChatMessage,
+    ChatRequest, ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
     FailAgentRunOutcome, ModelProvider, ProviderEvent, Result, Role, StopReason, Store,
     SubmitAgentRunResultOutcome,
 };
@@ -65,6 +66,7 @@ pub(crate) enum SandboxAgentRunWorkerOutcome {
     RetryScheduled(openwave_core::AgentRunId),
     Failed(openwave_core::AgentRunId),
     Cancelled(openwave_core::AgentRunId),
+    ParentResumed(openwave_core::AgentRunId),
     LeaseLost(openwave_core::AgentRunId),
 }
 
@@ -73,6 +75,7 @@ pub(crate) struct SandboxAgentRunWorker {
     store: Arc<dyn Store>,
     resolver: Arc<dyn ProviderResolver>,
     wake: Arc<Notify>,
+    turn_wake: Arc<Notify>,
     agent_config: AgentConfig,
     /// Each run receives a directory under this private root. The initial
     /// no-tools executor does not open it; retaining the boundary now means a
@@ -87,6 +90,7 @@ impl SandboxAgentRunWorker {
         store: Arc<dyn Store>,
         resolver: Arc<dyn ProviderResolver>,
         wake: Arc<Notify>,
+        turn_wake: Arc<Notify>,
         agent_config: AgentConfig,
         private_scratch_root: Option<PathBuf>,
         config: SandboxAgentRunWorkerConfig,
@@ -101,6 +105,7 @@ impl SandboxAgentRunWorker {
             store,
             resolver,
             wake,
+            turn_wake,
             agent_config,
             private_scratch_root,
             config,
@@ -148,6 +153,12 @@ impl SandboxAgentRunWorker {
     /// so focused integration tests can exercise the real durable transitions
     /// without starting permanent worker lanes.
     pub(crate) async fn run_once(&self) -> Result<SandboxAgentRunWorkerOutcome> {
+        for delivery in self.store.list_agent_run_inbox_candidates(16).await? {
+            match self.resume_parent(delivery).await? {
+                SandboxAgentRunWorkerOutcome::Idle => {}
+                outcome => return Ok(outcome),
+            }
+        }
         let lease_token = uuid::Uuid::new_v4();
         let lease = chrono_duration(self.config.lease)?;
         let Some(run) = self
@@ -164,6 +175,57 @@ impl SandboxAgentRunWorker {
         };
         self.wake.notify_one();
         self.process(run, lease_token).await
+    }
+
+    /// Advance one immutable child delivery to a durably resumable parent turn.
+    ///
+    /// The candidate scan is only recovery/latency plumbing. Exact inbox claim
+    /// and consume transitions own the fencing, so concurrent lanes and a
+    /// restart after child completion cannot double-resume the foreground turn.
+    async fn resume_parent(
+        &self,
+        delivery: AgentRunInboxEntry,
+    ) -> Result<SandboxAgentRunWorkerOutcome> {
+        let lease_token = uuid::Uuid::new_v4();
+        let lease = chrono_duration(self.config.lease)?;
+        let Some(claim) = self
+            .store
+            .claim_agent_run_inbox_entry(
+                delivery.parent_run_id,
+                delivery.child_run_id,
+                lease_token,
+                lease,
+            )
+            .await?
+        else {
+            return Ok(SandboxAgentRunWorkerOutcome::Idle);
+        };
+        let entry = match claim {
+            ClaimAgentRunInboxOutcome::Claimed(entry)
+            | ClaimAgentRunInboxOutcome::Existing(entry) => entry,
+        };
+        let Some(outcome) = self
+            .store
+            .consume_agent_run_inbox_entry_and_resume_turn(
+                entry.parent_run_id,
+                entry.child_run_id,
+                lease_token,
+            )
+            .await?
+        else {
+            return Ok(SandboxAgentRunWorkerOutcome::Idle);
+        };
+        match outcome {
+            ConsumeAgentRunInboxAndResumeTurnOutcome::Resumed { .. }
+            | ConsumeAgentRunInboxAndResumeTurnOutcome::Existing { .. } => {
+                // A committed `resuming` turn is authoritative. This only
+                // reduces the latency before the ordinary turn scan sees it.
+                self.turn_wake.notify_one();
+                Ok(SandboxAgentRunWorkerOutcome::ParentResumed(
+                    entry.child_run_id,
+                ))
+            }
+        }
     }
 
     async fn process(
@@ -439,8 +501,9 @@ mod tests {
     use async_trait::async_trait;
     use futures::stream::{self, BoxStream};
     use openwave_core::{
-        AcceptAgentRunOutcome, AgentRunExecution, CallId, Chat, ChatId, ChatRequest, DbStore,
-        ModelProvider, ProviderId, Role, Store,
+        AcceptAgentRunOutcome, AcceptTurnOutcome, AgentRunExecution, AgentRunInboxStatus, CallId,
+        Chat, ChatId, ChatRequest, DbStore, ModelProvider, ProviderId, Role, Store,
+        TurnCheckpointProgress, TurnId, TurnRunStatus, Usage,
     };
 
     use super::*;
@@ -545,6 +608,7 @@ mod tests {
             store.clone(),
             Arc::new(FixedResolver(provider.clone())),
             Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
             AgentConfig {
                 model: "sandbox-model".into(),
                 ..AgentConfig::default()
@@ -617,6 +681,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn durable_inbox_scan_resumes_a_parked_parent_without_a_wake() {
+        let (worker, store, _provider, chat, _dir) = fixture().await;
+        let turn_id = TurnId::new();
+        assert!(matches!(
+            store
+                .accept_turn(turn_id, chat.id, "sandbox-model", "delegate")
+                .await
+                .unwrap(),
+            AcceptTurnOutcome::Accepted(_)
+        ));
+        let foreground_lease = uuid::Uuid::new_v4();
+        let now = chrono::Utc::now();
+        let foreground = store
+            .claim_turn_run(foreground_lease, now, now + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .turn
+            .unwrap();
+        let call = CallId::new();
+        let child_id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
+        assert!(matches!(
+            store
+                .accept_sandbox_agent_run_and_park_turn(
+                    child_id,
+                    foreground.id,
+                    call,
+                    "return the child result",
+                    foreground_lease,
+                    foreground.steer_revision,
+                    TurnCheckpointProgress {
+                        model_steps: 1,
+                        usage: Usage::default(),
+                    },
+                    chrono::Utc::now(),
+                )
+                .await
+                .unwrap(),
+            Some(openwave_core::AcceptSandboxAgentRunAndParkTurnOutcome::Parked { .. })
+        ));
+        let child_lease = uuid::Uuid::new_v4();
+        assert_eq!(
+            store
+                .claim_agent_run(child_lease, chrono::Duration::minutes(1), 4, 2)
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            child_id
+        );
+        store
+            .submit_agent_run_result(child_id, child_lease, "child result")
+            .await
+            .unwrap()
+            .expect("exact child lease should complete");
+
+        // No notification is sent: a restarted worker's durable scan must
+        // still claim and consume this delivery.
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::ParentResumed(child_id)
+        );
+        let parent = openwave_core::AgentRunId::foreground_for_chat(chat.id);
+        assert_eq!(
+            store.list_agent_run_inbox(parent).await.unwrap()[0].status,
+            AgentRunInboxStatus::Consumed
+        );
+        assert_eq!(
+            store.get_turn_run(turn_id).await.unwrap().unwrap().status,
+            TurnRunStatus::Resuming
+        );
+    }
+
+    #[tokio::test]
     async fn acknowledges_cancellation_under_its_exact_live_lease() {
         let dir = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
@@ -651,6 +788,7 @@ mod tests {
             Arc::new(FixedResolver(Arc::new(BlockingProvider {
                 started: started.clone(),
             }))),
+            Arc::new(Notify::new()),
             Arc::new(Notify::new()),
             AgentConfig {
                 model: "sandbox-model".into(),
@@ -720,6 +858,7 @@ mod tests {
         let worker = SandboxAgentRunWorker::new(
             store.clone(),
             Arc::new(FixedResolver(Arc::new(FailingProvider))),
+            Arc::new(Notify::new()),
             Arc::new(Notify::new()),
             AgentConfig {
                 model: "m".into(),
@@ -801,6 +940,7 @@ mod tests {
                 provider: provider.clone(),
             }),
             Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
             AgentConfig {
                 model: "m".into(),
                 ..AgentConfig::default()
@@ -852,6 +992,7 @@ mod tests {
                 release: release.clone(),
                 provider: provider.clone(),
             }),
+            Arc::new(Notify::new()),
             Arc::new(Notify::new()),
             AgentConfig {
                 model: "m".into(),

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -47,9 +47,8 @@ pub struct AppState {
     pub(crate) turn_job_wake: Arc<Notify>,
     /// Wakes the bounded sandbox-run worker after delegated work commits.
     ///
-    /// The foreground spawn contract is still intentionally disabled in the
-    /// production registry; this signal makes its later enablement immediate
-    /// rather than relying on the worker's idle poll.
+    /// This is only a latency hint; the worker always uses its durable claim
+    /// scan as the correctness source after a missed or coalesced wake-up.
     pub(crate) agent_run_wake: Arc<Notify>,
     /// Wakes the source-blob retirement worker after a reference drop commits.
     pub(crate) blob_retirement_wake: Arc<Notify>,

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -11,11 +11,12 @@ use futures::stream::{self, BoxStream, StreamExt};
 use openwave_core::{
     AgentErrorInfo, AgentEvent, AgentRunInboxStatus, AgentRunStatus, ApprovalClass,
     BeginRootAttachmentChange, BlobStore, CallId, Chat, ChatId, ChatRequest, ChatRootAttachment,
-    ClientToolCallRequest, HostRootId, Message, ModelProvider, ParkTurnForClientCallOutcome,
-    Project, ProjectId, ProviderEvent, ProviderId, RootAttachmentChangeAction,
-    RootAttachmentChangeId, RootAttachmentOrigin, SecretProvider, SequencedEvent, StopReason, Tool,
-    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput,
-    ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
+    ClientToolCallRequest, ContentBlock, HostRootId, Message, ModelProvider,
+    ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent, ProviderId, Role,
+    RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentOrigin, SecretProvider,
+    SequencedEvent, StopReason, Tool, ToolCallExecution, ToolCallRecord, ToolCallResolution,
+    ToolCallStatus, ToolCtx, ToolOutput, ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus,
+    TurnSteerId, Usage,
 };
 use openwave_retrieval::{
     Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
@@ -6385,6 +6386,18 @@ async fn foreground_sandbox_spawn_parks_executes_delivers_and_resumes() {
     assert!(
         requests[1].tools.is_empty(),
         "sandbox receives no tool surface"
+    );
+    assert!(
+        requests[2].messages.iter().any(|message| {
+            message.role == Role::System
+                && message.content
+                    == vec![ContentBlock::Text {
+                        text:
+                            "Sandbox agent completed. Its exact final result follows:\nchild result"
+                                .into(),
+                    }]
+        }),
+        "the resumed foreground request must receive the durable child result"
     );
     assert!(requests[2]
         .tools

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -9,13 +9,13 @@ use axum::http::{header, Request, StatusCode};
 use futures::stream::{self, BoxStream, StreamExt};
 // Tests use the in-memory store; production wires LanceDB in `bind`.
 use openwave_core::{
-    AgentErrorInfo, AgentEvent, ApprovalClass, BeginRootAttachmentChange, BlobStore, CallId, Chat,
-    ChatId, ChatRequest, ChatRootAttachment, ClientToolCallRequest, HostRootId, Message,
-    ModelProvider, ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent, ProviderId,
-    RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentOrigin, SecretProvider,
-    SequencedEvent, StopReason, Tool, ToolCallExecution, ToolCallRecord, ToolCallResolution,
-    ToolCallStatus, ToolCtx, ToolOutput, ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus,
-    TurnSteerId, Usage,
+    AgentErrorInfo, AgentEvent, AgentRunInboxStatus, AgentRunStatus, ApprovalClass,
+    BeginRootAttachmentChange, BlobStore, CallId, Chat, ChatId, ChatRequest, ChatRootAttachment,
+    ClientToolCallRequest, HostRootId, Message, ModelProvider, ParkTurnForClientCallOutcome,
+    Project, ProjectId, ProviderEvent, ProviderId, RootAttachmentChangeAction,
+    RootAttachmentChangeId, RootAttachmentOrigin, SecretProvider, SequencedEvent, StopReason, Tool,
+    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput,
+    ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
 };
 use openwave_retrieval::{
     Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
@@ -48,6 +48,62 @@ impl ModelProvider for FakeProvider {
             },
         ])
         .boxed())
+    }
+}
+
+/// Drives the complete foreground-child-foreground round trip. The sandbox
+/// request is identified by its deliberately empty tool surface; foreground
+/// requests retain the registered delegation contract.
+#[derive(Default)]
+struct SandboxRoundTripProvider {
+    foreground_calls: AtomicUsize,
+    requests: std::sync::Mutex<Vec<ChatRequest>>,
+}
+
+#[async_trait]
+impl ModelProvider for SandboxRoundTripProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("sandbox-round-trip")
+    }
+
+    async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let sandbox = request.tools.is_empty();
+        self.requests.lock().unwrap().push(request);
+        let events = if sandbox {
+            vec![
+                ProviderEvent::TextDelta {
+                    text: "child result".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ]
+        } else if self.foreground_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "delegate-1".into(),
+                    name: openwave_core::SPAWN_SANDBOX_AGENT_TOOL.into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: r#"{"task":"Return a concise child result."}"#.into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ]
+        } else {
+            vec![
+                ProviderEvent::TextDelta {
+                    text: "parent resumed".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ]
+        };
+        Ok(stream::iter(events).boxed())
     }
 }
 
@@ -1286,6 +1342,7 @@ fn spawn_turn_worker_with_config(state: &AppState, config: turn_worker::TurnWork
         state.events.clone(),
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
+        state.agent_run_wake.clone(),
         state.agent_config.clone(),
         None,
         config,
@@ -4868,7 +4925,7 @@ async fn root_search_never_returns_project_owned_vectors() {
 }
 
 #[test]
-fn agent_deps_registers_server_tools_and_the_folder_consent_contract_without_sandbox_spawn() {
+fn agent_deps_registers_server_tools_and_the_foreground_sandbox_contract() {
     let (_retrieval, tools, _config) = agent_deps(
         Arc::new(HashEmbedder::default()),
         Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
@@ -4886,14 +4943,14 @@ fn agent_deps_registers_server_tools_and_the_folder_consent_contract_without_san
         !names
             .iter()
             .any(|name| name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL),
-        "production registry must not advertise sandbox spawning before an executor exists"
+        "the sandbox contract must only be advertised to a claimed foreground turn"
     );
     assert!(
-        !tools
+        tools
             .specs_for_foreground(true)
             .iter()
             .any(|spec| spec.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL),
-        "ordinary claimed foreground turns must not expose the disabled sandbox tool"
+        "foreground turns must expose the durable sandbox delegation contract"
     );
     assert_eq!(
         tools.execution(openwave_core::REQUEST_FOLDER_ACCESS_TOOL),
@@ -6243,6 +6300,99 @@ async fn post_message_runs_a_turn_and_journals_its_events() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn foreground_sandbox_spawn_parks_executes_delivers_and_resumes() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let provider = Arc::new(SandboxRoundTripProvider::default());
+    let mut tools = ToolRegistry::new();
+    tools.register_foreground_sandbox_spawn();
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(provider.clone())),
+        Arc::new(MemSecrets::default()),
+        Arc::new(tools),
+        build_retrieval(
+            Arc::new(HashEmbedder::default()),
+            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        )
+        .0,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    let sandbox_worker = sandbox_agent_run_worker::SandboxAgentRunWorker::new(
+        state.store.clone(),
+        state.resolver.clone(),
+        state.agent_run_wake.clone(),
+        state.turn_job_wake.clone(),
+        state.agent_config.clone(),
+        None,
+        sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default(),
+    );
+    tokio::spawn(sandbox_worker.run());
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "delegate this").await,
+        StatusCode::ACCEPTED
+    );
+    let events = wait_for_turn(&store, chat.id).await;
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCompleted { .. })
+    ));
+
+    let runs = store.list_agent_runs(chat.id).await.unwrap();
+    let child = runs
+        .iter()
+        .find(|run| run.parent_id.is_some())
+        .expect("foreground delegation should durably create one child");
+    assert_eq!(child.status, AgentRunStatus::Completed);
+    let parent = openwave_core::AgentRunId::foreground_for_chat(chat.id);
+    let inbox = store.list_agent_run_inbox(parent).await.unwrap();
+    assert_eq!(inbox.len(), 1);
+    assert_eq!(inbox[0].child_run_id, child.id);
+    assert_eq!(inbox[0].result.text, "child result");
+    assert_eq!(inbox[0].status, AgentRunInboxStatus::Consumed);
+    assert_eq!(inbox[0].claim_count, 1);
+    assert!(inbox[0].consumed_lease_token.is_some());
+
+    let turn = store.list_turn_runs(chat.id).await.unwrap().pop().unwrap();
+    assert_eq!(turn.status, TurnRunStatus::Completed);
+    assert_eq!(
+        turn.claim_count, 2,
+        "the resumed turn requires a fresh lease"
+    );
+    let requests = provider.requests.lock().unwrap();
+    assert_eq!(requests.len(), 3);
+    assert!(requests[0]
+        .tools
+        .iter()
+        .any(|tool| tool.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL));
+    assert!(
+        requests[1].tools.is_empty(),
+        "sandbox receives no tool surface"
+    );
+    assert!(requests[2]
+        .tools
+        .iter()
+        .any(|tool| tool.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn worker_drains_a_turn_queued_before_startup() {
     let dir = tempfile::tempdir().unwrap();
     let store: Arc<dyn Store> = Arc::new(
@@ -6658,6 +6808,7 @@ async fn worker_renews_a_near_expiry_ambiguous_claim_before_execution() {
         state.events.clone(),
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
+        state.agent_run_wake.clone(),
         state.agent_config.clone(),
         None,
         turn_worker::TurnWorkerConfig {
@@ -6752,6 +6903,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
         state.events.clone(),
         state.active_turns.clone(),
         state.turn_job_wake.clone(),
+        state.agent_run_wake.clone(),
         state.agent_config.clone(),
         None,
         turn_worker::TurnWorkerConfig {

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -72,6 +72,7 @@ pub(crate) struct TurnWorker {
     events: Arc<EventBus>,
     signals: Arc<TurnGuard>,
     wake: Arc<Notify>,
+    sandbox_agent_wake: Arc<Notify>,
     agent_config: AgentConfig,
     private_scratch_root: Option<PathBuf>,
     config: TurnWorkerConfig,
@@ -233,6 +234,7 @@ impl TurnWorker {
         events: Arc<EventBus>,
         signals: Arc<TurnGuard>,
         wake: Arc<Notify>,
+        sandbox_agent_wake: Arc<Notify>,
         agent_config: AgentConfig,
         private_scratch_root: Option<PathBuf>,
         config: TurnWorkerConfig,
@@ -250,6 +252,7 @@ impl TurnWorker {
             events,
             signals,
             wake,
+            sandbox_agent_wake,
             agent_config,
             private_scratch_root,
             config,
@@ -1175,6 +1178,12 @@ impl TurnWorker {
                                 ..
                             })) => {
                                 checkpoint_heartbeat.abort_and_wait().await;
+                                // The child and parent wait state are now one
+                                // durable transaction. This is intentionally
+                                // only a latency hint: the sandbox worker's
+                                // durable claim scan remains the correctness
+                                // source if the notification is lost.
+                                self.sandbox_agent_wake.notify_one();
                                 return Ok(TurnWorkerOutcome::WaitingForAgentRun(turn.id));
                             }
                             Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::SteerPending(_)))

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -46,7 +46,7 @@ differ:
 | --- | --- |
 | Responds directly in the chat | Works on one delegated task |
 | Final assistant text completes a turn | An explicit result submission completes the run |
-| Uses conversation-facing tools | Uses sandbox, project, and workspace tools |
+| Uses conversation-facing tools | Starts with no tools or shared conversation context |
 | Usually short-lived work | May park and resume over a longer period |
 | Streams answer content | Publishes bounded progress and a final result |
 
@@ -107,14 +107,11 @@ notification may reduce latency, but it is never the source of truth.
 
 ## Sandbox and host-access boundary
 
-A background agent receives private scratch space. Access to a project or host
-folder is capability-based and mediated by the host broker described in
-[Host access and connected folders](host-access.md). The model sees opaque root
-identities and root-relative paths, never unrestricted absolute host paths.
-
-An agent may request additional access, but only the trusted native host can
-show the picker and register the user's selection. The sandbox parks while that
-request is unresolved and resumes from its durable checkpoint afterward.
+A background agent has private runtime scratch, but the initial executor has no
+tools and cannot access that scratch, projects, host folders, the network, or
+the parent conversation. Broker-mediated folder access is a future capability;
+when introduced it must use the consent and durable-receipt protocol described
+in [Host access and connected folders](host-access.md), never absolute paths.
 
 The sandbox boundary should remain useful outside the desktop product. A local
 process sandbox is the first execution adapter; self-hosted and managed profiles
@@ -158,14 +155,17 @@ the exact lease segment that submitted it. The receipt, `completed` state, and
 one parent inbox entry commit together, so an ambiguous worker retry can recover
 its original result but cannot overwrite or double-deliver it. Each inbox entry
 then advances through its own fenced continuation state machine:
-`pending -> claimed -> consumed`. A parent continuation claims one exact child
+`pending -> claimed -> consumed` (or `cancelled` when its parked parent is
+cancelled). A parent continuation claims one exact child
 result only after the matching foreground checkpoint has committed, with a
 database-clock lease, and only that live lease can consume it. A result that
 arrives first remains pending; it is never leased merely because a process saw
 it before the parent reached its durable boundary.
 An expired claim can be reclaimed; a consumed entry retains the exact consuming
 lease as an immutable receipt, so an ambiguous consume retry recovers the same
-boundary without processing the child result twice. A foreground worker can
+boundary without processing the child result twice. Consumption also persists
+the exact terminal child text as a deterministic system transcript message, so
+the resumed model request sees it after a restart. A foreground worker can
 checkpoint its exact turn against a known child, releasing its turn lease and
 preserving model progress. Consumption then closes that checkpoint and moves
 the turn to `resuming` in the same transaction. `resuming` is the durable wake
@@ -176,8 +176,11 @@ immediately; a running worker first enters `cancelling` and must acknowledge its
 exact live lease. That acknowledgement writes its own immutable receipt, so only
 the worker that actually committed terminal cancellation can recover an
 ambiguous retry. An expired running lease is cancelled immediately on request
-rather than reclaimed. Parent inbox delivery is intentionally the next
-transition, not a process-local notification.
+rather than reclaimed. Cancelling a parked parent fences its owned sandbox
+child in the same durable transition: queued work is cancelled, running work
+is asked to acknowledge cancellation, and a delivered inbox receipt is retired.
+Parent inbox delivery is intentionally the next transition, not a process-local
+notification.
 
 ## Observing execution
 

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -70,17 +70,19 @@ spawn:
 6. The result, terminal child state, and immutable parent inbox entry commit
    together. A later wait transition may consume that entry and wake a parent.
 
-The bounded `spawn_sandbox_agent` contract and its foreground checkpoint wiring
-are prepared, but deliberately disabled in the production tool registry. The
-server now runs the executor that can claim and complete a child, but the tool
-will not be advertised until the final wiring wakes that worker after an atomic
-foreground spawn checkpoint. It will be a wait-form tool: it accepts one
-bounded `task`, derives the child identity from that exact tool call, and
-commits the queued child, durable wait, and release of the exact foreground
-worker lease in one transaction. It is advertised only to a claimed foreground
-turn; sandbox workers never receive it, and the store independently enforces
-depth one. A later non-blocking spawn tool can let the foreground continue after
-spawning, but must earn the same checkpoint and replay rules.
+The bounded `spawn_sandbox_agent` contract is available only to a durably
+claimed foreground turn. It is a wait-form tool: one bounded `task` derives a
+child identity from its exact tool call, then commits the queued child, durable
+wait, and release of the foreground lease in one transaction. Only after that
+commit does the server wake the bounded sandbox worker. The notification is a
+latency hint, not a correctness dependency: the worker polls durable child and
+inbox state, so a missed wake or restart cannot lose accepted work. A sandbox
+result is delivered, claimed under an exact continuation lease, consumed, and
+turns the parked foreground turn into a fresh durably claimable `resuming`
+attempt. The tool is never advertised to sandbox workers, and the store
+independently enforces depth one. A later non-blocking spawn tool can let the
+foreground continue after spawning, but must earn the same checkpoint and
+replay rules.
 
 The wait also carries an immutable atomic-admission marker. Only that receipt
 allows a later retry to recover the combined transition; an older path that
@@ -228,7 +230,7 @@ The implementation is intentionally incremental:
    context, over the durable lease/result boundary. *(Shipped.)*
 9. Enable the bounded foreground-only `spawn_sandbox_agent` contract, wake the
    sandbox worker after its atomic checkpoint, and resume the parked turn from
-   the already-delivered inbox receipt.
+   the already-delivered inbox receipt. *(Shipped.)*
 10. Route sandbox folder access through the host broker.
 11. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -630,8 +630,8 @@ leases and result delivery, and fail-closed provider routing.
 
 The main next steps are:
 
-- connect the durable agent-run hierarchy, depth-one sandbox scheduler, and
-  parent inbox to the shared execution loop;
+- extend the connected durable agent-run hierarchy with carefully scoped
+  sandbox-safe capabilities and UI status surfaces;
 - unify client execution, approvals, folder consent, user questions, resource
   waits, and child-agent waits as durable continuations that release workers;
 - persist model/tool step boundaries and side-effect receipts so sandbox and

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,7 +7,7 @@ identity.
 
 ## What exists today
 
-The current agent surface contains five tools:
+The current foreground agent surface contains six tools:
 
 | Tool | Purpose | Execution boundary |
 | --- | --- | --- |
@@ -16,6 +16,7 @@ The current agent surface contains five tools:
 | `write_file` | Atomically write private-scratch text | Server, workspace |
 | `search` | Search locally indexed project/chat documents | Server, read-only |
 | `request_folder_access` | Ask the trusted desktop host to connect another folder | Client continuation |
+| `spawn_sandbox_agent` | Delegate one bounded task and wait for its durable result | Foreground-only durable continuation |
 
 The host broker already supports listing connected roots, listing directories,
 and reading files, but those operations are not yet advertised directly to the
@@ -56,22 +57,19 @@ The foreground coordinator needs tools for:
 - spawning, inspecting, messaging, waiting for, cancelling, and reviewing
   depth-one sandbox agents.
 
-`spawn_sandbox_agent` has a prepared bounded contract and durable foreground
-checkpoint path, but is intentionally disabled in the production registry
-until a sandbox executor exists. Enabling it earlier would park a foreground
-chat with no worker able to complete the child.
+`spawn_sandbox_agent` is enabled only for a claimed foreground turn. It
+atomically admits a depth-one child and parks that turn; the child result is
+persisted as a system transcript message before the parent can resume. Sandbox
+agents never receive this tool.
 
-A background sandbox starts with a deliberately smaller surface:
+A background sandbox currently has **no tool surface and no shared
+conversation, filesystem, network, or host-folder access**. It receives one
+bounded task and its final text becomes the fenced result receipt. Sandboxes
+do not receive `spawn_sandbox_agent` and cannot create further agents.
 
-- confined command execution;
-- web search and image viewing;
-- project-document search/read;
-- `ask` and non-blocking `notify` communication with its parent;
-- a small durable task list;
-- explicit `submit_result` completion.
-
-Sandboxes do not receive `spawn_agent`. Ordinary assistant text does not
-complete a background run; `submit_result` is its successful terminal action.
+Future sandbox-safe capabilities (for example web search or broker-mediated
+folder reads) must be added one at a time behind the same durable continuation
+and consent boundaries.
 
 Later additions may include a scratchpad, pinned context, plan/execution modes,
 deliverable export, clipboard operations, generated images, and connected apps.


### PR DESCRIPTION
## Summary

- enable foreground-only sandbox delegation after atomic child acceptance and parent parking
- execute, deliver, persist, and resume child results through durable fenced transitions
- recover missed wake signals from durable inbox state and cascade parent cancellation to child work

## Validation

- cargo test -p openwave-core --lib --locked
- cargo test -p openwave-server --lib --locked
- cargo check -p openwave-core --test postgres_turn_state --features postgres --locked
- bw dev lint --rust --check