### PR TITLE
Project safe events to desktop clients

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1422,6 +1422,7 @@ impl Agent {
             });
             events.send(AgentEvent::ApprovalRequired {
                 call_id: call.call_id,
+                tool_name: call.name.clone(),
                 class: ApprovalClass::Sensitive,
                 summary,
             });

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -63,6 +63,9 @@ pub enum AgentEvent {
     ApprovalRequired {
         /// The call awaiting a decision.
         call_id: CallId,
+        /// Canonical registered tool identity. Renderer boundaries must map
+        /// this through a closed allowlist rather than serializing it directly.
+        tool_name: String,
         /// The approval class that triggered the prompt.
         class: ApprovalClass,
         /// A short, human-readable summary of what will happen.

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -26,7 +26,10 @@ import {
 import { Logomark } from "./Logomark";
 import { Composer } from "./Composer";
 import { MessageList, type ChatMessage } from "./MessageList";
-import type { ToolCallStatus } from "./ToolCallCard";
+import {
+  toolApprovalPresentation,
+  type ToolCallStatus,
+} from "./ToolCallCard";
 import { hydrateTranscriptHistory } from "./TranscriptHistory";
 import { useChatEventStream } from "./ChatEventStream";
 import { isNearBottom, scrollToLatest } from "./ChatScroll";
@@ -406,6 +409,7 @@ export default function App() {
     }
 
     if (event.type === "approval_required") {
+      const approval = toolApprovalPresentation(event.action);
       provisionalToolCallIdsRef.current.delete(event.call_id);
       setMessages((prev) =>
         updateToolCall(prev, event.call_id, (tool) => ({
@@ -419,7 +423,8 @@ export default function App() {
           id: nextId(),
           role: "approval",
           callId: event.call_id,
-          summary: event.summary,
+          summary: approval.summary,
+          canApprove: approval.canApprove,
         },
       ]);
       return;
@@ -440,7 +445,7 @@ export default function App() {
           status:
             tool.status === "cancelled"
               ? "cancelled"
-              : toolOutputFailed(event.output)
+              : event.status === "failed"
                 ? "failed"
                 : "completed",
         })),
@@ -453,7 +458,7 @@ export default function App() {
       hydratedMessageIdsRef.current.add(event.message_id);
       setMessages((prev) => [
         ...prev,
-        { id: event.message_id, role: "user", text: event.content },
+        { id: event.message_id, role: "user", text: event.text },
       ]);
       return;
     }
@@ -485,7 +490,7 @@ export default function App() {
         {
           id: nextId(),
           role: "error",
-          text: event.error.message,
+          text: "The turn could not be completed.",
         },
       ]);
     }
@@ -1180,11 +1185,6 @@ function discardToolCalls(messages: Msg[], callIds: Set<string>): Msg[] {
   return messages.filter(
     (message) => message.role !== "tool" || !callIds.has(message.callId),
   );
-}
-
-function toolOutputFailed(output: unknown): boolean {
-  if (!output || typeof output !== "object") return false;
-  return (output as { is_error?: unknown }).is_error === true;
 }
 
 function withoutConnectionState(status: string): string {

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -31,7 +31,13 @@ describe("MessageBubble", () => {
   it("keeps tool cards, approvals, and active streaming placeholders in sequence", () => {
     const messages: ChatMessage[] = [
       { id: "tool-1", role: "tool", callId: "call-1", name: "web_search", status: "running" },
-      { id: "approval-1", role: "approval", callId: "call-1", summary: "Search a site" },
+      {
+        id: "approval-1",
+        role: "approval",
+        callId: "call-1",
+        summary: "Search a site",
+        canApprove: true,
+      },
       { id: "assistant-2", role: "assistant", text: "" },
     ];
     const markup = renderToStaticMarkup(
@@ -56,6 +62,26 @@ describe("MessageBubble", () => {
     );
     expect(markup).toContain("message-approval");
     expect(markup).toContain('aria-label="Thinking"');
+  });
+
+  it("does not offer approval for an action without a safe description", () => {
+    const markup = renderToStaticMarkup(
+      <MessageBubble
+        message={{
+          id: "approval-unknown",
+          role: "approval",
+          callId: "call-unknown",
+          summary: "The exact action cannot be safely described.",
+          canApprove: false,
+        }}
+        busy
+        onApproval={noop}
+      />,
+    );
+
+    expect(markup).toContain("The exact action cannot be safely described.");
+    expect(markup).not.toContain(">Approve<");
+    expect(markup).toContain(">Reject<");
   });
 
   it("collapses only contiguous terminal tool activity using safe card copy", () => {

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -22,6 +22,7 @@ export type ChatMessage =
       role: "approval";
       callId: string;
       summary: string;
+      canApprove: boolean;
       resolved?: boolean;
     }
   | { id: string; role: "error"; text: string };
@@ -182,13 +183,15 @@ export function MessageBubble({
         <p>Approval needed: {message.summary}</p>
         {!message.resolved && (
           <div className="approval">
-            <button
-              type="button"
-              className="btn btn-primary"
-              onClick={() => onApproval(message.callId, "approve")}
-            >
-              Approve
-            </button>
+            {message.canApprove && (
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={() => onApproval(message.callId, "approve")}
+              >
+                Approve
+              </button>
+            )}
             <button
               type="button"
               className="btn"

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -1,6 +1,9 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { ToolCallCard } from "./ToolCallCard";
+import {
+  ToolCallCard,
+  toolApprovalPresentation,
+} from "./ToolCallCard";
 
 describe("ToolCallCard", () => {
   it("uses an allowlisted presentation and a polite live status", () => {
@@ -27,5 +30,25 @@ describe("ToolCallCard", () => {
     expect(markup).toContain("Tool complete");
     expect(markup).not.toContain("private_server");
     expect(markup).not.toContain("sensitive_path");
+  });
+
+  it("renders the fixed local-search presentation", () => {
+    const markup = renderToStaticMarkup(
+      <ToolCallCard name="search" status="completed" />,
+    );
+
+    expect(markup).toContain("Search documents");
+    expect(markup).toContain("Document search complete");
+  });
+
+  it("allows approval only for a fixed action description", () => {
+    expect(toolApprovalPresentation("web_search")).toEqual({
+      summary: "Allow this action: Search the web?",
+      canApprove: true,
+    });
+    expect(toolApprovalPresentation("mcp__private__upload")).toEqual({
+      summary: "The exact action cannot be safely described.",
+      canApprove: false,
+    });
   });
 });

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -21,11 +21,21 @@ export type ToolCallPresentation = {
   statusLabel: string;
 };
 
+export type ToolApprovalPresentation = {
+  summary: string;
+  canApprove: boolean;
+};
+
 // This is deliberately an allowlist rather than a display transformation of a
 // tool name. Tool events come from providers, and a card should never become a
 // side channel for an unexpected tool name, arguments, output, file path, or
 // provider diagnostic.
 const TOOL_PRESENTATIONS: Record<string, ToolPresentation> = {
+  search: {
+    label: "Search documents",
+    active: "Searching documents",
+    complete: "Document search complete",
+  },
   web_search: {
     label: "Search the web",
     active: "Searching the web",
@@ -118,6 +128,22 @@ export function toolCallPresentation(
     label: tool.label,
     statusLabel: statusPresentationResult.label,
     icon: statusPresentationResult.icon,
+  };
+}
+
+export function toolApprovalPresentation(
+  name: string,
+): ToolApprovalPresentation {
+  const tool = TOOL_PRESENTATIONS[name];
+  if (!tool) {
+    return {
+      summary: "The exact action cannot be safely described.",
+      canApprove: false,
+    };
+  }
+  return {
+    summary: `Allow this action: ${tool.label}?`,
+    canApprove: true,
   };
 }
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -124,22 +124,42 @@ export type SequencedEvent = {
 export type AgentEvent =
   | { type: "turn_started"; turn_id: string }
   | { type: "text_delta"; text: string }
-  | { type: "reasoning_delta"; text: string }
+  | { type: "reasoning_delta" }
   | { type: "stream_interrupted" }
-  | { type: "tool_call_started"; call_id: string; name: string }
-  | { type: "tool_call_args_delta"; call_id: string; fragment: string }
+  | { type: "tool_call_started"; call_id: string; name: RendererToolName }
+  | { type: "tool_call_args_delta"; call_id: string }
   | {
       type: "approval_required";
       call_id: string;
-      class: string;
-      summary: string;
+      action: RendererToolName;
+      class: "read_only" | "workspace" | "sensitive";
     }
   | { type: "approval_decided"; call_id: string; approved: boolean }
-  | { type: "tool_call_completed"; call_id: string; output: unknown }
-  | { type: "turn_completed"; usage: unknown; stop_reason: string }
-  | { type: "turn_failed"; error: { kind: string; message: string } }
-  | { type: "turn_cancelled"; usage: unknown }
-  | { type: "user_steered"; message_id: string; content: string };
+  | {
+      type: "tool_call_completed";
+      call_id: string;
+      status: "completed" | "failed";
+    }
+  | { type: "turn_completed" }
+  | { type: "turn_failed" }
+  | { type: "turn_cancelled" }
+  | { type: "user_steered"; message_id: string; text: string }
+  | { type: "context_truncated" }
+  | { type: "event_omitted" };
+
+export type RendererToolName =
+  | "search"
+  | "web_search"
+  | "read_file"
+  | "list_dir"
+  | "write_file"
+  | "request_folder_access"
+  | "connect_folder"
+  | "list_connected_folders"
+  | "list_folder"
+  | "read_connected_file"
+  | "spawn_sandbox_agent"
+  | "other";
 
 export type FolderAccessHint = "documents" | "downloads";
 

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -23,6 +23,7 @@ pub struct ApprovalBroker {
 
 struct Pending {
     chat_id: ChatId,
+    tool_name: String,
     registration_id: uuid::Uuid,
     tx: oneshot::Sender<ApprovalDecision>,
 }
@@ -60,12 +61,22 @@ impl ApprovalBroker {
         decision: ApprovalDecision,
     ) -> Result<(), DecideError> {
         let mut pending = self.pending.lock().unwrap();
-        let entry = pending.remove(&call_id).ok_or(DecideError::NotPending)?;
+        let entry = pending.get(&call_id).ok_or(DecideError::NotPending)?;
         if entry.chat_id != chat_id {
-            // Put it back — wrong chat shouldn't steal another chat's park.
-            pending.insert(call_id, entry);
             return Err(DecideError::WrongChat);
         }
+        if matches!(decision, ApprovalDecision::Approve)
+            && !crate::event_projection::RendererToolName::from(entry.tool_name.as_str())
+                .is_approvable()
+        {
+            // Keep the park intact so the same user can still reject it. The
+            // renderer cannot authorize an action the server cannot describe
+            // through its closed presentation allowlist.
+            return Err(DecideError::NotApprovable);
+        }
+        let entry = pending
+            .remove(&call_id)
+            .expect("pending approval checked above");
         // If the turn already dropped, the send fails; treat as not pending.
         entry
             .tx
@@ -82,6 +93,8 @@ pub enum DecideError {
     NotPending,
     /// The call is parked under a different chat.
     WrongChat,
+    /// The exact pending tool has no closed renderer approval presentation.
+    NotApprovable,
 }
 
 impl ApprovalGate for ApprovalBroker {
@@ -96,6 +109,7 @@ impl ApprovalGate for ApprovalBroker {
                 request.call_id,
                 Pending {
                     chat_id: request.chat_id,
+                    tool_name: request.tool_name,
                     registration_id,
                     tx,
                 },
@@ -137,7 +151,7 @@ mod tests {
             call_id,
             chat_id,
             turn_id: TurnId::new(),
-            tool_name: "shell".into(),
+            tool_name: "search".into(),
             class: ApprovalClass::Sensitive,
             summary: "run shell".into(),
         });
@@ -159,13 +173,48 @@ mod tests {
             call_id,
             chat_id,
             turn_id: TurnId::new(),
-            tool_name: "shell".into(),
+            tool_name: "search".into(),
             class: ApprovalClass::Sensitive,
             summary: "run".into(),
         });
         assert_eq!(
             broker.resolve(other, call_id, ApprovalDecision::Approve),
             Err(DecideError::WrongChat)
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_action_cannot_be_approved_but_can_be_rejected() {
+        let broker = ApprovalBroker::new();
+        let chat_id = ChatId::new();
+        let call_id = CallId::new();
+        let pending = broker.arm(ApprovalRequest {
+            call_id,
+            chat_id,
+            turn_id: TurnId::new(),
+            tool_name: "third_party_sensitive".into(),
+            class: ApprovalClass::Sensitive,
+            summary: "private model summary".into(),
+        });
+
+        assert_eq!(
+            broker.resolve(chat_id, call_id, ApprovalDecision::Approve),
+            Err(DecideError::NotApprovable)
+        );
+        broker
+            .resolve(
+                chat_id,
+                call_id,
+                ApprovalDecision::Reject {
+                    reason: "not allowed".into(),
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            pending.await,
+            ApprovalDecision::Reject {
+                reason: "not allowed".into()
+            }
         );
     }
 
@@ -201,7 +250,7 @@ mod tests {
             call_id,
             chat_id,
             turn_id: TurnId::new(),
-            tool_name: "shell".into(),
+            tool_name: "search".into(),
             class: ApprovalClass::Sensitive,
             summary: "run".into(),
         });

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -1,0 +1,304 @@
+//! Renderer-safe projection of the internal agent journal.
+//!
+//! The durable [`AgentEvent`] is an internal coordination record. It can contain
+//! model-generated tool arguments, tool results, host paths, reasoning, and
+//! provider diagnostics. WebSocket clients receive this deliberately closed
+//! projection instead.
+
+use openwave_core::{AgentEvent, ApprovalClass, CallId, MessageId, SequencedEvent, TurnId};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct RendererSequencedEvent {
+    pub seq: i64,
+    pub event: RendererAgentEvent,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum RendererAgentEvent {
+    TurnStarted {
+        turn_id: TurnId,
+    },
+    TextDelta {
+        text: String,
+    },
+    /// Signals progress without exposing provider reasoning.
+    ReasoningDelta,
+    StreamInterrupted,
+    ToolCallStarted {
+        call_id: CallId,
+        name: RendererToolName,
+    },
+    /// Preserves the journal cursor and tool lifecycle without argument bytes.
+    ToolCallArgsDelta {
+        call_id: CallId,
+    },
+    ApprovalRequired {
+        call_id: CallId,
+        action: RendererToolName,
+        class: ApprovalClass,
+    },
+    ApprovalDecided {
+        call_id: CallId,
+        approved: bool,
+    },
+    ToolCallCompleted {
+        call_id: CallId,
+        status: RendererToolStatus,
+    },
+    TurnCompleted,
+    TurnFailed,
+    TurnCancelled,
+    /// The message body is available through the transcript endpoint. Keeping
+    /// only its durable id lets clients reconcile without duplicating content.
+    UserSteered {
+        message_id: MessageId,
+        text: String,
+    },
+    ContextTruncated,
+    /// Fail-closed marker for a newer internal event until it gets an explicit
+    /// renderer projection. The sequence still advances without dropping it.
+    EventOmitted,
+}
+
+/// Tool names are model-controlled. Only names with fixed renderer
+/// presentations cross the boundary; everything else becomes `other`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RendererToolName {
+    Search,
+    WebSearch,
+    ReadFile,
+    ListDir,
+    WriteFile,
+    RequestFolderAccess,
+    ConnectFolder,
+    ListConnectedFolders,
+    ListFolder,
+    ReadConnectedFile,
+    SpawnSandboxAgent,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RendererToolStatus {
+    Completed,
+    Failed,
+}
+
+impl From<&str> for RendererToolName {
+    fn from(name: &str) -> Self {
+        match name {
+            "search" => Self::Search,
+            "web_search" => Self::WebSearch,
+            "read_file" => Self::ReadFile,
+            "list_dir" => Self::ListDir,
+            "write_file" => Self::WriteFile,
+            "request_folder_access" => Self::RequestFolderAccess,
+            "connect_folder" => Self::ConnectFolder,
+            "list_connected_folders" => Self::ListConnectedFolders,
+            "list_folder" => Self::ListFolder,
+            "read_connected_file" => Self::ReadConnectedFile,
+            "spawn_sandbox_agent" => Self::SpawnSandboxAgent,
+            _ => Self::Other,
+        }
+    }
+}
+
+impl RendererToolName {
+    /// Whether the renderer has a fixed, server-owned description that is
+    /// sufficient to present this action for an approval decision. This list
+    /// is intentionally narrower than the general tool-card allowlist: adding
+    /// a new Sensitive tool requires an explicit review of its approval copy.
+    pub(crate) const fn is_approvable(self) -> bool {
+        matches!(self, Self::Search)
+    }
+}
+
+impl From<&SequencedEvent> for RendererSequencedEvent {
+    fn from(value: &SequencedEvent) -> Self {
+        let event = match &value.event {
+            AgentEvent::TurnStarted { turn_id } => {
+                RendererAgentEvent::TurnStarted { turn_id: *turn_id }
+            }
+            AgentEvent::TextDelta { text } => RendererAgentEvent::TextDelta { text: text.clone() },
+            AgentEvent::ReasoningDelta { .. } => RendererAgentEvent::ReasoningDelta,
+            AgentEvent::StreamInterrupted => RendererAgentEvent::StreamInterrupted,
+            AgentEvent::ToolCallStarted { call_id, name } => RendererAgentEvent::ToolCallStarted {
+                call_id: *call_id,
+                name: name.as_str().into(),
+            },
+            AgentEvent::ToolCallArgsDelta { call_id, .. } => {
+                RendererAgentEvent::ToolCallArgsDelta { call_id: *call_id }
+            }
+            AgentEvent::ApprovalRequired {
+                call_id,
+                tool_name,
+                class,
+                ..
+            } => RendererAgentEvent::ApprovalRequired {
+                call_id: *call_id,
+                action: tool_name.as_str().into(),
+                class: *class,
+            },
+            AgentEvent::ApprovalDecided { call_id, approved } => {
+                RendererAgentEvent::ApprovalDecided {
+                    call_id: *call_id,
+                    approved: *approved,
+                }
+            }
+            AgentEvent::ToolCallCompleted { call_id, output } => {
+                RendererAgentEvent::ToolCallCompleted {
+                    call_id: *call_id,
+                    status: if output.is_error {
+                        RendererToolStatus::Failed
+                    } else {
+                        RendererToolStatus::Completed
+                    },
+                }
+            }
+            AgentEvent::TurnCompleted { .. } => RendererAgentEvent::TurnCompleted,
+            AgentEvent::TurnFailed { .. } => RendererAgentEvent::TurnFailed,
+            AgentEvent::TurnCancelled { .. } => RendererAgentEvent::TurnCancelled,
+            AgentEvent::UserSteered {
+                message_id,
+                content,
+            } => RendererAgentEvent::UserSteered {
+                message_id: *message_id,
+                text: content.clone(),
+            },
+            AgentEvent::ContextTruncated { .. } => RendererAgentEvent::ContextTruncated,
+            _ => RendererAgentEvent::EventOmitted,
+        };
+
+        Self {
+            seq: value.seq,
+            event,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openwave_core::{AgentError, ToolOutput};
+
+    use super::*;
+
+    #[test]
+    fn projection_redacts_internal_payloads_and_unknown_tool_names() {
+        let call_id = CallId::new();
+        let cases = [
+            AgentEvent::ReasoningDelta {
+                text: "private reasoning".into(),
+            },
+            AgentEvent::ToolCallStarted {
+                call_id,
+                name: "provider_tool_with_secret".into(),
+            },
+            AgentEvent::ToolCallArgsDelta {
+                call_id,
+                fragment: r#"{\"path\":\"/Users/private\"}"#.into(),
+            },
+            AgentEvent::ApprovalRequired {
+                call_id,
+                tool_name: "provider_tool_with_secret".into(),
+                class: ApprovalClass::Sensitive,
+                summary: "upload /Users/private/document.txt".into(),
+            },
+            AgentEvent::ToolCallCompleted {
+                call_id,
+                output: ToolOutput::error("secret output").with_data(serde_json::json!({
+                    "path": "/Users/private/document.txt",
+                })),
+            },
+            AgentEvent::TurnFailed {
+                error: (&AgentError::config("provider diagnostic")).into(),
+            },
+            AgentEvent::UserSteered {
+                message_id: MessageId::new(),
+                content: "visible steer text".into(),
+            },
+        ];
+
+        let serialized = cases
+            .iter()
+            .enumerate()
+            .map(|(index, event)| {
+                serde_json::to_string(&RendererSequencedEvent::from(&SequencedEvent {
+                    seq: index as i64 + 1,
+                    event: event.clone(),
+                }))
+                .unwrap()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        for forbidden in [
+            "private reasoning",
+            "provider_tool_with_secret",
+            "/Users/private",
+            "document.txt",
+            "secret output",
+            "provider diagnostic",
+            "fragment",
+            "output",
+            "summary",
+            "content",
+            "data",
+            "error",
+        ] {
+            assert!(!serialized.contains(forbidden), "leaked {forbidden}");
+        }
+        assert!(serialized.contains(r#""name":"other""#));
+        assert!(serialized.contains(r#""action":"other""#));
+        assert!(serialized.contains(r#""status":"failed""#));
+        assert!(serialized.contains(r#""text":"visible steer text""#));
+    }
+
+    #[test]
+    fn steered_messages_are_projected_inline_in_sequence_order() {
+        let first_id = MessageId::new();
+        let second_id = MessageId::new();
+        let projected = [
+            SequencedEvent {
+                seq: 41,
+                event: AgentEvent::UserSteered {
+                    message_id: first_id,
+                    content: "first".into(),
+                },
+            },
+            SequencedEvent {
+                seq: 42,
+                event: AgentEvent::UserSteered {
+                    message_id: second_id,
+                    content: "second".into(),
+                },
+            },
+        ]
+        .iter()
+        .map(RendererSequencedEvent::from)
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            projected,
+            vec![
+                RendererSequencedEvent {
+                    seq: 41,
+                    event: RendererAgentEvent::UserSteered {
+                        message_id: first_id,
+                        text: "first".into(),
+                    },
+                },
+                RendererSequencedEvent {
+                    seq: 42,
+                    event: RendererAgentEvent::UserSteered {
+                        message_id: second_id,
+                        text: "second".into(),
+                    },
+                },
+            ]
+        );
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -21,6 +21,7 @@ mod document_auditor;
 mod document_stage;
 mod document_worker;
 mod error;
+mod event_projection;
 mod extract;
 mod provider;
 mod providers;

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -22,6 +22,7 @@ use openwave_core::{
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::error::ServerError;
+use crate::event_projection::RendererSequencedEvent;
 use crate::extract::{Json, Path, Query};
 use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
 use crate::state::AppState;
@@ -1121,6 +1122,10 @@ pub async fn post_approval(
         Err(crate::approvals::DecideError::WrongChat) => Err(ServerError::not_found(format!(
             "no pending approval for call {call_id}"
         ))),
+        Err(crate::approvals::DecideError::NotApprovable) => Err(ServerError::conflict_kind(
+            "approval_action_not_presentable",
+            "this action cannot be approved from the renderer",
+        )),
     }
 }
 
@@ -1246,7 +1251,7 @@ async fn replay_after(
 /// Send one event as a JSON text frame. An event that fails to serialize is
 /// skipped rather than sent as an empty frame (which a client couldn't decode).
 async fn send_event(socket: &mut WebSocket, event: &SequencedEvent) -> Result<(), axum::Error> {
-    let Ok(json) = serde_json::to_string(event) else {
+    let Ok(json) = serde_json::to_string(&RendererSequencedEvent::from(event)) else {
         return Ok(());
     };
     socket.send(Message::Text(json.into())).await

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -27,6 +27,8 @@ use serde::de::DeserializeOwned;
 use tokio::sync::Notify;
 use tower::ServiceExt;
 
+use crate::event_projection::{RendererAgentEvent, RendererSequencedEvent};
+
 mod root_attachment;
 
 /// A provider that answers with a one-line completion and no tool calls.
@@ -8794,13 +8796,14 @@ async fn turn_fails_closed_with_no_provider_configured() {
 /// Sensitive tool that records whether it ran.
 struct SensitiveProbe {
     ran: Arc<std::sync::atomic::AtomicUsize>,
+    name: &'static str,
 }
 
 #[async_trait]
 impl Tool for SensitiveProbe {
     fn spec(&self) -> ToolSpec {
         ToolSpec {
-            name: "probe".into(),
+            name: self.name.into(),
             description: "sensitive probe".into(),
             input_schema: serde_json::json!({"type": "object"}),
         }
@@ -8821,6 +8824,7 @@ impl Tool for SensitiveProbe {
 /// Provider that asks for `probe` once, then finishes.
 struct ProbeProvider {
     calls: Arc<std::sync::atomic::AtomicUsize>,
+    tool_name: &'static str,
 }
 
 #[async_trait]
@@ -8837,7 +8841,7 @@ impl ModelProvider for ProbeProvider {
                 ProviderEvent::ToolCallStarted {
                     index: 0,
                     id: "call_probe".into(),
-                    name: "probe".into(),
+                    name: self.tool_name.into(),
                 },
                 ProviderEvent::ToolCallArgsDelta {
                     index: 0,
@@ -8873,12 +8877,16 @@ async fn approval_endpoint_unparks_a_sensitive_tool() {
         .unwrap(),
     );
     let ran = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let tools = Arc::new(ToolRegistry::new().with(Box::new(SensitiveProbe { ran: ran.clone() })));
+    let tools = Arc::new(ToolRegistry::new().with(Box::new(SensitiveProbe {
+        ran: ran.clone(),
+        name: "search",
+    })));
     let state = AppState::new(
         Config::desktop(dir.path()),
         store.clone(),
         Arc::new(FixedResolver(Arc::new(ProbeProvider {
             calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            tool_name: "search",
         }))),
         Arc::new(MemSecrets::default()),
         tools,
@@ -8965,6 +8973,115 @@ async fn approval_endpoint_unparks_a_sensitive_tool() {
         .await
         .unwrap();
     assert_eq!(again.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approval_endpoint_rejects_unpresentable_sensitive_tool_approval() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let ran = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let tool_name = "third_party_sensitive";
+    let tools = Arc::new(ToolRegistry::new().with(Box::new(SensitiveProbe {
+        ran: ran.clone(),
+        name: tool_name,
+    })));
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(ProbeProvider {
+            calls: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            tool_name,
+        }))),
+        Arc::new(MemSecrets::default()),
+        tools,
+        build_retrieval(
+            Arc::new(HashEmbedder::default()),
+            Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        )
+        .0,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "run it").await,
+        StatusCode::ACCEPTED
+    );
+    let call_id = {
+        let mut found = None;
+        for _ in 0..200 {
+            let events = store.list_events(chat.id, 0).await.unwrap();
+            if let Some(id) = events.iter().find_map(|event| match &event.event {
+                AgentEvent::ApprovalRequired { call_id, .. } => Some(*call_id),
+                _ => None,
+            }) {
+                found = Some(id);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        found.expect("turn should park on ApprovalRequired")
+    };
+
+    let approve = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/chats/{}/approvals/{call_id}", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"decision": "approve"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(approve.status(), StatusCode::CONFLICT);
+    let info: AgentErrorInfo = json_body(approve).await;
+    assert_eq!(info.kind, "approval_action_not_presentable");
+    assert_eq!(ran.load(std::sync::atomic::Ordering::SeqCst), 0);
+
+    let reject = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/chats/{}/approvals/{call_id}", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"decision": "reject"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(reject.status(), StatusCode::NO_CONTENT);
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert!(events.iter().any(|event| matches!(
+        event.event,
+        AgentEvent::ApprovalDecided {
+            approved: false,
+            ..
+        }
+    )));
+    assert_eq!(ran.load(std::sync::atomic::Ordering::SeqCst), 0);
 }
 
 #[tokio::test]
@@ -9113,6 +9230,46 @@ use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
+struct SensitiveEventProvider {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl ModelProvider for SensitiveEventProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("provider-secret-id")
+    }
+
+    async fn stream(&self, _request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let events = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "provider-secret-call-id".into(),
+                    name: "provider_secret_tool".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: r#"{"path":"/Users/private/file.txt","secret":"hunter2"}"#.into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ]
+        } else {
+            vec![
+                ProviderEvent::TextDelta {
+                    text: "safe assistant response".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ]
+        };
+        Ok(stream::iter(events).boxed())
+    }
+}
+
 /// Serve a router (with the given provider) over a real loopback socket.
 async fn serve_app_with(
     provider: Arc<dyn ModelProvider>,
@@ -9159,7 +9316,7 @@ async fn read_until_turns_end(
     chat: ChatId,
     after: i64,
     want: usize,
-) -> Vec<SequencedEvent> {
+) -> Vec<RendererSequencedEvent> {
     let mut request = format!("ws://{addr}/chats/{chat}/events?after={after}")
         .into_client_request()
         .unwrap();
@@ -9175,10 +9332,10 @@ async fn read_until_turns_end(
             let WsMessage::Text(text) = frame.unwrap() else {
                 continue;
             };
-            let event: SequencedEvent = serde_json::from_str(text.as_str()).unwrap();
+            let event: RendererSequencedEvent = serde_json::from_str(text.as_str()).unwrap();
             if matches!(
                 event.event,
-                AgentEvent::TurnCompleted { .. } | AgentEvent::TurnFailed { .. }
+                RendererAgentEvent::TurnCompleted | RendererAgentEvent::TurnFailed
             ) {
                 completed += 1;
             }
@@ -9200,15 +9357,118 @@ async fn read_until_turn_end(
     token: &str,
     chat: ChatId,
     after: i64,
-) -> Vec<SequencedEvent> {
+) -> Vec<RendererSequencedEvent> {
     read_until_turns_end(addr, token, chat, after, 1).await
 }
 
-fn decode_ws_event(message: WsMessage) -> SequencedEvent {
+fn decode_ws_event(message: WsMessage) -> RendererSequencedEvent {
     let WsMessage::Text(text) = message else {
         panic!("expected a JSON text event frame");
     };
     serde_json::from_str(text.as_str()).unwrap()
+}
+
+async fn read_raw_until_terminal<S>(socket: &mut S) -> Vec<serde_json::Value>
+where
+    S: futures::Stream<
+            Item = std::result::Result<WsMessage, tokio_tungstenite::tungstenite::Error>,
+        > + Unpin,
+{
+    let mut events = Vec::new();
+    let read = async {
+        while let Some(frame) = socket.next().await {
+            let WsMessage::Text(text) = frame.unwrap() else {
+                continue;
+            };
+            let event: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+            let terminal = matches!(
+                event["event"]["type"].as_str(),
+                Some("turn_completed" | "turn_failed" | "turn_cancelled")
+            );
+            events.push(event);
+            if terminal {
+                break;
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(5), read)
+        .await
+        .expect("turn did not terminate over the event socket");
+    events
+}
+
+fn assert_renderer_event_frames_are_redacted(events: &[serde_json::Value]) {
+    let serialized = serde_json::to_string(events).unwrap();
+    for forbidden in [
+        "provider-secret-id",
+        "provider-secret-call-id",
+        "provider_secret_tool",
+        "/Users/private",
+        "file.txt",
+        "hunter2",
+        "fragment",
+        "output",
+        "content",
+        "data",
+        "summary",
+        "usage",
+        "stop_reason",
+        "diagnostic",
+        "lease",
+        "checkpoint",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "event stream leaked {forbidden}"
+        );
+    }
+    assert!(events.iter().any(|event| event["event"]["name"] == "other"));
+    assert!(events.iter().any(|event| {
+        event["event"]["type"] == "tool_call_completed" && event["event"]["status"] == "failed"
+    }));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_live_and_replay_frames_use_the_renderer_safe_projection() {
+    let provider = Arc::new(SensitiveEventProvider {
+        calls: AtomicUsize::new(0),
+    });
+    let (addr, token, store, _dir) = serve_app_with(provider).await;
+    let client = reqwest::Client::new();
+    let chat = make_chat_http(&client, addr, &token).await;
+
+    let mut request = format!("ws://{addr}/chats/{}/events?after=0", chat.id)
+        .into_client_request()
+        .unwrap();
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut live_socket, _) = connect_async(request).await.unwrap();
+
+    send_message_http(&client, addr, &token, chat.id).await;
+    let live = read_raw_until_terminal(&mut live_socket).await;
+    assert_renderer_event_frames_are_redacted(&live);
+
+    wait_for_turn(&store, chat.id).await;
+    let mut replay_request = format!("ws://{addr}/chats/{}/events?after=0", chat.id)
+        .into_client_request()
+        .unwrap();
+    replay_request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {token}").parse().unwrap());
+    let (mut replay_socket, _) = connect_async(replay_request).await.unwrap();
+    let replay = read_raw_until_terminal(&mut replay_socket).await;
+    assert_renderer_event_frames_are_redacted(&replay);
+
+    let live_sequences = live
+        .iter()
+        .map(|event| event["seq"].clone())
+        .collect::<Vec<_>>();
+    let replay_sequences = replay
+        .iter()
+        .map(|event| event["seq"].clone())
+        .collect::<Vec<_>>();
+    assert_eq!(replay_sequences, live_sequences);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -9289,7 +9549,10 @@ async fn ws_replays_a_journal_gap_before_accepting_a_later_live_event() {
         recovered.iter().map(|event| event.seq).collect::<Vec<_>>(),
         vec![2, 3]
     );
-    assert_eq!(recovered[0].event, second);
+    assert_eq!(
+        recovered[0].event,
+        RendererAgentEvent::TextDelta { text: "two".into() }
+    );
     assert!(
         tokio::time::timeout(Duration::from_millis(100), socket.next())
             .await
@@ -9310,13 +9573,16 @@ async fn ws_replays_a_finished_turn_from_the_journal() {
 
     let events = read_until_turn_end(addr, &token, chat.id, 0).await;
     assert_eq!(events.first().unwrap().seq, 1, "replay starts at seq 1");
-    assert!(matches!(events[0].event, AgentEvent::TurnStarted { .. }));
+    assert!(matches!(
+        events[0].event,
+        RendererAgentEvent::TurnStarted { .. }
+    ));
     assert!(events
         .iter()
-        .any(|e| matches!(&e.event, AgentEvent::TextDelta { text } if text == "hi")));
+        .any(|e| matches!(&e.event, RendererAgentEvent::TextDelta { text } if text == "hi")));
     assert!(matches!(
         events.last().unwrap().event,
-        AgentEvent::TurnCompleted { .. }
+        RendererAgentEvent::TurnCompleted
     ));
     // Sequence numbers are strictly increasing.
     assert!(events.windows(2).all(|w| w[0].seq < w[1].seq));
@@ -9336,10 +9602,13 @@ async fn ws_streams_a_turn_started_after_connecting() {
     send_message_http(&client, addr, &token, chat.id).await;
 
     let events = reader.await.unwrap();
-    assert!(matches!(events[0].event, AgentEvent::TurnStarted { .. }));
+    assert!(matches!(
+        events[0].event,
+        RendererAgentEvent::TurnStarted { .. }
+    ));
     assert!(matches!(
         events.last().unwrap().event,
-        AgentEvent::TurnCompleted { .. }
+        RendererAgentEvent::TurnCompleted
     ));
 }
 
@@ -9380,13 +9649,16 @@ async fn ws_replays_one_turn_then_streams_the_next_live() {
     send_message_http(&client, addr, &token, chat.id).await;
 
     let events = reader.await.unwrap();
-    assert!(matches!(events[0].event, AgentEvent::TurnStarted { .. }));
+    assert!(matches!(
+        events[0].event,
+        RendererAgentEvent::TurnStarted { .. }
+    ));
     assert_eq!(events[0].seq, 1);
     assert!(events.windows(2).all(|w| w[0].seq < w[1].seq));
     assert_eq!(
         events
             .iter()
-            .filter(|e| matches!(e.event, AgentEvent::TurnCompleted { .. }))
+            .filter(|e| matches!(e.event, RendererAgentEvent::TurnCompleted))
             .count(),
         2,
         "both turns completed over one connection"
@@ -9456,8 +9728,8 @@ async fn ws_subprotocol_auth_succeeds() {
             let WsMessage::Text(text) = frame.unwrap() else {
                 continue;
             };
-            let event: SequencedEvent = serde_json::from_str(text.as_str()).unwrap();
-            if matches!(event.event, AgentEvent::TurnCompleted { .. }) {
+            let event: RendererSequencedEvent = serde_json::from_str(text.as_str()).unwrap();
+            if matches!(event.event, RendererAgentEvent::TurnCompleted) {
                 saw_completed = true;
                 break;
             }


### PR DESCRIPTION
## Summary
- project internal journal events into a closed renderer-safe WebSocket contract
- preserve sequence replay and tool lifecycle while redacting reasoning, arguments, outputs, approval text, provider diagnostics, and unknown tool names
- update the desktop to consume fixed approval, tool status, failure, and steer reconciliation fields
- cover both live and replay JSON frames with redaction sentinels

## Validation
- `cargo test -p openwave-server --locked -q -- --test-threads=1`
- `bw dev lint --rust --check`
- `cargo fmt --all --check`
- `pnpm test`
- `pnpm build`