### PR TITLE
Fix strict main validation

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1750,6 +1750,7 @@ impl Store for DbStore {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)] // Mirrors the Store checkpoint contract.
     async fn accept_sandbox_agent_run_and_park_turn(
         &self,
         child_run_id: AgentRunId,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -239,6 +239,7 @@ pub(in crate::db) async fn accept_agent_run(
 /// transaction. The sandbox parent comes from the locked turn, which binds
 /// child hierarchy and checkpoint scope without trusting a caller-supplied
 /// parent id.
+#[allow(clippy::too_many_arguments)] // Atomic checkpoint inputs form the durable receipt identity.
 pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
     store: &DbStore,
     child_run_id: AgentRunId,
@@ -763,8 +764,8 @@ pub(in crate::db) async fn request_agent_run_cancellation(
     }
 
     let immediate = status != AgentRunStatus::Running
-        || !run.lease_expires_at.is_some_and(|expiry| expiry > now)
-        || !run.deadline_at.is_some_and(|deadline| deadline > now);
+        || run.lease_expires_at.is_none_or(|expiry| expiry <= now)
+        || run.deadline_at.is_none_or(|deadline| deadline <= now);
     let next_status = if immediate {
         AgentRunStatus::Cancelled
     } else {
@@ -928,8 +929,8 @@ where
         return Ok(false);
     }
     let immediate = status != AgentRunStatus::Running
-        || !child.lease_expires_at.is_some_and(|expiry| expiry > now)
-        || !child.deadline_at.is_some_and(|deadline| deadline > now);
+        || child.lease_expires_at.is_none_or(|expiry| expiry <= now)
+        || child.deadline_at.is_none_or(|deadline| deadline <= now);
     let next = if immediate {
         AgentRunStatus::Cancelled
     } else {
@@ -1037,8 +1038,8 @@ pub(in crate::db) async fn finish_agent_run_cancellation(
     }
     if run.status != AgentRunStatus::Cancelling.as_str()
         || run.lease_token != Some(lease_token)
-        || !run.lease_expires_at.is_some_and(|expiry| expiry > now)
-        || !run.deadline_at.is_some_and(|deadline| deadline > now)
+        || run.lease_expires_at.is_none_or(|expiry| expiry <= now)
+        || run.deadline_at.is_none_or(|deadline| deadline <= now)
         || run.updated_at > now
     {
         transaction.commit().await.map_err(store_err)?;
@@ -1308,8 +1309,8 @@ pub(in crate::db) async fn submit_agent_run_result(
     if run.execution != AgentRunExecution::Sandbox.as_str()
         || run.status != AgentRunStatus::Running.as_str()
         || run.lease_token != Some(lease_token)
-        || !run.lease_expires_at.is_some_and(|expiry| expiry > now)
-        || !run.deadline_at.is_some_and(|deadline| deadline > now)
+        || run.lease_expires_at.is_none_or(|expiry| expiry <= now)
+        || run.deadline_at.is_none_or(|deadline| deadline <= now)
         || run.updated_at > now
     {
         transaction.commit().await.map_err(store_err)?;
@@ -1857,9 +1858,9 @@ pub(in crate::db) async fn consume_agent_run_inbox_entry_and_resume_turn(
     }
     if entry.status != AgentRunInboxStatus::Claimed
         || entry.lease_token != Some(lease_token)
-        || !entry
+        || entry
             .lease_expires_at
-            .is_some_and(|expires_at| expires_at > now)
+            .is_none_or(|expires_at| expires_at <= now)
     {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);

--- a/crates/openwave-core/src/db/ops/sandbox_tool.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_tool.rs
@@ -63,8 +63,8 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         || run.execution != AgentRunExecution::Sandbox.as_str()
         || run.status != AgentRunStatus::Running.as_str()
         || run.lease_token != Some(lease_token)
-        || !run.lease_expires_at.is_some_and(|expiry| expiry > now)
-        || !run.deadline_at.is_some_and(|deadline| deadline > now)
+        || run.lease_expires_at.is_none_or(|expiry| expiry <= now)
+        || run.deadline_at.is_none_or(|deadline| deadline <= now)
     {
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::LeaseLost);
@@ -276,9 +276,9 @@ pub(in crate::db) async fn heartbeat_sandbox_tool_call(
     };
     if call.status != SandboxToolCallStatus::Claimed.as_str()
         || call.executor_lease_token != Some(lease_token)
-        || !call
+        || call
             .executor_lease_expires_at
-            .is_some_and(|expiry| expiry > now)
+            .is_none_or(|expiry| expiry <= now)
     {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
@@ -349,9 +349,9 @@ pub(in crate::db) async fn resolve_sandbox_tool_call(
     };
     if call.status != SandboxToolCallStatus::Claimed.as_str()
         || call.executor_lease_token != Some(lease_token)
-        || !call
+        || call
             .executor_lease_expires_at
-            .is_some_and(|expiry| expiry > now)
+            .is_none_or(|expiry| expiry <= now)
     {
         transaction.commit().await.map_err(store_err)?;
         return Ok(ResolveSandboxToolCallOutcome::LeaseLost);

--- a/crates/openwave-core/src/db/ops/turn/agent_run_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/agent_run_wait.rs
@@ -58,6 +58,7 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
 
 /// Checkpoint one foreground turn using a caller-owned transaction with the
 /// chat and turn write locks already held.
+#[allow(clippy::too_many_arguments)] // The caller-held transaction and receipt fields must stay explicit.
 pub(in crate::db) async fn park_turn_for_agent_run_inbox_on<C>(
     conn: &C,
     turn_id: TurnId,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1090,6 +1090,7 @@ pub trait Store: Send + Sync {
     /// coordinator. Exact retries recover the immutable child and checkpoint
     /// receipt; a child accepted through any other path is never retrofitted
     /// into this transition.
+    #[allow(clippy::too_many_arguments)] // This durable checkpoint contract intentionally keeps its receipt fields explicit.
     async fn accept_sandbox_agent_run_and_park_turn(
         &self,
         _child_run_id: AgentRunId,

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -168,7 +168,7 @@ pub async fn put_web_search_credential(
     Json(body): Json<WebSearchCredentialUpdate>,
 ) -> Result<Json<WebSearchCredentialReadiness>, ServerError> {
     let provider = parse_web_search_provider(&provider)?;
-    if body.api_key.as_bytes().len() > MAX_WEB_SEARCH_CREDENTIAL_BYTES {
+    if body.api_key.len() > MAX_WEB_SEARCH_CREDENTIAL_BYTES {
         return Err(ServerError::bad_request(format!(
             "web search api_key must be at most {MAX_WEB_SEARCH_CREDENTIAL_BYTES} bytes"
         )));

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -470,15 +470,15 @@ impl SandboxAgentRunWorker {
         let Some(run) = self.store.get_agent_run(id).await? else {
             return Ok(SandboxAgentRunWorkerOutcome::LeaseLost(id));
         };
-        if run.status == AgentRunStatus::Cancelling && run.lease_token == Some(lease_token) {
-            if self
+        if run.status == AgentRunStatus::Cancelling
+            && run.lease_token == Some(lease_token)
+            && self
                 .store
                 .finish_agent_run_cancellation(id, lease_token)
                 .await?
                 .is_some()
-            {
-                return Ok(SandboxAgentRunWorkerOutcome::Cancelled(id));
-            }
+        {
+            return Ok(SandboxAgentRunWorkerOutcome::Cancelled(id));
         }
         Ok(SandboxAgentRunWorkerOutcome::LeaseLost(id))
     }

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -53,8 +53,8 @@ impl ModelProvider for FakeProvider {
 }
 
 /// Drives the complete foreground-child-foreground round trip. The sandbox
-/// request is identified by its deliberately empty tool surface; foreground
-/// requests retain the registered delegation contract.
+/// request is identified by its absence of the foreground delegation contract;
+/// its fixed web-search capability is deliberately separate.
 #[derive(Default)]
 struct SandboxRoundTripProvider {
     foreground_calls: AtomicUsize,
@@ -68,7 +68,10 @@ impl ModelProvider for SandboxRoundTripProvider {
     }
 
     async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
-        let sandbox = request.tools.is_empty();
+        let sandbox = !request
+            .tools
+            .iter()
+            .any(|tool| tool.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL);
         self.requests.lock().unwrap().push(request);
         let events = if sandbox {
             vec![
@@ -6562,8 +6565,11 @@ async fn foreground_sandbox_spawn_parks_executes_delivers_and_resumes() {
         .iter()
         .any(|tool| tool.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL));
     assert!(
-        requests[1].tools.is_empty(),
-        "sandbox receives no tool surface"
+        requests[1]
+            .tools
+            .iter()
+            .any(|tool| tool.name == openwave_core::SANDBOX_WEB_SEARCH_TOOL),
+        "sandbox receives only the fixed web-search tool surface"
     );
     assert!(
         requests[2].messages.iter().any(|message| {

--- a/crates/openwave-web-search/src/http.rs
+++ b/crates/openwave-web-search/src/http.rs
@@ -167,6 +167,36 @@ impl ReqwestHttpClient {
     }
 }
 
+#[cfg(feature = "http")]
+#[async_trait]
+impl HttpClient for ReqwestHttpClient {
+    async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
+        use futures::StreamExt;
+
+        let mut builder = self.client.post(request.url).json(&request.body);
+        for (name, value) in request.headers {
+            builder = builder.header(name, value);
+        }
+        let response = builder
+            .send()
+            .await
+            .map_err(|error| WebSearchError::Transport(error.to_string()))?;
+        let status = response.status().as_u16();
+        let mut stream = response.bytes_stream();
+        let mut body = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| WebSearchError::Transport(error.to_string()))?;
+            if body.len().saturating_add(chunk.len()) > MAX_HTTP_RESPONSE_BYTES {
+                return Err(WebSearchError::Transport(
+                    "web search response exceeded byte limit".into(),
+                ));
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok(HttpResponse { status, body })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -223,7 +253,8 @@ mod tests {
         let source_task = tokio::spawn(async move {
             let (mut stream, _) = source.accept().await.unwrap();
             let mut buffer = [0_u8; 2048];
-            stream.read(&mut buffer).await.unwrap();
+            let bytes_read = stream.read(&mut buffer).await.unwrap();
+            assert!(bytes_read > 0);
             stream
                 .write_all(
                     format!(
@@ -252,35 +283,5 @@ mod tests {
                 .await
                 .is_err()
         );
-    }
-}
-
-#[cfg(feature = "http")]
-#[async_trait]
-impl HttpClient for ReqwestHttpClient {
-    async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
-        use futures::StreamExt;
-
-        let mut builder = self.client.post(request.url).json(&request.body);
-        for (name, value) in request.headers {
-            builder = builder.header(name, value);
-        }
-        let response = builder
-            .send()
-            .await
-            .map_err(|error| WebSearchError::Transport(error.to_string()))?;
-        let status = response.status().as_u16();
-        let mut stream = response.bytes_stream();
-        let mut body = Vec::new();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|error| WebSearchError::Transport(error.to_string()))?;
-            if body.len().saturating_add(chunk.len()) > MAX_HTTP_RESPONSE_BYTES {
-                return Err(WebSearchError::Transport(
-                    "web search response exceeded byte limit".into(),
-                ));
-            }
-            body.extend_from_slice(&chunk);
-        }
-        Ok(HttpResponse { status, body })
     }
 }


### PR DESCRIPTION
## Summary
- align sandbox delegation coverage with the fixed web-search capability
- resolve strict Clippy findings in web-search and checkpoint paths

## Validation
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test -p openwave-server foreground_sandbox_spawn_parks_executes_delivers_and_resumes --locked
- cargo test -p openwave-web-search --locked
- bw dev lint --rust --check