### PR TITLE
Recover desktop chat event streams

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -28,6 +28,8 @@ import { Logomark } from "./Logomark";
 import { MessageMarkdown } from "./MessageMarkdown";
 import { ToolCallCard, type ToolCallStatus } from "./ToolCallCard";
 import { hydrateTranscriptHistory } from "./TranscriptHistory";
+import { useChatEventStream } from "./ChatEventStream";
+import { isNearBottom, scrollToLatest } from "./ChatScroll";
 
 type Msg =
   | { id: string; role: "user"; text: string }
@@ -96,6 +98,7 @@ export default function App() {
     "providers" | "web-search" | "folders" | null
   >(null);
   const [status, setStatus] = useState("starting…");
+  const [hasUnreadActivity, setHasUnreadActivity] = useState(false);
   const socketRef = useRef<WebSocket | null>(null);
   const socketGenerationRef = useRef(0);
   const chatSelectionRef = useRef(0);
@@ -103,6 +106,7 @@ export default function App() {
   const lastSeqRef = useRef(0);
   const assistantBufRef = useRef("");
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const followsLatestRef = useRef(true);
   const refreshFolderAccessRef = useRef<(() => void) | null>(null);
   const refreshAgentRunsRef = useRef<(() => void) | null>(null);
   const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
@@ -215,71 +219,19 @@ export default function App() {
     };
   }, [client, chat?.id]);
 
