### PR TITLE
Add bounded web search providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5954,6 +5954,22 @@ name = "openwave-slack"
 version = "0.0.0"
 
 [[package]]
+name = "openwave-web-search"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "openwave-core",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/openwave-web-search/Cargo.toml
+++ b/crates/openwave-web-search/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "openwave-web-search"
+description = "OpenWave web search: bounded provider-neutral contracts and direct HTTP adapters."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = []
+# A small reqwest implementation of the HTTP seam. It is opt-in so consumers
+# that only need the contract do not pull a network client into their process.
+http = ["dep:reqwest", "dep:futures"]
+
+[dependencies]
+async-trait = { workspace = true }
+chrono = { workspace = true }
+openwave-core = { path = "../openwave-core", default-features = false }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+url = "2"
+reqwest = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util", "time"] }

--- a/crates/openwave-web-search/src/credentials.rs
+++ b/crates/openwave-web-search/src/credentials.rs
@@ -1,0 +1,54 @@
+use openwave_core::SecretProvider;
+
+use crate::{WebSearchError, WebSearchProviderKind};
+
+/// Non-serializable, redacted API credential for one search provider.
+#[derive(Clone)]
+pub struct WebSearchCredential {
+    kind: WebSearchProviderKind,
+    api_key: String,
+}
+
+impl std::fmt::Debug for WebSearchCredential {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("WebSearchCredential")
+            .field("kind", &self.kind)
+            .field("api_key", &"***")
+            .finish()
+    }
+}
+
+impl WebSearchCredential {
+    #[must_use]
+    pub fn kind(&self) -> WebSearchProviderKind {
+        self.kind
+    }
+
+    /// The key is intentionally only exposed to provider adapters that attach
+    /// it to an HTTP request. Do not serialize or log this value.
+    pub(crate) fn api_key(&self) -> &str {
+        &self.api_key
+    }
+}
+
+/// Reads provider keys from the application's existing secret boundary.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WebSearchCredentials;
+
+impl WebSearchCredentials {
+    /// Resolve one provider's key. Missing or whitespace-only entries mean the
+    /// provider is disabled; callers must fail closed and make no request.
+    pub async fn load(
+        secrets: &dyn SecretProvider,
+        kind: WebSearchProviderKind,
+    ) -> Result<Option<WebSearchCredential>, WebSearchError> {
+        let value = secrets
+            .get_secret(kind.credential_key())
+            .await
+            .map_err(|error| WebSearchError::Transport(error.to_string()))?;
+        Ok(value
+            .filter(|value| !value.trim().is_empty())
+            .map(|api_key| WebSearchCredential { kind, api_key }))
+    }
+}

