### PR TITLE
Refine desktop message surface

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -23,33 +23,14 @@ import {
   type ConnectedFolder,
   type FolderAccessDecision,
 } from "./host";
-import { FolderAccessCard } from "./FolderAccessCard";
 import { Logomark } from "./Logomark";
-import { MessageMarkdown } from "./MessageMarkdown";
-import { ToolCallCard, type ToolCallStatus } from "./ToolCallCard";
+import { MessageList, type ChatMessage } from "./MessageList";
+import type { ToolCallStatus } from "./ToolCallCard";
 import { hydrateTranscriptHistory } from "./TranscriptHistory";
 import { useChatEventStream } from "./ChatEventStream";
 import { isNearBottom, scrollToLatest } from "./ChatScroll";
 
-type Msg =
-  | { id: string; role: "user"; text: string }
-  | { id: string; role: "assistant"; text: string }
-  | { id: string; role: "system"; text: string }
-  | {
-      id: string;
-      role: "tool";
-      callId: string;
-      name: string;
-      status: ToolCallStatus;
-    }
-  | {
-      id: string;
-      role: "approval";
-      callId: string;
-      summary: string;
-      resolved?: boolean;
-    }
-  | { id: string; role: "error"; text: string };
+type Msg = ChatMessage;
 
 let msgSeq = 0;
 const MAX_RECENT_TERMINAL_SANDBOX_RUNS = 2;
