### PR TITLE
Render live tool call cards

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -26,11 +26,19 @@ import {
 import { FolderAccessCard } from "./FolderAccessCard";
 import { Logomark } from "./Logomark";
 import { MessageMarkdown } from "./MessageMarkdown";
+import { ToolCallCard, type ToolCallStatus } from "./ToolCallCard";
 
 type Msg =
   | { id: string; role: "user"; text: string }
   | { id: string; role: "assistant"; text: string }
   | { id: string; role: "system"; text: string }
+  | {
+      id: string;
+      role: "tool";
+      callId: string;
+      name: string;
+      status: ToolCallStatus;
+    }
   | {
       id: string;
       role: "approval";
@@ -90,6 +98,7 @@ export default function App() {
   const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
   const visibleFolderCallIdsRef = useRef<Set<string>>(new Set());
   const cancelRequestTurnRef = useRef<string | null>(null);
+  const provisionalToolCallIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     let cancelled = false;
@@ -313,6 +322,7 @@ export default function App() {
     if (event.type === "turn_started") {
       refreshAgentRunsRef.current?.();
       assistantBufRef.current = "";
+      provisionalToolCallIdsRef.current = new Set();
       setBusy(true);
       setActiveTurnId(event.turn_id);
       setCancelPendingTurnId(null);
@@ -343,8 +353,10 @@ export default function App() {
 
     if (event.type === "stream_interrupted") {
       assistantBufRef.current = "";
+      const provisionalCallIds = provisionalToolCallIdsRef.current;
+      provisionalToolCallIdsRef.current = new Set();
       setMessages((prev) => {
-        const copy = [...prev];
+        const copy = discardToolCalls(prev, provisionalCallIds);
         if (copy[copy.length - 1]?.role === "assistant") {
           copy.pop();
         }
@@ -358,18 +370,33 @@ export default function App() {
       if (event.name === "request_folder_access") {
         refreshFolderAccessRef.current?.();
       }
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: nextId(),
-          role: "system",
-          text: `tool ${event.name}`,
-        },
-      ]);
+      provisionalToolCallIdsRef.current.add(event.call_id);
+      setMessages((prev) =>
+        upsertToolCall(prev, event.call_id, event.name, "running"),
+      );
+      return;
+    }
+
+    if (event.type === "tool_call_args_delta") {
+      // Arguments are intentionally not retained in renderer state. They can
+      // contain paths, file content, credentials, or provider-specific data.
+      setMessages((prev) =>
+        updateToolCall(prev, event.call_id, (tool) => ({
+          ...tool,
+          status: tool.status === "waiting_approval" ? tool.status : "running",
+        })),
+      );
       return;
     }
 
     if (event.type === "approval_required") {
+      provisionalToolCallIdsRef.current.delete(event.call_id);
+      setMessages((prev) =>
+        updateToolCall(prev, event.call_id, (tool) => ({
+          ...tool,
+          status: "waiting_approval",
+        })),
+      );
       setMessages((prev) => [
         ...prev,
         {
@@ -382,6 +409,29 @@ export default function App() {
       return;
     }
 
+    if (event.type === "approval_decided") {
+      setMessages((prev) =>
+        updateApprovalAndToolCall(prev, event.call_id, event.approved),
+      );
+      return;
+    }
+
+    if (event.type === "tool_call_completed") {
+      provisionalToolCallIdsRef.current.delete(event.call_id);
+      setMessages((prev) =>
+        updateToolCall(prev, event.call_id, (tool) => ({
+          ...tool,
+          status:
+            tool.status === "cancelled"
+              ? "cancelled"
+              : toolOutputFailed(event.output)
+                ? "failed"
+                : "completed",
+        })),
+      );
+      return;
+    }
+
     if (event.type === "user_steered") {
       setMessages((prev) => [
         ...prev,
@@ -391,26 +441,29 @@ export default function App() {
     }
 
     if (event.type === "turn_completed") {
+      provisionalToolCallIdsRef.current = new Set();
       resolveActiveTurn();
       refreshAgentRunsRef.current?.();
       return;
     }
 
     if (event.type === "turn_cancelled") {
+      provisionalToolCallIdsRef.current = new Set();
       resolveActiveTurn();
       refreshAgentRunsRef.current?.();
       setMessages((prev) => [
-        ...prev,
+        ...settleActiveToolCalls(prev, "cancelled"),
         { id: nextId(), role: "system", text: "turn cancelled" },
       ]);
       return;
     }
 
     if (event.type === "turn_failed") {
+      provisionalToolCallIdsRef.current = new Set();
       resolveActiveTurn();
       refreshAgentRunsRef.current?.();
       setMessages((prev) => [
-        ...prev,
+        ...settleActiveToolCalls(prev, "failed"),
         {
           id: nextId(),
           role: "error",
@@ -495,6 +548,7 @@ export default function App() {
       socketRef.current?.close();
       socketRef.current = null;
       assistantBufRef.current = "";
+      provisionalToolCallIdsRef.current = new Set();
       lastSeqRef.current = 0;
       setMessages([]);
       setAgentRuns([]);
@@ -791,6 +845,9 @@ export default function App() {
               </div>
             )}
             {messages.map((m) => {
+              if (m.role === "tool") {
+                return <ToolCallCard key={m.id} name={m.name} status={m.status} />;
+              }
               if (m.role === "approval") {
                 return (
                   <div key={m.id} className="bubble system">
@@ -909,6 +966,87 @@ export default function App() {
       </div>
     </div>
   );
+}
+
+function upsertToolCall(
+  messages: Msg[],
+  callId: string,
+  name: string,
+  status: ToolCallStatus,
+): Msg[] {
+  const existing = messages.findIndex(
+    (message) => message.role === "tool" && message.callId === callId,
+  );
+  if (existing >= 0) {
+    return messages.map((message, index) =>
+      index === existing && message.role === "tool" ? { ...message, status } : message,
+    );
+  }
+  return [...messages, { id: nextId(), role: "tool", callId, name, status }];
+}
+
+function updateToolCall(
+  messages: Msg[],
+  callId: string,
+  update: (tool: Extract<Msg, { role: "tool" }>) => Extract<Msg, { role: "tool" }>,
+): Msg[] {
+  return messages.map((message) =>
+    message.role === "tool" && message.callId === callId ? update(message) : message,
+  );
+}
+
+function updateApprovalAndToolCall(
+  messages: Msg[],
+  callId: string,
+  approved: boolean,
+): Msg[] {
+  return messages.map((message) => {
+    if (message.role === "approval" && message.callId === callId) {
+      return { ...message, resolved: true };
+    }
+    if (message.role === "tool" && message.callId === callId) {
+      return {
+        ...message,
+        status: approved ? "running" : "cancelled",
+      };
+    }
+    return message;
+  });
+}
+
+function settleActiveToolCalls(
+  messages: Msg[],
+  status: Extract<ToolCallStatus, "failed" | "cancelled">,
+): Msg[] {
+  const activeCallIds = new Set(
+    messages.flatMap((message) =>
+      message.role === "tool" &&
+      (message.status === "running" || message.status === "waiting_approval")
+        ? [message.callId]
+        : [],
+    ),
+  );
+  return messages.map((message) =>
+    message.role === "tool" &&
+    (message.status === "running" || message.status === "waiting_approval")
+      ? { ...message, status }
+      : message.role === "approval" &&
+          !message.resolved &&
+          activeCallIds.has(message.callId)
+        ? { ...message, resolved: true }
+      : message,
+  );
+}
+
+function discardToolCalls(messages: Msg[], callIds: Set<string>): Msg[] {
+  return messages.filter(
+    (message) => message.role !== "tool" || !callIds.has(message.callId),
+  );
+}
+
+function toolOutputFailed(output: unknown): boolean {
+  if (!output || typeof output !== "object") return false;
+  return (output as { is_error?: unknown }).is_error === true;
 }
 
 function withoutConnectionState(status: string): string {

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -1,0 +1,31 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ToolCallCard } from "./ToolCallCard";
+
+describe("ToolCallCard", () => {
+  it("uses an allowlisted presentation and a polite live status", () => {
+    const markup = renderToStaticMarkup(
+      <ToolCallCard name="web_search" status="running" />,
+    );
+
+    expect(markup).toContain("Search the web");
+    expect(markup).toContain("Searching the web");
+    expect(markup).toContain('role="status"');
+    expect(markup).toContain('aria-live="polite"');
+    expect(markup).toContain('aria-atomic="true"');
+  });
+
+  it("does not expose an unknown tool name", () => {
+    const markup = renderToStaticMarkup(
+      <ToolCallCard
+        name="mcp__private_server__read_a_sensitive_path"
+        status="completed"
+      />,
+    );
+
+    expect(markup).toContain("Use a tool");
+    expect(markup).toContain("Tool complete");
+    expect(markup).not.toContain("private_server");
+    expect(markup).not.toContain("sensitive_path");
+  });
+});

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,0 +1,116 @@
+export type ToolCallStatus =
+  | "running"
+  | "waiting_approval"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+type ToolCallCardProps = {
+  name: string;
+  status: ToolCallStatus;
+};
+
+type ToolPresentation = {
+  label: string;
+  active: string;
+  complete: string;
+};
+
+// This is deliberately an allowlist rather than a display transformation of a
+// tool name. Tool events come from providers, and a card should never become a
+// side channel for an unexpected tool name, arguments, output, file path, or
+// provider diagnostic.
+const TOOL_PRESENTATIONS: Record<string, ToolPresentation> = {
+  web_search: {
+    label: "Search the web",
+    active: "Searching the web",
+    complete: "Web search complete",
+  },
+  read_file: {
+    label: "Read a file",
+    active: "Reading a file",
+    complete: "File read complete",
+  },
+  list_dir: {
+    label: "Browse files",
+    active: "Browsing files",
+    complete: "File browse complete",
+  },
+  write_file: {
+    label: "Update a file",
+    active: "Updating a file",
+    complete: "File update complete",
+  },
+  request_folder_access: {
+    label: "Request folder access",
+    active: "Requesting folder access",
+    complete: "Folder access request complete",
+  },
+  connect_folder: {
+    label: "Connect a folder",
+    active: "Connecting a folder",
+    complete: "Folder connected",
+  },
+  list_connected_folders: {
+    label: "Check connected folders",
+    active: "Checking connected folders",
+    complete: "Connected folders checked",
+  },
+  read_connected_file: {
+    label: "Read a connected file",
+    active: "Reading a connected file",
+    complete: "Connected file read complete",
+  },
+  spawn_sandbox_agent: {
+    label: "Delegate a task",
+    active: "Delegating a task",
+    complete: "Delegated task complete",
+  },
+};
+
+const FALLBACK_TOOL: ToolPresentation = {
+  label: "Use a tool",
+  active: "Using a tool",
+  complete: "Tool complete",
+};
+
+export function ToolCallCard({ name, status }: ToolCallCardProps) {
+  const tool = TOOL_PRESENTATIONS[name] ?? FALLBACK_TOOL;
+  const presentation = statusPresentation(tool, status);
+
+  return (
+    <section
+      className={`tool-call-card is-${status}`}
+      aria-label={`${tool.label}: ${presentation.label}`}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <span className="tool-call-icon" aria-hidden="true">
+        {presentation.icon}
+      </span>
+      <div className="tool-call-copy">
+        <strong>{tool.label}</strong>
+        <span>{presentation.label}</span>
+      </div>
+      {status === "running" && (
+        <span className="tool-call-spinner" aria-hidden="true" />
+      )}
+    </section>
+  );
+}
+
+function statusPresentation(tool: ToolPresentation, status: ToolCallStatus) {
+  switch (status) {
+    case "waiting_approval":
+      return { icon: "…", label: "Waiting for approval" };
+    case "completed":
+      return { icon: "✓", label: tool.complete };
+    case "failed":
+      return { icon: "!", label: "Tool could not complete" };
+    case "cancelled":
+      return { icon: "–", label: "Not run" };
+    case "running":
+      return { icon: "↗", label: tool.active };
+  }
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -597,6 +597,85 @@ button {
   font-size: 0.82em;
 }
 
+.tool-call-card {
+  display: flex;
+  width: min(100%, 31rem);
+  align-self: flex-start;
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 0.6rem 0.7rem;
+  color: var(--muted);
+  background: var(--bg-elevated);
+}
+
+.tool-call-icon {
+  display: grid;
+  width: 1.55rem;
+  height: 1.55rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 5px;
+  color: var(--ink);
+  background: var(--user-bg);
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.tool-call-copy {
+  display: grid;
+  min-width: 0;
+  gap: 0.03rem;
+}
+
+.tool-call-copy strong {
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.tool-call-copy span {
+  font-size: 0.75rem;
+}
+
+.tool-call-spinner {
+  width: 0.8rem;
+  height: 0.8rem;
+  flex: 0 0 auto;
+  margin-left: auto;
+  border: 2px solid color-mix(in srgb, var(--muted) 25%, transparent);
+  border-top-color: var(--muted);
+  border-radius: 999px;
+  animation: tool-call-spin 800ms linear infinite;
+}
+
+.tool-call-card.is-completed .tool-call-icon {
+  color: oklch(0.42 0.13 150);
+  background: oklch(0.95 0.035 150);
+}
+
+.tool-call-card.is-failed .tool-call-icon {
+  color: var(--danger);
+  background: oklch(0.97 0.01 25);
+}
+
+.tool-call-card.is-cancelled {
+  opacity: 0.7;
+}
+
+@keyframes tool-call-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tool-call-spinner {
+    animation: none;
+  }
+}
+
 .folder-consent {
   align-self: flex-start;
   width: min(100%, 34rem);


### PR DESCRIPTION
## Summary
- replace raw tool-event bubbles with live call-ID-correlated tool cards
- show fixed safe labels and lifecycle states without retaining arguments, outputs, or diagnostics
- resolve approval, interruption, cancellation, and accessibility states explicitly

## Validation
- pnpm test
- pnpm build
- git diff --check