### PR TITLE
Add web search host policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5937,6 +5937,7 @@ dependencies = [
  "openwave-core",
  "openwave-retrieval",
  "openwave-router",
+ "openwave-web-search",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools", "keychain", "blob-fs"] }
 openwave-router = { path = "../openwave-router" }
 openwave-retrieval = { path = "../openwave-retrieval", features = ["vec-lance"] }
+openwave-web-search = { path = "../openwave-web-search", features = ["http"] }
 axum = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "sync", "macros", "time"] }
 tower-http = { version = "0.7", features = ["cors"] }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -29,6 +29,8 @@ mod routes;
 mod sandbox_agent_run_worker;
 mod state;
 mod turn_worker;
+/// Host-owned, inert web-search configuration and provider selection.
+pub mod web_search;
 
 use std::fs::{OpenOptions, TryLockError};
 use std::net::{Ipv4Addr, SocketAddr};
@@ -130,6 +132,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::search_project_documents),
         )
         .route("/models", get(routes::list_models))
+        .route(
+            "/web-search",
+            get(routes::get_web_search_config).put(routes::put_web_search_config),
+        )
         .route("/providers", get(routes::list_providers))
         .route(
             "/providers/{kind}",

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -23,6 +23,7 @@ use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
 use crate::state::AppState;
+use crate::web_search::{self, WebSearchConfigInfo, WebSearchConfigUpdate};
 
 mod client_execution;
 mod document;
@@ -104,6 +105,27 @@ pub async fn put_settings(
         model: read_model(&*state.store).await?,
         has_api_key: has_api_key(&*state.secrets).await,
     }))
+}
+
+/// `GET /web-search` — read host-owned web-search selection and readiness.
+/// No model tool is registered by this endpoint.
+pub async fn get_web_search_config(
+    State(state): State<AppState>,
+) -> Result<Json<WebSearchConfigInfo>, ServerError> {
+    Ok(Json(
+        web_search::config_info(&*state.store, &*state.secrets).await?,
+    ))
+}
+
+/// `PUT /web-search` — select a fixed provider and bounded timeout. Provider
+/// credentials remain in the OS keychain under fixed provider-owned names.
+pub async fn put_web_search_config(
+    State(state): State<AppState>,
+    Json(body): Json<WebSearchConfigUpdate>,
+) -> Result<Json<WebSearchConfigInfo>, ServerError> {
+    Ok(Json(
+        web_search::update_config(&*state.store, &*state.secrets, body).await?,
+    ))
 }
 
 /// The configured model, if any.

