### PR TITLE
Show sandbox web search activity

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -989,19 +989,48 @@ function AgentActivityPanel({
 }
 
 function AgentActivityItem({ run, label }: { run: AgentRun; label: string }) {
-  const status = readableAgentRunStatus(run.status);
+  const activity = sandboxActivityPresentation(run.activity);
+  const status = activity?.status ?? readableAgentRunStatus(run.status);
   return (
-    <li className={`agent-activity-item is-${run.status}`}>
+    <li
+      className={`agent-activity-item is-${run.status}${activity ? ` is-activity-${activity.sourceStatus}` : ""}`}
+    >
       <span className="agent-activity-indicator" aria-hidden="true" />
       <span className="agent-activity-item-copy">
-        <span>{label}</span>
+        <span>{activity?.label ?? label}</span>
         <span className="agent-activity-detail">
-          {agentRunStatusDescription(run.status)}
+          {activity?.detail ?? agentRunStatusDescription(run.status)}
         </span>
       </span>
       <strong>{status}</strong>
     </li>
   );
+}
+
+function sandboxActivityPresentation(
+  activity: AgentRun["activity"],
+): { label: string; detail: string; status: string; sourceStatus: string } | null {
+  if (!activity) return null;
+
+  switch (activity.kind) {
+    case "web_search":
+      switch (activity.status) {
+        case "waiting":
+          return {
+            label: "Web search",
+            detail: "Waiting to search",
+            status: "waiting",
+            sourceStatus: "waiting",
+          };
+        case "running":
+          return {
+            label: "Web search",
+            detail: "Searching the web",
+            status: "searching",
+            sourceStatus: "running",
+          };
+      }
+  }
 }
 
 function readableAgentRunStatus(status: AgentRun["status"]): string {

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -65,8 +65,19 @@ export type AgentRun = {
   started_at: string | null;
   finished_at: string | null;
   last_error_code: string | null;
+  /** A fixed, renderer-safe description of the currently live sandbox task. */
+  activity: SandboxActivity | null;
   created_at: string;
   updated_at: string;
+};
+
+/**
+ * Live sandbox activity is intentionally a closed vocabulary. The server never
+ * sends search inputs, results, provider identities, or executor diagnostics.
+ */
+export type SandboxActivity = {
+  kind: "web_search";
+  status: "waiting" | "running";
 };
 
 export type SequencedEvent = {

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -373,7 +373,8 @@ button {
 }
 
 .agent-activity-item.is-active .agent-activity-indicator,
-.agent-activity-item.is-running .agent-activity-indicator {
+.agent-activity-item.is-running .agent-activity-indicator,
+.agent-activity-item.is-activity-running .agent-activity-indicator {
   border-color: var(--accent);
   background: var(--accent);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);


### PR DESCRIPTION
## Summary
- render fixed safe labels for live sandbox web-search activity
- keep the desktop contract closed to waiting and running state
- retain the existing activity panel without displaying tool traces

## Validation
- pnpm --dir crates/openwave-desktop/ui build
- git diff --check