### PR TITLE
Add desktop agent activity panel

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -37,6 +37,8 @@ type Msg =
   | { id: string; role: "error"; text: string };
 
 let msgSeq = 0;
+const MAX_RECENT_TERMINAL_SANDBOX_RUNS = 2;
+
 function nextId(): string {
   msgSeq += 1;
   return `m${msgSeq}`;
@@ -748,7 +750,7 @@ export default function App() {
                 if (e.key === "Enter") e.currentTarget.blur();
               }}
             />
-            <AgentRunStatusSurface
+            <AgentActivityPanel
               runs={agentRuns}
               loading={agentRunsLoading}
               error={agentRunsError}
@@ -876,7 +878,7 @@ function withoutConnectionState(status: string): string {
   return status.replace(/ · (?:live|reconnecting)$/, "");
 }
 
-function AgentRunStatusSurface({
+function AgentActivityPanel({
   runs,
   loading,
   error,
@@ -888,56 +890,91 @@ function AgentRunStatusSurface({
   onRetry: () => void;
 }) {
   if (loading) {
-    return <div className="agent-runs-state">Loading agent state…</div>;
+    return <div className="agent-activity-state">Loading activity…</div>;
   }
 
   if (error) {
     return (
-      <div className="agent-runs-state is-error" title={error}>
-        Agent state unavailable
-        <button type="button" className="agent-runs-retry" onClick={onRetry}>
+      <div className="agent-activity-state is-error" role="status">
+        Activity unavailable
+        <button type="button" className="agent-activity-retry" onClick={onRetry}>
           Retry
         </button>
       </div>
     );
   }
 
-  if (runs.length === 0) {
-    return <div className="agent-runs-state">No agent runs yet</div>;
-  }
-
   const foreground = runs.find((run) => run.execution === "foreground");
   const sandboxes = runs.filter((run) => run.execution === "sandbox");
+  if (!foreground && sandboxes.length === 0) return null;
+
+  const activeSandboxes = sandboxes.filter((run) =>
+    isActiveAgentRunStatus(run.status),
+  );
+  const terminalSandboxes = sandboxes
+    .filter((run) => !isActiveAgentRunStatus(run.status))
+    .sort((left, right) => right.updated_at.localeCompare(left.updated_at));
+  const recentTerminalSandboxes = terminalSandboxes.slice(
+    0,
+    MAX_RECENT_TERMINAL_SANDBOX_RUNS,
+  );
+  const hiddenTerminalCount = terminalSandboxes.length - recentTerminalSandboxes.length;
+  const active = runs.some((run) => isActiveAgentRunStatus(run.status));
   return (
-    <div className="agent-runs" aria-label="Agent execution state">
-      <span className="agent-runs-label">Agents</span>
-      {foreground ? (
-        <AgentRunPill run={foreground} label="Conversation" />
-      ) : (
-        <span className="agent-run-empty">Conversation unavailable</span>
+    <section
+      className="agent-activity"
+      aria-label="Agent activity"
+      aria-live={active ? "polite" : "off"}
+    >
+      <div className="agent-activity-heading">
+        <span>Activity</span>
+        <span className="agent-activity-summary">
+          {activeSandboxes.length > 0
+            ? `${activeSandboxes.length} background ${activeSandboxes.length === 1 ? "task" : "tasks"}`
+            : recentTerminalSandboxes.length > 0
+              ? "Recent background work"
+              : "No background work"}
+        </span>
+      </div>
+      <ul className="agent-activity-list">
+        {foreground && <AgentActivityItem run={foreground} label="Conversation" />}
+        {activeSandboxes.map((run, index) => (
+          <AgentActivityItem
+            key={run.id}
+            run={run}
+            label={`Background task ${index + 1}`}
+          />
+        ))}
+        {recentTerminalSandboxes.map((run, index) => (
+          <AgentActivityItem
+            key={run.id}
+            run={run}
+            label={`Recent background task ${index + 1}`}
+          />
+        ))}
+      </ul>
+      {hiddenTerminalCount > 0 && (
+        <p className="agent-activity-history">
+          {hiddenTerminalCount} earlier {hiddenTerminalCount === 1 ? "result" : "results"}
+        </p>
       )}
-      {sandboxes.length === 0 ? (
-        <span className="agent-run-empty">No background work</span>
-      ) : (
-        sandboxes.map((run, index) => (
-          <AgentRunPill key={run.id} run={run} label={`Background ${index + 1}`} />
-        ))
-      )}
-    </div>
+    </section>
   );
 }
 
-function AgentRunPill({ run, label }: { run: AgentRun; label: string }) {
+function AgentActivityItem({ run, label }: { run: AgentRun; label: string }) {
   const status = readableAgentRunStatus(run.status);
-  const detail = run.last_error_detail || run.last_error_code || undefined;
   return (
-    <span
-      className={`agent-run-pill is-${run.status}`}
-      title={detail ? `${label}: ${status} — ${detail}` : `${label}: ${status}`}
-    >
-      <span>{label}</span>
+    <li className={`agent-activity-item is-${run.status}`}>
+      <span className="agent-activity-indicator" aria-hidden="true" />
+      <span className="agent-activity-item-copy">
+        <span>{label}</span>
+        <span className="agent-activity-detail">
+          {agentRunStatusDescription(run.status)}
+        </span>
+      </span>
       <strong>{status}</strong>
-    </span>
+    </li>
   );
 }
 
@@ -949,6 +986,35 @@ function readableAgentRunStatus(status: AgentRun["status"]): string {
       return "stopping";
     default:
       return status;
+  }
+}
+
+function isActiveAgentRunStatus(status: AgentRun["status"]): boolean {
+  return ["active", "queued", "running", "cancelling", "waiting", "retry_wait"].includes(
+    status,
+  );
+}
+
+function agentRunStatusDescription(status: AgentRun["status"]): string {
+  switch (status) {
+    case "active":
+      return "Ready for this conversation";
+    case "queued":
+      return "Queued to start";
+    case "running":
+      return "Working in the background";
+    case "cancelling":
+      return "Stopping";
+    case "waiting":
+      return "Waiting to continue";
+    case "retry_wait":
+      return "Waiting to retry";
+    case "completed":
+      return "Finished";
+    case "failed":
+      return "Could not finish";
+    case "cancelled":
+      return "Stopped";
   }
 }
 

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -282,83 +282,128 @@ button {
   font-size: 0.8rem;
 }
 
-.agent-runs,
-.agent-runs-state {
-  display: flex;
-  min-width: 0;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.4rem;
-  margin-left: auto;
-  font-size: 0.75rem;
-}
-
-.agent-runs-label {
-  color: var(--muted);
-  font-size: 0.68rem;
-  font-weight: 650;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.agent-run-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.32rem;
-  max-width: 15rem;
-  overflow: hidden;
+.agent-activity {
+  display: grid;
+  width: min(100%, 42rem);
+  gap: 0.5rem;
+  padding: 0.65rem 0.75rem;
   border: 1px solid var(--line);
-  border-radius: 999px;
-  padding: 0.19rem 0.45rem;
-  background: var(--bg-elevated);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--bg-elevated) 78%, var(--sidebar));
+}
+
+.agent-activity-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  color: var(--ink);
+  font-size: 0.78rem;
+  font-weight: 650;
+}
+
+.agent-activity-summary,
+.agent-activity-detail,
+.agent-activity-history {
   color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 450;
+}
+
+.agent-activity-list {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.agent-activity-history {
+  margin: 0;
+  padding-top: 0.15rem;
+  border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+}
+
+.agent-activity-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+  padding: 0.3rem 0;
+  border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+  font-size: 0.77rem;
+}
+
+.agent-activity-item-copy {
+  display: grid;
+  min-width: 0;
+}
+
+.agent-activity-item-copy > span:first-child,
+.agent-activity-item strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.agent-run-pill strong {
-  overflow: hidden;
-  color: var(--ink);
-  font-weight: 600;
-  text-overflow: ellipsis;
+.agent-activity-item strong {
+  color: var(--muted);
+  font-size: 0.71rem;
+  font-weight: 620;
+  text-transform: capitalize;
 }
 
-.agent-run-pill.is-active,
-.agent-run-pill.is-completed {
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+.agent-activity-indicator {
+  width: 0.5rem;
+  height: 0.5rem;
+  border: 1px solid color-mix(in srgb, var(--muted) 45%, var(--line));
+  border-radius: 999px;
+  background: var(--bg-elevated);
 }
 
-.agent-run-pill.is-queued,
-.agent-run-pill.is-running,
-.agent-run-pill.is-waiting,
-.agent-run-pill.is-retry_wait,
-.agent-run-pill.is-cancelling {
-  border-color: color-mix(in srgb, var(--ink) 24%, var(--line));
-  background: var(--sidebar-active);
+.agent-activity-item.is-active .agent-activity-indicator,
+.agent-activity-item.is-running .agent-activity-indicator {
+  border-color: var(--accent);
+  background: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
-.agent-run-pill.is-failed,
-.agent-run-pill.is-cancelled {
-  border-color: color-mix(in srgb, var(--danger) 38%, var(--line));
+.agent-activity-item.is-queued .agent-activity-indicator,
+.agent-activity-item.is-waiting .agent-activity-indicator,
+.agent-activity-item.is-retry_wait .agent-activity-indicator,
+.agent-activity-item.is-cancelling .agent-activity-indicator {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  background: color-mix(in srgb, var(--accent) 38%, var(--bg-elevated));
 }
 
-.agent-run-pill.is-failed strong,
-.agent-run-pill.is-cancelled strong,
-.agent-runs-state.is-error {
+.agent-activity-item.is-failed .agent-activity-indicator {
+  border-color: var(--danger);
+  background: var(--danger);
+}
+
+.agent-activity-item.is-completed .agent-activity-indicator {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  background: color-mix(in srgb, var(--accent) 26%, var(--bg-elevated));
+}
+
+.agent-activity-state {
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+.agent-activity-state.is-error {
   color: var(--danger);
 }
 
-.agent-run-empty,
-.agent-runs-state {
-  color: var(--muted);
-}
-
-.agent-runs-retry {
+.agent-activity-retry {
+  margin-left: 0.35rem;
   border: 0;
   padding: 0;
   color: inherit;
   background: transparent;
-  font-size: inherit;
-  font-weight: 600;
+  font: inherit;
+  font-weight: 650;
   text-decoration: underline;
 }
 
@@ -650,10 +695,8 @@ button {
     display: none;
   }
 
-  .agent-runs,
-  .agent-runs-state {
+  .agent-activity {
     width: 100%;
-    margin-left: 0;
   }
 
   .composer {


### PR DESCRIPTION
## Summary

- replace compact agent status pills with an accessible conversation activity panel
- show active background work and a bounded recent terminal history
- keep the renderer on the existing safe agent-run snapshot contract

## Validation

- pnpm --dir crates/openwave-desktop/ui build
- git diff --check
- adversarial review