### PR TITLE
Add assistant source presentation

### DIFF
--- a/crates/openwave-desktop/ui/src/AssistantSourceMarkerStream.test.ts
+++ b/crates/openwave-desktop/ui/src/AssistantSourceMarkerStream.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
+
+const MARKER = "[[ow-source:0123456789abcdef0123456789abcdef]]";
+
+describe("AssistantSourceMarkerStreamScrubber", () => {
+  it("removes a marker split at every possible delta boundary", () => {
+    const text = `Before ${MARKER} after.`;
+
+    for (let boundary = 0; boundary <= text.length; boundary += 1) {
+      const scrubber = new AssistantSourceMarkerStreamScrubber();
+      const first = scrubber.push(text.slice(0, boundary));
+      const second = scrubber.push(text.slice(boundary));
+      const finished = scrubber.finish();
+
+      expect(first).not.toContain("[[ow-source:");
+      expect(first + second + finished, `boundary ${boundary}`).toBe(
+        "Before  after.",
+      );
+    }
+  });
+
+  it("does not flash a valid marker delivered one character at a time", () => {
+    const scrubber = new AssistantSourceMarkerStreamScrubber();
+    let visible = "";
+
+    for (const character of `Answer ${MARKER} continues`) {
+      visible += scrubber.push(character);
+      expect(visible).not.toContain("[[");
+      expect(visible).not.toContain("[[ow-source:");
+      expect(visible).not.toContain("0123456789abcdef");
+    }
+
+    expect(visible + scrubber.finish()).toBe("Answer  continues");
+  });
+
+  it("removes adjacent valid markers and preserves surrounding prose", () => {
+    const scrubber = new AssistantSourceMarkerStreamScrubber();
+    const visible = scrubber.push(`A${MARKER}${MARKER}B`);
+
+    expect(visible + scrubber.finish()).toBe("AB");
+  });
+
+  it("preserves a malformed marker before removing a later valid marker", () => {
+    const malformed =
+      "[[ow-source:0123456789abcdef0123456789abcdeG]]";
+    const input = `Keep ${malformed}; hide ${MARKER}; done.`;
+    const split = input.indexOf(MARKER) + 18;
+    const scrubber = new AssistantSourceMarkerStreamScrubber();
+    const visible =
+      scrubber.push(input.slice(0, split)) +
+      scrubber.push(input.slice(split)) +
+      scrubber.finish();
+
+    expect(visible).toBe(`Keep ${malformed}; hide ; done.`);
+  });
+
+  it.each([
+    "[[ow-source:0123456789abcdef0123456789abcdeG]]",
+    "[[ow-source:0123456789abcdef0123456789abcde]]",
+    "[[ow-source:0123456789abcdef0123456789abcdef0]]",
+    "[[ow-source:0123456789abcdef0123456789abcdef]x",
+    "ordinary [[ow-sourcing:0123]] prose",
+  ])("preserves malformed marker-like prose: %s", (prose) => {
+    const scrubber = new AssistantSourceMarkerStreamScrubber();
+    const firstHalf = Math.floor(prose.length / 2);
+    const visible =
+      scrubber.push(prose.slice(0, firstHalf)) +
+      scrubber.push(prose.slice(firstHalf)) +
+      scrubber.finish();
+
+    expect(visible).toBe(prose);
+  });
+
+  it("flushes an incomplete candidate literally when a stream ends", () => {
+    const scrubber = new AssistantSourceMarkerStreamScrubber();
+    const incomplete = "Text [[ow-source:01234567";
+
+    expect(scrubber.push(incomplete)).toBe("Text ");
+    expect(scrubber.finish()).toBe("[[ow-source:01234567");
+    expect(scrubber.finish()).toBe("");
+  });
+});

