### PR TITLE
Resume sandbox web search calls

### DIFF
--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -14,6 +14,8 @@ use crate::tool::ToolSpec;
 
 /// Stable name for the foreground-only sandbox delegation tool.
 pub const SPAWN_SANDBOX_AGENT_TOOL: &str = "spawn_sandbox_agent";
+/// The only tool a depth-one sandbox may receive.
+pub const SANDBOX_WEB_SEARCH_TOOL: &str = "web_search";
 
 /// Maximum task length in Unicode scalar values advertised to a model.
 ///
@@ -68,6 +70,31 @@ pub fn spawn_sandbox_agent_tool_spec() -> ToolSpec {
                 }
             },
             "required": ["task"],
+            "additionalProperties": false
+        }),
+    }
+}
+
+/// Narrow, host-executed web-search contract for an isolated sandbox run.
+///
+/// This is deliberately not registered in the foreground tool registry. The
+/// sandbox worker checkpoints it under its own durable lease, and the host
+/// decides whether any configured provider may execute it.
+#[must_use]
+pub fn sandbox_web_search_tool_spec() -> ToolSpec {
+    ToolSpec {
+        name: SANDBOX_WEB_SEARCH_TOOL.into(),
+        description: "Search the public web for current information. Use at most once, with a focused query. Results may be unavailable when the host has not configured web search.".into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "minLength": 1, "maxLength": 1024 },
+                "max_results": { "type": "integer", "minimum": 1, "maximum": 10 },
+                "domains": { "type": "array", "items": { "type": "string" }, "maxItems": 20 },
+                "start_published_at": { "type": "string", "format": "date-time" },
+                "end_published_at": { "type": "string", "format": "date-time" }
+            },
+            "required": ["query"],
             "additionalProperties": false
         }),
     }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1879,6 +1879,13 @@ impl Store for DbStore {
         ops::sandbox_tool::get_sandbox_tool_call_receipt(self, id).await
     }
 
+    async fn list_sandbox_tool_calls_for_agent_run(
+        &self,
+        agent_run_id: AgentRunId,
+    ) -> Result<Vec<SandboxToolCall>> {
+        ops::sandbox_tool::list_sandbox_tool_calls_for_agent_run(self, agent_run_id).await
+    }
+
     async fn list_sandbox_tool_call_candidates(&self, limit: u64) -> Result<Vec<SandboxToolCall>> {
         ops::sandbox_tool::list_sandbox_tool_call_candidates(self, limit).await
     }

--- a/crates/openwave-core/src/db/ops/sandbox_tool.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_tool.rs
@@ -444,6 +444,24 @@ pub(in crate::db) async fn get_sandbox_tool_call_receipt(
         .transpose()
 }
 