--- a/crates/openwave-web-search/src/exa.rs
+++ b/crates/openwave-web-search/src/exa.rs
@@ -1,0 +1,219 @@
+//! Exa's direct `/search` adapter.
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::{
+    HttpClient, HttpRequest, WebSearchCredential, WebSearchError, WebSearchProvider,
+    WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult,
+};
+
+const EXA_SEARCH_URL: &str = "https://api.exa.ai/search";
+
+/// Exa adapter backed by an injected HTTP client.
+///
+/// It has no default constructor because the host must explicitly decide which
+/// HTTP policy and credential custody to use.
+#[derive(Clone, Debug)]
+pub struct ExaProvider<C> {
+    client: C,
+    credential: WebSearchCredential,
+}
+
+impl<C> ExaProvider<C> {
+    pub fn new(client: C, credential: WebSearchCredential) -> Result<Self, WebSearchError> {
+        if credential.kind() != WebSearchProviderKind::Exa {
+            return Err(WebSearchError::NotConfigured(WebSearchProviderKind::Exa));
+        }
+        Ok(Self { client, credential })
+    }
+}
+
+#[async_trait]
+impl<C: HttpClient> WebSearchProvider for ExaProvider<C> {
+    fn kind(&self) -> WebSearchProviderKind {
+        WebSearchProviderKind::Exa
+    }
+
+    async fn search(&self, request: WebSearchRequest) -> Result<WebSearchResponse, WebSearchError> {
+        request.validate()?;
+        let response = self
+            .client
+            .post_json(HttpRequest {
+                url: EXA_SEARCH_URL.into(),
+                headers: vec![
+                    ("x-api-key".into(), self.credential.api_key().into()),
+                    ("content-type".into(), "application/json".into()),
+                ],
+                body: request_body(&request),
+            })
+            .await?;
+        response.ensure_bounded()?;
+        if !(200..300).contains(&response.status) {
+            return Err(WebSearchError::HttpStatus {
+                provider: self.kind(),
+                status: response.status,
+            });
+        }
+        let payload: ExaSearchResponse = serde_json::from_slice(&response.body).map_err(|_| {
+            WebSearchError::InvalidResponse {
+                provider: self.kind(),
+            }
+        })?;
+        let results = payload
+            .results
+            .into_iter()
+            .filter_map(|result| normalize_result(result).ok())
+            .collect();
+        Ok(WebSearchResponse::new(self.kind(), results))
+    }
+}
+
+fn request_body(request: &WebSearchRequest) -> serde_json::Value {
+    let mut body = json!({
+        "query": request.query,
+        "type": "auto",
+        "numResults": request.max_results,
+        "contents": { "text": { "maxCharacters": crate::MAX_RESULT_CONTENT_CHARS } },
+    });
+    if !request.domains.is_empty() {
+        body["includeDomains"] = json!(request
+            .domains
+            .iter()
+            .map(|domain| domain.as_str())
+            .collect::<Vec<_>>());
+    }
+    if let Some(start) = request.start_published_at {
+        body["startPublishedDate"] = json!(start.to_rfc3339());
+    }
+    if let Some(end) = request.end_published_at {
+        body["endPublishedDate"] = json!(end.to_rfc3339());
+    }
+    body
+}
+
+#[derive(Deserialize)]
+struct ExaSearchResponse {
+    results: Vec<ExaResult>,
+}
+
+#[derive(Deserialize)]
+struct ExaResult {
+    url: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    highlights: Vec<String>,
+    #[serde(default)]
+    score: Option<f64>,
+    #[serde(default, rename = "publishedDate")]
+    published_date: Option<String>,
+    #[serde(default)]
+    image: Option<String>,
+}
+
+fn normalize_result(result: ExaResult) -> Result<WebSearchResult, WebSearchError> {
+    let snippet = result
+        .highlights
+        .into_iter()
+        .find(|highlight| !highlight.trim().is_empty())
+        .unwrap_or_else(|| result.text.clone());
+    let published_at = result
+        .published_date
+        .as_deref()
+        .and_then(parse_provider_timestamp);
+    WebSearchResult::new(
+        result.url,
+        result.title,
+        snippet,
+        (!result.text.trim().is_empty()).then_some(result.text),
+        result.score,
+        published_at,
+        result.image,
+        BTreeMap::new(),
+    )
+}
+
+fn parse_provider_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::{HttpResponse, WebSearchCredentials};
+    use openwave_core::{AgentError, SecretProvider};
+
+    #[derive(Clone)]
+    struct FakeHttpClient {
+        seen: Arc<Mutex<Vec<HttpRequest>>>,
+        response: HttpResponse,
+    }
+
+    struct StaticSecrets;
+
+    #[async_trait]
+    impl SecretProvider for StaticSecrets {
+        async fn get_secret(&self, key: &str) -> openwave_core::Result<Option<String>> {
+            Ok((key == WebSearchProviderKind::Exa.credential_key()).then(|| "exa-key".into()))
+        }
+
+        async fn set_secret(&self, _key: &str, _value: &str) -> openwave_core::Result<()> {
+            Err(AgentError::Secret("read only test secrets".into()))
+        }
+
+        async fn delete_secret(&self, _key: &str) -> openwave_core::Result<()> {
+            Err(AgentError::Secret("read only test secrets".into()))
+        }
+    }
+
+    #[async_trait]
+    impl HttpClient for FakeHttpClient {
+        async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
+            self.seen.lock().unwrap().push(request);
+            Ok(self.response.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_exa_response_and_sends_bounded_direct_request() {
+        let credential = WebSearchCredentials::load(&StaticSecrets, WebSearchProviderKind::Exa)
+            .await
+            .unwrap()
+            .unwrap();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let client = FakeHttpClient {
+            seen: Arc::clone(&seen),
+            response: HttpResponse {
+                status: 200,
+                body: br#"{"results":[{"url":"https://example.com/a#part","title":"Example","text":"full text","highlights":["short summary"],"score":0.8,"publishedDate":"2026-01-01T00:00:00Z"},{"url":"not-a-url","title":"skip"}]}"#.to_vec(),
+            },
+        };
+        let provider = ExaProvider::new(client, credential).unwrap();
+        let request = WebSearchRequest::new("latest openwave", 2)
+            .unwrap()
+            .with_domains(vec!["docs.example.com".parse().unwrap()])
+            .unwrap();
+        let response = provider.search(request).await.unwrap();
+
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(response.results[0].url, "https://example.com/a");
+        assert_eq!(response.results[0].snippet, "short summary");
+        let sent = seen.lock().unwrap();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0].url, EXA_SEARCH_URL);
+        assert_eq!(sent[0].body["numResults"], 2);
+        assert_eq!(sent[0].body["includeDomains"][0], "docs.example.com");
+        assert_eq!(sent[0].headers[0], ("x-api-key".into(), "exa-key".into()));
+    }
+}

