### PR TITLE
Synchronize approved folder attachments

### DIFF
--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -23,6 +23,7 @@ tauri-build = { version = "2", features = [] }
 serde_json = { workspace = true }
 
 [dependencies]
+chrono = { workspace = true }
 openwave-core = { path = "../openwave-core", default-features = false }
 openwave-host-broker = { path = "../openwave-host-broker" }
 openwave-server = { path = "../openwave-server" }

--- a/crates/openwave-desktop/src/client_execution.rs
+++ b/crates/openwave-desktop/src/client_execution.rs
@@ -13,8 +13,8 @@ use openwave_core::{
     ToolCallRecord, ToolCallStatus, REQUEST_FOLDER_ACCESS_TOOL,
 };
 use openwave_host_broker::{
-    ConsentMethod, ControlRequest, ControlResult, LookupRegisterRootReceiptRequest, OperationId,
-    RegisterRootReceipt, RegisterRootRequest,
+    ConsentMethod, ControlRequest, ControlResult, LookupRegisterRootReceiptRequest,
+    RegisterRootReceipt, RegisterRootRequest, RootSummary,
 };
 use serde::Deserialize;
 use tauri::{AppHandle, Manager, State};
@@ -24,6 +24,7 @@ use crate::host_access::{pick_folder, AuthoritativeContext, HostAccess};
 
 mod control_plane;
 pub(crate) mod folder_operations;
+mod product_sync;
 mod receipt_store;
 
 pub(crate) use control_plane::ControlPlaneClient;