--- a/crates/openwave-server/src/web_search.rs
+++ b/crates/openwave-server/src/web_search.rs
@@ -1,0 +1,346 @@
+//! Host-owned configuration and provider selection for web search.
+//!
+//! This module deliberately stops before model-tool registration or worker
+//! execution. A selected provider only becomes usable when a future host
+//! component explicitly asks [`resolve_provider`] for it. Provider endpoints
+//! are fixed in `openwave-web-search`; this config never accepts an endpoint,
+//! a secret reference, or a model-controlled network target.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use openwave_core::{Result, SecretProvider, Store};
+use openwave_web_search::{
+    ExaProvider, ReqwestHttpClient, TavilyProvider, WebSearchCredentials, WebSearchProvider,
+    WebSearchProviderKind,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::error::ServerError;
+
+/// Store key for the non-secret web-search configuration.
+const WEB_SEARCH_SETTING: &str = "web_search";
+/// Default end-to-end request timeout for a configured provider.
+pub const DEFAULT_TIMEOUT_MS: u64 = 20_000;
+/// Lower bound to avoid a configuration that cannot complete a normal TLS
+/// request, while still keeping retries and recovery responsive.
+pub const MIN_TIMEOUT_MS: u64 = 1_000;
+/// Upper bound on one provider request. Long-running work must be expressed as
+/// durable worker state rather than an unbounded HTTP call.
+pub const MAX_TIMEOUT_MS: u64 = 60_000;
+
+/// Non-secret host configuration. `provider: None` is the safe default: no
+/// credential lookup and no possible outbound request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebSearchConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<WebSearchProviderKind>,
+    #[serde(default = "default_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+impl Default for WebSearchConfig {
+    fn default() -> Self {
+        Self {
+            provider: None,
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+        }
+    }
+}
+
+impl WebSearchConfig {
+    fn validate(&self) -> std::result::Result<(), ServerError> {
+        if !(MIN_TIMEOUT_MS..=MAX_TIMEOUT_MS).contains(&self.timeout_ms) {
+            return Err(ServerError::bad_request(format!(
+                "web search timeout_ms must be between {MIN_TIMEOUT_MS} and {MAX_TIMEOUT_MS}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+const fn default_timeout_ms() -> u64 {
+    DEFAULT_TIMEOUT_MS
+}
+
+/// Public state returned by the local API. It intentionally reports only
+/// selection and credential presence — key material never crosses the secret
+/// boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WebSearchConfigInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<WebSearchProviderKind>,
+    pub timeout_ms: u64,
+    pub has_credential: bool,
+}
+
+/// Partial update accepted by `PUT /web-search`. An omitted `provider` leaves
+/// selection unchanged; an explicit `null` disables web search.
+#[derive(Debug, Deserialize)]
+pub struct WebSearchConfigUpdate {
+    #[serde(default, deserialize_with = "double_option")]
+    pub provider: Option<Option<WebSearchProviderKind>>,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+}
+
+fn double_option<'de, D, T>(deserializer: D) -> std::result::Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    serde::Deserialize::deserialize(deserializer).map(Some)
+}
+
+/// Read configured host policy. Malformed legacy/manual data fails closed.
+pub async fn read_config(store: &dyn Store) -> Result<WebSearchConfig> {
+    let config: WebSearchConfig = store
+        .get_setting(WEB_SEARCH_SETTING)
+        .await?
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default();
+    // Store contents may be hand-edited or left by an interrupted development
+    // build. Invalid timeout policy must not leave a selected provider usable.
+    if config.validate().is_err() {
+        return Ok(WebSearchConfig::default());
+    }
+    Ok(config)
+}
+
+async fn write_config(store: &dyn Store, config: &WebSearchConfig) -> Result<()> {
+    store
+        .set_setting(WEB_SEARCH_SETTING, &serde_json::to_value(config)?)
+        .await
+}
+
+/// Return the safe public representation of the current configuration.
+pub async fn config_info(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+) -> Result<WebSearchConfigInfo> {
+    let config = read_config(store).await?;
+    let has_credential = match config.provider {
+        Some(provider) => WebSearchCredentials::load(secrets, provider)
+            .await
+            .ok()
+            .flatten()
+            .is_some(),
+        None => false,
+    };
+    Ok(WebSearchConfigInfo {
+        provider: config.provider,
+        timeout_ms: config.timeout_ms,
+        has_credential,
+    })
+}
+
+/// Apply a non-secret host-policy update and return its public view.
+pub async fn update_config(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    update: WebSearchConfigUpdate,
+) -> std::result::Result<WebSearchConfigInfo, ServerError> {
+    let mut config = read_config(store).await?;
+    if let Some(provider) = update.provider {
+        config.provider = provider;
+    }
+    if let Some(timeout_ms) = update.timeout_ms {
+        config.timeout_ms = timeout_ms;
+    }
+    config.validate()?;
+    write_config(store, &config).await?;
+    config_info(store, secrets).await.map_err(Into::into)
+}
+
+/// Resolve the explicitly selected, credentialed provider for a future host
+/// worker. The returned provider is inert until its `search` method is called.
+///
+/// Secret resolution failures are intentionally projected to one generic
+/// message so keychain implementation details cannot escape through logs or
+/// local API responses. A missing key fails closed as `Ok(None)`.
+pub async fn resolve_provider(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, ServerError> {
+    let config = read_config(store).await?;
+    config.validate()?;
+    let Some(kind) = config.provider else {
+        return Ok(None);
+    };
+    let credential = WebSearchCredentials::load(secrets, kind)
+        .await
+        .map_err(|_| ServerError::internal("web search configuration is unavailable"))?;
+    let Some(credential) = credential else {
+        return Ok(None);
+    };
+    let client = ReqwestHttpClient::with_timeout(Duration::from_millis(config.timeout_ms))
+        .map_err(|_| ServerError::internal("web search configuration is unavailable"))?;
+    let provider: Arc<dyn WebSearchProvider> = match kind {
+        WebSearchProviderKind::Exa => Arc::new(
+            ExaProvider::new(client, credential)
+                .map_err(|_| ServerError::internal("web search configuration is unavailable"))?,
+        ),
+        WebSearchProviderKind::Tavily => Arc::new(
+            TavilyProvider::new(client, credential)
+                .map_err(|_| ServerError::internal("web search configuration is unavailable"))?,
+        ),
+    };
+    Ok(Some(provider))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use openwave_core::{AgentError, DbStore};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct TestSecrets(Mutex<HashMap<String, String>>);
+
+    #[async_trait]
+    impl SecretProvider for TestSecrets {
+        async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+            Ok(self.0.lock().unwrap().get(key).cloned())
+        }
+
+        async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
+            self.0
+                .lock()
+                .unwrap()
+                .insert(key.to_owned(), value.to_owned());
+            Ok(())
+        }
+
+        async fn delete_secret(&self, key: &str) -> Result<()> {
+            self.0.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    async fn test_store() -> (DbStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("web-search.db").display()
+        ))
+        .await
+        .unwrap();
+        (store, dir)
+    }
+
+    #[test]
+    fn default_is_disabled_and_timeout_is_bounded() {
+        let config = WebSearchConfig::default();
+        assert_eq!(config.provider, None);
+        assert_eq!(config.timeout_ms, DEFAULT_TIMEOUT_MS);
+        assert!(config.validate().is_ok());
+        assert!(WebSearchConfig {
+            provider: Some(WebSearchProviderKind::Exa),
+            timeout_ms: MIN_TIMEOUT_MS - 1,
+        }
+        .validate()
+        .is_err());
+        assert!(WebSearchConfig {
+            provider: Some(WebSearchProviderKind::Tavily),
+            timeout_ms: MAX_TIMEOUT_MS + 1,
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn selection_has_no_endpoint_or_secret_reference_field() {
+        let json = serde_json::to_value(WebSearchConfig {
+            provider: Some(WebSearchProviderKind::Exa),
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+        })
+        .unwrap();
+        assert_eq!(json["provider"], "exa");
+        assert!(json.get("endpoint").is_none());
+        assert!(json.get("credential").is_none());
+    }
+
+    #[test]
+    fn unsupported_provider_cannot_deserialize_into_selection() {
+        let config = serde_json::from_value::<WebSearchConfig>(serde_json::json!({
+            "provider": "untrusted_proxy",
+            "timeout_ms": DEFAULT_TIMEOUT_MS,
+        }));
+        assert!(config.is_err());
+    }
+
+    #[tokio::test]
+    async fn selected_provider_without_a_fixed_key_fails_closed() {
+        let (store, _dir) = test_store().await;
+        let secrets = TestSecrets::default();
+        let update = update_config(
+            &store,
+            &secrets,
+            WebSearchConfigUpdate {
+                provider: Some(Some(WebSearchProviderKind::Exa)),
+                timeout_ms: Some(MIN_TIMEOUT_MS),
+            },
+        )
+        .await;
+        let info = match update {
+            Ok(info) => info,
+            Err(_) => panic!("valid local web-search configuration was rejected"),
+        };
+
+        assert_eq!(info.provider, Some(WebSearchProviderKind::Exa));
+        assert!(!info.has_credential);
+        assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
+        assert!(secrets.0.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn disabled_configuration_does_not_even_read_a_secret() {
+        struct FailingSecrets;
+
+        #[async_trait]
+        impl SecretProvider for FailingSecrets {
+            async fn get_secret(&self, _key: &str) -> Result<Option<String>> {
+                Err(AgentError::Secret("must not be read".into()))
+            }
+
+            async fn set_secret(&self, _key: &str, _value: &str) -> Result<()> {
+                unreachable!()
+            }
+
+            async fn delete_secret(&self, _key: &str) -> Result<()> {
+                unreachable!()
+            }
+        }
+
+        let (store, _dir) = test_store().await;
+        let secrets = FailingSecrets;
+        let info = config_info(&store, &secrets).await.unwrap();
+        assert_eq!(info.provider, None);
+        assert!(!info.has_credential);
+        assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
+    }
+
+    #[tokio::test]
+    async fn invalid_persisted_timeout_reverts_to_disabled_policy() {
+        let (store, _dir) = test_store().await;
+        store
+            .set_setting(
+                WEB_SEARCH_SETTING,
+                &serde_json::json!({
+                    "provider": "tavily",
+                    "timeout_ms": MAX_TIMEOUT_MS + 1,
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            read_config(&store).await.unwrap(),
+            WebSearchConfig::default()
+        );
+    }
+}

--- a/crates/openwave-web-search/src/http.rs
+++ b/crates/openwave-web-search/src/http.rs
@@ -140,17 +140,30 @@ pub struct ReqwestHttpClient {
 
 #[cfg(feature = "http")]
 impl ReqwestHttpClient {
-    pub fn new() -> Result<Self, WebSearchError> {
+    /// Build a client with one bounded end-to-end request timeout.
+    ///
+    /// The caller owns the policy for the value. Redirects stay disabled for
+    /// every timeout so credentials are never replayed to another origin.
+    pub fn with_timeout(timeout: std::time::Duration) -> Result<Self, WebSearchError> {
+        if timeout.is_zero() {
+            return Err(WebSearchError::Transport(
+                "web search timeout must be greater than zero".into(),
+            ));
+        }
         let client = reqwest::Client::builder()
             // Providers authenticate the initial request. Never follow a
             // 307/308 (or any) redirect that could replay that credential to a
             // different origin.
             .redirect(reqwest::redirect::Policy::none())
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(20))
+            .connect_timeout(timeout.min(std::time::Duration::from_secs(10)))
+            .timeout(timeout)
             .build()
             .map_err(|error| WebSearchError::Transport(error.to_string()))?;
         Ok(Self { client })
+    }
+
+    pub fn new() -> Result<Self, WebSearchError> {
+        Self::with_timeout(std::time::Duration::from_secs(20))
     }
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,8 @@ Project documentation, versioned alongside the code.
   bounded sandbox scheduling plan.
 - [Tool architecture and roadmap](tools.md) — the current tool surface,
   foreground/sandbox split, provider boundaries, and web-search plan.
+- [Web search configuration](web-search.md) — the local host-owned Exa/Tavily
+  selection boundary and its current no-tool state.
 
 More to come as the product surfaces land (running locally, API reference, and
 writing tools).

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -126,9 +126,10 @@ model argument or persisted tool-call payload. The optional `http` feature
 provides a timeout- and response-size-bounded `reqwest` client; hosts may supply
 their own proxy, allow-list, audit, or test client through the same seam.
 
-No model-facing `web_search` tool is registered yet. The follow-on slice must
-wire provider selection and outbound-network policy at the sandbox/foreground
-execution boundary.
+`openwave-server` owns an explicit disabled-by-default Exa/Tavily selection
+and bounded request timeout, but has not connected it to a model-visible tool
+or worker. The follow-on slice must attach that host policy to the sandbox
+execution boundary and define its outbound-domain policy.
 
 **Depends on:** `openwave-core`.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -100,11 +100,14 @@ WebSearchTool
 ```
 
 The first slice supplies the normalized bounded contract, fixed secret keys,
-and direct Exa/Tavily adapters through an injected HTTP seam. It does **not**
-register `WebSearchTool` or grant any worker network access. Constructing an
-adapter is inert; only an explicit `search` call can send a request. The next
-slice must make a host-owned provider-selection and outbound-domain policy
-available to the worker that is allowed to invoke it.
+and direct Exa/Tavily adapters through an injected HTTP seam. The server now
+also owns a disabled-by-default provider selection and a 1–60 second request
+timeout at `GET`/`PUT /web-search`. That setting has no endpoint or credential
+reference, returns only whether the selected fixed key is present, and does not
+construct or call a provider. It does **not** register `WebSearchTool` or grant
+any worker network access. Constructing an adapter is inert; only an explicit
+`search` call can send a request. A later execution slice must still attach the
+host policy to a sandbox worker and define its outbound-domain policy.
 
 The normalized contract should cover query text, optional date/domain filters,
 bounded result count, canonical URL, title, snippet or extracted text, rank or

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -1,0 +1,44 @@
+# Web search configuration
+
+OpenWave has a bounded `openwave-web-search` library for direct Exa and Tavily
+search. It is intentionally separate from the model tool registry and agent
+workers. At this stage, configuring web search does not give an agent network
+access and does not cause any outbound request.
+
+## Local API
+
+The loopback API exposes a bearer-protected host policy at `/web-search`.
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /web-search` | Read the selected provider, timeout, and whether its fixed key is available. |
+| `PUT /web-search` | Select `exa`, `tavily`, or `null` to disable; optionally set the timeout. |
+
+Example:
+
+```json
+{
+  "provider": "exa",
+  "timeout_ms": 20000
+}
+```
+
+Timeouts must be between 1,000 and 60,000 milliseconds. There is no endpoint,
+proxy URL, arbitrary secret reference, or API-key field in this API. The Exa
+and Tavily adapters own their fixed HTTPS endpoints, disable redirects, and
+bound request input and retained response output.
+
+The response never contains a credential. It reports only `has_credential` for
+the currently selected provider. Keys are read from the OS keychain through
+`SecretProvider` under the fixed names `web_search.exa.api_key` and
+`web_search.tavily.api_key`. A missing key or disabled selection fails closed:
+there is no provider to invoke.
+
+## Current boundary
+
+`openwave-server::web_search::resolve_provider` is the host-only construction
+seam for a future approved execution worker. It is inert until that caller
+invokes `search`; no route invokes it. No model-visible `web_search` tool or
+sandbox tool loop exists yet. The next slice must explicitly attach this host
+policy to a sandbox worker, define an outbound-domain policy, and preserve the
+turn/checkpoint idempotency guarantees before search can be used by an agent.


### PR DESCRIPTION
## Summary

- add disabled-by-default local Exa/Tavily provider selection and bounded request timeout
- keep credentials in fixed keychain entries and return only readiness metadata
- document the inert policy boundary ahead of sandbox tool wiring

## Validation

- cargo test -p openwave-server web_search --locked
- bw dev lint --rust --check
- adversarial review