### PR TITLE
Hydrate safe tool history in chat

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -3,7 +3,6 @@ import {
   ApiClient,
   type AgentRun,
   type Chat,
-  type ChatMessage,
   type ModelInfo,
   type PendingFolderAccessRequest,
   type ProviderInfo,
@@ -28,6 +27,7 @@ import { FolderAccessCard } from "./FolderAccessCard";
 import { Logomark } from "./Logomark";
 import { MessageMarkdown } from "./MessageMarkdown";
 import { ToolCallCard, type ToolCallStatus } from "./ToolCallCard";
+import { hydrateTranscriptHistory } from "./TranscriptHistory";
 
 type Msg =
   | { id: string; role: "user"; text: string }
@@ -55,14 +55,6 @@ const MAX_RECENT_TERMINAL_SANDBOX_RUNS = 2;
 function nextId(): string {
   msgSeq += 1;
   return `m${msgSeq}`;
-}
-
-function messageFromSnapshot(message: ChatMessage): Msg {
-  return {
-    id: message.id,
-    role: message.role,
-    text: message.content,
-  };
 }
 
 export default function App() {
@@ -178,10 +170,32 @@ export default function App() {
         const transcript = await client.listChatMessages(chat.id);
         if (cancelled) return;
         lastSeqRef.current = transcript.last_event_seq;
-        hydratedMessageIdsRef.current = new Set(
-          transcript.messages.map((message) => message.id),
+        const hydrated = hydrateTranscriptHistory(
+          transcript.messages,
+          transcript.tool_activity,
         );
-        setMessages(transcript.messages.map(messageFromSnapshot));
+        hydratedMessageIdsRef.current = new Set(
+          hydrated
+            .filter((entry) => entry.kind === "message")
+            .map((entry) => entry.id),
+        );
+        setMessages(
+          hydrated.map((entry) =>
+            entry.kind === "tool"
+              ? {
+                  id: entry.id,
+                  role: "tool",
+                  callId: entry.id,
+                  name: entry.name,
+                  status: entry.status,
+                }
+              : {
+                  id: entry.id,
+                  role: entry.role,
+                  text: entry.text,
+                },
+          ),
+        );
         setHydratedChatId(chat.id);
       } catch (err) {
         if (!cancelled) {

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { hydrateTranscriptHistory } from "./TranscriptHistory";
+
+describe("hydrateTranscriptHistory", () => {
+  it("interleaves terminal safe tool cards with durable messages", () => {
+    const entries = hydrateTranscriptHistory(
+      [
+        {
+          id: "user-1",
+          role: "user",
+          content: "find this",
+          created_at: "2026-07-16T10:00:00Z",
+        },
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "done",
+          created_at: "2026-07-16T10:00:02Z",
+        },
+      ],
+      [
+        {
+          title: "Search the web",
+          status: "completed",
+          started_at: "2026-07-16T10:00:01Z",
+          finished_at: "2026-07-16T10:00:01Z",
+        },
+      ],
+    );
+
+    expect(entries).toEqual([
+      expect.objectContaining({ id: "user-1", kind: "message" }),
+      expect.objectContaining({
+        id: "tool-history:2026-07-16T10:00:01Z:0",
+        kind: "tool",
+        name: "web_search",
+        status: "completed",
+      }),
+      expect.objectContaining({ id: "assistant-1", kind: "message" }),
+    ]);
+  });
+
+  it("keeps the server's generic historical title on the generic card path", () => {
+    const [entry] = hydrateTranscriptHistory([], [
+      {
+        title: "Use a tool",
+        status: "failed",
+        started_at: "2026-07-16T10:00:00Z",
+        finished_at: null,
+      },
+    ]);
+
+    expect(entry).toMatchObject({
+      kind: "tool",
+      name: "historical_unknown_tool",
+      status: "failed",
+    });
+  });
+});

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -1,0 +1,63 @@
+import type { ChatMessage, ChatToolActivity } from "./api";
+import type { ToolCallStatus } from "./ToolCallCard";
+
+export type HydratedTranscriptEntry =
+  | {
+      id: string;
+      kind: "message";
+      role: ChatMessage["role"];
+      text: string;
+      createdAt: string;
+    }
+  | {
+      id: string;
+      kind: "tool";
+      name: string;
+      status: ToolCallStatus;
+      createdAt: string;
+    };
+
+// The history endpoint exposes titles rather than canonical tool names. Keep
+// the renderer on an explicit inverse allowlist so a server-side title change
+// cannot become a display path for provider names, arguments, or output.
+const HISTORY_TOOL_NAMES: Record<ChatToolActivity["title"], string> = {
+  "Search the web": "web_search",
+  "Read a file": "read_file",
+  "Browse files": "list_dir",
+  "Update a file": "write_file",
+  "Request folder access": "request_folder_access",
+  "Connect a folder": "connect_folder",
+  "Check connected folders": "list_connected_folders",
+  "Delegate a task": "spawn_sandbox_agent",
+  "Use a tool": "historical_unknown_tool",
+};
+
+/** Build a stable, presentation-only transcript from one durable snapshot. */
+export function hydrateTranscriptHistory(
+  messages: ChatMessage[],
+  toolActivity: ChatToolActivity[],
+): HydratedTranscriptEntry[] {
+  const entries: HydratedTranscriptEntry[] = [
+    ...messages.map((message) => ({
+      id: message.id,
+      kind: "message" as const,
+      role: message.role,
+      text: message.content,
+      createdAt: message.created_at,
+    })),
+    ...toolActivity.map((activity, index) => ({
+      // The server deliberately withholds a canonical call id. This identity
+      // is therefore local to one snapshot and only supports React rendering;
+      // it is never used to resolve or replay a tool operation.
+      id: `tool-history:${activity.started_at}:${index}`,
+      kind: "tool" as const,
+      name: HISTORY_TOOL_NAMES[activity.title],
+      status: activity.status,
+      createdAt: activity.started_at,
+    })),
+  ];
+
+  return entries.sort(
+    (left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt),
+  );
+}

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -55,8 +55,26 @@ export type ChatMessage = {
   created_at: string;
 };
 
+/** A fixed, terminal tool-card projection with no canonical tool data. */
+export type ChatToolActivity = {
+  title:
+    | "Search the web"
+    | "Read a file"
+    | "Browse files"
+    | "Update a file"
+    | "Request folder access"
+    | "Connect a folder"
+    | "Check connected folders"
+    | "Delegate a task"
+    | "Use a tool";
+  status: "completed" | "failed" | "cancelled";
+  started_at: string;
+  finished_at: string | null;
+};
+
 export type ChatTranscript = {
   messages: ChatMessage[];
+  tool_activity: ChatToolActivity[];
   last_event_seq: number;
 };
 


### PR DESCRIPTION
## Summary
- render terminal allowlisted tool activity when a conversation transcript is reloaded
- interleave historical cards with durable messages while preserving the live event cursor
- keep historical rendering on a fixed inverse allowlist with no canonical tool data

## Validation
- pnpm --dir crates/openwave-desktop/ui test
- pnpm --dir crates/openwave-desktop/ui build