### PR TITLE
Reconcile manual folder attachments

### DIFF
--- a/crates/openwave-desktop/src/client_execution.rs
+++ b/crates/openwave-desktop/src/client_execution.rs
@@ -26,13 +26,14 @@ mod control_plane;
 pub(crate) mod folder_operations;
 mod product_sync;
 mod receipt_store;
+pub(crate) mod root_attachment_reconciliation;
 
 pub(crate) use control_plane::ControlPlaneClient;
 use control_plane::ControlPlaneError;
 pub(crate) use receipt_store::ReceiptStore;
 use receipt_store::{
     FolderAccessIntent, FolderAccessReceipt, FolderOperationPhase, FolderOperationReceipt,
-    RegistrationPhase, StoredResolution,
+    ManualFolderConnectReceipt, ProductRootAttachmentSync, RegistrationPhase, StoredResolution,
 };
 
 const RECOVERY_IDLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
@@ -194,6 +195,7 @@ async fn execute_receipt(
     let resolution = match receipt.intent.clone() {
         FolderAccessIntent::Decline => declined_resolution()?,
         FolderAccessIntent::Selected { path } => {
+            let _root_change = state.root_changes.lock().await;
             drive_selected_folder(state, &mut receipt, context, path, mode).await?
         }
     };
@@ -237,6 +239,7 @@ async fn recover_after_claim_conflict(
     let resolution = match receipt.intent.clone() {
         FolderAccessIntent::Decline => declined_resolution()?,
         FolderAccessIntent::Selected { path } => {
+            let _root_change = state.root_changes.lock().await;
             drive_selected_folder(state, &mut receipt, context, path, ExecutionMode::Recovery)
                 .await?
         }
@@ -664,10 +667,12 @@ mod tests {
             expected_revision: 4,
             before_revision: 4,
             intent_revision: 5,
+            projection_existed_before: false,
             phase: RootAttachmentChangePhase::Completed,
             result_revision: Some(5),
             broker_currently_attached: Some(true),
             failure: None,
+            created_at: sync.created_at,
         };
         assert!(validate_product_change(&change, &receipt, &sync, context).is_ok());
 

--- a/crates/openwave-desktop/src/client_execution/control_plane.rs
+++ b/crates/openwave-desktop/src/client_execution/control_plane.rs
@@ -89,6 +89,11 @@ pub(super) struct RootAttachmentChangeResponse {
     pub(super) change: RootAttachmentChangeView,
 }
 
+#[derive(Debug, Deserialize)]
+struct PendingRootAttachmentChanges {
+    changes: Vec<RootAttachmentChangeView>,
+}
+
 /// Closed native view of the fields needed to fence exact product/broker
 /// reconciliation. Server-only executor metadata is intentionally absent.
 #[derive(Debug, Deserialize)]
@@ -102,10 +107,12 @@ pub(super) struct RootAttachmentChangeView {
     pub(super) expected_revision: i64,
     pub(super) before_revision: i64,
     pub(super) intent_revision: i64,
+    pub(super) projection_existed_before: bool,
     pub(super) phase: RootAttachmentChangePhase,
     pub(super) result_revision: Option<i64>,
     pub(super) broker_currently_attached: Option<bool>,
     pub(super) failure: Option<RootAttachmentChangeFailure>,
+    pub(super) created_at: DateTime<Utc>,
 }
 
 impl ControlPlaneClient {
@@ -217,6 +224,7 @@ impl ControlPlaneClient {
         chat_id: ChatId,
         change_id: RootAttachmentChangeId,
         root_id: HostRootId,
+        action: RootAttachmentChangeAction,
         expected_attachment_revision: i64,
         created_at: DateTime<Utc>,
     ) -> Result<RootAttachmentChangeResponse, ControlPlaneError> {
@@ -224,12 +232,22 @@ impl ControlPlaneClient {
             &format!("/chats/{chat_id}/root-attachment-changes/{change_id}/begin"),
             &BeginRootAttachmentRequest {
                 root_id,
-                action: RootAttachmentChangeAction::Attach,
+                action,
                 expected_attachment_revision,
                 created_at,
             },
         )
         .await
+    }
+
+    pub(super) async fn pending_root_attachment_changes(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<RootAttachmentChangeView>, ControlPlaneError> {
+        let response: PendingRootAttachmentChanges = self
+            .get(&format!("/root-attachment-changes/pending?limit={limit}"))
+            .await?;
+        Ok(response.changes)
     }
 
     pub(super) async fn finish_root_attachment_change(

--- a/crates/openwave-desktop/src/client_execution/product_sync.rs
+++ b/crates/openwave-desktop/src/client_execution/product_sync.rs
@@ -121,6 +121,7 @@ async fn drive_product_attachment(
             receipt.chat_id,
             sync.change_id,
             sync.root_id,
+            RootAttachmentChangeAction::Attach,
             sync.expected_attachment_revision,
             sync.created_at,
         )

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -12,6 +12,7 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 use chrono::{DateTime, Utc};
 use openwave_core::{CallId, ChatId, HostRootId, RootAttachmentChangeId, MAX_ATTACHMENT_REVISION};
+use openwave_host_broker::GrantSubject;
 use openwave_host_broker::OperationId;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -23,6 +24,7 @@ const MAX_EXECUTOR_BYTES: usize = 128;
 const MAX_RECEIPT_BYTES: usize = 128 * 1024;
 const MAX_RECEIPTS: usize = 1_024;
 const FOLDER_OPERATION_PREFIX: &str = "folder-operation-";
+const MANUAL_FOLDER_CONNECT_PREFIX: &str = "manual-folder-connect-";
 const MAX_SAFE_ROOT_DISPLAY_BYTES: usize = 1_024;
 
 pub(crate) struct ReceiptStore {
@@ -65,6 +67,23 @@ pub(super) struct FolderOperationReceipt {
     pub(super) phase: FolderOperationPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) resolution: Option<StoredResolution>,
+}
+
+/// App-private recovery state for a folder selected from the manual connected
+/// folders UI. Absolute paths and broker authority never leave native storage.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub(super) struct ManualFolderConnectReceipt {
+    version: u32,
+    pub(super) chat_id: ChatId,
+    pub(super) subject: GrantSubject,
+    pub(super) path: PathBuf,
+    pub(super) registration_operation_id: OperationId,
+    pub(super) change_id: RootAttachmentChangeId,
+    pub(super) cleanup_operation_id: OperationId,
+    pub(super) registration_phase: RegistrationPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) product_sync: Option<ProductRootAttachmentSync>,
 }
 
 /// Whether a read-only broker request may have been dispatched already.
@@ -180,6 +199,23 @@ impl std::fmt::Debug for FolderOperationReceipt {
     }
 }
 
+impl std::fmt::Debug for ManualFolderConnectReceipt {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ManualFolderConnectReceipt")
+            .field("version", &self.version)
+            .field("chat_id", &self.chat_id)
+            .field("subject", &self.subject)
+            .field("path", &"[redacted]")
+            .field("registration_operation_id", &self.registration_operation_id)
+            .field("change_id", &self.change_id)
+            .field("cleanup_operation_id", &self.cleanup_operation_id)
+            .field("registration_phase", &self.registration_phase)
+            .field("product_sync", &self.product_sync)
+            .finish()
+    }
+}
+
 impl std::fmt::Debug for FolderAccessIntent {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -246,6 +282,67 @@ impl FolderAccessReceipt {
             })
         {
             return Err(invalid_data("invalid client-execution receipt"));
+        }
+        Ok(())
+    }
+}
+
+impl ManualFolderConnectReceipt {
+    pub(super) fn new(chat_id: ChatId, subject: GrantSubject, path: PathBuf) -> Self {
+        let registration_operation_id = OperationId::new();
+        let mut change_id = RootAttachmentChangeId::new();
+        while *change_id.as_uuid() == registration_operation_id.as_uuid() {
+            change_id = RootAttachmentChangeId::new();
+        }
+        let cleanup_operation_id = loop {
+            let id = OperationId::new();
+            if id.as_uuid() != registration_operation_id.as_uuid()
+                && id.as_uuid() != *change_id.as_uuid()
+            {
+                break id;
+            }
+        };
+        Self {
+            version: RECEIPT_VERSION,
+            chat_id,
+            subject,
+            path,
+            registration_operation_id,
+            change_id,
+            cleanup_operation_id,
+            registration_phase: RegistrationPhase::NotStarted,
+            product_sync: None,
+        }
+    }
+
+    fn validate(&self) -> io::Result<()> {
+        if self.version != RECEIPT_VERSION
+            || self.chat_id.as_uuid().is_nil()
+            || !self.path.is_absolute()
+            || self.registration_operation_id.as_uuid() == *self.change_id.as_uuid()
+            || self.registration_operation_id == self.cleanup_operation_id
+            || self.cleanup_operation_id.as_uuid() == *self.change_id.as_uuid()
+            || (self.registration_phase == RegistrationPhase::NotStarted
+                && self.product_sync.is_some())
+        {
+            return Err(invalid_data("invalid manual folder-connect receipt"));
+        }
+        if self.subject.kind() == openwave_host_broker::SubjectKind::Conversation
+            && self.subject.id() != *self.chat_id.as_uuid()
+        {
+            return Err(invalid_data("manual folder-connect subject mismatch"));
+        }
+        if let Some(sync) = &self.product_sync {
+            if sync.change_id.as_uuid().is_nil()
+                || sync.display_name.is_empty()
+                || sync.display_name.len() > MAX_SAFE_ROOT_DISPLAY_BYTES
+                || sync.display_name.contains('\0')
+                || !(0..=MAX_ATTACHMENT_REVISION).contains(&sync.expected_attachment_revision)
+                || sync.change_id != self.change_id
+                || sync.cleanup_operation_id != self.cleanup_operation_id
+            {
+                return Err(invalid_data("manual folder-connect identity mismatch"));
+            }
         }
         Ok(())
     }
@@ -348,6 +445,22 @@ impl ReceiptStore {
         )
     }
 
