### PR TITLE
Expose safe sandbox activity

### DIFF
--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -65,7 +65,6 @@ export type AgentRun = {
   started_at: string | null;
   finished_at: string | null;
   last_error_code: string | null;
-  last_error_detail: string | null;
   created_at: string;
   updated_at: string;
 };

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -15,7 +15,8 @@ use tokio::sync::broadcast::error::RecvError;
 use openwave_core::{
     AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunExecution, AgentRunStatus,
     ApprovalDecision, CallId, Chat, ChatId, Project, ProjectId, RequestTurnCancellationOutcome,
-    SecretProvider, SequencedEvent, Store, TurnId, TurnSteer, TurnSteerId,
+    SandboxToolCall, SandboxToolCallStatus, SecretProvider, SequencedEvent, Store, TurnId,
+    TurnSteer, TurnSteerId,
 };
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
@@ -502,14 +503,20 @@ pub struct AgentRunSnapshot {
     pub status: AgentRunStatus,
     pub started_at: Option<chrono::DateTime<Utc>>,
     pub finished_at: Option<chrono::DateTime<Utc>>,
+    /// Stable, bounded classification suitable for renderer display.
     pub last_error_code: Option<String>,
-    pub last_error_detail: Option<String>,
+    /// The currently checkpointed, renderer-safe sandbox activity, if any.
+    ///
+    /// This is intentionally a small fixed vocabulary. It never exposes tool
+    /// arguments, results, provider call identities, executor leases, or raw
+    /// executor diagnostics.
+    pub activity: Option<SandboxActivitySnapshot>,
     pub created_at: chrono::DateTime<Utc>,
     pub updated_at: chrono::DateTime<Utc>,
 }
 
-impl From<AgentRun> for AgentRunSnapshot {
-    fn from(run: AgentRun) -> Self {
+impl AgentRunSnapshot {
+    fn from_run(run: AgentRun, activity: Option<SandboxActivitySnapshot>) -> Self {
         Self {
             id: run.id,
             parent_id: run.parent_id,
@@ -518,11 +525,60 @@ impl From<AgentRun> for AgentRunSnapshot {
             started_at: run.started_at,
             finished_at: run.finished_at,
             last_error_code: run.last_error_code,
-            last_error_detail: run.last_error_detail,
+            activity,
             created_at: run.created_at,
             updated_at: run.updated_at,
         }
     }
+}
+
+/// Fixed, renderer-safe names for live sandbox work.
+///
+/// Adding a new durable sandbox tool does not automatically expose it to a
+/// renderer: it must be deliberately admitted here with a safe label.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxActivityKind {
+    WebSearch,
+}
+
+/// Coarse checkpoint lifecycle suitable for display.
+///
+/// This intentionally does not mirror all durable executor states; only live
+/// work is represented, and terminal checkpoints produce no activity.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxActivityStatus {
+    Waiting,
+    Running,
+}
+
+/// Renderer-safe projection of one live sandbox checkpoint.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct SandboxActivitySnapshot {
+    pub kind: SandboxActivityKind,
+    pub status: SandboxActivityStatus,
+}
+
+fn sandbox_activity(calls: &[SandboxToolCall]) -> Option<SandboxActivitySnapshot> {
+    // A sandbox can have at most one live checkpoint. Inspecting the latest
+    // durable live checkpoint also prevents an older, completed activity from
+    // lingering in the UI after the run has advanced.
+    let call = calls.iter().rev().find(|call| !call.status.is_terminal())?;
+    let kind = match call.name.as_str() {
+        "web_search" => SandboxActivityKind::WebSearch,
+        // Unknown tool names are executor data, not a renderer API contract.
+        _ => return None,
+    };
+    let status = match call.status {
+        SandboxToolCallStatus::Accepted => SandboxActivityStatus::Waiting,
+        SandboxToolCallStatus::Claimed => SandboxActivityStatus::Running,
+        SandboxToolCallStatus::Completed
+        | SandboxToolCallStatus::Failed
+        | SandboxToolCallStatus::Cancelled => return None,
+        _ => return None,
+    };
+    Some(SandboxActivitySnapshot { kind, status })
 }
 
 /// `GET /chats/{id}/agent-runs` — list renderer-safe execution state.
