### PR TITLE
Add foreground turn stop control

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -64,6 +64,11 @@ export default function App() {
   >({});
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
+  const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
+  const [cancelPendingTurnId, setCancelPendingTurnId] = useState<string | null>(
+    null,
+  );
+  const [cancelError, setCancelError] = useState<string | null>(null);
   const [creatingChat, setCreatingChat] = useState(false);
   const [settingsPanel, setSettingsPanel] = useState<
     "providers" | "folders" | null
@@ -78,6 +83,7 @@ export default function App() {
   const refreshAgentRunsRef = useRef<(() => void) | null>(null);
   const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
   const visibleFolderCallIdsRef = useRef<Set<string>>(new Set());
+  const cancelRequestTurnRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -127,24 +133,62 @@ export default function App() {
     socketRef.current?.close();
     lastSeqRef.current = 0;
     const generation = ++socketGenerationRef.current;
-    const socket = client.openEvents(chat.id, 0, (event) => {
-      if (socketGenerationRef.current !== generation) return;
-      handleEvent(event);
-    });
-    socket.onopen = () => {
-      if (socketGenerationRef.current === generation) {
-        setStatus((s) => `${s} · live`);
+    let disposed = false;
+    let reconnectTimer: number | null = null;
+    let reconnectDelayMs = 250;
+
+    const scheduleReconnect = () => {
+      if (
+        disposed ||
+        socketGenerationRef.current !== generation ||
+        reconnectTimer !== null
+      ) {
+        return;
       }
+      setStatus((s) => `${withoutConnectionState(s)} · reconnecting`);
+      const delay = reconnectDelayMs;
+      reconnectDelayMs = Math.min(reconnectDelayMs * 2, 5_000);
+      reconnectTimer = window.setTimeout(() => {
+        reconnectTimer = null;
+        connect();
+      }, delay);
     };
-    socket.onerror = () => {
-      if (socketGenerationRef.current === generation) {
-        setStatus("websocket error");
+
+    const connect = () => {
+      if (disposed || socketGenerationRef.current !== generation) return;
+      let socket: WebSocket;
+      try {
+        socket = client.openEvents(chat.id, lastSeqRef.current, (event) => {
+          if (socketGenerationRef.current !== generation) return;
+          handleEvent(event);
+        });
+      } catch {
+        scheduleReconnect();
+        return;
       }
+      socketRef.current = socket;
+      socket.onopen = () => {
+        if (disposed || socketGenerationRef.current !== generation) return;
+        reconnectDelayMs = 250;
+        setStatus((s) => `${withoutConnectionState(s)} · live`);
+      };
+      socket.onerror = () => {
+        if (!disposed && socketGenerationRef.current === generation) {
+          setStatus((s) => `${withoutConnectionState(s)} · reconnecting`);
+        }
+      };
+      socket.onclose = () => {
+        if (socketRef.current === socket) socketRef.current = null;
+        scheduleReconnect();
+      };
     };
-    socketRef.current = socket;
+
+    connect();
     return () => {
-      socket.close();
-      if (socketRef.current === socket) socketRef.current = null;
+      disposed = true;
+      if (reconnectTimer !== null) window.clearTimeout(reconnectTimer);
+      socketRef.current?.close();
+      socketRef.current = null;
       if (socketGenerationRef.current === generation) {
         socketGenerationRef.current += 1;
       }
@@ -264,6 +308,10 @@ export default function App() {
       refreshAgentRunsRef.current?.();
       assistantBufRef.current = "";
       setBusy(true);
+      setActiveTurnId(event.turn_id);
+      setCancelPendingTurnId(null);
+      setCancelError(null);
+      cancelRequestTurnRef.current = null;
       setMessages((prev) => [
         ...prev,
         { id: nextId(), role: "assistant", text: "" },
@@ -337,13 +385,13 @@ export default function App() {
     }
 
     if (event.type === "turn_completed") {
-      setBusy(false);
+      resolveActiveTurn();
       refreshAgentRunsRef.current?.();
       return;
     }
 
     if (event.type === "turn_cancelled") {
-      setBusy(false);
+      resolveActiveTurn();
       refreshAgentRunsRef.current?.();
       setMessages((prev) => [
         ...prev,
@@ -353,7 +401,7 @@ export default function App() {
     }
 
     if (event.type === "turn_failed") {
-      setBusy(false);
+      resolveActiveTurn();
       refreshAgentRunsRef.current?.();
       setMessages((prev) => [
         ...prev,
@@ -364,6 +412,14 @@ export default function App() {
         },
       ]);
     }
+  }
+
+  function resolveActiveTurn() {
+    setBusy(false);
+    setActiveTurnId(null);
+    setCancelPendingTurnId(null);
+    setCancelError(null);
+    cancelRequestTurnRef.current = null;
   }
 
   async function refreshCatalog() {
@@ -383,15 +439,44 @@ export default function App() {
     setDraft("");
     setMessages((prev) => [...prev, { id: nextId(), role: "user", text: content }]);
     setBusy(true);
+    setActiveTurnId(turnId);
+    setCancelPendingTurnId(null);
+    setCancelError(null);
     try {
       await client.postMessage(chat.id, turnId, content);
       refreshAgentRunsRef.current?.();
     } catch (err) {
-      setBusy(false);
+      resolveActiveTurn();
       setMessages((prev) => [
         ...prev,
         { id: nextId(), role: "error", text: String(err) },
       ]);
+    }
+  }
+
+  async function onCancelActiveTurn() {
+    const turnId = activeTurnId;
+    if (
+      !client ||
+      !chat ||
+      !busy ||
+      !turnId ||
+      cancelRequestTurnRef.current === turnId
+    ) {
+      return;
+    }
+
+    cancelRequestTurnRef.current = turnId;
+    setCancelPendingTurnId(turnId);
+    setCancelError(null);
+    try {
+      await client.cancel(chat.id, turnId);
+    } catch (err) {
+      if (cancelRequestTurnRef.current === turnId) {
+        cancelRequestTurnRef.current = null;
+        setCancelPendingTurnId(null);
+        setCancelError(String(err));
+      }
     }
   }
 
@@ -411,6 +496,10 @@ export default function App() {
       setFolderAccessRequests([]);
       setFolderAccessErrors({});
       setDraft("");
+      setActiveTurnId(null);
+      setCancelPendingTurnId(null);
+      setCancelError(null);
+      cancelRequestTurnRef.current = null;
       setChat(created);
       setStatus(`chat ${created.id.slice(0, 8)}…`);
     } catch (err) {
@@ -741,6 +830,25 @@ export default function App() {
                 }
               }}
             />
+            {busy && activeTurnId && (
+              <div className="composer-turn-control" aria-live="polite">
+                <button
+                  type="button"
+                  className="btn btn-stop"
+                  disabled={cancelPendingTurnId === activeTurnId}
+                  onClick={() => void onCancelActiveTurn()}
+                >
+                  {cancelPendingTurnId === activeTurnId
+                    ? "Stopping…"
+                    : "Stop"}
+                </button>
+                {cancelError && (
+                  <span className="composer-turn-error" role="status">
+                    Couldn’t stop turn: {cancelError}
+                  </span>
+                )}
+              </div>
+            )}
             <button
               type="submit"
               className="btn btn-primary"
@@ -762,6 +870,10 @@ export default function App() {
       </div>
     </div>
   );
+}
+
+function withoutConnectionState(status: string): string {
+  return status.replace(/ · (?:live|reconnecting)$/, "");
 }
 
 function AgentRunStatusSurface({

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -458,7 +458,7 @@ button {
 
 .composer {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
   gap: 0.55rem;
   padding: 0.85rem clamp(1rem, 3vw, 2rem) 1rem;
   border-top: 1px solid var(--line);
@@ -473,6 +473,30 @@ button {
   border-radius: 8px;
   padding: 0.6rem 0.7rem;
   background: var(--bg);
+}
+
+.composer-turn-control {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.btn-stop {
+  border-color: color-mix(in srgb, var(--danger) 45%, var(--line));
+  color: var(--danger);
+}
+
+.btn-stop:hover:not(:disabled) {
+  border-color: var(--danger);
+  background: oklch(0.97 0.01 25);
+}
+
+.composer-turn-error {
+  max-width: min(22rem, 32vw);
+  color: var(--danger);
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
 }
 
 .settings {
@@ -630,5 +654,18 @@ button {
   .agent-runs-state {
     width: 100%;
     margin-left: 0;
+  }
+
+  .composer {
+    grid-template-columns: 1fr auto;
+  }
+
+  .composer-turn-control {
+    grid-column: 1 / -1;
+    justify-content: flex-end;
+  }
+
+  .composer-turn-error {
+    max-width: none;
   }
 }

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -525,8 +525,12 @@ The browser-facing API is not exposed on a public network interface.
 
 The current UI is a workspace-style conversation shell, not the complete
 product. It creates a new loose chat on each launch and supports provider setup,
-model selection, basic chat streaming, approval prompts, native connected-folder
-pick/list/revoke, and a concise foreground/background agent-status surface.
+model selection, basic chat streaming, a foreground-turn stop control, approval
+prompts, native connected-folder pick/list/revoke, and a concise
+foreground/background agent-status surface. The stop control sends cancellation
+for the exact active turn, prevents duplicate requests, and stays in a pending
+state until an authoritative terminal event arrives; it never treats a request
+as a locally completed cancellation.
 That surface reads a redacted durable snapshot and is only an observer: worker
 leases, delegated inputs, and scheduler control remain server-private.
 OpenWave's operational scratch stays in private app storage; user-selected paths
@@ -537,8 +541,8 @@ still use a server-derived per-chat private scratch directory and are not yet
 routed through connected roots; that scratch path is neither persisted nor
 returned to the renderer. The
 UI does not yet provide a chat picker, history reconstruction, projects,
-document ingestion, document search, cancel, or steer controls, even though much
-of that backend API already exists.
+document ingestion, document search, or steer controls, even though much of
+that backend API already exists.
 
 Because that chat is projectless, its `search` tool can see only the unscoped
 document corpus. Project-scoped documents are not reachable through the current


### PR DESCRIPTION
## Summary

- add an accessible Stop control for the active foreground turn
- keep cancellation state authoritative to terminal WebSocket events
- reconnect and replay the durable event journal after socket loss

## Validation

- pnpm --dir crates/openwave-desktop/ui build
- git diff --check