### PR TITLE
Add desktop web search setup

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -9,6 +9,9 @@ import {
   type ProviderKind,
   type SequencedEvent,
   type ServerInfo,
+  type WebSearchConfigInfo,
+  type WebSearchCredentialReadiness,
+  type WebSearchProviderKind,
 } from "./api";
 import { resolveServerInfo } from "./boot";
 import {
@@ -73,7 +76,7 @@ export default function App() {
   const [cancelError, setCancelError] = useState<string | null>(null);
   const [creatingChat, setCreatingChat] = useState(false);
   const [settingsPanel, setSettingsPanel] = useState<
-    "providers" | "folders" | null
+    "providers" | "web-search" | "folders" | null
   >(null);
   const [status, setStatus] = useState("starting…");
   const socketRef = useRef<WebSocket | null>(null);
@@ -669,6 +672,17 @@ export default function App() {
           >
             Providers
           </button>
+          <button
+            type="button"
+            className={`sidebar-action${settingsPanel === "web-search" ? " is-active" : ""}`}
+            onClick={() =>
+              setSettingsPanel((panel) =>
+                panel === "web-search" ? null : "web-search",
+              )
+            }
+          >
+            Web search
+          </button>
         </div>
       </aside>
 
@@ -704,6 +718,17 @@ export default function App() {
                   }
                 >
                   Providers
+                </button>
+                <button
+                  type="button"
+                  className={`btn${settingsPanel === "web-search" ? " is-active" : ""}`}
+                  onClick={() =>
+                    setSettingsPanel((panel) =>
+                      panel === "web-search" ? null : "web-search",
+                    )
+                  }
+                >
+                  Web search
                 </button>
               </div>
               <span className="status" title={status}>
@@ -868,6 +893,7 @@ export default function App() {
             onChanged={() => void refreshCatalog()}
           />
         )}
+        {settingsPanel === "web-search" && <WebSearchPanel client={client} />}
         {settingsPanel === "folders" && <FoldersPanel chat={chat} />}
       </div>
     </div>
@@ -1104,6 +1130,269 @@ function FoldersPanel({ chat }: { chat: Chat }) {
       {error && <div className="folder-error">{error}</div>}
     </aside>
   );
+}
+
+const MIN_WEB_SEARCH_TIMEOUT_MS = 1_000;
+const MAX_WEB_SEARCH_TIMEOUT_MS = 60_000;
+
+function WebSearchPanel({ client }: { client: ApiClient }) {
+  const [config, setConfig] = useState<WebSearchConfigInfo | null>(null);
+  const [credentials, setCredentials] = useState<WebSearchCredentialReadiness[]>([]);
+  const [provider, setProvider] = useState<WebSearchProviderKind | "">("");
+  const [timeoutMs, setTimeoutMs] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [savingConfig, setSavingConfig] = useState(false);
+  const [savingCredential, setSavingCredential] = useState(false);
+  const [removingCredential, setRemovingCredential] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    const [nextConfig, nextCredentials] = await Promise.all([
+      client.getWebSearchConfig(),
+      client.listWebSearchCredentials(),
+    ]);
+    setConfig(nextConfig);
+    setCredentials(nextCredentials.credentials);
+    setProvider(nextConfig.provider ?? "");
+    setTimeoutMs(String(nextConfig.timeout_ms));
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const [nextConfig, nextCredentials] = await Promise.all([
+          client.getWebSearchConfig(),
+          client.listWebSearchCredentials(),
+        ]);
+        if (cancelled) return;
+        setConfig(nextConfig);
+        setCredentials(nextCredentials.credentials);
+        setProvider(nextConfig.provider ?? "");
+        setTimeoutMs(String(nextConfig.timeout_ms));
+      } catch (err) {
+        if (!cancelled) setError(String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  const activeProvider = config?.provider;
+  const selectedCredential = activeProvider
+    ? credentials.find((credential) => credential.provider === activeProvider)
+    : undefined;
+  const selectedHasCredential = selectedCredential?.has_credential ?? false;
+  const working = savingConfig || savingCredential || removingCredential;
+  const state = webSearchState(config);
+
+  async function saveConfig() {
+    const parsedTimeout = Number(timeoutMs);
+    if (
+      !Number.isInteger(parsedTimeout) ||
+      parsedTimeout < MIN_WEB_SEARCH_TIMEOUT_MS ||
+      parsedTimeout > MAX_WEB_SEARCH_TIMEOUT_MS
+    ) {
+      setError(
+        `Timeout must be a whole number between ${MIN_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} and ${MAX_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} ms.`,
+      );
+      return;
+    }
+
+    setSavingConfig(true);
+    setError(null);
+    try {
+      const nextConfig = await client.putWebSearchConfig({
+        provider: provider || null,
+        timeout_ms: parsedTimeout,
+      });
+      setConfig(nextConfig);
+      setTimeoutMs(String(nextConfig.timeout_ms));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSavingConfig(false);
+    }
+  }
+
+  async function saveCredential() {
+    if (!activeProvider || !apiKey.trim()) return;
+    setSavingCredential(true);
+    setError(null);
+    try {
+      await client.putWebSearchCredential(activeProvider, apiKey.trim());
+      setApiKey("");
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSavingCredential(false);
+    }
+  }
+
+  async function removeCredential() {
+    if (!activeProvider) return;
+    setRemovingCredential(true);
+    setError(null);
+    try {
+      await client.deleteWebSearchCredential(activeProvider);
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setRemovingCredential(false);
+    }
+  }
+
+  return (
+    <aside className="settings web-search-settings" aria-busy={loading}>
+      <h2>Web search</h2>
+      <p>
+        Choose a local provider and a bounded request timeout. Existing keys are
+        never shown here.
+      </p>
+
+      {loading ? (
+        <div className="status">Loading web-search settings…</div>
+      ) : !config ? (
+        <div className="status">Web-search settings are unavailable.</div>
+      ) : (
+        <>
+          <div className={`web-search-state is-${state.kind}`} role="status">
+            <strong>{state.label}</strong>
+            <span>{state.description}</span>
+          </div>
+
+          <div className="provider">
+            <label className="settings-field">
+              <span>Provider</span>
+              <select
+                value={provider}
+                disabled={working}
+                onChange={(event) => setProvider(event.target.value as WebSearchProviderKind | "")}
+              >
+                <option value="">Disabled</option>
+                <option value="exa">Exa</option>
+                <option value="tavily">Tavily</option>
+              </select>
+            </label>
+
+            <label className="settings-field">
+              <span>Request timeout (ms)</span>
+              <input
+                type="number"
+                inputMode="numeric"
+                min={MIN_WEB_SEARCH_TIMEOUT_MS}
+                max={MAX_WEB_SEARCH_TIMEOUT_MS}
+                step="1000"
+                value={timeoutMs}
+                disabled={working}
+                onChange={(event) => setTimeoutMs(event.target.value)}
+              />
+            </label>
+            <p className="settings-hint">
+              Between {MIN_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} and {MAX_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} ms.
+            </p>
+            <div className="row">
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={working}
+                onClick={() => void saveConfig()}
+              >
+                {savingConfig ? "Saving…" : "Save configuration"}
+              </button>
+            </div>
+          </div>
+
+          {activeProvider && (
+            <div className="provider">
+              <h3>{activeProvider} credential</h3>
+              <span className="status">
+                {selectedHasCredential ? "credential saved" : "no credential saved"}
+              </span>
+              <label className="settings-field">
+                <span>{selectedHasCredential ? "Replace API key" : "API key"}</span>
+                <input
+                  type="password"
+                  placeholder="Paste a new API key"
+                  value={apiKey}
+                  maxLength={8_192}
+                  autoComplete="new-password"
+                  disabled={working}
+                  onChange={(event) => setApiKey(event.target.value)}
+                />
+              </label>
+              <div className="row">
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  disabled={working || !apiKey.trim()}
+                  onClick={() => void saveCredential()}
+                >
+                  {savingCredential ? "Saving…" : selectedHasCredential ? "Update key" : "Save key"}
+                </button>
+                {selectedHasCredential && (
+                  <button
+                    type="button"
+                    className="btn btn-danger"
+                    disabled={working}
+                    onClick={() => void removeCredential()}
+                  >
+                    {removingCredential ? "Removing…" : "Remove saved key"}
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+
+          {provider !== (activeProvider ?? "") && (
+            <p className="settings-hint">
+              Save the provider configuration before managing that provider’s key.
+            </p>
+          )}
+
+          <p className="settings-note">
+            This configures host-owned search access only. Search is not yet a
+            chat tool in this build.
+          </p>
+        </>
+      )}
+      {error && <div className="folder-error" role="alert">{error}</div>}
+    </aside>
+  );
+}
+
+function webSearchState(config: WebSearchConfigInfo | null): {
+  kind: "disabled" | "ready" | "not-configured";
+  label: string;
+  description: string;
+} {
+  if (!config?.provider) {
+    return {
+      kind: "disabled",
+      label: "Disabled",
+      description: "No web-search provider is selected.",
+    };
+  }
+  if (config.has_credential) {
+    return {
+      kind: "ready",
+      label: "Ready",
+      description: `${config.provider} is selected and has a saved credential.`,
+    };
+  }
+  return {
+    kind: "not-configured",
+    label: "Not configured",
+    description: `${config.provider} is selected but needs an API key.`,
+  };
 }
 
 function ProvidersPanel({

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -18,6 +18,22 @@ export type ModelInfo = {
   provider: string;
 };
 
+/** The fixed, host-owned search providers supported by this build. */
+export type WebSearchProviderKind = "exa" | "tavily";
+
+/** Non-secret web-search policy and readiness for its selected provider. */
+export type WebSearchConfigInfo = {
+  provider?: WebSearchProviderKind;
+  timeout_ms: number;
+  has_credential: boolean;
+};
+
+/** Readiness only: the API never returns an existing provider key. */
+export type WebSearchCredentialReadiness = {
+  provider: WebSearchProviderKind;
+  has_credential: boolean;
+};
+
 export type Chat = {
   id: string;
   title: string | null;
@@ -153,6 +169,47 @@ export class ApiClient {
 
   listModels(): Promise<{ models: ModelInfo[] }> {
     return this.json("/models", { headers: this.headers() });
+  }
+
+  getWebSearchConfig(): Promise<WebSearchConfigInfo> {
+    return this.json("/web-search", { headers: this.headers() });
+  }
+
+  putWebSearchConfig(body: {
+    provider?: WebSearchProviderKind | null;
+    timeout_ms?: number;
+  }): Promise<WebSearchConfigInfo> {
+    return this.json("/web-search", {
+      method: "PUT",
+      headers: this.headers(true),
+      body: JSON.stringify(body),
+    });
+  }
+
+  listWebSearchCredentials(): Promise<{
+    credentials: WebSearchCredentialReadiness[];
+  }> {
+    return this.json("/web-search/credentials", { headers: this.headers() });
+  }
+
+  putWebSearchCredential(
+    provider: WebSearchProviderKind,
+    apiKey: string,
+  ): Promise<WebSearchCredentialReadiness> {
+    return this.json(`/web-search/credentials/${provider}`, {
+      method: "PUT",
+      headers: this.headers(true),
+      body: JSON.stringify({ api_key: apiKey }),
+    });
+  }
+
+  deleteWebSearchCredential(
+    provider: WebSearchProviderKind,
+  ): Promise<WebSearchCredentialReadiness> {
+    return this.json(`/web-search/credentials/${provider}`, {
+      method: "DELETE",
+      headers: this.headers(),
+    });
   }
 
   createChat(model?: string): Promise<Chat> {

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -185,6 +185,16 @@ button {
   filter: brightness(1.15);
 }
 
+.btn-danger {
+  border-color: color-mix(in srgb, var(--danger) 45%, var(--line));
+  color: var(--danger);
+}
+
+.btn-danger:hover:not(:disabled) {
+  border-color: var(--danger);
+  background: oklch(0.97 0.01 25);
+}
+
 .btn:disabled,
 .new-chat:disabled {
   opacity: 0.5;
@@ -573,6 +583,59 @@ button {
   margin: 0;
   font-size: 0.9rem;
   text-transform: capitalize;
+}
+
+.web-search-state {
+  display: grid;
+  gap: 0.18rem;
+  padding: 0.65rem 0.7rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  background: var(--bg);
+  font-size: 0.82rem;
+}
+
+.web-search-state strong {
+  color: var(--ink);
+  font-size: 0.84rem;
+}
+
+.web-search-state.is-ready {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+}
+
+.web-search-state.is-not-configured {
+  border-color: color-mix(in srgb, var(--danger) 30%, var(--line));
+}
+
+.settings-field {
+  display: grid;
+  gap: 0.3rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.settings-field select,
+.settings-field input {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.35rem 0.45rem;
+  color: var(--ink);
+  background: var(--bg);
+}
+
+.settings-hint,
+.settings-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.settings-note {
+  margin-top: 1rem;
+  line-height: 1.5;
 }
 
 .folder-list {

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -40,6 +40,15 @@ from and written to the OS keychain through
 over 8 KiB. They never alter selection or timeout policy. A missing key or
 disabled selection fails closed: there is no provider to invoke.
 
+## Desktop setup
+
+The desktop sidebar has a **Web search** panel for this same local API. It
+shows whether the saved configuration is disabled, ready, or missing the
+selected provider's key; lets the user choose Exa or Tavily (or disable search),
+set the bounded timeout, and save, replace, or remove a key. Existing keys are
+never displayed or read into the renderer. Saving a key and saving provider
+selection are deliberately separate actions, matching the API boundary above.
+
 ## Current boundary
 
 `openwave-server::web_search::resolve_provider` is the host-only construction


### PR DESCRIPTION
## Summary

- add local Exa/Tavily web-search setup controls to the desktop settings surface
- support bounded provider selection, timeout updates, readiness, and fixed-key save/remove
- keep stored credentials write-only in the renderer

## Validation

- pnpm --dir crates/openwave-desktop/ui build
- git diff --check
- adversarial review