### PR TITLE
Derive the default document source

### DIFF
--- a/crates/openwave-retrieval/src/document.rs
+++ b/crates/openwave-retrieval/src/document.rs
@@ -15,7 +15,7 @@ use crate::error::{Result, RetrievalError};
 use crate::id::{ChunkId, DocumentId};
 
 /// Where an ingested document came from — its provenance for citations.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum DocumentSource {
@@ -25,13 +25,8 @@ pub enum DocumentSource {
         uri: String,
     },
     /// Content supplied inline with no external origin.
+    #[default]
     Inline,
-}
-
-impl Default for DocumentSource {
-    fn default() -> Self {
-        Self::Inline
-    }
 }
 
 impl DocumentSource {


### PR DESCRIPTION
## Summary
- derive `Default` for document provenance
- mark inline provenance as the default variant
- restore the full-workspace Clippy lane on main

## Validation
- `bw dev lint --rust --check`
- `git diff --check`