### PR TITLE
Execute sandbox web search checkpoints

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1833,6 +1833,32 @@ impl Store for DbStore {
         ops::sandbox_tool::claim_sandbox_tool_call(self, id, lease_token, lease_duration).await
     }
 
+    async fn claim_sandbox_tool_call_named(
+        &self,
+        id: CallId,
+        name: &str,
+        lease_token: uuid::Uuid,
+        lease_duration: chrono::Duration,
+    ) -> Result<ClaimSandboxToolCallOutcome> {
+        ops::sandbox_tool::claim_sandbox_tool_call_named(
+            self,
+            id,
+            name,
+            lease_token,
+            lease_duration,
+        )
+        .await
+    }
+
+    async fn heartbeat_sandbox_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        lease_duration: chrono::Duration,
+    ) -> Result<Option<chrono::Duration>> {
+        ops::sandbox_tool::heartbeat_sandbox_tool_call(self, id, lease_token, lease_duration).await
+    }
+
     async fn resolve_sandbox_tool_call(
         &self,
         id: CallId,
@@ -1855,6 +1881,14 @@ impl Store for DbStore {
 
     async fn list_sandbox_tool_call_candidates(&self, limit: u64) -> Result<Vec<SandboxToolCall>> {
         ops::sandbox_tool::list_sandbox_tool_call_candidates(self, limit).await
+    }
+
+    async fn list_sandbox_tool_call_candidates_named(
+        &self,
+        name: &str,
+        limit: u64,
+    ) -> Result<Vec<SandboxToolCall>> {
+        ops::sandbox_tool::list_sandbox_tool_call_candidates_named(self, name, limit).await
     }
 
     async fn request_agent_run_cancellation(

--- a/crates/openwave-core/src/db/ops/sandbox_tool.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_tool.rs
@@ -145,6 +145,29 @@ pub(in crate::db) async fn claim_sandbox_tool_call(
     lease_token: uuid::Uuid,
     lease_duration: Duration,
 ) -> Result<ClaimSandboxToolCallOutcome> {
+    claim_sandbox_tool_call_matching(store, id, None, lease_token, lease_duration).await
+}
+
+pub(in crate::db) async fn claim_sandbox_tool_call_named(
+    store: &DbStore,
+    id: CallId,
+    name: &str,
+    lease_token: uuid::Uuid,
+    lease_duration: Duration,
+) -> Result<ClaimSandboxToolCallOutcome> {
+    if !valid_tool_name(name) {
+        return Err(AgentError::Store("invalid sandbox tool name".into()));
+    }
+    claim_sandbox_tool_call_matching(store, id, Some(name), lease_token, lease_duration).await
+}
+
+async fn claim_sandbox_tool_call_matching(
+    store: &DbStore,
+    id: CallId,
+    expected_name: Option<&str>,
+    lease_token: uuid::Uuid,
+    lease_duration: Duration,
+) -> Result<ClaimSandboxToolCallOutcome> {
     if id.0.is_nil() || lease_token.is_nil() || lease_duration <= Duration::zero() {
         return Err(AgentError::Store(
             "invalid sandbox tool executor lease".into(),
@@ -164,6 +187,13 @@ pub(in crate::db) async fn claim_sandbox_tool_call(
         transaction.commit().await.map_err(store_err)?;
         return Ok(ClaimSandboxToolCallOutcome::Unavailable);
     };
+    // Check the immutable dispatch key before handling an expired lease. A
+    // web-search worker must never terminalize a future tool type merely
+    // because it happened to observe that call in a generic recovery scan.
+    if expected_name.is_some_and(|name| existing.name != name) {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(ClaimSandboxToolCallOutcome::Unavailable);
+    }
     if existing.status == SandboxToolCallStatus::Claimed.as_str()
         && existing.executor_lease_token == Some(lease_token)
         && existing
@@ -213,6 +243,71 @@ pub(in crate::db) async fn claim_sandbox_tool_call(
     Ok(ClaimSandboxToolCallOutcome::Claimed(call_from_model(
         claimed,
     )?))
+}
+
+/// Extend an exact sandbox-tool executor lease after rechecking the waiting
+/// sandbox run and its database-clock deadline. This is deliberately separate
+/// from the model-worker lease: a parked run has released that lease, and only
+/// this executor capability can authorize its outbound continuation.
+pub(in crate::db) async fn heartbeat_sandbox_tool_call(
+    store: &DbStore,
+    id: CallId,
+    lease_token: uuid::Uuid,
+    lease_duration: Duration,
+) -> Result<Option<Duration>> {
+    if id.0.is_nil() || lease_token.is_nil() || lease_duration <= Duration::zero() {
+        return Err(AgentError::Store(
+            "invalid sandbox tool executor heartbeat".into(),
+        ));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
+    let requested_expires_at = now.checked_add_signed(lease_duration).ok_or_else(|| {
+        AgentError::Store("sandbox tool executor lease overflows database time".into())
+    })?;
+    let Some(call) = entities::sandbox_tool_call::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if call.status != SandboxToolCallStatus::Claimed.as_str()
+        || call.executor_lease_token != Some(lease_token)
+        || !call
+            .executor_lease_expires_at
+            .is_some_and(|expiry| expiry > now)
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let Some(run) = find_by_id_on(&transaction, AgentRunId(call.agent_run_id)).await? else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let Some(deadline) = run.deadline_at.filter(|deadline| *deadline > now) else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    if run.chat_id != call.chat_id || run.status != AgentRunStatus::Waiting.as_str() {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let expires_at = requested_expires_at.min(deadline);
+    if call
+        .executor_lease_expires_at
+        .is_some_and(|current| current >= expires_at)
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(call.executor_lease_expires_at.map(|expiry| expiry - now));
+    }
+    let mut active: entities::sandbox_tool_call::ActiveModel = call.into();
+    active.executor_lease_expires_at = Set(Some(expires_at));
+    active.update(&transaction).await.map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(expires_at - now))
 }
 
 pub(in crate::db) async fn resolve_sandbox_tool_call(
@@ -360,6 +455,45 @@ pub(in crate::db) async fn list_sandbox_tool_call_candidates(
     }
     let now = database_now(&store.conn).await?;
     entities::sandbox_tool_call::Entity::find()
+        .filter(
+            sea_orm::Condition::any()
+                .add(
+                    entities::sandbox_tool_call::Column::Status
+                        .eq(SandboxToolCallStatus::Accepted.as_str()),
+                )
+                .add(
+                    entities::sandbox_tool_call::Column::Status
+                        .eq(SandboxToolCallStatus::Claimed.as_str())
+                        .and(entities::sandbox_tool_call::Column::ExecutorLeaseExpiresAt.lte(now)),
+                ),
+        )
+        .order_by_asc(entities::sandbox_tool_call::Column::CreatedAt)
+        .order_by_asc(entities::sandbox_tool_call::Column::Id)
+        .limit(limit)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(call_from_model)
+        .collect()
+}
+
+pub(in crate::db) async fn list_sandbox_tool_call_candidates_named(
+    store: &DbStore,
+    name: &str,
+    limit: u64,
+) -> Result<Vec<SandboxToolCall>> {
+    if !valid_tool_name(name) {
+        return Err(AgentError::Store("invalid sandbox tool name".into()));
+    }
+    if limit == 0 || limit > 256 {
+        return Err(AgentError::Store(
+            "invalid sandbox tool candidate limit".into(),
+        ));
+    }
+    let now = database_now(&store.conn).await?;
+    entities::sandbox_tool_call::Entity::find()
+        .filter(entities::sandbox_tool_call::Column::Name.eq(name))
         .filter(
             sea_orm::Condition::any()
                 .add(
@@ -619,4 +753,8 @@ fn status_from_db(value: &str) -> Result<SandboxToolCallStatus> {
             "invalid sandbox tool status {value}"
         ))),
     }
+}
+
+fn valid_tool_name(value: &str) -> bool {
+    !value.is_empty() && value.len() <= ToolCallRecord::MAX_LABEL_LEN && !value.contains('\0')
 }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1167,6 +1167,37 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// Claim one accepted sandbox call only when its immutable tool name is
+    /// exactly `name`. Executors use this filtered authority so one tool lane
+    /// can never terminalize another tool's durable work.
+    async fn claim_sandbox_tool_call_named(
+        &self,
+        _id: CallId,
+        _name: &str,
+        _lease_token: uuid::Uuid,
+        _lease_duration: chrono::Duration,
+    ) -> Result<ClaimSandboxToolCallOutcome> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Revalidate one exact live sandbox-tool executor lease against the
+    /// database clock and extend it up to its sandbox run deadline.
+    ///
+    /// This is the final cancellation/deadline fence before an executor may
+    /// begin an external operation. `None` means cancellation, expiry, a
+    /// terminal receipt, or a competing executor already won. `Some` returns
+    /// the remaining lease budget calculated from the same database-clock
+    /// transaction, so an executor need not compare host wall time to a stored
+    /// absolute expiry.
+    async fn heartbeat_sandbox_tool_call(
+        &self,
+        _id: CallId,
+        _lease_token: uuid::Uuid,
+        _lease_duration: chrono::Duration,
+    ) -> Result<Option<chrono::Duration>> {
+        agent_run_storage_unavailable()
+    }
+
     /// Atomically write one immutable terminal receipt under the exact live
     /// executor lease and make its sandbox run claimable for continuation.
     /// Exact ambiguous retries recover the same receipt.
@@ -1199,6 +1230,16 @@ pub trait Store: Send + Sync {
     /// executor recovery. Claiming remains the authority for ownership.
     async fn list_sandbox_tool_call_candidates(
         &self,
+        _limit: u64,
+    ) -> Result<Vec<crate::model::SandboxToolCall>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// List bounded oldest-first candidates for one exact immutable sandbox
+    /// tool name. The matching claim method remains the ownership authority.
+    async fn list_sandbox_tool_call_candidates_named(
+        &self,
+        _name: &str,
         _limit: u64,
     ) -> Result<Vec<crate::model::SandboxToolCall>> {
         agent_run_storage_unavailable()

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -27,6 +27,7 @@ mod providers;
 mod resolver;
 mod routes;
 mod sandbox_agent_run_worker;
+mod sandbox_web_search_worker;
 mod state;
 mod turn_worker;
 /// Host-owned, inert web-search configuration and provider selection.
@@ -227,6 +228,7 @@ pub struct Server {
     _document_worker: AbortTask,
     _turn_worker: AbortTask,
     _sandbox_agent_run_worker: AbortTask,
+    _sandbox_web_search_worker: AbortTask,
     _blob_retirement_worker: AbortTask,
     _blob_orphan_auditor: AbortTask,
     _instance_lock: InstanceLock,
@@ -418,6 +420,12 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
         Some(state.config.data_dir.join("scratch")),
         sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default(),
     );
+    let sandbox_web_search_worker = sandbox_web_search_worker::SandboxWebSearchWorker::new(
+        state.store.clone(),
+        state.secrets.clone(),
+        state.agent_run_wake.clone(),
+        sandbox_web_search_worker::SandboxWebSearchWorkerConfig::default(),
+    );
     let server_store = state.store.clone();
     let router = app(state);
 
@@ -432,6 +440,7 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
     let document_worker = tokio::spawn(document_worker.run());
     let turn_worker = tokio::spawn(turn_worker.run());
     let sandbox_agent_run_worker = tokio::spawn(sandbox_agent_run_worker.run());
+    let sandbox_web_search_worker = tokio::spawn(sandbox_web_search_worker.run());
     let blob_retirement_worker = tokio::spawn(blob_retirement_worker.run());
     let blob_orphan_auditor = tokio::spawn(blob_orphan_auditor.run());
 
@@ -446,6 +455,7 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
         _document_worker: AbortTask(document_worker),
         _turn_worker: AbortTask(turn_worker),
         _sandbox_agent_run_worker: AbortTask(sandbox_agent_run_worker),
+        _sandbox_web_search_worker: AbortTask(sandbox_web_search_worker),
         _blob_retirement_worker: AbortTask(blob_retirement_worker),
         _blob_orphan_auditor: AbortTask(blob_orphan_auditor),
         _instance_lock: instance_lock,

--- a/crates/openwave-server/src/sandbox_web_search_worker.rs
+++ b/crates/openwave-server/src/sandbox_web_search_worker.rs
@@ -1,0 +1,691 @@
+//! Durable execution of the one sandbox-safe web-search checkpoint.
+//!
+//! A model loop still has no advertised web-search tool. Only a durably
+//! accepted checkpoint can arrive here, where its exact executor lease is the
+//! authority for the bounded outbound operation.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use openwave_core::{
+    AgentError, ClaimSandboxToolCallOutcome, Result, SandboxToolCall, Store, ToolCallResolution,
+};
+use openwave_web_search::{
+    SearchDomain, WebSearchProvider, WebSearchRequest, WebSearchResponse, MAX_OUTPUT_BYTES,
+};
+use serde::Deserialize;
+use tokio::sync::Notify;
+
+use crate::web_search;
+
+const WEB_SEARCH_TOOL: &str = "web_search";
+const DEFAULT_MAX_RESULTS: usize = 5;
+const CANDIDATE_BATCH_SIZE: u64 = 16;
+const EGRESS_SAFETY_MARGIN: Duration = Duration::from_millis(250);
+
+#[async_trait]
+pub(crate) trait SandboxWebSearch: Send + Sync {
+    /// Resolve host policy and credentials without sending a request. The
+    /// worker revalidates its durable lease after this await and immediately
+    /// before it calls `WebSearchProvider::search`.
+    async fn resolve(
+        &self,
+    ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError>;
+}
+
+/// Deliberately non-diagnostic host search failures. Provider and secret
+/// details must never become checkpoint receipts or model context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SandboxWebSearchError {
+    Failed,
+}
+
+#[derive(Clone)]
+struct HostSandboxWebSearch {
+    store: Arc<dyn Store>,
+    secrets: Arc<dyn openwave_core::SecretProvider>,
+}
+
+#[async_trait]
+impl SandboxWebSearch for HostSandboxWebSearch {
+    async fn resolve(
+        &self,
+    ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError> {
+        web_search::resolve_provider(&*self.store, &*self.secrets)
+            .await
+            .map_err(|_| SandboxWebSearchError::Failed)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SandboxWebSearchWorkerConfig {
+    lease: Duration,
+    idle_min: Duration,
+    idle_cap: Duration,
+    failure_delay: Duration,
+    max_concurrency: usize,
+}
+
+impl Default for SandboxWebSearchWorkerConfig {
+    fn default() -> Self {
+        // The configured HTTP request is capped at 60 seconds. The executor
+        // lease leaves scheduling room, while the database caps it at the run
+        // deadline and the final local timeout stays below the live expiry.
+        Self {
+            lease: Duration::from_secs(75),
+            idle_min: Duration::from_millis(250),
+            idle_cap: Duration::from_secs(5),
+            failure_delay: Duration::from_secs(1),
+            max_concurrency: 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SandboxWebSearchWorkerOutcome {
+    Idle,
+    Resolved(openwave_core::CallId),
+    LeaseLost(openwave_core::CallId),
+}
+
+#[derive(Clone)]
+pub(crate) struct SandboxWebSearchWorker {
+    store: Arc<dyn Store>,
+    search: Arc<dyn SandboxWebSearch>,
+    wake: Arc<Notify>,
+    config: SandboxWebSearchWorkerConfig,
+}
+
+impl SandboxWebSearchWorker {
+    pub(crate) fn new(
+        store: Arc<dyn Store>,
+        secrets: Arc<dyn openwave_core::SecretProvider>,
+        wake: Arc<Notify>,
+        config: SandboxWebSearchWorkerConfig,
+    ) -> Self {
+        Self::with_search(
+            store.clone(),
+            Arc::new(HostSandboxWebSearch { store, secrets }),
+            wake,
+            config,
+        )
+    }
+
+    fn with_search(
+        store: Arc<dyn Store>,
+        search: Arc<dyn SandboxWebSearch>,
+        wake: Arc<Notify>,
+        config: SandboxWebSearchWorkerConfig,
+    ) -> Self {
+        assert!(!config.lease.is_zero());
+        assert!(config.max_concurrency > 0);
+        Self {
+            store,
+            search,
+            wake,
+            config,
+        }
+    }
+
+    pub(crate) async fn run(self) {
+        let mut lanes = tokio::task::JoinSet::new();
+        for _ in 0..self.config.max_concurrency {
+            lanes.spawn(self.clone().run_lane());
+        }
+        while let Some(result) = lanes.join_next().await {
+            if let Err(error) = result {
+                eprintln!("openwave: sandbox web-search worker lane stopped: {error}");
+                tokio::time::sleep(self.config.failure_delay).await;
+            }
+            lanes.spawn(self.clone().run_lane());
+        }
+    }
+
+    async fn run_lane(self) {
+        let mut idle_delay = self.config.idle_min;
+        loop {
+            match self.run_once().await {
+                Ok(SandboxWebSearchWorkerOutcome::Idle) => {
+                    tokio::select! {
+                        _ = tokio::time::sleep(idle_delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
+                }
+                Ok(_) => idle_delay = self.config.idle_min,
+                Err(error) => {
+                    eprintln!("openwave: sandbox web-search worker iteration failed: {error}");
+                    tokio::select! {
+                        _ = tokio::time::sleep(self.config.failure_delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                }
+            }
+        }
+    }
+
+    /// Claim and resolve one exact persisted sandbox tool checkpoint.
+    pub(crate) async fn run_once(&self) -> Result<SandboxWebSearchWorkerOutcome> {
+        for candidate in self
+            .store
+            .list_sandbox_tool_call_candidates_named(WEB_SEARCH_TOOL, CANDIDATE_BATCH_SIZE)
+            .await?
+        {
+            let lease_token = uuid::Uuid::new_v4();
+            let call = match self
+                .store
+                .claim_sandbox_tool_call_named(
+                    candidate.id,
+                    WEB_SEARCH_TOOL,
+                    lease_token,
+                    chrono_duration(self.config.lease)?,
+                )
+                .await?
+            {
+                ClaimSandboxToolCallOutcome::Claimed(call)
+                | ClaimSandboxToolCallOutcome::Existing(call) => call,
+                ClaimSandboxToolCallOutcome::Unavailable => continue,
+            };
+            self.wake.notify_one();
+            return self.process(call, lease_token).await;
+        }
+        Ok(SandboxWebSearchWorkerOutcome::Idle)
+    }
+
+    async fn process(
+        &self,
+        call: SandboxToolCall,
+        lease_token: uuid::Uuid,
+    ) -> Result<SandboxWebSearchWorkerOutcome> {
+        let resolution = match parse_web_search_request(&call) {
+            Err(resolution) => resolution,
+            Ok(request) => match self.search.resolve().await {
+                Ok(None) => failed_resolution(
+                    "web_search_disabled",
+                    "Web search is not configured for this host.",
+                ),
+                Err(SandboxWebSearchError::Failed) => {
+                    failed_resolution("web_search_failed", "Web search could not complete.")
+                }
+                Ok(Some(provider)) => {
+                    // This is the final database-clock cancellation/deadline/lease
+                    // proof after settings and credentials resolve, immediately
+                    // before the provider can observe an outbound request.
+                    let Some(expires_at) = self
+                        .store
+                        .heartbeat_sandbox_tool_call(
+                            call.id,
+                            lease_token,
+                            chrono_duration(
+                                self.config.lease.saturating_add(Duration::from_millis(1)),
+                            )?,
+                        )
+                        .await?
+                    else {
+                        return Ok(SandboxWebSearchWorkerOutcome::LeaseLost(call.id));
+                    };
+                    match remaining_execution_time(expires_at) {
+                        None => return Ok(SandboxWebSearchWorkerOutcome::LeaseLost(call.id)),
+                        Some(timeout) => {
+                            match tokio::time::timeout(timeout, provider.search(request)).await {
+                                Ok(Ok(response)) => serialize_response(response),
+                                Ok(Err(_)) => failed_resolution(
+                                    "web_search_failed",
+                                    "Web search could not complete.",
+                                ),
+                                Err(_) => failed_resolution(
+                                    "web_search_timed_out",
+                                    "Web search did not complete before its sandbox lease expired.",
+                                ),
+                            }
+                        }
+                    }
+                }
+            },
+        };
+        match self
+            .store
+            .resolve_sandbox_tool_call(call.id, lease_token, &resolution)
+            .await?
+        {
+            openwave_core::ResolveSandboxToolCallOutcome::Resolved
+            | openwave_core::ResolveSandboxToolCallOutcome::Existing => {
+                self.wake.notify_one();
+                Ok(SandboxWebSearchWorkerOutcome::Resolved(call.id))
+            }
+            openwave_core::ResolveSandboxToolCallOutcome::NotFound
+            | openwave_core::ResolveSandboxToolCallOutcome::AlreadyTerminal
+            | openwave_core::ResolveSandboxToolCallOutcome::LeaseLost => {
+                Ok(SandboxWebSearchWorkerOutcome::LeaseLost(call.id))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WebSearchArguments {
+    query: String,
+    #[serde(default = "default_max_results")]
+    max_results: usize,
+    #[serde(default)]
+    domains: Vec<String>,
+    #[serde(default)]
+    start_published_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    end_published_at: Option<DateTime<Utc>>,
+}
+
+const fn default_max_results() -> usize {
+    DEFAULT_MAX_RESULTS
+}
+
+fn parse_web_search_request(
+    call: &SandboxToolCall,
+) -> std::result::Result<WebSearchRequest, ToolCallResolution> {
+    if call.name != WEB_SEARCH_TOOL {
+        return Err(failed_resolution(
+            "unsupported_sandbox_tool",
+            "This sandbox tool is not available.",
+        ));
+    }
+    let arguments: WebSearchArguments =
+        serde_json::from_value(call.arguments.clone()).map_err(|_| {
+            failed_resolution(
+                "invalid_web_search_arguments",
+                "Web search arguments are invalid.",
+            )
+        })?;
+    let domains = arguments
+        .domains
+        .into_iter()
+        .map(SearchDomain::parse)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|_| {
+            failed_resolution(
+                "invalid_web_search_arguments",
+                "Web search arguments are invalid.",
+            )
+        })?;
+    WebSearchRequest::new(arguments.query, arguments.max_results)
+        .and_then(|request| request.with_domains(domains))
+        .and_then(|request| {
+            request.with_published_between(arguments.start_published_at, arguments.end_published_at)
+        })
+        .map_err(|_| {
+            failed_resolution(
+                "invalid_web_search_arguments",
+                "Web search arguments are invalid.",
+            )
+        })
+}
+
+fn remaining_execution_time(remaining: chrono::Duration) -> Option<Duration> {
+    let remaining = remaining.to_std().ok()?;
+    remaining
+        .checked_sub(EGRESS_SAFETY_MARGIN)
+        .filter(|value| !value.is_zero())
+}
+
+fn serialize_response(response: WebSearchResponse) -> ToolCallResolution {
+    match serde_json::to_string(&response) {
+        Ok(result) if result.len() <= MAX_OUTPUT_BYTES => ToolCallResolution::Completed { result },
+        // A bad injected adapter must not wedge the checkpoint or exceed its
+        // durable receipt budget.
+        Ok(_) | Err(_) => failed_resolution(
+            "web_search_output_invalid",
+            "Web search returned an invalid response.",
+        ),
+    }
+}
+
+fn failed_resolution(code: &str, result: &str) -> ToolCallResolution {
+    ToolCallResolution::Failed {
+        result: result.into(),
+        error_code: code.into(),
+        error_detail: None,
+    }
+}
+
+fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {
+    chrono::Duration::from_std(duration)
+        .map_err(|error| AgentError::msg(format!("invalid sandbox web-search duration: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    use openwave_core::{
+        AcceptAgentRunOutcome, AgentRunExecution, AgentRunId, AgentRunStatus, CallId, Chat, ChatId,
+        ClaimSandboxToolCallOutcome, DbStore, ParkSandboxToolCallOutcome,
+        RequestAgentRunCancellationOutcome, SandboxToolCallRequest, Store,
+    };
+    use openwave_web_search::{WebSearchProviderKind, WebSearchResult};
+
+    use super::*;
+
+    struct FakeSearch {
+        resolution: std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError>,
+    }
+
+    struct FakeProvider {
+        requests: Mutex<Vec<WebSearchRequest>>,
+        response: WebSearchResponse,
+    }
+
+    #[async_trait]
+    impl WebSearchProvider for FakeProvider {
+        fn kind(&self) -> WebSearchProviderKind {
+            WebSearchProviderKind::Exa
+        }
+
+        async fn search(
+            &self,
+            request: WebSearchRequest,
+        ) -> std::result::Result<WebSearchResponse, openwave_web_search::WebSearchError> {
+            self.requests.lock().unwrap().push(request);
+            Ok(self.response.clone())
+        }
+    }
+
+    #[async_trait]
+    impl SandboxWebSearch for FakeSearch {
+        async fn resolve(
+            &self,
+        ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, SandboxWebSearchError>
+        {
+            self.resolution.clone()
+        }
+    }
+
+    async fn test_store() -> (Arc<DbStore>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("test.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        (store, dir)
+    }
+
+    async fn checkpoint(
+        store: &Arc<DbStore>,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> SandboxToolCallRequest {
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: Some("sandbox web search".into()),
+            model: Some("model".into()),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let run = match store
+            .accept_agent_run(
+                AgentRunId::new(),
+                chat.id,
+                Some(AgentRunId::foreground_for_chat(chat.id)),
+                Some(CallId::new()),
+                AgentRunExecution::Sandbox,
+                Some("search"),
+            )
+            .await
+            .unwrap()
+        {
+            AcceptAgentRunOutcome::Accepted(run) => run,
+            outcome => panic!("unexpected sandbox admission: {outcome:?}"),
+        };
+        let worker_lease = uuid::Uuid::new_v4();
+        assert_eq!(
+            store
+                .claim_agent_run(worker_lease, chrono::Duration::minutes(5), 1, 1)
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            run.id
+        );
+        let request = SandboxToolCallRequest {
+            id: CallId::new(),
+            agent_run_id: run.id,
+            chat_id: chat.id,
+            provider_id: "provider-call".into(),
+            name: name.into(),
+            arguments,
+        };
+        assert!(matches!(
+            store
+                .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+                .await
+                .unwrap(),
+            ParkSandboxToolCallOutcome::Parked { .. }
+        ));
+        request
+    }
+
+    fn worker(store: Arc<DbStore>, search: Arc<dyn SandboxWebSearch>) -> SandboxWebSearchWorker {
+        SandboxWebSearchWorker::with_search(
+            store,
+            search,
+            Arc::new(Notify::new()),
+            SandboxWebSearchWorkerConfig::default(),
+        )
+    }
+
+    #[tokio::test]
+    async fn claimed_web_search_resolves_a_bounded_receipt_and_resumes_its_sandbox() {
+        let (store, _dir) = test_store().await;
+        let call = checkpoint(
+            &store,
+            WEB_SEARCH_TOOL,
+            serde_json::json!({"query":"durable search"}),
+        )
+        .await;
+        let provider = Arc::new(FakeProvider {
+            requests: Mutex::new(Vec::new()),
+            response: WebSearchResponse::new(WebSearchProviderKind::Exa, Vec::new()),
+        });
+        let fake = Arc::new(FakeSearch {
+            resolution: Ok(Some(provider.clone())),
+        });
+        assert_eq!(
+            worker(store.clone(), fake.clone())
+                .run_once()
+                .await
+                .unwrap(),
+            SandboxWebSearchWorkerOutcome::Resolved(call.id)
+        );
+        assert_eq!(
+            provider.requests.lock().unwrap()[0].max_results,
+            DEFAULT_MAX_RESULTS
+        );
+        let receipt = store
+            .get_sandbox_tool_call_receipt(call.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            receipt.status,
+            openwave_core::SandboxToolCallStatus::Completed
+        );
+        assert!(receipt.result.len() <= MAX_OUTPUT_BYTES);
+        assert_eq!(
+            store
+                .get_agent_run(call.agent_run_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            AgentRunStatus::RetryWait
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_checkpoints_resolve_without_search() {
+        let (store, _dir) = test_store().await;
+        let fake = Arc::new(FakeSearch {
+            resolution: Ok(None),
+        });
+        let malformed = checkpoint(
+            &store,
+            WEB_SEARCH_TOOL,
+            serde_json::json!({"query":"ok", "endpoint":"https://untrusted.example"}),
+        )
+        .await;
+        assert_eq!(
+            worker(store.clone(), fake.clone())
+                .run_once()
+                .await
+                .unwrap(),
+            SandboxWebSearchWorkerOutcome::Resolved(malformed.id)
+        );
+        // No provider exists, so malformed input cannot trigger egress.
+        assert_eq!(
+            store
+                .get_sandbox_tool_call_receipt(malformed.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .error_code
+                .as_deref(),
+            Some("invalid_web_search_arguments")
+        );
+    }
+
+    #[tokio::test]
+    async fn other_tool_names_stay_untouched_for_their_own_dispatcher() {
+        let (store, _dir) = test_store().await;
+        let unknown = checkpoint(&store, "untrusted_tool", serde_json::json!({"query":"ok"})).await;
+        let fake = Arc::new(FakeSearch {
+            resolution: Ok(None),
+        });
+        assert_eq!(
+            worker(store.clone(), fake).run_once().await.unwrap(),
+            SandboxWebSearchWorkerOutcome::Idle
+        );
+        assert!(store
+            .get_sandbox_tool_call_receipt(unknown.id)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn oversized_provider_output_becomes_a_bounded_failure_receipt() {
+        let (store, _dir) = test_store().await;
+        let call = checkpoint(
+            &store,
+            WEB_SEARCH_TOOL,
+            serde_json::json!({"query":"oversized"}),
+        )
+        .await;
+        let provider = Arc::new(FakeProvider {
+            requests: Mutex::new(Vec::new()),
+            response: WebSearchResponse {
+                provider: WebSearchProviderKind::Exa,
+                results: vec![WebSearchResult {
+                    url: "https://example.com/oversized".into(),
+                    title: "x".repeat(MAX_OUTPUT_BYTES),
+                    snippet: "x".repeat(MAX_OUTPUT_BYTES),
+                    content: None,
+                    score: None,
+                    published_at: None,
+                    image_url: None,
+                    metadata: BTreeMap::new(),
+                }],
+            },
+        });
+        let fake = Arc::new(FakeSearch {
+            resolution: Ok(Some(provider)),
+        });
+        assert_eq!(
+            worker(store.clone(), fake).run_once().await.unwrap(),
+            SandboxWebSearchWorkerOutcome::Resolved(call.id)
+        );
+        let receipt = store
+            .get_sandbox_tool_call_receipt(call.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            receipt.error_code.as_deref(),
+            Some("web_search_output_invalid")
+        );
+        assert!(receipt.result.len() <= openwave_core::SandboxToolCall::MAX_RESULT_BYTES);
+    }
+
+    #[tokio::test]
+    async fn stale_or_cancelled_claims_do_not_reach_search() {
+        let (store, _dir) = test_store().await;
+        let provider = Arc::new(FakeProvider {
+            requests: Mutex::new(Vec::new()),
+            response: WebSearchResponse::new(WebSearchProviderKind::Exa, Vec::new()),
+        });
+        let fake = Arc::new(FakeSearch {
+            resolution: Ok(Some(provider.clone())),
+        });
+        let stale = checkpoint(
+            &store,
+            WEB_SEARCH_TOOL,
+            serde_json::json!({"query":"stale"}),
+        )
+        .await;
+        let lease = uuid::Uuid::new_v4();
+        let claimed = match store
+            .claim_sandbox_tool_call(stale.id, lease, chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+        {
+            ClaimSandboxToolCallOutcome::Claimed(call) => call,
+            outcome => panic!("unexpected claim: {outcome:?}"),
+        };
+        assert_eq!(
+            worker(store.clone(), fake.clone())
+                .process(claimed, uuid::Uuid::new_v4())
+                .await
+                .unwrap(),
+            SandboxWebSearchWorkerOutcome::LeaseLost(stale.id)
+        );
+
+        let cancelled = checkpoint(
+            &store,
+            WEB_SEARCH_TOOL,
+            serde_json::json!({"query":"cancelled"}),
+        )
+        .await;
+        let cancelled_lease = uuid::Uuid::new_v4();
+        let claimed = match store
+            .claim_sandbox_tool_call(cancelled.id, cancelled_lease, chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+        {
+            ClaimSandboxToolCallOutcome::Claimed(call) => call,
+            outcome => panic!("unexpected claim: {outcome:?}"),
+        };
+        assert!(matches!(
+            store
+                .request_agent_run_cancellation(cancelled.agent_run_id)
+                .await
+                .unwrap(),
+            Some(RequestAgentRunCancellationOutcome::Cancelled(_))
+        ));
+        assert_eq!(
+            worker(store.clone(), fake.clone())
+                .process(claimed, cancelled_lease)
+                .await
+                .unwrap(),
+            SandboxWebSearchWorkerOutcome::LeaseLost(cancelled.id)
+        );
+        assert_eq!(provider.requests.lock().unwrap().len(), 0);
+    }
+}

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -106,8 +106,13 @@ timeout at `GET`/`PUT /web-search`. That setting has no endpoint or credential
 reference, returns only whether the selected fixed key is present, and does not
 construct or call a provider. It does **not** register `WebSearchTool` or grant
 any worker network access. Constructing an adapter is inert; only an explicit
-`search` call can send a request. A later execution slice must still attach the
-host policy to a sandbox worker and define its outbound-domain policy.
+`search` call can send a request. A separate sandbox checkpoint executor now
+attaches the host policy only after claiming and revalidating an exact durable
+`web_search` checkpoint. Its strict argument contract rejects unknown fields,
+and unavailable/error cases resolve a bounded immutable failure receipt. The
+sandbox model loop still advertises no tools, so no model-generated request can
+reach this executor yet. A later slice must add model-loop checkpoint emission
+and an explicit outbound-domain policy before search is model-usable.
 
 The normalized contract should cover query text, optional date/domain filters,
 bounded result count, canonical URL, title, snippet or extracted text, rank or

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -37,8 +37,18 @@ there is no provider to invoke.
 ## Current boundary
 
 `openwave-server::web_search::resolve_provider` is the host-only construction
-seam for a future approved execution worker. It is inert until that caller
-invokes `search`; no route invokes it. No model-visible `web_search` tool or
-sandbox tool loop exists yet. The next slice must explicitly attach this host
-policy to a sandbox worker, define an outbound-domain policy, and preserve the
-turn/checkpoint idempotency guarantees before search can be used by an agent.
+seam. It is inert until a caller invokes `search`; no route invokes it. The
+server's sandbox checkpoint executor may invoke it only after it has claimed a
+persisted `web_search` checkpoint. It resolves host settings and credentials,
+then revalidates the exact lease, cancellation state, and run deadline with the
+database clock immediately before calling the provider. It keeps its local
+execution timeout below that database-derived lease budget and resolves one
+immutable receipt.
+
+Malformed arguments, disabled selection, missing credentials, provider failure,
+timeout, and invalid output resolve a bounded redacted
+failure receipt rather than leaving a sandbox waiting. There is still no
+model-visible `web_search` tool or sandbox tool loop: without a durable
+checkpoint the executor does not construct a provider or make an outbound
+request. A later slice must add model-loop checkpoint emission and an explicit
+outbound-domain policy before search is model-usable.


### PR DESCRIPTION
## Summary

- add a bounded worker for durable sandbox web-search checkpoints
- claim and revalidate work under exact database-clock leases before provider egress
- resolve malformed, disabled, failed, and successful work into bounded durable receipts

## Validation

- cargo test -p openwave-server sandbox_web_search_worker --locked
- bw dev lint --rust --check
- adversarial review