+pub(in crate::db) async fn list_sandbox_tool_calls_for_agent_run(
+    store: &DbStore,
+    agent_run_id: AgentRunId,
+) -> Result<Vec<SandboxToolCall>> {
+    entities::sandbox_tool_call::Entity::find()
+        .filter(entities::sandbox_tool_call::Column::AgentRunId.eq(agent_run_id.0))
+        // The worker claim count is monotonic within the isolated run, unlike
+        // SQLite timestamps and random IDs, so it is the replay order.
+        .order_by_asc(entities::sandbox_tool_call::Column::ParkAttemptCount)
+        .order_by_asc(entities::sandbox_tool_call::Column::ParkClaimCount)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(call_from_model)
+        .collect()
+}
+
 pub(in crate::db) async fn list_sandbox_tool_call_candidates(
     store: &DbStore,
     limit: u64,

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -41,8 +41,9 @@ pub use agent::{
     Agent, AgentConfig, AgentTurnOutcome, ClaimedAgentEvent, SandboxAgentSpawnRequest, ToolRegistry,
 };
 pub use agent_tools::{
-    spawn_sandbox_agent_tool_spec, validate_spawn_sandbox_agent_arguments, SpawnSandboxAgentArgs,
-    MAX_SANDBOX_AGENT_TASK_CHARS, SPAWN_SANDBOX_AGENT_TOOL,
+    sandbox_web_search_tool_spec, spawn_sandbox_agent_tool_spec,
+    validate_spawn_sandbox_agent_arguments, SpawnSandboxAgentArgs, MAX_SANDBOX_AGENT_TASK_CHARS,
+    SANDBOX_WEB_SEARCH_TOOL, SPAWN_SANDBOX_AGENT_TOOL,
 };
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalRequest, AutoApproveGate, RefuseGate,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1226,6 +1226,16 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// List immutable sandbox tool checkpoints for one isolated run in creation
+    /// order. A resumed sandbox rebuilds only its own tool transcript from
+    /// these durable records and their terminal receipts.
+    async fn list_sandbox_tool_calls_for_agent_run(
+        &self,
+        _agent_run_id: AgentRunId,
+    ) -> Result<Vec<crate::model::SandboxToolCall>> {
+        agent_run_storage_unavailable()
+    }
+
     /// List bounded oldest-first accepted work and expired claims for durable
     /// executor recovery. Claiming remains the authority for ownership.
     async fn list_sandbox_tool_call_candidates(

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -1,8 +1,9 @@
 //! Execution for durably claimed sandboxed agent runs.
 //!
 //! A sandbox run intentionally is not a second foreground turn. It receives
-//! only its immutable delegated task, uses one model completion with no tools,
-//! and returns bounded text through the fenced agent-run result transition.
+//! only its immutable delegated task, may checkpoint one fixed host-owned web
+//! search call, and returns bounded text through the fenced agent-run result
+//! transition.
 //! That keeps the first execution surface small while preserving the same
 //! claim, heartbeat, cancellation, and replay mechanics as other workers.
 
@@ -12,10 +13,12 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use openwave_core::{
-    AgentConfig, AgentError, AgentRun, AgentRunInboxEntry, AgentRunStatus, ChatMessage,
-    ChatRequest, ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
-    FailAgentRunOutcome, ModelProvider, ProviderEvent, Result, Role, StopReason, Store,
-    SubmitAgentRunResultOutcome,
+    sandbox_web_search_tool_spec, AgentConfig, AgentError, AgentRun, AgentRunInboxEntry,
+    AgentRunStatus, CallId, ChatMessage, ChatRequest, ClaimAgentRunInboxOutcome,
+    ConsumeAgentRunInboxAndResumeTurnOutcome, ContentBlock, FailAgentRunOutcome, ModelProvider,
+    ParkSandboxToolCallOutcome, ProviderEvent, Result, Role, SandboxToolCall,
+    SandboxToolCallRequest, SandboxToolCallStatus, StopReason, Store, SubmitAgentRunResultOutcome,
+    ToolCallRecord,
 };
 use tokio::sync::Notify;
 
@@ -26,7 +29,8 @@ use crate::resolver::ProviderResolver;
 /// Deliberately do not inherit the foreground system prompt: it may describe
 /// interactive tools or conversation-wide responsibilities that are outside a
 /// depth-one child run's authority.
-const SANDBOX_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below and return a concise, self-contained result for your parent agent. You have no tools, cannot access the conversation, filesystem, network, or other agents, and must not ask to create or call tools.";
+const SANDBOX_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below and return a concise, self-contained result for your parent agent. You cannot access the conversation, filesystem, or other agents. You may use the single web_search tool at most once when current public-web information is necessary; otherwise finish directly.";
+const SANDBOX_WEB_SEARCH_TOOL_LIMIT: usize = 1;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SandboxAgentRunWorkerConfig {
@@ -67,6 +71,7 @@ pub(crate) enum SandboxAgentRunWorkerOutcome {
     Failed(openwave_core::AgentRunId),
     Cancelled(openwave_core::AgentRunId),
     ParentResumed(openwave_core::AgentRunId),
+    ToolCheckpointed(openwave_core::CallId),
     LeaseLost(openwave_core::AgentRunId),
 }
 
@@ -247,7 +252,12 @@ impl SandboxAgentRunWorker {
         })?;
         self.prepare_private_scratch(run.id)?;
 
-        let request = sandbox_request(&self.agent_config, task);
+        let previous_calls = self
+            .store
+            .list_sandbox_tool_calls_for_agent_run(run.id)
+            .await?;
+        let request =
+            sandbox_request(&self.agent_config, task, &previous_calls, &*self.store).await?;
         let provider = match self.resolve_provider(run.id, lease_token).await? {
             Ok(provider) => provider,
             Err(outcome) => return Ok(outcome),
@@ -276,7 +286,10 @@ impl SandboxAgentRunWorker {
         loop {
             tokio::select! {
                 result = &mut completion => match result {
-                    Ok(text) => return self.submit_result(run.id, lease_token, text).await,
+                    Ok(SandboxCompletion::Final(text)) => return self.submit_result(run.id, lease_token, text).await,
+                    Ok(SandboxCompletion::WebSearch { provider_id, arguments }) => {
+                        return self.park_web_search(run, lease_token, provider_id, arguments).await;
+                    }
                     // No terminal failure transition exists yet. Keep the exact
                     // lease alive only until its scheduler expiry; then the
                     // durable claim state machine safely retries or exhausts
@@ -382,6 +395,73 @@ impl SandboxAgentRunWorker {
         }
     }
 
+    async fn park_web_search(
+        &self,
+        run: AgentRun,
+        lease_token: uuid::Uuid,
+        provider_id: String,
+        arguments: serde_json::Value,
+    ) -> Result<SandboxAgentRunWorkerOutcome> {
+        let call = SandboxToolCallRequest {
+            id: CallId::new(),
+            agent_run_id: run.id,
+            chat_id: run.chat_id,
+            provider_id,
+            name: openwave_core::SANDBOX_WEB_SEARCH_TOOL.into(),
+            arguments,
+        };
+        let outcome = match self
+            .store
+            .park_agent_run_for_sandbox_tool_call(run.id, lease_token, &call)
+            .await
+        {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                // The local transaction may have committed before its response
+                // was lost. Recover only a checkpoint whose immutable payload
+                // and producing lease match this exact model completion; never
+                // issue a second model call or tool checkpoint on ambiguity.
+                let recovered = self
+                    .store
+                    .list_sandbox_tool_calls_for_agent_run(run.id)
+                    .await?
+                    .into_iter()
+                    .find(|existing| {
+                        existing.park_lease_token == lease_token
+                            && existing.provider_id == call.provider_id
+                            && existing.name == call.name
+                            && existing.arguments == call.arguments
+                    });
+                if let Some(call) = recovered {
+                    self.wake.notify_one();
+                    return Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id));
+                }
+                return Err(error);
+            }
+        };
+        match outcome {
+            ParkSandboxToolCallOutcome::Parked { call, .. }
+            | ParkSandboxToolCallOutcome::Existing { call, .. } => {
+                // This shared wake is only a latency hint; the dedicated
+                // executor's durable candidate scan remains the recovery path.
+                self.wake.notify_one();
+                Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id))
+            }
+            ParkSandboxToolCallOutcome::IdentityConflict => {
+                self.record_failure(
+                    run.id,
+                    lease_token,
+                    AgentError::msg("sandbox web-search checkpoint identity conflict"),
+                )
+                .await
+            }
+            ParkSandboxToolCallOutcome::LeaseLost => {
+                self.acknowledge_cancellation_or_lease_loss(run.id, lease_token)
+                    .await
+            }
+        }
+    }
+
     async fn acknowledge_cancellation_or_lease_loss(
         &self,
         id: openwave_core::AgentRunId,
@@ -430,23 +510,83 @@ impl SandboxAgentRunWorker {
     }
 }
 
-fn sandbox_request(config: &AgentConfig, task: String) -> ChatRequest {
-    ChatRequest {
+async fn sandbox_request(
+    config: &AgentConfig,
+    task: String,
+    calls: &[SandboxToolCall],
+    store: &dyn Store,
+) -> Result<ChatRequest> {
+    if calls.len() > SANDBOX_WEB_SEARCH_TOOL_LIMIT {
+        return Err(AgentError::msg("sandbox web-search tool budget exceeded"));
+    }
+    if config.max_steps == 0 || calls.len().saturating_add(1) > config.max_steps {
+        return Err(AgentError::msg("sandbox model-step budget exceeded"));
+    }
+    let mut messages = vec![ChatMessage::text(Role::User, task)];
+    for call in calls {
+        if call.name != openwave_core::SANDBOX_WEB_SEARCH_TOOL || !call.status.is_terminal() {
+            return Err(AgentError::msg("sandbox checkpoint cannot be resumed"));
+        }
+        let receipt = store
+            .get_sandbox_tool_call_receipt(call.id)
+            .await?
+            .ok_or_else(|| AgentError::msg("sandbox checkpoint is missing its receipt"))?;
+        messages.push(ChatMessage {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: call.provider_id.clone(),
+                name: call.name.clone(),
+                input: call.arguments.clone(),
+            }],
+        });
+        messages.push(ChatMessage {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: call.provider_id.clone(),
+                content: receipt.result,
+                is_error: receipt.status != SandboxToolCallStatus::Completed,
+            }],
+        });
+    }
+    Ok(ChatRequest {
         model: config.model.clone(),
         system: Some(SANDBOX_SYSTEM_PROMPT.into()),
-        messages: vec![ChatMessage::text(Role::User, task)],
-        tools: vec![],
+        messages,
+        // Once a receipt exists, omit the tool definition. This makes the
+        // depth-one sandbox's one-call budget visible to the model and turns a
+        // second call into a deterministic worker error rather than new work.
+        // A tool checkpoint consumes one model completion and a resumed final
+        // completion. Never advertise work that the remaining model budget
+        // cannot consume after its durable receipt arrives.
+        tools: if calls.is_empty() && config.max_steps >= 2 {
+            vec![sandbox_web_search_tool_spec()]
+        } else {
+            vec![]
+        },
         max_tokens: config.max_tokens,
         temperature: config.temperature,
-    }
+    })
+}
+
+enum SandboxCompletion {
+    Final(String),
+    WebSearch {
+        provider_id: String,
+        arguments: serde_json::Value,
+    },
 }
 
 async fn complete_sandbox_task(
     provider: Arc<dyn ModelProvider>,
     request: ChatRequest,
-) -> Result<String> {
+) -> Result<SandboxCompletion> {
+    let web_search_advertised = request
+        .tools
+        .iter()
+        .any(|tool| tool.name == openwave_core::SANDBOX_WEB_SEARCH_TOOL);
     let mut stream = provider.stream(request).await?;
     let mut text = String::new();
+    let mut calls = std::collections::BTreeMap::<u32, (String, String, String)>::new();
     while let Some(event) = stream.next().await {
         match event {
             ProviderEvent::TextDelta { text: delta } => {
@@ -458,15 +598,62 @@ async fn complete_sandbox_task(
                     )));
                 }
             }
