### PR TITLE
Manage web search credentials

### DIFF
--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -60,6 +60,7 @@ pub use error::ServerError;
 pub use state::AppState;
 
 const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_WEB_SEARCH_CREDENTIAL_BODY_BYTES: usize = 16 * 1024;
 
 /// Build the router: unauthenticated health check plus the token-guarded API.
 pub fn app(state: AppState) -> Router {
@@ -135,6 +136,16 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/web-search",
             get(routes::get_web_search_config).put(routes::put_web_search_config),
+        )
+        .route(
+            "/web-search/credentials",
+            get(routes::get_web_search_credentials),
+        )
+        .route(
+            "/web-search/credentials/{provider}",
+            axum::routing::put(routes::put_web_search_credential)
+                .delete(routes::delete_web_search_credential)
+                .layer(DefaultBodyLimit::max(MAX_WEB_SEARCH_CREDENTIAL_BODY_BYTES)),
         )
         .route("/providers", get(routes::list_providers))
         .route(

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -23,7 +23,10 @@ use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
 use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
 use crate::state::AppState;
-use crate::web_search::{self, WebSearchConfigInfo, WebSearchConfigUpdate};
+use crate::web_search::{
+    self, WebSearchConfigInfo, WebSearchConfigUpdate, WebSearchCredentialReadiness,
+    WebSearchCredentialsInfo,
+};
 
 mod client_execution;
 mod document;
@@ -126,6 +129,83 @@ pub async fn put_web_search_config(
     Ok(Json(
         web_search::update_config(&*state.store, &*state.secrets, body).await?,
     ))
+}
+
+/// Maximum API-key size accepted by the local credential endpoint. This is
+/// far beyond ordinary provider keys while keeping accidental pasted blobs out
+/// of the OS keychain.
+const MAX_WEB_SEARCH_CREDENTIAL_BYTES: usize = 8 * 1024;
+
+/// Body of `PUT /web-search/credentials/{provider}`. The custom `Debug`
+/// implementation redacts the only sensitive field.
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WebSearchCredentialUpdate {
+    pub api_key: String,
+}
+
+impl std::fmt::Debug for WebSearchCredentialUpdate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebSearchCredentialUpdate")
+            .field("api_key", &"***")
+            .finish()
+    }
+}
+
+/// `GET /web-search/credentials` — readiness for the fixed Exa and Tavily
+/// credential slots. This route never returns the stored keys.
+pub async fn get_web_search_credentials(
+    State(state): State<AppState>,
+) -> Result<Json<WebSearchCredentialsInfo>, ServerError> {
+    Ok(Json(web_search::credentials_info(&*state.secrets).await?))
+}
+
+/// `PUT /web-search/credentials/{provider}` — store a key in one fixed
+/// provider slot. It does not change provider selection or timeout policy.
+pub async fn put_web_search_credential(
+    State(state): State<AppState>,
+    Path(provider): Path<String>,
+    Json(body): Json<WebSearchCredentialUpdate>,
+) -> Result<Json<WebSearchCredentialReadiness>, ServerError> {
+    let provider = parse_web_search_provider(&provider)?;
+    if body.api_key.as_bytes().len() > MAX_WEB_SEARCH_CREDENTIAL_BYTES {
+        return Err(ServerError::bad_request(format!(
+            "web search api_key must be at most {MAX_WEB_SEARCH_CREDENTIAL_BYTES} bytes"
+        )));
+    }
+    let api_key = body.api_key.trim();
+    if api_key.is_empty() {
+        return Err(ServerError::bad_request(
+            "web search api_key must not be empty",
+        ));
+    }
+    Ok(Json(
+        web_search::write_credential(&*state.secrets, provider, api_key).await?,
+    ))
+}
+
+/// `DELETE /web-search/credentials/{provider}` — remove only that fixed
+/// provider key. It does not change provider selection or timeout policy.
+pub async fn delete_web_search_credential(
+    State(state): State<AppState>,
+    Path(provider): Path<String>,
+) -> Result<Json<WebSearchCredentialReadiness>, ServerError> {
+    let provider = parse_web_search_provider(&provider)?;
+    Ok(Json(
+        web_search::delete_credential(&*state.secrets, provider).await?,
+    ))
+}
+
+fn parse_web_search_provider(
+    value: &str,
+) -> std::result::Result<openwave_web_search::WebSearchProviderKind, ServerError> {
+    match value {
+        "exa" => Ok(openwave_web_search::WebSearchProviderKind::Exa),
+        "tavily" => Ok(openwave_web_search::WebSearchProviderKind::Tavily),
+        _ => Err(ServerError::not_found(format!(
+            "unknown web search provider kind: {value}"
+        ))),
+    }
 }
 
 /// The configured model, if any.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1355,6 +1355,41 @@ async fn test_app() -> (Router, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
     test_app_with(Arc::new(FakeProvider)).await
 }
 