@@ -535,15 +591,21 @@ pub async fn list_agent_runs(
         .get_chat(id)
         .await?
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
-    Ok(Json(
-        state
-            .store
-            .list_agent_runs(id)
-            .await?
-            .into_iter()
-            .map(AgentRunSnapshot::from)
-            .collect(),
-    ))
+    let runs = state.store.list_agent_runs(id).await?;
+    let mut snapshots = Vec::with_capacity(runs.len());
+    for run in runs {
+        let activity = if run.execution == AgentRunExecution::Sandbox {
+            let calls = state
+                .store
+                .list_sandbox_tool_calls_for_agent_run(run.id)
+                .await?;
+            sandbox_activity(&calls)
+        } else {
+            None
+        };
+        snapshots.push(AgentRunSnapshot::from_run(run, activity));
+    }
+    Ok(Json(snapshots))
 }
 
 /// Body of `POST /chats/{id}/messages`.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -9,11 +9,12 @@ use axum::http::{header, Request, StatusCode};
 use futures::stream::{self, BoxStream, StreamExt};
 // Tests use the in-memory store; production wires LanceDB in `bind`.
 use openwave_core::{
-    AgentErrorInfo, AgentEvent, AgentRunInboxStatus, AgentRunStatus, ApprovalClass,
-    BeginRootAttachmentChange, BlobStore, CallId, Chat, ChatId, ChatRequest, ChatRootAttachment,
-    ClientToolCallRequest, ContentBlock, HostRootId, Message, ModelProvider,
-    ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent, ProviderId, Role,
-    RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentOrigin, SecretProvider,
+    AcceptAgentRunOutcome, AgentErrorInfo, AgentEvent, AgentRunExecution, AgentRunId,
+    AgentRunInboxStatus, AgentRunStatus, ApprovalClass, BeginRootAttachmentChange, BlobStore,
+    CallId, Chat, ChatId, ChatRequest, ChatRootAttachment, ClientToolCallRequest, ContentBlock,
+    HostRootId, Message, ModelProvider, ParkSandboxToolCallOutcome, ParkTurnForClientCallOutcome,
+    Project, ProjectId, ProviderEvent, ProviderId, Role, RootAttachmentChangeAction,
+    RootAttachmentChangeId, RootAttachmentOrigin, SandboxToolCallRequest, SecretProvider,
     SequencedEvent, StopReason, Tool, ToolCallExecution, ToolCallRecord, ToolCallResolution,
     ToolCallStatus, ToolCtx, ToolOutput, ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus,
     TurnSteerId, Usage,
@@ -5347,6 +5348,232 @@ async fn create_then_get_and_list() {
         json_body(response).await
     };
     assert_eq!(listed, vec![created]);
+}
+
+#[tokio::test]
+async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat: Chat = {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/chats")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        json_body(response).await
+    };
+
+    let run = match store
+        .accept_agent_run(
+            AgentRunId::new(),
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("research"),
+        )
+        .await
+        .unwrap()
+    {
+        AcceptAgentRunOutcome::Accepted(run) => run,
+        outcome => panic!("unexpected sandbox admission: {outcome:?}"),
+    };
+    let worker_lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(worker_lease, chrono::Duration::minutes(5), 1, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        run.id
+    );
+    let checkpoint = SandboxToolCallRequest {
+        id: CallId::new(),
+        agent_run_id: run.id,
+        chat_id: chat.id,
+        provider_id: "provider-call-identity".into(),
+        name: "web_search".into(),
+        arguments: serde_json::json!({
+            "query": "private query that must not reach the renderer",
+            "api_key": "secret-value"
+        }),
+    };
+    assert!(matches!(
+        store
+            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &checkpoint)
+            .await
+            .unwrap(),
+        ParkSandboxToolCallOutcome::Parked { .. }
+    ));
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/agent-runs", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let snapshots: Vec<serde_json::Value> = json_body(response).await;
+    let snapshot = snapshots
+        .iter()
+        .find(|snapshot| snapshot.get("id") == Some(&serde_json::json!(run.id)))
+        .expect("sandbox snapshot is returned");
+    assert_eq!(
+        snapshot.get("activity"),
+        Some(&serde_json::json!({"kind": "web_search", "status": "waiting"}))
+    );
+
+    // The projection is intentionally independent of the durable checkpoint's
+    // sensitive executor data.
+    let encoded = serde_json::to_string(snapshot).unwrap();
+    for forbidden in [
+        "private query that must not reach the renderer",
+        "secret-value",
+        "provider-call-identity",
+        "arguments",
+        "lease_token",
+        "result",
+    ] {
+        assert!(!encoded.contains(forbidden), "snapshot leaked {forbidden}");
+    }
+
+    let executor_lease = uuid::Uuid::new_v4();
+    assert!(matches!(
+        store
+            .claim_sandbox_tool_call(checkpoint.id, executor_lease, chrono::Duration::minutes(5))
+            .await
+            .unwrap(),
+        openwave_core::ClaimSandboxToolCallOutcome::Claimed(_)
+    ));
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/agent-runs", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let snapshots: Vec<serde_json::Value> = json_body(response).await;
+    let snapshot = snapshots
+        .iter()
+        .find(|snapshot| snapshot.get("id") == Some(&serde_json::json!(run.id)))
+        .expect("sandbox snapshot is returned");
+    assert_eq!(
+        snapshot.get("activity"),
+        Some(&serde_json::json!({"kind": "web_search", "status": "running"}))
+    );
+}
+
+#[tokio::test]
+async fn agent_run_snapshots_omit_persisted_raw_failure_detail() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chats")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let chat: Chat = json_body(response).await;
+
+    let run = match store
+        .accept_agent_run(
+            AgentRunId::new(),
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("research"),
+        )
+        .await
+        .unwrap()
+    {
+        AcceptAgentRunOutcome::Accepted(run) => run,
+        outcome => panic!("unexpected sandbox admission: {outcome:?}"),
+    };
+    let lease_token = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(lease_token, chrono::Duration::minutes(5), 1, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        run.id
+    );
+    let raw_detail = "upstream request failed: Authorization: Bearer private-token";
+    assert!(store
+        .fail_agent_run(
+            run.id,
+            lease_token,
+            "sandbox_transport_failed",
+            raw_detail,
+            chrono::Duration::seconds(1),
+        )
+        .await
+        .unwrap()
+        .is_some());
+    assert_eq!(
+        store
+            .get_agent_run(run.id)
+            .await
+            .unwrap()
+            .expect("failed run remains persisted")
+            .last_error_detail
+            .as_deref(),
+        Some(raw_detail)
+    );
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/agent-runs", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let snapshots: Vec<serde_json::Value> = json_body(response).await;
+    let snapshot = snapshots
+        .iter()
+        .find(|snapshot| snapshot.get("id") == Some(&serde_json::json!(run.id)))
+        .expect("sandbox snapshot is returned");
+    assert_eq!(
+        snapshot.get("last_error_code"),
+        Some(&serde_json::json!("sandbox_transport_failed"))
+    );
+    assert!(snapshot.get("last_error_detail").is_none());
+    assert!(!serde_json::to_string(snapshot)
+        .unwrap()
+        .contains(raw_detail));
 }
 
 /// Create a project and return it.

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -191,7 +191,18 @@ queued, running, waiting, failed, and completed work, while workers continue to
 advance runs solely through fenced store transitions. A missing chat returns
 `404`, rather than revealing whether an unrelated run identifier exists.
 The response is deliberately renderer-safe: worker lease tokens, delegated
-input, and scheduler bookkeeping never cross this API boundary.
+input, raw failure details, and scheduler bookkeeping never cross this API
+boundary. A bounded failure code may be included for display and recovery
+guidance; detailed provider, transport, or executor diagnostics remain
+server-side.
+
+When a sandbox has a live, supported tool checkpoint, the snapshot may also
+contain a small `activity` object. Its values are a deliberately admitted,
+fixed display vocabulary—for example, `web_search` with `waiting` or
+`running` status. It is not a tool trace: queries, tool arguments, results,
+provider identifiers, executor leases, and raw failures remain server-side.
+New sandbox tools are invisible to the renderer until they receive their own
+safe activity projection.
 
 ## Reliability contract
 


### PR DESCRIPTION
## Summary
- project fixed, live sandbox activity through the chat-scoped agent-run API
- keep tool arguments, results, provider identities, leases, and raw diagnostics server-side
- remove raw agent-run error details from the renderer contract

## Validation
- bw dev lint --rust --check
- cargo test -p openwave-server agent_run_snapshots --locked
- pnpm --dir crates/openwave-desktop/ui build