@@ -1057,82 +1038,28 @@ export default function App() {
           </div>
 
           <div className="message-view">
-            <div
-              className="messages"
-              ref={scrollRef}
+            <MessageList
+              messages={messages}
+              folderAccessRequests={folderAccessRequests}
+              nativeHost={hasNativeHost()}
+              nativeBusy={resolvingFolderCalls.size > 0}
+              resolvingFolderCalls={resolvingFolderCalls}
+              folderAccessErrors={folderAccessErrors}
+              busy={busy}
+              scrollRef={scrollRef}
               onScroll={(event) => {
                 const followsLatest = isNearBottom(event.currentTarget);
                 followsLatestRef.current = followsLatest;
                 if (followsLatest) setHasUnreadActivity(false);
               }}
-            >
-              {messages.length === 0 && folderAccessRequests.length === 0 && (
-                <div className="bubble system">
-                  Configure a provider, pick a model, then send a message.
-                </div>
-              )}
-              {messages.map((m) => {
-                if (m.role === "tool") {
-                  return <ToolCallCard key={m.id} name={m.name} status={m.status} />;
-                }
-                if (m.role === "approval") {
-                  return (
-                    <div key={m.id} className="bubble system">
-                      <div>Approval needed: {m.summary}</div>
-                      {!m.resolved && (
-                        <div className="approval">
-                          <button
-                            type="button"
-                            className="btn btn-primary"
-                            onClick={() => void onApproval(m.callId, "approve")}
-                          >
-                            Approve
-                          </button>
-                          <button
-                            type="button"
-                            className="btn"
-                            onClick={() => void onApproval(m.callId, "reject")}
-                          >
-                            Reject
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  );
-                }
-                return (
-                  <div key={m.id} className={`bubble ${m.role}`}>
-                    {m.text ? (
-                      m.role === "assistant" || m.role === "user" ? (
-                        <MessageMarkdown>{m.text}</MessageMarkdown>
-                      ) : (
-                        m.text
-                      )
-                    ) : m.role === "assistant" && busy ? (
-                      "…"
-                    ) : (
-                      ""
-                    )}
-                  </div>
-                );
-              })}
-              {folderAccessRequests.map((request) => (
-                <FolderAccessCard
-                  key={request.callId}
-                  request={request}
-                  nativeHost={hasNativeHost()}
-                  nativeBusy={resolvingFolderCalls.size > 0}
-                  working={resolvingFolderCalls.has(request.callId)}
-                  error={folderAccessErrors[request.callId]}
-                  onDecision={(decision) =>
-                    void onFolderAccessDecision(request.callId, decision)
-                  }
-                  onCancel={() =>
-                    void onFolderAccessCancel(request.callId, request.turnId)
-                  }
-                />
-              ))}
-            </div>
+              onApproval={(callId, decision) => void onApproval(callId, decision)}
+              onFolderAccessDecision={(callId, decision) =>
+                void onFolderAccessDecision(callId, decision)
+              }
+              onFolderAccessCancel={(callId, turnId) =>
+                void onFolderAccessCancel(callId, turnId)
+              }
+            />
             {hasUnreadActivity && (
               <button
                 type="button"

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -1,0 +1,60 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MessageBubble, MessageList, type ChatMessage } from "./MessageList";
+
+const noop = () => undefined;
+
+describe("MessageBubble", () => {
+  it("keeps the user compact while rendering assistant Markdown without a bubble", () => {
+    const user = renderToStaticMarkup(
+      <MessageBubble
+        message={{ id: "user-1", role: "user", text: "Hello **there**" }}
+        busy={false}
+        onApproval={noop}
+      />,
+    );
+    const assistant = renderToStaticMarkup(
+      <MessageBubble
+        message={{ id: "assistant-1", role: "assistant", text: "## Answer" }}
+        busy={false}
+        onApproval={noop}
+      />,
+    );
+
+    expect(user).toContain('class="message message-user"');
+    expect(user).toContain("<strong>there</strong>");
+    expect(assistant).toContain('class="message message-assistant"');
+    expect(assistant).toContain("<h2>Answer</h2>");
+    expect(assistant).not.toContain("bubble");
+  });
+
+  it("keeps tool cards, approvals, and active streaming placeholders in sequence", () => {
+    const messages: ChatMessage[] = [
+      { id: "tool-1", role: "tool", callId: "call-1", name: "web_search", status: "running" },
+      { id: "approval-1", role: "approval", callId: "call-1", summary: "Search a site" },
+      { id: "assistant-2", role: "assistant", text: "" },
+    ];
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={messages}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        busy
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup.indexOf("Search the web")).toBeLessThan(
+      markup.indexOf("Approval needed"),
+    );
+    expect(markup).toContain("message-approval");
+    expect(markup).toContain('aria-label="Thinking"');
+  });
+});

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -1,0 +1,162 @@
+import type { RefObject, UIEvent } from "react";
+import type { PendingFolderAccessRequest } from "./api";
+import { FolderAccessCard } from "./FolderAccessCard";
+import type { FolderAccessDecision } from "./host";
+import { MessageMarkdown } from "./MessageMarkdown";
+import { ToolCallCard, type ToolCallStatus } from "./ToolCallCard";
+
+export type ChatMessage =
+  | { id: string; role: "user"; text: string }
+  | { id: string; role: "assistant"; text: string }
+  | { id: string; role: "system"; text: string }
+  | {
+      id: string;
+      role: "tool";
+      callId: string;
+      name: string;
+      status: ToolCallStatus;
+    }
+  | {
+      id: string;
+      role: "approval";
+      callId: string;
+      summary: string;
+      resolved?: boolean;
+    }
+  | { id: string; role: "error"; text: string };
+
+type MessageListProps = {
+  messages: ChatMessage[];
+  folderAccessRequests: PendingFolderAccessRequest[];
+  nativeHost: boolean;
+  nativeBusy: boolean;
+  resolvingFolderCalls: Set<string>;
+  folderAccessErrors: Record<string, string>;
+  busy: boolean;
+  scrollRef: RefObject<HTMLDivElement | null>;
+  onScroll: (event: UIEvent<HTMLDivElement>) => void;
+  onApproval: (callId: string, decision: "approve" | "reject") => void;
+  onFolderAccessDecision: (
+    callId: string,
+    decision: FolderAccessDecision,
+  ) => void;
+  onFolderAccessCancel: (callId: string, turnId: string) => void;
+};
+
+export function MessageList({
+  messages,
+  folderAccessRequests,
+  nativeHost,
+  nativeBusy,
+  resolvingFolderCalls,
+  folderAccessErrors,
+  busy,
+  scrollRef,
+  onScroll,
+  onApproval,
+  onFolderAccessDecision,
+  onFolderAccessCancel,
+}: MessageListProps) {
+  return (
+    <div className="messages" ref={scrollRef} onScroll={onScroll}>
+      {messages.length === 0 && folderAccessRequests.length === 0 && (
+        <div className="message-notice" role="status">
+          Configure a provider, pick a model, then send a message.
+        </div>
+      )}
+      {messages.map((message) => (
+        <MessageBubble
+          key={message.id}
+          message={message}
+          busy={busy}
+          onApproval={onApproval}
+        />
+      ))}
+      {folderAccessRequests.map((request) => (
+        <FolderAccessCard
+          key={request.callId}
+          request={request}
+          nativeHost={nativeHost}
+          nativeBusy={nativeBusy}
+          working={resolvingFolderCalls.has(request.callId)}
+          error={folderAccessErrors[request.callId]}
+          onDecision={(decision) =>
+            onFolderAccessDecision(request.callId, decision)
+          }
+          onCancel={() => onFolderAccessCancel(request.callId, request.turnId)}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function MessageBubble({
+  message,
+  busy,
+  onApproval,
+}: {
+  message: ChatMessage;
+  busy: boolean;
+  onApproval: (callId: string, decision: "approve" | "reject") => void;
+}) {
+  if (message.role === "tool") {
+    return <ToolCallCard name={message.name} status={message.status} />;
+  }
+
+  if (message.role === "approval") {
+    return (
+      <section className="message-approval" aria-label="Approval needed">
+        <p>Approval needed: {message.summary}</p>
+        {!message.resolved && (
+          <div className="approval">
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={() => onApproval(message.callId, "approve")}
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              className="btn"
+              onClick={() => onApproval(message.callId, "reject")}
+            >
+              Reject
+            </button>
+          </div>
+        )}
+      </section>
+    );
+  }
+
+  if (message.role === "assistant") {
+    return (
+      <article className="message message-assistant" aria-label="Assistant">
+        {message.text ? (
+          <MessageMarkdown>{message.text}</MessageMarkdown>
+        ) : busy ? (
+          <span className="message-stream-placeholder" aria-label="Thinking">
+            …
+          </span>
+        ) : null}
+      </article>
+    );
+  }
+
+  if (message.role === "user") {
+    return (
+      <article className="message message-user" aria-label="You">
+        <MessageMarkdown>{message.text}</MessageMarkdown>
+      </article>
+    );
+  }
+
+  return (
+    <div
+      className={`message-notice is-${message.role}`}
+      role={message.role === "error" ? "alert" : "status"}
+    >
+      {message.text}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -525,10 +525,10 @@ button {
 .messages {
   height: 100%;
   overflow: auto;
-  padding: 1.25rem clamp(1rem, 7vw, 7rem);
+  padding: 2rem clamp(1rem, 9vw, 10rem) 2.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1.15rem;
 }
 
 .new-activity {
@@ -550,37 +550,66 @@ button {
   background: var(--sidebar-active);
 }
 
-.bubble {
-  max-width: 46rem;
-  padding: 0.7rem 0.85rem;
-  border-radius: 8px;
-  word-break: break-word;
+.message {
+  width: min(100%, 48rem);
+  overflow-wrap: anywhere;
 }
 
-.bubble.user {
+.message-user {
+  width: fit-content;
+  max-width: min(80%, 38rem);
   align-self: flex-end;
-  background: var(--user-bg);
+  border-radius: 15px 15px 4px 15px;
+  padding: 0.52rem 0.78rem;
+  background: color-mix(in srgb, var(--sidebar-active) 84%, var(--bg-elevated));
+  color: var(--ink);
 }
 
-.bubble.assistant {
+.message-assistant {
   align-self: flex-start;
-  background: var(--assistant-bg);
-  border: 1px solid var(--line);
+  padding: 0.1rem 0;
+  background: transparent;
 }
 
-.bubble.system {
+.message-notice {
   align-self: center;
+  max-width: min(100%, 42rem);
+  padding: 0.35rem 0.6rem;
+  border-radius: 7px;
   color: var(--muted);
   font-size: 0.8rem;
-  background: transparent;
-  padding: 0.25rem 0.5rem;
+  text-align: center;
+  background: color-mix(in srgb, var(--sidebar) 68%, transparent);
 }
 
-.bubble.error {
+.message-notice.is-error {
   align-self: stretch;
   border: 1px solid color-mix(in srgb, var(--danger) 35%, var(--line));
   color: var(--danger);
   background: oklch(0.97 0.01 25);
+  text-align: left;
+}
+
+.message-stream-placeholder {
+  display: inline-block;
+  min-width: 1.2rem;
+  color: var(--muted);
+  letter-spacing: 0.12em;
+}
+
+.message-approval {
+  width: min(100%, 38rem);
+  align-self: flex-start;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--line));
+  border-radius: 9px;
+  padding: 0.7rem 0.8rem;
+  background: color-mix(in srgb, var(--bg-elevated) 88%, var(--sidebar));
+}
+
+.message-approval p {
+  margin: 0;
+  color: var(--ink);
+  font-size: 0.84rem;
 }
 
 .message-markdown {
@@ -731,7 +760,7 @@ button {
   border-radius: 9px;
   padding: 0.6rem 0.7rem;
   color: var(--muted);
-  background: var(--bg-elevated);
+  background: color-mix(in srgb, var(--bg-elevated) 88%, var(--sidebar));
 }
 
 .tool-call-icon {


### PR DESCRIPTION
## Summary

- extract conversation rendering into focused message list and bubble components
- distinguish compact user messages, readable full-width assistant Markdown, and system/error notices
- preserve tool, approval, folder-consent, and streaming placement with focused coverage

## Validation

- `pnpm test`
- `pnpm build`