### PR TITLE
Relay sandbox folder consent proposals

### DIFF
--- a/crates/openwave-core/src/client_tools.rs
+++ b/crates/openwave-core/src/client_tools.rs
@@ -103,8 +103,21 @@ impl RequestFolderAccessArgs {
         !self.reason.trim().is_empty()
             && self.reason.chars().count() <= MAX_FOLDER_ACCESS_REASON_CHARS
             && !self.reason.contains('\0')
+            && !contains_absolute_path_like_text(&self.reason)
             && self.requested_capabilities == [RequestedFolderCapability::ReadFiles]
     }
+}
+
+fn contains_absolute_path_like_text(value: &str) -> bool {
+    value.split_whitespace().any(|word| {
+        word.starts_with('/')
+            || word.starts_with("~/")
+            || word.starts_with("\\\\")
+            || (word.len() >= 3
+                && word.as_bytes()[0].is_ascii_alphabetic()
+                && word.as_bytes()[1] == b':'
+                && matches!(word.as_bytes()[2], b'/' | b'\\'))
+    })
 }
 
 /// Validate one canonical JSON payload before it crosses the trusted-client boundary.
@@ -146,6 +159,15 @@ pub fn request_folder_access_tool_spec() -> ToolSpec {
             "additionalProperties": false
         }),
     }
+}
+
+/// Sandbox-only contract for proposing that the foreground parent consider
+/// the normal folder-consent flow. It never opens a picker or grants access.
+#[must_use]
+pub fn sandbox_folder_access_proposal_tool_spec() -> ToolSpec {
+    let mut tool = request_folder_access_tool_spec();
+    tool.description = "Ask the foreground parent to decide whether it should ask the user to connect a folder. This is only a proposal: it grants no access, opens no picker, and must not include a path, root ID, or grant data.".into();
+    tool
 }
 
 /// Canonical arguments for [`LIST_CONNECTED_FOLDERS_TOOL`].