--- a/crates/openwave-desktop/ui/src/AssistantSourceMarkerStream.ts
+++ b/crates/openwave-desktop/ui/src/AssistantSourceMarkerStream.ts
@@ -1,0 +1,100 @@
+const MARKER_PREFIX = "[[ow-source:";
+const TOKEN_LENGTH = 32;
+const MARKER_LENGTH = MARKER_PREFIX.length + TOKEN_LENGTH + 2;
+
+/**
+ * Removes private source markers from streamed assistant text before it is
+ * rendered. Only the short tail that could still become a valid marker is
+ * retained between deltas; call finish when a stream ends or is interrupted
+ * to recover an incomplete marker as literal prose.
+ */
+export class AssistantSourceMarkerStreamScrubber {
+  private pending = "";
+
+  push(delta: string): string {
+    let input = this.pending + delta;
+    let output = "";
+    this.pending = "";
+
+    while (input.length > 0) {
+      const markerStart = input.indexOf(MARKER_PREFIX);
+      if (markerStart === -1) {
+        const pendingLength = longestPrefixSuffix(input);
+        output += input.slice(0, input.length - pendingLength);
+        this.pending = input.slice(input.length - pendingLength);
+        break;
+      }
+
+      output += input.slice(0, markerStart);
+      const candidate = input.slice(markerStart);
+      if (candidate.length >= MARKER_LENGTH) {
+        const possibleMarker = candidate.slice(0, MARKER_LENGTH);
+        if (isSourceMarker(possibleMarker)) {
+          input = candidate.slice(MARKER_LENGTH);
+          continue;
+        }
+      } else if (couldBecomeSourceMarker(candidate)) {
+        this.pending = candidate;
+        break;
+      }
+
+      // This looked like a marker prefix but cannot become a valid marker.
+      // Release one character and rescan so malformed prose is preserved and
+      // a valid marker beginning later in the same input is still detected.
+      output += candidate[0];
+      input = candidate.slice(1);
+    }
+
+    return output;
+  }
+
+  finish(): string {
+    const literal = this.pending;
+    this.pending = "";
+    return literal;
+  }
+}
+
+function isSourceMarker(value: string) {
+  if (
+    value.length !== MARKER_LENGTH ||
+    !value.startsWith(MARKER_PREFIX) ||
+    !value.endsWith("]]")
+  ) {
+    return false;
+  }
+
+  const token = value.slice(MARKER_PREFIX.length, -2);
+  return /^[0-9a-f]{32}$/.test(token);
+}
+
+function couldBecomeSourceMarker(value: string) {
+  if (value.length <= MARKER_PREFIX.length) {
+    return MARKER_PREFIX.startsWith(value);
+  }
+  if (!value.startsWith(MARKER_PREFIX) || value.length >= MARKER_LENGTH) {
+    return false;
+  }
+
+  const tokenEnd = Math.min(
+    value.length,
+    MARKER_PREFIX.length + TOKEN_LENGTH,
+  );
+  const token = value.slice(MARKER_PREFIX.length, tokenEnd);
+  if (!/^[0-9a-f]*$/.test(token)) {
+    return false;
+  }
+
+  const closing = value.slice(MARKER_PREFIX.length + TOKEN_LENGTH);
+  return closing === "" || closing === "]";
+}
+
+function longestPrefixSuffix(value: string) {
+  const maximum = Math.min(value.length, MARKER_PREFIX.length - 1);
+  for (let length = maximum; length > 0; length -= 1) {
+    if (MARKER_PREFIX.startsWith(value.slice(-length))) {
+      return length;
+    }
+  }
+  return 0;
+}

