### PR TITLE
Group completed tool activity

### DIFF
--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -57,4 +57,103 @@ describe("MessageBubble", () => {
     expect(markup).toContain("message-approval");
     expect(markup).toContain('aria-label="Thinking"');
   });
+
+  it("collapses only contiguous terminal tool activity using safe card copy", () => {
+    const messages: ChatMessage[] = [
+      { id: "tool-1", role: "tool", callId: "call-1", name: "web_search", status: "completed" },
+      { id: "tool-2", role: "tool", callId: "call-2", name: "read_file", status: "failed" },
+      { id: "assistant-1", role: "assistant", text: "Done" },
+      { id: "tool-3", role: "tool", callId: "call-3", name: "list_dir", status: "cancelled" },
+    ];
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={messages}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup).toContain('class="tool-activity-group"');
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain('aria-controls="tool-activity-group-0"');
+    expect(markup).toContain('id="tool-activity-group-0" hidden=""');
+    expect(markup).toContain("2 tool activities");
+    expect(markup).toContain("Search the web: Web search complete");
+    expect(markup).toContain("Read a file: Tool could not complete");
+    expect(markup.indexOf("Web search complete")).toBeLessThan(
+      markup.indexOf("Done"),
+    );
+    expect(markup.indexOf("Done")).toBeLessThan(markup.indexOf("Not run"));
+  });
+
+  it("leaves active and folder-access activity individually visible", () => {
+    const messages: ChatMessage[] = [
+      { id: "tool-1", role: "tool", callId: "call-1", name: "web_search", status: "completed" },
+      { id: "tool-2", role: "tool", callId: "call-2", name: "list_dir", status: "running" },
+      { id: "tool-3", role: "tool", callId: "call-3", name: "request_folder_access", status: "completed" },
+      { id: "tool-4", role: "tool", callId: "call-4", name: "read_file", status: "completed" },
+    ];
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={messages}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup).not.toContain("tool-activity-group");
+    expect(markup).toContain("Browsing files");
+    expect(markup).toContain("Folder access request complete");
+  });
+
+  it("does not expose provider tool names in an activity summary", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "tool-1",
+        role: "tool",
+        callId: "call-1",
+        name: "mcp__private_server__read_a_sensitive_path",
+        status: "completed",
+      },
+      { id: "tool-2", role: "tool", callId: "call-2", name: "web_search", status: "completed" },
+    ];
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={messages}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup).toContain("Use a tool: Tool complete");
+    expect(markup).not.toContain("private_server");
+    expect(markup).not.toContain("sensitive_path");
+  });
 });

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -1,9 +1,10 @@
-import type { RefObject, UIEvent } from "react";
+import type { ReactNode, RefObject, UIEvent } from "react";
 import type { PendingFolderAccessRequest } from "./api";
 import { FolderAccessCard } from "./FolderAccessCard";
 import type { FolderAccessDecision } from "./host";
 import { MessageMarkdown } from "./MessageMarkdown";
 import { ToolCallCard, type ToolCallStatus } from "./ToolCallCard";
+import { ToolActivityGroup } from "./ToolActivityGroup";
 
 export type ChatMessage =
   | { id: string; role: "user"; text: string }