--- a/crates/openwave-web-search/src/http.rs
+++ b/crates/openwave-web-search/src/http.rs
@@ -1,0 +1,273 @@
+use std::fmt;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use url::Url;
+
+use crate::WebSearchError;
+
+/// Largest JSON response an adapter may retain in memory or parse.
+pub const MAX_HTTP_RESPONSE_BYTES: usize = 1_000_000;
+
+#[derive(Clone, PartialEq)]
+pub struct HttpRequest {
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+    pub body: Value,
+}
+
+impl fmt::Debug for HttpRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let headers: Vec<(&str, &str)> = self
+            .headers
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.as_str(),
+                    if is_sensitive_name(name) {
+                        "***"
+                    } else {
+                        value
+                    },
+                )
+            })
+            .collect();
+        formatter
+            .debug_struct("HttpRequest")
+            .field("url", &redacted_url(&self.url))
+            .field("headers", &headers)
+            .field("body", &redacted_json(&self.body))
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub body: Vec<u8>,
+}
+
+impl HttpResponse {
+    /// Reject a custom HTTP implementation's oversized body before an adapter
+    /// asks `serde_json` to allocate for it.
+    pub fn ensure_bounded(&self) -> Result<(), WebSearchError> {
+        if self.body.len() > MAX_HTTP_RESPONSE_BYTES {
+            return Err(WebSearchError::Transport(
+                "web search response exceeded byte limit".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Minimal outbound HTTP seam. A host can provide proxy, allow-list, test, or
+/// auditing policy here without exposing that machinery to a model tool.
+#[async_trait]
+pub trait HttpClient: Send + Sync {
+    async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError>;
+}
+
+fn is_sensitive_name(name: &str) -> bool {
+    let name = name.to_ascii_lowercase().replace('_', "-");
+    name.contains("auth")
+        || name.contains("token")
+        || name.contains("secret")
+        || name.contains("credential")
+        || name.contains("password")
+        || name.contains("cookie")
+        || name.contains("session")
+        || name.contains("key")
+}
+
+fn redacted_url(url: &str) -> String {
+    let Ok(mut parsed) = Url::parse(url) else {
+        // An invalid URL cannot be dispatched by the concrete client. Avoid
+        // echoing it because it may still contain an accidental credential.
+        return "<invalid url>".into();
+    };
+    // URL userinfo is another credential channel. It is never useful in a
+    // diagnostic and must not survive Debug formatting.
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    let pairs: Vec<(String, String)> = parsed
+        .query_pairs()
+        .map(|(name, value)| {
+            (
+                name.to_string(),
+                if is_sensitive_name(&name) {
+                    "***".into()
+                } else {
+                    value.to_string()
+                },
+            )
+        })
+        .collect();
+    if !pairs.is_empty() {
+        let mut query = parsed.query_pairs_mut();
+        query.clear();
+        query.extend_pairs(pairs.iter().map(|(name, value)| (&**name, &**value)));
+    }
+    parsed.into()
+}
+
+fn redacted_json(value: &Value) -> Value {
+    match value {
+        Value::Array(values) => Value::Array(values.iter().map(redacted_json).collect()),
+        Value::Object(values) => Value::Object(
+            values
+                .iter()
+                .map(|(name, value)| {
+                    (
+                        name.clone(),
+                        if is_sensitive_name(name) {
+                            Value::String("***".into())
+                        } else {
+                            redacted_json(value)
+                        },
+                    )
+                })
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+#[cfg(feature = "http")]
+#[derive(Clone, Debug)]
+pub struct ReqwestHttpClient {
+    client: reqwest::Client,
+}
+
+#[cfg(feature = "http")]
+impl ReqwestHttpClient {
+    pub fn new() -> Result<Self, WebSearchError> {
+        let client = reqwest::Client::builder()
+            // Providers authenticate the initial request. Never follow a
+            // 307/308 (or any) redirect that could replay that credential to a
+            // different origin.
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(20))
+            .build()
+            .map_err(|error| WebSearchError::Transport(error.to_string()))?;
+        Ok(Self { client })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_debug_redacts_keys_in_headers_body_and_url() {
+        let request = HttpRequest {
+            url: "https://url-user:url-password@example.com/search?api_key=url-secret&query=public"
+                .into(),
+            headers: vec![
+                ("x-api-key".into(), "exa-secret".into()),
+                ("Authorization".into(), "Bearer auth-secret".into()),
+                ("x-auth".into(), "short-auth-secret".into()),
+                ("content-type".into(), "application/json".into()),
+            ],
+            body: serde_json::json!({
+                "api_key": "tavily-secret",
+                "nested": {
+                    "access_token": "nested-secret",
+                    "credential": "credential-secret",
+                    "query": "public",
+                },
+            }),
+        };
+
+        let debug = format!("{request:?}");
+        for secret in [
+            "url-secret",
+            "url-user",
+            "url-password",
+            "exa-secret",
+            "auth-secret",
+            "short-auth-secret",
+            "tavily-secret",
+            "nested-secret",
+            "credential-secret",
+        ] {
+            assert!(!debug.contains(secret), "debug leaked {secret}: {debug}");
+        }
+        assert!(debug.contains("***"));
+        assert!(debug.contains("public"));
+    }
+
+    #[cfg(feature = "http")]
+    #[tokio::test]
+    async fn reqwest_client_does_not_follow_cross_host_redirects_with_credentials() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_address = target.local_addr().unwrap();
+        let source = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let source_address = source.local_addr().unwrap();
+        let source_task = tokio::spawn(async move {
+            let (mut stream, _) = source.accept().await.unwrap();
+            let mut buffer = [0_u8; 2048];
+            stream.read(&mut buffer).await.unwrap();
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 307 Temporary Redirect\r\nLocation: http://{target_address}/steal\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+
+        let client = ReqwestHttpClient::new().unwrap();
+        let response = client
+            .post_json(HttpRequest {
+                url: format!("http://{source_address}/search"),
+                headers: vec![("x-api-key".into(), "not-for-the-redirect-target".into())],
+                body: serde_json::json!({ "query": "openwave" }),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.status, 307);
+        source_task.await.unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(150), target.accept())
+                .await
+                .is_err()
+        );
+    }
+}
+
+#[cfg(feature = "http")]
+#[async_trait]
+impl HttpClient for ReqwestHttpClient {
+    async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
+        use futures::StreamExt;
+
+        let mut builder = self.client.post(request.url).json(&request.body);
+        for (name, value) in request.headers {
+            builder = builder.header(name, value);
+        }
+        let response = builder
+            .send()
+            .await
+            .map_err(|error| WebSearchError::Transport(error.to_string()))?;
+        let status = response.status().as_u16();
+        let mut stream = response.bytes_stream();
+        let mut body = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| WebSearchError::Transport(error.to_string()))?;
+            if body.len().saturating_add(chunk.len()) > MAX_HTTP_RESPONSE_BYTES {
+                return Err(WebSearchError::Transport(
+                    "web search response exceeded byte limit".into(),
+                ));
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok(HttpResponse { status, body })
+    }
+}

--- a/crates/openwave-web-search/src/lib.rs
+++ b/crates/openwave-web-search/src/lib.rs
@@ -1,0 +1,31 @@
+//! Provider-neutral, bounded web search for OpenWave.
+//!
+//! This crate deliberately does not register a model tool, load credentials, or
+//! make network calls at construction time. A host explicitly resolves a
+//! provider's key from [`openwave_core::SecretProvider`], constructs an adapter,
+//! and calls [`WebSearchProvider::search`]. The same contract is therefore safe
+//! to use from a sandbox worker once that worker has an outbound-network policy.
+//!
+//! The Exa and Tavily adapters use their public HTTP APIs through the small
+//! [`HttpClient`] seam; no vendor SDK is required. `ReqwestHttpClient` is opt-in
+//! behind the `http` feature. Requests and normalized output are bounded before
+//! egress and before they can reach a model context.
+
+mod credentials;
+pub mod exa;
+mod http;
+pub mod tavily;
+mod types;
+
+pub use credentials::{WebSearchCredential, WebSearchCredentials};
+pub use exa::ExaProvider;
+#[cfg(feature = "http")]
+pub use http::ReqwestHttpClient;
+pub use http::{HttpClient, HttpRequest, HttpResponse, MAX_HTTP_RESPONSE_BYTES};
+pub use tavily::TavilyProvider;
+pub use types::{
+    SearchDomain, WebSearchError, WebSearchProvider, WebSearchProviderKind, WebSearchRequest,
+    WebSearchResponse, WebSearchResult, MAX_DOMAINS, MAX_OUTPUT_BYTES, MAX_OUTPUT_CHARS,
+    MAX_QUERY_CHARS, MAX_RESULTS, MAX_RESULT_CONTENT_CHARS, MAX_RESULT_SNIPPET_CHARS,
+    MAX_RESULT_TITLE_CHARS, MAX_RESULT_URL_BYTES,
+};

--- a/crates/openwave-web-search/src/tavily.rs
+++ b/crates/openwave-web-search/src/tavily.rs
@@ -1,0 +1,216 @@
+//! Tavily's direct `/search` adapter.
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::{
+    HttpClient, HttpRequest, WebSearchCredential, WebSearchError, WebSearchProvider,
+    WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult,
+};
+
+const TAVILY_SEARCH_URL: &str = "https://api.tavily.com/search";
+
+/// Tavily adapter backed by an injected HTTP client.
+#[derive(Clone, Debug)]
+pub struct TavilyProvider<C> {
+    client: C,
+    credential: WebSearchCredential,
+}
+
+impl<C> TavilyProvider<C> {
+    pub fn new(client: C, credential: WebSearchCredential) -> Result<Self, WebSearchError> {
+        if credential.kind() != WebSearchProviderKind::Tavily {
+            return Err(WebSearchError::NotConfigured(WebSearchProviderKind::Tavily));
+        }
+        Ok(Self { client, credential })
+    }
+}
+
+#[async_trait]
+impl<C: HttpClient> WebSearchProvider for TavilyProvider<C> {
+    fn kind(&self) -> WebSearchProviderKind {
+        WebSearchProviderKind::Tavily
+    }
+
+    async fn search(&self, request: WebSearchRequest) -> Result<WebSearchResponse, WebSearchError> {
+        request.validate()?;
+        let response = self
+            .client
+            .post_json(HttpRequest {
+                url: TAVILY_SEARCH_URL.into(),
+                headers: vec![("content-type".into(), "application/json".into())],
+                body: request_body(&request, self.credential.api_key()),
+            })
+            .await?;
+        response.ensure_bounded()?;
+        if !(200..300).contains(&response.status) {
+            return Err(WebSearchError::HttpStatus {
+                provider: self.kind(),
+                status: response.status,
+            });
+        }
+        let payload: TavilySearchResponse =
+            serde_json::from_slice(&response.body).map_err(|_| {
+                WebSearchError::InvalidResponse {
+                    provider: self.kind(),
+                }
+            })?;
+        let results = payload
+            .results
+            .into_iter()
+            .filter_map(|result| normalize_result(result).ok())
+            .collect();
+        Ok(WebSearchResponse::new(self.kind(), results))
+    }
+}
+
+fn request_body(request: &WebSearchRequest, api_key: &str) -> serde_json::Value {
+    let mut body = json!({
+        "api_key": api_key,
+        "query": request.query,
+        "max_results": request.max_results,
+        "search_depth": "basic",
+        "include_raw_content": false,
+        "include_images": false,
+    });
+    if !request.domains.is_empty() {
+        body["include_domains"] = json!(request
+            .domains
+            .iter()
+            .map(|domain| domain.as_str())
+            .collect::<Vec<_>>());
+    }
+    if let Some(start) = request.start_published_at {
+        body["start_date"] = json!(start.date_naive().to_string());
+    }
+    if let Some(end) = request.end_published_at {
+        body["end_date"] = json!(end.date_naive().to_string());
+    }
+    body
+}
+
+#[derive(Deserialize)]
+struct TavilySearchResponse {
+    results: Vec<TavilyResult>,
+}
+
+#[derive(Deserialize)]
+struct TavilyResult {
+    url: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    content: String,
+    #[serde(default)]
+    score: Option<f64>,
+    #[serde(default, rename = "published_date")]
+    published_date: Option<String>,
+}
+
+fn normalize_result(result: TavilyResult) -> Result<WebSearchResult, WebSearchError> {
+    let published_at = result
+        .published_date
+        .as_deref()
+        .and_then(parse_provider_timestamp);
+    WebSearchResult::new(
+        result.url,
+        result.title,
+        result.content.clone(),
+        Some(result.content),
+        result.score,
+        published_at,
+        None,
+        BTreeMap::new(),
+    )
+}
+
+fn parse_provider_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
+        .or_else(|| {
+            NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                .ok()
+                .and_then(|date| date.and_hms_opt(0, 0, 0))
+                .map(|value| value.and_utc())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::{HttpResponse, WebSearchCredentials};
+    use openwave_core::{AgentError, SecretProvider};
+
+    #[derive(Clone)]
+    struct FakeHttpClient {
+        request: Arc<Mutex<Option<HttpRequest>>>,
+    }
+
+    struct StaticSecrets;
+
+    #[async_trait]
+    impl SecretProvider for StaticSecrets {
+        async fn get_secret(&self, key: &str) -> openwave_core::Result<Option<String>> {
+            Ok(
+                (key == WebSearchProviderKind::Tavily.credential_key())
+                    .then(|| "tavily-key".into()),
+            )
+        }
+
+        async fn set_secret(&self, _key: &str, _value: &str) -> openwave_core::Result<()> {
+            Err(AgentError::Secret("read only test secrets".into()))
+        }
+
+        async fn delete_secret(&self, _key: &str) -> openwave_core::Result<()> {
+            Err(AgentError::Secret("read only test secrets".into()))
+        }
+    }
+
+    #[async_trait]
+    impl HttpClient for FakeHttpClient {
+        async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
+            *self.request.lock().unwrap() = Some(request);
+            Ok(HttpResponse {
+                status: 200,
+                body: br#"{"results":[{"url":"https://example.com/t","title":"Tavily","content":"bounded content","score":0.5,"published_date":"2026-01-01"}]}"#.to_vec(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_tavily_response_and_keeps_credential_out_of_headers() {
+        let credential = WebSearchCredentials::load(&StaticSecrets, WebSearchProviderKind::Tavily)
+            .await
+            .unwrap()
+            .unwrap();
+        let request = Arc::new(Mutex::new(None));
+        let provider = TavilyProvider::new(
+            FakeHttpClient {
+                request: Arc::clone(&request),
+            },
+            credential,
+        )
+        .unwrap();
+        let response = provider
+            .search(WebSearchRequest::new("openwave", 1).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.results[0].published_at.unwrap().to_rfc3339(),
+            "2026-01-01T00:00:00+00:00"
+        );
+        let sent = request.lock().unwrap();
+        let sent = sent.as_ref().unwrap();
+        assert_eq!(sent.url, TAVILY_SEARCH_URL);
+        assert_eq!(sent.body["api_key"], "tavily-key");
+        assert!(sent.headers.iter().all(|(_, value)| value != "tavily-key"));
+    }
+}

--- a/crates/openwave-web-search/src/types.rs
+++ b/crates/openwave-web-search/src/types.rs
@@ -1,0 +1,539 @@
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+
+/// Maximum Unicode scalar values accepted in a search query.
+pub const MAX_QUERY_CHARS: usize = 400;
+/// A provider request may ask for no more than this many normalized results.
+pub const MAX_RESULTS: usize = 10;
+/// A request may restrict results to no more than this many domains.
+pub const MAX_DOMAINS: usize = 20;
+/// Maximum title length preserved from a provider response.
+pub const MAX_RESULT_TITLE_CHARS: usize = 300;
+/// Maximum snippet length preserved from a provider response.
+pub const MAX_RESULT_SNIPPET_CHARS: usize = 2_000;
+/// Maximum extracted-content length preserved from a provider response.
+pub const MAX_RESULT_CONTENT_CHARS: usize = 4_000;
+/// Maximum bytes in a canonical result or image URL.
+pub const MAX_RESULT_URL_BYTES: usize = 2_048;
+/// Maximum UTF-8 bytes in a serialized normalized response.
+pub const MAX_OUTPUT_BYTES: usize = 16_000;
+/// Legacy name for the serialized response output budget.
+pub const MAX_OUTPUT_CHARS: usize = MAX_OUTPUT_BYTES;
+const MAX_DOMAIN_CHARS: usize = 253;
+const MAX_METADATA_ENTRIES: usize = 8;
+const MAX_METADATA_KEY_CHARS: usize = 64;
+const MAX_METADATA_VALUE_CHARS: usize = 256;
+
+/// A configured web-search backend. The stable string also selects its secret
+/// reference; it is intentionally not a model-controlled argument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebSearchProviderKind {
+    Exa,
+    Tavily,
+}
+
+impl WebSearchProviderKind {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Exa => "exa",
+            Self::Tavily => "tavily",
+        }
+    }
+
+    /// Stable key in the application [`SecretProvider`](openwave_core::SecretProvider).
+    #[must_use]
+    pub const fn credential_key(self) -> &'static str {
+        match self {
+            Self::Exa => "web_search.exa.api_key",
+            Self::Tavily => "web_search.tavily.api_key",
+        }
+    }
+}
+
+impl std::fmt::Display for WebSearchProviderKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// An allow-list domain. It is a host name only, never a URL or wildcard.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SearchDomain(String);
+
+impl SearchDomain {
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, WebSearchError> {
+        let value = value
+            .as_ref()
+            .trim()
+            .trim_end_matches('.')
+            .to_ascii_lowercase();
+        if value.is_empty() || value.chars().count() > MAX_DOMAIN_CHARS {
+            return Err(WebSearchError::InvalidRequest(
+                "invalid domain filter".into(),
+            ));
+        }
+        let parsed = Url::parse(&format!("https://{value}"))
+            .map_err(|_| WebSearchError::InvalidRequest("invalid domain filter".into()))?;
+        if parsed.host_str() != Some(value.as_str())
+            || parsed.path() != "/"
+            || parsed.port().is_some()
+            || value.contains('*')
+        {
+            return Err(WebSearchError::InvalidRequest(
+                "invalid domain filter".into(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::str::FromStr for SearchDomain {
+    type Err = WebSearchError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
+}
+
+/// Credential-free request passed to a configured web-search provider.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebSearchRequest {
+    pub query: String,
+    pub max_results: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub domains: Vec<SearchDomain>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_published_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_published_at: Option<DateTime<Utc>>,
+}
+
+impl WebSearchRequest {
+    pub fn new(query: impl AsRef<str>, max_results: usize) -> Result<Self, WebSearchError> {
+        let query = query.as_ref().trim();
+        if query.is_empty() || query.chars().count() > MAX_QUERY_CHARS || contains_control(query) {
+            return Err(WebSearchError::InvalidRequest("invalid query".into()));
+        }
+        if !(1..=MAX_RESULTS).contains(&max_results) {
+            return Err(WebSearchError::InvalidRequest(format!(
+                "max_results must be between 1 and {MAX_RESULTS}"
+            )));
+        }
+        let request = Self {
+            query: query.to_owned(),
+            max_results,
+            domains: Vec::new(),
+            start_published_at: None,
+            end_published_at: None,
+        };
+        request.validate()?;
+        Ok(request)
+    }
+
+    pub fn with_domains(mut self, domains: Vec<SearchDomain>) -> Result<Self, WebSearchError> {
+        if domains.len() > MAX_DOMAINS {
+            return Err(WebSearchError::InvalidRequest(format!(
+                "at most {MAX_DOMAINS} domain filters are allowed"
+            )));
+        }
+        self.domains = domains;
+        Ok(self)
+    }
+
+    pub fn with_published_between(
+        mut self,
+        start: Option<DateTime<Utc>>,
+        end: Option<DateTime<Utc>>,
+    ) -> Result<Self, WebSearchError> {
+        if start.is_some_and(|start| end.is_some_and(|end| start > end)) {
+            return Err(WebSearchError::InvalidRequest(
+                "publication start must not be after end".into(),
+            ));
+        }
+        self.start_published_at = start;
+        self.end_published_at = end;
+        Ok(self)
+    }
+
+    /// Revalidate public/deserialized fields at the egress boundary.
+    pub fn validate(&self) -> Result<(), WebSearchError> {
+        if self.query.trim().is_empty()
+            || self.query != self.query.trim()
+            || self.query.chars().count() > MAX_QUERY_CHARS
+            || contains_control(&self.query)
+        {
+            return Err(WebSearchError::InvalidRequest("invalid query".into()));
+        }
+        if !(1..=MAX_RESULTS).contains(&self.max_results) {
+            return Err(WebSearchError::InvalidRequest(format!(
+                "max_results must be between 1 and {MAX_RESULTS}"
+            )));
+        }
+        if self.domains.len() > MAX_DOMAINS
+            || self
+                .domains
+                .iter()
+                .any(|domain| SearchDomain::parse(domain.as_str()).is_err())
+        {
+            return Err(WebSearchError::InvalidRequest(
+                "invalid domain filters".into(),
+            ));
+        }
+        if self
+            .start_published_at
+            .is_some_and(|start| self.end_published_at.is_some_and(|end| start > end))
+        {
+            return Err(WebSearchError::InvalidRequest(
+                "publication start must not be after end".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// One normalized, citation-ready result. Provider-specific raw response data
+/// is deliberately omitted so it cannot leak credentials or unbounded blobs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WebSearchResult {
+    pub url: String,
+    pub title: String,
+    pub snippet: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_url: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, String>,
+}
+
+impl WebSearchResult {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        url: impl AsRef<str>,
+        title: impl AsRef<str>,
+        snippet: impl AsRef<str>,
+        content: Option<String>,
+        score: Option<f64>,
+        published_at: Option<DateTime<Utc>>,
+        image_url: Option<String>,
+        metadata: BTreeMap<String, String>,
+    ) -> Result<Self, WebSearchError> {
+        let url = canonical_http_url(url.as_ref())?;
+        let title = truncate(title.as_ref().trim(), MAX_RESULT_TITLE_CHARS);
+        let snippet = truncate(snippet.as_ref().trim(), MAX_RESULT_SNIPPET_CHARS);
+        let content = content
+            .map(|value| truncate(value.trim(), MAX_RESULT_CONTENT_CHARS))
+            .filter(|value| !value.is_empty());
+        let image_url = image_url.as_deref().map(canonical_http_url).transpose()?;
+        let score = score.filter(|value| value.is_finite());
+        let metadata = metadata
+            .into_iter()
+            .filter(|(key, value)| {
+                !key.is_empty()
+                    && key.chars().count() <= MAX_METADATA_KEY_CHARS
+                    && value.chars().count() <= MAX_METADATA_VALUE_CHARS
+            })
+            .take(MAX_METADATA_ENTRIES)
+            .collect();
+
+        Ok(Self {
+            url,
+            title,
+            snippet,
+            content,
+            score,
+            published_at,
+            image_url,
+            metadata,
+        })
+    }
+
+    fn text_len(&self) -> usize {
+        self.title.chars().count()
+            + self.snippet.chars().count()
+            + self
+                .content
+                .as_deref()
+                .map_or(0, |value| value.chars().count())
+    }
+
+    fn trim_to_text_budget(&mut self, budget: usize) {
+        let title_len = self.title.chars().count();
+        if title_len >= budget {
+            self.title = truncate(&self.title, budget);
+            self.snippet.clear();
+            self.content = None;
+            return;
+        }
+        let remaining = budget - title_len;
+        let snippet_len = self.snippet.chars().count();
+        if snippet_len >= remaining {
+            self.snippet = truncate(&self.snippet, remaining);
+            self.content = None;
+            return;
+        }
+        if let Some(content) = &self.content {
+            self.content = Some(truncate(content, remaining - snippet_len));
+        }
+    }
+}
+
+/// A fully normalized, bounded provider response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WebSearchResponse {
+    pub provider: WebSearchProviderKind,
+    pub results: Vec<WebSearchResult>,
+}
+
+impl WebSearchResponse {
+    pub fn new(provider: WebSearchProviderKind, mut results: Vec<WebSearchResult>) -> Self {
+        results.truncate(MAX_RESULTS);
+        let mut seen = std::collections::HashSet::new();
+        results.retain(|result| seen.insert(result.url.clone()));
+        let mut remaining = MAX_OUTPUT_BYTES;
+        for result in &mut results {
+            let allowed = remaining.min(result.text_len());
+            result.trim_to_text_budget(allowed);
+            remaining = remaining.saturating_sub(result.text_len());
+        }
+        results.retain(|result| !result.title.is_empty() || !result.snippet.is_empty());
+        let mut response = Self { provider, results };
+        response.enforce_output_budget();
+        response
+    }
+
+    fn enforce_output_budget(&mut self) {
+        while self.serialized_len() > MAX_OUTPUT_BYTES {
+            let excess = self.output_excess();
+            let Some(last) = self.results.last_mut() else {
+                break;
+            };
+            if let Some(key) = last.metadata.keys().next_back().cloned() {
+                last.metadata.remove(&key);
+                continue;
+            }
+            if last.image_url.take().is_some() {
+                continue;
+            }
+            if trim_string_field(&mut last.content, excess) {
+                continue;
+            }
+            if trim_required_field(&mut last.snippet, excess) {
+                continue;
+            }
+            if trim_required_field(&mut last.title, excess) {
+                continue;
+            }
+            self.results.pop();
+        }
+    }
+
+    fn serialized_len(&self) -> usize {
+        serde_json::to_vec(self).map_or(usize::MAX, |value| value.len())
+    }
+
+    fn output_excess(&self) -> usize {
+        self.serialized_len()
+            .saturating_sub(MAX_OUTPUT_BYTES)
+            .max(1)
+    }
+}
+
+/// A configured provider. Implementations must reject invalid requests before
+/// egress and return [`WebSearchResponse`] rather than provider-native JSON.
+#[async_trait]
+pub trait WebSearchProvider: Send + Sync {
+    fn kind(&self) -> WebSearchProviderKind;
+
+    async fn search(&self, request: WebSearchRequest) -> Result<WebSearchResponse, WebSearchError>;
+}
+
+#[derive(Debug, Error)]
+pub enum WebSearchError {
+    #[error("invalid web search request: {0}")]
+    InvalidRequest(String),
+    #[error("web search is not configured for {0}")]
+    NotConfigured(WebSearchProviderKind),
+    #[error("web search transport failed: {0}")]
+    Transport(String),
+    #[error("web search provider {provider} returned HTTP {status}")]
+    HttpStatus {
+        provider: WebSearchProviderKind,
+        status: u16,
+    },
+    #[error("web search provider {provider} returned an invalid response")]
+    InvalidResponse { provider: WebSearchProviderKind },
+    #[error("web search provider returned an invalid result URL")]
+    InvalidResultUrl,
+}
+
+fn canonical_http_url(value: &str) -> Result<String, WebSearchError> {
+    let mut parsed = Url::parse(value).map_err(|_| WebSearchError::InvalidResultUrl)?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return Err(WebSearchError::InvalidResultUrl);
+    }
+    parsed.set_fragment(None);
+    let canonical: String = parsed.into();
+    if canonical.len() > MAX_RESULT_URL_BYTES {
+        return Err(WebSearchError::InvalidResultUrl);
+    }
+    Ok(canonical)
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+fn contains_control(value: &str) -> bool {
+    value.chars().any(char::is_control)
+}
+
+fn trim_string_field(value: &mut Option<String>, excess: usize) -> bool {
+    let Some(current) = value else {
+        return false;
+    };
+    let trimmed = truncate_utf8_bytes(current, current.len().saturating_sub(excess));
+    if trimmed.is_empty() {
+        *value = None;
+    } else {
+        *current = trimmed;
+    }
+    true
+}
+
+fn trim_required_field(value: &mut String, excess: usize) -> bool {
+    if value.is_empty() {
+        return false;
+    }
+    *value = truncate_utf8_bytes(value, value.len().saturating_sub(excess));
+    true
+}
+
+fn truncate_utf8_bytes(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_owned();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value[..end].to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_rejects_empty_controls_and_large_values() {
+        assert!(WebSearchRequest::new("", 1).is_err());
+        assert!(WebSearchRequest::new("one\ntwo", 1).is_err());
+        assert!(WebSearchRequest::new("x".repeat(MAX_QUERY_CHARS + 1), 1).is_err());
+        assert!(WebSearchRequest::new("ok", 0).is_err());
+        assert!(WebSearchRequest::new("ok", MAX_RESULTS + 1).is_err());
+    }
+
+    #[test]
+    fn domain_filters_are_hosts_not_urls_or_wildcards() {
+        assert_eq!(
+            SearchDomain::parse("Docs.Example.com.").unwrap().as_str(),
+            "docs.example.com"
+        );
+        assert!(SearchDomain::parse("https://example.com").is_err());
+        assert!(SearchDomain::parse("*.example.com").is_err());
+        assert!(SearchDomain::parse("example.com/path").is_err());
+    }
+
+    #[test]
+    fn response_deduplicates_and_trims_its_total_output() {
+        let result = |url: &str| {
+            WebSearchResult::new(
+                url,
+                "x".repeat(MAX_RESULT_TITLE_CHARS),
+                "x".repeat(MAX_RESULT_SNIPPET_CHARS),
+                Some("x".repeat(MAX_RESULT_CONTENT_CHARS)),
+                Some(f64::NAN),
+                None,
+                None,
+                BTreeMap::new(),
+            )
+            .unwrap()
+        };
+        let response = WebSearchResponse::new(
+            WebSearchProviderKind::Exa,
+            (0..MAX_RESULTS)
+                .map(|index| result(&format!("https://example.com/{index}#fragment")))
+                .chain(std::iter::once(result("https://example.com/0")))
+                .collect(),
+        );
+        assert!(response.results.len() <= MAX_RESULTS);
+        assert!(!response.results.is_empty());
+        assert!(response.results.iter().all(|result| result.score.is_none()));
+        assert!(
+            response
+                .results
+                .iter()
+                .map(WebSearchResult::text_len)
+                .sum::<usize>()
+                <= MAX_OUTPUT_BYTES
+        );
+        assert!(serde_json::to_vec(&response).unwrap().len() <= MAX_OUTPUT_BYTES);
+        assert_eq!(response.results[0].url, "https://example.com/0");
+    }
+
+    #[test]
+    fn long_valid_urls_are_rejected_and_all_serialized_fields_fit_the_budget() {
+        let long_url = format!("https://example.com/{}", "a".repeat(MAX_RESULT_URL_BYTES));
+        assert!(WebSearchResult::new(
+            long_url,
+            "title",
+            "snippet",
+            None,
+            None,
+            None,
+            None,
+            BTreeMap::new(),
+        )
+        .is_err());
+
+        let response = WebSearchResponse::new(
+            WebSearchProviderKind::Tavily,
+            vec![WebSearchResult::new(
+                "https://example.com/short",
+                "\"".repeat(MAX_RESULT_TITLE_CHARS),
+                "\"".repeat(MAX_RESULT_SNIPPET_CHARS),
+                Some("\"".repeat(MAX_RESULT_CONTENT_CHARS)),
+                None,
+                None,
+                Some("https://example.com/image".into()),
+                (0..MAX_METADATA_ENTRIES)
+                    .map(|index| {
+                        (
+                            format!("key-{index}"),
+                            "\"".repeat(MAX_METADATA_VALUE_CHARS),
+                        )
+                    })
+                    .collect(),
+            )
+            .unwrap()],
+        );
+        assert!(serde_json::to_vec(&response).unwrap().len() <= MAX_OUTPUT_BYTES);
+    }
+}

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -12,9 +12,9 @@ libraries.
                                └────── openwave-server
                                             │
       libraries          openwave-mcp   openwave-retrieval   openwave-router
-                         openwave-host-broker                    │
-                               │             │                   │
-                               └─────────────┴───────────────────┘
+                         openwave-web-search   openwave-host-broker │
+                               │             │              │      │
+                               └─────────────┴──────────────┴──────┘
                                             │
       the seam                         openwave-core
 
@@ -112,6 +112,23 @@ lexical+dense search, reranking, and grounded citations behind a `VectorStore`
 seam with in-memory and durable embedded LanceDB backends. Durable source
 revisions and Parse→Index jobs are coordinated by `openwave-core` and
 `openwave-server`.
+
+**Depends on:** `openwave-core`.
+
+## `openwave-web-search` — provider-neutral web search 🟢
+
+The bounded request/result contract and direct HTTP adapters for Exa and
+Tavily. It is intentionally separate from both the model loop and the tool
+registry: loading a credential or constructing an adapter performs no egress,
+and calling search requires an explicit host-owned HTTP client. API keys are
+resolved only through `SecretProvider` under fixed provider keys, never from a
+model argument or persisted tool-call payload. The optional `http` feature
+provides a timeout- and response-size-bounded `reqwest` client; hosts may supply
+their own proxy, allow-list, audit, or test client through the same seam.
+
+No model-facing `web_search` tool is registered yet. The follow-on slice must
+wire provider selection and outbound-network policy at the sandbox/foreground
+execution boundary.
 
 **Depends on:** `openwave-core`.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -78,8 +78,8 @@ database tools, and recursive fleets remain deferred.
 
 ## Web search
 
-Web search should be a provider-neutral crate rather than HTTP code embedded in
-the core loop:
+Web search now has a provider-neutral `openwave-web-search` crate rather than
+HTTP code embedded in the core loop:
 
 ```text
 WebSearchProvider
@@ -98,6 +98,13 @@ WebSearchTool
 ├── bounded output and citations
 └── optional durable web-document ingestion
 ```
+
+The first slice supplies the normalized bounded contract, fixed secret keys,
+and direct Exa/Tavily adapters through an injected HTTP seam. It does **not**
+register `WebSearchTool` or grant any worker network access. Constructing an
+adapter is inert; only an explicit `search` call can send a request. The next
+slice must make a host-owned provider-selection and outbound-domain policy
+available to the worker that is allowed to invoke it.
 
 The normalized contract should cover query text, optional date/domain filters,
 bounded result count, canonical URL, title, snippet or extracted text, rank or


### PR DESCRIPTION
## Summary

- add a provider-neutral web-search crate with Exa and Tavily adapters
- keep credentials in fixed secret-provider keys and make HTTP transport opt-in
- bound normalized output and harden redirect and debug-redaction behavior

## Validation

- cargo test -p openwave-web-search --all-features --locked
- bw dev lint --rust --check