@@ -193,27 +194,7 @@ async fn execute_receipt(
     let resolution = match receipt.intent.clone() {
         FolderAccessIntent::Decline => declined_resolution()?,
         FolderAccessIntent::Selected { path } => {
-            if should_start_registration(mode, receipt.registration_phase) {
-                match client
-                    .heartbeat(receipt.chat_id, receipt.call_id, receipt.lease_token)
-                    .await
-                {
-                    Ok(()) => {
-                        let dispatch_deadline =
-                            tokio::time::Instant::now() + crate::broker::MUTATION_DISPATCH_WINDOW;
-                        receipt.registration_phase = RegistrationPhase::Attempted;
-                        state
-                            .receipts
-                            .save(&receipt)
-                            .map_err(private_receipt_error)?;
-                        register_selected_folder(state, &receipt, context, path, dispatch_deadline)
-                            .await?
-                    }
-                    Err(_) => recover_broker_outcome(state, &receipt, context).await?,
-                }
-            } else {
-                recover_broker_outcome(state, &receipt, context).await?
-            }
+            drive_selected_folder(state, &mut receipt, context, path, mode).await?
         }
     };
     receipt.resolution = Some(resolution.clone());
@@ -222,10 +203,6 @@ async fn execute_receipt(
         .save(&receipt)
         .map_err(private_receipt_error)?;
     publish_resolution(state, &receipt, &resolution).await
-}
-
-fn should_start_registration(mode: ExecutionMode, phase: RegistrationPhase) -> bool {
-    mode == ExecutionMode::Interactive && phase == RegistrationPhase::NotStarted
 }
 
 async fn recover_after_claim_conflict(
@@ -257,10 +234,11 @@ async fn recover_after_claim_conflict(
         return Err("folder-access request is owned by another desktop".to_owned());
     }
 
-    let resolution = match receipt.intent {
+    let resolution = match receipt.intent.clone() {
         FolderAccessIntent::Decline => declined_resolution()?,
-        FolderAccessIntent::Selected { .. } => {
-            recover_broker_outcome(state, &receipt, context).await?
+        FolderAccessIntent::Selected { path } => {
+            drive_selected_folder(state, &mut receipt, context, path, ExecutionMode::Recovery)
+                .await?
         }
     };
     receipt.resolution = Some(resolution.clone());
@@ -271,15 +249,91 @@ async fn recover_after_claim_conflict(
     publish_resolution(state, &receipt, &resolution).await
 }
 
-async fn register_selected_folder(
+enum RegistrationOutcome {
+    Unknown,
+    Registered(RootSummary),
+    Terminal(StoredResolution),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegistrationAction {
+    ResumeProduct,
+    Dispatch,
+    LookupOnly,
+}
+
+async fn drive_selected_folder(
+    state: &HostAccess,
+    receipt: &mut FolderAccessReceipt,
+    context: AuthoritativeContext,
+    path: PathBuf,
+    mode: ExecutionMode,
+) -> Result<StoredResolution, String> {
+    let action = registration_action(
+        mode,
+        receipt.registration_phase,
+        receipt.product_sync.is_some(),
+    );
+    if action == RegistrationAction::ResumeProduct {
+        return product_sync::resume_product_attachment(state, receipt, context).await;
+    }
+
+    let mut outcome = if action == RegistrationAction::LookupOnly {
+        recover_registration_outcome(state, receipt, context).await?
+    } else {
+        RegistrationOutcome::Unknown
+    };
+
+    if action == RegistrationAction::Dispatch {
+        let client = control_plane(state)?;
+        client
+            .heartbeat(receipt.chat_id, receipt.call_id, receipt.lease_token)
+            .await
+            .map_err(control_plane_error)?;
+        receipt.registration_phase = RegistrationPhase::Attempted;
+        state
+            .receipts
+            .save(receipt)
+            .map_err(private_receipt_error)?;
+        let dispatch_deadline =
+            tokio::time::Instant::now() + crate::broker::MUTATION_DISPATCH_WINDOW;
+        dispatch_registration(state, receipt, context, path, dispatch_deadline).await?;
+        outcome = recover_registration_outcome(state, receipt, context).await?;
+    }
+
+    match outcome {
+        RegistrationOutcome::Registered(root) => {
+            product_sync::synchronize_product_attachment(state, receipt, context, root).await
+        }
+        RegistrationOutcome::Terminal(resolution) => Ok(resolution),
+        RegistrationOutcome::Unknown => Err(
+            "folder registration has no durable broker outcome yet; recovery will retry".to_owned(),
+        ),
+    }
+}
+
+fn registration_action(
+    mode: ExecutionMode,
+    phase: RegistrationPhase,
+    has_product_sync: bool,
+) -> RegistrationAction {
+    if has_product_sync {
+        RegistrationAction::ResumeProduct
+    } else if mode == ExecutionMode::Interactive && phase == RegistrationPhase::NotStarted {
+        RegistrationAction::Dispatch
+    } else {
+        RegistrationAction::LookupOnly
+    }
+}
+
+async fn dispatch_registration(
     state: &HostAccess,
     receipt: &FolderAccessReceipt,
     context: AuthoritativeContext,
     path: PathBuf,
     dispatch_deadline: tokio::time::Instant,
-) -> Result<StoredResolution, String> {
-    let operation_id = OperationId::from_uuid(receipt.call_id.0)
-        .map_err(|_| "invalid folder-access operation identity".to_owned())?;
+) -> Result<(), String> {
+    let operation_id = receipt.registration_operation_id;
     let first = state
         .broker
         .control_without_retry(
@@ -300,16 +354,15 @@ async fn register_selected_folder(
         }
         Ok(_) => return Err("host broker returned an unexpected response".to_owned()),
     }
-    recover_broker_outcome(state, receipt, context).await
+    Ok(())
 }
 
-async fn recover_broker_outcome(
+async fn recover_registration_outcome(
     state: &HostAccess,
     receipt: &FolderAccessReceipt,
     context: AuthoritativeContext,
-) -> Result<StoredResolution, String> {
-    let operation_id = OperationId::from_uuid(receipt.call_id.0)
-        .map_err(|_| "invalid folder-access operation identity".to_owned())?;
+) -> Result<RegistrationOutcome, String> {
+    let operation_id = receipt.registration_operation_id;
     let result = state
         .broker
         .control(ControlRequest::LookupRegisterRootReceipt(
@@ -327,28 +380,42 @@ async fn recover_broker_outcome(
     if result.operation_id != operation_id {
         return Err("host broker returned a mismatched recovery receipt".to_owned());
     }
-    match result.receipt {
-        RegisterRootReceipt::Completed { root } => connected_resolution(root),
-        RegisterRootReceipt::Disconnected { .. } => Ok(failed_resolution(
-            "folder_access_disconnected",
-            "The selected folder is no longer connected.",
-            None,
-        )),
-        RegisterRootReceipt::Failed { error } => Ok(failed_resolution(
-            "folder_access_registration_failed",
-            "The selected folder could not be connected.",
-            Some(error.message),
-        )),
-        RegisterRootReceipt::Unknown | RegisterRootReceipt::Pending => Ok(failed_resolution(
+    registration_receipt_outcome(result.receipt)
+}
+
+fn registration_receipt_outcome(
+    receipt: RegisterRootReceipt,
+) -> Result<RegistrationOutcome, String> {
+    match receipt {
+        RegisterRootReceipt::Completed { root } => Ok(RegistrationOutcome::Registered(root)),
+        RegisterRootReceipt::Disconnected { .. } => {
+            Ok(RegistrationOutcome::Terminal(failed_resolution(
+                "folder_access_disconnected",
+                "The selected folder is no longer connected.",
+                None,
+            )))
+        }
+        RegisterRootReceipt::Failed { error } => {
+            Ok(RegistrationOutcome::Terminal(failed_resolution(
+                "folder_access_registration_failed",
+                "The selected folder could not be connected.",
+                Some(error.message),
+            )))
+        }
+        RegisterRootReceipt::Unknown => Ok(RegistrationOutcome::Terminal(failed_resolution(
             "folder_access_outcome_unknown",
             "Folder access was not granted because the native outcome could not be confirmed.",
             None,
-        )),
-        _ => Ok(failed_resolution(
+        ))),
+        RegisterRootReceipt::Pending => Err(
+            "folder registration is still pending in the host broker; recovery will retry"
+                .to_owned(),
+        ),
+        _ => Ok(RegistrationOutcome::Terminal(failed_resolution(
             "folder_access_receipt_unsupported",
             "Folder access was not granted because the native receipt was not understood.",
             None,
-        )),
+        ))),
     }
 }
 
@@ -476,6 +543,13 @@ fn private_receipt_error(_error: std::io::Error) -> String {
 
 #[cfg(test)]
 mod tests {
+    use openwave_core::{
+        HostRootId, RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentChangePhase,
+        RootAttachmentSubjectKind,
+    };
+
+    use super::product_sync::{attachment_operation_id, validate_product_change};
+    use super::receipt_store::{AttachmentPhase, CleanupPhase, ProductRootAttachmentSync};
     use super::*;
 
     #[test]
@@ -552,22 +626,111 @@ mod tests {
     }
 
     #[test]
-    fn recovery_never_starts_or_replays_registration() {
-        assert!(should_start_registration(
-            ExecutionMode::Interactive,
-            RegistrationPhase::NotStarted
+    fn product_attachment_validation_fences_identity_authority_and_broker_state() {
+        let chat_id = ChatId::new();
+        let call_id = CallId::new();
+        let mut receipt = FolderAccessReceipt::new(
+            chat_id,
+            call_id,
+            Uuid::new_v4(),
+            FolderAccessIntent::Selected {
+                path: PathBuf::from("/tmp/Documents"),
+            },
+        );
+        receipt.registration_phase = RegistrationPhase::Attempted;
+        let sync = ProductRootAttachmentSync {
+            change_id: RootAttachmentChangeId::new(),
+            root_id: HostRootId::from_uuid(Uuid::new_v4()).unwrap(),
+            display_name: "Documents".to_owned(),
+            expected_attachment_revision: 4,
+            created_at: chrono::Utc::now(),
+            cleanup_operation_id: openwave_host_broker::OperationId::new(),
+            cleanup_phase: CleanupPhase::NotStarted,
+            attachment_phase: AttachmentPhase::DispatchAttempted,
+        };
+        receipt.product_sync = Some(sync.clone());
+        let context = AuthoritativeContext {
+            chat_id: chat_id.0,
+            execution: openwave_host_broker::ExecutionContext::standalone(chat_id.0).unwrap(),
+            subject: openwave_host_broker::GrantSubject::conversation(chat_id.0).unwrap(),
+        };
+        let mut change = control_plane::RootAttachmentChangeView {
+            id: sync.change_id,
+            chat_id,
+            root_id: sync.root_id,
+            action: RootAttachmentChangeAction::Attach,
+            subject_kind: RootAttachmentSubjectKind::Conversation,
+            subject_id: chat_id.0,
+            expected_revision: 4,
+            before_revision: 4,
+            intent_revision: 5,
+            phase: RootAttachmentChangePhase::Completed,
+            result_revision: Some(5),
+            broker_currently_attached: Some(true),
+            failure: None,
+        };
+        assert!(validate_product_change(&change, &receipt, &sync, context).is_ok());
+
+        change.subject_id = Uuid::new_v4();
+        assert!(validate_product_change(&change, &receipt, &sync, context).is_err());
+        change.subject_id = chat_id.0;
+        change.broker_currently_attached = Some(false);
+        assert!(validate_product_change(&change, &receipt, &sync, context).is_err());
+    }
+
+    #[test]
+    fn attempted_registration_is_lookup_only_and_attachment_reuses_exact_identity() {
+        assert_eq!(
+            registration_action(
+                ExecutionMode::Interactive,
+                RegistrationPhase::NotStarted,
+                false,
+            ),
+            RegistrationAction::Dispatch
+        );
+        assert_eq!(
+            registration_action(
+                ExecutionMode::Interactive,
+                RegistrationPhase::Attempted,
+                false,
+            ),
+            RegistrationAction::LookupOnly
+        );
+        assert_eq!(
+            registration_action(
+                ExecutionMode::Recovery,
+                RegistrationPhase::NotStarted,
+                false,
+            ),
+            RegistrationAction::LookupOnly
+        );
+        assert_eq!(
+            registration_action(ExecutionMode::Recovery, RegistrationPhase::Attempted, false,),
+            RegistrationAction::LookupOnly
+        );
+        assert_eq!(
+            registration_action(ExecutionMode::Recovery, RegistrationPhase::Attempted, true,),
+            RegistrationAction::ResumeProduct
+        );
+        assert!(matches!(
+            registration_receipt_outcome(RegisterRootReceipt::Unknown).unwrap(),
+            RegistrationOutcome::Terminal(StoredResolution::Failed { error_code, .. })
+                if error_code == "folder_access_outcome_unknown"
         ));
-        assert!(!should_start_registration(
-            ExecutionMode::Interactive,
-            RegistrationPhase::Attempted
-        ));
-        assert!(!should_start_registration(
-            ExecutionMode::Recovery,
-            RegistrationPhase::NotStarted
-        ));
-        assert!(!should_start_registration(
-            ExecutionMode::Recovery,
-            RegistrationPhase::Attempted
-        ));
+
+        let sync = ProductRootAttachmentSync {
+            change_id: RootAttachmentChangeId::new(),
+            root_id: HostRootId::from_uuid(Uuid::new_v4()).unwrap(),
+            display_name: "Documents".to_owned(),
+            expected_attachment_revision: 0,
+            created_at: chrono::Utc::now(),
+            cleanup_operation_id: openwave_host_broker::OperationId::new(),
+            cleanup_phase: CleanupPhase::NotStarted,
+            attachment_phase: AttachmentPhase::DispatchAttempted,
+        };
+        let first = attachment_operation_id(&sync).unwrap();
+        let recovered = attachment_operation_id(&sync).unwrap();
+        assert_eq!(first, recovered);
+        assert_eq!(first.as_uuid(), *sync.change_id.as_uuid());
     }
 }

--- a/crates/openwave-desktop/src/client_execution/control_plane.rs
+++ b/crates/openwave-desktop/src/client_execution/control_plane.rs
@@ -1,6 +1,11 @@
 //! Authenticated loopback client for the durable client-execution API.
 
-use openwave_core::{CallId, ChatId, ToolCallRecord};
+use chrono::{DateTime, Utc};
+use openwave_core::{
+    CallId, ChatId, HostRootId, RootAttachmentChangeAction, RootAttachmentChangeFailure,
+    RootAttachmentChangeId, RootAttachmentChangePhase, RootAttachmentChangeTerminal,
+    RootAttachmentSubjectKind, ToolCallRecord,
+};
 use reqwest::StatusCode;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
@@ -23,8 +28,12 @@ pub(crate) struct ControlPlaneClient {
 pub(crate) enum ControlPlaneError {
     #[error("local control plane request failed")]
     Transport,
-    #[error("local control plane rejected the request ({status}): {message}")]
-    Http { status: u16, message: String },
+    #[error("local control plane rejected the request ({status}, {kind}): {message}")]
+    Http {
+        status: u16,
+        kind: String,
+        message: String,
+    },
     #[error("local control plane returned an invalid response")]
     Protocol,
 }
@@ -32,6 +41,10 @@ pub(crate) enum ControlPlaneError {
 impl ControlPlaneError {
     pub(super) fn is_conflict(&self) -> bool {
         matches!(self, Self::Http { status, .. } if *status == StatusCode::CONFLICT.as_u16())
+    }
+
+    pub(super) fn is_kind(&self, expected: &str) -> bool {
+        matches!(self, Self::Http { kind, .. } if kind == expected)
     }
 }
 
@@ -56,6 +69,43 @@ struct HeartbeatRequest {
 struct ResolveRequest<'a> {
     lease_token: Uuid,
     resolution: &'a StoredResolution,
+}
+
+#[derive(Serialize)]
+struct BeginRootAttachmentRequest {
+    root_id: HostRootId,
+    action: RootAttachmentChangeAction,
+    expected_attachment_revision: i64,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Serialize)]
+struct FinishRootAttachmentRequest<'a> {
+    terminal: &'a RootAttachmentChangeTerminal,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct RootAttachmentChangeResponse {
+    pub(super) change: RootAttachmentChangeView,
+}
+
+/// Closed native view of the fields needed to fence exact product/broker
+/// reconciliation. Server-only executor metadata is intentionally absent.
+#[derive(Debug, Deserialize)]
+pub(super) struct RootAttachmentChangeView {
+    pub(super) id: RootAttachmentChangeId,
+    pub(super) chat_id: ChatId,
+    pub(super) root_id: HostRootId,
+    pub(super) action: RootAttachmentChangeAction,
+    pub(super) subject_kind: RootAttachmentSubjectKind,
+    pub(super) subject_id: Uuid,
+    pub(super) expected_revision: i64,
+    pub(super) before_revision: i64,
+    pub(super) intent_revision: i64,
+    pub(super) phase: RootAttachmentChangePhase,
+    pub(super) result_revision: Option<i64>,
+    pub(super) broker_currently_attached: Option<bool>,
+    pub(super) failure: Option<RootAttachmentChangeFailure>,
 }
 
 impl ControlPlaneClient {
@@ -162,6 +212,38 @@ impl ControlPlaneClient {
         Ok(())
     }
 
+    pub(super) async fn begin_root_attachment_change(
+        &self,
+        chat_id: ChatId,
+        change_id: RootAttachmentChangeId,
+        root_id: HostRootId,
+        expected_attachment_revision: i64,
+        created_at: DateTime<Utc>,
+    ) -> Result<RootAttachmentChangeResponse, ControlPlaneError> {
+        self.post(
+            &format!("/chats/{chat_id}/root-attachment-changes/{change_id}/begin"),
+            &BeginRootAttachmentRequest {
+                root_id,
+                action: RootAttachmentChangeAction::Attach,
+                expected_attachment_revision,
+                created_at,
+            },
+        )
+        .await
+    }
+
+    pub(super) async fn finish_root_attachment_change(
+        &self,
+        change_id: RootAttachmentChangeId,
+        terminal: &RootAttachmentChangeTerminal,
+    ) -> Result<RootAttachmentChangeResponse, ControlPlaneError> {
+        self.post(
+            &format!("/root-attachment-changes/{change_id}/finish"),
+            &FinishRootAttachmentRequest { terminal },
+        )
+        .await
+    }
+
     async fn post<T: DeserializeOwned>(
         &self,
         path: &str,
@@ -190,17 +272,24 @@ impl ControlPlaneClient {
                 if response.status().is_server_error() && attempt + 1 < MAX_EXACT_ATTEMPTS {
                     last_error = ControlPlaneError::Http {
                         status,
+                        kind: "internal".to_owned(),
                         message: "request failed".to_owned(),
                     };
                     retry_pause(attempt).await;
                     continue;
                 }
-                let message = response
+                let error = response
                     .json::<ErrorBody>()
                     .await
-                    .map(|body| body.message)
-                    .unwrap_or_else(|_| "request failed".to_owned());
-                return Err(ControlPlaneError::Http { status, message });
+                    .unwrap_or_else(|_| ErrorBody {
+                        kind: "protocol".to_owned(),
+                        message: "request failed".to_owned(),
+                    });
+                return Err(ControlPlaneError::Http {
+                    status,
+                    kind: error.kind,
+                    message: error.message,
+                });
             }
             match response.json().await {
                 Ok(body) => return Ok(body),
@@ -236,17 +325,24 @@ impl ControlPlaneClient {
                 if response.status().is_server_error() && attempt + 1 < MAX_EXACT_ATTEMPTS {
                     last_error = ControlPlaneError::Http {
                         status,
+                        kind: "internal".to_owned(),
                         message: "request failed".to_owned(),
                     };
                     retry_pause(attempt).await;
                     continue;
                 }
-                let message = response
+                let error = response
                     .json::<ErrorBody>()
                     .await
-                    .map(|body| body.message)
-                    .unwrap_or_else(|_| "request failed".to_owned());
-                return Err(ControlPlaneError::Http { status, message });
+                    .unwrap_or_else(|_| ErrorBody {
+                        kind: "protocol".to_owned(),
+                        message: "request failed".to_owned(),
+                    });
+                return Err(ControlPlaneError::Http {
+                    status,
+                    kind: error.kind,
+                    message: error.message,
+                });
             }
             match response.json().await {
                 Ok(body) => return Ok(body),
@@ -268,6 +364,7 @@ async fn retry_pause(attempt: usize) {
 
 #[derive(Deserialize)]
 struct ErrorBody {
+    kind: String,
     message: String,
 }
 

--- a/crates/openwave-desktop/src/client_execution/product_sync.rs
+++ b/crates/openwave-desktop/src/client_execution/product_sync.rs
@@ -1,0 +1,820 @@
+//! Durable synchronization of a picker-registered broker root into the
+//! product conversation projection.
+
+use openwave_core::{
+    HostRootId, RootAttachmentChangeAction, RootAttachmentChangeFailure, RootAttachmentChangeId,
+    RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentSubjectKind,
+};
+use openwave_host_broker::{
+    ControlRequest, ControlResult, LookupRegisterRootReceiptRequest,
+    LookupRootAttachmentReceiptRequest, OperationId, RegisterRootReceipt,
+    RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
+    RootId, RootSummary, SubjectKind,
+};
+
+use super::control_plane::{ControlPlaneError, RootAttachmentChangeView};
+use super::receipt_store::{
+    AttachmentPhase, CleanupPhase, FolderAccessReceipt, ProductRootAttachmentSync, StoredResolution,
+};
+use super::{
+    connected_resolution, control_plane, control_plane_error, failed_resolution,
+    private_receipt_error,
+};
+use crate::host_access::{AuthoritativeContext, HostAccess};
+
+pub(super) async fn synchronize_product_attachment(
+    state: &HostAccess,
+    receipt: &mut FolderAccessReceipt,
+    registration_context: AuthoritativeContext,
+    root: RootSummary,
+) -> Result<StoredResolution, String> {
+    let root_id = HostRootId::from_uuid(root.root_id.as_uuid())
+        .map_err(|_| "host broker returned an invalid registered root".to_owned())?;
+    let current_context = state.context(receipt.chat_id.0).await?;
+    if current_context.subject != registration_context.subject
+        || current_context.chat_id != registration_context.chat_id
+    {
+        return Err("conversation authority changed during folder registration".to_owned());
+    }
+
+    if receipt.product_sync.is_none() {
+        let store = state
+            .store()
+            .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+        let chat = store
+            .get_chat(receipt.chat_id)
+            .await
+            .map_err(|_| "could not load the conversation attachment revision".to_owned())?
+            .ok_or_else(|| "conversation not found".to_owned())?;
+        let mut change_id = RootAttachmentChangeId::new();
+        while change_id.as_uuid() == &receipt.call_id.0
+            || *change_id.as_uuid() == receipt.registration_operation_id.as_uuid()
+        {
+            change_id = RootAttachmentChangeId::new();
+        }
+        receipt.product_sync = Some(ProductRootAttachmentSync {
+            change_id,
+            root_id,
+            display_name: root.display_name.clone(),
+            expected_attachment_revision: chat.attachment_revision,
+            created_at: chrono::Utc::now(),
+            cleanup_operation_id: distinct_operation_id(receipt, change_id),
+            cleanup_phase: CleanupPhase::NotStarted,
+            attachment_phase: AttachmentPhase::Prepared,
+        });
+        // This exact id, CAS fence, and timestamp must survive an ambiguous
+        // begin response or process exit. Save them before product dispatch.
+        state
+            .receipts
+            .save(receipt)
+            .map_err(private_receipt_error)?;
+    }
+    drive_product_attachment(state, receipt, current_context, root).await
+}
+
+pub(super) async fn resume_product_attachment(
+    state: &HostAccess,
+    receipt: &mut FolderAccessReceipt,
+    context: AuthoritativeContext,
+) -> Result<StoredResolution, String> {
+    let sync = receipt
+        .product_sync
+        .clone()
+        .ok_or_else(|| "folder attachment recovery metadata is missing".to_owned())?;
+    let root_id = RootId::from_uuid(*sync.root_id.as_uuid())
+        .map_err(|_| "invalid recovered folder root identity".to_owned())?;
+    drive_product_attachment(
+        state,
+        receipt,
+        context,
+        RootSummary {
+            root_id,
+            display_name: sync.display_name,
+        },
+    )
+    .await
+}
+
+async fn drive_product_attachment(
+    state: &HostAccess,
+    receipt: &mut FolderAccessReceipt,
+    current_context: AuthoritativeContext,
+    root: RootSummary,
+) -> Result<StoredResolution, String> {
+    let root_id = HostRootId::from_uuid(root.root_id.as_uuid())
+        .map_err(|_| "host broker returned an invalid registered root".to_owned())?;
+    let sync = receipt
+        .product_sync
+        .clone()
+        .ok_or_else(|| "folder attachment recovery metadata is missing".to_owned())?;
+    if sync.root_id != root_id || sync.display_name != root.display_name {
+        return Err("registered root changed during folder attachment recovery".to_owned());
+    }
+
+    let client = control_plane(state)?;
+    client
+        .heartbeat(receipt.chat_id, receipt.call_id, receipt.lease_token)
+        .await
+        .map_err(control_plane_error)?;
+    let begun = match client
+        .begin_root_attachment_change(
+            receipt.chat_id,
+            sync.change_id,
+            sync.root_id,
+            sync.expected_attachment_revision,
+            sync.created_at,
+        )
+        .await
+    {
+        Ok(begun) => begun,
+        Err(error) if permanent_product_begin_failure(&error) => {
+            cleanup_rejected_registration(
+                state,
+                receipt,
+                &sync,
+                current_context,
+                error.is_kind("root_attachment_identity_conflict"),
+            )
+            .await?;
+            return Ok(failed_resolution(
+                "folder_access_product_sync_rejected",
+                "The selected folder could not be synchronized with this conversation.",
+                None,
+            ));
+        }
+        Err(error) => return Err(product_begin_error(error, sync.change_id)),
+    };
+    validate_product_change(&begun.change, receipt, &sync, current_context)?;
+
+    match begun.change.phase {
+        RootAttachmentChangePhase::Completed => {
+            verify_completed_product_attachment(state, &begun.change).await?;
+            return connected_resolution(root);
+        }
+        RootAttachmentChangePhase::Failed => {
+            verify_failed_product_attachment(state, &begun.change).await?;
+            return Ok(product_attachment_failed_resolution(&begun.change));
+        }
+        RootAttachmentChangePhase::AwaitingBroker => {}
+    }
+
+    let terminal = reconcile_broker_attachment(state, receipt, &sync, current_context).await?;
+    let finished = client
+        .finish_root_attachment_change(sync.change_id, &terminal)
+        .await
+        .map_err(|error| product_finish_error(error, sync.change_id))?;
+    validate_product_change(&finished.change, receipt, &sync, current_context)?;
+    match finished.change.phase {
+        RootAttachmentChangePhase::Completed => {
+            verify_completed_product_attachment(state, &finished.change).await?;
+            connected_resolution(root)
+        }
+        RootAttachmentChangePhase::Failed => {
+            verify_failed_product_attachment(state, &finished.change).await?;
+            Ok(product_attachment_failed_resolution(&finished.change))
+        }
+        RootAttachmentChangePhase::AwaitingBroker => Err(
+            "product folder attachment remained pending after its terminal broker receipt"
+                .to_owned(),
+        ),
+    }
+}
+
+fn distinct_operation_id(
+    receipt: &FolderAccessReceipt,
+    change_id: RootAttachmentChangeId,
+) -> OperationId {
+    loop {
+        let id = OperationId::new();
+        if id.as_uuid() != receipt.call_id.0
+            && id.as_uuid() != receipt.registration_operation_id.as_uuid()
+            && id.as_uuid() != *change_id.as_uuid()
+        {
+            return id;
+        }
+    }
+}
+
+async fn cleanup_rejected_registration(
+    state: &HostAccess,
+    receipt: &mut FolderAccessReceipt,
+    sync: &ProductRootAttachmentSync,
+    context: AuthoritativeContext,
+    allow_identity_collision: bool,
+) -> Result<(), String> {
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let chat = store
+        .get_chat(receipt.chat_id)
+        .await
+        .map_err(|_| "could not inspect the rejected folder attachment".to_owned())?
+        .ok_or_else(|| "conversation not found".to_owned())?;
+    if chat
+        .root_attachments
+        .iter()
+        .any(|attachment| attachment.root_id == sync.root_id)
+    {
+        // A concurrent exact product attach already converged this root. Never
+        // tear down authority that current product state still names.
+        return Ok(());
+    }
+    if !allow_identity_collision
+        && store
+            .get_root_attachment_change(sync.change_id)
+            .await
+            .map_err(|_| "could not inspect rejected folder attachment work".to_owned())?
+            .is_some()
+    {
+        return Err("rejected folder attachment identity still owns product work".to_owned());
+    }
+
+    if cleanup_receipt(state, receipt, sync, context)
+        .await?
+        .is_none()
+    {
+        if let Some(stored) = receipt.product_sync.as_mut() {
+            stored.cleanup_phase = CleanupPhase::DispatchAttempted;
+        }
+        state
+            .receipts
+            .save(receipt)
+            .map_err(private_receipt_error)?;
+
+        let broker_root_id = RootId::from_uuid(*sync.root_id.as_uuid())
+            .map_err(|_| "invalid cleanup folder root identity".to_owned())?;
+        let deadline = tokio::time::Instant::now() + crate::broker::MUTATION_DISPATCH_WINDOW;
+        let first = state
+            .broker
+            .control_without_retry(
+                ControlRequest::DetachRoot(RootAttachmentMutationRequest {
+                    operation_id: sync.cleanup_operation_id,
+                    subject: context.subject,
+                    conversation_id: context.chat_id,
+                    root_id: broker_root_id,
+                }),
+                deadline,
+            )
+            .await;
+        match first {
+            Ok(ControlResult::DetachRoot(_)) | Err(_) => {}
+            Ok(_) => return Err("host broker returned an unexpected cleanup response".to_owned()),
+        }
+        if cleanup_receipt(state, receipt, sync, context)
+            .await?
+            .is_none()
+        {
+            return Err("folder cleanup has no durable broker outcome yet".to_owned());
+        }
+    }
+
+    if let Some(stored) = receipt.product_sync.as_mut() {
+        stored.cleanup_phase = CleanupPhase::Completed;
+    }
+    state
+        .receipts
+        .save(receipt)
+        .map_err(private_receipt_error)?;
+    let chat = store
+        .get_chat(receipt.chat_id)
+        .await
+        .map_err(|_| "could not verify rejected folder cleanup".to_owned())?
+        .ok_or_else(|| "conversation not found".to_owned())?;
+    if chat
+        .root_attachments
+        .iter()
+        .any(|attachment| attachment.root_id == sync.root_id)
+        || (!allow_identity_collision
+            && store
+                .get_root_attachment_change(sync.change_id)
+                .await
+                .map_err(|_| "could not verify rejected folder cleanup".to_owned())?
+                .is_some())
+    {
+        return Err("rejected folder cleanup contradicts product state".to_owned());
+    }
+    Ok(())
+}
+
+async fn cleanup_receipt(
+    state: &HostAccess,
+    receipt: &FolderAccessReceipt,
+    sync: &ProductRootAttachmentSync,
+    context: AuthoritativeContext,
+) -> Result<Option<()>, String> {
+    let broker_root_id = RootId::from_uuid(*sync.root_id.as_uuid())
+        .map_err(|_| "invalid cleanup folder root identity".to_owned())?;
+    let result = state
+        .broker
+        .control(ControlRequest::LookupRootAttachmentReceipt(
+            LookupRootAttachmentReceiptRequest {
+                operation_id: sync.cleanup_operation_id,
+                subject: context.subject,
+                conversation_id: context.chat_id,
+                root_id: broker_root_id,
+                mutation: RootAttachmentMutationKind::Detach,
+            },
+        ))
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::LookupRootAttachmentReceipt(result) = result else {
+        return Err("host broker returned an unexpected cleanup receipt".to_owned());
+    };
+    if result.operation_id != sync.cleanup_operation_id {
+        return Err("host broker returned a mismatched cleanup receipt".to_owned());
+    }
+    match cleanup_receipt_outcome(result.receipt, broker_root_id)? {
+        CleanupReceiptOutcome::Unknown => Ok(None),
+        CleanupReceiptOutcome::Detached => Ok(Some(())),
+        CleanupReceiptOutcome::FailedNeedsRegistrationCheck => {
+            confirm_registration_disconnected(state, receipt, sync, context).await?;
+            Ok(Some(()))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CleanupReceiptOutcome {
+    Unknown,
+    Detached,
+    FailedNeedsRegistrationCheck,
+}
+
+fn cleanup_receipt_outcome(
+    receipt: RootAttachmentMutationReceipt,
+    broker_root_id: RootId,
+) -> Result<CleanupReceiptOutcome, String> {
+    match receipt {
+        RootAttachmentMutationReceipt::Unknown => Ok(CleanupReceiptOutcome::Unknown),
+        RootAttachmentMutationReceipt::Completed {
+            result,
+            currently_attached,
+        } if result.root_id == broker_root_id
+            && result.mutation == RootAttachmentMutationKind::Detach
+            && !currently_attached =>
+        {
+            Ok(CleanupReceiptOutcome::Detached)
+        }
+        RootAttachmentMutationReceipt::Completed { .. } => {
+            Err("host broker cleanup receipt contradicts live attachment state".to_owned())
+        }
+        RootAttachmentMutationReceipt::Failed { .. } => {
+            Ok(CleanupReceiptOutcome::FailedNeedsRegistrationCheck)
+        }
+        _ => Err("host broker returned an unsupported cleanup receipt".to_owned()),
+    }
+}
+
+async fn confirm_registration_disconnected(
+    state: &HostAccess,
+    receipt: &FolderAccessReceipt,
+    sync: &ProductRootAttachmentSync,
+    context: AuthoritativeContext,
+) -> Result<(), String> {
+    let result = state
+        .broker
+        .control(ControlRequest::LookupRegisterRootReceipt(
+            LookupRegisterRootReceiptRequest {
+                operation_id: receipt.registration_operation_id,
+                subject: context.subject,
+                conversation_id: context.chat_id,
+            },
+        ))
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::LookupRegisterRootReceipt(result) = result else {
+        return Err("host broker returned an unexpected registration cleanup receipt".to_owned());
+    };
+    if result.operation_id != receipt.registration_operation_id {
+        return Err("host broker returned a mismatched registration cleanup receipt".to_owned());
+    }
+    registration_disconnected_outcome(result.receipt, sync)
+}
+
+fn registration_disconnected_outcome(
+    receipt: RegisterRootReceipt,
+    sync: &ProductRootAttachmentSync,
+) -> Result<(), String> {
+    match receipt {
+        RegisterRootReceipt::Disconnected { root }
+            if root.root_id.as_uuid() == *sync.root_id.as_uuid()
+                && root.display_name == sync.display_name =>
+        {
+            Ok(())
+        }
+        RegisterRootReceipt::Disconnected { .. } => {
+            Err("registration cleanup receipt names a different root".to_owned())
+        }
+        RegisterRootReceipt::Completed { .. }
+        | RegisterRootReceipt::Pending
+        | RegisterRootReceipt::Unknown
+        | RegisterRootReceipt::Failed { .. } => {
+            Err("rejected folder cleanup is not authoritatively detached".to_owned())
+        }
+        _ => Err("host broker returned an unsupported registration cleanup receipt".to_owned()),
+    }
+}
+
+async fn reconcile_broker_attachment(
+    state: &HostAccess,
+    receipt: &mut FolderAccessReceipt,
+    sync: &ProductRootAttachmentSync,
+    context: AuthoritativeContext,
+) -> Result<RootAttachmentChangeTerminal, String> {
+    if let Some(terminal) = lookup_broker_attachment(state, sync, context).await? {
+        return Ok(terminal);
+    }
+
+    let client = control_plane(state)?;
+    client
+        .heartbeat(receipt.chat_id, receipt.call_id, receipt.lease_token)
+        .await
+        .map_err(control_plane_error)?;
+    if let Some(stored) = receipt.product_sync.as_mut() {
+        stored.attachment_phase = AttachmentPhase::DispatchAttempted;
+    }
+    state
+        .receipts
+        .save(receipt)
+        .map_err(private_receipt_error)?;
+
+    let operation_id = attachment_operation_id(sync)?;
+    let broker_root_id = RootId::from_uuid(*sync.root_id.as_uuid())
+        .map_err(|_| "invalid product folder root identity".to_owned())?;
+    let dispatch_deadline = tokio::time::Instant::now() + crate::broker::MUTATION_DISPATCH_WINDOW;
+    let first = state
+        .broker
+        .control_without_retry(
+            ControlRequest::AttachRoot(RootAttachmentMutationRequest {
+                operation_id,
+                subject: context.subject,
+                conversation_id: context.chat_id,
+                root_id: broker_root_id,
+            }),
+            dispatch_deadline,
+        )
+        .await;
+    match first {
+        Ok(ControlResult::AttachRoot(_)) | Err(_) => {}
+        Ok(_) => return Err("host broker returned an unexpected attachment response".to_owned()),
+    }
+
+    lookup_broker_attachment(state, sync, context)
+        .await?
+        .ok_or_else(|| {
+            "folder attachment has no durable broker outcome yet; recovery will retry".to_owned()
+        })
+}
+
+async fn lookup_broker_attachment(
+    state: &HostAccess,
+    sync: &ProductRootAttachmentSync,
+    context: AuthoritativeContext,
+) -> Result<Option<RootAttachmentChangeTerminal>, String> {
+    let operation_id = attachment_operation_id(sync)?;
+    let broker_root_id = RootId::from_uuid(*sync.root_id.as_uuid())
+        .map_err(|_| "invalid product folder root identity".to_owned())?;
+    let result = state
+        .broker
+        .control(ControlRequest::LookupRootAttachmentReceipt(
+            LookupRootAttachmentReceiptRequest {
+                operation_id,
+                subject: context.subject,
+                conversation_id: context.chat_id,
+                root_id: broker_root_id,
+                mutation: RootAttachmentMutationKind::Attach,
+            },
+        ))
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::LookupRootAttachmentReceipt(result) = result else {
+        return Err("host broker returned an unexpected attachment receipt".to_owned());
+    };
+    if result.operation_id != operation_id {
+        return Err("host broker returned a mismatched attachment receipt".to_owned());
+    }
+    attachment_receipt_terminal(result.receipt, broker_root_id)
+}
+
+fn attachment_receipt_terminal(
+    receipt: RootAttachmentMutationReceipt,
+    broker_root_id: RootId,
+) -> Result<Option<RootAttachmentChangeTerminal>, String> {
+    match receipt {
+        RootAttachmentMutationReceipt::Unknown => Ok(None),
+        RootAttachmentMutationReceipt::Completed {
+            result,
+            currently_attached,
+        } => {
+            if result.root_id != broker_root_id
+                || result.mutation != RootAttachmentMutationKind::Attach
+            {
+                return Err("host broker and product folder attachment state disagree".to_owned());
+            }
+            if currently_attached {
+                Ok(Some(RootAttachmentChangeTerminal::Completed {
+                    broker_changed: result.changed,
+                    broker_currently_attached: true,
+                }))
+            } else {
+                Ok(Some(RootAttachmentChangeTerminal::Failed {
+                    broker_changed: Some(result.changed),
+                    broker_currently_attached: Some(false),
+                    failure: RootAttachmentChangeFailure {
+                        code: "broker_attachment_disconnected".to_owned(),
+                        message:
+                            "The selected folder was disconnected before synchronization completed."
+                                .to_owned(),
+                        retryable: false,
+                    },
+                }))
+            }
+        }
+        RootAttachmentMutationReceipt::Failed { .. } => {
+            Ok(Some(RootAttachmentChangeTerminal::Failed {
+                broker_changed: None,
+                broker_currently_attached: None,
+                failure: RootAttachmentChangeFailure {
+                    code: "broker_attachment_failed".to_owned(),
+                    message: "The host broker could not complete this folder attachment."
+                        .to_owned(),
+                    retryable: false,
+                },
+            }))
+        }
+        _ => Err("host broker returned an unsupported attachment receipt".to_owned()),
+    }
+}
+
+pub(super) fn attachment_operation_id(
+    sync: &ProductRootAttachmentSync,
+) -> Result<OperationId, String> {
+    OperationId::from_uuid(*sync.change_id.as_uuid())
+        .map_err(|_| "invalid product folder attachment identity".to_owned())
+}
+
+pub(super) fn validate_product_change(
+    change: &RootAttachmentChangeView,
+    receipt: &FolderAccessReceipt,
+    sync: &ProductRootAttachmentSync,
+    context: AuthoritativeContext,
+) -> Result<(), String> {
+    let subject_kind = match context.subject.kind() {
+        SubjectKind::Project => RootAttachmentSubjectKind::Project,
+        SubjectKind::Conversation => RootAttachmentSubjectKind::Conversation,
+    };
+    if change.id != sync.change_id
+        || change.chat_id != receipt.chat_id
+        || change.root_id != sync.root_id
+        || change.action != RootAttachmentChangeAction::Attach
+        || change.subject_kind != subject_kind
+        || change.subject_id != context.subject.id()
+        || change.expected_revision != sync.expected_attachment_revision
+        || change.before_revision != sync.expected_attachment_revision
+        || change.intent_revision < change.before_revision
+        || change.intent_revision > change.before_revision.saturating_add(1)
+    {
+        return Err(
+            "local control plane returned a mismatched product folder attachment".to_owned(),
+        );
+    }
+    if change.phase == RootAttachmentChangePhase::Completed
+        && (change.result_revision.is_none()
+            || change.broker_currently_attached != Some(true)
+            || change.failure.is_some())
+    {
+        return Err(
+            "completed product folder attachment has contradictory terminal state".to_owned(),
+        );
+    }
+    Ok(())
+}
+
+async fn verify_completed_product_attachment(
+    state: &HostAccess,
+    change: &RootAttachmentChangeView,
+) -> Result<(), String> {
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let chat = store
+        .get_chat(change.chat_id)
+        .await
+        .map_err(|_| "could not verify the product folder attachment".to_owned())?
+        .ok_or_else(|| "conversation not found".to_owned())?;
+    if Some(chat.attachment_revision) != change.result_revision
+        || !chat
+            .root_attachments
+            .iter()
+            .any(|attachment| attachment.root_id == change.root_id)
+    {
+        return Err("host broker and product folder attachment state disagree".to_owned());
+    }
+    Ok(())
+}
+
+async fn verify_failed_product_attachment(
+    state: &HostAccess,
+    change: &RootAttachmentChangeView,
+) -> Result<(), String> {
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let chat = store
+        .get_chat(change.chat_id)
+        .await
+        .map_err(|_| "could not verify the failed product folder attachment".to_owned())?
+        .ok_or_else(|| "conversation not found".to_owned())?;
+    let newly_projected = change.intent_revision > change.before_revision;
+    if Some(chat.attachment_revision) != change.result_revision
+        || (newly_projected
+            && chat
+                .root_attachments
+                .iter()
+                .any(|attachment| attachment.root_id == change.root_id))
+    {
+        return Err("failed product folder attachment did not roll back safely".to_owned());
+    }
+    Ok(())
+}
+
+fn product_attachment_failed_resolution(change: &RootAttachmentChangeView) -> StoredResolution {
+    let detail = change
+        .failure
+        .as_ref()
+        .map(|failure| failure.message.clone());
+    failed_resolution(
+        "folder_access_product_sync_failed",
+        "The selected folder could not be synchronized with this conversation.",
+        detail,
+    )
+}
+
+fn product_begin_error(error: ControlPlaneError, change_id: RootAttachmentChangeId) -> String {
+    if error.is_kind("root_attachment_revision_conflict") {
+        return format!(
+            "folder attachment {change_id} was fenced by a conversation revision change"
+        );
+    }
+    if error.is_conflict() {
+        return format!("folder attachment {change_id} could not begin safely: {error}");
+    }
+    control_plane_error(error)
+}
+
+fn permanent_product_begin_failure(error: &ControlPlaneError) -> bool {
+    [
+        "root_attachment_revision_conflict",
+        "root_attachment_identity_conflict",
+        "root_attachment_capacity_exceeded",
+        "root_attachment_revision_exhausted",
+    ]
+    .iter()
+    .any(|kind| error.is_kind(kind))
+}
+
+fn product_finish_error(error: ControlPlaneError, change_id: RootAttachmentChangeId) -> String {
+    if error.is_kind("root_attachment_broker_state_mismatch") || error.is_conflict() {
+        return format!("folder attachment {change_id} failed closed: {error}");
+    }
+    control_plane_error(error)
+}
+
+#[cfg(test)]
+mod tests {
+    use openwave_host_broker::{ErrorCode, ErrorResponse};
+
+    use super::*;
+
+    #[test]
+    fn stable_begin_conflicts_terminalize_but_chat_busy_defers() {
+        let conflict = |kind: &str| ControlPlaneError::Http {
+            status: 409,
+            kind: kind.to_owned(),
+            message: "conflict".to_owned(),
+        };
+        assert!(permanent_product_begin_failure(&conflict(
+            "root_attachment_revision_conflict"
+        )));
+        assert!(permanent_product_begin_failure(&conflict(
+            "root_attachment_identity_conflict"
+        )));
+        assert!(!permanent_product_begin_failure(&conflict(
+            "root_attachment_chat_busy"
+        )));
+    }
+
+    #[test]
+    fn durable_broker_failure_becomes_a_bounded_product_terminal() {
+        let root_id = RootId::new();
+        let terminal = attachment_receipt_terminal(
+            RootAttachmentMutationReceipt::Failed {
+                error: ErrorResponse {
+                    code: ErrorCode::HostIo,
+                    message: "private broker detail".to_owned(),
+                    retryable: true,
+                },
+            },
+            root_id,
+        )
+        .unwrap()
+        .unwrap();
+        let RootAttachmentChangeTerminal::Failed { failure, .. } = terminal else {
+            panic!("expected failed product terminal")
+        };
+        assert_eq!(failure.code, "broker_attachment_failed");
+        assert!(!failure.message.contains("private broker detail"));
+        assert!(!failure.retryable);
+    }
+
+    #[test]
+    fn historical_attach_revocation_rolls_back_and_cleanup_requires_detached_state() {
+        let root_id = RootId::new();
+        let terminal = attachment_receipt_terminal(
+            RootAttachmentMutationReceipt::Completed {
+                result: openwave_host_broker::RootAttachmentMutationResult {
+                    root_id,
+                    mutation: RootAttachmentMutationKind::Attach,
+                    changed: true,
+                },
+                currently_attached: false,
+            },
+            root_id,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(matches!(
+            terminal,
+            RootAttachmentChangeTerminal::Failed {
+                broker_changed: Some(true),
+                broker_currently_attached: Some(false),
+                ..
+            }
+        ));
+
+        assert_eq!(
+            cleanup_receipt_outcome(
+                RootAttachmentMutationReceipt::Completed {
+                    result: openwave_host_broker::RootAttachmentMutationResult {
+                        root_id,
+                        mutation: RootAttachmentMutationKind::Detach,
+                        changed: true,
+                    },
+                    currently_attached: false,
+                },
+                root_id,
+            )
+            .unwrap(),
+            CleanupReceiptOutcome::Detached
+        );
+    }
+
+    #[test]
+    fn revoke_before_cleanup_confirms_detachment_through_registration_receipt() {
+        let root_id = RootId::new();
+        assert_eq!(
+            cleanup_receipt_outcome(
+                RootAttachmentMutationReceipt::Failed {
+                    error: ErrorResponse {
+                        code: ErrorCode::InvalidRoot,
+                        message: "unknown root".to_owned(),
+                        retryable: false,
+                    },
+                },
+                root_id,
+            )
+            .unwrap(),
+            CleanupReceiptOutcome::FailedNeedsRegistrationCheck
+        );
+        let sync = ProductRootAttachmentSync {
+            change_id: RootAttachmentChangeId::new(),
+            root_id: HostRootId::from_uuid(root_id.as_uuid()).unwrap(),
+            display_name: "Documents".to_owned(),
+            expected_attachment_revision: 0,
+            created_at: chrono::Utc::now(),
+            cleanup_operation_id: OperationId::new(),
+            cleanup_phase: CleanupPhase::DispatchAttempted,
+            attachment_phase: AttachmentPhase::Prepared,
+        };
+        assert!(registration_disconnected_outcome(
+            RegisterRootReceipt::Disconnected {
+                root: RootSummary {
+                    root_id,
+                    display_name: "Documents".to_owned(),
+                },
+            },
+            &sync,
+        )
+        .is_ok());
+        assert!(registration_disconnected_outcome(
+            RegisterRootReceipt::Completed {
+                root: RootSummary {
+                    root_id,
+                    display_name: "Documents".to_owned(),
+                },
+            },
+            &sync,
+        )
+        .is_err());
+    }
+}

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -10,17 +10,20 @@ use std::{
 #[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
-use openwave_core::{CallId, ChatId};
+use chrono::{DateTime, Utc};
+use openwave_core::{CallId, ChatId, HostRootId, RootAttachmentChangeId, MAX_ATTACHMENT_REVISION};
+use openwave_host_broker::OperationId;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-const RECEIPT_VERSION: u32 = 1;
+const RECEIPT_VERSION: u32 = 3;
 const RECEIPT_DIRECTORY: &str = "client-executions";
 const EXECUTOR_FILE: &str = "executor-id";
 const MAX_EXECUTOR_BYTES: usize = 128;
 const MAX_RECEIPT_BYTES: usize = 128 * 1024;
 const MAX_RECEIPTS: usize = 1_024;
 const FOLDER_OPERATION_PREFIX: &str = "folder-operation-";
+const MAX_SAFE_ROOT_DISPLAY_BYTES: usize = 1_024;
 
 pub(crate) struct ReceiptStore {
     directory: PathBuf,
@@ -37,7 +40,10 @@ pub(super) struct FolderAccessReceipt {
     pub(super) executor_id: Uuid,
     pub(super) lease_token: Uuid,
     pub(super) intent: FolderAccessIntent,
+    pub(super) registration_operation_id: OperationId,
     pub(super) registration_phase: RegistrationPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) product_sync: Option<ProductRootAttachmentSync>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) resolution: Option<StoredResolution>,
 }
@@ -87,6 +93,46 @@ pub(super) enum RegistrationPhase {
     Attempted,
 }
 
+/// Exact product-side attachment identity persisted before begin or broker
+/// attachment dispatch. The change id also identifies the broker's idempotent
+/// `AttachRoot` mutation, but is independent of both the tool call and the
+/// picker registration mutation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub(super) struct ProductRootAttachmentSync {
+    pub(super) change_id: RootAttachmentChangeId,
+    pub(super) root_id: HostRootId,
+    pub(super) display_name: String,
+    pub(super) expected_attachment_revision: i64,
+    pub(super) created_at: DateTime<Utc>,
+    pub(super) cleanup_operation_id: OperationId,
+    #[serde(default)]
+    pub(super) cleanup_phase: CleanupPhase,
+    #[serde(default)]
+    pub(super) attachment_phase: AttachmentPhase,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum CleanupPhase {
+    #[default]
+    NotStarted,
+    DispatchAttempted,
+    Completed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum AttachmentPhase {
+    /// Product begin has not necessarily committed and no broker attachment
+    /// dispatch has been admitted yet.
+    #[default]
+    Prepared,
+    /// The exact broker attachment id may have been dispatched. Recovery must
+    /// consult its durable receipt before sending the same id again.
+    DispatchAttempted,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
 pub(super) enum StoredResolution {
@@ -111,7 +157,9 @@ impl std::fmt::Debug for FolderAccessReceipt {
             .field("executor_id", &self.executor_id)
             .field("lease_token", &"[redacted]")
             .field("intent", &self.intent)
+            .field("registration_operation_id", &self.registration_operation_id)
             .field("registration_phase", &self.registration_phase)
+            .field("product_sync", &self.product_sync)
             .field("resolution", &self.resolution)
             .finish()
     }
@@ -158,7 +206,9 @@ impl FolderAccessReceipt {
             executor_id,
             lease_token: Uuid::new_v4(),
             intent,
+            registration_operation_id: OperationId::new(),
             registration_phase: RegistrationPhase::NotStarted,
+            product_sync: None,
             resolution: None,
         }
     }
@@ -169,11 +219,31 @@ impl FolderAccessReceipt {
             || self.call_id.0.is_nil()
             || self.executor_id.is_nil()
             || self.lease_token.is_nil()
+            || self.registration_operation_id.as_uuid() == self.call_id.0
             || matches!(&self.intent, FolderAccessIntent::Selected { path } if !path.is_absolute())
             || matches!(
                 (&self.intent, self.registration_phase),
                 (FolderAccessIntent::Decline, RegistrationPhase::Attempted)
             )
+            || matches!(
+                (&self.intent, &self.product_sync),
+                (FolderAccessIntent::Decline, Some(_))
+            )
+            || (self.product_sync.is_some()
+                && self.registration_phase != RegistrationPhase::Attempted)
+            || self.product_sync.as_ref().is_some_and(|sync| {
+                sync.change_id.as_uuid().is_nil()
+                    || sync.change_id.as_uuid() == &self.call_id.0
+                    || *sync.change_id.as_uuid() == self.registration_operation_id.as_uuid()
+                    || sync.display_name.is_empty()
+                    || sync.display_name.len() > MAX_SAFE_ROOT_DISPLAY_BYTES
+                    || sync.display_name.contains('\0')
+                    || sync.cleanup_operation_id.as_uuid() == self.call_id.0
+                    || sync.cleanup_operation_id.as_uuid()
+                        == self.registration_operation_id.as_uuid()
+                    || sync.cleanup_operation_id.as_uuid() == *sync.change_id.as_uuid()
+                    || !(0..=MAX_ATTACHMENT_REVISION).contains(&sync.expected_attachment_revision)
+            })
         {
             return Err(invalid_data("invalid client-execution receipt"));
         }
@@ -541,6 +611,10 @@ mod tests {
         );
         store.save(&receipt).unwrap();
         assert_eq!(store.load_all().unwrap(), vec![receipt.clone()]);
+        assert_ne!(
+            receipt.registration_operation_id.as_uuid(),
+            receipt.call_id.0
+        );
         let debug = format!("{receipt:?}");
         assert!(!debug.contains(&receipt.lease_token.to_string()));
         assert!(!debug.contains(&temp.path().display().to_string()));
@@ -556,6 +630,69 @@ mod tests {
 
         let reopened = ReceiptStore::open(temp.path()).unwrap();
         assert_eq!(reopened.executor_id(), executor_id);
+    }
+
+    #[test]
+    fn product_attachment_identity_and_revision_are_durable_and_independent() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(temp.path()).unwrap();
+        let mut receipt = FolderAccessReceipt::new(
+            ChatId::new(),
+            CallId::new(),
+            store.executor_id(),
+            FolderAccessIntent::Selected {
+                path: temp.path().join("Documents"),
+            },
+        );
+        receipt.registration_phase = RegistrationPhase::Attempted;
+        let sync = ProductRootAttachmentSync {
+            change_id: RootAttachmentChangeId::new(),
+            root_id: HostRootId::from_uuid(Uuid::new_v4()).unwrap(),
+            display_name: "Documents".to_owned(),
+            expected_attachment_revision: 7,
+            created_at: Utc::now(),
+            cleanup_operation_id: OperationId::new(),
+            cleanup_phase: CleanupPhase::NotStarted,
+            attachment_phase: AttachmentPhase::Prepared,
+        };
+        assert_ne!(sync.change_id.as_uuid(), &receipt.call_id.0);
+        assert_ne!(
+            *sync.change_id.as_uuid(),
+            receipt.registration_operation_id.as_uuid()
+        );
+        assert_ne!(sync.cleanup_operation_id.as_uuid(), receipt.call_id.0);
+        assert_ne!(
+            sync.cleanup_operation_id.as_uuid(),
+            receipt.registration_operation_id.as_uuid()
+        );
+        assert_ne!(
+            sync.cleanup_operation_id.as_uuid(),
+            *sync.change_id.as_uuid()
+        );
+        receipt.product_sync = Some(sync.clone());
+        store.save(&receipt).unwrap();
+        let recovered = store.load_all().unwrap().pop().unwrap();
+        assert_eq!(recovered.product_sync, Some(sync));
+
+        receipt.product_sync.as_mut().unwrap().cleanup_phase = CleanupPhase::Completed;
+        receipt.resolution = Some(StoredResolution::Failed {
+            result: r#"{"status":"unavailable"}"#.to_owned(),
+            error_code: "folder_access_product_sync_rejected".to_owned(),
+            error_detail: None,
+        });
+        store.save(&receipt).unwrap();
+        assert!(matches!(
+            store.load_all().unwrap().pop().unwrap().resolution,
+            Some(StoredResolution::Failed { error_code, .. })
+                if error_code == "folder_access_product_sync_rejected"
+        ));
+        store.remove(receipt.call_id).unwrap();
+        assert!(store.load_all().unwrap().is_empty());
+
+        let mut reused = receipt.clone();
+        reused.product_sync.as_mut().unwrap().change_id =
+            RootAttachmentChangeId::from_uuid(receipt.call_id.0).unwrap();
+        assert!(store.save(&reused).is_err());
     }
 
     #[test]

--- a/crates/openwave-server/src/tests/root_attachment.rs
+++ b/crates/openwave-server/src/tests/root_attachment.rs
@@ -339,7 +339,9 @@ async fn root_attachment_finish_is_exact_scoped_and_keeps_contradictions_pending
     let terminal = serde_json::json!({
         "terminal": {
             "status": "completed",
-            "broker_changed": true,
+            // Picker registration already attaches the root, so the exact
+            // follow-up AttachRoot receipt legitimately reports no mutation.
+            "broker_changed": false,
             "broker_currently_attached": true
         }
     });
@@ -360,7 +362,7 @@ async fn root_attachment_finish_is_exact_scoped_and_keeps_contradictions_pending
         serde_json::json!({
             "terminal": {
                 "status": "completed",
-                "broker_changed": false,
+                "broker_changed": true,
                 "broker_currently_attached": true
             }
         }),
@@ -464,6 +466,70 @@ async fn root_attachment_finish_is_exact_scoped_and_keeps_contradictions_pending
     )
     .await;
     assert_eq!(nil.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn disconnected_attach_receipt_rolls_back_product_intent_and_clears_pending() {
+    let executor_id = uuid::Uuid::new_v4();
+    let (router, token, store, _dir) = test_app_with_executor_id(executor_id).await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let root_id = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let change_id = RootAttachmentChangeId::new();
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &format!(
+            "/chats/{}/root-attachment-changes/{change_id}/begin",
+            chat.id
+        ),
+        root_attachment_begin_body(
+            root_id,
+            RootAttachmentChangeAction::Attach,
+            0,
+            chrono::Utc::now(),
+        ),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(store
+        .get_chat(chat.id)
+        .await
+        .unwrap()
+        .unwrap()
+        .root_attachments
+        .iter()
+        .any(|attachment| attachment.root_id == root_id));
+
+    let response = post_native_json(
+        &router,
+        &bearer,
+        &format!("/root-attachment-changes/{change_id}/finish"),
+        serde_json::json!({
+            "terminal": {
+                "status": "failed",
+                "broker_changed": true,
+                "broker_currently_attached": false,
+                "failure": {
+                    "code": "broker_attachment_disconnected",
+                    "message": "The selected folder was disconnected before synchronization completed.",
+                    "retryable": false
+                }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let projected = store.get_chat(chat.id).await.unwrap().unwrap();
+    assert!(!projected
+        .root_attachments
+        .iter()
+        .any(|attachment| attachment.root_id == root_id));
+    assert!(store
+        .list_pending_root_attachment_changes(executor_id, 64)
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 #[tokio::test]

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -225,7 +225,13 @@ two-step product workflow, not a privileged broker operation:
    policy, and records only those capabilities. Command execution, destructive
    writes, and other high-risk access require their own explicit permission
    dialogs.
-4. The original operation can retry against the returned opaque root identity.
+4. After broker registration is confirmed, the desktop durably records a fresh
+   root-attachment change identity, the observed conversation attachment
+   revision, and the immutable creation time before beginning product work. It
+   then reconciles the same-ID broker `AttachRoot`, finishes the product change,
+   and verifies that the final chat projection contains the root. Only that
+   converged state resolves the agent request as connected.
+5. The original operation can retry against the returned opaque root identity.
    Cancelling or rejecting the picker resolves the request without any grant.
 
 The control plane should persist the request and its resolution so a restart or
@@ -363,18 +369,35 @@ This will land in independently reviewable pieces:
    grant. The desktop now polls that authoritative pending-work boundary, shows
    a bounded consent card, and keeps the picker, claim token, selected path, and
    broker mutation inside the native process. App-private receipts preserve the
-   exact operation ID, claim token, intent, and terminal payload across a crash.
+   exact registration operation ID, claim token, intent, product change ID,
+   attachment-revision fence, and terminal payload across a crash. These
+   identities are separate from the tool call and from each other. The private
+   receipt also keeps the bounded root display summary and a distinct exact
+   cleanup operation, so product recovery no longer depends on registration
+   remaining connected.
    A pre-effect phase is synced before the one registration dispatch, and the
    dispatch must begin inside a short post-heartbeat deadline. Recovery runs in
    the background with bounded backoff; it may query the broker receipt and
-   publish a known result, but it never starts or replays registration.
+   publish a known result, but an attempted receipt never starts or replays
+   registration. A confirmed registration now begins and finishes the durable
+   product root-attachment state machine through the private native routes;
+   exact broker attachment recovery is lookup-first, and `connected` is held
+   until a final product projection read matches the terminal receipt. A
+   permanent product begin rejection drives a same-conversation `DetachRoot`
+   cleanup before resolving failure; it never broadens that cleanup into
+   project-wide revocation. If that detach itself reports a durable failure
+   because another trusted action already revoked the root, recovery accepts
+   cleanup only after the original registration receipt authoritatively reports
+   the same root disconnected. A historical attach receipt whose live state is now
+   detached finishes product work as failed and rolls back its provisional root.
 8. **Pathless baseline complete:** project/chat `workspace_dir` is gone. The
    pre-v1 schema stores bounded ordered opaque root projections and revisions,
    while runtime-only legacy scratch is derived under private server data and
    never returned by the product API. The broker now supports exact,
    idempotent per-conversation attach/detach plus read-only recovery receipts.
-   The durable product-side attachment operation is now implemented in core.
-   Native routes and the reconciliation loop remain separate slices.
+   The durable product-side attachment operation is implemented in core and
+   used by the agent-approved folder-consent path. Manual connect/disconnect
+   controls and startup-wide reconciliation remain separate slices.
 9. Route built-in file tools through the operation interface and remove direct
    ambient host-directory opening from `ToolCtx`.
 10. Port bounded imports, writes, approvals, and confined command execution as

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -174,8 +174,10 @@ scratch capability. Its path is neither persisted on the chat nor returned by
 the product API. The desktop can connect, list, and revoke multiple folders
 through a native picker and capability-gated host-broker sidecar; it exposes only
 opaque root IDs and display names to the renderer. Foreground tool calls can now
-list/read roots already attached to their stored chat context; broader root
-attachment synchronization remains a separate durable state-machine slice.
+list/read roots already attached to their stored chat context. An approved
+agent folder request now converges through the durable product root-attachment
+state machine before it can report `connected`; manual connect/disconnect
+synchronization remains a separate slice.
 See [Host access and connected folders](host-access.md). The agent loop can now
 produce a durable client-wait checkpoint for the registered folder-request
 contract. The desktop discovers those pending requests from durable state and
@@ -261,7 +263,8 @@ query and periodic polling of pending work remain authoritative after a restart
 or missed notification. The picker opens before the claim, so the client does
 not hold a lease while the user is deciding. Once a choice exists, an app-private
 receipt binds the conversation, call, stable executor, fresh claim token, and
-intent. The call ID is also the broker registration operation ID.
+intent. It also owns a separately generated broker registration operation ID;
+the tool call identity is never reused as a broker mutation identity.
 
 The native executor retries only exact, idempotent control-plane operations.
 Claim, heartbeat, and resolve also require a second per-launch native credential
@@ -270,10 +273,25 @@ executor syncs a durable pre-effect phase. The broker registration is then
 queued once with a short dispatch deadline inside the renewed lease. After a
 response, disconnect, or crash, the executor asks the broker for the registration
 receipt and records the de-sensitized terminal payload before resolving the
-client call. A background reconciler retries read-only lookup and exact result
-publication with bounded backoff. On restart it can publish a stored payload or
-reconcile a known broker outcome; it never starts registration from a recovery
-receipt. Declining or closing the picker completes the call with a typed
+client call. A confirmed registration then receives a second durable identity:
+a root-attachment change ID paired with the exact observed attachment revision,
+creation time, safe root summary, and a separate same-conversation cleanup ID.
+That private product-sync receipt becomes authoritative on restart, so recovery
+does not depend on the earlier registration still being connected. Native
+control begins that product change through the
+separately credentialed executor API, queries or dispatches the same-ID broker
+`AttachRoot`, finishes from its exact receipt, and verifies the final chat
+projection. Only then can the tool publish `connected`. A background reconciler
+retries read-only lookup and exact result publication with bounded backoff. On
+restart it can publish stored payloads or reconcile known registration and
+attachment outcomes; an `attempted` registration receipt is lookup-only and
+never starts or replays registration. If a permanent revision, capacity, or
+identity fence rejects product begin, native recovery first drives the distinct
+exact `DetachRoot` cleanup to a confirmed conversation-local terminal state;
+if detach reports failure after a concurrent revoke, the original registration
+receipt must independently confirm that exact root is disconnected. Only then
+may it publish a bounded tool failure. Declining or closing the picker completes
+the call with a typed
 `declined` result rather than treating consent as an execution error.
 
 For crash recovery, the broker exposes a de-sensitized registration-receipt
@@ -548,9 +566,10 @@ routed through connected roots; that scratch path is neither persisted nor
 returned to the renderer. The UI does not yet provide projects, document
 ingestion/search/catalog views, structured citations, or steer controls, even
 though much of that backend API already exists. Connected-folder consent and
-reads work, but live picker paths still need to reconcile broker mutations
-through the durable product root-attachment state machine before those
-projections can be treated as one source of truth.
+reads work. Agent-approved picker results now reconcile broker registration,
+exact attachment, and the durable product projection before reporting success.
+The manual connect/disconnect controls still need the same convergence path
+before every folder UI action shares one source of truth.
 
 Because that chat is projectless, its `search` tool can see only the unscoped
 document corpus. Project-scoped documents are not reachable through the current
@@ -648,8 +667,8 @@ The main next steps are:
   waits, and child-agent waits as durable continuations that release workers;
 - persist model/tool step boundaries and side-effect receipts so sandbox and
   foreground runs can resume safely after process loss;
-- synchronize native picker connections into the pathless project/conversation
-  root projection with exact CAS and broker reconciliation;
+- synchronize manual native connect/disconnect controls into the same pathless
+  project/conversation root projection used by agent-approved folder requests;
 - route built-in file tools through explicit broker roots while keeping private
   per-chat scratch separate;
 - add resumable checkpoints and explicit idempotency policy around remaining


### PR DESCRIPTION
## Summary
- persist separate broker registration and product attachment identities for approved folder requests
- reconcile the registered broker root through the durable root-attachment begin/finish API before publishing `connected`
- recover exact receipts across restarts, fail closed on mismatched state, and terminalize permanent failures without replaying registration
- document the agent-approved convergence path and remaining manual connect/disconnect work

## Validation
- `cargo test -p openwave-desktop --lib`
- `cargo test -p openwave-server root_attachment_finish_is_exact_scoped_and_keeps_contradictions_pending`
- `bw dev lint --rust`