-            ProviderEvent::ToolCallStarted { .. } | ProviderEvent::ToolCallArgsDelta { .. } => {
-                return Err(AgentError::msg(
-                    "sandbox agent requested a tool on the no-tools execution surface",
-                ));
+            ProviderEvent::ToolCallStarted { index, id, name } => {
+                if calls.insert(index, (id, name, String::new())).is_some() {
+                    return Err(AgentError::msg(
+                        "sandbox agent emitted duplicate tool-call index",
+                    ));
+                }
+            }
+            ProviderEvent::ToolCallArgsDelta { index, fragment } => {
+                let Some((_, _, arguments)) = calls.get_mut(&index) else {
+                    return Err(AgentError::msg(
+                        "sandbox agent emitted tool arguments before its call",
+                    ));
+                };
+                if arguments.len().saturating_add(fragment.len())
+                    > ToolCallRecord::MAX_ARGUMENT_BYTES
+                {
+                    return Err(AgentError::msg(
+                        "sandbox agent tool arguments exceed the durable checkpoint limit",
+                    ));
+                }
+                arguments.push_str(&fragment);
             }
             ProviderEvent::Stop { reason } => {
-                if matches!(reason, StopReason::ToolUse | StopReason::Cancelled) {
+                if matches!(reason, StopReason::Cancelled) {
                     return Err(AgentError::msg(
                         "sandbox agent did not produce a final result",
+                    ));
+                }
+                if reason == StopReason::ToolUse {
+                    if !web_search_advertised {
+                        return Err(AgentError::msg(
+                            "sandbox agent requested an unadvertised tool",
+                        ));
+                    }
+                    if !text.is_empty() || calls.len() != 1 {
+                        return Err(AgentError::msg(
+                            "sandbox agent emitted an ambiguous tool checkpoint",
+                        ));
+                    }
+                    let (_, (provider_id, name, arguments)) = calls.into_iter().next().unwrap();
+                    if name != openwave_core::SANDBOX_WEB_SEARCH_TOOL || provider_id.is_empty() {
+                        return Err(AgentError::msg(
+                            "sandbox agent requested an unavailable tool",
+                        ));
+                    }
+                    let arguments = serde_json::from_str(&arguments).map_err(|_| {
+                        AgentError::msg("sandbox agent emitted invalid web-search arguments")
+                    })?;
+                    return Ok(SandboxCompletion::WebSearch {
+                        provider_id,
+                        arguments,
+                    });
+                }
+                if !calls.is_empty() {
+                    return Err(AgentError::msg(
+                        "sandbox agent stopped with an incomplete tool call",
                     ));
                 }
                 if text.trim().is_empty() {
@@ -474,7 +661,7 @@ async fn complete_sandbox_task(
                         "sandbox agent produced an empty final result",
                     ));
                 }
-                return Ok(text);
+                return Ok(SandboxCompletion::Final(text));
             }
             ProviderEvent::ReasoningDelta { .. } | ProviderEvent::Usage(_) => {}
             _ => {
@@ -503,7 +690,7 @@ mod tests {
     use openwave_core::{
         AcceptAgentRunOutcome, AcceptTurnOutcome, AgentRunExecution, AgentRunInboxStatus, CallId,
         Chat, ChatId, ChatRequest, DbStore, ModelProvider, ProviderId, Role, Store,
-        TurnCheckpointProgress, TurnId, TurnRunStatus, Usage,
+        ToolCallResolution, TurnCheckpointProgress, TurnId, TurnRunStatus, Usage,
     };
 
     use super::*;
@@ -542,6 +729,52 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct WebSearchThenFinalProvider {
+        requests: Mutex<Vec<ChatRequest>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for WebSearchThenFinalProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("sandbox-web-search")
+        }
+
+        async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let call_number = {
+                let mut requests = self.requests.lock().unwrap();
+                requests.push(request);
+                requests.len()
+            };
+            let events = if call_number == 1 {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "search_1".into(),
+                        name: openwave_core::SANDBOX_WEB_SEARCH_TOOL.into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: r#"{"query":"OpenWave"}"#.into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta {
+                        text: "search-informed answer".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
     struct DelayedResolver {
         entered: Arc<Notify>,
         release: Arc<Notify>,
@@ -562,6 +795,19 @@ mod tests {
     }
 
     struct FailingProvider;
+
+    struct EventProvider(Vec<ProviderEvent>);
+
+    #[async_trait]
+    impl ModelProvider for EventProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("events")
+        }
+
+        async fn stream(&self, _request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            Ok(stream::iter(self.0.clone()).boxed())
+        }
+    }
 
     #[async_trait]
     impl ModelProvider for FailingProvider {
@@ -669,7 +915,7 @@ mod tests {
 
         let requests = provider.requests.lock().unwrap();
         assert_eq!(requests.len(), 1);
-        assert!(requests[0].tools.is_empty());
+        assert_eq!(requests[0].tools, vec![sandbox_web_search_tool_spec()]);
         assert_eq!(
             requests[0].messages,
             vec![ChatMessage::text(
@@ -678,6 +924,201 @@ mod tests {
             )]
         );
         assert_eq!(requests[0].system.as_deref(), Some(SANDBOX_SYSTEM_PROMPT));
+    }
+
+    #[tokio::test]
+    async fn checkpoints_one_web_search_and_rebuilds_its_receipt_before_finalizing() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = sandbox_chat();
+        store.create_chat(&chat).await.unwrap();
+        let provider = Arc::new(WebSearchThenFinalProvider::default());
+        let worker = SandboxAgentRunWorker::new(
+            store.clone(),
+            Arc::new(FixedResolver(provider.clone())),
+            Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
+            AgentConfig {
+                model: "sandbox-model".into(),
+                max_steps: 2,
+                ..AgentConfig::default()
+            },
+            None,
+            SandboxAgentRunWorkerConfig::default(),
+        );
+        let spawn = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
+        store
+            .accept_agent_run(
+                id,
+                chat.id,
+                Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
+                Some(spawn),
+                AgentRunExecution::Sandbox,
+                Some("Research this."),
+            )
+            .await
+            .unwrap();
+
+        let call_id = match worker.run_once().await.unwrap() {
+            SandboxAgentRunWorkerOutcome::ToolCheckpointed(call_id) => call_id,
+            outcome => panic!("unexpected outcome: {outcome:?}"),
+        };
+        assert_eq!(
+            store.get_agent_run(id).await.unwrap().unwrap().status,
+            AgentRunStatus::Waiting
+        );
+        let executor_lease = uuid::Uuid::new_v4();
+        store
+            .claim_sandbox_tool_call(call_id, executor_lease, chrono::Duration::minutes(1))
+            .await
+            .unwrap();
+        store
+            .resolve_sandbox_tool_call(
+                call_id,
+                executor_lease,
+                &ToolCallResolution::Completed {
+                    result: "{\"results\":[]}".into(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::Completed(id)
+        );
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[1].tools.is_empty());
+        assert!(
+            matches!(&requests[1].messages[1].content[0], ContentBlock::ToolUse { id, name, input } if id == "search_1" && name == openwave_core::SANDBOX_WEB_SEARCH_TOOL && input == &serde_json::json!({"query":"OpenWave"}))
+        );
+        assert!(
+            matches!(&requests[1].messages[2].content[0], ContentBlock::ToolResult { tool_use_id, content, is_error } if tool_use_id == "search_1" && content == "{\"results\":[]}" && !is_error)
+        );
+    }
+
+    #[tokio::test]
+    async fn refuses_ambiguous_or_unavailable_sandbox_tool_events_without_checkpointing() {
+        let request = ChatRequest {
+            model: "m".into(),
+            system: None,
+            messages: vec![],
+            tools: vec![],
+            max_tokens: None,
+            temperature: None,
+        };
+        for events in [
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "one".into(),
+                    name: "web_search".into(),
+                },
+                ProviderEvent::ToolCallStarted {
+                    index: 1,
+                    id: "two".into(),
+                    name: "web_search".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ],
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "one".into(),
+                    name: "read_file".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{}".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ],
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "one".into(),
+                    name: "web_search".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ],
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "one".into(),
+                    name: "web_search".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "x".repeat(ToolCallRecord::MAX_ARGUMENT_BYTES + 1),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ],
+        ] {
+            assert!(
+                complete_sandbox_task(Arc::new(EventProvider(events)), request.clone())
+                    .await
+                    .is_err()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_fence_prevents_a_stale_worker_from_parking_web_search() {
+        let (worker, store, _provider, chat, _dir) = fixture().await;
+        let spawn = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
+        store
+            .accept_agent_run(
+                id,
+                chat.id,
+                Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
+                Some(spawn),
+                AgentRunExecution::Sandbox,
+                Some("Research this."),
+            )
+            .await
+            .unwrap();
+        let lease = uuid::Uuid::new_v4();
+        let run = store
+            .claim_agent_run(lease, chrono::Duration::minutes(1), 4, 2)
+            .await
+            .unwrap()
+            .unwrap();
+        store.request_agent_run_cancellation(id).await.unwrap();
+        assert_eq!(
+            worker
+                .park_web_search(
+                    run,
+                    lease,
+                    "search_1".into(),
+                    serde_json::json!({"query":"OpenWave"})
+                )
+                .await
+                .unwrap(),
+            SandboxAgentRunWorkerOutcome::Cancelled(id),
+        );
+        assert!(store
+            .list_sandbox_tool_calls_for_agent_run(id)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]
@@ -1026,8 +1467,15 @@ mod tests {
         assert!(provider.requests.lock().unwrap().is_empty());
     }
 
-    #[test]
-    fn sandbox_request_does_not_inherit_foreground_system_or_tools() {
+    #[tokio::test]
+    async fn sandbox_request_does_not_inherit_foreground_system_or_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap();
         let request = sandbox_request(
             &AgentConfig {
                 model: "m".into(),
@@ -1035,9 +1483,52 @@ mod tests {
                 ..AgentConfig::default()
             },
             "task".into(),
-        );
+            &[],
+            &store,
+        )
+        .await
+        .unwrap();
         assert_eq!(request.system.as_deref(), Some(SANDBOX_SYSTEM_PROMPT));
+        assert_eq!(request.tools, vec![sandbox_web_search_tool_spec()]);
+    }
+
+    #[tokio::test]
+    async fn one_model_step_never_advertises_unconsumable_web_search_work() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap();
+        let request = sandbox_request(
+            &AgentConfig {
+                model: "m".into(),
+                max_steps: 1,
+                ..AgentConfig::default()
+            },
+            "task".into(),
+            &[],
+            &store,
+        )
+        .await
+        .unwrap();
         assert!(request.tools.is_empty());
+        let provider = Arc::new(EventProvider(vec![
+            ProviderEvent::ToolCallStarted {
+                index: 0,
+                id: "search_1".into(),
+                name: openwave_core::SANDBOX_WEB_SEARCH_TOOL.into(),
+            },
+            ProviderEvent::ToolCallArgsDelta {
+                index: 0,
+                fragment: r#"{"query":"OpenWave"}"#.into(),
+            },
+            ProviderEvent::Stop {
+                reason: StopReason::ToolUse,
+            },
+        ]));
+        assert!(complete_sandbox_task(provider, request).await.is_err());
     }
 
     fn sandbox_chat() -> Chat {

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -229,13 +229,15 @@ The implementation is intentionally incremental:
 6. Persist shared model/tool step boundaries and side-effect receipts.
 7. Atomically join durable inbox consumption with a parent turn checkpoint and
    durable `resuming` wake signal. *(Shipped.)*
-8. Run isolated one-shot sandbox tasks with no tools or shared conversation
-   context, over the durable lease/result boundary. *(Shipped.)*
+8. Run isolated sandbox tasks with no shared conversation context, over the
+   durable lease/result boundary. *(Shipped.)*
 9. Enable the bounded foreground-only `spawn_sandbox_agent` contract, wake the
    sandbox worker after its atomic checkpoint, and resume the parked turn from
    the already-delivered inbox receipt. *(Shipped.)*
-10. Route sandbox folder access through the host broker.
-11. Add desktop surfaces for queued, running, waiting, failed, and completed
+10. Add the one-call sandbox `web_search` checkpoint, host executor, and
+    receipt-backed model resume. *(Shipped.)*
+11. Route sandbox folder access through the host broker.
+12. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.
-12. Add richer context lifecycle, parallel-safe tool groups, and further
+13. Add richer context lifecycle, parallel-safe tool groups, and further
    orchestration only after these recovery boundaries are proven.

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -127,9 +127,11 @@ provides a timeout- and response-size-bounded `reqwest` client; hosts may supply
 their own proxy, allow-list, audit, or test client through the same seam.
 
 `openwave-server` owns an explicit disabled-by-default Exa/Tavily selection
-and bounded request timeout, but has not connected it to a model-visible tool
-or worker. The follow-on slice must attach that host policy to the sandbox
-execution boundary and define its outbound-domain policy.
+and bounded request timeout. Its depth-one sandbox loop may durably checkpoint
+the one fixed `web_search` contract, and the server worker resolves that exact
+checkpoint under a fenced lease. The foreground registry and recursive
+sandboxes never receive this contract. The follow-on slice defines the
+outbound-domain policy before expanding the search surface.
 
 **Depends on:** `openwave-core`.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -62,14 +62,18 @@ atomically admits a depth-one child and parks that turn; the child result is
 persisted as a system transcript message before the parent can resume. Sandbox
 agents never receive this tool.
 
-A background sandbox currently has **no tool surface and no shared
-conversation, filesystem, network, or host-folder access**. It receives one
-bounded task and its final text becomes the fenced result receipt. Sandboxes
-do not receive `spawn_sandbox_agent` and cannot create further agents.
+A background sandbox has no shared conversation, filesystem, network, or
+host-folder access. It receives one bounded task and may be offered exactly
+one fixed `web_search` contract when its remaining model-step budget can also
+consume the result. The worker atomically parks the sandbox under its exact
+lease; a separate host-owned executor performs the bounded search and writes
+an immutable receipt. On a later claim, the sandbox reconstructs the matching
+`ToolUse`/`ToolResult` from that receipt before it can finalize. Sandboxes do
+not receive `spawn_sandbox_agent` and cannot create further agents.
 
-Future sandbox-safe capabilities (for example web search or broker-mediated
-folder reads) must be added one at a time behind the same durable continuation
-and consent boundaries.
+Future sandbox-safe capabilities, such as broker-mediated folder reads, must
+be added one at a time behind the same durable continuation and consent
+boundaries.
 
 Later additions may include a scratchpad, pinned context, plan/execution modes,
 deliverable export, clipboard operations, generated images, and connected apps.
@@ -110,9 +114,11 @@ any worker network access. Constructing an adapter is inert; only an explicit
 attaches the host policy only after claiming and revalidating an exact durable
 `web_search` checkpoint. Its strict argument contract rejects unknown fields,
 and unavailable/error cases resolve a bounded immutable failure receipt. The
-sandbox model loop still advertises no tools, so no model-generated request can
-reach this executor yet. A later slice must add model-loop checkpoint emission
-and an explicit outbound-domain policy before search is model-usable.
+sandbox model loop may now emit the one fixed checkpoint, with a bounded
+argument collector and deterministic rejection of unknown, partial, or
+multiple calls. The foreground loop remains separate and does not receive this
+tool. Outbound-domain policy is the next hardening slice before broadening the
+search surface.
 
 The normalized contract should cover query text, optional date/domain filters,
 bounded result count, canonical URL, title, snippet or extracted text, rank or

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -62,8 +62,10 @@ immutable receipt.
 
 Malformed arguments, disabled selection, missing credentials, provider failure,
 timeout, and invalid output resolve a bounded redacted
-failure receipt rather than leaving a sandbox waiting. There is still no
-model-visible `web_search` tool or sandbox tool loop: without a durable
-checkpoint the executor does not construct a provider or make an outbound
-request. A later slice must add model-loop checkpoint emission and an explicit
-outbound-domain policy before search is model-usable.
+failure receipt rather than leaving a sandbox waiting. The depth-one sandbox
+model loop may advertise only this fixed `web_search` schema, at most once and
+only when two model steps remain. It parks the immutable call before any
+egress; when the receipt resolves, its next claim rebuilds the same
+`ToolUse`/`ToolResult` pair and may finalize. No foreground or recursive agent
+receives the schema. An explicit outbound-domain policy remains the next
+hardening slice before broadening this search surface.


### PR DESCRIPTION
## Summary

- let sandbox runs checkpoint one bounded web-search tool call under their exact lease
- rebuild sandbox context from immutable tool receipts before resuming the model
- enforce model-step and streamed-argument bounds around the sandbox tool loop

## Validation

- cargo test -p openwave-server sandbox_agent_run_worker --locked
- bw dev lint --rust --check
- adversarial review