--- a/crates/openwave-desktop/ui/src/AssistantSources.test.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantSources.test.tsx
@@ -1,0 +1,118 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AssistantSources, type AssistantSource } from "./AssistantSources";
+
+function source(overrides: Partial<AssistantSource> = {}): AssistantSource {
+  return {
+    id: "private-source-id",
+    ordinal: 1,
+    excerpt: "A short supporting excerpt.",
+    heading: "Project notes",
+    pages: [2, 3],
+    ...overrides,
+  };
+}
+
+describe("AssistantSources", () => {
+  it("renders nothing for an empty source set", () => {
+    expect(renderToStaticMarkup(<AssistantSources sources={[]} />)).toBe("");
+  });
+
+  it("renders compact source pills and a native accessible disclosure", () => {
+    const markup = renderToStaticMarkup(
+      <AssistantSources
+        sources={[
+          source(),
+          source({ id: "second-private-id", ordinal: 2, pages: [7] }),
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("<details");
+    expect(markup).toContain("<summary");
+    expect(markup).toContain("2 sources");
+    expect(markup).toContain('class="assistant-source-pill"');
+    expect(markup).toContain('aria-label="Source 1"');
+    expect(markup).toContain("Pages 2, 3");
+    expect(markup).toContain("Page 7");
+  });
+
+  it("orders sources by ordinal without mutating equal-ordinal input order", () => {
+    const sources = [
+      source({ id: "equal-first", ordinal: 2, heading: "First equal" }),
+      source({ id: "later", ordinal: 4, heading: "Later" }),
+      source({ id: "earlier", ordinal: 1, heading: "Earlier" }),
+      source({ id: "equal-second", ordinal: 2, heading: "Second equal" }),
+    ];
+    const markup = renderToStaticMarkup(
+      <AssistantSources sources={sources} />,
+    );
+
+    expect(markup.indexOf("Earlier")).toBeLessThan(
+      markup.indexOf("First equal"),
+    );
+    expect(markup.indexOf("First equal")).toBeLessThan(
+      markup.indexOf("Second equal"),
+    );
+    expect(markup.indexOf("Second equal")).toBeLessThan(
+      markup.indexOf("Later"),
+    );
+    expect(sources.map(({ ordinal }) => ordinal)).toEqual([2, 4, 1, 2]);
+  });
+
+  it("renders the full server-bounded set of twenty sources", () => {
+    const sources = Array.from({ length: 20 }, (_, index) =>
+      source({
+        id: `private-${index + 1}`,
+        ordinal: index + 1,
+        heading: `Source heading ${index + 1}`,
+      }),
+    );
+    const markup = renderToStaticMarkup(
+      <AssistantSources sources={sources} />,
+    );
+
+    expect(markup).toContain("20 sources");
+    expect(markup).toContain("Source heading 20");
+    expect(markup.match(/class="assistant-source"/g)).toHaveLength(20);
+  });
+
+  it("renders source copy as bounded plain text and never exposes identity", () => {
+    const longHeading = `Heading <script>unsafe()</script> ${"h".repeat(180)}`;
+    const longExcerpt = `<img src=x onerror=unsafe()>${"e".repeat(650)}`;
+    const markup = renderToStaticMarkup(
+      <AssistantSources
+        sources={[
+          source({
+            id: "/Users/name/Documents/private.pdf#retrieval-token",
+            heading: longHeading,
+            excerpt: longExcerpt,
+            pages: [9, 8, 7, 6, 5, 4, 3, 2, 1, 1, -4, 2.5],
+          }),
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("&lt;script&gt;unsafe()&lt;/script&gt;");
+    expect(markup).toContain("&lt;img src=x onerror=unsafe()&gt;");
+    expect(markup).not.toContain("<script>");
+    expect(markup).not.toContain("<img");
+    expect(markup).not.toContain("/Users/name");
+    expect(markup).not.toContain("retrieval-token");
+    expect(markup).toContain("Pages 1, 2, 3, 4, 5, 6, 7, 8");
+    expect(markup).not.toContain("Pages 1, 2, 3, 4, 5, 6, 7, 8, 9");
+    expect(markup.match(/…/g)).toHaveLength(2);
+    expect(markup).not.toContain("href=");
+  });
+
+  it("omits empty headings and invalid page references", () => {
+    const markup = renderToStaticMarkup(
+      <AssistantSources
+        sources={[source({ heading: "  ", pages: [0, -1, 1.5, Number.NaN] })]}
+      />,
+    );
+
+    expect(markup).not.toContain("<strong>");
+    expect(markup).not.toContain("assistant-source-pages");
+  });
+});

--- a/crates/openwave-desktop/ui/src/AssistantSources.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantSources.tsx
@@ -1,0 +1,116 @@
+export type AssistantSource = Readonly<{
+  id: string;
+  ordinal: number;
+  excerpt: string;
+  heading: string | null;
+  pages: number[];
+}>;
+
+type AssistantSourcesProps = {
+  sources: readonly AssistantSource[];
+};
+
+// Matches the server's MAX_ASSISTANT_CITATIONS contract. Keeping the guard in
+// the renderer prevents an unexpectedly large payload from growing the DOM.
+const MAX_SOURCES = 20;
+const MAX_HEADING_CHARACTERS = 160;
+const MAX_EXCERPT_CHARACTERS = 600;
+const MAX_PAGE_REFERENCES = 8;
+
+/**
+ * A closed, presentation-only view of evidence attached to an assistant
+ * response. It intentionally has no navigation callbacks: source identity,
+ * storage paths, and retrieval tokens stay outside the rendered surface.
+ */
+export function AssistantSources({ sources }: AssistantSourcesProps) {
+  const visibleSources = [...sources]
+    .map((source, inputIndex) => ({ source, inputIndex }))
+    .sort(
+      (left, right) =>
+        left.source.ordinal - right.source.ordinal ||
+        left.inputIndex - right.inputIndex,
+    )
+    .slice(0, MAX_SOURCES);
+
+  if (visibleSources.length === 0) {
+    return null;
+  }
+
+  const sourceLabel =
+    visibleSources.length === 1
+      ? "1 source"
+      : `${visibleSources.length} sources`;
+
+  return (
+    <details className="assistant-sources">
+      <summary className="assistant-sources-toggle">
+        <span className="assistant-sources-label">{sourceLabel}</span>
+        <span className="assistant-source-pills" aria-hidden="true">
+          {visibleSources.map(({ source, inputIndex }) => (
+            <span
+              className="assistant-source-pill"
+              key={`${source.id}:${inputIndex}`}
+            >
+              {source.ordinal}
+            </span>
+          ))}
+        </span>
+        <span className="assistant-sources-chevron" aria-hidden="true">
+          ›
+        </span>
+      </summary>
+      <ol className="assistant-source-list">
+        {visibleSources.map(({ source, inputIndex }) => (
+          <li
+            className="assistant-source"
+            key={`${source.id}:${inputIndex}`}
+            aria-label={`Source ${source.ordinal}`}
+          >
+            <span className="assistant-source-number" aria-hidden="true">
+              {source.ordinal}
+            </span>
+            <div className="assistant-source-copy">
+              {boundedText(source.heading, MAX_HEADING_CHARACTERS) ? (
+                <strong>
+                  {boundedText(source.heading, MAX_HEADING_CHARACTERS)}
+                </strong>
+              ) : null}
+              <p>{boundedText(source.excerpt, MAX_EXCERPT_CHARACTERS)}</p>
+              <PageReferences pages={source.pages} />
+            </div>
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
+
+function PageReferences({ pages }: { pages: readonly number[] }) {
+  const visiblePages = [...new Set(pages)]
+    .filter((page) => Number.isSafeInteger(page) && page > 0)
+    .sort((left, right) => left - right)
+    .slice(0, MAX_PAGE_REFERENCES);
+
+  if (visiblePages.length === 0) {
+    return null;
+  }
+
+  const label = visiblePages.length === 1 ? "Page" : "Pages";
+  return (
+    <span className="assistant-source-pages">
+      {label} {visiblePages.join(", ")}
+    </span>
+  );
+}
+
+function boundedText(value: string | null, maximum: number) {
+  if (value === null) {
+    return "";
+  }
+
+  const characters = Array.from(value.trim());
+  if (characters.length <= maximum) {
+    return characters.join("");
+  }
+  return `${characters.slice(0, maximum).join("")}…`;
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -582,6 +582,119 @@ button {
   background: transparent;
 }
 
+.assistant-sources {
+  width: min(100%, 38rem);
+  margin-top: 0.7rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.assistant-sources-toggle {
+  display: flex;
+  width: fit-content;
+  max-width: 100%;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 7px;
+  padding: 0.22rem 0.32rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.assistant-sources-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.assistant-sources-toggle:hover,
+.assistant-sources-toggle:focus-visible {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--sidebar-active) 58%, transparent);
+}
+
+.assistant-sources-label {
+  font-weight: 600;
+}
+
+.assistant-source-pills {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 0.22rem;
+}
+
+.assistant-source-pill,
+.assistant-source-number {
+  display: inline-grid;
+  width: 1.28rem;
+  height: 1.28rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink);
+  background: color-mix(in srgb, var(--bg-elevated) 82%, var(--sidebar));
+  font-size: 0.69rem;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.assistant-sources-chevron {
+  font-size: 1rem;
+  line-height: 1;
+  transition: transform 120ms ease;
+}
+
+.assistant-sources[open] .assistant-sources-chevron {
+  transform: rotate(90deg);
+}
+
+.assistant-source-list {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0.45rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.assistant-source {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  border-left: 1px solid var(--line);
+  padding: 0.4rem 0.5rem;
+}
+
+.assistant-source-number {
+  margin-top: 0.08rem;
+}
+
+.assistant-source-copy {
+  display: grid;
+  min-width: 0;
+  gap: 0.18rem;
+}
+
+.assistant-source-copy strong {
+  overflow-wrap: anywhere;
+  color: var(--ink);
+  font-size: 0.79rem;
+  font-weight: 600;
+}
+
+.assistant-source-copy p {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.assistant-source-pages {
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-weight: 550;
+}
+
 .message-notice {
   align-self: center;
   max-width: min(100%, 42rem);
@@ -903,8 +1016,10 @@ button {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .tool-call-spinner {
+  .tool-call-spinner,
+  .assistant-sources-chevron {
     animation: none;
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- add an accessible, compact source disclosure for assistant messages
- add a bounded incremental source-marker scrubber for streamed text
- cover ordering, privacy, rendering bounds, interruption, and fragmented stream markers

## Validation
- desktop UI test suite (53 tests)
- TypeScript check and Vite production build
- git diff --check