+    pub(super) fn save_manual_connect(
+        &self,
+        receipt: &ManualFolderConnectReceipt,
+    ) -> io::Result<()> {
+        receipt.validate()?;
+        let bytes = serde_json::to_vec(receipt).map_err(invalid_data)?;
+        if bytes.len() > MAX_RECEIPT_BYTES {
+            return Err(invalid_data("manual folder-connect receipt is too large"));
+        }
+        write_atomically(
+            &self.directory,
+            &self.manual_connect_receipt_path(receipt.change_id),
+            &bytes,
+        )
+    }
+
     pub(super) fn remove(&self, call_id: CallId) -> io::Result<()> {
         match fs::remove_file(self.receipt_path(call_id)) {
             Ok(()) => sync_directory(&self.directory),
@@ -358,6 +471,17 @@ impl ReceiptStore {
 
     pub(super) fn remove_operation(&self, call_id: CallId) -> io::Result<()> {
         match fs::remove_file(self.operation_receipt_path(call_id)) {
+            Ok(()) => sync_directory(&self.directory),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(super) fn remove_manual_connect(
+        &self,
+        change_id: RootAttachmentChangeId,
+    ) -> io::Result<()> {
+        match fs::remove_file(self.manual_connect_receipt_path(change_id)) {
             Ok(()) => sync_directory(&self.directory),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(error) => Err(error),
@@ -376,6 +500,9 @@ impl ReceiptStore {
                 continue;
             }
             if file_name.starts_with(FOLDER_OPERATION_PREFIX) {
+                continue;
+            }
+            if file_name.starts_with(MANUAL_FOLDER_CONNECT_PREFIX) {
                 continue;
             }
             if file_name.starts_with('.') && file_name.ends_with(".tmp") {
@@ -456,6 +583,50 @@ impl ReceiptStore {
         Ok(receipts)
     }
 
+    pub(super) fn load_manual_connects(&self) -> io::Result<Vec<ManualFolderConnectReceipt>> {
+        let mut receipts = Vec::new();
+        let mut change_ids = HashSet::new();
+        for entry in fs::read_dir(&self.directory)? {
+            let entry = entry?;
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                return Err(invalid_data("invalid client-execution receipt name"));
+            };
+            let Some(change_id) = file_name
+                .strip_prefix(MANUAL_FOLDER_CONNECT_PREFIX)
+                .and_then(|name| name.strip_suffix(".json"))
+            else {
+                continue;
+            };
+            if receipts.len() >= MAX_RECEIPTS {
+                return Err(invalid_data("too many pending manual folder connects"));
+            }
+            let change_id = change_id
+                .parse::<Uuid>()
+                .map_err(invalid_data)
+                .and_then(|id| RootAttachmentChangeId::from_uuid(id).map_err(invalid_data))?;
+            validate_private_file(&entry.path(), MAX_RECEIPT_BYTES)?;
+            let mut bytes = Vec::new();
+            File::open(entry.path())?
+                .take((MAX_RECEIPT_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)?;
+            if bytes.len() > MAX_RECEIPT_BYTES {
+                return Err(invalid_data("manual folder-connect receipt is too large"));
+            }
+            let receipt: ManualFolderConnectReceipt =
+                serde_json::from_slice(&bytes).map_err(invalid_data)?;
+            receipt.validate()?;
+            if receipt.change_id != change_id || !change_ids.insert(change_id) {
+                return Err(invalid_data(
+                    "manual folder-connect receipt identity mismatch",
+                ));
+            }
+            receipts.push(receipt);
+        }
+        receipts.sort_by_key(|receipt| receipt.change_id.to_string());
+        Ok(receipts)
+    }
+
     fn receipt_path(&self, call_id: CallId) -> PathBuf {
         self.directory.join(format!("{call_id}.json"))
     }
@@ -463,6 +634,11 @@ impl ReceiptStore {
     fn operation_receipt_path(&self, call_id: CallId) -> PathBuf {
         self.directory
             .join(format!("{FOLDER_OPERATION_PREFIX}{call_id}.json"))
+    }
+
+    fn manual_connect_receipt_path(&self, change_id: RootAttachmentChangeId) -> PathBuf {
+        self.directory
+            .join(format!("{MANUAL_FOLDER_CONNECT_PREFIX}{change_id}.json"))
     }
 }
 
@@ -708,6 +884,44 @@ mod tests {
         assert!(!debug.contains(&receipt.lease_token.to_string()));
         store.remove_operation(receipt.call_id).unwrap();
         assert!(store.load_operations().unwrap().is_empty());
+    }
+
+    #[test]
+    fn manual_connect_receipts_keep_paths_private_and_identities_distinct() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(temp.path()).unwrap();
+        let chat_id = ChatId::new();
+        let subject = GrantSubject::conversation(chat_id.0).unwrap();
+        let path = temp.path().join("Documents");
+        let mut receipt = ManualFolderConnectReceipt::new(chat_id, subject, path.clone());
+        store.save_manual_connect(&receipt).unwrap();
+        assert_eq!(store.load_manual_connects().unwrap(), vec![receipt.clone()]);
+        assert!(store.load_all().unwrap().is_empty());
+        assert!(!format!("{receipt:?}").contains(path.to_str().unwrap()));
+        assert_ne!(
+            receipt.registration_operation_id.as_uuid(),
+            *receipt.change_id.as_uuid()
+        );
+        assert_ne!(
+            receipt.cleanup_operation_id.as_uuid(),
+            *receipt.change_id.as_uuid()
+        );
+
+        receipt.registration_phase = RegistrationPhase::Attempted;
+        receipt.product_sync = Some(ProductRootAttachmentSync {
+            change_id: receipt.change_id,
+            root_id: HostRootId::from_uuid(Uuid::new_v4()).unwrap(),
+            display_name: "Documents".to_owned(),
+            expected_attachment_revision: 3,
+            created_at: Utc::now(),
+            cleanup_operation_id: receipt.cleanup_operation_id,
+            cleanup_phase: CleanupPhase::NotStarted,
+            attachment_phase: AttachmentPhase::Prepared,
+        });
+        store.save_manual_connect(&receipt).unwrap();
+        assert_eq!(store.load_manual_connects().unwrap(), vec![receipt.clone()]);
+        store.remove_manual_connect(receipt.change_id).unwrap();
+        assert!(store.load_manual_connects().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/openwave-desktop/src/client_execution/root_attachment_reconciliation.rs
+++ b/crates/openwave-desktop/src/client_execution/root_attachment_reconciliation.rs
@@ -1,0 +1,908 @@
+//! Native reconciliation for manual connected-folder mutations.
+//!
+//! Product intent is committed before the broker mutation. Every broker call
+//! uses the product change UUID as its idempotency identity, and recovery
+//! always looks up that exact receipt before dispatching it again.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use chrono::{DateTime, Timelike, Utc};
+use openwave_core::{
+    ChatId, HostRootId, RootAttachmentChangeAction, RootAttachmentChangeFailure,
+    RootAttachmentChangeId, RootAttachmentChangePhase, RootAttachmentChangeTerminal,
+    RootAttachmentSubjectKind, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+};
+use openwave_host_broker::{
+    ConsentMethod, ControlRequest, ControlResult, ExecutionContext,
+    LookupRegisterRootReceiptRequest, LookupRootAttachmentReceiptRequest, OperationId,
+    RegisterRootReceipt, RegisterRootRequest, RootAttachmentMutationKind,
+    RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootId, RootSummary, SubjectKind,
+};
+use tauri::Manager;
+
+use super::control_plane::{ControlPlaneError, RootAttachmentChangeView};
+use super::{
+    control_plane, control_plane_error, ManualFolderConnectReceipt, ProductRootAttachmentSync,
+    RegistrationPhase,
+};
+use crate::host_access::{AuthoritativeContext, ConnectedFolder, HostAccess};
+
+const RECOVERY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+const RECOVERY_LIMIT: usize = 64;
+static MANUAL_RECOVERY_CURSOR: AtomicUsize = AtomicUsize::new(0);
+static PRODUCT_RECOVERY_CURSOR: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone, Copy)]
+struct BeginFingerprint {
+    id: RootAttachmentChangeId,
+    chat_id: ChatId,
+    root_id: HostRootId,
+    action: RootAttachmentChangeAction,
+    expected_revision: i64,
+    created_at: DateTime<Utc>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConnectMode {
+    Interactive,
+    Recovery,
+}
+
+/// Register a picker-selected path and report success only after product and
+/// broker attachment state have converged.
+pub(crate) async fn connect_selected_folder(
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    path: PathBuf,
+) -> Result<ConnectedFolder, String> {
+    let mut receipt =
+        ManualFolderConnectReceipt::new(ChatId::from(context.chat_id), context.subject, path);
+    state
+        .receipts
+        .save_manual_connect(&receipt)
+        .map_err(private_receipt_error)?;
+    drive_manual_connect(state, &mut receipt, ConnectMode::Interactive).await
+}
+
+/// Begin and drive an exact conversation-only detach. Global root revocation
+/// is deliberately not part of the renderer's connected-folder action.
+pub(crate) async fn disconnect_root(
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    root_id: RootId,
+) -> Result<bool, String> {
+    let product_root_id = HostRootId::from_uuid(root_id.as_uuid())
+        .map_err(|_| "invalid connected folder identity".to_owned())?;
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let chat = store
+        .get_chat(ChatId::from(context.chat_id))
+        .await
+        .map_err(|_| "could not load connected folders".to_owned())?
+        .ok_or_else(|| "conversation not found".to_owned())?;
+    if !chat
+        .root_attachments
+        .iter()
+        .any(|attachment| attachment.root_id == product_root_id)
+    {
+        return Ok(false);
+    }
+
+    let fingerprint = BeginFingerprint {
+        id: RootAttachmentChangeId::new(),
+        chat_id: chat.id,
+        root_id: product_root_id,
+        action: RootAttachmentChangeAction::Detach,
+        expected_revision: chat.attachment_revision,
+        created_at: canonical_now(),
+    };
+    let begun = control_plane(state)?
+        .begin_root_attachment_change(
+            fingerprint.chat_id,
+            fingerprint.id,
+            fingerprint.root_id,
+            fingerprint.action,
+            fingerprint.expected_revision,
+            fingerprint.created_at,
+        )
+        .await
+        .map_err(begin_error)?;
+    validate_begin_change(&begun.change, context, fingerprint)?;
+    let finished = drive_change(state, begun.change).await?;
+    verify_product_terminal(state, &finished).await?;
+    match finished.phase {
+        RootAttachmentChangePhase::Completed => Ok(true),
+        RootAttachmentChangePhase::Failed => {
+            Err("The folder could not be disconnected safely. It remains connected.".to_owned())
+        }
+        RootAttachmentChangePhase::AwaitingBroker => {
+            Err("folder disconnection is still pending".to_owned())
+        }
+    }
+}
+
+/// Bounded startup and steady-state recovery of private picker receipts and
+/// server-owned attachment changes. One native loop owns this work; each pass
+/// is sequential and capped so large backlogs cannot monopolize the runtime.
+pub(crate) async fn recover_root_attachment_changes(app: tauri::AppHandle) {
+    loop {
+        if let Err(error) = recover_once(&app).await {
+            eprintln!("openwave-desktop: root attachment recovery deferred: {error}");
+        }
+        tokio::time::sleep(RECOVERY_INTERVAL).await;
+    }
+}
+
+async fn recover_once(app: &tauri::AppHandle) -> Result<(), String> {
+    let state = app.state::<HostAccess>();
+    let receipts = state
+        .receipts
+        .load_manual_connects()
+        .map_err(private_receipt_error)?;
+    let locally_owned = receipts
+        .iter()
+        .map(|receipt| receipt.change_id)
+        .collect::<HashSet<_>>();
+    for mut receipt in rotating_batch(receipts, &MANUAL_RECOVERY_CURSOR) {
+        let exclusive = state.root_changes.lock().await;
+        if let Err(error) =
+            drive_manual_connect(state.inner(), &mut receipt, ConnectMode::Recovery).await
+        {
+            eprintln!("openwave-desktop: manual folder connection deferred: {error}");
+        }
+        drop(exclusive);
+        tokio::task::yield_now().await;
+    }
+
+    let pending = control_plane(state.inner())?
+        .pending_root_attachment_changes(MAX_PENDING_ROOT_ATTACHMENT_CHANGES as usize)
+        .await
+        .map_err(control_plane_error)?;
+    for change in rotating_batch(pending, &PRODUCT_RECOVERY_CURSOR) {
+        if locally_owned.contains(&change.id) {
+            continue;
+        }
+        let exclusive = state.root_changes.lock().await;
+        if let Err(error) = recover_pending_change(state.inner(), change).await {
+            eprintln!("openwave-desktop: pending root attachment deferred: {error}");
+        }
+        drop(exclusive);
+        tokio::task::yield_now().await;
+    }
+    Ok(())
+}
+
+fn rotating_batch<T>(mut work: Vec<T>, cursor: &AtomicUsize) -> impl Iterator<Item = T> {
+    if !work.is_empty() {
+        let start = cursor.fetch_add(RECOVERY_LIMIT, Ordering::Relaxed) % work.len();
+        work.rotate_left(start);
+    }
+    work.into_iter().take(RECOVERY_LIMIT)
+}
+
+async fn recover_pending_change(
+    state: &HostAccess,
+    change: RootAttachmentChangeView,
+) -> Result<(), String> {
+    let context = state.context(change.chat_id.0).await?;
+    validate_change_context(&change, context)?;
+    let finished = drive_change(state, change).await?;
+    verify_product_terminal(state, &finished).await
+}
+
+async fn drive_manual_connect(
+    state: &HostAccess,
+    receipt: &mut ManualFolderConnectReceipt,
+    mode: ConnectMode,
+) -> Result<ConnectedFolder, String> {
+    if receipt.registration_phase == RegistrationPhase::NotStarted {
+        if mode == ConnectMode::Recovery {
+            // The picker selection was persisted, but native dispatch was not.
+            // A restart must never turn that stale selection into new authority.
+            state
+                .receipts
+                .remove_manual_connect(receipt.change_id)
+                .map_err(private_receipt_error)?;
+            return Err("unstarted folder connection was discarded".to_owned());
+        }
+        receipt.registration_phase = RegistrationPhase::Attempted;
+        state
+            .receipts
+            .save_manual_connect(receipt)
+            .map_err(private_receipt_error)?;
+        let deadline = tokio::time::Instant::now() + crate::broker::MUTATION_DISPATCH_WINDOW;
+        let first = state
+            .broker
+            .control_without_retry(
+                ControlRequest::RegisterRoot(RegisterRootRequest {
+                    operation_id: receipt.registration_operation_id,
+                    subject: receipt.subject,
+                    conversation_id: receipt.chat_id.0,
+                    path: receipt.path.clone(),
+                    consent_method: ConsentMethod::FolderPicker,
+                }),
+                deadline,
+            )
+            .await;
+        match first {
+            Ok(ControlResult::RegisterRoot(_)) | Err(_) => {}
+            Ok(_) => {
+                return Err("host broker returned an unexpected registration response".to_owned())
+            }
+        }
+    }
+
+    let root = match lookup_registration(state, receipt).await? {
+        RegisterRootReceipt::Completed { root } => root,
+        RegisterRootReceipt::Unknown if mode == ConnectMode::Recovery => {
+            state
+                .receipts
+                .remove_manual_connect(receipt.change_id)
+                .map_err(private_receipt_error)?;
+            return Err("unknown folder registration was discarded".to_owned());
+        }
+        RegisterRootReceipt::Unknown | RegisterRootReceipt::Pending => {
+            return Err("folder registration has no durable outcome yet".to_owned())
+        }
+        RegisterRootReceipt::Disconnected { .. } | RegisterRootReceipt::Failed { .. } => {
+            state
+                .receipts
+                .remove_manual_connect(receipt.change_id)
+                .map_err(private_receipt_error)?;
+            return Err("The selected folder could not be connected.".to_owned());
+        }
+        _ => return Err("host broker returned an unsupported registration receipt".to_owned()),
+    };
+
+    let context = match state.context(receipt.chat_id.0).await {
+        Ok(context) if context.subject == receipt.subject => context,
+        _ => {
+            if receipt.product_sync.is_none() {
+                install_product_sync(receipt, &root, 0)?;
+                state
+                    .receipts
+                    .save_manual_connect(receipt)
+                    .map_err(private_receipt_error)?;
+            }
+            cleanup_rejected_registration(state, receipt, stored_context(receipt)?).await?;
+            return Err("conversation authority changed during folder registration".to_owned());
+        }
+    };
+    if receipt.product_sync.is_none() {
+        let store = state
+            .store()
+            .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+        let chat = store
+            .get_chat(receipt.chat_id)
+            .await
+            .map_err(|_| "could not load the folder attachment revision".to_owned())?
+            .ok_or_else(|| "conversation not found".to_owned())?;
+        install_product_sync(receipt, &root, chat.attachment_revision)?;
+        state
+            .receipts
+            .save_manual_connect(receipt)
+            .map_err(private_receipt_error)?;
+    }
+    let sync = receipt
+        .product_sync
+        .clone()
+        .ok_or_else(|| "manual folder attachment metadata is missing".to_owned())?;
+    if *sync.root_id.as_uuid() != root.root_id.as_uuid()
+        || sync.display_name != root.display_name
+        || sync.change_id != receipt.change_id
+    {
+        return Err("registered folder changed during recovery".to_owned());
+    }
+
+    let begun = match control_plane(state)?
+        .begin_root_attachment_change(
+            receipt.chat_id,
+            sync.change_id,
+            sync.root_id,
+            RootAttachmentChangeAction::Attach,
+            sync.expected_attachment_revision,
+            sync.created_at,
+        )
+        .await
+    {
+        Ok(begun) => begun,
+        Err(error) if permanent_begin_failure(&error) => {
+            if product_contains_root(state, receipt.chat_id, sync.root_id).await? {
+                match lookup_registration(state, receipt).await? {
+                    RegisterRootReceipt::Completed { root: current }
+                        if current.root_id == root.root_id
+                            && current.display_name == root.display_name =>
+                    {
+                        state
+                            .receipts
+                            .remove_manual_connect(receipt.change_id)
+                            .map_err(private_receipt_error)?;
+                        return Ok(connected_folder(root));
+                    }
+                    _ => {
+                        return Err("product and broker folder attachment state disagree".to_owned())
+                    }
+                }
+            }
+            cleanup_rejected_registration(state, receipt, context).await?;
+            return Err(
+                "The selected folder could not be synchronized with this conversation.".to_owned(),
+            );
+        }
+        Err(error) => return Err(begin_error(error)),
+    };
+    validate_begin_change(
+        &begun.change,
+        context,
+        BeginFingerprint {
+            id: sync.change_id,
+            chat_id: receipt.chat_id,
+            root_id: sync.root_id,
+            action: RootAttachmentChangeAction::Attach,
+            expected_revision: sync.expected_attachment_revision,
+            created_at: sync.created_at,
+        },
+    )?;
+    let finished = drive_change(state, begun.change).await?;
+    verify_product_terminal(state, &finished).await?;
+    match finished.phase {
+        RootAttachmentChangePhase::Completed => {
+            state
+                .receipts
+                .remove_manual_connect(receipt.change_id)
+                .map_err(private_receipt_error)?;
+            Ok(connected_folder(root))
+        }
+        RootAttachmentChangePhase::Failed => {
+            state
+                .receipts
+                .remove_manual_connect(receipt.change_id)
+                .map_err(private_receipt_error)?;
+            Err("The selected folder could not be synchronized with this conversation.".to_owned())
+        }
+        RootAttachmentChangePhase::AwaitingBroker => {
+            Err("folder attachment is still pending".to_owned())
+        }
+    }
+}
+
+fn install_product_sync(
+    receipt: &mut ManualFolderConnectReceipt,
+    root: &RootSummary,
+    expected_attachment_revision: i64,
+) -> Result<(), String> {
+    let root_id = HostRootId::from_uuid(root.root_id.as_uuid())
+        .map_err(|_| "host broker returned an invalid root identity".to_owned())?;
+    receipt.product_sync = Some(ProductRootAttachmentSync {
+        change_id: receipt.change_id,
+        root_id,
+        display_name: root.display_name.clone(),
+        expected_attachment_revision,
+        created_at: canonical_now(),
+        cleanup_operation_id: receipt.cleanup_operation_id,
+        cleanup_phase: super::receipt_store::CleanupPhase::NotStarted,
+        attachment_phase: super::receipt_store::AttachmentPhase::Prepared,
+    });
+    Ok(())
+}
+
+fn stored_context(receipt: &ManualFolderConnectReceipt) -> Result<AuthoritativeContext, String> {
+    let execution = match receipt.subject.kind() {
+        SubjectKind::Project => {
+            ExecutionContext::project_chat(receipt.chat_id.0, receipt.subject.id())
+        }
+        SubjectKind::Conversation => ExecutionContext::standalone(receipt.chat_id.0),
+    }
+    .map_err(|_| "invalid stored folder authority".to_owned())?;
+    Ok(AuthoritativeContext {
+        chat_id: receipt.chat_id.0,
+        execution,
+        subject: receipt.subject,
+    })
+}
+
+async fn lookup_registration(
+    state: &HostAccess,
+    receipt: &ManualFolderConnectReceipt,
+) -> Result<RegisterRootReceipt, String> {
+    let result = state
+        .broker
+        .control(ControlRequest::LookupRegisterRootReceipt(
+            LookupRegisterRootReceiptRequest {
+                operation_id: receipt.registration_operation_id,
+                subject: receipt.subject,
+                conversation_id: receipt.chat_id.0,
+            },
+        ))
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::LookupRegisterRootReceipt(result) = result else {
+        return Err("host broker returned an unexpected registration receipt".to_owned());
+    };
+    if result.operation_id != receipt.registration_operation_id {
+        return Err("host broker returned a mismatched registration receipt".to_owned());
+    }
+    Ok(result.receipt)
+}
+
+async fn cleanup_rejected_registration(
+    state: &HostAccess,
+    receipt: &mut ManualFolderConnectReceipt,
+    context: AuthoritativeContext,
+) -> Result<(), String> {
+    let sync = receipt
+        .product_sync
+        .clone()
+        .ok_or_else(|| "manual folder cleanup metadata is missing".to_owned())?;
+    if product_contains_root(state, receipt.chat_id, sync.root_id).await? {
+        return Err("folder is already present in product state".to_owned());
+    }
+    let root_id = RootId::from_uuid(*sync.root_id.as_uuid())
+        .map_err(|_| "invalid cleanup root identity".to_owned())?;
+    let mut cleanup = lookup_mutation(
+        state,
+        context,
+        sync.cleanup_operation_id,
+        root_id,
+        RootAttachmentChangeAction::Detach,
+    )
+    .await?;
+    if matches!(cleanup, RootAttachmentMutationReceipt::Unknown) {
+        if let Some(stored) = receipt.product_sync.as_mut() {
+            stored.cleanup_phase = super::receipt_store::CleanupPhase::DispatchAttempted;
+        }
+        state
+            .receipts
+            .save_manual_connect(receipt)
+            .map_err(private_receipt_error)?;
+        dispatch_mutation(
+            state,
+            context,
+            sync.cleanup_operation_id,
+            root_id,
+            RootAttachmentChangeAction::Detach,
+        )
+        .await?;
+        cleanup = lookup_mutation(
+            state,
+            context,
+            sync.cleanup_operation_id,
+            root_id,
+            RootAttachmentChangeAction::Detach,
+        )
+        .await?;
+    }
+    match cleanup {
+        RootAttachmentMutationReceipt::Completed {
+            result,
+            currently_attached: false,
+        } if result.root_id == root_id && result.mutation == RootAttachmentMutationKind::Detach => {
+        }
+        RootAttachmentMutationReceipt::Failed { .. } => {
+            let registration = lookup_registration(state, receipt).await?;
+            match registration {
+                RegisterRootReceipt::Disconnected { root }
+                    if root.root_id == root_id && root.display_name == sync.display_name => {}
+                _ => return Err("folder cleanup has no authoritative detached outcome".to_owned()),
+            }
+        }
+        _ => return Err("folder cleanup has no durable detached outcome yet".to_owned()),
+    }
+    if product_contains_root(state, receipt.chat_id, sync.root_id).await? {
+        return Err("folder cleanup contradicts product state".to_owned());
+    }
+    if let Some(stored) = receipt.product_sync.as_mut() {
+        stored.cleanup_phase = super::receipt_store::CleanupPhase::Completed;
+    }
+    state
+        .receipts
+        .save_manual_connect(receipt)
+        .map_err(private_receipt_error)?;
+    state
+        .receipts
+        .remove_manual_connect(receipt.change_id)
+        .map_err(private_receipt_error)
+}
+
+async fn drive_change(
+    state: &HostAccess,
+    change: RootAttachmentChangeView,
+) -> Result<RootAttachmentChangeView, String> {
+    if change.phase != RootAttachmentChangePhase::AwaitingBroker {
+        return Ok(change);
+    }
+    let context = state.context(change.chat_id.0).await?;
+    validate_change_context(&change, context)?;
+    let operation_id = operation_id(change.id)?;
+    let root_id = RootId::from_uuid(*change.root_id.as_uuid())
+        .map_err(|_| "invalid product root identity".to_owned())?;
+    let mut receipt = lookup_mutation(state, context, operation_id, root_id, change.action).await?;
+    if matches!(receipt, RootAttachmentMutationReceipt::Unknown) {
+        dispatch_mutation(state, context, operation_id, root_id, change.action).await?;
+        receipt = lookup_mutation(state, context, operation_id, root_id, change.action).await?;
+    }
+    let terminal = mutation_terminal(receipt, root_id, change.action)?
+        .ok_or_else(|| "root attachment has no durable broker outcome yet".to_owned())?;
+    let finished = control_plane(state)?
+        .finish_root_attachment_change(change.id, &terminal)
+        .await
+        .map_err(finish_error)?;
+    validate_same_change(&change, &finished.change)?;
+    Ok(finished.change)
+}
+
+async fn lookup_mutation(
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    operation_id: OperationId,
+    root_id: RootId,
+    action: RootAttachmentChangeAction,
+) -> Result<RootAttachmentMutationReceipt, String> {
+    let result = state
+        .broker
+        .control(ControlRequest::LookupRootAttachmentReceipt(
+            LookupRootAttachmentReceiptRequest {
+                operation_id,
+                subject: context.subject,
+                conversation_id: context.chat_id,
+                root_id,
+                mutation: mutation_kind(action),
+            },
+        ))
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::LookupRootAttachmentReceipt(result) = result else {
+        return Err("host broker returned an unexpected attachment receipt".to_owned());
+    };
+    if result.operation_id != operation_id {
+        return Err("host broker returned a mismatched attachment receipt".to_owned());
+    }
+    Ok(result.receipt)
+}
+
+async fn dispatch_mutation(
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    operation_id: OperationId,
+    root_id: RootId,
+    action: RootAttachmentChangeAction,
+) -> Result<(), String> {
+    let request = RootAttachmentMutationRequest {
+        operation_id,
+        subject: context.subject,
+        conversation_id: context.chat_id,
+        root_id,
+    };
+    let control = match action {
+        RootAttachmentChangeAction::Attach => ControlRequest::AttachRoot(request),
+        RootAttachmentChangeAction::Detach => ControlRequest::DetachRoot(request),
+    };
+    let deadline = tokio::time::Instant::now() + crate::broker::MUTATION_DISPATCH_WINDOW;
+    match state.broker.control_without_retry(control, deadline).await {
+        Ok(ControlResult::AttachRoot(_)) if action == RootAttachmentChangeAction::Attach => Ok(()),
+        Ok(ControlResult::DetachRoot(_)) if action == RootAttachmentChangeAction::Detach => Ok(()),
+        Err(_) => Ok(()),
+        Ok(_) => Err("host broker returned an unexpected attachment response".to_owned()),
+    }
+}
+
+fn mutation_terminal(
+    receipt: RootAttachmentMutationReceipt,
+    root_id: RootId,
+    action: RootAttachmentChangeAction,
+) -> Result<Option<RootAttachmentChangeTerminal>, String> {
+    let desired = action == RootAttachmentChangeAction::Attach;
+    match receipt {
+        RootAttachmentMutationReceipt::Unknown => Ok(None),
+        RootAttachmentMutationReceipt::Completed {
+            result,
+            currently_attached,
+        } => {
+            if result.root_id != root_id || result.mutation != mutation_kind(action) {
+                return Err("broker attachment receipt contradicts product intent".to_owned());
+            }
+            if currently_attached == desired {
+                Ok(Some(RootAttachmentChangeTerminal::Completed {
+                    broker_changed: result.changed,
+                    broker_currently_attached: currently_attached,
+                }))
+            } else {
+                Ok(Some(RootAttachmentChangeTerminal::Failed {
+                    broker_changed: Some(result.changed),
+                    broker_currently_attached: Some(currently_attached),
+                    failure: safe_failure(
+                        "broker_attachment_superseded",
+                        "The folder attachment changed before synchronization completed.",
+                    ),
+                }))
+            }
+        }
+        RootAttachmentMutationReceipt::Failed { .. } => {
+            Ok(Some(RootAttachmentChangeTerminal::Failed {
+                broker_changed: None,
+                broker_currently_attached: None,
+                failure: safe_failure(
+                    "broker_attachment_failed",
+                    "The host broker could not complete this folder attachment change.",
+                ),
+            }))
+        }
+        _ => Err("host broker returned an unsupported attachment receipt".to_owned()),
+    }
+}
+
+fn safe_failure(code: &str, message: &str) -> RootAttachmentChangeFailure {
+    RootAttachmentChangeFailure {
+        code: code.to_owned(),
+        message: message.to_owned(),
+        retryable: false,
+    }
+}
+
+fn mutation_kind(action: RootAttachmentChangeAction) -> RootAttachmentMutationKind {
+    match action {
+        RootAttachmentChangeAction::Attach => RootAttachmentMutationKind::Attach,
+        RootAttachmentChangeAction::Detach => RootAttachmentMutationKind::Detach,
+    }
+}
+
+fn operation_id(change_id: RootAttachmentChangeId) -> Result<OperationId, String> {
+    OperationId::from_uuid(*change_id.as_uuid())
+        .map_err(|_| "invalid root attachment change identity".to_owned())
+}
+
+fn validate_begin_change(
+    change: &RootAttachmentChangeView,
+    context: AuthoritativeContext,
+    expected: BeginFingerprint,
+) -> Result<(), String> {
+    validate_change_context(change, context)?;
+    if change.id != expected.id
+        || change.chat_id != expected.chat_id
+        || change.root_id != expected.root_id
+        || change.action != expected.action
+        || change.expected_revision != expected.expected_revision
+        || change.created_at != expected.created_at
+    {
+        return Err("local control plane returned the wrong root attachment operation".to_owned());
+    }
+    Ok(())
+}
+
+fn validate_change_context(
+    change: &RootAttachmentChangeView,
+    context: AuthoritativeContext,
+) -> Result<(), String> {
+    let expected_subject_kind = match context.subject.kind() {
+        SubjectKind::Project => RootAttachmentSubjectKind::Project,
+        SubjectKind::Conversation => RootAttachmentSubjectKind::Conversation,
+    };
+    let expected_intent_revision = change.before_revision.checked_add(i64::from(
+        change.action == RootAttachmentChangeAction::Attach && !change.projection_existed_before,
+    ));
+    let terminal_shape_valid = match change.phase {
+        RootAttachmentChangePhase::AwaitingBroker => {
+            change.result_revision.is_none()
+                && change.broker_currently_attached.is_none()
+                && change.failure.is_none()
+        }
+        RootAttachmentChangePhase::Completed => {
+            change.result_revision.is_some()
+                && change.broker_currently_attached
+                    == Some(change.action == RootAttachmentChangeAction::Attach)
+                && change.failure.is_none()
+        }
+        RootAttachmentChangePhase::Failed => {
+            change.result_revision.is_some()
+                && change.failure.is_some()
+                && !change.broker_currently_attached.is_some_and(|attached| {
+                    attached == (change.action == RootAttachmentChangeAction::Attach)
+                })
+        }
+    };
+    if change.id.as_uuid().is_nil()
+        || change.chat_id.0 != context.chat_id
+        || change.subject_kind != expected_subject_kind
+        || change.subject_id != context.subject.id()
+        || change.before_revision != change.expected_revision
+        || expected_intent_revision != Some(change.intent_revision)
+        || !terminal_shape_valid
+    {
+        return Err("local control plane returned a mismatched root attachment change".to_owned());
+    }
+    Ok(())
+}
+
+fn validate_same_change(
+    expected: &RootAttachmentChangeView,
+    actual: &RootAttachmentChangeView,
+) -> Result<(), String> {
+    if actual.id != expected.id
+        || actual.chat_id != expected.chat_id
+        || actual.root_id != expected.root_id
+        || actual.action != expected.action
+        || actual.subject_kind != expected.subject_kind
+        || actual.subject_id != expected.subject_id
+        || actual.expected_revision != expected.expected_revision
+        || actual.before_revision != expected.before_revision
+        || actual.intent_revision != expected.intent_revision
+        || actual.projection_existed_before != expected.projection_existed_before
+        || actual.created_at != expected.created_at
+        || actual.phase == RootAttachmentChangePhase::AwaitingBroker
+    {
+        return Err("local control plane changed root attachment identity".to_owned());
+    }
+    Ok(())
+}
+
+fn canonical_now() -> DateTime<Utc> {
+    let now = Utc::now();
+    now.with_nanosecond((now.nanosecond() / 1_000) * 1_000)
+        .expect("microsecond timestamp is valid")
+}
+
+async fn verify_product_terminal(
+    state: &HostAccess,
+    change: &RootAttachmentChangeView,
+) -> Result<(), String> {
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let chat = store
+        .get_chat(change.chat_id)
+        .await
+        .map_err(|_| "could not verify connected folders".to_owned())?
+        .ok_or_else(|| "conversation not found".to_owned())?;
+    if Some(chat.attachment_revision) != change.result_revision {
+        return Err("product folder revision does not match its terminal change".to_owned());
+    }
+    let attached = chat
+        .root_attachments
+        .iter()
+        .any(|attachment| attachment.root_id == change.root_id);
+    let expected = match change.phase {
+        RootAttachmentChangePhase::Completed => change.action == RootAttachmentChangeAction::Attach,
+        RootAttachmentChangePhase::Failed => change.projection_existed_before,
+        RootAttachmentChangePhase::AwaitingBroker => {
+            return Err("root attachment is not terminal".to_owned())
+        }
+    };
+    if attached != expected {
+        return Err("product and broker folder attachment state disagree".to_owned());
+    }
+    Ok(())
+}
+
+async fn product_contains_root(
+    state: &HostAccess,
+    chat_id: ChatId,
+    root_id: HostRootId,
+) -> Result<bool, String> {
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    Ok(store
+        .get_chat(chat_id)
+        .await
+        .map_err(|_| "could not inspect connected folders".to_owned())?
+        .is_some_and(|chat| {
+            chat.root_attachments
+                .iter()
+                .any(|attachment| attachment.root_id == root_id)
+        }))
+}
+
+fn connected_folder(root: RootSummary) -> ConnectedFolder {
+    ConnectedFolder {
+        root_id: root.root_id,
+        display_name: root.display_name,
+    }
+}
+
+fn permanent_begin_failure(error: &ControlPlaneError) -> bool {
+    [
+        "root_attachment_revision_conflict",
+        "root_attachment_identity_conflict",
+        "root_attachment_capacity_exceeded",
+        "root_attachment_revision_exhausted",
+    ]
+    .iter()
+    .any(|kind| error.is_kind(kind))
+}
+
+fn begin_error(error: ControlPlaneError) -> String {
+    if error.is_conflict() {
+        "folder attachment could not begin safely".to_owned()
+    } else {
+        control_plane_error(error)
+    }
+}
+
+fn finish_error(error: ControlPlaneError) -> String {
+    if error.is_conflict() {
+        "folder attachment failed closed".to_owned()
+    } else {
+        control_plane_error(error)
+    }
+}
+
+fn private_receipt_error(_error: std::io::Error) -> String {
+    "could not update private folder recovery state".to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_host_broker::{ErrorCode, ErrorResponse, RootAttachmentMutationResult};
+
+    #[test]
+    fn attach_and_detach_receipts_map_to_exact_terminals() {
+        let root_id = RootId::new();
+        for action in [
+            RootAttachmentChangeAction::Attach,
+            RootAttachmentChangeAction::Detach,
+        ] {
+            let desired = action == RootAttachmentChangeAction::Attach;
+            let terminal = mutation_terminal(
+                RootAttachmentMutationReceipt::Completed {
+                    result: RootAttachmentMutationResult {
+                        root_id,
+                        mutation: mutation_kind(action),
+                        changed: true,
+                    },
+                    currently_attached: desired,
+                },
+                root_id,
+                action,
+            )
+            .unwrap()
+            .unwrap();
+            assert!(matches!(
+                terminal,
+                RootAttachmentChangeTerminal::Completed { .. }
+            ));
+        }
+    }
+
+    #[test]
+    fn stale_current_state_and_broker_errors_fail_with_safe_bounded_details() {
+        let root_id = RootId::new();
+        let stale = mutation_terminal(
+            RootAttachmentMutationReceipt::Completed {
+                result: RootAttachmentMutationResult {
+                    root_id,
+                    mutation: RootAttachmentMutationKind::Attach,
+                    changed: true,
+                },
+                currently_attached: false,
+            },
+            root_id,
+            RootAttachmentChangeAction::Attach,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(matches!(stale, RootAttachmentChangeTerminal::Failed { .. }));
+
+        let failed = mutation_terminal(
+            RootAttachmentMutationReceipt::Failed {
+                error: ErrorResponse {
+                    code: ErrorCode::HostIo,
+                    message: "/private/secret/path".to_owned(),
+                    retryable: true,
+                },
+            },
+            root_id,
+            RootAttachmentChangeAction::Detach,
+        )
+        .unwrap()
+        .unwrap();
+        let RootAttachmentChangeTerminal::Failed { failure, .. } = failed else {
+            panic!("expected safe failure")
+        };
+        assert!(!failure.message.contains("secret"));
+        assert!(!failure.retryable);
+    }
+}

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -4,8 +4,7 @@ use std::path::PathBuf;
 
 use openwave_core::{ChatId, Store};
 use openwave_host_broker::{
-    ConsentMethod, ControlRequest, ExecutionContext, GrantSubject, OperationEnvelope, OperationId,
-    OperationRequest, OperationResult, RegisterRootRequest, RevokeRootRequest, RootId,
+    ExecutionContext, GrantSubject, OperationEnvelope, OperationRequest, OperationResult, RootId,
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, State};
@@ -19,6 +18,7 @@ use crate::client_execution::{ControlPlaneClient, ReceiptStore};
 pub(crate) struct HostAccess {
     pub(super) broker: BrokerClient,
     pub(super) picker: Mutex<()>,
+    pub(super) root_changes: Mutex<()>,
     store: OnceCell<std::sync::Arc<dyn Store>>,
     pub(super) control_plane: OnceCell<ControlPlaneClient>,
     pub(super) receipts: ReceiptStore,
@@ -35,6 +35,7 @@ impl HostAccess {
         Ok(Self {
             broker: BrokerClient::new(app, data_dir, home_dir),
             picker: Mutex::const_new(()),
+            root_changes: Mutex::const_new(()),
             store: OnceCell::new(),
             control_plane: OnceCell::new(),
             receipts,
@@ -135,8 +136,8 @@ pub(crate) struct DisconnectFolderRequest {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConnectedFolder {
-    root_id: RootId,
-    display_name: String,
+    pub(crate) root_id: RootId,
+    pub(crate) display_name: String,
 }
 
 #[tauri::command]
@@ -158,24 +159,12 @@ pub(crate) async fn connect_folder(
         return Err("the folder picker returned an invalid path".to_owned());
     }
 
-    let result = state
-        .broker
-        .control(ControlRequest::RegisterRoot(RegisterRootRequest {
-            operation_id: OperationId::new(),
-            subject: context.subject,
-            conversation_id: context.chat_id,
-            path,
-            consent_method: ConsentMethod::FolderPicker,
-        }))
-        .await
-        .map_err(|error| error.to_string())?;
-    let openwave_host_broker::ControlResult::RegisterRoot(result) = result else {
-        return Err("host broker returned an unexpected response".to_owned());
-    };
-    Ok(Some(ConnectedFolder {
-        root_id: result.root.root_id,
-        display_name: result.root.display_name,
-    }))
+    let _root_change = state.root_changes.lock().await;
+    crate::client_execution::root_attachment_reconciliation::connect_selected_folder(
+        &state, context, path,
+    )
+    .await
+    .map(Some)
 }
 
 #[tauri::command]
@@ -184,6 +173,14 @@ pub(crate) async fn list_connected_folders(
     chat_id: Uuid,
 ) -> Result<Vec<ConnectedFolder>, String> {
     let context = state.context(chat_id).await?;
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let chat = store
+        .get_chat(ChatId::from(chat_id))
+        .await
+        .map_err(|_| "could not load connected folders".to_owned())?
+        .ok_or_else(|| "conversation not found".to_owned())?;
     let request_id = openwave_host_broker::RequestId::new();
     let result = state
         .broker
@@ -198,8 +195,14 @@ pub(crate) async fn list_connected_folders(
     let OperationResult::ListRoots { roots } = result else {
         return Err("host broker returned an unexpected response".to_owned());
     };
+    let product_roots = chat
+        .root_attachments
+        .iter()
+        .map(|attachment| *attachment.root_id.as_uuid())
+        .collect::<std::collections::HashSet<_>>();
     Ok(roots
         .into_iter()
+        .filter(|root| product_roots.contains(&root.root_id.as_uuid()))
         .map(|root| ConnectedFolder {
             root_id: root.root_id,
             display_name: root.display_name,
@@ -213,19 +216,13 @@ pub(crate) async fn disconnect_folder(
     request: DisconnectFolderRequest,
 ) -> Result<bool, String> {
     let context = state.context(request.chat_id).await?;
-    let result = state
-        .broker
-        .control(ControlRequest::RevokeRoot(RevokeRootRequest {
-            operation_id: OperationId::new(),
-            subject: context.subject,
-            root_id: request.root_id,
-        }))
-        .await
-        .map_err(|error| error.to_string())?;
-    let openwave_host_broker::ControlResult::RevokeRoot(result) = result else {
-        return Err("host broker returned an unexpected response".to_owned());
-    };
-    Ok(result.revoked)
+    let _root_change = state.root_changes.lock().await;
+    crate::client_execution::root_attachment_reconciliation::disconnect_root(
+        &state,
+        context,
+        request.root_id,
+    )
+    .await
 }
 
 pub(super) async fn pick_folder(

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -176,6 +176,13 @@ async fn boot_server(
         )
         .await;
     });
+    let root_attachment_app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        client_execution::root_attachment_reconciliation::recover_root_attachment_changes(
+            root_attachment_app,
+        )
+        .await;
+    });
     server.serve().await.map_err(|e| e.to_string())
 }
 

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -42,10 +42,10 @@ revision. Project defaults are snapshotted into a new chat's exact attachment
 set; later project changes cannot silently widen that chat. These product rows
 are not grants: they contain no path, capability, consent, or display name, and
 host access still requires the broker's live attachment and authorization. The
-product store now has a durable attachment-change state machine and a
-native-only HTTP boundary for driving it, but the current picker still updates
-broker state directly. A native reconciler is the next slice, before any tool
-treats the projection as usable context.
+product store has a durable attachment-change state machine and a native-only
+HTTP boundary for driving it. Both user-facing connected-folder actions and
+agent-approved picker requests now converge the broker attachment and product
+projection through that state machine before reporting success.
 
 ### Native attachment-change boundary
 
@@ -79,9 +79,11 @@ the desktop supplies its private persisted identity before binding the server.
 Finish timestamps are clamped to immutable creation time under the store lock,
 so clock skew cannot strand a conversation's single pending operation.
 
-This boundary deliberately does not call the broker. Dispatch, unknown-receipt
-recovery, and retry policy belong to the forthcoming desktop reconciler, which
-will use these routes around the broker's idempotent attach/detach operations.
+This boundary deliberately does not call the broker. The desktop reconciler
+looks up the exact broker receipt first, dispatches the same idempotent attach
+or detach identity only when it is unknown, and then supplies the terminal
+observation to the product state machine. Startup recovery is sequential and
+bounded to 64 oldest pending changes per pass.
 
 ## The four layers
 
@@ -143,7 +145,8 @@ The Tauri host—not the renderer—owns the control handle. It opens the native
 folder picker, resolves the renderer's chat ID against the server's authoritative
 store, derives project or standalone ownership from that record, and forwards
 the picker result. Re-registering the same pinned filesystem object for the same
-subject reuses the root and only adds a missing conversation attachment.
+subject reuses the root. A separate product attachment change then confirms the
+exact conversation attachment before the renderer sees it as connected.
 
 The **renderer** presents connected folders and permission choices. It receives
 safe summaries, not the broker's persisted absolute-path registry.
@@ -175,6 +178,19 @@ receipt lets a recovering native client distinguish unknown, completed, and
 failed work without starting or replaying the mutation. Attachment changes are
 computed and published in one durable state replacement, so they do not expose
 a recoverable intermediate phase.
+
+The desktop's manual Disconnect action uses this conversation-only detach; it
+does not invoke global revocation. The connected-folder list is the intersection
+of the chat's pathless product projection and the broker's live safe summaries,
+so neither a broker-only registration nor a product-only intent is presented as
+converged access.
+
+Manual picker registration has a separate app-private receipt because it begins
+before product intent exists. The receipt contains the selected absolute path,
+original broker subject, and three distinct operation identities; none are
+serialized to the renderer. Recovery never starts a registration that was not
+already marked attempted. Once product begin commits, the server-owned pending
+change is the authoritative recovery queue for both attach and detach.
 
 The product database coordinates its side of the operation separately. It
 stores an `awaiting_broker` change before native code talks to the broker, then

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -176,8 +176,10 @@ through a native picker and capability-gated host-broker sidecar; it exposes onl
 opaque root IDs and display names to the renderer. Foreground tool calls can now
 list/read roots already attached to their stored chat context. An approved
 agent folder request now converges through the durable product root-attachment
-state machine before it can report `connected`; manual connect/disconnect
-synchronization remains a separate slice.
+state machine before it can report `connected`. The same state machine backs
+the manual Connected folders UI: Disconnect is conversation-scoped instead of
+global revocation, and a bounded native startup loop resumes exact pending
+attach or detach identities after a crash.
 See [Host access and connected folders](host-access.md). The agent loop can now
 produce a durable client-wait checkpoint for the registered folder-request
 contract. The desktop discovers those pending requests from durable state and


### PR DESCRIPTION
## Summary
- route manual folder connect and disconnect through durable product/broker attachment changes
- recover exact pending registration and attachment operations after restart
- serialize native root mutations and list only product/broker-converged folders
- document the manual and startup reconciliation protocol

## Validation
- `cargo test -p openwave-desktop --lib` (29 passed before and after rebase)
- `cargo check -p openwave-desktop`
- `bw dev lint --rust --check`
- `cargo fmt --all -- --check`
- `git diff --check`