### PR TITLE
Execute connected folder reads

### DIFF
--- a/crates/openwave-core/src/client_tools.rs
+++ b/crates/openwave-core/src/client_tools.rs
@@ -12,6 +12,18 @@ use crate::ToolSpec;
 /// Stable tool name for asking the user to connect another folder.
 pub const REQUEST_FOLDER_ACCESS_TOOL: &str = "request_folder_access";
 
+/// Foreground-only tool names for inspecting folders the user already connected.
+///
+/// These contracts are model proposals, not host authority. The native executor
+/// resolves the conversation from durable state and reauthorizes every broker
+/// operation against that context.
+pub const LIST_CONNECTED_FOLDERS_TOOL: &str = "list_connected_folders";
+pub const LIST_FOLDER_TOOL: &str = "list_folder";
+pub const READ_CONNECTED_FILE_TOOL: &str = "read_connected_file";
+
+/// Maximum UTF-8 bytes in a root-relative path supplied by the model.
+pub const MAX_CONNECTED_FOLDER_PATH_BYTES: usize = 1_024;
+
 /// Maximum user-facing explanation length advertised to the model.
 pub const MAX_FOLDER_ACCESS_REASON_CHARS: usize = 500;
 
@@ -136,6 +148,133 @@ pub fn request_folder_access_tool_spec() -> ToolSpec {
     }
 }
 