@@ -57,6 +58,8 @@ export function MessageList({
   onFolderAccessDecision,
   onFolderAccessCancel,
 }: MessageListProps) {
+  const messageItems = groupMessageItems(messages, busy, onApproval);
+
   return (
     <div className="messages" ref={scrollRef} onScroll={onScroll}>
       {messages.length === 0 && folderAccessRequests.length === 0 && (
@@ -64,14 +67,7 @@ export function MessageList({
           Configure a provider, pick a model, then send a message.
         </div>
       )}
-      {messages.map((message) => (
-        <MessageBubble
-          key={message.id}
-          message={message}
-          busy={busy}
-          onApproval={onApproval}
-        />
-      ))}
+      {messageItems}
       {folderAccessRequests.map((request) => (
         <FolderAccessCard
           key={request.callId}
@@ -88,6 +84,83 @@ export function MessageList({
       ))}
     </div>
   );
+}
+
+function isGroupableTerminalTool(
+  message: ChatMessage,
+): message is Extract<ChatMessage, { role: "tool" }> {
+  // Folder access is an authority boundary. It stays separate even when its
+  // corresponding tool event is terminal, so it cannot be mistaken for a
+  // passive historical activity item.
+  return (
+    message.role === "tool" &&
+    message.name !== "request_folder_access" &&
+    (message.status === "completed" ||
+      message.status === "failed" ||
+      message.status === "cancelled")
+  );
+}
+
+export function groupMessageItems(
+  messages: ChatMessage[],
+  busy: boolean,
+  onApproval: (callId: string, decision: "approve" | "reject") => void,
+) {
+  const items: ReactNode[] = [];
+  let index = 0;
+  let groupIndex = 0;
+
+  while (index < messages.length) {
+    const message = messages[index];
+
+    if (!isGroupableTerminalTool(message)) {
+      items.push(
+        <MessageBubble
+          key={message.id}
+          message={message}
+          busy={busy}
+          onApproval={onApproval}
+        />,
+      );
+      index += 1;
+      continue;
+    }
+
+    const activities = [message];
+    index += 1;
+    while (index < messages.length) {
+      const nextMessage = messages[index];
+      if (!isGroupableTerminalTool(nextMessage)) {
+        break;
+      }
+
+      activities.push(nextMessage);
+      index += 1;
+    }
+
+    if (activities.length === 1) {
+      items.push(
+        <MessageBubble
+          key={message.id}
+          message={message}
+          busy={busy}
+          onApproval={onApproval}
+        />,
+      );
+      continue;
+    }
+
+    items.push(
+      <ToolActivityGroup
+        key={activities[0].id}
+        activities={activities}
+        groupIndex={groupIndex}
+      />,
+    );
+    groupIndex += 1;
+  }
+
+  return items;
 }
 
 export function MessageBubble({

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import {
+  ToolCallCard,
+  toolCallPresentation,
+  type ToolCallStatus,
+} from "./ToolCallCard";
+
+type ToolActivity = {
+  id: string;
+  name: string;
+  status: ToolCallStatus;
+};
+
+type ToolActivityGroupProps = {
+  activities: ToolActivity[];
+  groupIndex: number;
+};
+
+export function ToolActivityGroup({
+  activities,
+  groupIndex,
+}: ToolActivityGroupProps) {
+  const [expanded, setExpanded] = useState(false);
+  const contentId = `tool-activity-group-${groupIndex}`;
+  const summary = activities
+    .map((activity) => toolCallPresentation(activity.name, activity.status))
+    .map(({ label, statusLabel }) => `${label}: ${statusLabel}`)
+    .join(" · ");
+  const actionLabel = `${activities.length} tool activities`;
+
+  return (
+    <section className="tool-activity-group" aria-label="Tool activity">
+      <button
+        type="button"
+        className="tool-activity-group-toggle"
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="tool-activity-group-icon" aria-hidden="true">
+          {expanded ? "⌄" : "›"}
+        </span>
+        <span className="tool-activity-group-copy">
+          <strong>{actionLabel}</strong>
+          <span>{summary}</span>
+        </span>
+      </button>
+      <div
+        id={contentId}
+        hidden={!expanded}
+        className="tool-activity-group-list"
+      >
+        {activities.map((activity) => (
+          <ToolCallCard
+            key={activity.id}
+            name={activity.name}
+            status={activity.status}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -16,6 +16,11 @@ type ToolPresentation = {
   complete: string;
 };
 
+export type ToolCallPresentation = {
+  label: string;
+  statusLabel: string;
+};
+
 // This is deliberately an allowlist rather than a display transformation of a
 // tool name. Tool events come from providers, and a card should never become a
 // side channel for an unexpected tool name, arguments, output, file path, or
@@ -75,13 +80,12 @@ const FALLBACK_TOOL: ToolPresentation = {
 };
 
 export function ToolCallCard({ name, status }: ToolCallCardProps) {
-  const tool = TOOL_PRESENTATIONS[name] ?? FALLBACK_TOOL;
-  const presentation = statusPresentation(tool, status);
+  const presentation = toolCallPresentation(name, status);
 
   return (
     <section
       className={`tool-call-card is-${status}`}
-      aria-label={`${tool.label}: ${presentation.label}`}
+      aria-label={`${presentation.label}: ${presentation.statusLabel}`}
       role="status"
       aria-live="polite"
       aria-atomic="true"
@@ -90,14 +94,31 @@ export function ToolCallCard({ name, status }: ToolCallCardProps) {
         {presentation.icon}
       </span>
       <div className="tool-call-copy">
-        <strong>{tool.label}</strong>
-        <span>{presentation.label}</span>
+        <strong>{presentation.label}</strong>
+        <span>{presentation.statusLabel}</span>
       </div>
       {status === "running" && (
         <span className="tool-call-spinner" aria-hidden="true" />
       )}
     </section>
   );
+}
+
+// Callers that summarize activity must use the same allowlisted presentation
+// as the card. In particular, do not transform provider-supplied tool names
+// into text for a summary.
+export function toolCallPresentation(
+  name: string,
+  status: ToolCallStatus,
+): ToolCallPresentation & { icon: string } {
+  const tool = TOOL_PRESENTATIONS[name] ?? FALLBACK_TOOL;
+  const statusPresentationResult = statusPresentation(tool, status);
+
+  return {
+    label: tool.label,
+    statusLabel: statusPresentationResult.label,
+    icon: statusPresentationResult.icon,
+  };
 }
 
 function statusPresentation(tool: ToolPresentation, status: ToolCallStatus) {

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -817,6 +817,74 @@ button {
   opacity: 0.7;
 }
 
+.tool-activity-group {
+  width: min(100%, 31rem);
+  align-self: flex-start;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--bg-elevated) 88%, var(--sidebar));
+}
+
+.tool-activity-group-toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 0.55rem;
+  border: 0;
+  border-radius: 8px;
+  padding: 0.6rem 0.65rem;
+  color: var(--muted);
+  background: transparent;
+  text-align: left;
+}
+
+.tool-activity-group-toggle:hover,
+.tool-activity-group-toggle:focus-visible {
+  background: color-mix(in srgb, var(--sidebar-active) 65%, transparent);
+}
+
+.tool-activity-group-icon {
+  width: 1.15rem;
+  flex: 0 0 auto;
+  color: var(--ink);
+  font-size: 1.3rem;
+  line-height: 1;
+  text-align: center;
+}
+
+.tool-activity-group-copy {
+  display: grid;
+  min-width: 0;
+  gap: 0.04rem;
+}
+
+.tool-activity-group-copy strong,
+.tool-activity-group-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tool-activity-group-copy strong {
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.tool-activity-group-copy span {
+  font-size: 0.75rem;
+}
+
+.tool-activity-group-list {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0 0.65rem 0.65rem;
+}
+
+.tool-activity-group-list .tool-call-card {
+  width: 100%;
+}
+
 @keyframes tool-call-spin {
   to {
     transform: rotate(360deg);


### PR DESCRIPTION
## Summary

- collapse contiguous terminal tool activity into an accessible, expandable group
- keep active, approval, and folder-access activity individually visible
- share the allowlisted tool presentation between cards and group summaries

## Validation

- pnpm test
- pnpm build