### PR TITLE
Add local document library journey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5845,6 +5845,8 @@ dependencies = [
 name = "openwave-desktop"
 version = "0.0.0"
 dependencies = [
+ "cap-fs-ext",
+ "cap-std",
  "chrono",
  "openwave-core",
  "openwave-host-broker",
@@ -5860,6 +5862,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "unicode-general-category",
  "uuid",
  "windows-sys 0.61.2",
 ]
@@ -5947,6 +5950,7 @@ dependencies = [
  "tokio-tungstenite 0.30.0",
  "tower",
  "tower-http 0.7.0",
+ "unicode-general-category",
  "uuid",
 ]
 
@@ -9535,6 +9539,12 @@ name = "unicode-blocks"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ futures = "0.3"
 futures-timer = "3"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
+unicode-general-category = "1.1.0"
 chrono = { version = "0.4", features = ["serde"] }
 windows-sys = "0.61"
 sea-orm = { version = "1", default-features = false, features = ["macros", "runtime-tokio-rustls", "with-uuid", "with-chrono", "with-json"] }

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -24,6 +24,8 @@ serde_json = { workspace = true }
 
 [dependencies]
 chrono = { workspace = true }
+cap-fs-ext.workspace = true
+cap-std.workspace = true
 openwave-core = { path = "../openwave-core", default-features = false }
 openwave-host-broker = { path = "../openwave-host-broker" }
 openwave-server = { path = "../openwave-server" }
@@ -35,6 +37,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "process", "rt-multi-thread", "macros", "sync", "time"] }
+unicode-general-category = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -6,6 +6,18 @@ webview. The UI talks to that local API over HTTP + WebSocket (subprotocol auth)
 The native host also owns the folder picker and a private host-broker sidecar;
 the renderer receives opaque folder IDs and display names, never absolute paths.
 
+The Documents surface derives its corpus from the authoritative current chat:
+project chats use that project's documents and loose chats use the unscoped
+corpus. A native file picker
+accepts text and Markdown files, opens the selected regular file once without
+following a final symlink, applies the upload bound to the open handle, and sends
+the bytes directly to the in-process API. The webview receives only a safe
+catalog/search projection: bounded display titles, processing states, and plain
+passages. Source paths, bytes, index metadata, and generation identities remain
+native/server-side.
+Canonical document routes also require the native executor credential in this
+embedding, so the renderer's ordinary bearer cannot bypass that projection.
+
 When an agent needs a folder outside the current context, the chat UI renders a
 bounded consent card from the local API's authoritative pending-work list. The
 user can decline or ask the native host to open a picker. Native code then owns

