### PR TITLE
Protect pending client execution details

### DIFF
--- a/crates/openwave-desktop/src/client_execution/control_plane.rs
+++ b/crates/openwave-desktop/src/client_execution/control_plane.rs
@@ -124,7 +124,7 @@ impl ControlPlaneClient {
         &self,
         chat_id: ChatId,
     ) -> Result<Vec<ToolCallRecord>, ControlPlaneError> {
-        self.get(&format!("/chats/{chat_id}/client-executions/pending"))
+        self.get(&format!("/chats/{chat_id}/client-executions/pending/raw"))
             .await
     }
 
@@ -220,6 +220,7 @@ impl ControlPlaneClient {
                 .http
                 .get(format!("{}{path}", self.base_url))
                 .bearer_auth(&self.token)
+                .header(CLIENT_EXECUTOR_HEADER, self.executor_token.clone())
                 .send()
                 .await
             {

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { parseFolderAccessRequest } from "./api";
+
+describe("parseFolderAccessRequest", () => {
+  it("accepts only the closed renderer-safe consent projection", () => {
+    expect(
+      parseFolderAccessRequest({
+        call_id: "call-1",
+        turn_id: "turn-1",
+        reason:
+          "The assistant needs read access to files outside the folders connected to this conversation.",
+        folder_hint: "documents",
+        claimed: true,
+      }),
+    ).toEqual({
+      callId: "call-1",
+      turnId: "turn-1",
+      reason:
+        "The assistant needs read access to files outside the folders connected to this conversation.",
+      folderHint: "documents",
+      claimedByDesktop: true,
+    });
+
+    expect(
+      parseFolderAccessRequest({
+        call_id: "call-2",
+        turn_id: "turn-2",
+        reason:
+          "The assistant needs read access to files outside the folders connected to this conversation.",
+        folder_hint: null,
+        claimed: false,
+      }),
+    ).toEqual({
+      callId: "call-2",
+      turnId: "turn-2",
+      reason:
+        "The assistant needs read access to files outside the folders connected to this conversation.",
+      folderHint: null,
+      claimedByDesktop: false,
+    });
+  });
+
+  it("rejects canonical tool records and extended projections", () => {
+    expect(
+      parseFolderAccessRequest({
+        call_id: "call-1",
+        turn_id: "turn-1",
+        reason:
+          "The assistant needs read access to files outside the folders connected to this conversation.",
+        folder_hint: null,
+        claimed: false,
+        arguments: { path: "/Users/private" },
+      }),
+    ).toBeNull();
+
+    expect(
+      parseFolderAccessRequest({
+        id: "call-1",
+        chat_id: "chat-1",
+        turn_id: "turn-1",
+        name: "request_folder_access",
+        arguments: { reason: "Read files" },
+        provider_id: "provider-secret",
+        client_executor_id: "executor-secret",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects malformed user-facing fields", () => {
+    expect(
+      parseFolderAccessRequest({
+        call_id: "call-1",
+        turn_id: "turn-1",
+        reason: "Model-controlled secret prose",
+        folder_hint: null,
+        claimed: false,
+      }),
+    ).toBeNull();
+
+    expect(
+      parseFolderAccessRequest({
+        call_id: "call-1",
+        turn_id: "turn-1",
+        reason: " ",
+        folder_hint: "desktop",
+        claimed: "yes",
+      }),
+    ).toBeNull();
+  });
+});

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -152,6 +152,9 @@ export type PendingFolderAccessRequest = {
   claimedByDesktop: boolean;
 };
 
+const RENDERER_FOLDER_ACCESS_REASON =
+  "The assistant needs read access to files outside the folders connected to this conversation.";
+
 const WS_HANDSHAKE = "openwave-v1";
 const WS_TOKEN_PREFIX = "openwave-token.";
 
@@ -358,7 +361,7 @@ export class ApiClient {
 
     const requests = new Map<string, PendingFolderAccessRequest>();
     for (const item of body) {
-      const request = parseFolderAccessRequest(item, chatId);
+      const request = parseFolderAccessRequest(item);
       if (request && !requests.has(request.callId)) {
         requests.set(request.callId, request);
       }
@@ -382,50 +385,33 @@ export class ApiClient {
   }
 }
 
-function parseFolderAccessRequest(
+export function parseFolderAccessRequest(
   value: unknown,
-  chatId: string,
 ): PendingFolderAccessRequest | null {
   if (!isRecord(value)) return null;
-  if (
-    typeof value.id !== "string" ||
-    value.id.length === 0 ||
-    typeof value.turn_id !== "string" ||
-    value.turn_id.length === 0 ||
-    value.chat_id !== chatId ||
-    value.name !== "request_folder_access" ||
-    value.execution !== "client" ||
-    value.status !== "pending" ||
-    !(value.client_executor_id === null ||
-      typeof value.client_executor_id === "string")
-  ) {
-    return null;
-  }
-
-  const args = value.arguments;
-  if (!isRecord(args)) return null;
-  const keys = Object.keys(args);
+  const keys = Object.keys(value);
   if (
     keys.some(
       (key) =>
+        key !== "call_id" &&
+        key !== "turn_id" &&
         key !== "reason" &&
-        key !== "requested_capabilities" &&
-        key !== "folder_hint",
+        key !== "folder_hint" &&
+        key !== "claimed",
     ) ||
-    typeof args.reason !== "string" ||
-    args.reason.trim().length === 0 ||
-    [...args.reason].length > 500 ||
-    args.reason.includes("\0") ||
-    !Array.isArray(args.requested_capabilities) ||
-    args.requested_capabilities.length !== 1 ||
-    args.requested_capabilities[0] !== "read_files"
+    typeof value.call_id !== "string" ||
+    value.call_id.length === 0 ||
+    typeof value.turn_id !== "string" ||
+    value.turn_id.length === 0 ||
+    typeof value.reason !== "string" ||
+    value.reason !== RENDERER_FOLDER_ACCESS_REASON ||
+    typeof value.claimed !== "boolean"
   ) {
     return null;
   }
-
-  const folderHint = args.folder_hint;
+  const folderHint = value.folder_hint;
   if (
-    folderHint !== undefined &&
+    folderHint !== null &&
     folderHint !== "documents" &&
     folderHint !== "downloads"
   ) {
@@ -433,11 +419,11 @@ function parseFolderAccessRequest(
   }
 
   return {
-    callId: value.id,
+    callId: value.call_id,
     turnId: value.turn_id,
-    reason: args.reason,
-    folderHint: folderHint ?? null,
-    claimedByDesktop: value.client_executor_id !== null,
+    reason: value.reason,
+    folderHint,
+    claimedByDesktop: value.claimed,
   };
 }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -72,6 +72,10 @@ pub fn app(state: AppState) -> Router {
     // unknown path still answers `404` (not `401`), and `/healthz` stays open.
     let client_executor_api = Router::new()
         .route(
+            "/chats/{id}/client-executions/pending/raw",
+            get(routes::list_pending_client_executions_raw),
+        )
+        .route(
             "/chats/{id}/client-executions/{call_id}/claim",
             post(routes::claim_client_execution),
         )
@@ -192,7 +196,7 @@ pub fn app(state: AppState) -> Router {
         .route("/chats/{id}/steer", post(routes::post_steer))
         .route(
             "/chats/{id}/client-executions/pending",
-            get(routes::list_pending_client_executions),
+            get(routes::list_pending_folder_access_requests),
         )
         .route(
             "/chats/{id}/approvals/{call_id}",

--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -3,8 +3,9 @@
 //! Polling is authoritative; event streams are only a latency hint. A client
 //! generates a fresh secret lease token before claiming, then retains it across
 //! ambiguous HTTP responses and presents it for every heartbeat or resolution.
-//! Claim, heartbeat, and resolve also require the server's native-only executor
-//! credential; pending polling uses ordinary API authentication.
+//! Raw polling, claim, heartbeat, and resolve require the server's native-only
+//! executor credential. The renderer-facing pending route returns a closed,
+//! presentation-only projection of folder-access requests.
 
 use axum::extract::State;
 use serde::{Deserialize, Serialize};
@@ -12,7 +13,9 @@ use serde::{Deserialize, Serialize};
 use chrono::{Duration, Utc};
 use openwave_core::{
     CallId, ChatId, ClaimClientToolCallOutcome, HeartbeatClientToolCallOutcome,
-    ResolveToolCallOutcome, ToolCallRecord, ToolCallResolution, TurnRunStatus,
+    RequestFolderAccessArgs, RequestedFolderHint, ResolveToolCallOutcome, ToolCallExecution,
+    ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnId, TurnRunStatus,
+    REQUEST_FOLDER_ACCESS_TOOL,
 };
 
 use crate::error::ServerError;
@@ -20,6 +23,8 @@ use crate::extract::{Json, Path};
 use crate::state::AppState;
 
 const CLIENT_EXECUTION_LEASE: Duration = Duration::seconds(60);
+const RENDERER_FOLDER_ACCESS_REASON: &str =
+    "The assistant needs read access to files outside the folders connected to this conversation.";
 
 /// Caller-owned claim identity. The lease token is a secret capability and
 /// must be generated freshly for a new claim attempt.
@@ -121,16 +126,65 @@ pub struct ResolvedClientExecution {
     pub disposition: ResolutionDisposition,
 }
 
-/// `GET /chats/{id}/client-executions/pending` — authoritative pending work.
+/// One folder-access request that is safe for an untrusted renderer to present.
 ///
-/// Includes visible executor and expiry metadata for recovery, but never the
-/// secret lease token. Unknown chats return `404` rather than an empty list.
-pub async fn list_pending_client_executions(
+/// This intentionally omits the canonical tool name and arguments, chat and
+/// executor identities, provider metadata, lifecycle details, and diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PendingFolderAccessRequest {
+    pub call_id: CallId,
+    pub turn_id: TurnId,
+    pub reason: String,
+    pub folder_hint: Option<RequestedFolderHint>,
+    pub claimed: bool,
+}
+
+/// `GET /chats/{id}/client-executions/pending` — renderer-safe consent prompts.
+///
+/// Unknown, malformed, or non-folder-access client calls are omitted rather
+/// than exposing their canonical records across the renderer boundary.
+pub async fn list_pending_folder_access_requests(
+    State(state): State<AppState>,
+    Path(id): Path<ChatId>,
+) -> Result<Json<Vec<PendingFolderAccessRequest>>, ServerError> {
+    ensure_chat(&state, id).await?;
+    let requests = state
+        .store
+        .list_pending_client_tool_calls(id)
+        .await?
+        .into_iter()
+        .filter_map(renderer_folder_access_request)
+        .collect();
+    Ok(Json(requests))
+}
+
+/// Native-only authoritative pending work used by the trusted executor.
+pub async fn list_pending_client_executions_raw(
     State(state): State<AppState>,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<ToolCallRecord>>, ServerError> {
     ensure_chat(&state, id).await?;
     Ok(Json(state.store.list_pending_client_tool_calls(id).await?))
+}
+
+fn renderer_folder_access_request(call: ToolCallRecord) -> Option<PendingFolderAccessRequest> {
+    if call.name != REQUEST_FOLDER_ACCESS_TOOL
+        || call.execution != ToolCallExecution::Client
+        || call.status != ToolCallStatus::Pending
+    {
+        return None;
+    }
+    let arguments: RequestFolderAccessArgs = serde_json::from_value(call.arguments).ok()?;
+    if !arguments.is_well_formed() {
+        return None;
+    }
+    Some(PendingFolderAccessRequest {
+        call_id: call.id,
+        turn_id: call.turn_id,
+        reason: RENDERER_FOLDER_ACCESS_REASON.to_owned(),
+        folder_hint: arguments.folder_hint,
+        claimed: call.client_executor_id.is_some(),
+    })
 }
 
 /// `POST .../{call_id}/claim` — atomically acquire or recover one exact claim.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -2769,8 +2769,12 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         .clone()
         .oneshot(
             Request::builder()
-                .uri(format!("/chats/{}/client-executions/pending", chat.id))
+                .uri(format!("/chats/{}/client-executions/pending/raw", chat.id))
                 .header(header::AUTHORIZATION, &bearer)
+                .header(
+                    crate::auth::CLIENT_EXECUTOR_HEADER,
+                    crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
+                )
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -2927,6 +2931,193 @@ async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently(
         .await
         .unwrap()
         .is_empty());
+}
+
+#[tokio::test]
+async fn renderer_pending_client_executions_are_a_closed_folder_consent_projection() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let request = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "provider-secret".into(),
+        name: openwave_core::REQUEST_FOLDER_ACCESS_TOOL.into(),
+        arguments: serde_json::json!({
+            "reason": "Read the project notes",
+            "requested_capabilities": ["read_files"],
+            "folder_hint": "documents",
+        }),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: chrono::Utc::now(),
+        resolved_at: None,
+    };
+    let request = match store.accept_tool_call(&request).await.unwrap() {
+        openwave_core::AcceptToolCallOutcome::Accepted(call)
+        | openwave_core::AcceptToolCallOutcome::Existing(call) => call,
+        openwave_core::AcceptToolCallOutcome::IdentityConflict => panic!("fresh call conflicted"),
+    };
+    let unrelated = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "other-provider-secret".into(),
+        name: "connect_folder".into(),
+        arguments: serde_json::json!({"host_path": "/Users/private"}),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: chrono::Utc::now(),
+        resolved_at: None,
+    };
+    store.accept_tool_call(&unrelated).await.unwrap();
+    let malformed = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "malformed-provider-secret".into(),
+        name: openwave_core::REQUEST_FOLDER_ACCESS_TOOL.into(),
+        arguments: serde_json::json!({
+            "reason": "Read /Users/private",
+            "requested_capabilities": ["read_files"],
+        }),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: chrono::Utc::now(),
+        resolved_at: None,
+    };
+    store.accept_tool_call(&malformed).await.unwrap();
+    let dangerous_reasons = [
+        "Read `/Users/private/report.pdf` sentinel-backtick",
+        "Read [/Users/private/report.pdf] sentinel-markdown",
+        "Read file:///Users/private/report.pdf sentinel-file-uri",
+        r"Read `\\server\share\secret.txt` sentinel-unc",
+        r"Read `C:\Users\private\secret.txt` sentinel-drive",
+        "ordinary-secret-prose",
+    ];
+    for reason in dangerous_reasons {
+        let dangerous = ToolCallRecord {
+            id: CallId::new(),
+            chat_id: chat.id,
+            turn_id: TurnId::new(),
+            provider_id: "dangerous-provider-secret".into(),
+            name: openwave_core::REQUEST_FOLDER_ACCESS_TOOL.into(),
+            arguments: serde_json::json!({
+                "reason": reason,
+                "requested_capabilities": ["read_files"],
+            }),
+            execution: ToolCallExecution::Client,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: chrono::Utc::now(),
+            resolved_at: None,
+        };
+        store.accept_tool_call(&dangerous).await.unwrap();
+    }
+
+    let renderer = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/client-executions/pending", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(renderer.status(), StatusCode::OK);
+    let renderer: serde_json::Value = json_body(renderer).await;
+    let renderer_requests = renderer.as_array().unwrap();
+    assert_eq!(renderer_requests.len(), dangerous_reasons.len() + 1);
+    assert!(renderer_requests.iter().any(|value| {
+        value["call_id"] == request.id.to_string()
+            && value["turn_id"] == request.turn_id.to_string()
+            && value["folder_hint"] == "documents"
+            && value["claimed"] == false
+    }));
+    assert!(renderer_requests.iter().all(|value| {
+        value["reason"]
+            == "The assistant needs read access to files outside the folders connected to this conversation."
+    }));
+    let serialized = renderer.to_string();
+    for forbidden in [
+        "provider-secret",
+        "other-provider-secret",
+        "malformed-provider-secret",
+        "dangerous-provider-secret",
+        "request_folder_access",
+        "connect_folder",
+        "arguments",
+        "chat_id",
+        "provider_id",
+        "client_executor_id",
+        "status",
+        "execution",
+        "/Users/private",
+        "sentinel-backtick",
+        "sentinel-markdown",
+        "sentinel-file-uri",
+        "sentinel-unc",
+        "sentinel-drive",
+        "ordinary-secret-prose",
+    ] {
+        assert!(!serialized.contains(forbidden), "leaked {forbidden}");
+    }
+
+    let raw_uri = format!("/chats/{}/client-executions/pending/raw", chat.id);
+    let renderer_raw = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(&raw_uri)
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(renderer_raw.status(), StatusCode::UNAUTHORIZED);
+
+    let native_raw = router
+        .oneshot(
+            Request::builder()
+                .uri(raw_uri)
+                .header(header::AUTHORIZATION, &bearer)
+                .header(
+                    crate::auth::CLIENT_EXECUTOR_HEADER,
+                    crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(native_raw.status(), StatusCode::OK);
+    let native: Vec<ToolCallRecord> = json_body(native_raw).await;
+    assert_eq!(native.len(), dangerous_reasons.len() + 3);
+    assert!(native.iter().any(|call| call == &request));
+    assert!(native.iter().any(|call| call.name == "connect_folder"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- move authoritative client-execution polling behind the native executor credential
- expose only validated folder-consent fields to the renderer
- reject extended or canonical tool records at the desktop UI boundary

## Validation
- `cargo fmt --all -- --check`
- `bw dev lint --rust --check`
- `cargo test -p openwave-server --locked`
- `cargo test -p openwave-desktop client_execution::control_plane::tests --locked`
- `pnpm test`
- `pnpm build`