+/// Canonical arguments for [`LIST_CONNECTED_FOLDERS_TOOL`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ListConnectedFoldersArgs {}
+
+/// Canonical arguments for [`LIST_FOLDER_TOOL`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ListFolderArgs {
+    /// Opaque id returned by `list_connected_folders` or folder consent.
+    pub root_id: uuid::Uuid,
+    /// Root-relative directory path; an empty path means the connected root.
+    pub path: String,
+}
+
+/// Canonical arguments for [`READ_CONNECTED_FILE_TOOL`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReadConnectedFileArgs {
+    /// Opaque id returned by `list_connected_folders` or folder consent.
+    pub root_id: uuid::Uuid,
+    /// Nonempty root-relative file path.
+    pub path: String,
+}
+
+impl ListFolderArgs {
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        !self.root_id.is_nil() && valid_connected_folder_path(&self.path, true)
+    }
+}
+
+impl ReadConnectedFileArgs {
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        !self.root_id.is_nil() && valid_connected_folder_path(&self.path, false)
+    }
+}
+
+/// Validate a canonical model payload before it is durably checkpointed.
+#[must_use]
+pub fn validate_list_connected_folders_arguments(arguments: &Value) -> bool {
+    serde_json::from_value::<ListConnectedFoldersArgs>(arguments.clone()).is_ok()
+}
+
+/// Validate a canonical model payload before it is durably checkpointed.
+#[must_use]
+pub fn validate_list_folder_arguments(arguments: &Value) -> bool {
+    serde_json::from_value::<ListFolderArgs>(arguments.clone())
+        .is_ok_and(|arguments| arguments.is_well_formed())
+}
+
+/// Validate a canonical model payload before it is durably checkpointed.
+#[must_use]
+pub fn validate_read_connected_file_arguments(arguments: &Value) -> bool {
+    serde_json::from_value::<ReadConnectedFileArgs>(arguments.clone())
+        .is_ok_and(|arguments| arguments.is_well_formed())
+}
+
+#[must_use]
+pub fn list_connected_folders_tool_spec() -> ToolSpec {
+    ToolSpec {
+        name: LIST_CONNECTED_FOLDERS_TOOL.into(),
+        description: "List folders already connected to this conversation. Results contain opaque root IDs and display names only; use request_folder_access to ask the user to choose another folder.".into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        }),
+    }
+}
+
+#[must_use]
+pub fn list_folder_tool_spec() -> ToolSpec {
+    ToolSpec {
+        name: LIST_FOLDER_TOOL.into(),
+        description: "List a directory below an already connected folder. Use only an opaque root_id and a root-relative path; never use an absolute path or parent traversal.".into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "root_id": { "type": "string", "format": "uuid" },
+                "path": { "type": "string", "maxLength": MAX_CONNECTED_FOLDER_PATH_BYTES, "description": "Root-relative directory path; empty means the folder root." }
+            },
+            "required": ["root_id", "path"],
+            "additionalProperties": false
+        }),
+    }
+}
+
+#[must_use]
+pub fn read_connected_file_tool_spec() -> ToolSpec {
+    ToolSpec {
+        name: READ_CONNECTED_FILE_TOOL.into(),
+        description: "Read a UTF-8 text file below an already connected folder. Use only an opaque root_id and a nonempty root-relative path; never use an absolute path or parent traversal.".into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "root_id": { "type": "string", "format": "uuid" },
+                "path": { "type": "string", "minLength": 1, "maxLength": MAX_CONNECTED_FOLDER_PATH_BYTES, "description": "Root-relative text file path." }
+            },
+            "required": ["root_id", "path"],
+            "additionalProperties": false
+        }),
+    }
+}
+
+fn valid_connected_folder_path(path: &str, allow_root: bool) -> bool {
+    if path.len() > MAX_CONNECTED_FOLDER_PATH_BYTES
+        || path.contains('\0')
+        || path.contains('\\')
+        || path.starts_with('/')
+        || path.ends_with('/')
+    {
+        return false;
+    }
+    if path.is_empty() {
+        return allow_root;
+    }
+    path.split('/').all(|part| {
+        !part.is_empty()
+            && part != "."
+            && part != ".."
+            && !part.contains(':')
+            && !part.chars().any(char::is_control)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,5 +357,61 @@ mod tests {
             serde_json::to_value(RequestFolderAccessResult::Declined).unwrap(),
             serde_json::json!({ "status": "declined" })
         );
+    }
+
+    #[test]
+    fn connected_folder_tools_are_pathless_and_conservatively_bounded() {
+        assert!(validate_list_connected_folders_arguments(
+            &serde_json::json!({})
+        ));
+        assert!(!validate_list_connected_folders_arguments(
+            &serde_json::json!({
+                "root_id": uuid::Uuid::new_v4()
+            })
+        ));
+
+        let root_id = uuid::Uuid::new_v4();
+        assert!(validate_list_folder_arguments(&serde_json::json!({
+            "root_id": root_id,
+            "path": ""
+        })));
+        assert!(validate_read_connected_file_arguments(&serde_json::json!({
+            "root_id": root_id,
+            "path": "notes/today.txt"
+        })));
+        for path in [
+            "/tmp/secret",
+            "../secret",
+            "notes/../secret",
+            "notes\\secret",
+            "C:secret",
+        ] {
+            assert!(!validate_read_connected_file_arguments(
+                &serde_json::json!({
+                    "root_id": root_id,
+                    "path": path
+                })
+            ));
+        }
+        assert!(!validate_read_connected_file_arguments(
+            &serde_json::json!({
+                "root_id": root_id,
+                "path": ""
+            })
+        ));
+    }
+
+    #[test]
+    fn connected_folder_specs_do_not_advertise_host_paths_or_authority() {
+        let list = list_connected_folders_tool_spec();
+        let directory = list_folder_tool_spec();
+        let file = read_connected_file_tool_spec();
+        assert_eq!(list.name, LIST_CONNECTED_FOLDERS_TOOL);
+        assert_eq!(directory.name, LIST_FOLDER_TOOL);
+        assert_eq!(file.name, READ_CONNECTED_FILE_TOOL);
+        assert_eq!(directory.input_schema["additionalProperties"], false);
+        assert_eq!(file.input_schema["additionalProperties"], false);
+        assert!(!directory.description.contains("project_id"));
+        assert!(!file.description.contains("grant"));
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -52,9 +52,14 @@ pub use approval::{
 pub use blob::FsBlobStore;
 pub use cancel::{CancelToken, Cancelled};
 pub use client_tools::{
-    request_folder_access_tool_spec, validate_request_folder_access_arguments,
-    RequestFolderAccessArgs, RequestFolderAccessResult, RequestedFolderCapability,
-    RequestedFolderHint, MAX_FOLDER_ACCESS_REASON_CHARS, REQUEST_FOLDER_ACCESS_TOOL,
+    list_connected_folders_tool_spec, list_folder_tool_spec, read_connected_file_tool_spec,
+    request_folder_access_tool_spec, validate_list_connected_folders_arguments,
+    validate_list_folder_arguments, validate_read_connected_file_arguments,
+    validate_request_folder_access_arguments, ListConnectedFoldersArgs, ListFolderArgs,
+    ReadConnectedFileArgs, RequestFolderAccessArgs, RequestFolderAccessResult,
+    RequestedFolderCapability, RequestedFolderHint, LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL,
+    MAX_CONNECTED_FOLDER_PATH_BYTES, MAX_FOLDER_ACCESS_REASON_CHARS, READ_CONNECTED_FILE_TOOL,
+    REQUEST_FOLDER_ACCESS_TOOL,
 };
 pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]

--- a/crates/openwave-desktop/src/client_execution.rs
+++ b/crates/openwave-desktop/src/client_execution.rs
@@ -23,12 +23,16 @@ use uuid::Uuid;
 use crate::host_access::{pick_folder, AuthoritativeContext, HostAccess};
 
 mod control_plane;
+pub(crate) mod folder_operations;
 mod receipt_store;
 
 pub(crate) use control_plane::ControlPlaneClient;
 use control_plane::ControlPlaneError;
 pub(crate) use receipt_store::ReceiptStore;
-use receipt_store::{FolderAccessIntent, FolderAccessReceipt, RegistrationPhase, StoredResolution};
+use receipt_store::{
+    FolderAccessIntent, FolderAccessReceipt, FolderOperationPhase, FolderOperationReceipt,
+    RegistrationPhase, StoredResolution,
+};
 
 const RECOVERY_IDLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 const RECOVERY_MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(30);

--- a/crates/openwave-desktop/src/client_execution/folder_operations.rs
+++ b/crates/openwave-desktop/src/client_execution/folder_operations.rs
@@ -1,0 +1,501 @@
+//! Durable native executor for foreground inspection of already connected folders.
+//!
+//! The renderer never supplies an execution context, host path, grant, or
+//! broker handle. Canonical tool arguments are recovered from the checkpointed
+//! server call, while the native executor derives current chat authority before
+//! each broker operation.
+
+use std::collections::HashSet;
+
+use openwave_core::{
+    validate_list_connected_folders_arguments, validate_list_folder_arguments,
+    validate_read_connected_file_arguments, CallId, ListFolderArgs, ReadConnectedFileArgs,
+    ToolCallExecution, ToolCallRecord, ToolCallStatus, LIST_CONNECTED_FOLDERS_TOOL,
+    LIST_FOLDER_TOOL, READ_CONNECTED_FILE_TOOL,
+};
+use openwave_host_broker::{
+    OperationEnvelope, OperationRequest, OperationResult, PathRequest, RelativePath, RootId,
+    PROTOCOL_VERSION,
+};
+use tauri::Manager;
+
+use crate::host_access::{AuthoritativeContext, HostAccess};
+
+use super::{
+    control_plane, control_plane_error, private_receipt_error, FolderOperationPhase,
+    FolderOperationReceipt, StoredResolution,
+};
+
+const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+const MAX_DIRECTORY_ENTRIES: usize = 128;
+const MAX_RESULT_CONTENT_BYTES: usize = 60 * 1024;
+const MAX_FILE_CONTENT_BYTES: usize = 56 * 1024;
+
+/// Recover persisted outcomes, then discover new matching client calls. The
+/// loop is deliberately native-owned: no renderer event or user action is an
+/// execution authority.
+pub(crate) async fn recover_connected_folder_operations(app: tauri::AppHandle) {
+    loop {
+        let failed = recover_once(&app).await;
+        if failed {
+            eprintln!("openwave-desktop: connected-folder executor deferred work");
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+async fn recover_once(app: &tauri::AppHandle) -> bool {
+    let state = app.state::<HostAccess>();
+    let receipts = match state.receipts.load_operations() {
+        Ok(receipts) => receipts,
+        Err(error) => {
+            eprintln!("openwave-desktop: connected-folder receipt recovery failed: {error}");
+            return true;
+        }
+    };
+    let recovered_call_ids: HashSet<CallId> =
+        receipts.iter().map(|receipt| receipt.call_id).collect();
+    let mut failed = false;
+    for receipt in receipts {
+        if let Err(error) = execute_receipt(&state, receipt).await {
+            eprintln!("openwave-desktop: connected-folder receipt deferred: {error}");
+            failed = true;
+        }
+    }
+
+    let Some(store) = state.store() else {
+        return true;
+    };
+    let client = match control_plane(&state) {
+        Ok(client) => client,
+        Err(_) => return true,
+    };
+    let chats = match store.list_chats().await {
+        Ok(chats) => chats,
+        Err(_) => return true,
+    };
+    for chat in chats {
+        let calls = match client.pending(chat.id).await {
+            Ok(calls) => calls,
+            Err(_) => {
+                failed = true;
+                continue;
+            }
+        };
+        for call in calls
+            .into_iter()
+            .filter(|call| should_discover_call(call, &recovered_call_ids))
+        {
+            let receipt =
+                FolderOperationReceipt::new(chat.id, call.id, state.receipts.executor_id());
+            if let Err(error) = execute_receipt(&state, receipt).await {
+                eprintln!("openwave-desktop: connected-folder execution deferred: {error}");
+                failed = true;
+            }
+        }
+    }
+    failed
+}
+
+fn should_discover_call(call: &ToolCallRecord, recovered_call_ids: &HashSet<CallId>) -> bool {
+    !recovered_call_ids.contains(&call.id) && is_connected_folder_call(call)
+}
+
+async fn execute_receipt(
+    state: &HostAccess,
+    mut receipt: FolderOperationReceipt,
+) -> Result<(), String> {
+    if let Some(resolution) = receipt.resolution.clone() {
+        return publish_resolution(state, &receipt, &resolution).await;
+    }
+    if dispatch_is_ambiguous(&receipt) {
+        return terminalize_interrupted_dispatch(state, &mut receipt).await;
+    }
+
+    let context = state.context(receipt.chat_id.0).await?;
+
+    // Persist the chosen lease token before claiming. If a response is lost,
+    // recovery retries the exact claim rather than leaving a live lease with no
+    // local recovery authority.
+    state
+        .receipts
+        .save_operation(&receipt)
+        .map_err(private_receipt_error)?;
+    let client = control_plane(state)?;
+    let claim = match client
+        .claim(
+            receipt.chat_id,
+            receipt.call_id,
+            receipt.executor_id,
+            receipt.lease_token,
+        )
+        .await
+    {
+        Ok(claim) => claim,
+        Err(error) if error.is_conflict() => {
+            return recover_after_claim_conflict(state, &mut receipt).await;
+        }
+        Err(error) => return Err(control_plane_error(error)),
+    };
+    if claim.call.chat_id != receipt.chat_id
+        || claim.call.id != receipt.call_id
+        || claim.lease_token != receipt.lease_token
+        || claim.call.client_executor_id != Some(receipt.executor_id)
+        || !is_connected_folder_call(&claim.call)
+    {
+        return Err("local control plane returned an invalid connected-folder request".to_owned());
+    }
+
+    client
+        .heartbeat(receipt.chat_id, receipt.call_id, receipt.lease_token)
+        .await
+        .map_err(control_plane_error)?;
+    // This is the final durable fence before host I/O. If the process stops
+    // afterwards, a read may have reached the broker, so recovery must publish
+    // the safe interrupted result rather than issue another request.
+    receipt.phase = FolderOperationPhase::DispatchStarted;
+    state
+        .receipts
+        .save_operation(&receipt)
+        .map_err(private_receipt_error)?;
+    let resolution = execute_operation(state, context, &claim.call).await;
+    receipt.resolution = Some(resolution);
+    state
+        .receipts
+        .save_operation(&receipt)
+        .map_err(private_receipt_error)?;
+    publish_resolution(
+        state,
+        &receipt,
+        receipt.resolution.as_ref().expect("stored above"),
+    )
+    .await
+}
+
+fn dispatch_is_ambiguous(receipt: &FolderOperationReceipt) -> bool {
+    receipt.phase == FolderOperationPhase::DispatchStarted && receipt.resolution.is_none()
+}
+
+async fn terminalize_interrupted_dispatch(
+    state: &HostAccess,
+    receipt: &mut FolderOperationReceipt,
+) -> Result<(), String> {
+    receipt.resolution = Some(interrupted_resolution());
+    state
+        .receipts
+        .save_operation(receipt)
+        .map_err(private_receipt_error)?;
+    publish_resolution(
+        state,
+        receipt,
+        receipt.resolution.as_ref().expect("stored above"),
+    )
+    .await
+}
+
+/// A read may have reached the broker before a desktop process died, but the
+/// broker deliberately has no read-result receipt to replay. If the persisted
+/// client claim can no longer be recovered, terminalize with the same exact
+/// lease token instead of issuing another ambiguous read. The server accepts
+/// that token through its expired-claim resolution path only after the lease is
+/// actually expired.
+async fn recover_after_claim_conflict(
+    state: &HostAccess,
+    receipt: &mut FolderOperationReceipt,
+) -> Result<(), String> {
+    let client = control_plane(state)?;
+    let pending = client
+        .pending(receipt.chat_id)
+        .await
+        .map_err(control_plane_error)?;
+    let Some(call) = pending.into_iter().find(|call| call.id == receipt.call_id) else {
+        return state
+            .receipts
+            .remove_operation(receipt.call_id)
+            .map_err(private_receipt_error);
+    };
+    if call.chat_id != receipt.chat_id || !is_connected_folder_call(&call) {
+        return Err("local control plane returned an invalid connected-folder request".to_owned());
+    }
+    if call.client_executor_id != Some(receipt.executor_id) {
+        return state
+            .receipts
+            .remove_operation(receipt.call_id)
+            .map_err(private_receipt_error);
+    }
+
+    terminalize_interrupted_dispatch(state, receipt).await
+}
+
+async fn execute_operation(
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    call: &ToolCallRecord,
+) -> StoredResolution {
+    let request = match broker_request(call) {
+        Ok(request) => request,
+        Err(()) => return unavailable("invalid_request", "The folder request was not available."),
+    };
+    let result = state
+        .broker
+        .operation(OperationEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: openwave_host_broker::RequestId::new(),
+            context: context.execution,
+            request,
+        })
+        .await;
+    match result {
+        Ok(result) => serialize_result(result),
+        // Broker transport errors are intentionally not surfaced to the model.
+        // Authorization is rechecked by the broker before bytes are released.
+        Err(_) => unavailable(
+            "folder_unavailable",
+            "That connected folder is no longer available to this conversation. You can ask the user to connect a folder again.",
+        ),
+    }
+}
+
+fn broker_request(call: &ToolCallRecord) -> Result<OperationRequest, ()> {
+    match call.name.as_str() {
+        LIST_CONNECTED_FOLDERS_TOOL => Ok(OperationRequest::ListRoots),
+        LIST_FOLDER_TOOL => {
+            let args: ListFolderArgs =
+                serde_json::from_value(call.arguments.clone()).map_err(|_| ())?;
+            let root_id = RootId::from_uuid(args.root_id).map_err(|_| ())?;
+            let path = RelativePath::parse(&args.path).map_err(|_| ())?;
+            Ok(OperationRequest::ListDirectory(PathRequest {
+                root_id,
+                path,
+            }))
+        }
+        READ_CONNECTED_FILE_TOOL => {
+            let args: ReadConnectedFileArgs =
+                serde_json::from_value(call.arguments.clone()).map_err(|_| ())?;
+            let root_id = RootId::from_uuid(args.root_id).map_err(|_| ())?;
+            let path = RelativePath::parse(&args.path).map_err(|_| ())?;
+            if path.is_root() {
+                return Err(());
+            }
+            Ok(OperationRequest::ReadFile(PathRequest { root_id, path }))
+        }
+        _ => Err(()),
+    }
+}
+
+fn serialize_result(result: OperationResult) -> StoredResolution {
+    let result = match result {
+        OperationResult::ListRoots { roots } => serde_json::json!({
+            "status": "ok",
+            "folders": roots.into_iter().take(MAX_DIRECTORY_ENTRIES).map(|root| serde_json::json!({
+                "root_id": root.root_id,
+                "display_name": root.display_name,
+            })).collect::<Vec<_>>(),
+        }),
+        OperationResult::ListDirectory { entries } => serde_json::json!({
+            "status": "ok",
+            "entries": entries.into_iter().take(MAX_DIRECTORY_ENTRIES).map(|entry| serde_json::json!({
+                "name": entry.name,
+                "kind": entry.kind,
+            })).collect::<Vec<_>>(),
+        }),
+        OperationResult::ReadFile(file) => {
+            let (content, truncated) = truncate_utf8(&file.content, MAX_FILE_CONTENT_BYTES);
+            serde_json::json!({
+                "status": "ok",
+                "content": content,
+                "truncated": truncated,
+            })
+        }
+        _ => {
+            return unavailable(
+                "unsupported_result",
+                "The connected-folder operation is not available.",
+            )
+        }
+    };
+    match serde_json::to_string(&result) {
+        Ok(result) if result.len() <= MAX_RESULT_CONTENT_BYTES => {
+            StoredResolution::Completed { result }
+        }
+        _ => unavailable(
+            "result_too_large",
+            "The connected-folder result was too large to return.",
+        ),
+    }
+}
+
+fn truncate_utf8(value: &str, max_bytes: usize) -> (String, bool) {
+    if value.len() <= max_bytes {
+        return (value.to_owned(), false);
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    (value[..end].to_owned(), true)
+}
+
+fn unavailable(code: &str, message: &str) -> StoredResolution {
+    StoredResolution::Failed {
+        result: serde_json::json!({ "status": "unavailable", "message": message }).to_string(),
+        error_code: code.to_owned(),
+        error_detail: None,
+    }
+}
+
+fn interrupted_resolution() -> StoredResolution {
+    unavailable(
+        "folder_operation_interrupted",
+        "The folder operation could not be safely resumed after an interruption. Please try again.",
+    )
+}
+
+async fn publish_resolution(
+    state: &HostAccess,
+    receipt: &FolderOperationReceipt,
+    resolution: &StoredResolution,
+) -> Result<(), String> {
+    let client = control_plane(state)?;
+    match client
+        .resolve(
+            receipt.chat_id,
+            receipt.call_id,
+            receipt.lease_token,
+            resolution,
+        )
+        .await
+    {
+        Ok(()) => state
+            .receipts
+            .remove_operation(receipt.call_id)
+            .map_err(private_receipt_error),
+        Err(error) if error.is_conflict() => {
+            let pending = client
+                .pending(receipt.chat_id)
+                .await
+                .map_err(control_plane_error)?
+                .into_iter()
+                .any(|call| call.id == receipt.call_id);
+            if pending {
+                Err("connected-folder result no longer owns the pending request".to_owned())
+            } else {
+                state
+                    .receipts
+                    .remove_operation(receipt.call_id)
+                    .map_err(private_receipt_error)
+            }
+        }
+        Err(error) => Err(control_plane_error(error)),
+    }
+}
+
+fn is_connected_folder_call(call: &ToolCallRecord) -> bool {
+    if call.execution != ToolCallExecution::Client || call.status != ToolCallStatus::Pending {
+        return false;
+    }
+    match call.name.as_str() {
+        LIST_CONNECTED_FOLDERS_TOOL => validate_list_connected_folders_arguments(&call.arguments),
+        LIST_FOLDER_TOOL => validate_list_folder_arguments(&call.arguments),
+        READ_CONNECTED_FILE_TOOL => validate_read_connected_file_arguments(&call.arguments),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::ChatId;
+
+    #[test]
+    fn results_are_bounded_and_do_not_include_host_error_detail() {
+        let result = serialize_result(OperationResult::ReadFile(
+            openwave_host_broker::ReadFileResult {
+                content: "x".repeat(MAX_FILE_CONTENT_BYTES + 1),
+                bytes: MAX_FILE_CONTENT_BYTES + 1,
+            },
+        ));
+        let StoredResolution::Completed { result } = result else {
+            panic!("expected bounded result");
+        };
+        assert!(result.len() <= MAX_RESULT_CONTENT_BYTES);
+        assert!(result.contains("\"truncated\":true"));
+    }
+
+    #[test]
+    fn native_executor_accepts_only_valid_foreground_folder_calls() {
+        let call = ToolCallRecord {
+            id: CallId::new(),
+            chat_id: ChatId::new(),
+            turn_id: openwave_core::TurnId::new(),
+            provider_id: "tool-1".into(),
+            name: LIST_FOLDER_TOOL.into(),
+            arguments: serde_json::json!({ "root_id": uuid::Uuid::new_v4(), "path": "notes" }),
+            execution: ToolCallExecution::Client,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: chrono::Utc::now(),
+            resolved_at: None,
+        };
+        assert!(is_connected_folder_call(&call));
+        let mut forged = call;
+        forged.arguments =
+            serde_json::json!({ "root_id": uuid::Uuid::new_v4(), "path": "../secret" });
+        assert!(!is_connected_folder_call(&forged));
+    }
+
+    #[test]
+    fn pending_discovery_never_replaces_a_recovered_operation_receipt() {
+        let call = ToolCallRecord {
+            id: CallId::new(),
+            chat_id: ChatId::new(),
+            turn_id: openwave_core::TurnId::new(),
+            provider_id: "tool-1".into(),
+            name: LIST_CONNECTED_FOLDERS_TOOL.into(),
+            arguments: serde_json::json!({}),
+            execution: ToolCallExecution::Client,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: chrono::Utc::now(),
+            resolved_at: None,
+        };
+        assert!(should_discover_call(&call, &HashSet::new()));
+        assert!(!should_discover_call(&call, &HashSet::from([call.id])));
+    }
+
+    #[test]
+    fn interrupted_claims_are_terminalized_without_replaying_the_read() {
+        let StoredResolution::Failed {
+            result,
+            error_code,
+            error_detail,
+        } = interrupted_resolution()
+        else {
+            panic!("interrupted folder work must have a stable terminal result");
+        };
+        assert_eq!(error_code, "folder_operation_interrupted");
+        assert!(error_detail.is_none());
+        assert!(result.contains("could not be safely resumed"));
+        assert!(!result.contains("/Users/"));
+    }
+
+    #[test]
+    fn dispatch_started_receipt_is_terminalized_even_with_a_live_lease() {
+        let mut receipt =
+            FolderOperationReceipt::new(ChatId::new(), CallId::new(), uuid::Uuid::new_v4());
+        assert_eq!(receipt.phase, FolderOperationPhase::NotStarted);
+        assert!(!dispatch_is_ambiguous(&receipt));
+        receipt.phase = FolderOperationPhase::DispatchStarted;
+        // Recovery checks this persisted phase before claiming, so it cannot
+        // run a second read while the original lease still remains live.
+        assert!(dispatch_is_ambiguous(&receipt));
+    }
+}

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -1,6 +1,7 @@
 //! App-private recovery receipts for native client execution.
 
 use std::{
+    collections::HashSet,
     fs::{self, File, OpenOptions, TryLockError},
     io::{self, Read, Write},
     path::{Path, PathBuf},
@@ -17,8 +18,9 @@ const RECEIPT_VERSION: u32 = 1;
 const RECEIPT_DIRECTORY: &str = "client-executions";
 const EXECUTOR_FILE: &str = "executor-id";
 const MAX_EXECUTOR_BYTES: usize = 128;
-const MAX_RECEIPT_BYTES: usize = 64 * 1024;
+const MAX_RECEIPT_BYTES: usize = 128 * 1024;
 const MAX_RECEIPTS: usize = 1_024;
+const FOLDER_OPERATION_PREFIX: &str = "folder-operation-";
 
 pub(crate) struct ReceiptStore {
     directory: PathBuf,
@@ -38,6 +40,37 @@ pub(super) struct FolderAccessReceipt {
     pub(super) registration_phase: RegistrationPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) resolution: Option<StoredResolution>,
+}
+
+/// Durable receipt for one read-only foreground folder operation.
+///
+/// It intentionally stores no host path or authority. The canonical request is
+/// recovered from the server-owned tool call; this receipt preserves only the
+/// exact native lease and terminal model result across desktop restarts.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub(super) struct FolderOperationReceipt {
+    version: u32,
+    pub(super) chat_id: ChatId,
+    pub(super) call_id: CallId,
+    pub(super) executor_id: Uuid,
+    pub(super) lease_token: Uuid,
+    #[serde(default)]
+    pub(super) phase: FolderOperationPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) resolution: Option<StoredResolution>,
+}
+
+/// Whether a read-only broker request may have been dispatched already.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum FolderOperationPhase {
+    /// No host operation has been sent. Exact claim recovery may continue.
+    #[default]
+    NotStarted,
+    /// A final lease heartbeat succeeded and broker dispatch may have begun.
+    /// Recovery must terminalize rather than issue another read.
+    DispatchStarted,
 }
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -79,6 +112,21 @@ impl std::fmt::Debug for FolderAccessReceipt {
             .field("lease_token", &"[redacted]")
             .field("intent", &self.intent)
             .field("registration_phase", &self.registration_phase)
+            .field("resolution", &self.resolution)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for FolderOperationReceipt {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("FolderOperationReceipt")
+            .field("version", &self.version)
+            .field("chat_id", &self.chat_id)
+            .field("call_id", &self.call_id)
+            .field("executor_id", &self.executor_id)
+            .field("lease_token", &"[redacted]")
+            .field("phase", &self.phase)
             .field("resolution", &self.resolution)
             .finish()
     }
@@ -128,6 +176,32 @@ impl FolderAccessReceipt {
             )
         {
             return Err(invalid_data("invalid client-execution receipt"));
+        }
+        Ok(())
+    }
+}
+
+impl FolderOperationReceipt {
+    pub(super) fn new(chat_id: ChatId, call_id: CallId, executor_id: Uuid) -> Self {
+        Self {
+            version: RECEIPT_VERSION,
+            chat_id,
+            call_id,
+            executor_id,
+            lease_token: Uuid::new_v4(),
+            phase: FolderOperationPhase::NotStarted,
+            resolution: None,
+        }
+    }
+
+    fn validate(&self) -> io::Result<()> {
+        if self.version != RECEIPT_VERSION
+            || self.chat_id.0.is_nil()
+            || self.call_id.0.is_nil()
+            || self.executor_id.is_nil()
+            || self.lease_token.is_nil()
+        {
+            return Err(invalid_data("invalid folder-operation receipt"));
         }
         Ok(())
     }
@@ -191,8 +265,29 @@ impl ReceiptStore {
         write_atomically(&self.directory, &self.receipt_path(receipt.call_id), &bytes)
     }
 
+    pub(super) fn save_operation(&self, receipt: &FolderOperationReceipt) -> io::Result<()> {
+        receipt.validate()?;
+        let bytes = serde_json::to_vec(receipt).map_err(invalid_data)?;
+        if bytes.len() > MAX_RECEIPT_BYTES {
+            return Err(invalid_data("folder-operation receipt is too large"));
+        }
+        write_atomically(
+            &self.directory,
+            &self.operation_receipt_path(receipt.call_id),
+            &bytes,
+        )
+    }
+
     pub(super) fn remove(&self, call_id: CallId) -> io::Result<()> {
         match fs::remove_file(self.receipt_path(call_id)) {
+            Ok(()) => sync_directory(&self.directory),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(super) fn remove_operation(&self, call_id: CallId) -> io::Result<()> {
+        match fs::remove_file(self.operation_receipt_path(call_id)) {
             Ok(()) => sync_directory(&self.directory),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(error) => Err(error),
@@ -208,6 +303,9 @@ impl ReceiptStore {
                 return Err(invalid_data("invalid client-execution receipt name"));
             };
             if matches!(file_name, EXECUTOR_FILE | "receipts.lock") {
+                continue;
+            }
+            if file_name.starts_with(FOLDER_OPERATION_PREFIX) {
                 continue;
             }
             if file_name.starts_with('.') && file_name.ends_with(".tmp") {
@@ -243,8 +341,58 @@ impl ReceiptStore {
         Ok(receipts)
     }
 
+    pub(super) fn load_operations(&self) -> io::Result<Vec<FolderOperationReceipt>> {
+        let mut receipts = Vec::new();
+        let mut call_ids = HashSet::new();
+        for entry in fs::read_dir(&self.directory)? {
+            let entry = entry?;
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                return Err(invalid_data("invalid client-execution receipt name"));
+            };
+            let Some(call_id) = file_name
+                .strip_prefix(FOLDER_OPERATION_PREFIX)
+                .and_then(|name| name.strip_suffix(".json"))
+            else {
+                continue;
+            };
+            if receipts.len() >= MAX_RECEIPTS {
+                return Err(invalid_data("too many pending client-execution receipts"));
+            }
+            let call_id = call_id
+                .parse::<Uuid>()
+                .map(CallId::from)
+                .map_err(invalid_data)?;
+            validate_private_file(&entry.path(), MAX_RECEIPT_BYTES)?;
+            let mut bytes = Vec::new();
+            File::open(entry.path())?
+                .take((MAX_RECEIPT_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)?;
+            if bytes.len() > MAX_RECEIPT_BYTES {
+                return Err(invalid_data("folder-operation receipt is too large"));
+            }
+            let receipt: FolderOperationReceipt =
+                serde_json::from_slice(&bytes).map_err(invalid_data)?;
+            receipt.validate()?;
+            if receipt.call_id != call_id {
+                return Err(invalid_data("folder-operation receipt identity mismatch"));
+            }
+            if !call_ids.insert(call_id) {
+                return Err(invalid_data("duplicate folder-operation receipt identity"));
+            }
+            receipts.push(receipt);
+        }
+        receipts.sort_by_key(|receipt| receipt.call_id.to_string());
+        Ok(receipts)
+    }
+
     fn receipt_path(&self, call_id: CallId) -> PathBuf {
         self.directory.join(format!("{call_id}.json"))
+    }
+
+    fn operation_receipt_path(&self, call_id: CallId) -> PathBuf {
+        self.directory
+            .join(format!("{FOLDER_OPERATION_PREFIX}{call_id}.json"))
     }
 }
 
@@ -408,6 +556,21 @@ mod tests {
 
         let reopened = ReceiptStore::open(temp.path()).unwrap();
         assert_eq!(reopened.executor_id(), executor_id);
+    }
+
+    #[test]
+    fn folder_operation_receipts_are_separate_and_keep_lease_tokens_private() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(temp.path()).unwrap();
+        let receipt =
+            FolderOperationReceipt::new(ChatId::new(), CallId::new(), store.executor_id());
+        store.save_operation(&receipt).unwrap();
+        assert_eq!(store.load_operations().unwrap(), vec![receipt.clone()]);
+        assert!(store.load_all().unwrap().is_empty());
+        let debug = format!("{receipt:?}");
+        assert!(!debug.contains(&receipt.lease_token.to_string()));
+        store.remove_operation(receipt.call_id).unwrap();
+        assert!(store.load_operations().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -47,6 +47,10 @@ impl HostAccess {
             .map_err(|_| "host access store was initialized more than once".to_owned())
     }
 
+    pub(crate) fn store(&self) -> Option<&std::sync::Arc<dyn Store>> {
+        self.store.get()
+    }
+
     /// Stable private identity shared by native receipts and server recovery.
     pub(crate) const fn client_executor_id(&self) -> Uuid {
         self.receipts.executor_id()

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -141,5 +141,12 @@ async fn boot_server(
     tauri::async_runtime::spawn(async move {
         client_execution::recover_folder_access_receipts(recovery_app).await;
     });
+    let folder_operation_app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        client_execution::folder_operations::recover_connected_folder_operations(
+            folder_operation_app,
+        )
+        .await;
+    });
     server.serve().await.map_err(|e| e.to_string())
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -46,9 +46,12 @@ use tower_http::cors::{AllowOrigin, CorsLayer};
 use uuid::Uuid;
 
 use openwave_core::{
-    request_folder_access_tool_spec, validate_request_folder_access_arguments, AgentConfig,
-    AgentError, Config, DbStore, KeychainSecretProvider, ListDir, Profile, ReadFile, Result,
-    SecretProvider, Store, ToolRegistry, WriteFile,
+    list_connected_folders_tool_spec, list_folder_tool_spec, read_connected_file_tool_spec,
+    request_folder_access_tool_spec, validate_list_connected_folders_arguments,
+    validate_list_folder_arguments, validate_read_connected_file_arguments,
+    validate_request_folder_access_arguments, AgentConfig, AgentError, Config, DbStore,
+    KeychainSecretProvider, ListDir, Profile, ReadFile, Result, SecretProvider, Store,
+    ToolRegistry, WriteFile,
 };
 use openwave_retrieval::{
     Embedder, HashEmbedder, LanceVectorStore, OpenAiEmbedder, ParserRegistry, PlainTextParser,
@@ -492,6 +495,15 @@ fn agent_deps(
     tools.register_validated_client(
         request_folder_access_tool_spec(),
         validate_request_folder_access_arguments,
+    );
+    tools.register_validated_client(
+        list_connected_folders_tool_spec(),
+        validate_list_connected_folders_arguments,
+    );
+    tools.register_validated_client(list_folder_tool_spec(), validate_list_folder_arguments);
+    tools.register_validated_client(
+        read_connected_file_tool_spec(),
+        validate_read_connected_file_arguments,
     );
     // The foreground worker parks atomically with child acceptance, and the
     // bounded sandbox worker is started from the same state below. Sandboxed

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -109,9 +109,11 @@ notification may reduce latency, but it is never the source of truth.
 
 A background agent has private runtime scratch, but the initial executor has no
 tools and cannot access that scratch, projects, host folders, the network, or
-the parent conversation. Broker-mediated folder access is a future capability;
-when introduced it must use the consent and durable-receipt protocol described
-in [Host access and connected folders](host-access.md), never absolute paths.
+the parent conversation. Foreground chats may inspect already attached roots,
+but sandbox agents do not receive the broker transport or these tool contracts.
+Future sandbox folder access must use the parent-mediated consent and
+durable-receipt protocol described in [Host access and connected folders](host-access.md),
+never absolute paths.
 
 The sandbox boundary should remain useful outside the desktop product. A local
 process sandbox is the first execution adapter; self-hosted and managed profiles

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -163,15 +163,19 @@ The built-in server registry currently contains:
   user-facing reason, one read capability proposal, and an optional well-known
   picker hint for Documents or Downloads. It has no server executor and grants
   nothing.
+- `list_connected_folders`, `list_folder`, and `read_connected_file`,
+  foreground-only client continuations that can inspect only roots already
+  attached to the authoritative chat. The native executor derives that context
+  from stored state, persists its bounded result, and never exposes host paths
+  or broker diagnostics to the renderer or model.
 
 Today these file tools still operate inside a server-derived, pinned per-chat
 scratch capability. Its path is neither persisted on the chat nor returned by
 the product API. The desktop can connect, list, and revoke multiple folders
 through a native picker and capability-gated host-broker sidecar; it exposes only
-opaque root IDs and display names to the renderer. The next native slice will
-synchronize broker connections through core's durable attachment-change state
-machine, and the following tool-routing slice will resolve operations through
-those roots.
+opaque root IDs and display names to the renderer. Foreground tool calls can now
+list/read roots already attached to their stored chat context; broader root
+attachment synchronization remains a separate durable state-machine slice.
 See [Host access and connected folders](host-access.md). The agent loop can now
 produce a durable client-wait checkpoint for the registered folder-request
 contract. The desktop discovers those pending requests from durable state and

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,7 +7,7 @@ identity.
 
 ## What exists today
 
-The current foreground agent surface contains six tools:
+The current foreground agent surface contains nine tools:
 
 | Tool | Purpose | Execution boundary |
 | --- | --- | --- |
@@ -16,11 +16,16 @@ The current foreground agent surface contains six tools:
 | `write_file` | Atomically write private-scratch text | Server, workspace |
 | `search` | Search locally indexed project/chat documents | Server, read-only |
 | `request_folder_access` | Ask the trusted desktop host to connect another folder | Client continuation |
+| `list_connected_folders` | List roots already attached to this chat | Native client continuation |
+| `list_folder` | List one directory below an attached root | Native client continuation |
+| `read_connected_file` | Read bounded UTF-8 text below an attached root | Native client continuation |
 | `spawn_sandbox_agent` | Delegate one bounded task and wait for its durable result | Foreground-only durable continuation |
 
-The host broker already supports listing connected roots, listing directories,
-and reading files, but those operations are not yet advertised directly to the
-model. Requesting access and using an approved root remain separate operations.
+The connected-folder calls are foreground-only. Their arguments contain only
+an opaque root ID and a bounded root-relative path; native code recovers the
+stored chat context, reauthorizes with the broker, and persists the exact
+model-facing result before resolving the parked turn. Requesting access and
+using an approved root remain separate operations.
 
 ## Core module layout
 


### PR DESCRIPTION
## Summary
- add foreground tools to list connected folders, list a connected directory, and read a connected file
- execute each operation through the native broker with chat-derived authority and bounded safe results
- preserve durable client-execution recovery without repeating ambiguous host I/O

## Validation
- cargo test -p openwave-core client_tools --locked
- cargo test -p openwave-desktop client_execution --locked
- bw dev lint --rust --check
- cargo fmt --all -- --check