--- a/crates/openwave-desktop/src/documents.rs
+++ b/crates/openwave-desktop/src/documents.rs
@@ -1,0 +1,605 @@
+//! Native document-library bridge.
+//!
+//! File paths and bytes terminate here. The webview receives a deliberately
+//! small catalog/search projection and never sees source locations, indexing
+//! identities, generation metadata, or canonical document payloads.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
+use openwave_core::{ChatId, DocumentProcessingStatus, ProjectId, Store};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_dialog::DialogExt;
+use tokio::sync::oneshot;
+use unicode_general_category::{get_general_category, GeneralCategory};
+use uuid::Uuid;
+
+use crate::host_access::HostAccess;
+use crate::{wait_server_info, AppState};
+
+const MAX_IMPORT_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_SEARCH_QUERY_CHARS: usize = 500;
+const MAX_RENDERER_SNIPPET_CHARS: usize = 4_000;
+const DOCUMENT_PAGE_SIZE: usize = 200;
+const MAX_LIBRARY_DOCUMENTS: usize = 1_000;
+const CLIENT_EXECUTOR_HEADER: &str = "x-openwave-client-executor";
+
+#[derive(Debug, Deserialize)]
+struct CatalogPage {
+    documents: Vec<CatalogDocument>,
+    next_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CatalogDocument {
+    document_id: Uuid,
+    title: Option<String>,
+    media_type: String,
+    processing_status: DocumentProcessingStatus,
+    updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LibraryDocument {
+    document_id: String,
+    title: Option<String>,
+    media_type: String,
+    processing_status: DocumentProcessingStatus,
+    updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LibraryCatalog {
+    documents: Vec<LibraryDocument>,
+    truncated: bool,
+}
+
+impl From<CatalogDocument> for LibraryDocument {
+    fn from(document: CatalogDocument) -> Self {
+        Self {
+            document_id: document.document_id.to_string(),
+            title: document
+                .title
+                .and_then(|title| is_safe_renderer_text(&title, 255, false).then_some(title)),
+            media_type: if document.media_type.starts_with("text/markdown") {
+                "text/markdown".to_owned()
+            } else {
+                "text/plain".to_owned()
+            },
+            processing_status: document.processing_status,
+            updated_at: document.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    citations: Vec<SearchCitation>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchCitation {
+    document_id: Uuid,
+    snippet: String,
+    heading_path: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LibrarySearchResult {
+    document_id: String,
+    snippet: String,
+    heading: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ImportedDocument {
+    document_id: String,
+    display_name: String,
+    processing_status: DocumentProcessingStatus,
+}
+
+#[derive(Debug, Deserialize)]
+struct IngestResponse {
+    document_id: Uuid,
+    processing_status: DocumentProcessingStatus,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct SearchLibraryRequest {
+    chat_id: Uuid,
+    query: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct LibraryRequest {
+    chat_id: Uuid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LibraryScope {
+    Unscoped,
+    Project(ProjectId),
+}
+
+#[tauri::command]
+pub(crate) async fn list_library_documents(
+    state: State<'_, Arc<AppState>>,
+    host_access: State<'_, HostAccess>,
+    request: LibraryRequest,
+) -> Result<LibraryCatalog, String> {
+    let scope = resolve_library_scope(&host_access, request.chat_id).await?;
+    let info = wait_server_info(state.inner()).await?;
+    let http = local_client();
+    let path = documents_path(scope);
+    let mut cursor: Option<String> = None;
+    let mut documents = Vec::new();
+    let truncated;
+    loop {
+        let mut request = http
+            .get(format!("{}{}", info.base_url, path))
+            .query(&[("limit", DOCUMENT_PAGE_SIZE.to_string())]);
+        if let Some(cursor) = cursor.as_deref() {
+            request = request.query(&[("cursor", cursor)]);
+        }
+        let response = native_auth(request, &info)
+            .send()
+            .await
+            .map_err(|_| "Could not load the document library".to_owned())?;
+        if !response.status().is_success() {
+            return Err("Could not load the document library".to_owned());
+        }
+        let page = response
+            .json::<CatalogPage>()
+            .await
+            .map_err(|_| "The document library returned an invalid response".to_owned())?;
+        documents.extend(page.documents.into_iter().map(LibraryDocument::from));
+        cursor = page.next_cursor;
+        if documents.len() >= MAX_LIBRARY_DOCUMENTS || cursor.is_none() {
+            let overflowed = documents.len() > MAX_LIBRARY_DOCUMENTS;
+            documents.truncate(MAX_LIBRARY_DOCUMENTS);
+            truncated = overflowed || cursor.is_some();
+            break;
+        }
+    }
+    Ok(LibraryCatalog {
+        documents,
+        truncated,
+    })
+}
+
+#[tauri::command]
+pub(crate) async fn search_library_documents(
+    state: State<'_, Arc<AppState>>,
+    host_access: State<'_, HostAccess>,
+    request: SearchLibraryRequest,
+) -> Result<Vec<LibrarySearchResult>, String> {
+    let query = request.query.trim();
+    if query.is_empty() || query.chars().count() > MAX_SEARCH_QUERY_CHARS {
+        return Err("Enter a search between 1 and 500 characters".to_owned());
+    }
+    let scope = resolve_library_scope(&host_access, request.chat_id).await?;
+    let info = wait_server_info(state.inner()).await?;
+    let response = native_auth(
+        local_client().post(format!("{}{}", info.base_url, search_path(scope))),
+        &info,
+    )
+    .json(&serde_json::json!({ "query": query, "k": 8 }))
+    .send()
+    .await
+    .map_err(|_| "Could not search the document library".to_owned())?;
+    if !response.status().is_success() {
+        return Err("Could not search the document library".to_owned());
+    }
+    let response = response
+        .json::<SearchResponse>()
+        .await
+        .map_err(|_| "Document search returned an invalid response".to_owned())?;
+    Ok(response
+        .citations
+        .into_iter()
+        .map(safe_search_result)
+        .collect())
+}
+
+#[tauri::command]
+pub(crate) async fn import_library_document(
+    app: AppHandle,
+    app_state: State<'_, Arc<AppState>>,
+    host_access: State<'_, HostAccess>,
+    request: LibraryRequest,
+) -> Result<Option<ImportedDocument>, String> {
+    // Validate before presenting native consent, then resolve again after the
+    // user returns so a long-lived picker cannot retain stale project scope.
+    resolve_library_scope(&host_access, request.chat_id).await?;
+    let _picker = host_access
+        .picker
+        .try_lock()
+        .map_err(|_| "A file or folder picker is already open".to_owned())?;
+    let Some(path) = pick_document(&app).await? else {
+        return Ok(None);
+    };
+    let (media_type, display_name) = import_metadata(&path)?;
+    let source_bytes = tauri::async_runtime::spawn_blocking(move || read_selected_document(&path))
+        .await
+        .map_err(|_| "Could not read the selected document".to_owned())??;
+    if source_bytes.is_empty() {
+        return Err("The selected document is empty".to_owned());
+    }
+
+    let scope = resolve_library_scope(&host_access, request.chat_id).await?;
+    let info = wait_server_info(app_state.inner()).await?;
+    let response = native_auth(
+        local_client().post(format!("{}{}", info.base_url, raw_documents_path(scope))),
+        &info,
+    )
+    .query(&[("title", display_name.as_str())])
+    .header(reqwest::header::CONTENT_TYPE, media_type)
+    .body(source_bytes)
+    .send()
+    .await
+    .map_err(|_| "Could not import the selected document".to_owned())?;
+    if !response.status().is_success() {
+        return Err("Could not import the selected document".to_owned());
+    }
+    let accepted = response
+        .json::<IngestResponse>()
+        .await
+        .map_err(|_| "Document import returned an invalid response".to_owned())?;
+    Ok(Some(ImportedDocument {
+        document_id: accepted.document_id.to_string(),
+        display_name,
+        processing_status: accepted.processing_status,
+    }))
+}
+
+async fn resolve_library_scope(
+    host_access: &HostAccess,
+    chat_id: Uuid,
+) -> Result<LibraryScope, String> {
+    if chat_id.is_nil() {
+        return Err("Invalid conversation".to_owned());
+    }
+    let store = host_access
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    resolve_library_scope_from_store(store.as_ref(), chat_id).await
+}
+
+async fn resolve_library_scope_from_store(
+    store: &dyn Store,
+    chat_id: Uuid,
+) -> Result<LibraryScope, String> {
+    let chat = store
+        .get_chat(ChatId::from(chat_id))
+        .await
+        .map_err(|_| "Could not load the conversation".to_owned())?
+        .ok_or_else(|| "Conversation not found".to_owned())?;
+    Ok(match chat.project_id {
+        Some(project_id) => LibraryScope::Project(project_id),
+        None => LibraryScope::Unscoped,
+    })
+}
+
+fn documents_path(scope: LibraryScope) -> String {
+    match scope {
+        LibraryScope::Unscoped => "/documents".to_owned(),
+        LibraryScope::Project(project_id) => format!("/projects/{project_id}/documents"),
+    }
+}
+
+fn raw_documents_path(scope: LibraryScope) -> String {
+    format!("{}/raw", documents_path(scope))
+}
+
+fn search_path(scope: LibraryScope) -> String {
+    match scope {
+        LibraryScope::Unscoped => "/search".to_owned(),
+        LibraryScope::Project(project_id) => format!("/projects/{project_id}/search"),
+    }
+}
+
+fn native_auth(
+    request: reqwest::RequestBuilder,
+    info: &crate::NativeServerInfo,
+) -> reqwest::RequestBuilder {
+    request
+        .bearer_auth(&info.token)
+        .header(CLIENT_EXECUTOR_HEADER, &info.executor_token)
+}
+
+fn local_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .expect("fixed local HTTP client configuration is valid")
+}
+
+async fn pick_document(app: &AppHandle) -> Result<Option<PathBuf>, String> {
+    let (tx, rx) = oneshot::channel();
+    let mut picker = app
+        .dialog()
+        .file()
+        .set_title("Import a text or Markdown document")
+        .add_filter("Text and Markdown", &["txt", "md", "markdown"]);
+    if let Some(window) = app.get_webview_window("main") {
+        picker = picker.set_parent(&window);
+    }
+    picker.pick_file(move |path| {
+        let _ = tx.send(path);
+    });
+    rx.await
+        .map_err(|_| "The document picker closed unexpectedly".to_owned())?
+        .map(tauri_plugin_dialog::FilePath::into_path)
+        .transpose()
+        .map_err(|_| "The document picker returned an invalid file".to_owned())
+}
+
+fn import_metadata(path: &Path) -> Result<(&'static str, String), String> {
+    if !path.is_absolute() {
+        return Err("The document picker returned an invalid file".to_owned());
+    }
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase);
+    let media_type = match extension.as_deref() {
+        Some("md" | "markdown") => "text/markdown",
+        Some("txt") => "text/plain",
+        _ => return Err("Choose a .txt, .md, or .markdown file".to_owned()),
+    };
+    let display_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| {
+            !name.is_empty() && name.chars().count() <= 255 && name.chars().all(is_safe_title_char)
+        })
+        .ok_or_else(|| "The selected document has an invalid name".to_owned())?;
+    Ok((media_type, display_name.to_owned()))
+}
+
+fn read_selected_document(path: &Path) -> Result<Vec<u8>, String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "The document picker returned an invalid file".to_owned())?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| "The document picker returned an invalid file".to_owned())?;
+    let directory = Dir::open_ambient_dir(parent, ambient_authority())
+        .map_err(|_| "Could not read the selected document".to_owned())?;
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = directory
+        .open_with(file_name, &options)
+        .map_err(|_| "Could not read the selected document".to_owned())?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| "Could not read the selected document".to_owned())?;
+    if !metadata.is_file() {
+        return Err("Choose a text or Markdown file".to_owned());
+    }
+    if metadata.len() > MAX_IMPORT_BYTES {
+        return Err("Documents must be 16 MB or smaller".to_owned());
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_IMPORT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| "Could not read the selected document".to_owned())?;
+    if bytes.len() as u64 > MAX_IMPORT_BYTES {
+        return Err("Documents must be 16 MB or smaller".to_owned());
+    }
+    Ok(bytes)
+}
+
+fn is_safe_title_char(character: char) -> bool {
+    !matches!(
+        get_general_category(character),
+        GeneralCategory::Control
+            | GeneralCategory::Format
+            | GeneralCategory::LineSeparator
+            | GeneralCategory::ParagraphSeparator
+    )
+}
+
+fn is_safe_renderer_text(value: &str, max_chars: usize, allow_line_breaks: bool) -> bool {
+    !value.is_empty()
+        && value.chars().count() <= max_chars
+        && value.chars().all(|character| {
+            (is_safe_title_char(character)
+                || (allow_line_breaks && matches!(character, '\n' | '\r' | '\t')))
+                && character != '\0'
+        })
+}
+
+fn safe_search_result(citation: SearchCitation) -> LibrarySearchResult {
+    let snippet = citation
+        .snippet
+        .chars()
+        .filter(|character| {
+            is_safe_title_char(*character) || matches!(character, '\n' | '\r' | '\t')
+        })
+        .take(MAX_RENDERER_SNIPPET_CHARS)
+        .collect();
+    LibrarySearchResult {
+        document_id: citation.document_id.to_string(),
+        snippet,
+        heading: citation
+            .heading_path
+            .last()
+            .filter(|heading| is_safe_renderer_text(heading.trim(), 200, false))
+            .map(|heading| heading.trim().to_owned()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn chat_record_is_the_only_authority_for_library_scope() {
+        use openwave_core::{Chat, DbStore, Project};
+
+        let directory = tempfile::tempdir().unwrap();
+        let store = DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            directory.path().join("library-scope.db").display()
+        ))
+        .await
+        .unwrap();
+        let project = Project {
+            id: ProjectId::new(),
+            title: Some("Project".to_owned()),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: chrono::Utc::now(),
+        };
+        store.create_project(&project).await.unwrap();
+        let standalone = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: chrono::Utc::now(),
+        };
+        let project_chat = Chat {
+            id: ChatId::new(),
+            project_id: Some(project.id),
+            ..standalone.clone()
+        };
+        store.create_chat(&standalone).await.unwrap();
+        store.create_chat(&project_chat).await.unwrap();
+
+        assert_eq!(
+            resolve_library_scope_from_store(&store, standalone.id.0)
+                .await
+                .unwrap(),
+            LibraryScope::Unscoped
+        );
+        assert_eq!(
+            resolve_library_scope_from_store(&store, project_chat.id.0)
+                .await
+                .unwrap(),
+            LibraryScope::Project(project.id)
+        );
+        assert_eq!(documents_path(LibraryScope::Unscoped), "/documents");
+        assert_eq!(
+            documents_path(LibraryScope::Project(project.id)),
+            format!("/projects/{}/documents", project.id)
+        );
+
+        let injected = serde_json::json!({
+            "chatId": standalone.id,
+            "projectId": project.id,
+        });
+        assert!(serde_json::from_value::<LibraryRequest>(injected).is_err());
+        let injected_search = serde_json::json!({
+            "chatId": standalone.id,
+            "projectId": project.id,
+            "query": "notes",
+        });
+        assert!(serde_json::from_value::<SearchLibraryRequest>(injected_search).is_err());
+    }
+
+    #[test]
+    fn import_metadata_exposes_only_a_bounded_filename() {
+        let (media_type, name) =
+            import_metadata(Path::new("/Users/private/notes/plan.md")).unwrap();
+        assert_eq!(media_type, "text/markdown");
+        assert_eq!(name, "plan.md");
+        assert!(!name.contains("private"));
+        assert!(import_metadata(Path::new("/Users/private/plan.pdf")).is_err());
+        assert!(import_metadata(Path::new("relative.md")).is_err());
+        assert!(import_metadata(Path::new("/Users/private/bad\u{202e}txt.md")).is_err());
+        for unsafe_character in ['\u{200d}', '\u{206a}', '\u{206f}', '\u{2028}', '\u{2029}'] {
+            let path = format!("/Users/private/bad{unsafe_character}.md");
+            assert!(import_metadata(Path::new(&path)).is_err());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn selected_document_reader_rejects_symlinks_and_growth_past_the_limit() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target.md");
+        std::fs::write(&target, "private").unwrap();
+        let link = directory.path().join("link.md");
+        symlink(&target, &link).unwrap();
+        assert!(read_selected_document(&link).is_err());
+
+        let oversized = directory.path().join("oversized.md");
+        let file = std::fs::File::create(&oversized).unwrap();
+        file.set_len(MAX_IMPORT_BYTES + 1).unwrap();
+        assert_eq!(
+            read_selected_document(&oversized).unwrap_err(),
+            "Documents must be 16 MB or smaller"
+        );
+    }
+
+    #[test]
+    fn renderer_search_projection_drops_canonical_metadata_and_bounds_text() {
+        let result = safe_search_result(SearchCitation {
+            document_id: Uuid::nil(),
+            snippet: format!("{}\u{202e}", "x".repeat(MAX_RENDERER_SNIPPET_CHARS + 20)),
+            heading_path: vec!["Private heading".to_owned()],
+        });
+        let json = serde_json::to_value(result).unwrap();
+        assert_eq!(
+            json["snippet"].as_str().unwrap().chars().count(),
+            MAX_RENDERER_SNIPPET_CHARS
+        );
+        assert_eq!(json["heading"], "Private heading");
+        assert!(!json["snippet"].as_str().unwrap().contains('\u{202e}'));
+        let serialized = json.to_string();
+        for forbidden in [
+            "chunk", "span", "score", "region", "revision", "token", "path",
+        ] {
+            assert!(!serialized.contains(forbidden));
+        }
+    }
+
+    #[test]
+    fn renderer_catalog_projection_has_a_closed_safe_shape() {
+        let document = LibraryDocument::from(CatalogDocument {
+            document_id: Uuid::nil(),
+            title: Some("notes.md".to_owned()),
+            media_type: "text/markdown".to_owned(),
+            processing_status: DocumentProcessingStatus::Ready,
+            updated_at: "2026-07-18T00:00:00Z".to_owned(),
+        });
+        let json = serde_json::to_value(document).unwrap();
+        let keys = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            keys,
+            [
+                "documentId",
+                "mediaType",
+                "processingStatus",
+                "title",
+                "updatedAt"
+            ]
+        );
+        let serialized = json.to_string();
+        for forbidden in ["uri", "revision", "fingerprint", "content", "token", "path"] {
+            assert!(!serialized.contains(forbidden));
+        }
+    }
+}

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -16,6 +16,7 @@ use openwave_core::Config;
 
 mod broker;
 mod client_execution;
+mod documents;
 mod host_access;
 
 /// Connection details the webview needs to reach the in-process API.
@@ -28,14 +29,34 @@ pub struct ServerInfo {
     pub token: String,
 }
 
+#[derive(Clone)]
+struct NativeServerInfo {
+    base_url: String,
+    token: String,
+    executor_token: String,
+}
+
+impl NativeServerInfo {
+    fn renderer_info(&self) -> ServerInfo {
+        ServerInfo {
+            base_url: self.base_url.clone(),
+            token: self.token.clone(),
+        }
+    }
+}
+
 struct AppState {
     /// Filled once the accept loop is bound; awaited by `server_info`.
-    info_rx: watch::Receiver<Option<ServerInfo>>,
+    info_rx: watch::Receiver<Option<NativeServerInfo>>,
 }
 
 /// Return the bound server address and token (waits until bind completes).
 #[tauri::command]
 async fn server_info(state: tauri::State<'_, Arc<AppState>>) -> Result<ServerInfo, String> {
+    Ok(wait_server_info(state.inner()).await?.renderer_info())
+}
+
+async fn wait_server_info(state: &Arc<AppState>) -> Result<NativeServerInfo, String> {
     let mut rx = state.info_rx.clone();
     loop {
         if let Some(info) = rx.borrow().clone() {
@@ -44,6 +65,24 @@ async fn server_info(state: tauri::State<'_, Arc<AppState>>) -> Result<ServerInf
         rx.changed()
             .await
             .map_err(|_| "server failed to start".to_string())?;
+    }
+}
+
+#[cfg(test)]
+mod server_info_tests {
+    use super::*;
+
+    #[test]
+    fn renderer_server_info_never_contains_native_credential() {
+        let native = NativeServerInfo {
+            base_url: "http://127.0.0.1:1234".to_owned(),
+            token: "renderer-bearer".to_owned(),
+            executor_token: "native-credential-sentinel".to_owned(),
+        };
+        let serialized = serde_json::to_string(&native.renderer_info()).unwrap();
+        assert!(serialized.contains("renderer-bearer"));
+        assert!(!serialized.contains("native-credential-sentinel"));
+        assert!(!serialized.contains("executor"));
     }
 }
 
@@ -87,6 +126,9 @@ pub fn run() {
         .manage(state)
         .invoke_handler(tauri::generate_handler![
             server_info,
+            documents::import_library_document,
+            documents::list_library_documents,
+            documents::search_library_documents,
             client_execution::resolve_folder_access_request,
             host_access::connect_folder,
             host_access::list_connected_folders,
@@ -118,7 +160,7 @@ pub fn run() {
 /// Bind the local API and park the accept loop for the life of the process.
 async fn boot_server(
     app: tauri::AppHandle,
-    info_tx: watch::Sender<Option<ServerInfo>>,
+    info_tx: watch::Sender<Option<NativeServerInfo>>,
     data_dir: PathBuf,
 ) -> Result<(), String> {
     let client_executor_id = app.state::<host_access::HostAccess>().client_executor_id();
@@ -134,8 +176,12 @@ async fn boot_server(
     let token = server.token().to_string();
     let executor_token = server.client_executor_token().to_string();
     app.state::<host_access::HostAccess>()
-        .initialize_control_plane(base_url.clone(), token.clone(), executor_token)?;
-    let info = ServerInfo { base_url, token };
+        .initialize_control_plane(base_url.clone(), token.clone(), executor_token.clone())?;
+    let info = NativeServerInfo {
+        base_url,
+        token,
+        executor_token,
+    };
     let _ = info_tx.send(Some(info));
     let recovery_app = app.clone();
     tauri::async_runtime::spawn(async move {

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -33,6 +33,7 @@ import {
 import { hydrateTranscriptHistory } from "./TranscriptHistory";
 import { useChatEventStream } from "./ChatEventStream";
 import { isNearBottom, scrollToLatest } from "./ChatScroll";
+import { DocumentsView } from "./DocumentsView";
 
 type Msg = ChatMessage;
 
@@ -82,6 +83,7 @@ export default function App() {
   const [settingsPanel, setSettingsPanel] = useState<
     "providers" | "web-search" | "folders" | null
   >(null);
+  const [primaryView, setPrimaryView] = useState<"chat" | "documents">("chat");
   const [status, setStatus] = useState("starting…");
   const [hasUnreadActivity, setHasUnreadActivity] = useState(false);
   const socketRef = useRef<WebSocket | null>(null);
@@ -574,6 +576,7 @@ export default function App() {
   async function onNewChat() {
     if (!client || creatingChat || deletionInFlightRef.current) return;
     setCreatingChat(true);
+    setPrimaryView("chat");
     try {
       const created = await client.createChat(chat?.model ?? models[0]?.id);
       socketGenerationRef.current += 1;
@@ -657,6 +660,8 @@ export default function App() {
   }
 
   function selectChat(next: Chat, force = false) {
+    setPrimaryView("chat");
+    setSettingsPanel(null);
     if (next.id === chat?.id || creatingChat || (!force && deletionInFlightRef.current)) return;
     socketGenerationRef.current += 1;
     socketRef.current?.close();
@@ -832,18 +837,32 @@ export default function App() {
           {creatingChat ? "Starting…" : deletingChatId ? "Deleting…" : "New chat"}
         </button>
 
+        {hasNativeHost() && (
+          <button
+            type="button"
+            className={`sidebar-action sidebar-library${primaryView === "documents" ? " is-active" : ""}`}
+            onClick={() => {
+              setSettingsPanel(null);
+              setPrimaryView("documents");
+            }}
+          >
+            <span aria-hidden="true">▤</span>
+            Documents
+          </button>
+        )}
+
         <div className="sidebar-section">
           <span className="sidebar-label">Conversations</span>
           <div className="conversation-list" aria-label="Conversations">
             {chats.map((item) => (
               <div
                 key={item.id}
-                className={`conversation-row${item.id === chat.id ? " is-active" : ""}`}
+                className={`conversation-row${primaryView === "chat" && item.id === chat.id ? " is-active" : ""}`}
               >
                 <button
                   type="button"
                   className="conversation-item"
-                  aria-current={item.id === chat.id ? "page" : undefined}
+                  aria-current={primaryView === "chat" && item.id === chat.id ? "page" : undefined}
                   disabled={deletingChatId !== null || creatingChat}
                   onClick={() => selectChat(item)}
                 >
@@ -871,11 +890,12 @@ export default function App() {
             <button
               type="button"
               className={`sidebar-action${settingsPanel === "folders" ? " is-active" : ""}`}
-              onClick={() =>
+              onClick={() => {
+                setPrimaryView("chat");
                 setSettingsPanel((panel) =>
                   panel === "folders" ? null : "folders",
-                )
-              }
+                );
+              }}
             >
               Folders
             </button>
@@ -883,29 +903,37 @@ export default function App() {
           <button
             type="button"
             className={`sidebar-action${settingsPanel === "providers" ? " is-active" : ""}`}
-            onClick={() =>
+            onClick={() => {
+              setPrimaryView("chat");
               setSettingsPanel((panel) =>
                 panel === "providers" ? null : "providers",
-              )
-            }
+              );
+            }}
           >
             Providers
           </button>
           <button
             type="button"
             className={`sidebar-action${settingsPanel === "web-search" ? " is-active" : ""}`}
-            onClick={() =>
+            onClick={() => {
+              setPrimaryView("chat");
               setSettingsPanel((panel) =>
                 panel === "web-search" ? null : "web-search",
-              )
-            }
+              );
+            }}
           >
             Web search
           </button>
         </div>
       </aside>
 
-      <div className={`main${settingsPanel ? " with-settings" : ""}`}>
+      <div
+        className={`main${primaryView === "chat" && settingsPanel ? " with-settings" : ""}`}
+      >
+        {primaryView === "documents" ? (
+          <DocumentsView chatId={chat.id} onBack={() => setPrimaryView("chat")} />
+        ) : (
+          <>
         <section className="chat-pane">
           <header className="conversation-header">
             <div>
@@ -954,6 +982,18 @@ export default function App() {
             </div>
             <div className="conversation-header-actions">
               <div className="mobile-settings-actions">
+                {hasNativeHost() && (
+                  <button
+                    type="button"
+                    className="btn"
+                    onClick={() => {
+                      setSettingsPanel(null);
+                      setPrimaryView("documents");
+                    }}
+                  >
+                    Documents
+                  </button>
+                )}
                 {hasNativeHost() && (
                   <button
                     type="button"
@@ -1106,6 +1146,8 @@ export default function App() {
         )}
         {settingsPanel === "web-search" && <WebSearchPanel client={client} />}
         {settingsPanel === "folders" && <FoldersPanel chat={chat} />}
+          </>
+        )}
       </div>
     </div>
   );

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -1,0 +1,292 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  importLibraryDocument,
+  listLibraryDocuments,
+  searchLibraryDocuments,
+  type ImportedDocument,
+  type LibraryDocument,
+  type LibrarySearchResult,
+} from "./documents";
+
+export function DocumentsView({
+  chatId,
+  onBack,
+}: {
+  chatId: string;
+  onBack: () => void;
+}) {
+  const [documents, setDocuments] = useState<LibraryDocument[]>([]);
+  const [catalogTruncated, setCatalogTruncated] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [imported, setImported] = useState<ImportedDocument | null>(null);
+  const [query, setQuery] = useState("");
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const [results, setResults] = useState<LibrarySearchResult[] | null>(null);
+  const mountedRef = useRef(true);
+  const catalogRequestRef = useRef(0);
+  const searchRequestRef = useRef(0);
+
+  async function refreshCatalog(showLoading = false) {
+    const request = ++catalogRequestRef.current;
+    if (showLoading) setLoading(true);
+    try {
+      const next = await listLibraryDocuments(chatId);
+      if (!mountedRef.current || request !== catalogRequestRef.current) return;
+      setDocuments(next.documents);
+      setCatalogTruncated(next.truncated);
+      setError(null);
+    } catch (err) {
+      if (!mountedRef.current || request !== catalogRequestRef.current) return;
+      setError(friendlyError(err, "Could not load your documents."));
+    } finally {
+      if (mountedRef.current && request === catalogRequestRef.current) {
+        setLoading(false);
+      }
+    }
+  }
+
+  useEffect(() => {
+    mountedRef.current = true;
+    setDocuments([]);
+    setCatalogTruncated(false);
+    setError(null);
+    setImported(null);
+    setResults(null);
+    setSearchError(null);
+    setSearching(false);
+    searchRequestRef.current += 1;
+    void refreshCatalog(true);
+    return () => {
+      mountedRef.current = false;
+      catalogRequestRef.current += 1;
+      searchRequestRef.current += 1;
+    };
+  }, [chatId]);
+
+  const processing = documents.some((document) =>
+    ["queued", "processing"].includes(document.processingStatus),
+  );
+
+  useEffect(() => {
+    if (!processing) return;
+    const interval = window.setInterval(() => void refreshCatalog(), 2_000);
+    return () => window.clearInterval(interval);
+  }, [processing]);
+
+  async function onImport() {
+    if (importing) return;
+    setImporting(true);
+    setError(null);
+    setImported(null);
+    try {
+      const accepted = await importLibraryDocument(chatId);
+      if (!mountedRef.current || !accepted) return;
+      setImported(accepted);
+      await refreshCatalog();
+    } catch (err) {
+      if (mountedRef.current) {
+        setError(friendlyError(err, "Could not import that document."));
+      }
+    } finally {
+      if (mountedRef.current) setImporting(false);
+    }
+  }
+
+  async function onSearch(event: React.FormEvent) {
+    event.preventDefault();
+    const normalized = query.trim();
+    if (!normalized || searching) return;
+    const request = ++searchRequestRef.current;
+    setSearching(true);
+    setSearchError(null);
+    try {
+      const next = await searchLibraryDocuments(chatId, normalized);
+      if (!mountedRef.current || request !== searchRequestRef.current) return;
+      setResults(next);
+    } catch (err) {
+      if (!mountedRef.current || request !== searchRequestRef.current) return;
+      setSearchError(friendlyError(err, "Could not search your documents."));
+      setResults(null);
+    } finally {
+      if (mountedRef.current && request === searchRequestRef.current) {
+        setSearching(false);
+      }
+    }
+  }
+
+  const titles = new Map(
+    documents.map((document) => [document.documentId, documentTitle(document)]),
+  );
+
+  return (
+    <section className="documents-view" aria-labelledby="documents-title">
+      <header className="documents-header">
+        <div>
+          <p className="eyebrow">Local library</p>
+          <h1 id="documents-title">Documents</h1>
+          <p>
+            Add text and Markdown files, then search the passages OpenWave has
+            prepared on this device.
+          </p>
+        </div>
+        <div className="documents-header-actions">
+          <button type="button" className="btn documents-back" onClick={onBack}>
+            Back to chat
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={importing}
+            onClick={() => void onImport()}
+          >
+            {importing ? "Importing…" : "Import document…"}
+          </button>
+        </div>
+      </header>
+
+      <div className="documents-content">
+        {imported && (
+          <div className="document-notice" role="status">
+            <strong>{imported.displayName}</strong> was added. OpenWave is preparing
+            it for search.
+          </div>
+        )}
+        {error && (
+          <div className="document-error" role="alert">
+            <span>{error}</span>
+            <button type="button" className="btn" onClick={() => void refreshCatalog(true)}>
+              Try again
+            </button>
+          </div>
+        )}
+
+        <section className="document-search" aria-labelledby="document-search-title">
+          <div>
+            <h2 id="document-search-title">Search your library</h2>
+            <p>Search finds relevant passages in documents that are ready.</p>
+          </div>
+          <form onSubmit={(event) => void onSearch(event)}>
+            <input
+              aria-label="Search documents"
+              placeholder="What are you looking for?"
+              maxLength={500}
+              value={query}
+              onChange={(event) => {
+                searchRequestRef.current += 1;
+                setSearching(false);
+                setSearchError(null);
+                setResults(null);
+                setQuery(event.target.value);
+              }}
+            />
+            <button
+              type="submit"
+              className="btn"
+              disabled={searching || !query.trim()}
+            >
+              {searching ? "Searching…" : "Search"}
+            </button>
+          </form>
+          {searchError && <p className="document-search-error">{searchError}</p>}
+          {results !== null && (
+            <div className="document-results" aria-live="polite">
+              {results.length === 0 ? (
+                <p className="document-empty-small">No matching passages found.</p>
+              ) : (
+                results.map((result, index) => (
+                  <article className="document-result" key={`${result.documentId}-${index}`}>
+                    <div className="document-result-source">
+                      <strong>{titles.get(result.documentId) ?? "Local document"}</strong>
+                      {result.heading && <span>{result.heading}</span>}
+                    </div>
+                    <p>{result.snippet}</p>
+                  </article>
+                ))
+              )}
+            </div>
+          )}
+        </section>
+
+        <section className="document-catalog" aria-labelledby="document-catalog-title">
+          <div className="document-section-heading">
+            <div>
+              <h2 id="document-catalog-title">Your documents</h2>
+              <p>{documents.length} {documents.length === 1 ? "document" : "documents"}</p>
+              {catalogTruncated && (
+                <p>Showing the newest 1,000 documents.</p>
+              )}
+            </div>
+            <button
+              type="button"
+              className="document-refresh"
+              disabled={loading}
+              onClick={() => void refreshCatalog(true)}
+            >
+              Refresh
+            </button>
+          </div>
+
+          {loading && documents.length === 0 ? (
+            <div className="document-empty" role="status">
+              Loading your document library…
+            </div>
+          ) : documents.length === 0 && !error ? (
+            <div className="document-empty">
+              <strong>Your library is empty</strong>
+              <span>Import a text or Markdown file to make it searchable.</span>
+            </div>
+          ) : (
+            <div className="document-list">
+              {documents.map((document) => (
+                <article className="document-row" key={document.documentId}>
+                  <div className="document-icon" aria-hidden="true">⌑</div>
+                  <div className="document-copy">
+                    <strong>{documentTitle(document)}</strong>
+                    <span>
+                      {mediaTypeLabel(document.mediaType)} · Updated {formatDate(document.updatedAt)}
+                    </span>
+                  </div>
+                  <DocumentStatus status={document.processingStatus} />
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </section>
+  );
+}
+
+function DocumentStatus({ status }: { status: LibraryDocument["processingStatus"] }) {
+  const label =
+    status === "ready"
+      ? "Ready"
+      : status === "failed"
+        ? "Needs attention"
+        : status === "processing"
+          ? "Processing"
+          : "Queued";
+  return <span className={`document-status is-${status}`}>{label}</span>;
+}
+
+function documentTitle(document: LibraryDocument): string {
+  return document.title?.trim() || `Document ${document.documentId.slice(0, 8)}`;
+}
+
+function mediaTypeLabel(mediaType: string): string {
+  return mediaType.startsWith("text/markdown") ? "Markdown" : "Text";
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(
+    new Date(value),
+  );
+}
+
+function friendlyError(error: unknown, fallback: string): string {
+  const message = String(error).replace(/^Error:\s*/, "").trim();
+  return message && message.length <= 240 ? message : fallback;
+}

--- a/crates/openwave-desktop/ui/src/documents.test.ts
+++ b/crates/openwave-desktop/ui/src/documents.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseImportedDocument,
+  parseLibraryCatalog,
+  parseLibrarySearchResults,
+} from "./documents";
+
+const documentId = "6c3df6af-bc62-4a66-a34e-29f327eaef41";
+
+describe("document library renderer projections", () => {
+  it("accepts the closed catalog and import shapes", () => {
+    expect(
+      parseLibraryCatalog({
+        documents: [
+          {
+            documentId,
+            title: "notes.md",
+            mediaType: "text/markdown",
+            processingStatus: "processing",
+            updatedAt: "2026-07-18T12:00:00Z",
+          },
+        ],
+        truncated: false,
+      }).documents,
+    ).toHaveLength(1);
+
+    expect(
+      parseImportedDocument({
+        documentId,
+        displayName: "notes.md",
+        processingStatus: "queued",
+      }),
+    ).toEqual({
+      documentId,
+      displayName: "notes.md",
+      processingStatus: "queued",
+    });
+    expect(parseImportedDocument(null)).toBeNull();
+    const unicodeName = `${"😀".repeat(250)}.md`;
+    expect(
+      parseImportedDocument({
+        documentId,
+        displayName: unicodeName,
+        processingStatus: "queued",
+      })?.displayName,
+    ).toBe(unicodeName);
+  });
+
+  it("rejects catalog fields that could reveal native or indexing details", () => {
+    for (const field of [
+      "uri",
+      "sourcePath",
+      "contentRevision",
+      "indexedRevision",
+      "indexFingerprint",
+      "generationToken",
+      "content",
+    ]) {
+      expect(() =>
+        parseLibraryCatalog({
+          documents: [
+            {
+              documentId,
+              title: "notes.md",
+              mediaType: "text/markdown",
+              processingStatus: "ready",
+              updatedAt: "2026-07-18T12:00:00Z",
+              [field]: "private",
+            },
+          ],
+          truncated: false,
+        }),
+      ).toThrow("Invalid document library response");
+    }
+  });
+
+  it("accepts plain search passages and rejects canonical result metadata", () => {
+    expect(
+      parseLibrarySearchResults([
+        { documentId, snippet: "A matching passage", heading: "Overview" },
+      ]),
+    ).toEqual([
+      { documentId, snippet: "A matching passage", heading: "Overview" },
+    ]);
+
+    expect(() =>
+      parseLibrarySearchResults([
+        {
+          documentId,
+          snippet: "A matching passage",
+          heading: null,
+          chunkId: "private",
+          score: 0.9,
+          sourceRegions: [{ path: "/private/notes.md" }],
+        },
+      ]),
+    ).toThrow("Invalid document search response");
+  });
+
+  it("rejects malformed, oversized, and unbounded projections", () => {
+    expect(() =>
+      parseImportedDocument({
+        documentId: "not-a-document-id",
+        displayName: "notes.md",
+        processingStatus: "ready",
+      }),
+    ).toThrow("Invalid document import response");
+    for (const unsafe of ["\u200d", "\u206a", "\u206f", "\u2028", "\u2029"]) {
+      expect(() =>
+        parseImportedDocument({
+          documentId,
+          displayName: `report${unsafe}.md`,
+          processingStatus: "ready",
+        }),
+      ).toThrow("Invalid document import response");
+      expect(() =>
+        parseLibrarySearchResults([
+          { documentId, snippet: `unsafe${unsafe}`, heading: null },
+        ]),
+      ).toThrow("Invalid document search response");
+    }
+    expect(() =>
+      parseImportedDocument({
+        documentId,
+        displayName: "report\u202etxt.md",
+        processingStatus: "ready",
+      }),
+    ).toThrow("Invalid document import response");
+    expect(() =>
+      parseLibrarySearchResults([
+        { documentId, snippet: "x".repeat(4_001), heading: null },
+      ]),
+    ).toThrow("Invalid document search response");
+    expect(() =>
+      parseLibrarySearchResults(
+        Array.from({ length: 9 }, () => ({ documentId, snippet: "x", heading: null })),
+      ),
+    ).toThrow("Invalid document search response");
+  });
+});

--- a/crates/openwave-desktop/ui/src/documents.ts
+++ b/crates/openwave-desktop/ui/src/documents.ts
@@ -1,0 +1,190 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type DocumentProcessingStatus =
+  | "queued"
+  | "processing"
+  | "ready"
+  | "failed";
+
+export type LibraryDocument = {
+  documentId: string;
+  title: string | null;
+  mediaType: string;
+  processingStatus: DocumentProcessingStatus;
+  updatedAt: string;
+};
+
+export type ImportedDocument = {
+  documentId: string;
+  displayName: string;
+  processingStatus: DocumentProcessingStatus;
+};
+
+export type LibrarySearchResult = {
+  documentId: string;
+  snippet: string;
+  heading: string | null;
+};
+
+export type LibraryCatalog = {
+  documents: LibraryDocument[];
+  truncated: boolean;
+};
+
+export async function listLibraryDocuments(chatId: string): Promise<LibraryCatalog> {
+  return parseLibraryCatalog(
+    await invoke("list_library_documents", { request: { chatId } }),
+  );
+}
+
+export async function importLibraryDocument(
+  chatId: string,
+): Promise<ImportedDocument | null> {
+  return parseImportedDocument(
+    await invoke("import_library_document", { request: { chatId } }),
+  );
+}
+
+export async function searchLibraryDocuments(
+  chatId: string,
+  query: string,
+): Promise<LibrarySearchResult[]> {
+  return parseLibrarySearchResults(
+    await invoke("search_library_documents", { request: { chatId, query } }),
+  );
+}
+
+export function parseLibraryCatalog(value: unknown): LibraryCatalog {
+  if (!isExactRecord(value, ["documents", "truncated"])) {
+    throw new Error("Invalid document library response");
+  }
+  if (!Array.isArray(value.documents) || value.documents.length > 1_000) {
+    throw new Error("Invalid document library response");
+  }
+  if (typeof value.truncated !== "boolean") {
+    throw new Error("Invalid document library response");
+  }
+  return {
+    documents: value.documents.map(parseLibraryDocument),
+    truncated: value.truncated,
+  };
+}
+
+export function parseImportedDocument(value: unknown): ImportedDocument | null {
+  if (value === null) return null;
+  if (!isExactRecord(value, ["documentId", "displayName", "processingStatus"])) {
+    throw new Error("Invalid document import response");
+  }
+  if (
+    !isUuid(value.documentId) ||
+    typeof value.displayName !== "string" ||
+    value.displayName.length === 0 ||
+    !isSafeRendererText(value.displayName, 255, false) ||
+    !isProcessingStatus(value.processingStatus)
+  ) {
+    throw new Error("Invalid document import response");
+  }
+  return {
+    documentId: value.documentId,
+    displayName: value.displayName,
+    processingStatus: value.processingStatus,
+  };
+}
+
+export function parseLibrarySearchResults(value: unknown): LibrarySearchResult[] {
+  if (!Array.isArray(value) || value.length > 8) {
+    throw new Error("Invalid document search response");
+  }
+  return value.map((item) => {
+    if (!isExactRecord(item, ["documentId", "snippet", "heading"])) {
+      throw new Error("Invalid document search response");
+    }
+    if (
+      !isUuid(item.documentId) ||
+      typeof item.snippet !== "string" ||
+      !isSafeRendererText(item.snippet, 4_000, true) ||
+      (item.heading !== null &&
+        (typeof item.heading !== "string" ||
+          !isSafeRendererText(item.heading, 200, false)))
+    ) {
+      throw new Error("Invalid document search response");
+    }
+    return {
+      documentId: item.documentId,
+      snippet: item.snippet,
+      heading: item.heading,
+    };
+  });
+}
+
+function parseLibraryDocument(value: unknown): LibraryDocument {
+  if (
+    !isExactRecord(value, [
+      "documentId",
+      "title",
+      "mediaType",
+      "processingStatus",
+      "updatedAt",
+    ])
+  ) {
+    throw new Error("Invalid document library response");
+  }
+  if (
+    !isUuid(value.documentId) ||
+    (value.title !== null &&
+      (typeof value.title !== "string" ||
+        !isSafeRendererText(value.title, 255, false))) ||
+    typeof value.mediaType !== "string" ||
+    value.mediaType.length === 0 ||
+    value.mediaType.length > 255 ||
+    !isProcessingStatus(value.processingStatus) ||
+    typeof value.updatedAt !== "string" ||
+    !Number.isFinite(Date.parse(value.updatedAt))
+  ) {
+    throw new Error("Invalid document library response");
+  }
+  return {
+    documentId: value.documentId,
+    title: value.title,
+    mediaType: value.mediaType,
+    processingStatus: value.processingStatus,
+    updatedAt: value.updatedAt,
+  };
+}
+
+function isProcessingStatus(value: unknown): value is DocumentProcessingStatus {
+  return ["queued", "processing", "ready", "failed"].includes(String(value));
+}
+
+function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  );
+}
+
+function isSafeRendererText(
+  value: string,
+  maxCodePoints: number,
+  allowLineBreaks: boolean,
+): boolean {
+  const characters = [...value];
+  if (characters.length > maxCodePoints) return false;
+  return characters.every((character) => {
+    if (allowLineBreaks && ["\n", "\r", "\t"].includes(character)) return true;
+    return !DISALLOWED_RENDERER_CATEGORY.test(character);
+  });
+}
+
+const DISALLOWED_RENDERER_CATEGORY = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u;
+
+function isExactRecord(
+  value: unknown,
+  keys: readonly string[],
+): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const actual = Object.keys(value);
+  return actual.length === keys.length && actual.every((key) => keys.includes(key));
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -173,6 +173,17 @@ button {
   background: var(--sidebar-active);
 }
 
+.sidebar-library {
+  margin-top: -0.75rem;
+  color: var(--ink);
+}
+
+.sidebar-library span {
+  width: 1rem;
+  color: var(--muted);
+  text-align: center;
+}
+
 .conversation-item {
   flex: 1 1 auto;
 }
@@ -1182,6 +1193,288 @@ button {
   margin-top: 0.5rem;
 }
 
+.documents-view {
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--bg);
+}
+
+.documents-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2.2rem clamp(1.25rem, 5vw, 4rem) 1.7rem;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--bg-elevated) 86%, var(--bg));
+}
+
+.documents-header h1,
+.documents-header p,
+.document-search h2,
+.document-search p,
+.document-catalog h2,
+.document-catalog p {
+  margin: 0;
+}
+
+.documents-header h1 {
+  margin-top: 0.15rem;
+  font-size: 1.65rem;
+  font-weight: 630;
+  letter-spacing: -0.035em;
+}
+
+.documents-header > div > p:last-child {
+  max-width: 41rem;
+  margin-top: 0.45rem;
+  color: var(--muted);
+}
+
+.documents-header-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.55rem;
+}
+
+.documents-back {
+  display: none;
+}
+
+.documents-content {
+  display: grid;
+  width: min(100%, 68rem);
+  gap: 1.25rem;
+  margin: 0 auto;
+  padding: 1.6rem clamp(1.25rem, 5vw, 4rem) 4rem;
+}
+
+.document-notice,
+.document-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--accent) 48%, var(--line));
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-elevated));
+  font-size: 0.84rem;
+}
+
+.document-notice strong {
+  margin-right: 0.2rem;
+}
+
+.document-error {
+  border-color: color-mix(in srgb, var(--danger) 42%, var(--line));
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 5%, var(--bg-elevated));
+}
+
+.document-search,
+.document-catalog {
+  padding: 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--bg-elevated);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--ink) 4%, transparent);
+}
+
+.document-search h2,
+.document-catalog h2 {
+  font-size: 0.98rem;
+  font-weight: 620;
+}
+
+.document-search > div:first-child > p,
+.document-section-heading p {
+  margin-top: 0.2rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.document-search form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.55rem;
+  margin-top: 0.85rem;
+}
+
+.document-search input {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.55rem 0.7rem;
+  background: var(--bg);
+}
+
+.document-search input:focus {
+  outline: 2px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  outline-offset: 1px;
+}
+
+.document-search-error {
+  margin-top: 0.65rem !important;
+  color: var(--danger);
+  font-size: 0.8rem;
+}
+
+.document-results {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 0.85rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--line);
+}
+
+.document-result {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.document-result-source {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+}
+
+.document-result-source span {
+  color: var(--muted);
+}
+
+.document-result p {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: color-mix(in srgb, var(--ink) 88%, var(--muted));
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+.document-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.85rem;
+}
+
+.document-refresh {
+  border: 0;
+  padding: 0.25rem;
+  color: var(--muted);
+  background: transparent;
+  font-size: 0.78rem;
+}
+
+.document-refresh:hover:not(:disabled) {
+  color: var(--ink);
+}
+
+.document-refresh:disabled {
+  cursor: wait;
+  opacity: 0.5;
+}
+
+.document-list {
+  display: grid;
+  border-top: 1px solid var(--line);
+}
+
+.document-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 4.25rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.document-row:last-child {
+  border-bottom: 0;
+}
+
+.document-icon {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  color: var(--muted);
+  background: var(--bg);
+}
+
+.document-copy {
+  display: grid;
+  min-width: 0;
+  gap: 0.15rem;
+}
+
+.document-copy strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.86rem;
+  font-weight: 590;
+}
+
+.document-copy span {
+  color: var(--muted);
+  font-size: 0.74rem;
+}
+
+.document-status {
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  color: var(--muted);
+  background: var(--sidebar);
+  font-size: 0.72rem;
+  font-weight: 570;
+}
+
+.document-status.is-ready {
+  color: oklch(0.39 0.12 150);
+  background: color-mix(in srgb, var(--accent) 13%, var(--bg));
+}
+
+.document-status.is-processing,
+.document-status.is-queued {
+  color: oklch(0.47 0.11 75);
+  background: oklch(0.96 0.035 80);
+}
+
+.document-status.is-failed {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 9%, var(--bg));
+}
+
+.document-empty,
+.document-empty-small {
+  display: grid;
+  place-items: center;
+  gap: 0.25rem;
+  min-height: 8rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  text-align: center;
+}
+
+.document-empty strong {
+  color: var(--ink);
+}
+
+.document-empty-small {
+  min-height: 3rem;
+  border-top: 0;
+}
+
 @media (max-width: 720px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -1232,5 +1525,33 @@ button {
 
   .composer-turn-error {
     max-width: none;
+  }
+
+  .documents-header {
+    flex-direction: column;
+    padding: 1.25rem;
+  }
+
+  .documents-header-actions,
+  .documents-header-actions .btn {
+    width: 100%;
+  }
+
+  .documents-back {
+    display: block;
+  }
+
+  .documents-content {
+    padding: 1rem 0.75rem 2rem;
+  }
+
+  .document-row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .document-status {
+    grid-column: 2;
+    justify-self: start;
+    margin-top: -0.5rem;
   }
 }

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
+unicode-general-category = { workspace = true }
 chrono = { workspace = true }
 sha2 = { workspace = true }
 cap-std = { workspace = true }

--- a/crates/openwave-server/src/auth.rs
+++ b/crates/openwave-server/src/auth.rs
@@ -53,7 +53,7 @@ pub async fn require_token(
     }
 }
 
-/// Require the second credential held only by the trusted native executor.
+/// Require the second credential held only by the trusted native host.
 pub async fn require_client_executor_token(
     State(state): State<AppState>,
     request: Request,

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -4,8 +4,8 @@
 //! one local API rather than linking the loop directly, so all surfaces share a
 //! single wiring of `Config`, `Store`, and (next slice) the agent. The server
 //! binds to an ephemeral **loopback** port and mints a per-launch **bearer
-//! token**. Trusted client-execution mutations require a second per-launch
-//! credential that renderer-facing clients are never given.
+//! token**. Trusted native operations require a second per-launch credential
+//! that renderer-facing clients are never given.
 //!
 //! The surface runs turns end to end: the chat CRUD routes, `POST
 //! /chats/{id}/messages` to start a turn (one per chat at a time), and
@@ -71,55 +71,7 @@ const MAX_WEB_SEARCH_CREDENTIAL_BODY_BYTES: usize = 16 * 1024;
 pub fn app(state: AppState) -> Router {
     // `route_layer` applies the token check to matched API routes only, so an
     // unknown path still answers `404` (not `401`), and `/healthz` stays open.
-    let client_executor_api = Router::new()
-        .route(
-            "/chats/{id}/client-executions/pending/raw",
-            get(routes::list_pending_client_executions_raw),
-        )
-        .route(
-            "/chats/{id}/client-executions/{call_id}/claim",
-            post(routes::claim_client_execution),
-        )
-        .route(
-            "/chats/{id}/client-executions/{call_id}/heartbeat",
-            post(routes::heartbeat_client_execution),
-        )
-        .route(
-            "/chats/{id}/client-executions/{call_id}/resolve",
-            post(routes::resolve_client_execution),
-        );
-    let client_executor_api = if state.root_attachment_routes_enabled {
-        client_executor_api
-            .route(
-                "/chats/{chat_id}/root-attachment-changes/{change_id}/begin",
-                post(routes::begin_root_attachment_change),
-            )
-            .route(
-                "/root-attachment-changes/pending",
-                get(routes::list_pending_root_attachment_changes),
-            )
-            .route(
-                "/root-attachment-changes/{change_id}/finish",
-                post(routes::finish_root_attachment_change),
-            )
-    } else {
-        client_executor_api
-    }
-    .route_layer(axum::middleware::from_fn_with_state(
-        state.clone(),
-        auth::require_client_executor_token,
-    ));
-
-    let api = Router::new()
-        .route(
-            "/settings",
-            get(routes::get_settings).put(routes::put_settings),
-        )
-        .route(
-            "/projects",
-            post(routes::create_project).get(routes::list_projects),
-        )
-        .route("/projects/{id}", get(routes::get_project))
+    let document_api = Router::new()
         .route(
             "/projects/{project_id}/documents",
             post(routes::ingest_project_document).get(routes::list_project_documents),
@@ -141,6 +93,75 @@ pub fn app(state: AppState) -> Router {
             "/projects/{project_id}/search",
             post(routes::search_project_documents),
         )
+        .route(
+            "/documents",
+            post(routes::ingest_document).get(routes::list_documents),
+        )
+        .route(
+            "/documents/raw",
+            post(routes::ingest_raw_document).layer(DefaultBodyLimit::max(MAX_RAW_DOCUMENT_BYTES)),
+        )
+        .route(
+            "/documents/{id}",
+            get(routes::get_document).delete(routes::delete_document),
+        )
+        .route("/documents/{id}/retry", post(routes::retry_document))
+        .route("/search", post(routes::search_documents));
+
+    let client_executor_api = Router::new()
+        .route(
+            "/chats/{id}/client-executions/pending/raw",
+            get(routes::list_pending_client_executions_raw),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/claim",
+            post(routes::claim_client_execution),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/heartbeat",
+            post(routes::heartbeat_client_execution),
+        )
+        .route(
+            "/chats/{id}/client-executions/{call_id}/resolve",
+            post(routes::resolve_client_execution),
+        );
+    // A native embedding gives the renderer only the primary bearer, so its
+    // canonical document surface joins the native-only router. A headless
+    // embedding has no separate renderer trust boundary and deliberately keeps
+    // the same API on its primary bearer for CLI/API compatibility.
+    let (client_executor_api, public_document_api) = if state.root_attachment_routes_enabled {
+        let client_executor_api = client_executor_api
+            .route(
+                "/chats/{chat_id}/root-attachment-changes/{change_id}/begin",
+                post(routes::begin_root_attachment_change),
+            )
+            .route(
+                "/root-attachment-changes/pending",
+                get(routes::list_pending_root_attachment_changes),
+            )
+            .route(
+                "/root-attachment-changes/{change_id}/finish",
+                post(routes::finish_root_attachment_change),
+            )
+            .merge(document_api);
+        (client_executor_api, Router::new())
+    } else {
+        (client_executor_api, document_api)
+    };
+    let client_executor_api = client_executor_api.route_layer(
+        axum::middleware::from_fn_with_state(state.clone(), auth::require_client_executor_token),
+    );
+
+    let api = Router::new()
+        .route(
+            "/settings",
+            get(routes::get_settings).put(routes::put_settings),
+        )
+        .route(
+            "/projects",
+            post(routes::create_project).get(routes::list_projects),
+        )
+        .route("/projects/{id}", get(routes::get_project))
         .route("/models", get(routes::list_models))
         .route(
             "/web-search",
@@ -165,20 +186,7 @@ pub fn app(state: AppState) -> Router {
             "/providers/{kind}/credential",
             axum::routing::delete(routes::delete_provider_credential),
         )
-        .route(
-            "/documents",
-            post(routes::ingest_document).get(routes::list_documents),
-        )
-        .route(
-            "/documents/raw",
-            post(routes::ingest_raw_document).layer(DefaultBodyLimit::max(MAX_RAW_DOCUMENT_BYTES)),
-        )
-        .route(
-            "/documents/{id}",
-            get(routes::get_document).delete(routes::delete_document),
-        )
-        .route("/documents/{id}/retry", post(routes::retry_document))
-        .route("/search", post(routes::search_documents))
+        .merge(public_document_api)
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
         .route(
             "/chats/{id}",
@@ -307,7 +315,7 @@ impl Server {
         &self.token
     }
 
-    /// The second per-launch credential for trusted client-execution mutations.
+    /// The second per-launch credential for trusted native-only operations.
     pub fn client_executor_token(&self) -> &str {
         &self.client_executor_token
     }

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -5,6 +5,7 @@ use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use unicode_general_category::{get_general_category, GeneralCategory};
 
 use openwave_core::{
     DocumentJobId, DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceBlob,
@@ -38,6 +39,9 @@ pub struct IngestDocument {
 pub struct RawDocumentQuery {
     /// Optional source URI used for provenance and idempotent document identity.
     pub uri: Option<String>,
+    /// Optional human-facing title. This is metadata only and never used as a
+    /// source locator.
+    pub title: Option<String>,
 }
 
 /// Result of `POST /documents`.
@@ -225,6 +229,7 @@ async fn ingest_document_in_scope(
         state,
         project_id,
         body.uri,
+        None,
         body.media_type.unwrap_or_else(|| "text/plain".to_owned()),
         body.content.into_bytes(),
     )
@@ -280,6 +285,7 @@ async fn ingest_raw_document_in_scope(
         state,
         project_id,
         query.uri,
+        query.title,
         media_type.to_owned(),
         source_bytes,
     )
@@ -290,6 +296,7 @@ async fn publish_document_source(
     state: &AppState,
     project_id: Option<ProjectId>,
     source_uri: Option<String>,
+    title: Option<String>,
     media_type: String,
     source_bytes: Vec<u8>,
 ) -> Result<(StatusCode, Json<IngestResult>), ServerError> {
@@ -299,6 +306,7 @@ async fn publish_document_source(
         Some(uri) if !uri.is_empty() => Some(uri.to_owned()),
         _ => None,
     };
+    let title = normalize_document_title(title.as_deref())?;
     let parser_fingerprint = state
         .retrieval
         .canonical_fingerprint_for(&media_type)
@@ -329,7 +337,7 @@ async fn publish_document_source(
                 project_id,
                 source_uri,
                 media_type,
-                title: None,
+                title,
                 source_blob,
                 updated_at: Utc::now(),
             },
@@ -348,6 +356,61 @@ async fn publish_document_source(
             processing_status: revision.processing_status,
         }),
     ))
+}
+
+fn is_safe_document_title_char(character: char) -> bool {
+    !matches!(
+        get_general_category(character),
+        GeneralCategory::Control
+            | GeneralCategory::Format
+            | GeneralCategory::LineSeparator
+            | GeneralCategory::ParagraphSeparator
+    )
+}
+
+fn normalize_document_title(title: Option<&str>) -> Result<Option<String>, ServerError> {
+    let Some(raw_title) = title else {
+        return Ok(None);
+    };
+    if raw_title
+        .chars()
+        .any(|character| !is_safe_document_title_char(character))
+    {
+        return Err(ServerError::bad_request(
+            "document title contains unsupported control characters",
+        ));
+    }
+    let title = raw_title.trim();
+    if title.is_empty() {
+        return Ok(None);
+    }
+    if title.chars().count() > 255 {
+        return Err(ServerError::bad_request(
+            "document title must be at most 255 characters",
+        ));
+    }
+    Ok(Some(title.to_owned()))
+}
+
+#[cfg(test)]
+mod title_tests {
+    use super::*;
+
+    #[test]
+    fn renderer_titles_reject_all_visual_control_categories() {
+        for unsafe_character in [
+            '\u{0000}', '\u{200d}', '\u{206a}', '\u{206f}', '\u{2028}', '\u{2029}',
+        ] {
+            assert!(
+                normalize_document_title(Some(&format!("report{unsafe_character}.md"))).is_err()
+            );
+        }
+        let unicode_title = format!("{}.md", "😀".repeat(252));
+        assert_eq!(unicode_title.chars().count(), 255);
+        let normalized = normalize_document_title(Some(&unicode_title));
+        assert!(normalized.is_ok());
+        assert_eq!(normalized.ok().flatten(), Some(unicode_title));
+    }
 }
 
 /// `POST /documents/{id}/retry` — explicitly revive the current exact failed

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -60,7 +60,7 @@ pub struct AppState {
     pub agent_config: AgentConfig,
     /// The secret every request must present as `Authorization: Bearer <token>`.
     pub token: Arc<str>,
-    /// A second per-launch secret required for client-execution mutations.
+    /// A second per-launch secret required for native-only operations.
     pub(crate) client_executor_token: Arc<str>,
     /// Stable private identity owning native attachment reconciliation work.
     pub(crate) client_executor_id: Uuid,

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -3853,6 +3853,54 @@ async fn raw_ingest_enforces_media_type_body_and_project_scope() {
 }
 
 #[tokio::test]
+async fn raw_ingest_persists_a_safe_title_without_requiring_a_source_path() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    let response = post_raw(
+        &router,
+        &bearer,
+        "/documents/raw?title=meeting%20notes.md",
+        Some("text/markdown"),
+        b"# Notes".to_vec(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let accepted: serde_json::Value = json_body(response).await;
+    let document_id = accepted["document_id"].as_str().unwrap().parse().unwrap();
+    let document = store.get_document(document_id).await.unwrap().unwrap();
+    assert_eq!(document.title.as_deref(), Some("meeting notes.md"));
+    assert_eq!(document.source_uri, None);
+
+    let spoofed = post_raw(
+        &router,
+        &bearer,
+        "/documents/raw?title=report%E2%80%AEtxt.md",
+        Some("text/markdown"),
+        b"# Notes".to_vec(),
+    )
+    .await;
+    assert_eq!(spoofed.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn headless_embedding_keeps_document_api_on_its_primary_bearer() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/documents")
+                .header(header::AUTHORIZATION, bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn raw_ingest_has_an_explicit_limit_and_preserves_payload_too_large() {
     let (router, token, _store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");

--- a/crates/openwave-server/src/tests/root_attachment.rs
+++ b/crates/openwave-server/src/tests/root_attachment.rs
@@ -55,6 +55,112 @@ async fn assert_conflict_kind(response: axum::response::Response, expected: &str
     assert_eq!(body["kind"], expected);
 }
 
+#[tokio::test]
+async fn embedded_renderer_bearer_cannot_reach_canonical_document_routes() {
+    let (router, token, _store, _dir) = test_app_with_executor_id(uuid::Uuid::new_v4()).await;
+    let bearer = format!("Bearer {token}");
+    let ingest_body = serde_json::json!({
+        "uri": "file:///Users/private/review-sentinel.md",
+        "content": "private-content-sentinel",
+        "media_type": "text/markdown",
+    });
+    let accepted = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/documents")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(
+                    crate::auth::CLIENT_EXECUTOR_HEADER,
+                    crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
+                )
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(ingest_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(accepted.status(), StatusCode::ACCEPTED);
+    let accepted: serde_json::Value = json_body(accepted).await;
+    let document_id = accepted["document_id"].as_str().unwrap();
+    let project_id = ProjectId::new();
+
+    for (method, uri, body) in [
+        ("GET", "/documents".to_owned(), Body::empty()),
+        ("GET", format!("/documents/{document_id}"), Body::empty()),
+        (
+            "POST",
+            "/search".to_owned(),
+            Body::from(r#"{"query":"private-content-sentinel"}"#),
+        ),
+        (
+            "POST",
+            "/documents".to_owned(),
+            Body::from(ingest_body.to_string()),
+        ),
+        (
+            "POST",
+            "/documents/raw".to_owned(),
+            Body::from("private-content-sentinel"),
+        ),
+        ("DELETE", format!("/documents/{document_id}"), Body::empty()),
+        (
+            "GET",
+            format!("/projects/{project_id}/documents"),
+            Body::empty(),
+        ),
+        (
+            "GET",
+            format!("/projects/{project_id}/documents/{document_id}"),
+            Body::empty(),
+        ),
+        (
+            "POST",
+            format!("/projects/{project_id}/search"),
+            Body::from(r#"{"query":"private-content-sentinel"}"#),
+        ),
+    ] {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(body)
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8_lossy(&bytes);
+        for sentinel in [
+            "/Users/private",
+            "review-sentinel",
+            "private-content-sentinel",
+            "content_revision",
+            "index_fingerprint",
+        ] {
+            assert!(
+                !body.contains(sentinel),
+                "renderer denial leaked {sentinel}"
+            );
+        }
+    }
+
+    let native_detail = get_native(&router, &bearer, &format!("/documents/{document_id}")).await;
+    assert_eq!(native_detail.status(), StatusCode::OK);
+    let native_detail: serde_json::Value = json_body(native_detail).await;
+    assert_eq!(
+        native_detail["uri"],
+        "file:///Users/private/review-sentinel.md"
+    );
+    assert!(native_detail.get("content_revision").is_some());
+}
+
 fn root_attachment_begin_body(
     root_id: HostRootId,
     action: RootAttachmentChangeAction,

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -563,13 +563,25 @@ opaque folder summaries. Projects and chats store only ordered opaque root IDs
 and attachment revisions—never host paths or grants. Built-in agent file tools
 still use a server-derived per-chat private scratch directory and are not yet
 routed through connected roots; that scratch path is neither persisted nor
-returned to the renderer. The UI does not yet provide projects, document
-ingestion/search/catalog views, structured citations, or steer controls, even
-though much of that backend API already exists. Connected-folder consent and
-reads work. Agent-approved picker results now reconcile broker registration,
-exact attachment, and the durable product projection before reporting success.
-The manual connect/disconnect controls still need the same convergence path
-before every folder UI action shares one source of truth.
+returned to the renderer. The UI does not yet provide projects, structured
+citations, or steer controls. Its Documents surface derives scope from the
+authoritative current chat: project chats use that project's corpus and loose
+chats use the unscoped corpus. It lists the catalog, imports a user-picked text
+or Markdown file, polls durable processing status, and searches ready passages.
+Native code reads the selected file and calls the existing local document APIs;
+the renderer sees only bounded titles, lifecycle states, and plain-text search
+passages, never the source path, source bytes, generation identities, index
+metadata, or canonical search records. Connected-folder consent and reads work.
+Agent-approved picker results now reconcile broker registration, exact
+attachment, and the durable product projection before reporting success. The
+manual connect/disconnect controls still need the same convergence path before
+every folder UI action shares one source of truth.
+
+In the native embedding, canonical document routes require the second
+native-executor credential withheld from the renderer. Headless embeddings keep
+those routes on their primary bearer because they do not have a webview trust
+boundary. The native document bridge follows bounded catalog cursors and reports
+when it has intentionally stopped at the newest 1,000 records.
 
 Because that chat is projectless, its `search` tool can see only the unscoped
 document corpus. Project-scoped documents are not reachable through the current


### PR DESCRIPTION
## Summary
- add a chat-scoped desktop Documents surface with bounded catalog pagination, processing states, and local search
- import text and Markdown through a native picker without exposing paths or bytes to the renderer
- derive project or unscoped corpus authority from the durable chat record, never renderer-supplied project state
- protect canonical document routes with the native credential in embedded desktop while preserving headless API access
- project catalog and search responses through closed, bounded native DTOs with Unicode visual-control filtering
- persist safe display titles for raw document ingestion and refresh architecture docs

## Validation
- `cargo test -p openwave-desktop --lib` (26 passed)
- focused embedded renderer denial, headless access, raw title, and Unicode category server tests (4 passed)
- `pnpm test` (30 passed)
- `pnpm build`
- `bw --repo-root "$PWD" dev lint --rust --check`
- `cargo fmt --all -- --check`
- `git diff --check`