### PR TITLE
Show connected folder activity

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -989,7 +989,7 @@ function AgentActivityPanel({
 }
 
 function AgentActivityItem({ run, label }: { run: AgentRun; label: string }) {
-  const activity = sandboxActivityPresentation(run.activity);
+  const activity = agentActivityPresentation(run.activity);
   const status = activity?.status ?? readableAgentRunStatus(run.status);
   return (
     <li
@@ -1007,7 +1007,7 @@ function AgentActivityItem({ run, label }: { run: AgentRun; label: string }) {
   );
 }
 
-function sandboxActivityPresentation(
+function agentActivityPresentation(
   activity: AgentRun["activity"],
 ): { label: string; detail: string; status: string; sourceStatus: string } | null {
   if (!activity) return null;
@@ -1027,6 +1027,57 @@ function sandboxActivityPresentation(
             label: "Web search",
             detail: "Searching the web",
             status: "searching",
+            sourceStatus: "running",
+          };
+      }
+    case "list_connected_folders":
+      switch (activity.status) {
+        case "waiting":
+          return {
+            label: "Connected folders",
+            detail: "Waiting to check connected folders",
+            status: "waiting",
+            sourceStatus: "waiting",
+          };
+        case "running":
+          return {
+            label: "Connected folders",
+            detail: "Checking connected folders",
+            status: "checking",
+            sourceStatus: "running",
+          };
+      }
+    case "list_folder":
+      switch (activity.status) {
+        case "waiting":
+          return {
+            label: "Folder",
+            detail: "Waiting to list a folder",
+            status: "waiting",
+            sourceStatus: "waiting",
+          };
+        case "running":
+          return {
+            label: "Folder",
+            detail: "Listing a folder",
+            status: "listing",
+            sourceStatus: "running",
+          };
+      }
+    case "read_connected_file":
+      switch (activity.status) {
+        case "waiting":
+          return {
+            label: "File",
+            detail: "Waiting to read a file",
+            status: "waiting",
+            sourceStatus: "waiting",
+          };
+        case "running":
+          return {
+            label: "File",
+            detail: "Reading a file",
+            status: "reading",
             sourceStatus: "running",
           };
       }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -65,18 +65,23 @@ export type AgentRun = {
   started_at: string | null;
   finished_at: string | null;
   last_error_code: string | null;
-  /** A fixed, renderer-safe description of the currently live sandbox task. */
-  activity: SandboxActivity | null;
+  /** A fixed, renderer-safe description of the currently live agent task. */
+  activity: AgentActivity | null;
   created_at: string;
   updated_at: string;
 };
 
 /**
- * Live sandbox activity is intentionally a closed vocabulary. The server never
- * sends search inputs, results, provider identities, or executor diagnostics.
+ * Live agent activity is intentionally a closed vocabulary. The server never
+ * sends tool inputs, results, host paths, grants, executor identities, leases,
+ * provider identities, or diagnostics.
  */
-export type SandboxActivity = {
-  kind: "web_search";
+export type AgentActivity = {
+  kind:
+    | "web_search"
+    | "list_connected_folders"
+    | "list_folder"
+    | "read_connected_file";
   status: "waiting" | "running";
 };
 

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -15,8 +15,8 @@ use tokio::sync::broadcast::error::RecvError;
 use openwave_core::{
     AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunExecution, AgentRunStatus,
     ApprovalDecision, CallId, Chat, ChatId, Project, ProjectId, RequestTurnCancellationOutcome,
-    SandboxToolCall, SandboxToolCallStatus, SecretProvider, SequencedEvent, Store, TurnId,
-    TurnSteer, TurnSteerId,
+    SandboxToolCall, SandboxToolCallStatus, SecretProvider, SequencedEvent, Store,
+    ToolCallExecution, ToolCallRecord, ToolCallStatus, TurnId, TurnSteer, TurnSteerId,
 };
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
@@ -505,18 +505,18 @@ pub struct AgentRunSnapshot {
     pub finished_at: Option<chrono::DateTime<Utc>>,
     /// Stable, bounded classification suitable for renderer display.
     pub last_error_code: Option<String>,
-    /// The currently checkpointed, renderer-safe sandbox activity, if any.
+    /// The currently checkpointed, renderer-safe activity, if any.
     ///
     /// This is intentionally a small fixed vocabulary. It never exposes tool
     /// arguments, results, provider call identities, executor leases, or raw
     /// executor diagnostics.
-    pub activity: Option<SandboxActivitySnapshot>,
+    pub activity: Option<AgentActivitySnapshot>,
     pub created_at: chrono::DateTime<Utc>,
     pub updated_at: chrono::DateTime<Utc>,
 }
 
 impl AgentRunSnapshot {
-    fn from_run(run: AgentRun, activity: Option<SandboxActivitySnapshot>) -> Self {
+    fn from_run(run: AgentRun, activity: Option<AgentActivitySnapshot>) -> Self {
         Self {
             id: run.id,
             parent_id: run.parent_id,
@@ -532,14 +532,17 @@ impl AgentRunSnapshot {
     }
 }
 
-/// Fixed, renderer-safe names for live sandbox work.
+/// Fixed, renderer-safe names for supported live work.
 ///
-/// Adding a new durable sandbox tool does not automatically expose it to a
-/// renderer: it must be deliberately admitted here with a safe label.
+/// Adding a durable tool does not automatically expose it to a renderer: it
+/// must be deliberately admitted here with a safe label.
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum SandboxActivityKind {
+pub enum AgentActivityKind {
     WebSearch,
+    ListConnectedFolders,
+    ListFolder,
+    ReadConnectedFile,
 }
 
 /// Coarse checkpoint lifecycle suitable for display.
@@ -548,37 +551,65 @@ pub enum SandboxActivityKind {
 /// work is represented, and terminal checkpoints produce no activity.
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum SandboxActivityStatus {
+pub enum AgentActivityStatus {
     Waiting,
     Running,
 }
 
-/// Renderer-safe projection of one live sandbox checkpoint.
+/// Renderer-safe projection of one live supported checkpoint.
 #[derive(Debug, Clone, Copy, Serialize)]
-pub struct SandboxActivitySnapshot {
-    pub kind: SandboxActivityKind,
-    pub status: SandboxActivityStatus,
+pub struct AgentActivitySnapshot {
+    pub kind: AgentActivityKind,
+    pub status: AgentActivityStatus,
 }
 
-fn sandbox_activity(calls: &[SandboxToolCall]) -> Option<SandboxActivitySnapshot> {
+fn sandbox_activity(calls: &[SandboxToolCall]) -> Option<AgentActivitySnapshot> {
     // A sandbox can have at most one live checkpoint. Inspecting the latest
     // durable live checkpoint also prevents an older, completed activity from
     // lingering in the UI after the run has advanced.
     let call = calls.iter().rev().find(|call| !call.status.is_terminal())?;
     let kind = match call.name.as_str() {
-        "web_search" => SandboxActivityKind::WebSearch,
+        "web_search" => AgentActivityKind::WebSearch,
         // Unknown tool names are executor data, not a renderer API contract.
         _ => return None,
     };
     let status = match call.status {
-        SandboxToolCallStatus::Accepted => SandboxActivityStatus::Waiting,
-        SandboxToolCallStatus::Claimed => SandboxActivityStatus::Running,
+        SandboxToolCallStatus::Accepted => AgentActivityStatus::Waiting,
+        SandboxToolCallStatus::Claimed => AgentActivityStatus::Running,
         SandboxToolCallStatus::Completed
         | SandboxToolCallStatus::Failed
         | SandboxToolCallStatus::Cancelled => return None,
         _ => return None,
     };
-    Some(SandboxActivitySnapshot { kind, status })
+    Some(AgentActivitySnapshot { kind, status })
+}
+
+fn foreground_activity(
+    calls: &[ToolCallRecord],
+    now: chrono::DateTime<Utc>,
+) -> Option<AgentActivitySnapshot> {
+    // A foreground turn can park on exactly one client tool call. Looking at
+    // the latest live supported call means a completed folder operation never
+    // lingers after its continuation advances.
+    let call = calls.iter().rev().find(|call| {
+        call.execution == ToolCallExecution::Client && call.status == ToolCallStatus::Pending
+    })?;
+    let kind = match call.name.as_str() {
+        "list_connected_folders" => AgentActivityKind::ListConnectedFolders,
+        "list_folder" => AgentActivityKind::ListFolder,
+        "read_connected_file" => AgentActivityKind::ReadConnectedFile,
+        // Unknown client tools are executor data, not a renderer API contract.
+        _ => return None,
+    };
+    let status = if call
+        .client_lease_expires_at
+        .is_some_and(|expires_at| expires_at > now)
+    {
+        AgentActivityStatus::Running
+    } else {
+        AgentActivityStatus::Waiting
+    };
+    Some(AgentActivitySnapshot { kind, status })
 }
 
 /// `GET /chats/{id}/agent-runs` — list renderer-safe execution state.
@@ -592,6 +623,11 @@ pub async fn list_agent_runs(
         .await?
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
     let runs = state.store.list_agent_runs(id).await?;
+    // This read model needs only live client checkpoints. Loading the complete
+    // tool-call transcript here would needlessly deserialize historical model
+    // arguments, results, and local diagnostics just to render current work.
+    let client_calls = state.store.list_pending_client_tool_calls(id).await?;
+    let now = Utc::now();
     let mut snapshots = Vec::with_capacity(runs.len());
     for run in runs {
         let activity = if run.execution == AgentRunExecution::Sandbox {
@@ -600,12 +636,87 @@ pub async fn list_agent_runs(
                 .list_sandbox_tool_calls_for_agent_run(run.id)
                 .await?;
             sandbox_activity(&calls)
+        } else if run.execution == AgentRunExecution::Foreground {
+            foreground_activity(&client_calls, now)
         } else {
             None
         };
         snapshots.push(AgentRunSnapshot::from_run(run, activity));
     }
     Ok(Json(snapshots))
+}
+
+#[cfg(test)]
+mod activity_tests {
+    use super::*;
+
+    fn client_call(name: &str, lease_expires_at: Option<chrono::DateTime<Utc>>) -> ToolCallRecord {
+        ToolCallRecord {
+            id: CallId::new(),
+            chat_id: ChatId::new(),
+            turn_id: TurnId::new(),
+            provider_id: "provider-call-identity".into(),
+            name: name.into(),
+            arguments: serde_json::json!({
+                "root_id": "5b3e9987-5ebf-4bb0-bc6f-0c041b156027",
+                "path": "taxes/2026/private-return.txt",
+                "grant": "private-grant"
+            }),
+            execution: ToolCallExecution::Client,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: Some("private-error-code".into()),
+            error_detail: Some("private error detail".into()),
+            client_executor_id: Some(uuid::Uuid::new_v4()),
+            client_lease_expires_at: lease_expires_at,
+            created_at: Utc::now(),
+            resolved_at: None,
+        }
+    }
+
+    #[test]
+    fn foreground_folder_activity_has_a_closed_safe_vocabulary() {
+        let now = Utc::now();
+        for (name, kind) in [
+            ("list_connected_folders", "list_connected_folders"),
+            ("list_folder", "list_folder"),
+            ("read_connected_file", "read_connected_file"),
+        ] {
+            let activity = foreground_activity(
+                &[client_call(name, Some(now + chrono::Duration::minutes(1)))],
+                now,
+            )
+            .expect("supported foreground folder work is visible");
+            assert_eq!(
+                serde_json::to_value(activity).unwrap(),
+                serde_json::json!({"kind": kind, "status": "running"})
+            );
+        }
+
+        let waiting = foreground_activity(&[client_call("list_folder", None)], now)
+            .expect("an unclaimed folder operation is visible");
+        assert_eq!(
+            serde_json::to_value(waiting).unwrap(),
+            serde_json::json!({"kind": "list_folder", "status": "waiting"})
+        );
+
+        assert!(foreground_activity(&[client_call("unknown_client_tool", None)], now).is_none());
+
+        let rendered = serde_json::to_string(
+            &foreground_activity(&[client_call("read_connected_file", None)], now).unwrap(),
+        )
+        .unwrap();
+        for forbidden in [
+            "5b3e9987-5ebf-4bb0-bc6f-0c041b156027",
+            "taxes/2026/private-return.txt",
+            "private-grant",
+            "provider-call-identity",
+            "private-error-code",
+            "private error detail",
+        ] {
+            assert!(!rendered.contains(forbidden), "activity leaked {forbidden}");
+        }
+    }
 }
 
 /// Body of `POST /chats/{id}/messages`.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -5486,6 +5486,182 @@ async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
 }
 
 #[tokio::test]
+async fn agent_run_snapshots_expose_only_safe_live_foreground_folder_activity() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let historical_argument = "historical-private-argument".repeat(4_000);
+    let historical_result = "historical-private-result".repeat(16_000);
+    let historical = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "historical-provider-call-identity".into(),
+        name: "read_connected_file".into(),
+        arguments: serde_json::json!({"path": historical_argument}),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: chrono::Utc::now(),
+        resolved_at: None,
+    };
+    let historical = match store.accept_tool_call(&historical).await.unwrap() {
+        openwave_core::AcceptToolCallOutcome::Accepted(call) => call,
+        outcome => panic!("unexpected historical-call admission: {outcome:?}"),
+    };
+    let historical_lease = uuid::Uuid::new_v4();
+    let historical_now = chrono::Utc::now();
+    assert!(matches!(
+        store
+            .claim_client_tool_call(
+                historical.id,
+                chat.id,
+                uuid::Uuid::new_v4(),
+                historical_lease,
+                historical_now,
+                historical_now + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        openwave_core::ClaimClientToolCallOutcome::Claimed(_)
+    ));
+    assert!(matches!(
+        store
+            .resolve_client_tool_call_and_append_event(
+                historical.id,
+                chat.id,
+                historical_lease,
+                chrono::Utc::now(),
+                &ToolCallResolution::Completed {
+                    result: historical_result.clone(),
+                },
+                chrono::Utc::now(),
+            )
+            .await
+            .unwrap()
+            .outcome,
+        openwave_core::ResolveToolCallOutcome::Resolved
+    ));
+
+    let root_id = "5b3e9987-5ebf-4bb0-bc6f-0c041b156027";
+    let relative_path = "taxes/2026/private-return.txt";
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "provider-call-identity".into(),
+        name: "read_connected_file".into(),
+        arguments: serde_json::json!({
+            "root_id": root_id,
+            "path": relative_path,
+            "grant": "private-grant"
+        }),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: chrono::Utc::now(),
+        resolved_at: None,
+    };
+    let call = match store.accept_tool_call(&call).await.unwrap() {
+        openwave_core::AcceptToolCallOutcome::Accepted(call) => call,
+        outcome => panic!("unexpected client-call admission: {outcome:?}"),
+    };
+
+    let snapshot = |router: Router| async {
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/chats/{}/agent-runs", chat.id))
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let snapshots: Vec<serde_json::Value> = json_body(response).await;
+        snapshots
+            .into_iter()
+            .find(|snapshot| snapshot.get("execution") == Some(&serde_json::json!("foreground")))
+            .expect("foreground snapshot is returned")
+    };
+
+    let waiting = snapshot(router.clone()).await;
+    assert_eq!(
+        waiting.get("activity"),
+        Some(&serde_json::json!({
+            "kind": "read_connected_file",
+            "status": "waiting"
+        }))
+    );
+    let encoded = serde_json::to_string(&waiting).unwrap();
+    for forbidden in [
+        root_id,
+        relative_path,
+        "private-grant",
+        "provider-call-identity",
+        &historical_argument,
+        &historical_result,
+    ] {
+        assert!(!encoded.contains(forbidden), "snapshot leaked {forbidden}");
+    }
+
+    let lease = uuid::Uuid::new_v4();
+    let now = chrono::Utc::now();
+    assert!(matches!(
+        store
+            .claim_client_tool_call(
+                call.id,
+                chat.id,
+                uuid::Uuid::new_v4(),
+                lease,
+                now,
+                now + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap(),
+        openwave_core::ClaimClientToolCallOutcome::Claimed(_)
+    ));
+    assert_eq!(
+        snapshot(router.clone()).await.get("activity"),
+        Some(&serde_json::json!({
+            "kind": "read_connected_file",
+            "status": "running"
+        }))
+    );
+
+    assert!(matches!(
+        store
+            .resolve_client_tool_call_and_append_event(
+                call.id,
+                chat.id,
+                lease,
+                chrono::Utc::now(),
+                &ToolCallResolution::Completed {
+                    result: "private result".into(),
+                },
+                chrono::Utc::now(),
+            )
+            .await
+            .unwrap()
+            .outcome,
+        openwave_core::ResolveToolCallOutcome::Resolved
+    ));
+    assert_eq!(
+        snapshot(router).await.get("activity"),
+        Some(&serde_json::Value::Null)
+    );
+}
+
+#[tokio::test]
 async fn agent_run_snapshots_omit_persisted_raw_failure_detail() {
     let (router, token, store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -198,13 +198,15 @@ boundary. A bounded failure code may be included for display and recovery
 guidance; detailed provider, transport, or executor diagnostics remain
 server-side.
 
-When a sandbox has a live, supported tool checkpoint, the snapshot may also
+When an agent has a live, supported tool checkpoint, the snapshot may also
 contain a small `activity` object. Its values are a deliberately admitted,
-fixed display vocabulary—for example, `web_search` with `waiting` or
-`running` status. It is not a tool trace: queries, tool arguments, results,
+fixed display vocabulary—for example, sandbox `web_search` or foreground
+`list_connected_folders`, `list_folder`, and `read_connected_file`, each with
+`waiting` or `running` status. It is not a tool trace: queries, tool arguments,
+results, folder/root identities, relative paths, filenames, host paths, grants,
 provider identifiers, executor leases, and raw failures remain server-side.
-New sandbox tools are invisible to the renderer until they receive their own
-safe activity projection.
+New tools are invisible to the renderer until they receive their own safe
+activity projection.
 
 ## Reliability contract
 


### PR DESCRIPTION
## Summary
- project fixed waiting and running activity for live foreground connected-folder operations
- render concise activity labels without exposing tool traces
- query only pending client checkpoints in the activity read model

## Validation
- cargo test -p openwave-server agent_run_snapshots_expose_only_safe_live_ --locked
- cargo clippy -p openwave-server --tests --locked -- -D warnings
- pnpm --dir crates/openwave-desktop/ui build
- bw dev lint --rust --check