-  useEffect(() => {
-    if (!client || !chat || hydratedChatId !== chat.id) return;
-    socketRef.current?.close();
-    const generation = ++socketGenerationRef.current;
-    let disposed = false;
-    let reconnectTimer: number | null = null;
-    let reconnectDelayMs = 250;
-
-    const scheduleReconnect = () => {
-      if (
-        disposed ||
-        socketGenerationRef.current !== generation ||
-        reconnectTimer !== null
-      ) {
-        return;
-      }
-      setStatus((s) => `${withoutConnectionState(s)} · reconnecting`);
-      const delay = reconnectDelayMs;
-      reconnectDelayMs = Math.min(reconnectDelayMs * 2, 5_000);
-      reconnectTimer = window.setTimeout(() => {
-        reconnectTimer = null;
-        connect();
-      }, delay);
-    };
-
-    const connect = () => {
-      if (disposed || socketGenerationRef.current !== generation) return;
-      let socket: WebSocket;
-      try {
-        socket = client.openEvents(chat.id, lastSeqRef.current, (event) => {
-          if (socketGenerationRef.current !== generation) return;
-          handleEvent(event);
-        });
-      } catch {
-        scheduleReconnect();
-        return;
-      }
-      socketRef.current = socket;
-      socket.onopen = () => {
-        if (disposed || socketGenerationRef.current !== generation) return;
-        reconnectDelayMs = 250;
-        setStatus((s) => `${withoutConnectionState(s)} · live`);
-      };
-      socket.onerror = () => {
-        if (!disposed && socketGenerationRef.current === generation) {
-          setStatus((s) => `${withoutConnectionState(s)} · reconnecting`);
-        }
-      };
-      socket.onclose = () => {
-        if (socketRef.current === socket) socketRef.current = null;
-        scheduleReconnect();
-      };
-    };
-
-    connect();
-    return () => {
-      disposed = true;
-      if (reconnectTimer !== null) window.clearTimeout(reconnectTimer);
-      socketRef.current?.close();
-      socketRef.current = null;
-      if (socketGenerationRef.current === generation) {
-        socketGenerationRef.current += 1;
-      }
-    };
-  }, [client, chat?.id, hydratedChatId]);
+  useChatEventStream({
+    client,
+    chatId: chat?.id ?? null,
+    ready: hydratedChatId === chat?.id,
+    afterRef: lastSeqRef,
+    socketRef,
+    generationRef: socketGenerationRef,
+    onEvent: handleEvent,
+    onConnectionState: (connectionState) =>
+      setStatus((current) =>
+        `${withoutConnectionState(current)} · ${connectionState}`,
+      ),
+  });
 
   useEffect(() => {
     if (!client || !chat) return;
@@ -371,7 +323,13 @@ export default function App() {
   }, [client, chat?.id]);
 
   useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    if (followsLatestRef.current) {
+      scrollToLatest(scroll);
+    } else {
+      setHasUnreadActivity(true);
+    }
   }, [messages]);
 
   useEffect(() => {
@@ -380,8 +338,13 @@ export default function App() {
       (callId) => !visibleFolderCallIdsRef.current.has(callId),
     );
     visibleFolderCallIdsRef.current = next;
-    if (gainedRequest) {
-      scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+    if (!gainedRequest) return;
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    if (followsLatestRef.current) {
+      scrollToLatest(scroll);
+    } else {
+      setHasUnreadActivity(true);
     }
   }, [folderAccessRequests]);
 
@@ -632,6 +595,8 @@ export default function App() {
       assistantBufRef.current = "";
       provisionalToolCallIdsRef.current = new Set();
       lastSeqRef.current = 0;
+      followsLatestRef.current = true;
+      setHasUnreadActivity(false);
       setMessages([]);
       hydratedMessageIdsRef.current = new Set();
       setAgentRuns([]);
@@ -711,6 +676,8 @@ export default function App() {
     socketRef.current = null;
     assistantBufRef.current = "";
     lastSeqRef.current = 0;
+    followsLatestRef.current = true;
+    setHasUnreadActivity(false);
     setMessages([]);
     hydratedMessageIdsRef.current = new Set();
     setAgentRuns([]);
@@ -1089,73 +1056,96 @@ export default function App() {
             />
           </div>
 
-          <div className="messages" ref={scrollRef}>
-            {messages.length === 0 && folderAccessRequests.length === 0 && (
-              <div className="bubble system">
-                Configure a provider, pick a model, then send a message.
-              </div>
-            )}
-            {messages.map((m) => {
-              if (m.role === "tool") {
-                return <ToolCallCard key={m.id} name={m.name} status={m.status} />;
-              }
-              if (m.role === "approval") {
+          <div className="message-view">
+            <div
+              className="messages"
+              ref={scrollRef}
+              onScroll={(event) => {
+                const followsLatest = isNearBottom(event.currentTarget);
+                followsLatestRef.current = followsLatest;
+                if (followsLatest) setHasUnreadActivity(false);
+              }}
+            >
+              {messages.length === 0 && folderAccessRequests.length === 0 && (
+                <div className="bubble system">
+                  Configure a provider, pick a model, then send a message.
+                </div>
+              )}
+              {messages.map((m) => {
+                if (m.role === "tool") {
+                  return <ToolCallCard key={m.id} name={m.name} status={m.status} />;
+                }
+                if (m.role === "approval") {
+                  return (
+                    <div key={m.id} className="bubble system">
+                      <div>Approval needed: {m.summary}</div>
+                      {!m.resolved && (
+                        <div className="approval">
+                          <button
+                            type="button"
+                            className="btn btn-primary"
+                            onClick={() => void onApproval(m.callId, "approve")}
+                          >
+                            Approve
+                          </button>
+                          <button
+                            type="button"
+                            className="btn"
+                            onClick={() => void onApproval(m.callId, "reject")}
+                          >
+                            Reject
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  );
+                }
                 return (
-                  <div key={m.id} className="bubble system">
-                    <div>Approval needed: {m.summary}</div>
-                    {!m.resolved && (
-                      <div className="approval">
-                        <button
-                          type="button"
-                          className="btn btn-primary"
-                          onClick={() => void onApproval(m.callId, "approve")}
-                        >
-                          Approve
-                        </button>
-                        <button
-                          type="button"
-                          className="btn"
-                          onClick={() => void onApproval(m.callId, "reject")}
-                        >
-                          Reject
-                        </button>
-                      </div>
+                  <div key={m.id} className={`bubble ${m.role}`}>
+                    {m.text ? (
+                      m.role === "assistant" || m.role === "user" ? (
+                        <MessageMarkdown>{m.text}</MessageMarkdown>
+                      ) : (
+                        m.text
+                      )
+                    ) : m.role === "assistant" && busy ? (
+                      "…"
+                    ) : (
+                      ""
                     )}
                   </div>
                 );
-              }
-              return (
-                <div key={m.id} className={`bubble ${m.role}`}>
-                  {m.text ? (
-                    m.role === "assistant" || m.role === "user" ? (
-                      <MessageMarkdown>{m.text}</MessageMarkdown>
-                    ) : (
-                      m.text
-                    )
-                  ) : m.role === "assistant" && busy ? (
-                    "…"
-                  ) : (
-                    ""
-                  )}
-                </div>
-              );
-            })}
-            {folderAccessRequests.map((request) => (
-              <FolderAccessCard
-                key={request.callId}
-                request={request}
-                nativeHost={hasNativeHost()}
-                nativeBusy={resolvingFolderCalls.size > 0}
-                working={resolvingFolderCalls.has(request.callId)}
-                error={folderAccessErrors[request.callId]}
-                onDecision={(decision) =>
-                  void onFolderAccessDecision(request.callId, decision)
-                }
-                onCancel={() =>
-                  void onFolderAccessCancel(request.callId, request.turnId)
-                }
-              />
-            ))}
+              })}
+              {folderAccessRequests.map((request) => (
+                <FolderAccessCard
+                  key={request.callId}
+                  request={request}
+                  nativeHost={hasNativeHost()}
+                  nativeBusy={resolvingFolderCalls.size > 0}
+                  working={resolvingFolderCalls.has(request.callId)}
+                  error={folderAccessErrors[request.callId]}
+                  onDecision={(decision) =>
+                    void onFolderAccessDecision(request.callId, decision)
+                  }
+                  onCancel={() =>
+                    void onFolderAccessCancel(request.callId, request.turnId)
+                  }
+                />
+              ))}
+            </div>
+            {hasUnreadActivity && (
+              <button
+                type="button"
+                className="new-activity"
+                onClick={() => {
+                  followsLatestRef.current = true;
+                  setHasUnreadActivity(false);
+                  if (scrollRef.current) scrollToLatest(scrollRef.current);
+                }}
+              >
+                New activity ↓
+              </button>
+            )}
           </div>
 
           <form

--- a/crates/openwave-desktop/ui/src/ChatEventStream.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatEventStream.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  INITIAL_RECONNECT_DELAY_MS,
+  MAX_RECONNECT_DELAY_MS,
+  isCurrentConnection,
+  nextReconnectDelay,
+} from "./ChatEventStream";
+
+describe("chat event reconnect helpers", () => {
+  it("uses bounded exponential backoff", () => {
+    expect(nextReconnectDelay(INITIAL_RECONNECT_DELAY_MS)).toBe(500);
+    expect(nextReconnectDelay(4_000)).toBe(MAX_RECONNECT_DELAY_MS);
+    expect(nextReconnectDelay(MAX_RECONNECT_DELAY_MS)).toBe(
+      MAX_RECONNECT_DELAY_MS,
+    );
+  });
+
+  it("rejects disposed and superseded socket callbacks", () => {
+    expect(isCurrentConnection(false, 3, 3)).toBe(true);
+    expect(isCurrentConnection(true, 3, 3)).toBe(false);
+    expect(isCurrentConnection(false, 3, 4)).toBe(false);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatEventStream.ts
+++ b/crates/openwave-desktop/ui/src/ChatEventStream.ts
@@ -1,0 +1,121 @@
+import { useEffect, useRef, type MutableRefObject } from "react";
+import type { ApiClient, SequencedEvent } from "./api";
+
+export const INITIAL_RECONNECT_DELAY_MS = 250;
+export const MAX_RECONNECT_DELAY_MS = 5_000;
+
+/** The next bounded backoff value after scheduling one reconnect attempt. */
+export function nextReconnectDelay(delayMs: number): number {
+  return Math.min(delayMs * 2, MAX_RECONNECT_DELAY_MS);
+}
+
+/** Guards callbacks from a chat that was explicitly replaced or disposed. */
+export function isCurrentConnection(
+  disposed: boolean,
+  expectedGeneration: number,
+  currentGeneration: number,
+): boolean {
+  return !disposed && expectedGeneration === currentGeneration;
+}
+
+type ConnectionState = "live" | "reconnecting";
+
+type ChatEventStreamOptions = {
+  client: ApiClient | null;
+  chatId: string | null;
+  ready: boolean;
+  afterRef: MutableRefObject<number>;
+  socketRef: MutableRefObject<WebSocket | null>;
+  generationRef: MutableRefObject<number>;
+  onEvent: (event: SequencedEvent) => void;
+  onConnectionState: (state: ConnectionState) => void;
+};
+
+/**
+ * Keeps a selected chat's event stream alive without allowing an old chat or
+ * an intentionally closed socket to reconnect over the current selection.
+ */
+export function useChatEventStream({
+  client,
+  chatId,
+  ready,
+  afterRef,
+  socketRef,
+  generationRef,
+  onEvent,
+  onConnectionState,
+}: ChatEventStreamOptions): void {
+  const onEventRef = useRef(onEvent);
+  const onConnectionStateRef = useRef(onConnectionState);
+  onEventRef.current = onEvent;
+  onConnectionStateRef.current = onConnectionState;
+
+  useEffect(() => {
+    if (!client || !chatId || !ready) return;
+
+    socketRef.current?.close();
+    const generation = ++generationRef.current;
+    let disposed = false;
+    let reconnectTimer: number | null = null;
+    let reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+
+    const isCurrent = () =>
+      isCurrentConnection(disposed, generation, generationRef.current);
+
+    const scheduleReconnect = () => {
+      if (!isCurrent() || reconnectTimer !== null) return;
+      onConnectionStateRef.current("reconnecting");
+      const delay = reconnectDelayMs;
+      reconnectDelayMs = nextReconnectDelay(reconnectDelayMs);
+      reconnectTimer = window.setTimeout(() => {
+        reconnectTimer = null;
+        connect();
+      }, delay);
+    };
+
+    const connect = () => {
+      if (!isCurrent()) return;
+      let socket: WebSocket;
+      try {
+        socket = client.openEvents(chatId, afterRef.current, (event) => {
+          if (isCurrent() && socketRef.current === socket) {
+            onEventRef.current(event);
+          }
+        });
+      } catch {
+        scheduleReconnect();
+        return;
+      }
+
+      socketRef.current = socket;
+      socket.onopen = () => {
+        if (!isCurrent() || socketRef.current !== socket) return;
+        reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+        onConnectionStateRef.current("live");
+      };
+      socket.onerror = () => {
+        if (!isCurrent() || socketRef.current !== socket) return;
+        // Browser error events are not required to be followed by close. Close
+        // this socket so the one reconnect path owns recovery in either case.
+        socket.close();
+        scheduleReconnect();
+      };
+      socket.onclose = () => {
+        if (socketRef.current !== socket) return;
+        socketRef.current = null;
+        scheduleReconnect();
+      };
+    };
+
+    connect();
+    return () => {
+      disposed = true;
+      if (reconnectTimer !== null) window.clearTimeout(reconnectTimer);
+      if (socketRef.current) {
+        socketRef.current.close();
+        socketRef.current = null;
+      }
+      if (generationRef.current === generation) generationRef.current += 1;
+    };
+  }, [afterRef, chatId, client, generationRef, ready, socketRef]);
+}

--- a/crates/openwave-desktop/ui/src/ChatScroll.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatScroll.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AUTO_SCROLL_THRESHOLD_PX,
+  isNearBottom,
+  scrollToLatest,
+} from "./ChatScroll";
+
+describe("chat scroll behavior", () => {
+  it("only follows new activity near the bottom", () => {
+    expect(
+      isNearBottom({ scrollTop: 828, clientHeight: 100, scrollHeight: 1_000 }),
+    ).toBe(true);
+    expect(
+      isNearBottom({ scrollTop: 827, clientHeight: 100, scrollHeight: 1_000 }),
+    ).toBe(false);
+    expect(AUTO_SCROLL_THRESHOLD_PX).toBe(72);
+  });
+
+  it("scrolls to the latest item when explicitly requested", () => {
+    const scrollTo = vi.fn();
+    scrollToLatest({ scrollHeight: 2_000, scrollTo });
+    expect(scrollTo).toHaveBeenCalledWith({ top: 2_000, behavior: "smooth" });
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatScroll.ts
+++ b/crates/openwave-desktop/ui/src/ChatScroll.ts
@@ -1,0 +1,19 @@
+export const AUTO_SCROLL_THRESHOLD_PX = 72;
+
+type ScrollMetrics = {
+  scrollTop: number;
+  clientHeight: number;
+  scrollHeight: number;
+};
+
+/** Whether a new streamed item should keep the reader pinned to the latest. */
+export function isNearBottom(
+  { scrollTop, clientHeight, scrollHeight }: ScrollMetrics,
+  thresholdPx = AUTO_SCROLL_THRESHOLD_PX,
+): boolean {
+  return scrollHeight - (scrollTop + clientHeight) <= thresholdPx;
+}
+
+export function scrollToLatest(element: Pick<HTMLElement, "scrollHeight" | "scrollTo">): void {
+  element.scrollTo({ top: element.scrollHeight, behavior: "smooth" });
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -517,12 +517,37 @@ button {
   text-decoration: underline;
 }
 
+.message-view {
+  position: relative;
+  min-height: 0;
+}
+
 .messages {
+  height: 100%;
   overflow: auto;
   padding: 1.25rem clamp(1rem, 7vw, 7rem);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.new-activity {
+  position: absolute;
+  z-index: 1;
+  right: clamp(1rem, 7vw, 7rem);
+  bottom: 1rem;
+  border: 1px solid color-mix(in srgb, var(--ink) 26%, var(--line));
+  border-radius: 999px;
+  padding: 0.38rem 0.7rem;
+  color: var(--ink);
+  background: var(--bg-elevated);
+  box-shadow: 0 4px 16px color-mix(in srgb, var(--ink) 14%, transparent);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.new-activity:hover {
+  background: var(--sidebar-active);
 }
 
 .bubble {
@@ -1068,6 +1093,10 @@ button {
 
   .messages {
     padding-inline: 1rem;
+  }
+
+  .new-activity {
+    right: 1rem;
   }
 
   .conversation-header .status {


### PR DESCRIPTION
## Summary

- reconnect the selected chat event stream with bounded backoff after an unexpected socket error or close
- isolate stream lifecycle and scroll decisions in focused desktop helpers
- keep the transcript pinned only while the reader is near the latest activity, with a New activity control otherwise

## Validation

- `pnpm exec vitest run --reporter=verbose`
- `pnpm build`