+/// A normal authenticated local API plus a handle to its test-only secret
+/// store, for asserting web-search credential routes never touch other keys.
+async fn test_app_with_web_search_secrets() -> (Router, Arc<str>, Arc<MemSecrets>, tempfile::TempDir)
+{
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let secrets = Arc::new(MemSecrets::default());
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        secrets.clone(),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    (app(state), token, secrets, dir)
+}
+
 #[tokio::test]
 async fn app_state_roots_blob_storage_under_the_data_directory() {
     let dir = tempfile::tempdir().unwrap();
@@ -5862,6 +5897,149 @@ async fn put_empty_api_key_is_rejected() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     let info: AgentErrorInfo = json_body(response).await;
     assert_eq!(info.kind, "bad_request");
+}
+
+#[tokio::test]
+async fn web_search_credential_routes_are_authenticated_and_never_return_keys() {
+    let (router, token, secrets, _dir) = test_app_with_web_search_secrets().await;
+    let bearer = format!("Bearer {token}");
+
+    let unauthenticated = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/web-search/credentials")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+
+    let initial = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/web-search/credentials")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(initial.status(), StatusCode::OK);
+    assert_eq!(
+        json_body::<serde_json::Value>(initial).await,
+        serde_json::json!({
+            "credentials": [
+                {"provider": "exa", "has_credential": false},
+                {"provider": "tavily", "has_credential": false}
+            ]
+        })
+    );
+
+    let key = "exa-secret-that-must-not-cross-the-api-boundary";
+    let put = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/web-search/credentials/exa")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(serde_json::json!({"api_key": key}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(put.status(), StatusCode::OK);
+    let put_body = to_bytes(put.into_body(), usize::MAX).await.unwrap();
+    assert!(!std::str::from_utf8(&put_body).unwrap().contains(key));
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&put_body).unwrap(),
+        serde_json::json!({"provider": "exa", "has_credential": true})
+    );
+    assert_eq!(
+        secrets
+            .get_secret("web_search.exa.api_key")
+            .await
+            .unwrap()
+            .as_deref(),
+        Some(key)
+    );
+    assert_eq!(
+        secrets
+            .get_secret("web_search.tavily.api_key")
+            .await
+            .unwrap(),
+        None
+    );
+
+    let deleted = router
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/web-search/credentials/exa")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(deleted.status(), StatusCode::OK);
+    assert_eq!(
+        json_body::<serde_json::Value>(deleted).await,
+        serde_json::json!({"provider": "exa", "has_credential": false})
+    );
+    assert_eq!(
+        secrets.get_secret("web_search.exa.api_key").await.unwrap(),
+        None
+    );
+}
+
+#[tokio::test]
+async fn web_search_credential_write_validates_fixed_provider_and_key_bounds() {
+    let (router, token, secrets, _dir) = test_app_with_web_search_secrets().await;
+    let bearer = format!("Bearer {token}");
+
+    for body in [
+        serde_json::json!({"api_key": ""}),
+        serde_json::json!({"api_key": " \n\t "}),
+        serde_json::json!({"api_key": "x".repeat(8 * 1024 + 1)}),
+        serde_json::json!({"api_key": "valid", "unexpected": true}),
+    ] {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/web-search/credentials/exa")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    let unknown = router
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/web-search/credentials/arbitrary-secret-name")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"api_key": "valid"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+    assert!(secrets.0.lock().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/openwave-server/src/web_search.rs
+++ b/crates/openwave-server/src/web_search.rs
@@ -29,6 +29,12 @@ pub const MIN_TIMEOUT_MS: u64 = 1_000;
 /// durable worker state rather than an unbounded HTTP call.
 pub const MAX_TIMEOUT_MS: u64 = 60_000;
 
+/// The fixed providers this host can hold a credential for. Keeping this
+/// allow-list here means a local API route can never turn an arbitrary path
+/// segment into a keychain key.
+const CREDENTIAL_PROVIDERS: [WebSearchProviderKind; 2] =
+    [WebSearchProviderKind::Exa, WebSearchProviderKind::Tavily];
+
 /// Non-secret host configuration. `provider: None` is the safe default: no
 /// credential lookup and no possible outbound request.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -72,6 +78,20 @@ pub struct WebSearchConfigInfo {
     pub provider: Option<WebSearchProviderKind>,
     pub timeout_ms: u64,
     pub has_credential: bool,
+}
+
+/// Credential readiness for one fixed web-search provider. This public shape
+/// deliberately carries no secret material.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct WebSearchCredentialReadiness {
+    pub provider: WebSearchProviderKind,
+    pub has_credential: bool,
+}
+
+/// Credential readiness for every provider OpenWave supports locally.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WebSearchCredentialsInfo {
+    pub credentials: Vec<WebSearchCredentialReadiness>,
 }
 
 /// Partial update accepted by `PUT /web-search`. An omitted `provider` leaves