@@ -308,6 +330,12 @@ mod tests {
         assert!(!invalid.is_well_formed());
         invalid = args;
         invalid.reason = format!("{}x", " ".repeat(MAX_FOLDER_ACCESS_REASON_CHARS));
+        assert!(!invalid.is_well_formed());
+        invalid = RequestFolderAccessArgs {
+            reason: "Read /Users/example/Documents".into(),
+            requested_capabilities: vec![RequestedFolderCapability::ReadFiles],
+            folder_hint: None,
+        };
         assert!(!invalid.is_well_formed());
         assert!(
             serde_json::from_value::<RequestFolderAccessArgs>(serde_json::json!({

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -413,6 +413,8 @@ pub mod agent_run_result {
         pub lease_token: Uuid,
         pub attempt_count: i32,
         pub claim_count: i32,
+        pub payload_kind: String,
+        pub payload_json: String,
         pub text: String,
         pub submitted_at: DateTimeUtc,
     }

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -1,3 +1,4 @@
+use sea_orm::DatabaseBackend;
 use sea_orm_migration::prelude::*;
 
 use super::{
@@ -20,6 +21,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddToolCalls),
             Box::new(AddDocuments),
             Box::new(AddSandboxToolCalls),
+            Box::new(AddAgentRunResultPayload),
         ]
     }
 }
@@ -3686,6 +3688,79 @@ impl MigrationName for AddSandboxToolCalls {
     }
 }
 
+struct AddAgentRunResultPayload;
+
+impl MigrationName for AddAgentRunResultPayload {
+    fn name(&self) -> &str {
+        "m20260716_000008_add_agent_run_result_payload"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddAgentRunResultPayload {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AgentRunResult::Table)
+                    .add_column(
+                        ColumnDef::new(AgentRunResult::PayloadKind)
+                            .string_len(32)
+                            .not_null()
+                            .default("final_text"),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AgentRunResult::Table)
+                    .add_column(
+                        ColumnDef::new(AgentRunResult::PayloadJson)
+                            .text()
+                            .not_null()
+                            .default("{\\\"text\\\":\\\"\\\"}"),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        let existing_payloads = match manager.get_database_backend() {
+            DatabaseBackend::Postgres => {
+                "UPDATE agent_run_result SET payload_json = json_build_object('text', text)::text"
+            }
+            DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
+                "UPDATE agent_run_result SET payload_json = json_object('text', text)"
+            }
+        };
+        manager
+            .get_connection()
+            .execute_unprepared(existing_payloads)
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AgentRunResult::Table)
+                    .drop_column(AgentRunResult::PayloadJson)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AgentRunResult::Table)
+                    .drop_column(AgentRunResult::PayloadKind)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
 #[async_trait::async_trait]
 impl MigrationTrait for AddSandboxToolCalls {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
@@ -3855,6 +3930,8 @@ enum AgentRunResult {
     LeaseToken,
     AttemptCount,
     ClaimCount,
+    PayloadKind,
+    PayloadJson,
     Text,
     SubmittedAt,
 }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1923,6 +1923,16 @@ impl Store for DbStore {
         ops::agent_run::submit_agent_run_result(self, id, lease_token, text).await
     }
 
+    async fn submit_agent_run_folder_access_proposal(
+        &self,
+        id: AgentRunId,
+        lease_token: uuid::Uuid,
+        request: &crate::RequestFolderAccessArgs,
+    ) -> Result<Option<SubmitAgentRunResultOutcome>> {
+        ops::agent_run::submit_agent_run_folder_access_proposal(self, id, lease_token, request)
+            .await
+    }
+
     async fn fail_agent_run(
         &self,
         id: AgentRunId,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -8,7 +8,7 @@ use crate::error::{AgentError, Result};
 use crate::id::{AgentRunId, CallId, ChatId, MessageId, TurnId};
 use crate::model::{
     AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunInboxStatus, AgentRunResult,
-    AgentRunStatus, TurnRun,
+    AgentRunResultPayload, AgentRunStatus, TurnRun,
 };
 use crate::storage::{
     AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, ClaimAgentRunInboxOutcome,
@@ -16,6 +16,7 @@ use crate::storage::{
     FinishAgentRunCancellationOutcome, ParkTurnForAgentRunInboxOutcome,
     RequestAgentRunCancellationOutcome, SubmitAgentRunResultOutcome,
 };
+use crate::{RequestFolderAccessArgs, RequestedFolderHint};
 
 use super::super::{entities, store_err, DbStore};
 use super::{
@@ -1236,11 +1237,14 @@ pub(in crate::db) async fn fail_agent_run(
         return Err(AgentError::Store("sandbox run missing parent".into()));
     };
     let text = format!("Sandbox task failed ({error_code}): {error_detail}");
+    let payload = AgentRunResultPayload::FinalText { text: text.clone() };
     entities::agent_run_result::ActiveModel {
         agent_run_id: Set(id.0),
         lease_token: Set(lease_token),
         attempt_count: Set(run.attempt_count),
         claim_count: Set(run.claim_count),
+        payload_kind: Set(agent_run_result_payload_kind(&payload).into()),
+        payload_json: Set(agent_run_result_payload_json(&payload)?),
         text: Set(text),
         submitted_at: Set(now),
     }
@@ -1283,12 +1287,44 @@ pub(in crate::db) async fn submit_agent_run_result(
     lease_token: uuid::Uuid,
     text: &str,
 ) -> Result<Option<SubmitAgentRunResultOutcome>> {
-    if lease_token.is_nil() || text.is_empty() || text.chars().count() > AgentRun::MAX_RESULT_LEN {
-        return Err(AgentError::Store(format!(
-            "agent-run result requires a non-nil lease token and 1..={} characters",
-            AgentRun::MAX_RESULT_LEN
-        )));
-    }
+    submit_agent_run_result_payload(
+        store,
+        id,
+        lease_token,
+        AgentRunResultPayload::FinalText {
+            text: text.to_owned(),
+        },
+    )
+    .await
+}
+
+/// Submit the one typed folder-consent proposal a sandbox may return to its
+/// foreground parent. This is a terminal child result, never a client call.
+pub(in crate::db) async fn submit_agent_run_folder_access_proposal(
+    store: &DbStore,
+    id: AgentRunId,
+    lease_token: uuid::Uuid,
+    request: &RequestFolderAccessArgs,
+) -> Result<Option<SubmitAgentRunResultOutcome>> {
+    submit_agent_run_result_payload(
+        store,
+        id,
+        lease_token,
+        AgentRunResultPayload::FolderAccessProposal {
+            request: request.clone(),
+        },
+    )
+    .await
+}
+
+async fn submit_agent_run_result_payload(
+    store: &DbStore,
+    id: AgentRunId,
+    lease_token: uuid::Uuid,
+    payload: AgentRunResultPayload,
+) -> Result<Option<SubmitAgentRunResultOutcome>> {
+    validate_agent_run_result_payload(&payload)?;
+    let text = agent_run_result_display_text(&payload);
     let transaction = store.conn.begin().await.map_err(store_err)?;
     acquire_agent_run_claim_lock(&transaction).await?;
     let now = database_now(&transaction).await?;
@@ -1299,14 +1335,17 @@ pub(in crate::db) async fn submit_agent_run_result(
     {
         let result = agent_run_result_from_model(result)?;
         transaction.commit().await.map_err(store_err)?;
-        return Ok((result.lease_token == lease_token && result.text == text)
-            .then_some(SubmitAgentRunResultOutcome::Existing(result)));
+        return Ok(
+            (result.lease_token == lease_token && result.payload == payload)
+                .then_some(SubmitAgentRunResultOutcome::Existing(result)),
+        );
     }
     let Some(run) = find_by_id_on(&transaction, id).await? else {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     };
     if run.execution != AgentRunExecution::Sandbox.as_str()
+        || run.depth != 1
         || run.status != AgentRunStatus::Running.as_str()
         || run.lease_token != Some(lease_token)
         || run.lease_expires_at.is_none_or(|expiry| expiry <= now)
@@ -1341,7 +1380,9 @@ pub(in crate::db) async fn submit_agent_run_result(
         lease_token: Set(lease_token),
         attempt_count: Set(run.attempt_count),
         claim_count: Set(run.claim_count),
-        text: Set(text.to_owned()),
+        payload_kind: Set(agent_run_result_payload_kind(&payload).into()),
+        payload_json: Set(agent_run_result_payload_json(&payload)?),
+        text: Set(text),
         submitted_at: Set(now),
     }
     .insert(&transaction)
@@ -2278,14 +2319,16 @@ where
             (lease_token, attempt_count, claim_count)
         }
     };
+    let text = format!("Sandbox task failed ({error_code}): {error_detail}");
+    let payload = AgentRunResultPayload::FinalText { text: text.clone() };
     entities::agent_run_result::ActiveModel {
         agent_run_id: Set(candidate.id),
         lease_token: Set(lease_token),
         attempt_count: Set(attempt_count),
         claim_count: Set(claim_count),
-        text: Set(format!(
-            "Sandbox task failed ({error_code}): {error_detail}"
-        )),
+        payload_kind: Set(agent_run_result_payload_kind(&payload).into()),
+        payload_json: Set(agent_run_result_payload_json(&payload)?),
+        text: Set(text),
         submitted_at: Set(now),
     }
     .insert(conn)
@@ -2445,14 +2488,104 @@ fn agent_run_result_from_model(model: entities::agent_run_result::Model) -> Resu
     {
         return Err(AgentError::Store("invalid stored agent-run result".into()));
     }
+    let payload = agent_run_result_payload_from_columns(&model.payload_kind, &model.payload_json)?;
+    if model.text != agent_run_result_display_text(&payload) {
+        return Err(AgentError::Store(
+            "agent-run result display text does not match its typed payload".into(),
+        ));
+    }
     Ok(AgentRunResult {
         agent_run_id: AgentRunId(model.agent_run_id),
         lease_token: model.lease_token,
         attempt_count: model.attempt_count,
         claim_count: model.claim_count,
+        payload,
         text: model.text,
         submitted_at: model.submitted_at,
     })
+}
+
+fn validate_agent_run_result_payload(payload: &AgentRunResultPayload) -> Result<()> {
+    match payload {
+        AgentRunResultPayload::FinalText { text }
+            if !text.is_empty() && text.chars().count() <= AgentRun::MAX_RESULT_LEN =>
+        {
+            Ok(())
+        }
+        AgentRunResultPayload::FinalText { .. } => Err(AgentError::Store(format!(
+            "agent-run result requires 1..={} characters",
+            AgentRun::MAX_RESULT_LEN
+        ))),
+        AgentRunResultPayload::FolderAccessProposal { request } if request.is_well_formed() => {
+            Ok(())
+        }
+        AgentRunResultPayload::FolderAccessProposal { .. } => Err(AgentError::Store(
+            "invalid sandbox folder-access proposal".into(),
+        )),
+    }
+}
+
+fn agent_run_result_payload_kind(payload: &AgentRunResultPayload) -> &'static str {
+    match payload {
+        AgentRunResultPayload::FinalText { .. } => "final_text",
+        AgentRunResultPayload::FolderAccessProposal { .. } => "folder_access_proposal",
+    }
+}
+
+fn agent_run_result_payload_json(payload: &AgentRunResultPayload) -> Result<String> {
+    match payload {
+        AgentRunResultPayload::FinalText { text } => serde_json::to_string(&serde_json::json!({
+            "text": text,
+        })),
+        AgentRunResultPayload::FolderAccessProposal { request } => serde_json::to_string(request),
+    }
+    .map_err(|error| AgentError::Store(format!("serialize agent-run result payload: {error}")))
+}
+
+fn agent_run_result_payload_from_columns(kind: &str, json: &str) -> Result<AgentRunResultPayload> {
+    let payload = match kind {
+        "final_text" => {
+            #[derive(serde::Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct FinalTextPayload {
+                text: String,
+            }
+            let payload = serde_json::from_str::<FinalTextPayload>(json).map_err(|_| {
+                AgentError::Store("invalid stored final-text agent-run result payload".into())
+            })?;
+            AgentRunResultPayload::FinalText { text: payload.text }
+        }
+        "folder_access_proposal" => {
+            let request = serde_json::from_str::<RequestFolderAccessArgs>(json).map_err(|_| {
+                AgentError::Store("invalid stored folder-access proposal payload".into())
+            })?;
+            AgentRunResultPayload::FolderAccessProposal { request }
+        }
+        _ => {
+            return Err(AgentError::Store(
+                "invalid stored agent-run result payload kind".into(),
+            ))
+        }
+    };
+    validate_agent_run_result_payload(&payload)?;
+    Ok(payload)
+}
+
+fn agent_run_result_display_text(payload: &AgentRunResultPayload) -> String {
+    match payload {
+        AgentRunResultPayload::FinalText { text } => text.clone(),
+        AgentRunResultPayload::FolderAccessProposal { request } => {
+            let hint = match request.folder_hint {
+                Some(RequestedFolderHint::Documents) => "\nPicker hint: Documents",
+                Some(RequestedFolderHint::Downloads) => "\nPicker hint: Downloads",
+                None => "",
+            };
+            format!(
+                "Sandbox agent requested that you decide whether to ask the user to connect a folder. This grants no access. If appropriate, issue the normal request_folder_access tool; otherwise continue without host access.\nReason: {}\nRequested capability: read_files{hint}",
+                request.reason
+            )
+        }
+    }
 }
 
 fn agent_run_inbox_from_models(
@@ -2634,10 +2767,13 @@ where
         }
     };
     let message_id = MessageId::sandbox_result_for_child(entry.child_run_id);
-    let content = format!(
-        "Sandbox agent {disposition}. Its exact final result follows:\n{}",
-        entry.result.text
-    );
+    let content = match &entry.result.payload {
+        AgentRunResultPayload::FinalText { .. } => format!(
+            "Sandbox agent {disposition}. Its exact final result follows:\n{}",
+            entry.result.text
+        ),
+        AgentRunResultPayload::FolderAccessProposal { .. } => entry.result.text.clone(),
+    };
     let existing = entities::message::Entity::find_by_id(message_id.0)
         .one(conn)
         .await

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -5,10 +5,10 @@ use crate::{
     ClaimAgentRunInboxOutcome, ClaimSandboxToolCallOutcome,
     ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome, DbStore,
     FinishAgentRunCancellationOutcome, MessageId, ParkSandboxToolCallOutcome,
-    ParkTurnForAgentRunInboxOutcome, RequestAgentRunCancellationOutcome,
-    ResolveSandboxToolCallOutcome, Role, SandboxToolCallRequest, Store,
-    SubmitAgentRunResultOutcome, ToolCallResolution, TurnCheckpointProgress, TurnId, TurnRunStatus,
-    Usage,
+    ParkTurnForAgentRunInboxOutcome, RequestAgentRunCancellationOutcome, RequestFolderAccessArgs,
+    RequestedFolderCapability, RequestedFolderHint, ResolveSandboxToolCallOutcome, Role,
+    SandboxToolCallRequest, Store, SubmitAgentRunResultOutcome, ToolCallResolution,
+    TurnCheckpointProgress, TurnId, TurnRunStatus, Usage,
 };
 use chrono::{Duration, Utc};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
@@ -944,6 +944,72 @@ async fn sandbox_result_submission_is_fenced_and_idempotent() {
         .is_none());
     assert!(store
         .submit_agent_run_result(child_id, lease_token, "different result")
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn sandbox_folder_proposal_is_typed_fenced_and_idempotent() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let child_id = AgentRunId::new();
+    store
+        .accept_agent_run(
+            child_id,
+            chat.id,
+            Some(AgentRunId::foreground_for_chat(chat.id)),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("ask the parent about folder consent"),
+        )
+        .await
+        .unwrap();
+    let lease_token = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(lease_token, Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    let request = RequestFolderAccessArgs {
+        reason: "Read the documents needed for this task".into(),
+        requested_capabilities: vec![RequestedFolderCapability::ReadFiles],
+        folder_hint: Some(RequestedFolderHint::Documents),
+    };
+    let result = match store
+        .submit_agent_run_folder_access_proposal(child_id, lease_token, &request)
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        SubmitAgentRunResultOutcome::Completed(result) => result,
+        outcome => panic!("unexpected proposal submission outcome: {outcome:?}"),
+    };
+    assert!(matches!(
+        &result.payload,
+        crate::AgentRunResultPayload::FolderAccessProposal { request: stored } if stored == &request
+    ));
+    assert!(result.text.contains("This grants no access"));
+    assert!(!result.text.contains("root_id"));
+    assert!(matches!(
+        store
+            .submit_agent_run_folder_access_proposal(child_id, lease_token, &request)
+            .await
+            .unwrap(),
+        Some(SubmitAgentRunResultOutcome::Existing(existing)) if existing == result
+    ));
+    let changed = RequestFolderAccessArgs {
+        reason: "Read a different folder".into(),
+        ..request.clone()
+    };
+    assert!(store
+        .submit_agent_run_folder_access_proposal(child_id, lease_token, &changed)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .submit_agent_run_folder_access_proposal(child_id, uuid::Uuid::new_v4(), &request)
         .await
         .unwrap()
         .is_none());

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -53,13 +53,13 @@ pub use blob::FsBlobStore;
 pub use cancel::{CancelToken, Cancelled};
 pub use client_tools::{
     list_connected_folders_tool_spec, list_folder_tool_spec, read_connected_file_tool_spec,
-    request_folder_access_tool_spec, validate_list_connected_folders_arguments,
-    validate_list_folder_arguments, validate_read_connected_file_arguments,
-    validate_request_folder_access_arguments, ListConnectedFoldersArgs, ListFolderArgs,
-    ReadConnectedFileArgs, RequestFolderAccessArgs, RequestFolderAccessResult,
-    RequestedFolderCapability, RequestedFolderHint, LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL,
-    MAX_CONNECTED_FOLDER_PATH_BYTES, MAX_FOLDER_ACCESS_REASON_CHARS, READ_CONNECTED_FILE_TOOL,
-    REQUEST_FOLDER_ACCESS_TOOL,
+    request_folder_access_tool_spec, sandbox_folder_access_proposal_tool_spec,
+    validate_list_connected_folders_arguments, validate_list_folder_arguments,
+    validate_read_connected_file_arguments, validate_request_folder_access_arguments,
+    ListConnectedFoldersArgs, ListFolderArgs, ReadConnectedFileArgs, RequestFolderAccessArgs,
+    RequestFolderAccessResult, RequestedFolderCapability, RequestedFolderHint,
+    LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL, MAX_CONNECTED_FOLDER_PATH_BYTES,
+    MAX_FOLDER_ACCESS_REASON_CHARS, READ_CONNECTED_FILE_TOOL, REQUEST_FOLDER_ACCESS_TOOL,
 };
 pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
@@ -74,16 +74,16 @@ pub use id::{
 pub use keychain::KeychainSecretProvider;
 pub use model::{
     validate_source_regions, AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunInboxStatus,
-    AgentRunResult, AgentRunStatus, BeginRootAttachmentChange, BlobRetirement,
-    BlobRetirementStatus, ByteSpan, Chat, ChatRootAttachment, ClientToolCallRequest,
-    DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus, DocumentListCursor,
-    DocumentParseOutput, DocumentProcessingStatus, DocumentRecord, DocumentScope,
-    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message,
-    Project, Role, RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
-    RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
-    RootAttachmentSubjectKind, SandboxToolCall, SandboxToolCallReceipt, SandboxToolCallRequest,
-    SandboxToolCallStatus, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
-    ToolCallResolution, ToolCallStatus, TurnAgentRunWait, TurnAgentRunWaitStatus,
+    AgentRunResult, AgentRunResultPayload, AgentRunStatus, BeginRootAttachmentChange,
+    BlobRetirement, BlobRetirementStatus, ByteSpan, Chat, ChatRootAttachment,
+    ClientToolCallRequest, DocumentGeneration, DocumentJob, DocumentJobKind, DocumentJobStatus,
+    DocumentListCursor, DocumentParseOutput, DocumentProcessingStatus, DocumentRecord,
+    DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert,
+    Message, Project, Role, RootAttachmentChange, RootAttachmentChangeAction,
+    RootAttachmentChangeFailure, RootAttachmentChangePhase, RootAttachmentChangeTerminal,
+    RootAttachmentOrigin, RootAttachmentSubjectKind, SandboxToolCall, SandboxToolCallReceipt,
+    SandboxToolCallRequest, SandboxToolCallStatus, SourceLocation, SourceRegion, ToolCallExecution,
+    ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnAgentRunWait, TurnAgentRunWaitStatus,
     TurnCheckpointProgress, TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt,
     TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus, MAX_ATTACHMENT_REVISION,
     MAX_ROOT_ATTACHMENTS,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1162,10 +1162,30 @@ pub struct AgentRunResult {
     pub attempt_count: i32,
     /// Exact claim segment that produced the result.
     pub claim_count: i32,
-    /// Bounded final text returned to the parent in a later delivery slice.
+    /// Typed terminal payload returned to the parent in a later delivery slice.
+    pub payload: AgentRunResultPayload,
+    /// Bounded deterministic display text for the terminal payload.
     pub text: String,
     /// Database time at which the terminal submission committed.
     pub submitted_at: DateTime<Utc>,
+}
+
+/// One immutable terminal outcome produced by a sandbox child.
+///
+/// These are deliberately proposals rather than authority. A folder-access
+/// proposal has no root identity, path, grant, or client-call identity; the
+/// foreground parent must independently decide whether to ask the trusted
+/// client through its ordinary tool.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgentRunResultPayload {
+    /// Ordinary final text from the sandbox model.
+    FinalText { text: String },
+    /// A sandbox request for its foreground parent to consider folder consent.
+    FolderAccessProposal {
+        /// Non-authoritative, validated request arguments.
+        request: crate::RequestFolderAccessArgs,
+    },
 }
 
 /// One immutable result delivered from a sandbox child to its foreground parent.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1287,6 +1287,18 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// Atomically submit one validated folder-consent proposal as a sandbox's
+    /// typed terminal receipt. This only wakes the foreground parent through
+    /// its durable inbox; it cannot grant host access or invoke a client tool.
+    async fn submit_agent_run_folder_access_proposal(
+        &self,
+        _id: AgentRunId,
+        _lease_token: uuid::Uuid,
+        _request: &crate::RequestFolderAccessArgs,
+    ) -> Result<Option<SubmitAgentRunResultOutcome>> {
+        agent_run_storage_unavailable()
+    }
+
     /// Fence one exact sandbox lease after an execution failure. Attempts below
     /// the run budget become replay-safe retry work; the final attempt writes a
     /// parent-visible terminal receipt in the same transaction as `failed`.

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -13,12 +13,12 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use openwave_core::{
-    sandbox_web_search_tool_spec, AgentConfig, AgentError, AgentRun, AgentRunInboxEntry,
-    AgentRunStatus, CallId, ChatMessage, ChatRequest, ClaimAgentRunInboxOutcome,
-    ConsumeAgentRunInboxAndResumeTurnOutcome, ContentBlock, FailAgentRunOutcome, ModelProvider,
-    ParkSandboxToolCallOutcome, ProviderEvent, Result, Role, SandboxToolCall,
-    SandboxToolCallRequest, SandboxToolCallStatus, StopReason, Store, SubmitAgentRunResultOutcome,
-    ToolCallRecord,
+    sandbox_folder_access_proposal_tool_spec, sandbox_web_search_tool_spec, AgentConfig,
+    AgentError, AgentRun, AgentRunInboxEntry, AgentRunStatus, CallId, ChatMessage, ChatRequest,
+    ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome, ContentBlock,
+    FailAgentRunOutcome, ModelProvider, ParkSandboxToolCallOutcome, ProviderEvent,
+    RequestFolderAccessArgs, Result, Role, SandboxToolCall, SandboxToolCallRequest,
+    SandboxToolCallStatus, StopReason, Store, SubmitAgentRunResultOutcome, ToolCallRecord,
 };
 use tokio::sync::Notify;
 
@@ -29,7 +29,7 @@ use crate::resolver::ProviderResolver;
 /// Deliberately do not inherit the foreground system prompt: it may describe
 /// interactive tools or conversation-wide responsibilities that are outside a
 /// depth-one child run's authority.
-const SANDBOX_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below and return a concise, self-contained result for your parent agent. You cannot access the conversation, filesystem, or other agents. You may use the single web_search tool at most once when current public-web information is necessary; otherwise finish directly.";
+const SANDBOX_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below and return a concise, self-contained result for your parent agent. You cannot access the conversation, filesystem, connected folders, or other agents. You may use at most one tool: web_search when current public-web information is necessary, or request_folder_access only to propose that your foreground parent decide whether to ask the user. The proposal grants no access and cannot open a picker. Otherwise finish directly.";
 const SANDBOX_WEB_SEARCH_TOOL_LIMIT: usize = 1;
 
 #[derive(Debug, Clone, Copy)]
@@ -290,6 +290,9 @@ impl SandboxAgentRunWorker {
                     Ok(SandboxCompletion::WebSearch { provider_id, arguments }) => {
                         return self.park_web_search(run, lease_token, provider_id, arguments).await;
                     }
+                    Ok(SandboxCompletion::FolderAccessProposal { request }) => {
+                        return self.submit_folder_access_proposal(run.id, lease_token, request).await;
+                    }
                     // No terminal failure transition exists yet. Keep the exact
                     // lease alive only until its scheduler expiry; then the
                     // durable claim state machine safely retries or exhausts
@@ -382,6 +385,28 @@ impl SandboxAgentRunWorker {
         match self
             .store
             .submit_agent_run_result(id, lease_token, &text)
+            .await?
+        {
+            Some(SubmitAgentRunResultOutcome::Completed(_))
+            | Some(SubmitAgentRunResultOutcome::Existing(_)) => {
+                Ok(SandboxAgentRunWorkerOutcome::Completed(id))
+            }
+            None => {
+                self.acknowledge_cancellation_or_lease_loss(id, lease_token)
+                    .await
+            }
+        }
+    }
+
+    async fn submit_folder_access_proposal(
+        &self,
+        id: openwave_core::AgentRunId,
+        lease_token: uuid::Uuid,
+        request: RequestFolderAccessArgs,
+    ) -> Result<SandboxAgentRunWorkerOutcome> {
+        match self
+            .store
+            .submit_agent_run_folder_access_proposal(id, lease_token, &request)
             .await?
         {
             Some(SubmitAgentRunResultOutcome::Completed(_))
@@ -559,7 +584,12 @@ async fn sandbox_request(
         // completion. Never advertise work that the remaining model budget
         // cannot consume after its durable receipt arrives.
         tools: if calls.is_empty() && config.max_steps >= 2 {
-            vec![sandbox_web_search_tool_spec()]
+            vec![
+                sandbox_web_search_tool_spec(),
+                sandbox_folder_access_proposal_tool_spec(),
+            ]
+        } else if calls.is_empty() && config.max_steps >= 1 {
+            vec![sandbox_folder_access_proposal_tool_spec()]
         } else {
             vec![]
         },
@@ -574,6 +604,9 @@ enum SandboxCompletion {
         provider_id: String,
         arguments: serde_json::Value,
     },
+    FolderAccessProposal {
+        request: RequestFolderAccessArgs,
+    },
 }
 
 async fn complete_sandbox_task(
@@ -584,6 +617,10 @@ async fn complete_sandbox_task(
         .tools
         .iter()
         .any(|tool| tool.name == openwave_core::SANDBOX_WEB_SEARCH_TOOL);
+    let folder_proposal_advertised = request
+        .tools
+        .iter()
+        .any(|tool| tool.name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL);
     let mut stream = provider.stream(request).await?;
     let mut text = String::new();
     let mut calls = std::collections::BTreeMap::<u32, (String, String, String)>::new();
@@ -627,29 +664,43 @@ async fn complete_sandbox_task(
                     ));
                 }
                 if reason == StopReason::ToolUse {
-                    if !web_search_advertised {
-                        return Err(AgentError::msg(
-                            "sandbox agent requested an unadvertised tool",
-                        ));
-                    }
                     if !text.is_empty() || calls.len() != 1 {
                         return Err(AgentError::msg(
                             "sandbox agent emitted an ambiguous tool checkpoint",
                         ));
                     }
                     let (_, (provider_id, name, arguments)) = calls.into_iter().next().unwrap();
-                    if name != openwave_core::SANDBOX_WEB_SEARCH_TOOL || provider_id.is_empty() {
+                    if provider_id.is_empty() {
                         return Err(AgentError::msg(
                             "sandbox agent requested an unavailable tool",
                         ));
                     }
-                    let arguments = serde_json::from_str(&arguments).map_err(|_| {
-                        AgentError::msg("sandbox agent emitted invalid web-search arguments")
-                    })?;
-                    return Ok(SandboxCompletion::WebSearch {
-                        provider_id,
-                        arguments,
-                    });
+                    if name == openwave_core::SANDBOX_WEB_SEARCH_TOOL && web_search_advertised {
+                        let arguments = serde_json::from_str(&arguments).map_err(|_| {
+                            AgentError::msg("sandbox agent emitted invalid web-search arguments")
+                        })?;
+                        return Ok(SandboxCompletion::WebSearch {
+                            provider_id,
+                            arguments,
+                        });
+                    }
+                    if name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL
+                        && folder_proposal_advertised
+                    {
+                        let request = serde_json::from_str::<RequestFolderAccessArgs>(&arguments)
+                            .map_err(|_| {
+                            AgentError::msg("sandbox agent emitted invalid folder-access proposal")
+                        })?;
+                        if !request.is_well_formed() {
+                            return Err(AgentError::msg(
+                                "sandbox agent emitted invalid folder-access proposal",
+                            ));
+                        }
+                        return Ok(SandboxCompletion::FolderAccessProposal { request });
+                    }
+                    return Err(AgentError::msg(
+                        "sandbox agent requested an unadvertised tool",
+                    ));
                 }
                 if !calls.is_empty() {
                     return Err(AgentError::msg(
@@ -915,7 +966,13 @@ mod tests {
 
         let requests = provider.requests.lock().unwrap();
         assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].tools, vec![sandbox_web_search_tool_spec()]);
+        assert_eq!(
+            requests[0].tools,
+            vec![
+                sandbox_web_search_tool_spec(),
+                sandbox_folder_access_proposal_tool_spec(),
+            ]
+        );
         assert_eq!(
             requests[0].messages,
             vec![ChatMessage::text(
@@ -1192,6 +1249,111 @@ mod tests {
             store.get_turn_run(turn_id).await.unwrap().unwrap().status,
             TurnRunStatus::Resuming
         );
+    }
+
+    #[tokio::test]
+    async fn folder_proposal_completes_the_child_then_resumes_the_parent_without_a_tool_checkpoint()
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = sandbox_chat();
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "sandbox-model", "delegate")
+            .await
+            .unwrap();
+        let foreground_lease = uuid::Uuid::new_v4();
+        let now = chrono::Utc::now();
+        let foreground = store
+            .claim_turn_run(foreground_lease, now, now + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .turn
+            .unwrap();
+        let call = CallId::new();
+        let child_id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
+        assert!(matches!(
+            store
+                .accept_sandbox_agent_run_and_park_turn(
+                    child_id,
+                    foreground.id,
+                    call,
+                    "ask whether a folder is needed",
+                    foreground_lease,
+                    foreground.steer_revision,
+                    TurnCheckpointProgress {
+                        model_steps: 1,
+                        usage: Usage::default()
+                    },
+                    chrono::Utc::now(),
+                )
+                .await
+                .unwrap(),
+            Some(openwave_core::AcceptSandboxAgentRunAndParkTurnOutcome::Parked { .. })
+        ));
+        let provider = Arc::new(EventProvider(vec![
+            ProviderEvent::ToolCallStarted {
+                index: 0,
+                id: "folder_1".into(),
+                name: openwave_core::REQUEST_FOLDER_ACCESS_TOOL.into(),
+            },
+            ProviderEvent::ToolCallArgsDelta {
+                index: 0,
+                fragment: r#"{"reason":"Read documents needed for the task","requested_capabilities":["read_files"],"folder_hint":"documents"}"#.into(),
+            },
+            ProviderEvent::Stop { reason: StopReason::ToolUse },
+        ]));
+        let worker = SandboxAgentRunWorker::new(
+            store.clone(),
+            Arc::new(FixedResolver(provider)),
+            Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
+            AgentConfig {
+                model: "sandbox-model".into(),
+                max_steps: 2,
+                ..AgentConfig::default()
+            },
+            None,
+            SandboxAgentRunWorkerConfig::default(),
+        );
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::Completed(child_id)
+        );
+        assert!(store
+            .list_sandbox_tool_calls_for_agent_run(child_id)
+            .await
+            .unwrap()
+            .is_empty());
+        let inbox = store
+            .list_agent_run_inbox(openwave_core::AgentRunId::foreground_for_chat(chat.id))
+            .await
+            .unwrap();
+        assert!(matches!(
+            &inbox[0].result.payload,
+            openwave_core::AgentRunResultPayload::FolderAccessProposal { request }
+                if request.reason == "Read documents needed for the task"
+        ));
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::ParentResumed(child_id)
+        );
+        let messages = store.list_messages(chat.id).await.unwrap();
+        let proposal = messages.last().unwrap();
+        assert_eq!(proposal.role, Role::System);
+        assert!(proposal.content.contains("This grants no access"));
+        assert!(proposal
+            .content
+            .contains("normal request_folder_access tool"));
+        assert!(!proposal.content.contains("root_id"));
     }
 
     #[tokio::test]
@@ -1489,7 +1651,13 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(request.system.as_deref(), Some(SANDBOX_SYSTEM_PROMPT));
-        assert_eq!(request.tools, vec![sandbox_web_search_tool_spec()]);
+        assert_eq!(
+            request.tools,
+            vec![
+                sandbox_web_search_tool_spec(),
+                sandbox_folder_access_proposal_tool_spec(),
+            ]
+        );
     }
 
     #[tokio::test]
@@ -1513,7 +1681,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(request.tools.is_empty());
+        assert_eq!(
+            request.tools,
+            vec![sandbox_folder_access_proposal_tool_spec()]
+        );
         let provider = Arc::new(EventProvider(vec![
             ProviderEvent::ToolCallStarted {
                 index: 0,

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -152,10 +152,14 @@ The scheduler's ownership rules are deliberately strict:
 - a worker's writes must carry its exact live lease token, so a reclaimed or
   expired worker cannot resume ownership.
 
-Final sandbox text is stored as an immutable receipt keyed by the child run and
-the exact lease segment that submitted it. The receipt, `completed` state, and
-one parent inbox entry commit together, so an ambiguous worker retry can recover
-its original result but cannot overwrite or double-deliver it. Each inbox entry
+Final sandbox output is stored as an immutable typed receipt keyed by the child
+run and the exact lease segment that submitted it. Besides final text, the only
+current non-text outcome is a validated folder-consent proposal. It carries no
+host path, root identity, broker grant, or client-call identity; it only tells
+the foreground parent to decide whether the existing foreground consent tool is
+appropriate. The receipt, `completed` state, and one parent inbox entry commit
+together, so an ambiguous worker retry can recover its original result but
+cannot overwrite or double-deliver it. Each inbox entry
 then advances through its own fenced continuation state machine:
 `pending -> claimed -> consumed` (or `cancelled` when its parked parent is
 cancelled). A parent continuation claims one exact child
@@ -249,8 +253,11 @@ The implementation is intentionally incremental:
    the already-delivered inbox receipt. *(Shipped.)*
 10. Add the one-call sandbox `web_search` checkpoint, host executor, and
     receipt-backed model resume. *(Shipped.)*
-11. Route sandbox folder access through the host broker.
-12. Add desktop surfaces for queued, running, waiting, failed, and completed
+11. Let a sandbox relay a typed folder-consent proposal to its foreground
+    parent, without host access or a picker. *(Shipped.)*
+12. Add a fenced read-only proxy for roots the foreground chat already
+    attached; sandbox broker access remains deferred.
+13. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.
-13. Add richer context lifecycle, parallel-safe tool groups, and further
+14. Add richer context lifecycle, parallel-safe tool groups, and further
    orchestration only after these recovery boundaries are proven.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -69,12 +69,17 @@ agents never receive this tool.
 
 A background sandbox has no shared conversation, filesystem, network, or
 host-folder access. It receives one bounded task and may be offered exactly
-one fixed `web_search` contract when its remaining model-step budget can also
-consume the result. The worker atomically parks the sandbox under its exact
-lease; a separate host-owned executor performs the bounded search and writes
-an immutable receipt. On a later claim, the sandbox reconstructs the matching
-`ToolUse`/`ToolResult` from that receipt before it can finalize. Sandboxes do
-not receive `spawn_sandbox_agent` and cannot create further agents.
+one tool call: `web_search` when its remaining model-step budget can also
+consume the result, or a sandbox-only `request_folder_access` proposal. The
+proposal is a typed terminal child result, not a client call: it cannot open a
+picker, name a root, expose a path, or grant access. Its foreground parent
+receives deterministic system context and independently decides whether to
+issue the ordinary foreground `request_folder_access` client tool. The worker
+atomically parks only web search under its exact lease; a separate host-owned
+executor performs that bounded search and writes an immutable receipt. On a
+later claim, the sandbox reconstructs the matching `ToolUse`/`ToolResult` from
+that receipt before it can finalize. Sandboxes do not receive
+`spawn_sandbox_agent` and cannot create further agents.
 
 Future sandbox-safe capabilities, such as broker-mediated folder reads, must
 be added one at a time behind the same durable continuation and consent


### PR DESCRIPTION
## Summary
- let a depth-one sandbox submit a typed folder-consent proposal as its immutable terminal result
- resume the foreground parent with deterministic non-authoritative context
- keep all broker, picker, desktop, API, and renderer paths out of the proposal relay

## Validation
- cargo test -p openwave-core db::tests::agent_run --locked
- cargo test -p openwave-server sandbox_agent_run_worker --locked
- cargo clippy -p openwave-core -p openwave-server --all-targets --locked -- -D warnings
- bw dev lint --rust --check
- cargo fmt --all -- --check