### PR TITLE
Add durable conversation navigation

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1218,7 +1218,8 @@ impl Agent {
             }
         }
         for msg in msgs {
-            self.persist(chat.id, turn_id, Role::User, &msg.content)
+            let message_id = self
+                .persist(chat.id, turn_id, Role::User, &msg.content)
                 .await?;
             transcript.push(ChatMessage {
                 role: Role::User,
@@ -1227,6 +1228,7 @@ impl Agent {
                 }],
             });
             events.send(AgentEvent::UserSteered {
+                message_id,
                 content: msg.content,
             });
         }
@@ -1478,17 +1480,19 @@ impl Agent {
         turn_id: TurnId,
         role: Role,
         content: &str,
-    ) -> Result<()> {
+    ) -> Result<MessageId> {
+        let id = MessageId::new();
         self.store
             .append_message(&Message {
-                id: MessageId::new(),
+                id,
                 chat_id,
                 turn_id,
                 role,
                 content: content.to_string(),
                 created_at: Utc::now(),
             })
-            .await
+            .await?;
+        Ok(id)
     }
 
     async fn load_transcript(&self, chat_id: crate::id::ChatId) -> Result<Vec<ChatMessage>> {
@@ -3389,7 +3393,7 @@ mod tests {
                 AgentEvent::StreamInterrupted => {
                     interrupted = true;
                 }
-                AgentEvent::UserSteered { content } => {
+                AgentEvent::UserSteered { content, .. } => {
                     assert_eq!(content, "please change course");
                     steered = true;
                 }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1682,12 +1682,32 @@ impl Store for DbStore {
         ops::conversation::set_chat_model(self, id, model).await
     }
 
+    async fn set_chat_title(&self, id: ChatId, title: Option<String>) -> Result<()> {
+        ops::conversation::set_chat_title(self, id, title).await
+    }
+
+    async fn update_chat_metadata(
+        &self,
+        id: ChatId,
+        title: Option<Option<String>>,
+        model: Option<Option<String>>,
+    ) -> Result<bool> {
+        ops::conversation::update_chat_metadata(self, id, title, model).await
+    }
+
     async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
         ops::conversation::get_chat(self, id).await
     }
 
     async fn list_chats(&self) -> Result<Vec<Chat>> {
         ops::conversation::list_chats(self).await
+    }
+
+    async fn get_chat_transcript(
+        &self,
+        id: ChatId,
+    ) -> Result<Option<crate::storage::ChatTranscriptSnapshot>> {
+        ops::conversation::get_chat_transcript(self, id).await
     }
 
     async fn begin_root_attachment_change(

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -13,6 +13,7 @@ use crate::model::{
     ChatRootAttachment, Message, Role, RootAttachmentOrigin, ToolCallRecord, TurnRunStatus,
     MAX_ROOT_ATTACHMENTS,
 };
+use crate::storage::ChatTranscriptSnapshot;
 
 use super::super::{entities, project_from_models, store_err, DbStore};
 use super::turn::canonical_db_timestamp;
@@ -201,6 +202,58 @@ pub(in crate::db) async fn set_chat_model(
     Ok(())
 }
 
+pub(in crate::db) async fn set_chat_title(
+    store: &DbStore,
+    id: ChatId,
+    title: Option<String>,
+) -> Result<()> {
+    entities::chat::Entity::update_many()
+        .col_expr(
+            entities::chat::Column::Title,
+            sea_orm::sea_query::Expr::value(title),
+        )
+        .filter(entities::chat::Column::Id.eq(id.0))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+pub(in crate::db) async fn update_chat_metadata(
+    store: &DbStore,
+    id: ChatId,
+    title: Option<Option<String>>,
+    model: Option<Option<String>>,
+) -> Result<bool> {
+    if title.is_none() && model.is_none() {
+        return Ok(entities::chat::Entity::find_by_id(id.0)
+            .one(&store.conn)
+            .await
+            .map_err(store_err)?
+            .is_some());
+    }
+
+    let mut update = entities::chat::Entity::update_many();
+    if let Some(title) = title {
+        update = update.col_expr(
+            entities::chat::Column::Title,
+            sea_orm::sea_query::Expr::value(title),
+        );
+    }
+    if let Some(model) = model {
+        update = update.col_expr(
+            entities::chat::Column::Model,
+            sea_orm::sea_query::Expr::value(model),
+        );
+    }
+    let result = update
+        .filter(entities::chat::Column::Id.eq(id.0))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
 pub(in crate::db) async fn get_chat(store: &DbStore, id: ChatId) -> Result<Option<Chat>> {
     let mut rows = entities::chat::Entity::find_by_id(id.0)
         .find_with_related(entities::chat_root_attachment::Entity)
@@ -230,6 +283,36 @@ pub(in crate::db) async fn list_chats(store: &DbStore) -> Result<Vec<Chat>> {
             .then_with(|| right.id.0.cmp(&left.id.0))
     });
     Ok(chats)
+}
+
+/// Read the visible transcript and cursor for future journal replay under the
+/// same per-chat fence. Every message/event writer takes this fence, so no turn
+/// can commit between the two reads. Only a terminal event is represented by
+/// the durable assistant transcript; a later active turn's streamed deltas
+/// must remain after the cursor for the renderer to reconstruct it on replay.
+pub(in crate::db) async fn get_chat_transcript(
+    store: &DbStore,
+    chat_id: ChatId,
+) -> Result<Option<ChatTranscriptSnapshot>> {
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let messages = list_messages_on(&transaction, chat_id).await?;
+    let last_event_seq = entities::event::Entity::find()
+        .filter(entities::event::Column::ChatId.eq(chat_id.0))
+        .filter(entities::event::Column::Terminal.eq(true))
+        .order_by_desc(entities::event::Column::Seq)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .map_or(0, |event| event.seq);
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(ChatTranscriptSnapshot {
+        messages,
+        last_event_seq,
+    }))
 }
 
 pub(in crate::db) async fn append_message(store: &DbStore, message: &Message) -> Result<()> {
@@ -275,10 +358,17 @@ pub(in crate::db) async fn append_message(store: &DbStore, message: &Message) ->
 }
 
 pub(in crate::db) async fn list_messages(store: &DbStore, chat_id: ChatId) -> Result<Vec<Message>> {
+    list_messages_on(&store.conn, chat_id).await
+}
+
+async fn list_messages_on<C>(conn: &C, chat_id: ChatId) -> Result<Vec<Message>>
+where
+    C: ConnectionTrait,
+{
     entities::message::Entity::find()
         .filter(entities::message::Column::ChatId.eq(chat_id.0))
         .order_by_asc(entities::message::Column::Seq)
-        .all(&store.conn)
+        .all(conn)
         .await
         .map_err(store_err)?
         .into_iter()

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -488,6 +488,7 @@ pub(in crate::db) async fn apply_turn_steer(
         .ok_or_else(|| AgentError::Store(format!("applied steer {steer_id} disappeared")))?;
     ensure_exact_applied_message_on(&transaction, &applied).await?;
     let event = AgentEvent::UserSteered {
+        message_id: MessageId(applied.id),
         content: applied.content.clone(),
     };
     let seq = append_event_on(
@@ -640,6 +641,7 @@ where
         })?;
     let payload = serde_json::from_value::<AgentEvent>(event.payload.clone())?;
     let expected = AgentEvent::UserSteered {
+        message_id: MessageId(steer.id),
         content: steer.content.clone(),
     };
     if event.chat_id != steer.chat_id

--- a/crates/openwave-core/src/db/tests/turn_steer.rs
+++ b/crates/openwave-core/src/db/tests/turn_steer.rs
@@ -238,6 +238,7 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
     assert_eq!(
         applied.event.event,
         AgentEvent::UserSteered {
+            message_id: MessageId(steer_id.0),
             content: "change course".into(),
         }
     );
@@ -333,6 +334,7 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
     assert_eq!(
         second.event.event,
         AgentEvent::UserSteered {
+            message_id: MessageId(second_id.0),
             content: "one more thing".into(),
         }
     );

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -13,7 +13,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::error::AgentErrorInfo;
-use crate::id::{CallId, TurnId};
+use crate::id::{CallId, MessageId, TurnId};
 use crate::provider::{StopReason, Usage};
 use crate::tool::{ApprovalClass, ToolOutput};
 
@@ -103,8 +103,11 @@ pub enum AgentEvent {
     },
     /// A mid-turn steer message was injected into the running turn. The turn
     /// continues (unlike `TurnCancelled`); the content is also persisted as a
-    /// user message.
+    /// user message. `message_id` lets reconnecting renderers reconcile the
+    /// event with that durable message without lossy content matching.
     UserSteered {
+        /// Stable id of the persisted user message.
+        message_id: MessageId,
         /// The steered user text.
         content: String,
     },
@@ -164,5 +167,19 @@ mod tests {
         };
         let json = serde_json::to_string(&ev).unwrap();
         assert_eq!(serde_json::from_str::<AgentEvent>(&json).unwrap(), ev);
+    }
+
+    #[test]
+    fn user_steer_roundtrips_with_its_durable_message_id() {
+        let message_id = MessageId::new();
+        let ev = AgentEvent::UserSteered {
+            message_id,
+            content: "remember this".into(),
+        };
+
+        let json = serde_json::to_value(&ev).unwrap();
+        assert_eq!(json["type"], "user_steered");
+        assert_eq!(json["message_id"], message_id.to_string());
+        assert_eq!(serde_json::from_value::<AgentEvent>(json).unwrap(), ev);
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -107,7 +107,7 @@ pub use storage::{
     ParkTurnForAgentRunInboxOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
     RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome,
     ResolveSandboxToolCallOutcome, ResolveToolCallOutcome, SecretProvider, Store,
-    SubmitAgentRunResultOutcome, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+    SubmitAgentRunResultOutcome, ChatTranscriptSnapshot, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -38,6 +38,17 @@ use crate::provider::{StopReason, Usage};
 /// Largest pending attachment-reconciliation page accepted by [`Store`].
 pub const MAX_PENDING_ROOT_ATTACHMENT_CHANGES: u64 = 256;
 
+/// A mutually consistent conversation transcript and event-journal cursor.
+///
+/// The cursor is captured under the same per-chat fence as `messages`, so a
+/// renderer can hydrate durable text and then subscribe after this cursor
+/// without dropping an event committed during the handoff.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatTranscriptSnapshot {
+    pub messages: Vec<Message>,
+    pub last_event_seq: i64,
+}
+
 /// Why maintenance determined that a document needs an index job.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DocumentIndexJobReason {
@@ -1005,9 +1016,27 @@ pub trait Store: Send + Sync {
     /// List chats, most-recently-created first.
     async fn list_chats(&self) -> Result<Vec<Chat>>;
 
+    /// Atomically load a chat's durable messages and its event-journal
+    /// watermark. Returns `None` when the chat does not exist.
+    async fn get_chat_transcript(&self, id: ChatId) -> Result<Option<ChatTranscriptSnapshot>>;
+
     /// Set (or clear, with `None`) a chat's model override. A no-op if the chat
     /// doesn't exist.
     async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()>;
+
+    /// Set (or clear, with `None`) a chat's human-facing title. A no-op if the
+    /// chat doesn't exist.
+    async fn set_chat_title(&self, id: ChatId, title: Option<String>) -> Result<()>;
+
+    /// Atomically update whichever user-editable chat metadata fields are
+    /// present. An outer `None` leaves that field alone; an inner `None`
+    /// clears it. Returns `false` if the chat does not exist.
+    async fn update_chat_metadata(
+        &self,
+        id: ChatId,
+        title: Option<Option<String>>,
+        model: Option<Option<String>>,
+    ) -> Result<bool>;
 
     /// Atomically begin one exact broker-backed attachment change.
     ///

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -1337,11 +1337,56 @@ impl Store for MemStore {
     async fn list_chats(&self) -> Result<Vec<Chat>> {
         Ok(self.chats.lock().unwrap().values().cloned().collect())
     }
+    async fn get_chat_transcript(
+        &self,
+        id: ChatId,
+    ) -> Result<Option<ChatTranscriptSnapshot>> {
+        if !self.chats.lock().unwrap().contains_key(&id) {
+            return Ok(None);
+        }
+        let last_event_seq = self
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(chat_id, _)| *chat_id == id)
+            .map(|(_, event)| event.seq)
+            .max()
+            .unwrap_or(0);
+        Ok(Some(ChatTranscriptSnapshot {
+            messages: Vec::new(),
+            last_event_seq,
+        }))
+    }
     async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()> {
         if let Some(chat) = self.chats.lock().unwrap().get_mut(&id) {
             chat.model = model;
         }
         Ok(())
+    }
+    async fn set_chat_title(&self, id: ChatId, title: Option<String>) -> Result<()> {
+        if let Some(chat) = self.chats.lock().unwrap().get_mut(&id) {
+            chat.title = title;
+        }
+        Ok(())
+    }
+    async fn update_chat_metadata(
+        &self,
+        id: ChatId,
+        title: Option<Option<String>>,
+        model: Option<Option<String>>,
+    ) -> Result<bool> {
+        let mut chats = self.chats.lock().unwrap();
+        let Some(chat) = chats.get_mut(&id) else {
+            return Ok(false);
+        };
+        if let Some(title) = title {
+            chat.title = title;
+        }
+        if let Some(model) = model {
+            chat.model = model;
+        }
+        Ok(true)
     }
     async fn begin_root_attachment_change(
         &self,

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -1239,6 +1239,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
     assert_eq!(
         applied.event.event,
         AgentEvent::UserSteered {
+            message_id: MessageId(steer_id.0),
             content: "postgres steer".into(),
         }
     );

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -3,6 +3,7 @@ import {
   ApiClient,
   type AgentRun,
   type Chat,
+  type ChatMessage,
   type ModelInfo,
   type PendingFolderAccessRequest,
   type ProviderInfo,
@@ -56,11 +57,22 @@ function nextId(): string {
   return `m${msgSeq}`;
 }
 
+function messageFromSnapshot(message: ChatMessage): Msg {
+  return {
+    id: message.id,
+    role: message.role,
+    text: message.content,
+  };
+}
+
 export default function App() {
   const [bootError, setBootError] = useState<string | null>(null);
   const [info, setInfo] = useState<ServerInfo | null>(null);
   const [client, setClient] = useState<ApiClient | null>(null);
   const [chat, setChat] = useState<Chat | null>(null);
+  const [hydratedChatId, setHydratedChatId] = useState<string | null>(null);
+  const [chats, setChats] = useState<Chat[]>([]);
+  const [chatsError, setChatsError] = useState<string | null>(null);
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [messages, setMessages] = useState<Msg[]>([]);
@@ -84,12 +96,17 @@ export default function App() {
   );
   const [cancelError, setCancelError] = useState<string | null>(null);
   const [creatingChat, setCreatingChat] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState("");
+  const [savingTitle, setSavingTitle] = useState(false);
   const [settingsPanel, setSettingsPanel] = useState<
     "providers" | "web-search" | "folders" | null
   >(null);
   const [status, setStatus] = useState("starting…");
   const socketRef = useRef<WebSocket | null>(null);
   const socketGenerationRef = useRef(0);
+  const chatSelectionRef = useRef(0);
+  const hydratedMessageIdsRef = useRef<Set<string>>(new Set());
   const lastSeqRef = useRef(0);
   const assistantBufRef = useRef("");
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -123,16 +140,21 @@ export default function App() {
     let cancelled = false;
     (async () => {
       try {
-        const [catalog, providerList] = await Promise.all([
+        const [catalog, providerList, existingChats] = await Promise.all([
           client.listModels(),
           client.listProviders(),
+          client.listChats(),
         ]);
         if (cancelled) return;
         setModels(catalog.models);
         setProviders(providerList.providers);
-        const created = await client.createChat(catalog.models[0]?.id);
+        setChats(existingChats);
+        const created =
+          existingChats[0] ??
+          (await client.createChat(catalog.models[0]?.id));
         if (cancelled) return;
-        setChat(created);
+        if (existingChats.length === 0) setChats([created]);
+        activateChat(created);
         setStatus(`chat ${created.id.slice(0, 8)}…`);
       } catch (err) {
         if (!cancelled) setBootError(String(err));
@@ -145,8 +167,41 @@ export default function App() {
 
   useEffect(() => {
     if (!client || !chat) return;
+    let cancelled = false;
+    setHydratedChatId(null);
+    setMessages([]);
+    hydratedMessageIdsRef.current = new Set();
+    (async () => {
+      try {
+        const transcript = await client.listChatMessages(chat.id);
+        if (cancelled) return;
+        lastSeqRef.current = transcript.last_event_seq;
+        hydratedMessageIdsRef.current = new Set(
+          transcript.messages.map((message) => message.id),
+        );
+        setMessages(transcript.messages.map(messageFromSnapshot));
+        setHydratedChatId(chat.id);
+      } catch (err) {
+        if (!cancelled) {
+          setMessages([
+            {
+              id: nextId(),
+              role: "error",
+              text: `Could not load this conversation: ${String(err)}`,
+            },
+          ]);
+          setHydratedChatId(chat.id);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, chat?.id]);
+
+  useEffect(() => {
+    if (!client || !chat || hydratedChatId !== chat.id) return;
     socketRef.current?.close();
-    lastSeqRef.current = 0;
     const generation = ++socketGenerationRef.current;
     let disposed = false;
     let reconnectTimer: number | null = null;
@@ -208,7 +263,7 @@ export default function App() {
         socketGenerationRef.current += 1;
       }
     };
-  }, [client, chat?.id]);
+  }, [client, chat?.id, hydratedChatId]);
 
   useEffect(() => {
     if (!client || !chat) return;
@@ -433,9 +488,11 @@ export default function App() {
     }
 
     if (event.type === "user_steered") {
+      if (hydratedMessageIdsRef.current.has(event.message_id)) return;
+      hydratedMessageIdsRef.current.add(event.message_id);
       setMessages((prev) => [
         ...prev,
-        { id: nextId(), role: "user", text: event.content },
+        { id: event.message_id, role: "user", text: event.content },
       ]);
       return;
     }
@@ -493,6 +550,8 @@ export default function App() {
 
   async function onSend() {
     if (!client || !chat || !draft.trim() || busy) return;
+    const chatId = chat.id;
+    const selection = chatSelectionRef.current;
     const content = draft.trim();
     const turnId = crypto.randomUUID();
     setDraft("");
@@ -502,9 +561,11 @@ export default function App() {
     setCancelPendingTurnId(null);
     setCancelError(null);
     try {
-      await client.postMessage(chat.id, turnId, content);
+      await client.postMessage(chatId, turnId, content);
+      if (chatSelectionRef.current !== selection) return;
       refreshAgentRunsRef.current?.();
     } catch (err) {
+      if (chatSelectionRef.current !== selection) return;
       resolveActiveTurn();
       setMessages((prev) => [
         ...prev,
@@ -524,14 +585,19 @@ export default function App() {
     ) {
       return;
     }
+    const selection = chatSelectionRef.current;
+    const chatId = chat.id;
 
     cancelRequestTurnRef.current = turnId;
     setCancelPendingTurnId(turnId);
     setCancelError(null);
     try {
-      await client.cancel(chat.id, turnId);
+      await client.cancel(chatId, turnId);
     } catch (err) {
-      if (cancelRequestTurnRef.current === turnId) {
+      if (
+        chatSelectionRef.current === selection &&
+        cancelRequestTurnRef.current === turnId
+      ) {
         cancelRequestTurnRef.current = null;
         setCancelPendingTurnId(null);
         setCancelError(String(err));
@@ -540,7 +606,7 @@ export default function App() {
   }
 
   async function onNewChat() {
-    if (!client || creatingChat || busy) return;
+    if (!client || creatingChat) return;
     setCreatingChat(true);
     try {
       const created = await client.createChat(chat?.model ?? models[0]?.id);
@@ -551,16 +617,20 @@ export default function App() {
       provisionalToolCallIdsRef.current = new Set();
       lastSeqRef.current = 0;
       setMessages([]);
+      hydratedMessageIdsRef.current = new Set();
       setAgentRuns([]);
       setAgentRunsError(null);
       setFolderAccessRequests([]);
       setFolderAccessErrors({});
       setDraft("");
+      setBusy(false);
       setActiveTurnId(null);
       setCancelPendingTurnId(null);
       setCancelError(null);
       cancelRequestTurnRef.current = null;
-      setChat(created);
+      activateChat(created);
+      setChats((current) => [created, ...current]);
+      setChatsError(null);
       setStatus(`chat ${created.id.slice(0, 8)}…`);
     } catch (err) {
       setMessages((prev) => [
@@ -576,10 +646,71 @@ export default function App() {
     }
   }
 
+  function activateChat(next: Chat) {
+    chatSelectionRef.current += 1;
+    setChat(next);
+  }
+
+  function selectChat(next: Chat) {
+    if (next.id === chat?.id || creatingChat) return;
+    socketGenerationRef.current += 1;
+    socketRef.current?.close();
+    socketRef.current = null;
+    assistantBufRef.current = "";
+    lastSeqRef.current = 0;
+    setMessages([]);
+    hydratedMessageIdsRef.current = new Set();
+    setAgentRuns([]);
+    setAgentRunsError(null);
+    setFolderAccessRequests([]);
+    setFolderAccessErrors({});
+    setDraft("");
+    setBusy(false);
+    setActiveTurnId(null);
+    setCancelPendingTurnId(null);
+    setCancelError(null);
+    cancelRequestTurnRef.current = null;
+    setEditingTitle(false);
+    activateChat(next);
+    setStatus(`chat ${next.id.slice(0, 8)}…`);
+  }
+
+  async function onRenameChat() {
+    if (!client || !chat || savingTitle) return;
+    const chatId = chat.id;
+    const selection = chatSelectionRef.current;
+    setSavingTitle(true);
+    try {
+      const updated = await client.patchChatTitle(chatId, titleDraft.trim() || null);
+      setChats((current) =>
+        current.map((item) => (item.id === updated.id ? updated : item)),
+      );
+      if (chatSelectionRef.current !== selection) return;
+      setChat(updated);
+      setEditingTitle(false);
+    } catch (err) {
+      if (chatSelectionRef.current !== selection) return;
+      setChatsError(`Could not rename conversation: ${String(err)}`);
+    } finally {
+      setSavingTitle(false);
+    }
+  }
+
   async function onModelChange(modelId: string) {
     if (!client || !chat) return;
-    const updated = await client.patchChatModel(chat.id, modelId || null);
+    const chatId = chat.id;
+    const selection = chatSelectionRef.current;
+    const updated = await client.patchChatModel(chatId, modelId || null);
+    if (chatSelectionRef.current !== selection) {
+      setChats((current) =>
+        current.map((item) => (item.id === updated.id ? updated : item)),
+      );
+      return;
+    }
     setChat(updated);
+    setChats((current) =>
+      current.map((item) => (item.id === updated.id ? updated : item)),
+    );
   }
 
   async function onApproval(callId: string, decision: "approve" | "reject") {
@@ -688,18 +819,29 @@ export default function App() {
           type="button"
           className="new-chat"
           onClick={() => void onNewChat()}
-          disabled={busy || creatingChat}
+          disabled={creatingChat}
         >
           <span aria-hidden="true">+</span>
           {creatingChat ? "Starting…" : "New chat"}
         </button>
 
         <div className="sidebar-section">
-          <span className="sidebar-label">Workspace</span>
-          <div className="conversation-item is-active">
-            <span className="conversation-dot" aria-hidden="true" />
-            <span>{chat.title?.trim() || "New conversation"}</span>
+          <span className="sidebar-label">Conversations</span>
+          <div className="conversation-list" aria-label="Conversations">
+            {chats.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className={`conversation-item${item.id === chat.id ? " is-active" : ""}`}
+                aria-current={item.id === chat.id ? "page" : undefined}
+                onClick={() => selectChat(item)}
+              >
+                <span className="conversation-dot" aria-hidden="true" />
+                <span>{item.title?.trim() || "New conversation"}</span>
+              </button>
+            ))}
           </div>
+          {chatsError && <p className="sidebar-error">{chatsError}</p>}
         </div>
 
         <div className="sidebar-footer">
@@ -746,7 +888,42 @@ export default function App() {
           <header className="conversation-header">
             <div>
               <p className="eyebrow">Conversation</p>
-              <h1>{chat.title?.trim() || "New conversation"}</h1>
+              {editingTitle ? (
+                <form
+                  className="conversation-title-editor"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void onRenameChat();
+                  }}
+                >
+                  <input
+                    autoFocus
+                    value={titleDraft}
+                    aria-label="Conversation title"
+                    onChange={(event) => setTitleDraft(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Escape") setEditingTitle(false);
+                    }}
+                  />
+                  <button type="submit" className="btn" disabled={savingTitle}>
+                    {savingTitle ? "Saving…" : "Save"}
+                  </button>
+                </form>
+              ) : (
+                <div className="conversation-title-row">
+                  <h1>{chat.title?.trim() || "New conversation"}</h1>
+                  <button
+                    type="button"
+                    className="title-action"
+                    onClick={() => {
+                      setTitleDraft(chat.title ?? "");
+                      setEditingTitle(true);
+                    }}
+                  >
+                    Rename
+                  </button>
+                </div>
+              )}
             </div>
             <div className="conversation-header-actions">
               <div className="mobile-settings-actions">

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -47,6 +47,19 @@ export type Chat = {
   created_at: string;
 };
 
+/** One visible, durable transcript entry in conversation order. */
+export type ChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  created_at: string;
+};
+
+export type ChatTranscript = {
+  messages: ChatMessage[];
+  last_event_seq: number;
+};
+
 /** A durable foreground coordinator or sandboxed background run. */
 export type AgentRun = {
   id: string;
@@ -108,7 +121,7 @@ export type AgentEvent =
   | { type: "turn_completed"; usage: unknown; stop_reason: string }
   | { type: "turn_failed"; error: { kind: string; message: string } }
   | { type: "turn_cancelled"; usage: unknown }
-  | { type: "user_steered"; content: string };
+  | { type: "user_steered"; message_id: string; content: string };
 
 export type FolderAccessHint = "documents" | "downloads";
 
@@ -232,6 +245,24 @@ export class ApiClient {
       method: "POST",
       headers: this.headers(true),
       body: JSON.stringify({ model: model || undefined }),
+    });
+  }
+
+  listChats(): Promise<Chat[]> {
+    return this.json("/chats", { headers: this.headers() });
+  }
+
+  listChatMessages(chatId: string): Promise<ChatTranscript> {
+    return this.json(`/chats/${chatId}/messages`, {
+      headers: this.headers(),
+    });
+  }
+
+  patchChatTitle(chatId: string, title: string | null): Promise<Chat> {
+    return this.json(`/chats/${chatId}`, {
+      method: "PATCH",
+      headers: this.headers(true),
+      body: JSON.stringify({ title }),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -110,6 +110,14 @@ button {
 .sidebar-section {
   display: grid;
   gap: 0.45rem;
+  min-height: 0;
+}
+
+.conversation-list {
+  display: grid;
+  max-height: min(46vh, 32rem);
+  gap: 0.12rem;
+  overflow-y: auto;
 }
 
 .sidebar-label {
@@ -137,6 +145,11 @@ button {
   text-align: left;
 }
 
+.conversation-item:hover {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--sidebar-active) 72%, transparent);
+}
+
 .conversation-item.is-active,
 .sidebar-action.is-active,
 .sidebar-action:hover {
@@ -156,6 +169,13 @@ button {
   flex: 0 0 auto;
   border-radius: 999px;
   background: var(--accent);
+}
+
+.sidebar-error {
+  margin: 0;
+  padding: 0 0.4rem;
+  color: var(--danger);
+  font-size: 0.75rem;
 }
 
 .sidebar-footer {
@@ -239,6 +259,36 @@ button {
   font-size: 1rem;
   font-weight: 620;
   letter-spacing: -0.015em;
+}
+
+.conversation-title-row,
+.conversation-title-editor {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.conversation-title-editor input {
+  width: min(22rem, 48vw);
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 0.36rem 0.5rem;
+  background: var(--bg-elevated);
+  font-size: 1rem;
+  font-weight: 620;
+}
+
+.title-action {
+  border: 0;
+  padding: 0.15rem 0.25rem;
+  color: var(--muted);
+  background: transparent;
+  font-size: 0.76rem;
+}
+
+.title-action:hover {
+  color: var(--ink);
+  text-decoration: underline;
 }
 
 .conversation-header-actions,

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -179,6 +179,7 @@ pub fn app(state: AppState) -> Router {
             "/chats/{id}",
             get(routes::get_chat).patch(routes::patch_chat),
         )
+        .route("/chats/{id}/messages", get(routes::list_chat_messages))
         .route("/chats/{id}/agent-runs", get(routes::list_agent_runs))
         .route(
             "/settings/api-key",

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -14,8 +14,10 @@ use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{
     AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunExecution, AgentRunStatus,
-    ApprovalDecision, CallId, Chat, ChatId, Project, ProjectId, RequestTurnCancellationOutcome,
-    SandboxToolCall, SandboxToolCallStatus, SecretProvider, SequencedEvent, Store,
+    ApprovalDecision, CallId, Chat, ChatId, Message as StoredMessage, MessageId, Project,
+    ProjectId,
+    RequestTurnCancellationOutcome, Role, SandboxToolCall, SandboxToolCallStatus,
+    SecretProvider, SequencedEvent, Store,
     ToolCallExecution, ToolCallRecord, ToolCallStatus, TurnId, TurnSteer, TurnSteerId,
 };
 
@@ -446,31 +448,107 @@ pub async fn create_chat(
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChatUpdate {
+    /// An explicit `null` clears the title. Non-empty titles are trimmed before
+    /// persistence so sidebar labels remain stable across clients.
+    #[serde(default, deserialize_with = "double_option")]
+    pub title: Option<Option<String>>,
     #[serde(default, deserialize_with = "double_option")]
     pub model: Option<Option<String>>,
 }
 
-/// `PATCH /chats/{id}` — update a chat's model selection; returns the chat. This
-/// is what a chat UI's model selector writes to.
+/// `PATCH /chats/{id}` — update the human-facing title and/or model selection.
 pub async fn patch_chat(
     State(state): State<AppState>,
     Path(id): Path<ChatId>,
     Json(body): Json<ChatUpdate>,
 ) -> Result<Json<Chat>, ServerError> {
+    // Validate every supplied field before touching durable state. This keeps a
+    // mixed request all-or-nothing from the user's point of view.
+    if body.model.as_ref().is_some_and(|model| {
+        model.as_deref().is_some_and(str::is_empty)
+    }) {
+        return Err(ServerError::bad_request("model must not be empty"));
+    }
+    let title = body.title.map(|title| {
+        title
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+    });
+
     let mut chat = state
         .store
         .get_chat(id)
         .await?
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
 
+    if !state
+        .store
+        .update_chat_metadata(id, title.clone(), body.model.clone())
+        .await?
+    {
+        return Err(ServerError::not_found(format!("chat {id} not found")));
+    }
+    if let Some(title) = title {
+        chat.title = title;
+    }
     if let Some(model) = body.model {
-        if model.as_deref().is_some_and(str::is_empty) {
-            return Err(ServerError::bad_request("model must not be empty"));
-        }
-        state.store.set_chat_model(id, model.clone()).await?;
         chat.model = model;
     }
     Ok(Json(chat))
+}
+
+/// A renderer-safe durable transcript entry. Internal routing and tool state
+/// deliberately remain behind the server boundary.
+#[derive(Debug, Serialize)]
+pub struct ChatMessageSnapshot {
+    pub id: MessageId,
+    pub role: Role,
+    pub content: String,
+    pub created_at: chrono::DateTime<Utc>,
+}
+
+/// One visible transcript plus the durable journal watermark that produced it.
+/// The renderer uses the watermark to subscribe only to future events, avoiding
+/// duplicate text when reopening a completed conversation.
+#[derive(Debug, Serialize)]
+pub struct ChatTranscript {
+    pub messages: Vec<ChatMessageSnapshot>,
+    pub last_event_seq: i64,
+}
+
+impl From<StoredMessage> for ChatMessageSnapshot {
+    fn from(message: StoredMessage) -> Self {
+        Self {
+            id: message.id,
+            role: message.role,
+            content: message.content,
+            created_at: message.created_at,
+        }
+    }
+}
+
+/// `GET /chats/{id}/messages` — replay the visible durable transcript in
+/// commit order. The existence check prevents a missing chat from looking like
+/// an empty conversation.
+pub async fn list_chat_messages(
+    State(state): State<AppState>,
+    Path(id): Path<ChatId>,
+) -> Result<Json<ChatTranscript>, ServerError> {
+    let transcript = state
+        .store
+        .get_chat_transcript(id)
+        .await?
+        .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
+    let messages = transcript
+        .messages
+        .into_iter()
+        .filter(|message| matches!(message.role, Role::User | Role::Assistant))
+        .map(ChatMessageSnapshot::from)
+        .collect();
+    Ok(Json(ChatTranscript {
+        messages,
+        last_event_seq: transcript.last_event_seq,
+    }))
 }
 
 /// `GET /chats` — list chats, most-recently-created first.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -12,7 +12,7 @@ use openwave_core::{
     AcceptAgentRunOutcome, AgentErrorInfo, AgentEvent, AgentRunExecution, AgentRunId,
     AgentRunInboxStatus, AgentRunStatus, ApprovalClass, BeginRootAttachmentChange, BlobStore,
     CallId, Chat, ChatId, ChatRequest, ChatRootAttachment, ClientToolCallRequest, ContentBlock,
-    HostRootId, Message, ModelProvider, ParkSandboxToolCallOutcome, ParkTurnForClientCallOutcome,
+    HostRootId, Message, MessageId, ModelProvider, ParkSandboxToolCallOutcome, ParkTurnForClientCallOutcome,
     Project, ProjectId, ProviderEvent, ProviderId, Role, RootAttachmentChangeAction,
     RootAttachmentChangeId, RootAttachmentOrigin, SandboxToolCallRequest, SecretProvider,
     SequencedEvent, StopReason, Tool, ToolCallExecution, ToolCallRecord, ToolCallResolution,
@@ -152,6 +152,44 @@ impl ModelProvider for GatedProvider {
                 reason: StopReason::EndTurn,
             }
         })
+        .boxed())
+    }
+}
+
+/// Completes one turn, then leaves the next turn live after one text delta.
+/// This models reopening a conversation while a response is still streaming.
+struct ReplayBoundaryProvider {
+    calls: AtomicUsize,
+    active_delta_entered: Arc<Notify>,
+}
+
+#[async_trait]
+impl ModelProvider for ReplayBoundaryProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("replay-boundary")
+    }
+
+    async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            return Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "durable answer".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed());
+        }
+
+        let entered = self.active_delta_entered.clone();
+        Ok(stream::once(async move {
+            entered.notify_one();
+            ProviderEvent::TextDelta {
+                text: "still streaming".into(),
+            }
+        })
+        .chain(stream::pending())
         .boxed())
     }
 }
@@ -711,8 +749,25 @@ impl Store for PauseTerminalStore {
     async fn list_chats(&self) -> Result<Vec<Chat>> {
         self.inner.list_chats().await
     }
+    async fn get_chat_transcript(
+        &self,
+        id: ChatId,
+    ) -> Result<Option<openwave_core::ChatTranscriptSnapshot>> {
+        self.inner.get_chat_transcript(id).await
+    }
     async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()> {
         self.inner.set_chat_model(id, model).await
+    }
+    async fn set_chat_title(&self, id: ChatId, title: Option<String>) -> Result<()> {
+        self.inner.set_chat_title(id, title).await
+    }
+    async fn update_chat_metadata(
+        &self,
+        id: ChatId,
+        title: Option<Option<String>>,
+        model: Option<Option<String>>,
+    ) -> Result<bool> {
+        self.inner.update_chat_metadata(id, title, model).await
     }
     async fn get_turn_run(&self, id: TurnId) -> Result<Option<openwave_core::TurnRun>> {
         self.inner.get_turn_run(id).await
@@ -1921,7 +1976,7 @@ async fn interrupt_steer_preempts_a_running_turn_and_continues() {
     let user_steered_at = events.iter().position(|e| {
         matches!(
             &e.event,
-            AgentEvent::UserSteered { content } if content == "change course"
+            AgentEvent::UserSteered { content, .. } if content == "change course"
         )
     });
     assert!(
@@ -1930,7 +1985,7 @@ async fn interrupt_steer_preempts_a_running_turn_and_continues() {
     );
     assert!(events.iter().any(|e| matches!(
         &e.event,
-        AgentEvent::UserSteered { content } if content == "change course"
+        AgentEvent::UserSteered { content, .. } if content == "change course"
     )));
     assert!(matches!(
         events.last().map(|e| &e.event),
@@ -2067,7 +2122,7 @@ async fn boundary_steer_commits_the_candidate_and_instruction_atomically() {
             .iter()
             .filter(|event| matches!(
                 &event.event,
-                AgentEvent::UserSteered { content } if content == "continue with this"
+                AgentEvent::UserSteered { content, .. } if content == "continue with this"
             ))
             .count(),
         1,
@@ -2161,7 +2216,7 @@ async fn durable_steer_poll_recovers_a_missing_local_notification() {
     assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
     assert!(events.iter().any(|event| matches!(
         &event.event,
-        AgentEvent::UserSteered { content } if content == "recover from the database"
+        AgentEvent::UserSteered { content, .. } if content == "recover from the database"
     )));
     assert!(matches!(
         events.last().map(|event| &event.event),
@@ -2297,7 +2352,7 @@ async fn durable_steer_retries_heartbeat_races_and_ambiguous_application() {
             .iter()
             .filter(|event| matches!(
                 &event.event,
-                AgentEvent::UserSteered { content } if content == "recover exactly"
+                AgentEvent::UserSteered { content, .. } if content == "recover exactly"
             ))
             .count(),
         1,
@@ -2425,7 +2480,7 @@ async fn committed_steer_event_recovers_when_cancellation_wins_ambiguous_respons
             .iter()
             .filter(|event| matches!(
                 &event.event,
-                AgentEvent::UserSteered { content } if content == "apply before cancellation"
+                AgentEvent::UserSteered { content, .. } if content == "apply before cancellation"
             ))
             .count(),
         1,
@@ -2508,7 +2563,7 @@ async fn queued_steer_is_applied_when_the_worker_claims_the_turn() {
     let events = wait_for_turn(&store, chat.id).await;
     assert!(events.iter().any(|event| matches!(
         &event.event,
-        AgentEvent::UserSteered { content } if content == "queued direction"
+        AgentEvent::UserSteered { content, .. } if content == "queued direction"
     )));
     let messages = store.list_messages(chat.id).await.unwrap();
     assert_eq!(
@@ -6028,6 +6083,261 @@ async fn patch_chat_sets_and_clears_the_model() {
 }
 
 #[tokio::test]
+async fn patch_chat_sets_and_clears_a_trimmed_title() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    let renamed = patch_chat(
+        &router,
+        &bearer,
+        chat.id,
+        serde_json::json!({"title": "  Project notes  "}),
+    )
+    .await;
+    assert_eq!(renamed.status(), StatusCode::OK);
+    assert_eq!(
+        json_body::<Chat>(renamed).await.title.as_deref(),
+        Some("Project notes")
+    );
+
+    let rejected = patch_chat(
+        &router,
+        &bearer,
+        chat.id,
+        serde_json::json!({"title": "must not persist", "model": ""}),
+    )
+    .await;
+    assert_eq!(rejected.status(), StatusCode::BAD_REQUEST);
+    let fetched: Chat = json_body(
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/chats/{}", chat.id))
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(fetched.title.as_deref(), Some("Project notes"));
+
+    let cleared = patch_chat(&router, &bearer, chat.id, serde_json::json!({"title": null})).await;
+    assert_eq!(cleared.status(), StatusCode::OK);
+    assert_eq!(json_body::<Chat>(cleared).await.title, None);
+}
+
+#[tokio::test]
+async fn chat_transcript_replays_only_visible_durable_messages() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    store
+        .append_message(&Message {
+            id: MessageId::new(),
+            chat_id: chat.id,
+            turn_id: TurnId::new(),
+            role: Role::User,
+            content: "remember this".into(),
+            created_at: chrono::Utc::now(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .append_event(chat.id, &AgentEvent::TextDelta { text: "live".into() })
+            .await
+            .unwrap(),
+        1
+    );
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/messages", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let transcript: serde_json::Value = json_body(response).await;
+    assert_eq!(transcript["messages"][0]["role"], "user");
+    assert_eq!(transcript["messages"][0]["content"], "remember this");
+    assert_eq!(
+        transcript["last_event_seq"], 0,
+        "a nonterminal delta must replay after a durable transcript snapshot"
+    );
+}
+
+#[tokio::test]
+async fn transcript_cursor_replays_an_active_turn_after_the_durable_boundary() {
+    let active_delta_entered = Arc::new(Notify::new());
+    let (router, token, store, _dir) = test_app_with(Arc::new(ReplayBoundaryProvider {
+        calls: AtomicUsize::new(0),
+        active_delta_entered: active_delta_entered.clone(),
+    }))
+    .await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "first turn").await,
+        StatusCode::ACCEPTED
+    );
+    let first_events = wait_for_turn(&store, chat.id).await;
+    let terminal_seq = first_events
+        .iter()
+        .find_map(|event| {
+            matches!(event.event, AgentEvent::TurnCompleted { .. }).then_some(event.seq)
+        })
+        .expect("the completed first turn has a terminal journal event");
+
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "second turn").await,
+        StatusCode::ACCEPTED
+    );
+    tokio::time::timeout(Duration::from_secs(2), active_delta_entered.notified())
+        .await
+        .expect("second turn entered the live provider stream");
+    for _ in 0..100 {
+        if store
+            .list_events(chat.id, terminal_seq)
+            .await
+            .unwrap()
+            .iter()
+            .any(|event| {
+                matches!(&event.event, AgentEvent::TextDelta { text } if text == "still streaming")
+            })
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/messages", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let transcript: serde_json::Value = json_body(response).await;
+    assert_eq!(transcript["last_event_seq"], terminal_seq);
+    assert!(transcript["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|message| message["content"] == "durable answer"));
+
+    let replay = store
+        .list_events(chat.id, transcript["last_event_seq"].as_i64().unwrap())
+        .await
+        .unwrap();
+    assert!(replay
+        .iter()
+        .any(|event| matches!(event.event, AgentEvent::TurnStarted { .. })));
+    assert!(replay.iter().any(
+        |event| matches!(&event.event, AgentEvent::TextDelta { text } if text == "still streaming")
+    ));
+}
+
+#[tokio::test]
+async fn transcript_hydration_reconciles_an_active_steer_by_message_identity() {
+    let gate = Arc::new(Notify::new());
+    let (router, token, store, _dir) =
+        test_app_with(Arc::new(GatedProvider { gate })).await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "start").await,
+        StatusCode::ACCEPTED
+    );
+    for _ in 0..100 {
+        if store
+            .get_turn_run(turn_id)
+            .await
+            .unwrap()
+            .is_some_and(|turn| turn.status == TurnRunStatus::Running)
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        steer_turn(&router, &bearer, chat.id, turn_id, "remember this", true).await,
+        StatusCode::ACCEPTED
+    );
+
+    let mut steered = None;
+    for _ in 0..200 {
+        if let Some(event) = store
+            .list_events(chat.id, 0)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|event| matches!(&event.event, AgentEvent::UserSteered { content, .. } if content == "remember this"))
+        {
+            steered = Some(event);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let steered = steered.expect("active steer was journaled");
+    let message_id = match steered.event {
+        AgentEvent::UserSteered { message_id, .. } => message_id.to_string(),
+        _ => unreachable!("filtered steer event"),
+    };
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/messages", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let transcript: serde_json::Value = json_body(response).await;
+    assert!(transcript["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|message| message["id"] == message_id && message["content"] == "remember this"));
+
+    let replay = store
+        .list_events(chat.id, transcript["last_event_seq"].as_i64().unwrap())
+        .await
+        .unwrap();
+    let replayed_message_id = replay.into_iter().find_map(|event| match event.event {
+        AgentEvent::UserSteered { message_id, .. } => Some(message_id.to_string()),
+        _ => None,
+    });
+    assert_eq!(replayed_message_id.as_deref(), Some(message_id.as_str()));
+
+    // This is the renderer's reconciliation rule: the exact durable identity,
+    // not matching text, suppresses a replayed steer already in the snapshot.
+    let mut hydrated_ids = transcript["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|message| message["id"].as_str().map(str::to_owned))
+        .collect::<std::collections::HashSet<_>>();
+    assert!(!hydrated_ids.insert(message_id));
+}
+
+#[tokio::test]
 async fn patch_chat_rejects_empty_model_and_unknown_chat() {
     let (router, token, _store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
@@ -7887,7 +8197,7 @@ async fn steer_wins_a_completion_race_and_restarts_generation() {
         .position(|event| {
             matches!(
                 &event.event,
-                AgentEvent::UserSteered { content } if content == "replace the answer"
+                AgentEvent::UserSteered { content, .. } if content == "replace the answer"
             )
         })
         .expect("the next generation applies the durable steer");

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -1908,6 +1908,7 @@ mod committed_event_drain_tests {
         let committed = SequencedEvent {
             seq: 7,
             event: AgentEvent::UserSteered {
+                message_id: MessageId::new(),
                 content: "already durable".into(),
             },
         };


### PR DESCRIPTION
## Summary
- load, create, select, rename, and hydrate durable conversations in the desktop
- atomically snapshot visible history with a replay cursor that preserves active streams
- guard navigation against stale async responses and reconcile steers by durable message identity

## Validation
- cargo test -p openwave-core --locked
- cargo test -p openwave-server --locked
- pnpm --dir crates/openwave-desktop/ui build
- bw dev lint --rust --check
- git diff --check