### PR TITLE
Refine desktop composer interactions

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -24,6 +24,7 @@ import {
   type FolderAccessDecision,
 } from "./host";
 import { Logomark } from "./Logomark";
+import { Composer } from "./Composer";
 import { MessageList, type ChatMessage } from "./MessageList";
 import type { ToolCallStatus } from "./ToolCallCard";
 import { hydrateTranscriptHistory } from "./TranscriptHistory";
@@ -1075,52 +1076,20 @@ export default function App() {
             )}
           </div>
 
-          <form
-            className="composer"
-            onSubmit={(e) => {
-              e.preventDefault();
-              void onSend();
-            }}
-          >
-            <textarea
-              value={draft}
-              placeholder="Message OpenWave…"
-              disabled={deletingChatId !== null}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && !e.shiftKey) {
-                  e.preventDefault();
-                  void onSend();
-                }
-              }}
-            />
-            {busy && activeTurnId && (
-              <div className="composer-turn-control" aria-live="polite">
-                <button
-                  type="button"
-                  className="btn btn-stop"
-                  disabled={cancelPendingTurnId === activeTurnId}
-                  onClick={() => void onCancelActiveTurn()}
-                >
-                  {cancelPendingTurnId === activeTurnId
-                    ? "Stopping…"
-                    : "Stop"}
-                </button>
-                {cancelError && (
-                  <span className="composer-turn-error" role="status">
-                    Couldn’t stop turn: {cancelError}
-                  </span>
-                )}
-              </div>
-            )}
-            <button
-              type="submit"
-              className="btn btn-primary"
-              disabled={busy || !draft.trim() || deletingChatId !== null}
-            >
-              Send
-            </button>
-          </form>
+          <Composer
+            activeTurnId={activeTurnId}
+            busy={busy}
+            cancelError={cancelError}
+            cancelPending={
+              activeTurnId !== null && cancelPendingTurnId === activeTurnId
+            }
+            disabled={deletingChatId !== null}
+            draft={draft}
+            onDraftChange={setDraft}
+            onSend={onSend}
+            onStop={onCancelActiveTurn}
+            resetKey={chat?.id ?? "no-chat"}
+          />
         </section>
 
         {settingsPanel === "providers" && (

--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -1,0 +1,125 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  boundedComposerHeight,
+  Composer,
+  MAX_COMPOSER_LINES,
+  shouldRestoreComposerFocus,
+  shouldSubmitComposerKey,
+} from "./Composer";
+
+const noop = async () => undefined;
+
+describe("Composer", () => {
+  it("submits only an unmodified Enter outside IME composition", () => {
+    expect(
+      shouldSubmitComposerKey({
+        key: "Enter",
+        shiftKey: false,
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+        isComposing: false,
+        keyCode: 13,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSubmitComposerKey({
+        key: "Enter",
+        shiftKey: true,
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+        isComposing: false,
+        keyCode: 13,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSubmitComposerKey({
+        key: "Enter",
+        shiftKey: false,
+        ctrlKey: false,
+        altKey: false,
+        metaKey: false,
+        isComposing: true,
+        keyCode: 229,
+      }),
+    ).toBe(false);
+    for (const modifier of ["ctrlKey", "altKey", "metaKey"] as const) {
+      expect(
+        shouldSubmitComposerKey({
+          key: "Enter",
+          shiftKey: false,
+          ctrlKey: modifier === "ctrlKey",
+          altKey: modifier === "altKey",
+          metaKey: modifier === "metaKey",
+          isComposing: false,
+          keyCode: 13,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("caps auto-grow at six lines while retaining a one-line minimum", () => {
+    const lineHeight = 20;
+    const padding = 12;
+
+    expect(boundedComposerHeight(0, lineHeight, padding)).toBe(32);
+    expect(boundedComposerHeight(92, lineHeight, padding)).toBe(92);
+    expect(boundedComposerHeight(500, lineHeight, padding)).toBe(
+      MAX_COMPOSER_LINES * lineHeight + padding,
+    );
+  });
+
+  it("does not restore focus into a newly selected conversation", () => {
+    expect(shouldRestoreComposerFocus("chat-1", "chat-1", false)).toBe(true);
+    expect(shouldRestoreComposerFocus("chat-1", "chat-2", false)).toBe(false);
+    expect(shouldRestoreComposerFocus("chat-1", "chat-1", true)).toBe(false);
+  });
+
+  it("keeps one action slot and presents the stop control during a turn", () => {
+    const markup = renderToStaticMarkup(
+      <Composer
+        activeTurnId="turn-1"
+        busy
+        cancelError={null}
+        cancelPending={false}
+        disabled={false}
+        draft="A later draft"
+        onDraftChange={vi.fn()}
+        onSend={noop}
+        onStop={noop}
+        resetKey="chat-1"
+      />,
+    );
+
+    expect(markup).toContain('class="composer-actions"');
+    expect(markup).toContain("Stop");
+    expect(markup).not.toContain(">Send<");
+    expect(markup).toContain('aria-label="Stop response"');
+    expect(markup).toContain('aria-label="Message"');
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain('role="status"');
+  });
+
+  it("disables an empty draft without hiding the send control", () => {
+    const markup = renderToStaticMarkup(
+      <Composer
+        activeTurnId={null}
+        busy={false}
+        cancelError={null}
+        cancelPending={false}
+        disabled={false}
+        draft="   "
+        onDraftChange={vi.fn()}
+        onSend={noop}
+        onStop={noop}
+        resetKey="chat-1"
+      />,
+    );
+
+    expect(markup).toContain(">Send<");
+    expect(markup).toContain('type="submit"');
+    expect(markup).toContain('disabled=""');
+  });
+});

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -1,0 +1,186 @@
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  useLayoutEffect,
+  useRef,
+} from "react";
+
+const MIN_COMPOSER_LINES = 1;
+export const MAX_COMPOSER_LINES = 6;
+
+type ComposerKeyEvent = Pick<
+  KeyboardEvent<HTMLTextAreaElement>["nativeEvent"],
+  | "altKey"
+  | "ctrlKey"
+  | "isComposing"
+  | "key"
+  | "keyCode"
+  | "metaKey"
+  | "shiftKey"
+>;
+
+export function shouldSubmitComposerKey(event: ComposerKeyEvent): boolean {
+  return (
+    event.key === "Enter" &&
+    !event.shiftKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey &&
+    !event.isComposing &&
+    event.keyCode !== 229
+  );
+}
+
+export function shouldRestoreComposerFocus(
+  submissionKey: string,
+  currentKey: string,
+  inputDisabled: boolean,
+): boolean {
+  return submissionKey === currentKey && !inputDisabled;
+}
+
+export function boundedComposerHeight(
+  scrollHeight: number,
+  lineHeight: number,
+  verticalInsets: number,
+): number {
+  const minimum = lineHeight * MIN_COMPOSER_LINES + verticalInsets;
+  const maximum = lineHeight * MAX_COMPOSER_LINES + verticalInsets;
+  return Math.max(minimum, Math.min(scrollHeight, maximum));
+}
+
+function resizeComposerTextarea(textarea: HTMLTextAreaElement): void {
+  const styles = window.getComputedStyle(textarea);
+  const lineHeight = Number.parseFloat(styles.lineHeight) || 20;
+  const verticalInsets =
+    (Number.parseFloat(styles.paddingTop) || 0) +
+    (Number.parseFloat(styles.paddingBottom) || 0) +
+    (Number.parseFloat(styles.borderTopWidth) || 0) +
+    (Number.parseFloat(styles.borderBottomWidth) || 0);
+  const maximum = lineHeight * MAX_COMPOSER_LINES + verticalInsets;
+
+  textarea.style.height = "auto";
+  textarea.style.height = `${boundedComposerHeight(
+    textarea.scrollHeight,
+    lineHeight,
+    verticalInsets,
+  )}px`;
+  textarea.style.overflowY = textarea.scrollHeight > maximum ? "auto" : "hidden";
+}
+
+export type ComposerProps = {
+  activeTurnId: string | null;
+  busy: boolean;
+  cancelError: string | null;
+  cancelPending: boolean;
+  disabled: boolean;
+  draft: string;
+  onDraftChange: (draft: string) => void;
+  onSend: () => Promise<void>;
+  onStop: () => Promise<void>;
+  resetKey: string;
+};
+
+export function Composer({
+  activeTurnId,
+  busy,
+  cancelError,
+  cancelPending,
+  disabled,
+  draft,
+  onDraftChange,
+  onSend,
+  onStop,
+  resetKey,
+}: ComposerProps) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const latestResetKeyRef = useRef(resetKey);
+  latestResetKeyRef.current = resetKey;
+  const inputDisabled = disabled || busy;
+  const canSend = !inputDisabled && Boolean(draft.trim());
+
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) resizeComposerTextarea(textarea);
+  }, [draft, resetKey]);
+
+  async function submit(): Promise<void> {
+    if (!canSend) return;
+    const submissionKey = resetKey;
+    await onSend();
+
+    // A successful send enters a running turn and keeps the input disabled.
+    // If the request fails, the input becomes available again and returns focus
+    // so the user can continue without another click.
+    window.requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (
+        textarea &&
+        shouldRestoreComposerFocus(
+          submissionKey,
+          latestResetKeyRef.current,
+          textarea.disabled,
+        )
+      ) {
+        textarea.focus();
+      }
+    });
+  }
+
+  function onChange(event: ChangeEvent<HTMLTextAreaElement>) {
+    onDraftChange(event.target.value);
+  }
+
+  return (
+    <form
+      className="composer"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void submit();
+      }}
+    >
+      <textarea
+        ref={textareaRef}
+        value={draft}
+        placeholder="Message OpenWave…"
+        aria-label="Message"
+        disabled={inputDisabled}
+        onChange={onChange}
+        onKeyDown={(event) => {
+          if (!shouldSubmitComposerKey(event.nativeEvent)) return;
+          event.preventDefault();
+          void submit();
+        }}
+      />
+      <div className="composer-actions">
+        {busy && activeTurnId ? (
+          <button
+            type="button"
+            className="btn btn-stop"
+            aria-label={cancelPending ? "Stopping response" : "Stop response"}
+            disabled={disabled || cancelPending}
+            onClick={() => void onStop()}
+          >
+            {cancelPending ? "Stopping…" : "Stop"}
+          </button>
+        ) : (
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={!canSend}
+          >
+            Send
+          </button>
+        )}
+      </div>
+      <span className="sr-only" role="status">
+        {busy ? "Agent is responding" : "Ready to send"}
+      </span>
+      {cancelError && (
+        <span className="composer-turn-error" role="status">
+          Couldn’t stop turn: {cancelError}
+        </span>
+      )}
+    </form>
+  );
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -883,7 +883,7 @@ button {
 
 .composer {
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.55rem;
   padding: 0.85rem clamp(1rem, 3vw, 2rem) 1rem;
   border-top: 1px solid var(--line);
@@ -892,19 +892,23 @@ button {
 
 .composer textarea {
   resize: none;
-  min-height: 3rem;
-  max-height: 10rem;
+  min-height: calc(1.45rem + 1.2rem + 2px);
+  max-height: calc(8.7rem + 1.2rem + 2px);
   border: 1px solid var(--line);
   border-radius: 8px;
   padding: 0.6rem 0.7rem;
   background: var(--bg);
+  line-height: 1.45rem;
+  overflow-y: hidden;
 }
 
-.composer-turn-control {
+.composer-actions {
   display: flex;
-  min-width: 0;
   align-items: center;
-  gap: 0.45rem;
+}
+
+.composer-actions .btn {
+  min-width: 5.5rem;
 }
 
 .btn-stop {
@@ -918,10 +922,23 @@ button {
 }
 
 .composer-turn-error {
+  grid-column: 1 / -1;
   max-width: min(22rem, 32vw);
   color: var(--danger);
   font-size: 0.78rem;
   overflow-wrap: anywhere;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .settings {


### PR DESCRIPTION
## Summary

- extract the chat composer into a focused desktop UI component
- add IME-safe keyboard sending, bounded auto-grow, and a stable send/stop action slot
- cover composer keyboard, sizing, accessibility, and disabled-state behavior

## Validation

- `pnpm test`
- `pnpm build`