@@ -131,6 +151,59 @@ pub async fn config_info(
         provider: config.provider,
         timeout_ms: config.timeout_ms,
         has_credential,
+    })
+}
+
+/// Return readiness for every fixed provider without reading or returning any
+/// key material. Storage errors are projected to one generic server error so
+/// keychain implementation details cannot cross the local API boundary.
+pub async fn credentials_info(
+    secrets: &dyn SecretProvider,
+) -> std::result::Result<WebSearchCredentialsInfo, ServerError> {
+    let mut credentials = Vec::with_capacity(CREDENTIAL_PROVIDERS.len());
+    for provider in CREDENTIAL_PROVIDERS {
+        let has_credential = WebSearchCredentials::load(secrets, provider)
+            .await
+            .map_err(|_| ServerError::internal("web search credential storage is unavailable"))?
+            .is_some();
+        credentials.push(WebSearchCredentialReadiness {
+            provider,
+            has_credential,
+        });
+    }
+    Ok(WebSearchCredentialsInfo { credentials })
+}
+
+/// Store a non-empty, already validated credential under the provider's fixed
+/// key. The provider kind is an enum rather than caller-controlled storage
+/// input, so this cannot address other application secrets.
+pub async fn write_credential(
+    secrets: &dyn SecretProvider,
+    provider: WebSearchProviderKind,
+    api_key: &str,
+) -> std::result::Result<WebSearchCredentialReadiness, ServerError> {
+    secrets
+        .set_secret(provider.credential_key(), api_key)
+        .await
+        .map_err(|_| ServerError::internal("web search credential storage is unavailable"))?;
+    Ok(WebSearchCredentialReadiness {
+        provider,
+        has_credential: true,
+    })
+}
+
+/// Delete only the selected provider's fixed credential key.
+pub async fn delete_credential(
+    secrets: &dyn SecretProvider,
+    provider: WebSearchProviderKind,
+) -> std::result::Result<WebSearchCredentialReadiness, ServerError> {
+    secrets
+        .delete_secret(provider.credential_key())
+        .await
+        .map_err(|_| ServerError::internal("web search credential storage is unavailable"))?;
+    Ok(WebSearchCredentialReadiness {
+        provider,
+        has_credential: false,
     })
 }
 

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -13,6 +13,9 @@ The loopback API exposes a bearer-protected host policy at `/web-search`.
 | --- | --- |
 | `GET /web-search` | Read the selected provider, timeout, and whether its fixed key is available. |
 | `PUT /web-search` | Select `exa`, `tavily`, or `null` to disable; optionally set the timeout. |
+| `GET /web-search/credentials` | Read readiness for the fixed Exa and Tavily key slots. |
+| `PUT /web-search/credentials/{provider}` | Store a key for `exa` or `tavily`; returns readiness only. |
+| `DELETE /web-search/credentials/{provider}` | Delete that fixed provider key; returns readiness only. |
 
 Example:
 
@@ -28,11 +31,14 @@ proxy URL, arbitrary secret reference, or API-key field in this API. The Exa
 and Tavily adapters own their fixed HTTPS endpoints, disable redirects, and
 bound request input and retained response output.
 
-The response never contains a credential. It reports only `has_credential` for
-the currently selected provider. Keys are read from the OS keychain through
+No response contains a credential. `/web-search` reports only
+`has_credential` for the currently selected provider, while
+`/web-search/credentials` reports readiness for both fixed slots. Keys are read
+from and written to the OS keychain through
 `SecretProvider` under the fixed names `web_search.exa.api_key` and
-`web_search.tavily.api_key`. A missing key or disabled selection fails closed:
-there is no provider to invoke.
+`web_search.tavily.api_key`. Credential writes reject empty values and values
+over 8 KiB. They never alter selection or timeout policy. A missing key or
+disabled selection fails closed: there is no provider to invoke.
 
 ## Current boundary
 


### PR DESCRIPTION
## Summary

- add authenticated fixed-key credential management for Exa and Tavily
- return readiness metadata without exposing secret values
- document the local credential boundary separately from provider selection

## Validation

- cargo test -p openwave-server web_search_credential --locked
- bw dev lint --rust --check
- adversarial review