### PR TITLE
Add durable assistant citation provenance

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -33,6 +33,10 @@ use crate::approval::{
     ApprovalRequiredPublication, RefuseGate, ToolApprovalKind,
 };
 use crate::cancel::CancelToken;
+use crate::citation::{
+    classify_source_reference_candidate, parse_assistant_citations, AssistantCitationReference,
+    SourceReferenceCandidate,
+};
 use crate::context;
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
@@ -281,6 +285,8 @@ pub enum AgentTurnOutcome {
     Completed {
         /// The final message to publish with the terminal state transition.
         output: Message,
+        /// Ordered opaque evidence references stripped from the final text.
+        citations: Vec<AssistantCitationReference>,
         /// Aggregate provider usage for the eventual terminal event.
         usage: Usage,
         /// Provider stop reason for the eventual terminal event.
@@ -491,6 +497,113 @@ impl EventSink<'_> {
     }
 }
 
+/// Holds only a suffix that could still become an exact source reference.
+/// Non-text provider events that arrive inside that suffix wait with it so an
+/// eventual malformed reference can be replayed in its original order.
+struct AssistantStreamEventFilter<'a, 'b> {
+    sink: &'a EventSink<'b>,
+    candidate: String,
+    pending: Vec<AgentEvent>,
+}
+
+impl<'a, 'b> AssistantStreamEventFilter<'a, 'b> {
+    fn new(sink: &'a EventSink<'b>) -> Self {
+        Self {
+            sink,
+            candidate: String::new(),
+            pending: Vec::new(),
+        }
+    }
+
+    fn send(&mut self, event: AgentEvent) {
+        if self.candidate.is_empty() {
+            self.sink.send(event);
+        } else {
+            self.pending.push(event);
+        }
+    }
+
+    fn send_text(&mut self, delta: &str) {
+        let mut safe = String::new();
+        for character in delta.chars() {
+            if self.candidate.is_empty() && character != '[' {
+                safe.push(character);
+                continue;
+            }
+            if !safe.is_empty() {
+                self.sink.send(AgentEvent::TextDelta {
+                    text: std::mem::take(&mut safe),
+                });
+            }
+            self.candidate.push(character);
+            self.pending.push(AgentEvent::TextDelta {
+                text: character.to_string(),
+            });
+            self.resolve_candidate();
+        }
+        if !safe.is_empty() {
+            self.sink.send(AgentEvent::TextDelta { text: safe });
+        }
+    }
+
+    fn resolve_candidate(&mut self) {
+        loop {
+            match classify_source_reference_candidate(&self.candidate) {
+                SourceReferenceCandidate::Possible => return,
+                SourceReferenceCandidate::Complete => {
+                    self.candidate.clear();
+                    for event in self.pending.drain(..) {
+                        if !matches!(event, AgentEvent::TextDelta { .. }) {
+                            self.sink.send(event);
+                        }
+                    }
+                    return;
+                }
+                SourceReferenceCandidate::Invalid => {
+                    let first_len = self
+                        .candidate
+                        .chars()
+                        .next()
+                        .expect("an invalid candidate is nonempty")
+                        .len_utf8();
+                    self.candidate.drain(..first_len);
+                    let first_text = self
+                        .pending
+                        .iter()
+                        .position(|event| matches!(event, AgentEvent::TextDelta { .. }))
+                        .expect("each candidate character has a pending text event");
+                    for event in self.pending.drain(..=first_text) {
+                        self.sink.send(event);
+                    }
+                    while self
+                        .pending
+                        .first()
+                        .is_some_and(|event| !matches!(event, AgentEvent::TextDelta { .. }))
+                    {
+                        self.sink.send(self.pending.remove(0));
+                    }
+                    if self.candidate.is_empty() {
+                        debug_assert!(self.pending.is_empty());
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    fn finish(&mut self) {
+        self.candidate.clear();
+        for event in self.pending.drain(..) {
+            self.sink.send(event);
+        }
+    }
+
+    fn discard(&mut self) {
+        self.candidate.clear();
+        self.pending.clear();
+    }
+}
+
 fn reserve_event_ordinal(next: &AtomicI32) -> Result<i32> {
     next.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |ordinal| {
         ordinal.checked_add(1).filter(|next| *next < i32::MAX)
@@ -527,6 +640,11 @@ struct PendingCall {
     provider_id: String,
     name: String,
     args: String,
+}
+
+struct AssistantCandidate {
+    content: String,
+    citations: Vec<AssistantCitationReference>,
 }
 
 impl Agent {
@@ -807,6 +925,7 @@ impl Agent {
                 Cancelled,
                 Steered,
             }
+            let mut streamed_events = AssistantStreamEventFilter::new(events);
             let stream_end = loop {
                 let event = match future::select(
                     stream.next(),
@@ -821,17 +940,15 @@ impl Agent {
                 };
                 match event {
                     ProviderEvent::TextDelta { text: delta } => {
-                        events.send(AgentEvent::TextDelta {
-                            text: delta.clone(),
-                        });
                         text.push_str(&delta);
+                        streamed_events.send_text(&delta);
                     }
                     ProviderEvent::ReasoningDelta { text: delta } => {
-                        events.send(AgentEvent::ReasoningDelta { text: delta });
+                        streamed_events.send(AgentEvent::ReasoningDelta { text: delta });
                     }
                     ProviderEvent::ToolCallStarted { index, id, name } => {
                         let call_id = CallId::new();
-                        events.send(AgentEvent::ToolCallStarted {
+                        streamed_events.send(AgentEvent::ToolCallStarted {
                             call_id,
                             name: name.clone(),
                         });
@@ -845,7 +962,7 @@ impl Agent {
                     }
                     ProviderEvent::ToolCallArgsDelta { index, fragment } => {
                         if let Some(&i) = by_index.get(&index) {
-                            events.send(AgentEvent::ToolCallArgsDelta {
+                            streamed_events.send(AgentEvent::ToolCallArgsDelta {
                                 call_id: calls[i].call_id,
                                 fragment: fragment.clone(),
                             });
@@ -861,6 +978,14 @@ impl Agent {
                     ProviderEvent::Stop { reason } => stop_reason = reason,
                 }
             };
+            if matches!(stream_end, StreamEnd::Steered) {
+                streamed_events.discard();
+            } else {
+                // Normal completion and cancellation retain malformed or
+                // incomplete marker-like prose exactly. Only a steer discards
+                // the entire candidate under StreamInterrupted semantics.
+                streamed_events.finish();
+            }
             // Prefer cancel when both cancel and interrupt are ready (cancel is
             // the left arm of the nested select). Also catch a cancel that raced
             // the final stream event.
@@ -876,6 +1001,13 @@ impl Agent {
                     .await?;
                 continue;
             }
+
+            let parsed = parse_assistant_citations(&text);
+            let candidate = AssistantCandidate {
+                content: parsed.content,
+                citations: parsed.references,
+            };
+            let text = &candidate.content;
 
             let client_calls = calls
                 .iter()
@@ -1023,8 +1155,7 @@ impl Agent {
             if !text.is_empty() {
                 blocks.push(ContentBlock::Text { text: text.clone() });
                 if !calls.is_empty() {
-                    self.persist(chat.id, turn_id, Role::Assistant, &text)
-                        .await?;
+                    self.persist_assistant(chat.id, turn_id, &candidate).await?;
                 }
             }
             let mut recovered_results: HashMap<CallId, ToolOutput> = HashMap::new();
@@ -1113,7 +1244,8 @@ impl Agent {
                     created_at: Utc::now(),
                 };
                 if publish_terminal && !text.is_empty() {
-                    self.store.append_message(&output).await?;
+                    self.append_assistant_exact_retry(&output, &candidate.citations)
+                        .await?;
                 }
                 // Drain steers until the inbox is quiet, then complete. A steer
                 // that arrives as the stream finished must continue the turn
@@ -1134,7 +1266,7 @@ impl Agent {
                             chat,
                             turn_id,
                             &mut transcript,
-                            (!publish_terminal && !text.is_empty()).then_some(text.as_str()),
+                            (!publish_terminal && !text.is_empty()).then_some(&candidate),
                             events,
                         )
                         .await?
@@ -1144,6 +1276,7 @@ impl Agent {
                     if self.durable_steer_lease.is_some() {
                         return Ok(AgentTurnOutcome::Completed {
                             output,
+                            citations: candidate.citations.clone(),
                             usage: total_usage,
                             stop_reason,
                             steer_revision: generation_steer_revision,
@@ -1160,6 +1293,7 @@ impl Agent {
                     }) {
                         return Ok(AgentTurnOutcome::Completed {
                             output,
+                            citations: candidate.citations.clone(),
                             usage: total_usage,
                             stop_reason,
                             steer_revision: generation_steer_revision,
@@ -1285,7 +1419,7 @@ impl Agent {
         chat: &Chat,
         turn_id: TurnId,
         transcript: &mut Vec<ChatMessage>,
-        preceding_assistant: Option<&str>,
+        preceding_assistant: Option<&AssistantCandidate>,
         events: &EventSink<'_>,
     ) -> Result<bool> {
         let msgs = self.steer.drain();
@@ -1302,9 +1436,8 @@ impl Agent {
             )));
         }
         if self.durable_steer_lease.is_none() {
-            if let Some(text) = preceding_assistant {
-                self.persist(chat.id, turn_id, Role::Assistant, text)
-                    .await?;
+            if let Some(candidate) = preceding_assistant {
+                self.persist_assistant(chat.id, turn_id, candidate).await?;
             }
         }
         for msg in msgs {
@@ -1323,15 +1456,18 @@ impl Agent {
             });
         }
         let preceding = preceding_assistant
-            .filter(|text| !text.is_empty() && !durable.is_empty())
-            .map(|text| Message {
+            .filter(|candidate| !candidate.content.is_empty() && !durable.is_empty())
+            .map(|candidate| Message {
                 id: MessageId::new(),
                 chat_id: chat.id,
                 turn_id,
                 role: Role::Assistant,
-                content: text.to_owned(),
+                content: candidate.content.clone(),
                 created_at: Utc::now(),
             });
+        let preceding_citations = preceding_assistant
+            .filter(|candidate| !candidate.content.is_empty() && !durable.is_empty())
+            .map_or(&[][..], |candidate| candidate.citations.as_slice());
         if !durable.is_empty() {
             events.flush().await?;
         }
@@ -1346,6 +1482,7 @@ impl Agent {
                     steer.id,
                     event_ordinal,
                     preceding_assistant,
+                    if index == 0 { preceding_citations } else { &[] },
                 )
                 .await?;
             let steer = match journaled.outcome {
@@ -1434,6 +1571,7 @@ impl Agent {
         steer_id: crate::id::TurnSteerId,
         attempt_event_ordinal: i32,
         preceding_assistant: Option<&Message>,
+        preceding_citations: &[AssistantCitationReference],
     ) -> Result<JournaledTurnSteerOutcome> {
         let mut exact_retry_attempted = false;
         loop {
@@ -1445,6 +1583,7 @@ impl Agent {
                     steer_id,
                     attempt_event_ordinal,
                     preceding_assistant,
+                    preceding_citations,
                     Utc::now(),
                 )
                 .await
@@ -1767,6 +1906,47 @@ impl Agent {
         Ok(id)
     }
 
+    async fn persist_assistant(
+        &self,
+        chat_id: crate::id::ChatId,
+        turn_id: TurnId,
+        candidate: &AssistantCandidate,
+    ) -> Result<MessageId> {
+        let id = MessageId::new();
+        let message = Message {
+            id,
+            chat_id,
+            turn_id,
+            role: Role::Assistant,
+            content: candidate.content.clone(),
+            created_at: Utc::now(),
+        };
+        self.append_assistant_exact_retry(&message, &candidate.citations)
+            .await?;
+        Ok(id)
+    }
+
+    async fn append_assistant_exact_retry(
+        &self,
+        message: &Message,
+        citations: &[AssistantCitationReference],
+    ) -> Result<()> {
+        if self
+            .store
+            .append_assistant_message_with_citations(message, citations)
+            .await
+            .is_err()
+        {
+            // The first response can be lost after commit. Reuse every stable
+            // request field so storage can prove and recover only that exact
+            // message/citation sequence.
+            self.store
+                .append_assistant_message_with_citations(message, citations)
+                .await?;
+        }
+        Ok(())
+    }
+
     async fn load_transcript(&self, chat_id: crate::id::ChatId) -> Result<Vec<ChatMessage>> {
         let messages = self.store.list_messages(chat_id).await?;
         let tool_calls = self.store.list_tool_calls(chat_id).await?;
@@ -2009,6 +2189,70 @@ mod tests {
             .collect()
     }
 
+    fn streamed_text(events: &[AgentEvent]) -> String {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                AgentEvent::TextDelta { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn stream_filter_preserves_normal_and_cancel_tails_but_discards_steered_tail() {
+        let incomplete = "normal [[ow-source:abcdef";
+        let (normal_tx, normal_rx) = unbounded();
+        let normal_sink = EventSink::Legacy(&normal_tx);
+        let mut normal = AssistantStreamEventFilter::new(&normal_sink);
+        for character in incomplete.chars() {
+            normal.send_text(&character.to_string());
+        }
+        normal.finish();
+        drop(normal);
+        drop(normal_tx);
+        let normal_events = normal_rx.collect::<Vec<_>>().await;
+        assert_eq!(streamed_text(&normal_events), incomplete);
+
+        let malformed = "cancel [[ow-source:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA]]";
+        let (cancel_tx, cancel_rx) = unbounded();
+        let cancel_sink = EventSink::Legacy(&cancel_tx);
+        let mut cancelled = AssistantStreamEventFilter::new(&cancel_sink);
+        for character in malformed.chars() {
+            cancelled.send_text(&character.to_string());
+        }
+        // Cancellation uses the same literal flush as a normal stream end
+        // before the terminal cancellation event is published.
+        cancelled.finish();
+        cancelled.send(AgentEvent::TurnCancelled {
+            usage: Usage::default(),
+        });
+        drop(cancelled);
+        drop(cancel_tx);
+        let cancel_events = cancel_rx.collect::<Vec<_>>().await;
+        assert_eq!(streamed_text(&cancel_events), malformed);
+        assert!(matches!(
+            cancel_events.last(),
+            Some(AgentEvent::TurnCancelled { .. })
+        ));
+
+        let (steer_tx, steer_rx) = unbounded();
+        let steer_sink = EventSink::Legacy(&steer_tx);
+        let mut steered = AssistantStreamEventFilter::new(&steer_sink);
+        steered.send_text("steer ");
+        steered.send_text("[[ow-source:abcdef");
+        steered.discard();
+        steered.send(AgentEvent::StreamInterrupted);
+        drop(steered);
+        drop(steer_tx);
+        let steer_events = steer_rx.collect::<Vec<_>>().await;
+        assert_eq!(streamed_text(&steer_events), "steer ");
+        assert!(matches!(
+            steer_events.last(),
+            Some(AgentEvent::StreamInterrupted)
+        ));
+    }
+
     #[test]
     fn client_tool_arguments_are_parsed_without_forgiving_malformed_json() {
         assert_eq!(
@@ -2035,6 +2279,173 @@ mod tests {
 
     struct ContextRecordingTool {
         observed_project: Arc<Mutex<Option<Option<ProjectId>>>>,
+    }
+
+    struct CitationSearchTool {
+        source_token: uuid::Uuid,
+    }
+
+    #[async_trait]
+    impl Tool for CitationSearchTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: "search".into(),
+                description: "test search".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::ReadOnly
+        }
+
+        async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+            let document_id = crate::DocumentId::new();
+            let span = crate::ByteSpan::new(0, 8);
+            Ok(
+                ToolOutput::text("search result").with_private_evidence(vec![
+                    crate::RetrievalEvidenceInput {
+                        rank: 1,
+                        source_token: self.source_token,
+                        document_id,
+                        generation: crate::DocumentGeneration {
+                            content_revision: 1,
+                            revision_token: uuid::Uuid::new_v4(),
+                        },
+                        chunk_id: crate::ChunkId::derive(document_id, span.start, span.end),
+                        span,
+                        snippet: "evidence".into(),
+                        heading_path: vec!["Facts".into()],
+                        source_regions: Vec::new(),
+                        source: crate::RetrievalEvidenceSource::Inline,
+                    },
+                ]),
+            )
+        }
+    }
+
+    struct IntermediateCitationProvider {
+        calls: AtomicUsize,
+        marker: String,
+    }
+
+    #[async_trait]
+    impl ModelProvider for IntermediateCitationProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("citation-test")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let step = self.calls.fetch_add(1, Ordering::SeqCst);
+            let events = match step {
+                0 => vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "search_1".into(),
+                        name: "search".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: "{}".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ],
+                1 => {
+                    let candidate = format!("intermediate {}", self.marker);
+                    let mut events = candidate
+                        .chars()
+                        .map(|character| ProviderEvent::TextDelta {
+                            text: character.to_string(),
+                        })
+                        .collect::<Vec<_>>();
+                    events.extend([
+                        ProviderEvent::ToolCallStarted {
+                            index: 0,
+                            id: "read_1".into(),
+                            name: "read_file".into(),
+                        },
+                        ProviderEvent::ToolCallArgsDelta {
+                            index: 0,
+                            fragment: r#"{"path":"note.txt"}"#.into(),
+                        },
+                        ProviderEvent::Stop {
+                            reason: StopReason::ToolUse,
+                        },
+                    ]);
+                    events
+                }
+                _ => vec![
+                    ProviderEvent::TextDelta {
+                        text: "final".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ],
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    #[tokio::test]
+    async fn intermediate_assistant_source_marker_is_stripped_and_attached_atomically() {
+        let db = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("citations.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let source_token = uuid::Uuid::new_v4();
+        let marker =
+            crate::format_source_reference(crate::AssistantCitationReference { source_token });
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::write(workspace.path().join("note.txt"), "note").unwrap();
+        let agent = Agent::new(
+            Arc::new(IntermediateCitationProvider {
+                calls: AtomicUsize::new(0),
+                marker,
+            }),
+            Arc::new(
+                ToolRegistry::new()
+                    .with(Box::new(CitationSearchTool { source_token }))
+                    .with(Box::new(ReadFile)),
+            ),
+            store.clone(),
+            AgentConfig {
+                model: "test".into(),
+                tool_scratch: Some(tool_scratch(workspace.path())),
+                ..Default::default()
+            },
+        );
+        let (tx, _rx) = unbounded();
+        agent.run_turn(&chat, "question", &tx).await.unwrap();
+        let transcript = store.get_chat_transcript(chat.id).await.unwrap().unwrap();
+        assert!(transcript
+            .messages
+            .iter()
+            .all(|message| !message.content.contains("[[ow-source:")));
+        let intermediate = transcript
+            .messages
+            .iter()
+            .find(|message| message.content == "intermediate ")
+            .expect("clean intermediate assistant message");
+        assert_eq!(transcript.citations.len(), 1);
+        assert_eq!(transcript.citations[0].message_id, intermediate.id);
     }
 
     #[async_trait]

--- a/crates/openwave-core/src/citation.rs
+++ b/crates/openwave-core/src/citation.rs
@@ -1,0 +1,227 @@
+//! Closed source-reference grammar for durable assistant citations.
+//!
+//! Search tools expose opaque references to the model. The agent removes those
+//! references from final text and hands only their typed identities to storage;
+//! renderer clients never see the grammar or its underlying call identity.
+
+use std::collections::HashSet;
+
+use crate::RetrievalEvidenceInput;
+use crate::{AssistantCitationId, MessageId};
+
+const SOURCE_REFERENCE_PREFIX: &str = "[[ow-source:";
+const SOURCE_REFERENCE_SUFFIX: &str = "]]";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceReferenceCandidate {
+    Possible,
+    Complete,
+    Invalid,
+}
+
+/// Most distinct evidence rows one assistant message may cite.
+pub const MAX_ASSISTANT_CITATIONS: usize = RetrievalEvidenceInput::MAX_RESULTS;
+pub const MAX_CITATION_EXCERPT_CHARS: usize = 600;
+pub const MAX_CITATION_HEADING_CHARS: usize = 160;
+pub const MAX_CITATION_PAGES: usize = 8;
+
+/// One opaque reference selected by a model from a search result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AssistantCitationReference {
+    pub source_token: uuid::Uuid,
+}
+
+/// Final assistant text after reserved references have been removed, plus the
+/// first-use ordering of references that can be resolved by durable storage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedAssistantCitations {
+    pub content: String,
+    pub references: Vec<AssistantCitationReference>,
+}
+
+/// Renderer-safe historical citation projected from immutable evidence.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct AssistantCitationSnapshot {
+    pub id: AssistantCitationId,
+    #[serde(skip)]
+    pub message_id: MessageId,
+    pub ordinal: u16,
+    pub excerpt: String,
+    pub heading: Option<String>,
+    pub pages: Vec<u32>,
+}
+
+/// Produce the exact closed reference a search result gives to the model.
+#[must_use]
+pub fn format_source_reference(reference: AssistantCitationReference) -> String {
+    format!(
+        "{SOURCE_REFERENCE_PREFIX}{}{SOURCE_REFERENCE_SUFFIX}",
+        reference.source_token.simple()
+    )
+}
+
+/// Strip reserved references without interpreting Markdown.
+///
+/// Structurally complete reserved tokens are always removed from user-visible
+/// text. Exact lowercase-hex tokens become typed references; unknown tokens can
+/// be ignored by storage. Duplicates retain their first
+/// position and the result is bounded independently of provider output size.
+#[must_use]
+pub fn parse_assistant_citations(text: &str) -> ParsedAssistantCitations {
+    let mut content = String::with_capacity(text.len());
+    let mut references = Vec::new();
+    let mut seen = HashSet::new();
+    let mut remainder = text;
+
+    while let Some(start) = remainder.find(SOURCE_REFERENCE_PREFIX) {
+        content.push_str(&remainder[..start]);
+        let token = &remainder[start + SOURCE_REFERENCE_PREFIX.len()..];
+        let Some(payload) = token.get(..32) else {
+            content.push_str(SOURCE_REFERENCE_PREFIX);
+            remainder = token;
+            continue;
+        };
+        let Some(after_payload) = token.get(32..) else {
+            unreachable!("a 32-byte token prefix has a remainder")
+        };
+        let Some(reference) = after_payload
+            .starts_with(SOURCE_REFERENCE_SUFFIX)
+            .then(|| parse_reference_payload(payload))
+            .flatten()
+        else {
+            content.push_str(SOURCE_REFERENCE_PREFIX);
+            remainder = token;
+            continue;
+        };
+        if references.len() < MAX_ASSISTANT_CITATIONS && seen.insert(reference) {
+            references.push(reference);
+        }
+        remainder = &after_payload[SOURCE_REFERENCE_SUFFIX.len()..];
+    }
+    content.push_str(remainder);
+
+    ParsedAssistantCitations {
+        content,
+        references,
+    }
+}
+
+pub(crate) fn classify_source_reference_candidate(candidate: &str) -> SourceReferenceCandidate {
+    if candidate.len() < SOURCE_REFERENCE_PREFIX.len() {
+        return if SOURCE_REFERENCE_PREFIX.starts_with(candidate) {
+            SourceReferenceCandidate::Possible
+        } else {
+            SourceReferenceCandidate::Invalid
+        };
+    }
+    if !candidate.starts_with(SOURCE_REFERENCE_PREFIX) {
+        return SourceReferenceCandidate::Invalid;
+    }
+    let remainder = &candidate[SOURCE_REFERENCE_PREFIX.len()..];
+    let payload_len = remainder.len().min(32);
+    if !remainder.as_bytes()[..payload_len]
+        .iter()
+        .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+    {
+        return SourceReferenceCandidate::Invalid;
+    }
+    if remainder.len() < 32 {
+        return SourceReferenceCandidate::Possible;
+    }
+    let suffix = &remainder[32..];
+    if suffix == SOURCE_REFERENCE_SUFFIX {
+        SourceReferenceCandidate::Complete
+    } else if SOURCE_REFERENCE_SUFFIX.starts_with(suffix) {
+        SourceReferenceCandidate::Possible
+    } else {
+        SourceReferenceCandidate::Invalid
+    }
+}
+
+fn parse_reference_payload(payload: &str) -> Option<AssistantCitationReference> {
+    if payload.len() != 32
+        || !payload
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return None;
+    }
+    let source_token = uuid::Uuid::parse_str(payload).ok()?;
+    Some(AssistantCitationReference { source_token })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_strips_and_deduplicates_exact_references_without_markdown() {
+        let first = AssistantCitationReference {
+            source_token: uuid::Uuid::new_v4(),
+        };
+        let second = AssistantCitationReference {
+            source_token: uuid::Uuid::new_v4(),
+        };
+        let text = format!(
+            "Grounded {first_ref} answer {second_ref}{first_ref}",
+            first_ref = format_source_reference(first),
+            second_ref = format_source_reference(second),
+        );
+        let parsed = parse_assistant_citations(&text);
+        assert_eq!(parsed.content, "Grounded  answer ");
+        assert_eq!(parsed.references, [first, second]);
+    }
+
+    #[test]
+    fn parser_strips_well_formed_unknown_tokens_and_preserves_malformed_text() {
+        let parsed = parse_assistant_citations(
+            " before [[ow-source:not-a-token]] middle \
+             [[ow-source:00000000000000000000000000000000]] after \
+             [[ow-source:still-being-written ",
+        );
+        assert_eq!(
+            parsed.references,
+            [AssistantCitationReference {
+                source_token: uuid::Uuid::nil(),
+            }]
+        );
+        assert_eq!(
+            parsed.content,
+            " before [[ow-source:not-a-token]] middle  after [[ow-source:still-being-written "
+        );
+    }
+
+    #[test]
+    fn parser_preserves_whitespace_and_every_near_miss() {
+        let valid = AssistantCitationReference {
+            source_token: uuid::Uuid::new_v4(),
+        };
+        let valid_marker = format_source_reference(valid);
+        let text = format!(
+            "\n[[ow-source:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]]\n\
+             [[ow-source:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb]]\n\
+             [[ow-source:CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC]]\n\
+             [[ow-source:short ordinary paragraph and a later ]] marker\n\
+             {valid_marker} tail 🌊\n"
+        );
+        let parsed = parse_assistant_citations(&text);
+        assert_eq!(parsed.references, [valid]);
+        assert_eq!(parsed.content, text.replace(&valid_marker, ""));
+    }
+
+    #[test]
+    fn parser_bounds_distinct_references_but_strips_all_tokens() {
+        let references = (0..MAX_ASSISTANT_CITATIONS + 2)
+            .map(|_| AssistantCitationReference {
+                source_token: uuid::Uuid::new_v4(),
+            })
+            .collect::<Vec<_>>();
+        let text = references
+            .iter()
+            .map(|reference| format_source_reference(*reference))
+            .collect::<String>();
+        let parsed = parse_assistant_citations(&text);
+        assert!(parsed.content.is_empty());
+        assert_eq!(parsed.references, references[..MAX_ASSISTANT_CITATIONS]);
+    }
+}

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -701,6 +701,7 @@ pub mod turn_steer {
         pub status: String,
         pub applied_lease_token: Option<Uuid>,
         pub message_id: Option<Uuid>,
+        pub preceding_assistant_message_id: Option<Uuid>,
         pub created_at: DateTimeUtc,
         pub resolved_at: Option<DateTimeUtc>,
     }
@@ -788,6 +789,7 @@ pub mod retrieval_evidence {
         pub call_id: Uuid,
         #[sea_orm(primary_key, auto_increment = false)]
         pub rank: i32,
+        pub source_token: Uuid,
         pub chat_id: Uuid,
         pub turn_id: Uuid,
         pub document_id: Uuid,
@@ -807,6 +809,50 @@ pub mod retrieval_evidence {
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
     pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod assistant_citation {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "assistant_citation")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub message_id: Uuid,
+        pub ordinal: i32,
+        pub chat_id: Uuid,
+        pub turn_id: Uuid,
+        pub evidence_call_id: Uuid,
+        pub evidence_rank: i32,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter)]
+    pub enum Relation {
+        RetrievalEvidence,
+    }
+
+    impl RelationTrait for Relation {
+        fn def(&self) -> RelationDef {
+            match self {
+                Self::RetrievalEvidence => Entity::belongs_to(super::retrieval_evidence::Entity)
+                    .from((Column::EvidenceCallId, Column::EvidenceRank))
+                    .to((
+                        super::retrieval_evidence::Column::CallId,
+                        super::retrieval_evidence::Column::Rank,
+                    ))
+                    .into(),
+            }
+        }
+    }
+
+    impl Related<super::retrieval_evidence::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::RetrievalEvidence.def()
+        }
+    }
 
     impl ActiveModelBehavior for ActiveModel {}
 }

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -1885,6 +1885,7 @@ impl MigrationTrait for Init {
             .eq(TurnSteerStatus::Pending.as_str())
             .and(Expr::col(TurnSteer::AppliedLeaseToken).is_null())
             .and(Expr::col(TurnSteer::MessageId).is_null())
+            .and(Expr::col(TurnSteer::PrecedingAssistantMessageId).is_null())
             .and(Expr::col(TurnSteer::ResolvedAt).is_null());
         let applied_steer = Expr::col(TurnSteer::Status)
             .eq(TurnSteerStatus::Applied.as_str())
@@ -1895,6 +1896,7 @@ impl MigrationTrait for Init {
             .eq(TurnSteerStatus::Rejected.as_str())
             .and(Expr::col(TurnSteer::AppliedLeaseToken).is_null())
             .and(Expr::col(TurnSteer::MessageId).is_null())
+            .and(Expr::col(TurnSteer::PrecedingAssistantMessageId).is_null())
             .and(Expr::col(TurnSteer::ResolvedAt).is_not_null());
         manager
             .create_table(
@@ -1924,6 +1926,7 @@ impl MigrationTrait for Init {
                     )
                     .col(ColumnDef::new(TurnSteer::AppliedLeaseToken).uuid())
                     .col(ColumnDef::new(TurnSteer::MessageId).uuid())
+                    .col(ColumnDef::new(TurnSteer::PrecedingAssistantMessageId).uuid())
                     .col(
                         ColumnDef::new(TurnSteer::CreatedAt)
                             .timestamp_with_time_zone()
@@ -1940,6 +1943,19 @@ impl MigrationTrait for Init {
                             .to_col(TurnRun::ChatId)
                             .to_col(TurnRun::Id)
                             .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_turn_steer_preceding_assistant")
+                            .from_tbl(TurnSteer::Table)
+                            .from_col(TurnSteer::PrecedingAssistantMessageId)
+                            .from_col(TurnSteer::ChatId)
+                            .from_col(TurnSteer::TurnId)
+                            .to_tbl(Message::Table)
+                            .to_col(Message::Id)
+                            .to_col(Message::ChatId)
+                            .to_col(Message::TurnId)
+                            .on_delete(ForeignKeyAction::Restrict),
                     )
                     .foreign_key(
                         ForeignKey::create()
@@ -2669,6 +2685,11 @@ async fn create_retrieval_evidence_table(manager: &SchemaManager<'_>) -> Result<
                 .table(RetrievalEvidence::Table)
                 .col(ColumnDef::new(RetrievalEvidence::CallId).uuid().not_null())
                 .col(ColumnDef::new(RetrievalEvidence::Rank).integer().not_null())
+                .col(
+                    ColumnDef::new(RetrievalEvidence::SourceToken)
+                        .uuid()
+                        .not_null(),
+                )
                 .col(ColumnDef::new(RetrievalEvidence::ChatId).uuid().not_null())
                 .col(ColumnDef::new(RetrievalEvidence::TurnId).uuid().not_null())
                 .col(
@@ -2751,6 +2772,126 @@ async fn create_retrieval_evidence_table(manager: &SchemaManager<'_>) -> Result<
                             .eq("inline")
                             .and(Expr::col(RetrievalEvidence::SourceUri).is_null())),
                 )
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_retrieval_evidence_source_token")
+                .table(RetrievalEvidence::Table)
+                .col(RetrievalEvidence::SourceToken)
+                .unique()
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_retrieval_evidence_exact_owner")
+                .table(RetrievalEvidence::Table)
+                .col(RetrievalEvidence::CallId)
+                .col(RetrievalEvidence::Rank)
+                .col(RetrievalEvidence::ChatId)
+                .col(RetrievalEvidence::TurnId)
+                .unique()
+                .to_owned(),
+        )
+        .await
+}
+
+async fn create_assistant_citation_table(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(AssistantCitation::Table)
+                .col(
+                    ColumnDef::new(AssistantCitation::Id)
+                        .uuid()
+                        .not_null()
+                        .primary_key(),
+                )
+                .col(
+                    ColumnDef::new(AssistantCitation::MessageId)
+                        .uuid()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AssistantCitation::Ordinal)
+                        .integer()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(AssistantCitation::ChatId).uuid().not_null())
+                .col(ColumnDef::new(AssistantCitation::TurnId).uuid().not_null())
+                .col(
+                    ColumnDef::new(AssistantCitation::EvidenceCallId)
+                        .uuid()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(AssistantCitation::EvidenceRank)
+                        .integer()
+                        .not_null(),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_assistant_citation_message")
+                        .from_tbl(AssistantCitation::Table)
+                        .from_col(AssistantCitation::MessageId)
+                        .from_col(AssistantCitation::ChatId)
+                        .from_col(AssistantCitation::TurnId)
+                        .to_tbl(Message::Table)
+                        .to_col(Message::Id)
+                        .to_col(Message::ChatId)
+                        .to_col(Message::TurnId)
+                        .on_delete(ForeignKeyAction::Cascade),
+                )
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_assistant_citation_evidence")
+                        .from_tbl(AssistantCitation::Table)
+                        .from_col(AssistantCitation::EvidenceCallId)
+                        .from_col(AssistantCitation::EvidenceRank)
+                        .from_col(AssistantCitation::ChatId)
+                        .from_col(AssistantCitation::TurnId)
+                        .to_tbl(RetrievalEvidence::Table)
+                        .to_col(RetrievalEvidence::CallId)
+                        .to_col(RetrievalEvidence::Rank)
+                        .to_col(RetrievalEvidence::ChatId)
+                        .to_col(RetrievalEvidence::TurnId)
+                        .on_delete(ForeignKeyAction::Cascade),
+                )
+                .check(
+                    Expr::col(AssistantCitation::Ordinal)
+                        .between(1, crate::MAX_ASSISTANT_CITATIONS as i32),
+                )
+                .check(
+                    Expr::col(AssistantCitation::EvidenceRank)
+                        .between(1, crate::RetrievalEvidenceInput::MAX_RESULTS as i32),
+                )
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_assistant_citation_message_ordinal")
+                .table(AssistantCitation::Table)
+                .col(AssistantCitation::MessageId)
+                .col(AssistantCitation::Ordinal)
+                .unique()
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
+                .name("idx_assistant_citation_message_evidence")
+                .table(AssistantCitation::Table)
+                .col(AssistantCitation::MessageId)
+                .col(AssistantCitation::EvidenceCallId)
+                .col(AssistantCitation::EvidenceRank)
+                .unique()
                 .to_owned(),
         )
         .await
@@ -3019,6 +3160,7 @@ impl MigrationTrait for AddToolCalls {
             .await?;
 
         create_retrieval_evidence_table(manager).await?;
+        create_assistant_citation_table(manager).await?;
 
         manager
             .create_table(
@@ -3177,6 +3319,9 @@ impl MigrationTrait for AddToolCalls {
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(AssistantCitation::Table).to_owned())
+            .await?;
         manager
             .drop_table(Table::drop().table(RetrievalEvidence::Table).to_owned())
             .await?;
@@ -4000,6 +4145,7 @@ enum RetrievalEvidence {
     Table,
     CallId,
     Rank,
+    SourceToken,
     ChatId,
     TurnId,
     DocumentId,
@@ -4013,6 +4159,18 @@ enum RetrievalEvidence {
     SourceRegions,
     SourceKind,
     SourceUri,
+}
+
+#[derive(DeriveIden)]
+enum AssistantCitation {
+    Table,
+    Id,
+    MessageId,
+    Ordinal,
+    ChatId,
+    TurnId,
+    EvidenceCallId,
+    EvidenceRank,
 }
 
 #[derive(DeriveIden)]
@@ -4350,6 +4508,7 @@ enum TurnSteer {
     Status,
     AppliedLeaseToken,
     MessageId,
+    PrecedingAssistantMessageId,
     CreatedAt,
     ResolvedAt,
 }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -2093,6 +2093,7 @@ impl Store for DbStore {
         steer_id: TurnSteerId,
         attempt_event_ordinal: i32,
         preceding_assistant: Option<&Message>,
+        preceding_citations: &[crate::AssistantCitationReference],
         now: chrono::DateTime<Utc>,
     ) -> Result<Option<JournaledTurnSteerOutcome>> {
         ops::turn::apply_turn_steer(
@@ -2102,6 +2103,7 @@ impl Store for DbStore {
             steer_id,
             attempt_event_ordinal,
             preceding_assistant,
+            preceding_citations,
             now,
         )
         .await
@@ -2136,6 +2138,31 @@ impl Store for DbStore {
             expected_steer_revision,
             now,
             output,
+            usage,
+            stop_reason,
+        )
+        .await
+    }
+
+    async fn complete_turn_run_with_citations_and_append_event(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
+        now: chrono::DateTime<Utc>,
+        output: &Message,
+        citations: &[crate::AssistantCitationReference],
+        usage: Usage,
+        stop_reason: StopReason,
+    ) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
+        ops::turn::complete_turn_run_with_citations_and_append_event(
+            self,
+            id,
+            lease_token,
+            expected_steer_revision,
+            now,
+            output,
+            citations,
             usage,
             stop_reason,
         )
@@ -2272,6 +2299,14 @@ impl Store for DbStore {
 
     async fn append_message(&self, message: &Message) -> Result<()> {
         ops::conversation::append_message(self, message).await
+    }
+
+    async fn append_assistant_message_with_citations(
+        &self,
+        message: &Message,
+        references: &[crate::AssistantCitationReference],
+    ) -> Result<()> {
+        ops::citation::append_assistant_message(self, message, references).await
     }
 
     async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>> {
@@ -2506,6 +2541,25 @@ impl Store for DbStore {
         event: &AgentEvent,
     ) -> Result<Option<SequencedEvent>> {
         ops::turn::recover_exact_terminal_event(self, turn_id, lease_token, event).await
+    }
+
+    async fn recover_exact_completed_turn_event(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        output: &Message,
+        citations: &[crate::AssistantCitationReference],
+        event: &AgentEvent,
+    ) -> Result<Option<SequencedEvent>> {
+        ops::turn::recover_exact_completed_turn_event(
+            self,
+            turn_id,
+            lease_token,
+            output,
+            citations,
+            event,
+        )
+        .await
     }
 
     async fn list_events(&self, chat_id: ChatId, after: i64) -> Result<Vec<SequencedEvent>> {

--- a/crates/openwave-core/src/db/ops/citation.rs
+++ b/crates/openwave-core/src/db/ops/citation.rs
@@ -1,0 +1,303 @@
+use std::collections::HashSet;
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait,
+};
+
+use crate::citation::{
+    parse_assistant_citations, AssistantCitationReference, AssistantCitationSnapshot,
+    MAX_ASSISTANT_CITATIONS, MAX_CITATION_EXCERPT_CHARS, MAX_CITATION_HEADING_CHARS,
+    MAX_CITATION_PAGES,
+};
+use crate::error::{AgentError, Result};
+use crate::id::{AssistantCitationId, ChatId, MessageId, TurnId};
+use crate::model::{Message, Role, SourceLocation};
+
+use super::super::{entities, store_err, DbStore};
+use super::acquire_chat_write_lock;
+use super::conversation::{
+    next_message_seq_on, reserve_message_identity_on, MESSAGE_IDENTITY_OWNER_MESSAGE,
+};
+
+pub(in crate::db) async fn append_assistant_message(
+    store: &DbStore,
+    message: &Message,
+    references: &[AssistantCitationReference],
+) -> Result<()> {
+    validate_assistant_message(message, references)?;
+    let created_at = super::turn::canonical_db_timestamp(message.created_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, message.chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "chat {} does not exist",
+            message.chat_id
+        )));
+    }
+    if !reserve_message_identity_on(
+        &transaction,
+        message.id,
+        message.chat_id,
+        message.turn_id,
+        MESSAGE_IDENTITY_OWNER_MESSAGE,
+    )
+    .await?
+    {
+        transaction.rollback().await.map_err(store_err)?;
+        if exact_appended_message_on(store, message, references).await? {
+            return Ok(());
+        }
+        return Err(AgentError::Store(format!(
+            "message identity {} is already reserved",
+            message.id
+        )));
+    }
+    let evidence =
+        resolve_references_on(&transaction, message.chat_id, message.turn_id, references).await?;
+    entities::message::ActiveModel {
+        id: Set(message.id.0),
+        chat_id: Set(message.chat_id.0),
+        turn_id: Set(message.turn_id.0),
+        seq: Set(next_message_seq_on(&transaction, message.chat_id).await?),
+        role: Set("assistant".into()),
+        content: Set(message.content.clone()),
+        created_at: Set(created_at),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    insert_for_message_on(&transaction, message, &evidence).await?;
+    transaction.commit().await.map_err(store_err)
+}
+
+async fn exact_appended_message_on(
+    store: &DbStore,
+    message: &Message,
+    references: &[AssistantCitationReference],
+) -> Result<bool> {
+    let created_at = super::turn::canonical_db_timestamp(message.created_at)?;
+    let Some(stored) = entities::message::Entity::find_by_id(message.id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(false);
+    };
+    if stored.chat_id != message.chat_id.0
+        || stored.turn_id != message.turn_id.0
+        || stored.role != "assistant"
+        || stored.content != message.content
+        || stored.created_at != created_at
+    {
+        return Ok(false);
+    }
+    let expected = resolve_references_on(&store.conn, message.chat_id, message.turn_id, references)
+        .await?
+        .into_iter()
+        .map(|evidence| AssistantCitationReference {
+            source_token: evidence.source_token,
+        })
+        .collect::<Vec<_>>();
+    Ok(exact_references_for_message_on(&store.conn, message.id).await? == expected)
+}
+
+pub(in crate::db) fn validate_assistant_message(
+    message: &Message,
+    references: &[AssistantCitationReference],
+) -> Result<()> {
+    if message.role != Role::Assistant || message.id.0.is_nil() {
+        return Err(AgentError::Store(
+            "citations require a non-nil assistant message".into(),
+        ));
+    }
+    if parse_assistant_citations(&message.content).content != message.content {
+        return Err(AgentError::Store(
+            "assistant message contains an unstripped source reference".into(),
+        ));
+    }
+    if references.len() > MAX_ASSISTANT_CITATIONS
+        || references.iter().copied().collect::<HashSet<_>>().len() != references.len()
+    {
+        return Err(AgentError::Store(
+            "assistant citation references are invalid".into(),
+        ));
+    }
+    Ok(())
+}
+
+pub(in crate::db) async fn resolve_references_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+    turn_id: TurnId,
+    references: &[AssistantCitationReference],
+) -> Result<Vec<entities::retrieval_evidence::Model>>
+where
+    C: ConnectionTrait,
+{
+    let mut evidence = Vec::with_capacity(references.len());
+    for reference in references {
+        if let Some(row) = entities::retrieval_evidence::Entity::find()
+            .filter(entities::retrieval_evidence::Column::SourceToken.eq(reference.source_token))
+            .filter(entities::retrieval_evidence::Column::ChatId.eq(chat_id.0))
+            .filter(entities::retrieval_evidence::Column::TurnId.eq(turn_id.0))
+            .one(conn)
+            .await
+            .map_err(store_err)?
+        {
+            evidence.push(row);
+        }
+    }
+    Ok(evidence)
+}
+
+pub(in crate::db) async fn insert_for_message_on<C>(
+    conn: &C,
+    message: &Message,
+    evidence: &[entities::retrieval_evidence::Model],
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    if evidence.is_empty() {
+        return Ok(());
+    }
+    let rows = evidence
+        .iter()
+        .enumerate()
+        .map(|(index, row)| entities::assistant_citation::ActiveModel {
+            id: Set(AssistantCitationId::derive(
+                message.id,
+                u16::try_from(index + 1).expect("citation limit fits u16"),
+            )
+            .0),
+            message_id: Set(message.id.0),
+            ordinal: Set(i32::try_from(index + 1).expect("citation limit fits i32")),
+            chat_id: Set(message.chat_id.0),
+            turn_id: Set(message.turn_id.0),
+            evidence_call_id: Set(row.call_id),
+            evidence_rank: Set(row.rank),
+        })
+        .collect::<Vec<_>>();
+    entities::assistant_citation::Entity::insert_many(rows)
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+pub(in crate::db) async fn exact_references_for_message_on<C>(
+    conn: &C,
+    message_id: MessageId,
+) -> Result<Vec<AssistantCitationReference>>
+where
+    C: ConnectionTrait,
+{
+    let rows = entities::assistant_citation::Entity::find()
+        .find_also_related(entities::retrieval_evidence::Entity)
+        .filter(entities::assistant_citation::Column::MessageId.eq(message_id.0))
+        .order_by_asc(entities::assistant_citation::Column::Ordinal)
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    let mut references = Vec::with_capacity(rows.len());
+    for (row, evidence) in rows {
+        let evidence = evidence
+            .ok_or_else(|| AgentError::Store("assistant citation evidence disappeared".into()))?;
+        if evidence.chat_id != row.chat_id || evidence.turn_id != row.turn_id {
+            return Err(AgentError::Store(
+                "assistant citation evidence owner is corrupt".into(),
+            ));
+        }
+        references.push(AssistantCitationReference {
+            source_token: evidence.source_token,
+        });
+    }
+    Ok(references)
+}
+
+pub(in crate::db) async fn list_snapshots_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+) -> Result<Vec<AssistantCitationSnapshot>>
+where
+    C: ConnectionTrait,
+{
+    let rows = entities::assistant_citation::Entity::find()
+        .find_also_related(entities::retrieval_evidence::Entity)
+        .filter(entities::assistant_citation::Column::ChatId.eq(chat_id.0))
+        .order_by_asc(entities::assistant_citation::Column::MessageId)
+        .order_by_asc(entities::assistant_citation::Column::Ordinal)
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    let mut snapshots = Vec::with_capacity(rows.len());
+    let mut ordinal_owner = None;
+    let mut expected_ordinal = 1_i32;
+    for (row, evidence) in rows {
+        let evidence = evidence
+            .ok_or_else(|| AgentError::Store("assistant citation evidence disappeared".into()))?;
+        if ordinal_owner != Some(row.message_id) {
+            ordinal_owner = Some(row.message_id);
+            expected_ordinal = 1;
+        }
+        if row.ordinal != expected_ordinal
+            || !(1..=MAX_ASSISTANT_CITATIONS as i32).contains(&row.ordinal)
+            || row.id
+                != AssistantCitationId::derive(
+                    MessageId(row.message_id),
+                    u16::try_from(row.ordinal).expect("validated citation ordinal fits u16"),
+                )
+                .0
+        {
+            return Err(AgentError::Store(
+                "assistant citation ordering or identity is corrupt".into(),
+            ));
+        }
+        expected_ordinal += 1;
+        let evidence = super::client_execution::evidence_from_model(evidence)?;
+        if evidence.chat_id != chat_id
+            || evidence.turn_id.0 != row.turn_id
+            || evidence.call_id.0 != row.evidence_call_id
+            || i32::from(evidence.evidence.rank) != row.evidence_rank
+        {
+            return Err(AgentError::Store(
+                "assistant citation projection owner is corrupt".into(),
+            ));
+        }
+        let mut pages = Vec::new();
+        for region in evidence.evidence.source_regions {
+            let SourceLocation::Page { number } = region.location;
+            let page = number.get();
+            if !pages.contains(&page) {
+                pages.push(page);
+                if pages.len() == MAX_CITATION_PAGES {
+                    break;
+                }
+            }
+        }
+        let headings = evidence.evidence.heading_path;
+        let heading = (!headings.is_empty()).then(|| {
+            headings
+                .join(" > ")
+                .chars()
+                .take(MAX_CITATION_HEADING_CHARS)
+                .collect()
+        });
+        snapshots.push(AssistantCitationSnapshot {
+            id: AssistantCitationId(row.id),
+            message_id: MessageId(row.message_id),
+            ordinal: u16::try_from(row.ordinal)
+                .map_err(|_| AgentError::Store("invalid assistant citation ordinal".into()))?,
+            excerpt: evidence
+                .evidence
+                .snippet
+                .chars()
+                .take(MAX_CITATION_EXCERPT_CHARS)
+                .collect(),
+            heading,
+            pages,
+        });
+    }
+    Ok(snapshots)
+}

--- a/crates/openwave-core/src/db/ops/client_execution.rs
+++ b/crates/openwave-core/src/db/ops/client_execution.rs
@@ -470,10 +470,16 @@ fn validate_evidence_request(
     {
         return Err(AgentError::Store("invalid retrieval evidence owner".into()));
     }
+    let mut source_tokens = std::collections::HashSet::with_capacity(evidence.len());
     for (index, item) in evidence.iter().enumerate() {
         let expected_rank = u16::try_from(index + 1)
             .map_err(|_| AgentError::Store("retrieval evidence rank exhausted".into()))?;
         validate_evidence_item(item, expected_rank)?;
+        if !source_tokens.insert(item.source_token) {
+            return Err(AgentError::Store(
+                "retrieval evidence source tokens must be unique".into(),
+            ));
+        }
     }
     Ok(())
 }
@@ -494,6 +500,7 @@ fn validate_evidence_item(item: &RetrievalEvidenceInput, expected_rank: u16) -> 
     if item.rank != expected_rank
         || item.rank == 0
         || usize::from(item.rank) > RetrievalEvidenceInput::MAX_RESULTS
+        || item.source_token.is_nil()
         || item.generation.content_revision < 1
         || item.generation.revision_token.is_nil()
         || item.span.is_empty()
@@ -572,6 +579,7 @@ where
             Ok(entities::retrieval_evidence::ActiveModel {
                 call_id: Set(call.id),
                 rank: Set(i32::from(item.rank)),
+                source_token: Set(item.source_token),
                 chat_id: Set(call.chat_id),
                 turn_id: Set(call.turn_id),
                 document_id: Set(item.document_id.0),
@@ -599,7 +607,9 @@ where
     Ok(())
 }
 
-fn evidence_from_model(model: entities::retrieval_evidence::Model) -> Result<RetrievalEvidence> {
+pub(in crate::db) fn evidence_from_model(
+    model: entities::retrieval_evidence::Model,
+) -> Result<RetrievalEvidence> {
     let span_start = usize::try_from(model.span_start)
         .map_err(|_| AgentError::Store("invalid stored evidence span".into()))?;
     let span_end = usize::try_from(model.span_end)
@@ -610,6 +620,7 @@ fn evidence_from_model(model: entities::retrieval_evidence::Model) -> Result<Ret
     let evidence = RetrievalEvidenceInput {
         rank: u16::try_from(model.rank)
             .map_err(|_| AgentError::Store("invalid stored evidence rank".into()))?,
+        source_token: model.source_token,
         document_id: model.document_id.into(),
         generation: crate::DocumentGeneration {
             content_revision: model.content_revision,

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -522,11 +522,13 @@ pub(in crate::db) async fn get_chat_transcript(
         return Ok(None);
     }
     let messages = list_messages_on(&transaction, chat_id).await?;
+    let citations = super::citation::list_snapshots_on(&transaction, chat_id).await?;
     let tool_activity = list_terminal_tool_activity_on(&transaction, chat_id).await?;
     let last_event_seq = terminal_event_cursor_on(&transaction, chat_id).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(Some(ChatTranscriptSnapshot {
         messages,
+        citations,
         tool_activity,
         last_event_seq,
     }))

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -8,6 +8,7 @@ use super::{entities, store_err};
 pub(in crate::db) mod agent_run;
 pub(in crate::db) mod approval;
 pub(in crate::db) mod blob;
+pub(in crate::db) mod citation;
 pub(in crate::db) mod client_execution;
 pub(in crate::db) mod conversation;
 pub(in crate::db) mod document;

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -36,10 +36,11 @@ pub(in crate::db) use client_wait::{
 };
 
 pub(in crate::db) use resolution::{
-    complete_turn_run, complete_turn_run_and_append_event, finish_turn_cancellation,
+    complete_turn_run, complete_turn_run_and_append_event,
+    complete_turn_run_with_citations_and_append_event, finish_turn_cancellation,
     finish_turn_cancellation_and_append_event, record_turn_run_failure,
-    record_turn_run_failure_and_append_event, request_turn_cancellation,
-    request_turn_cancellation_and_append_event,
+    record_turn_run_failure_and_append_event, recover_exact_completed_turn_event,
+    request_turn_cancellation, request_turn_cancellation_and_append_event,
 };
 pub(in crate::db) use steer::{accept_turn_steer, apply_turn_steer, list_pending_turn_steers};
 

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -47,6 +47,7 @@ pub(in crate::db) async fn complete_turn_run(
         expected_steer_revision,
         now,
         output,
+        &[],
         None,
     )
     .await?
@@ -72,11 +73,56 @@ pub(in crate::db) async fn complete_turn_run_and_append_event(
         expected_steer_revision,
         now,
         output,
+        &[],
         Some(&event),
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(in crate::db) async fn complete_turn_run_with_citations_and_append_event(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
+    now: chrono::DateTime<Utc>,
+    output: &Message,
+    citations: &[crate::AssistantCitationReference],
+    usage: Usage,
+    stop_reason: StopReason,
+) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
+    let event = AgentEvent::TurnCompleted { usage, stop_reason };
+    complete_turn_run_inner(
+        store,
+        id,
+        lease_token,
+        expected_steer_revision,
+        now,
+        output,
+        citations,
+        Some(&event),
+    )
+    .await
+}
+
+pub(in crate::db) async fn recover_exact_completed_turn_event(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    output: &Message,
+    citations: &[crate::AssistantCitationReference],
+    event: &AgentEvent,
+) -> Result<Option<SequencedEvent>> {
+    if exact_completed_turn_on(store, id, lease_token, output, citations)
+        .await?
+        .is_none()
+    {
+        return Ok(None);
+    }
+    exact_terminal_event_on(&store.conn, id, Some(lease_token), Some(event)).await
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn complete_turn_run_inner(
     store: &DbStore,
     id: TurnId,
@@ -84,9 +130,11 @@ async fn complete_turn_run_inner(
     expected_steer_revision: i64,
     now: chrono::DateTime<Utc>,
     output: &Message,
+    citations: &[crate::AssistantCitationReference],
     terminal_event: Option<&AgentEvent>,
 ) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
     validate_turn_output(id, lease_token, output)?;
+    super::super::citation::validate_assistant_message(output, citations)?;
     let now = canonical_db_timestamp(now)?;
     let output_created_at = canonical_db_timestamp(output.created_at)?;
     if output_created_at > now {
@@ -136,6 +184,7 @@ async fn complete_turn_run_inner(
     {
         if existing.output_message_id != Some(output.id.0)
             || !exact_completed_output_on(&transaction, output).await?
+            || !exact_completed_citations_on(&transaction, output, citations).await?
         {
             return Err(AgentError::Store(format!(
                 "turn {id} was already completed with different output"
@@ -196,7 +245,9 @@ async fn complete_turn_run_inner(
     .await?
     {
         transaction.rollback().await.map_err(store_err)?;
-        if let Some(existing) = exact_completed_turn_on(store, id, lease_token, output).await? {
+        if let Some(existing) =
+            exact_completed_turn_on(store, id, lease_token, output, citations).await?
+        {
             let sequenced_event =
                 exact_terminal_event_on(&store.conn, id, Some(lease_token), terminal_event).await?;
             return Ok(Some(JournaledTurnOutcome {
@@ -220,7 +271,9 @@ async fn complete_turn_run_inner(
     };
     if let Err(error) = message.insert(&transaction).await {
         transaction.rollback().await.map_err(store_err)?;
-        if let Some(existing) = exact_completed_turn_on(store, id, lease_token, output).await? {
+        if let Some(existing) =
+            exact_completed_turn_on(store, id, lease_token, output, citations).await?
+        {
             let sequenced_event =
                 exact_terminal_event_on(&store.conn, id, Some(lease_token), terminal_event).await?;
             return Ok(Some(JournaledTurnOutcome {
@@ -230,6 +283,14 @@ async fn complete_turn_run_inner(
         }
         return Err(store_err(error));
     }
+    let evidence = super::super::citation::resolve_references_on(
+        &transaction,
+        output.chat_id,
+        output.turn_id,
+        citations,
+    )
+    .await?;
+    super::super::citation::insert_for_message_on(&transaction, output, &evidence).await?;
 
     let completed = entities::turn_run::Entity::update_many()
         .col_expr(
@@ -769,6 +830,7 @@ async fn exact_completed_turn_on(
     id: TurnId,
     lease_token: uuid::Uuid,
     output: &Message,
+    citations: &[crate::AssistantCitationReference],
 ) -> Result<Option<TurnRun>> {
     let Some(receipt) = entities::turn_claim::Entity::find_by_id(lease_token)
         .one(&store.conn)
@@ -793,12 +855,36 @@ async fn exact_completed_turn_on(
     }
     if existing.output_message_id != Some(output.id.0)
         || !exact_completed_output_on(&store.conn, output).await?
+        || !exact_completed_citations_on(&store.conn, output, citations).await?
     {
         return Err(AgentError::Store(format!(
             "turn {id} was already completed with different output"
         )));
     }
     Ok(Some(turn_run_from_model(existing)?))
+}
+
+async fn exact_completed_citations_on<C>(
+    conn: &C,
+    output: &Message,
+    citations: &[crate::AssistantCitationReference],
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let expected = super::super::citation::resolve_references_on(
+        conn,
+        output.chat_id,
+        output.turn_id,
+        citations,
+    )
+    .await?
+    .into_iter()
+    .map(|evidence| crate::AssistantCitationReference {
+        source_token: evidence.source_token,
+    })
+    .collect::<Vec<_>>();
+    Ok(super::super::citation::exact_references_for_message_on(conn, output.id).await? == expected)
 }
 
 async fn journal_chat_id(

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -129,6 +129,7 @@ pub(in crate::db) async fn accept_turn_steer(
         status: Set(TurnSteerStatus::Pending.as_str().into()),
         applied_lease_token: Set(None),
         message_id: Set(None),
+        preceding_assistant_message_id: Set(None),
         created_at: Set(now),
         resolved_at: Set(None),
     }
@@ -241,6 +242,7 @@ pub(in crate::db) async fn list_pending_turn_steers(
         .map(Some)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::db) async fn apply_turn_steer(
     store: &DbStore,
     turn_id: TurnId,
@@ -248,6 +250,7 @@ pub(in crate::db) async fn apply_turn_steer(
     steer_id: TurnSteerId,
     attempt_event_ordinal: i32,
     preceding_assistant: Option<&crate::model::Message>,
+    preceding_citations: &[crate::AssistantCitationReference],
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<JournaledTurnSteerOutcome>> {
     if turn_id.0.is_nil() || lease_token.is_nil() || steer_id.0.is_nil() {
@@ -258,6 +261,13 @@ pub(in crate::db) async fn apply_turn_steer(
     if !(1..i32::MAX).contains(&attempt_event_ordinal) {
         return Err(AgentError::Store(
             "steer event ordinal must be positive and below the terminal slot".into(),
+        ));
+    }
+    if let Some(message) = preceding_assistant {
+        super::super::citation::validate_assistant_message(message, preceding_citations)?;
+    } else if !preceding_citations.is_empty() {
+        return Err(AgentError::Store(
+            "preceding citations require an assistant message".into(),
         ));
     }
     let now = canonical_db_timestamp(now)?;
@@ -291,9 +301,39 @@ pub(in crate::db) async fn apply_turn_steer(
     if status == TurnSteerStatus::Applied {
         let exact = steer.turn_id == turn_id.0 && steer.applied_lease_token == Some(lease_token);
         let outcome = if exact {
+            if steer.preceding_assistant_message_id
+                != preceding_assistant.map(|message| message.id.0)
+            {
+                return Err(AgentError::Store(format!(
+                    "applied turn steer {steer_id} has different preceding assistant presence"
+                )));
+            }
             ensure_exact_applied_message_on(&transaction, &steer).await?;
             if let Some(preceding) = preceding_assistant {
                 ensure_exact_preceding_message_on(&transaction, &steer, preceding).await?;
+                let expected = super::super::citation::resolve_references_on(
+                    &transaction,
+                    preceding.chat_id,
+                    preceding.turn_id,
+                    preceding_citations,
+                )
+                .await?
+                .into_iter()
+                .map(|evidence| crate::AssistantCitationReference {
+                    source_token: evidence.source_token,
+                })
+                .collect::<Vec<_>>();
+                let stored = super::super::citation::exact_references_for_message_on(
+                    &transaction,
+                    preceding.id,
+                )
+                .await?;
+                if stored != expected {
+                    return Err(AgentError::Store(format!(
+                        "applied turn steer {} has different preceding citations",
+                        TurnSteerId(steer.id)
+                    )));
+                }
             }
             let event =
                 exact_applied_event_on(&transaction, &steer, lease_token, attempt_event_ordinal)
@@ -391,6 +431,14 @@ pub(in crate::db) async fn apply_turn_steer(
             transaction.rollback().await.map_err(store_err)?;
             return Err(store_err(error));
         }
+        let evidence = super::super::citation::resolve_references_on(
+            &transaction,
+            preceding.chat_id,
+            preceding.turn_id,
+            preceding_citations,
+        )
+        .await?;
+        super::super::citation::insert_for_message_on(&transaction, preceding, &evidence).await?;
     }
 
     if !transfer_steer_message_identity_on(
@@ -434,6 +482,10 @@ pub(in crate::db) async fn apply_turn_steer(
             sea_orm::sea_query::Expr::value(Some(steer.id)),
         )
         .col_expr(
+            entities::turn_steer::Column::PrecedingAssistantMessageId,
+            sea_orm::sea_query::Expr::value(preceding_assistant.map(|message| message.id.0)),
+        )
+        .col_expr(
             entities::turn_steer::Column::ResolvedAt,
             sea_orm::sea_query::Expr::value(Some(now)),
         )
@@ -441,6 +493,7 @@ pub(in crate::db) async fn apply_turn_steer(
         .filter(entities::turn_steer::Column::Status.eq(TurnSteerStatus::Pending.as_str()))
         .filter(entities::turn_steer::Column::AppliedLeaseToken.is_null())
         .filter(entities::turn_steer::Column::MessageId.is_null())
+        .filter(entities::turn_steer::Column::PrecedingAssistantMessageId.is_null())
         .filter(entities::turn_steer::Column::ResolvedAt.is_null())
         .exec(&transaction)
         .await

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -3,8 +3,8 @@ use crate::model::{
     ByteSpan, ChatRootAttachment, DocumentParseOutput, DocumentSourceBlob, DocumentSourceUpsert,
     RetrievalEvidenceInput, RetrievalEvidenceSource, RootAttachmentChangeAction,
     RootAttachmentChangeFailure, RootAttachmentChangeTerminal, RootAttachmentOrigin,
-    SourceLocation, ToolCallExecution, ToolCallResolution, ToolCallStatus, MAX_ATTACHMENT_REVISION,
-    MAX_ROOT_ATTACHMENTS,
+    SourceLocation, SourceRegion, ToolCallExecution, ToolCallResolution, ToolCallStatus,
+    MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
 };
 use crate::storage::ApplyTurnSteerOutcome;
 use crate::{ApprovalClass, ChunkId, ToolApprovalStatus};
@@ -5991,7 +5991,15 @@ async fn client_wait_parks_resolves_and_recovers_exactly() {
     let first_steer_at = Utc::now();
     assert!(matches!(
         store
-            .apply_turn_steer(turn_id, turn_lease, stale_steer_id, 1, None, first_steer_at,)
+            .apply_turn_steer(
+                turn_id,
+                turn_lease,
+                stale_steer_id,
+                1,
+                None,
+                &[],
+                first_steer_at,
+            )
             .await
             .unwrap()
             .unwrap()
@@ -6056,6 +6064,7 @@ async fn client_wait_parks_resolves_and_recovers_exactly() {
                 pending_steer_id,
                 2,
                 None,
+                &[],
                 second_steer_at,
             )
             .await
@@ -9547,6 +9556,7 @@ async fn retrieval_evidence_is_atomic_generation_fenced_and_survives_source_chan
     let span = ByteSpan::new(0, source.canonical_text.len());
     let evidence = RetrievalEvidenceInput {
         rank: 1,
+        source_token: uuid::Uuid::new_v4(),
         document_id: source.id,
         generation: document.generation(),
         chunk_id: ChunkId::derive(source.id, span.start, span.end),
@@ -9593,6 +9603,152 @@ async fn retrieval_evidence_is_atomic_generation_fenced_and_survives_source_chan
     assert_eq!(stored[0].turn_id, call.turn_id);
     assert_eq!(stored[0].evidence, evidence);
 
+    let second_call = ToolCallRecord {
+        id: CallId::new(),
+        provider_id: "search_2".into(),
+        created_at: updated_at + chrono::Duration::milliseconds(1),
+        ..call.clone()
+    };
+    store.accept_tool_call(&second_call).await.unwrap();
+    let private_tail = "PRIVATE_RENDERER_TAIL";
+    let long_snippet = format!("{}{private_tail}", "x".repeat(700));
+    let long_span = ByteSpan::new(0, long_snippet.len());
+    let second_evidence = RetrievalEvidenceInput {
+        source_token: uuid::Uuid::new_v4(),
+        chunk_id: ChunkId::derive(source.id, long_span.start, long_span.end),
+        span: long_span,
+        snippet: long_snippet,
+        heading_path: vec!["H".repeat(200)],
+        source_regions: (0..9)
+            .map(|index| SourceRegion {
+                span: ByteSpan::new(index, index + 1),
+                location: SourceLocation::Page {
+                    number: std::num::NonZeroU32::new(
+                        u32::try_from(index + 1).expect("test page fits u32"),
+                    )
+                    .unwrap(),
+                },
+            })
+            .collect(),
+        ..evidence.clone()
+    };
+    store
+        .resolve_server_tool_call_with_evidence(
+            second_call.id,
+            &resolution,
+            resolved_at,
+            std::slice::from_ref(&second_evidence),
+        )
+        .await
+        .unwrap();
+
+    let assistant = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: call.turn_id,
+        role: Role::Assistant,
+        content: "Grounded answer".into(),
+        created_at: resolved_at + chrono::Duration::seconds(1),
+    };
+    let reference = crate::AssistantCitationReference {
+        source_token: evidence.source_token,
+    };
+    let second_reference = crate::AssistantCitationReference {
+        source_token: second_evidence.source_token,
+    };
+    let unknown_reference = crate::AssistantCitationReference {
+        source_token: uuid::Uuid::new_v4(),
+    };
+    store
+        .append_assistant_message_with_citations(
+            &assistant,
+            &[unknown_reference, second_reference, reference],
+        )
+        .await
+        .unwrap();
+    store
+        .append_assistant_message_with_citations(
+            &assistant,
+            &[unknown_reference, second_reference, reference],
+        )
+        .await
+        .unwrap();
+    assert!(store
+        .append_assistant_message_with_citations(&assistant, &[reference, second_reference])
+        .await
+        .is_err());
+    assert!(store
+        .append_assistant_message_with_citations(
+            &Message {
+                content: "different".into(),
+                ..assistant.clone()
+            },
+            &[second_reference, reference],
+        )
+        .await
+        .is_err());
+    let snapshot = store.get_chat_transcript(chat.id).await.unwrap().unwrap();
+    assert_eq!(snapshot.citations.len(), 2);
+    assert_eq!(snapshot.citations[0].message_id, assistant.id);
+    assert_eq!(snapshot.citations[0].ordinal, 1);
+    assert_eq!(snapshot.citations[1].ordinal, 2);
+    assert_eq!(snapshot.citations[0].excerpt.chars().count(), 600);
+    assert!(!snapshot.citations[0].excerpt.contains(private_tail));
+    assert_eq!(
+        snapshot.citations[0]
+            .heading
+            .as_ref()
+            .unwrap()
+            .chars()
+            .count(),
+        160
+    );
+    assert_eq!(snapshot.citations[0].pages, [1, 2, 3, 4, 5, 6, 7, 8]);
+
+    let other_chat = sample_chat();
+    store.create_chat(&other_chat).await.unwrap();
+    let cross_chat = Message {
+        id: MessageId::new(),
+        chat_id: other_chat.id,
+        turn_id: call.turn_id,
+        role: Role::Assistant,
+        content: "cross chat".into(),
+        created_at: assistant.created_at,
+    };
+    store
+        .append_assistant_message_with_citations(&cross_chat, &[reference])
+        .await
+        .unwrap();
+    assert!(store
+        .get_chat_transcript(other_chat.id)
+        .await
+        .unwrap()
+        .unwrap()
+        .citations
+        .is_empty());
+    let cross_turn = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        role: Role::Assistant,
+        content: "cross turn".into(),
+        created_at: assistant.created_at,
+    };
+    store
+        .append_assistant_message_with_citations(&cross_turn, &[reference])
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .get_chat_transcript(chat.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .citations
+            .len(),
+        2
+    );
+
     let mut conflicting = evidence.clone();
     conflicting.generation.revision_token = uuid::Uuid::new_v4();
     assert_eq!(
@@ -9627,6 +9783,17 @@ async fn retrieval_evidence_is_atomic_generation_fenced_and_survives_source_chan
         store.list_retrieval_evidence(call.id).await.unwrap(),
         stored
     );
+    let historical = store.get_chat_transcript(chat.id).await.unwrap().unwrap();
+    assert_eq!(historical.citations, snapshot.citations);
+    assert_eq!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted
+    );
+    assert!(entities::assistant_citation::Entity::find()
+        .all(&store.conn)
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 #[tokio::test]
@@ -9656,6 +9823,7 @@ async fn invalid_retrieval_identity_rolls_back_tool_completion() {
     let document_id = DocumentId::new();
     let invalid = RetrievalEvidenceInput {
         rank: 1,
+        source_token: uuid::Uuid::new_v4(),
         document_id,
         generation: DocumentGeneration {
             content_revision: 1,
@@ -9692,6 +9860,7 @@ async fn invalid_retrieval_identity_rolls_back_tool_completion() {
     let oversized_span = ByteSpan::new(0, oversized_snippet.len());
     let oversized = RetrievalEvidenceInput {
         rank: 1,
+        source_token: uuid::Uuid::new_v4(),
         document_id,
         generation: DocumentGeneration {
             content_revision: 1,
@@ -9716,6 +9885,7 @@ async fn invalid_retrieval_identity_rolls_back_tool_completion() {
     let nul_span = ByteSpan::new(0, 4);
     let nul = RetrievalEvidenceInput {
         rank: 1,
+        source_token: uuid::Uuid::new_v4(),
         document_id,
         generation: DocumentGeneration {
             content_revision: 1,
@@ -9742,6 +9912,7 @@ async fn invalid_retrieval_identity_rolls_back_tool_completion() {
         let span = ByteSpan::new(start, start + 4);
         let outside_storage_range = RetrievalEvidenceInput {
             rank: 1,
+            source_token: uuid::Uuid::new_v4(),
             document_id,
             generation: DocumentGeneration {
                 content_revision: 1,

--- a/crates/openwave-core/src/db/tests/turn_steer.rs
+++ b/crates/openwave-core/src/db/tests/turn_steer.rs
@@ -16,6 +16,7 @@ fn pending_turn_steer(
         status: Set(TurnSteerStatus::Pending.as_str().into()),
         applied_lease_token: Set(None),
         message_id: Set(None),
+        preceding_assistant_message_id: Set(None),
         created_at: Set(now),
         resolved_at: Set(None),
     }
@@ -214,6 +215,54 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
         None
     );
 
+    let source_token = uuid::Uuid::new_v4();
+    let search_call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id: turn.id,
+        provider_id: "search_for_steer".into(),
+        name: "search".into(),
+        arguments: serde_json::json!({"query": "candidate"}),
+        execution: ToolCallExecution::Server,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: Utc::now(),
+        resolved_at: None,
+    };
+    store.accept_tool_call(&search_call).await.unwrap();
+    let document_id = DocumentId::new();
+    let span = ByteSpan::new(0, 8);
+    let evidence = RetrievalEvidenceInput {
+        rank: 1,
+        source_token,
+        document_id,
+        generation: DocumentGeneration {
+            content_revision: 1,
+            revision_token: uuid::Uuid::new_v4(),
+        },
+        chunk_id: ChunkId::derive(document_id, span.start, span.end),
+        span,
+        snippet: "evidence".into(),
+        heading_path: vec!["Section".into()],
+        source_regions: Vec::new(),
+        source: RetrievalEvidenceSource::Inline,
+    };
+    store
+        .resolve_server_tool_call_with_evidence(
+            search_call.id,
+            &ToolCallResolution::Completed {
+                result: "search result".into(),
+            },
+            Utc::now(),
+            &[evidence],
+        )
+        .await
+        .unwrap();
+    let citation = crate::AssistantCitationReference { source_token };
     let candidate = Message {
         id: MessageId::new(),
         chat_id: chat.id,
@@ -230,6 +279,7 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
             steer_id,
             1,
             Some(&candidate),
+            &[citation],
             apply_at,
         )
         .await
@@ -250,6 +300,9 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
     assert_eq!(applied.status, TurnSteerStatus::Applied);
     assert_eq!(applied.applied_lease_token, Some(lease_token));
     assert_eq!(applied.message_id, Some(MessageId(steer_id.0)));
+    let transcript = store.get_chat_transcript(chat.id).await.unwrap().unwrap();
+    assert_eq!(transcript.citations.len(), 1);
+    assert_eq!(transcript.citations[0].message_id, candidate.id);
     assert_eq!(
         applied.resolved_at,
         Some(DateTime::<Utc>::from_timestamp_micros(apply_at.timestamp_micros()).unwrap())
@@ -316,6 +369,7 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
             steer_id,
             1,
             Some(&candidate),
+            &[citation],
             Utc::now(),
         )
         .await
@@ -326,8 +380,26 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
         ApplyTurnSteerOutcome::Existing(_)
     ));
     assert_eq!(recovered.event, applied_event);
+    assert!(store
+        .apply_turn_steer(
+            turn.id,
+            lease_token,
+            steer_id,
+            1,
+            Some(&candidate),
+            &[crate::AssistantCitationReference {
+                source_token: uuid::Uuid::nil(),
+            }],
+            Utc::now(),
+        )
+        .await
+        .is_err());
+    assert!(store
+        .apply_turn_steer(turn.id, lease_token, steer_id, 1, None, &[], Utc::now(),)
+        .await
+        .is_err());
     let second = store
-        .apply_turn_steer(turn.id, lease_token, second_id, 2, None, Utc::now())
+        .apply_turn_steer(turn.id, lease_token, second_id, 2, None, &[], Utc::now())
         .await
         .unwrap()
         .unwrap();
@@ -384,11 +456,61 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
     };
     assert!(matches!(
         store
-            .complete_turn_run(turn.id, lease_token, 2, fresh_completed_at, &fresh_output)
+            .complete_turn_run_with_citations_and_append_event(
+                turn.id,
+                lease_token,
+                2,
+                fresh_completed_at,
+                &fresh_output,
+                &[citation],
+                Usage::default(),
+                StopReason::EndTurn,
+            )
             .await
             .unwrap(),
-        Some(CompleteTurnRunOutcome::Completed(_))
+        Some(JournaledTurnOutcome {
+            outcome: CompleteTurnRunOutcome::Completed(_),
+            terminal_event: Some(_),
+        })
     ));
+    assert!(matches!(
+        store
+            .complete_turn_run_with_citations_and_append_event(
+                turn.id,
+                lease_token,
+                2,
+                Utc::now(),
+                &fresh_output,
+                &[citation],
+                Usage::default(),
+                StopReason::EndTurn,
+            )
+            .await
+            .unwrap(),
+        Some(JournaledTurnOutcome {
+            outcome: CompleteTurnRunOutcome::Existing(_),
+            terminal_event: Some(_),
+        })
+    ));
+    assert!(store
+        .complete_turn_run_with_citations_and_append_event(
+            turn.id,
+            lease_token,
+            2,
+            Utc::now(),
+            &fresh_output,
+            &[],
+            Usage::default(),
+            StopReason::EndTurn,
+        )
+        .await
+        .is_err());
+    let transcript = store.get_chat_transcript(chat.id).await.unwrap().unwrap();
+    assert_eq!(transcript.citations.len(), 2);
+    assert!(transcript
+        .citations
+        .iter()
+        .any(|citation| citation.message_id == fresh_output.id));
     assert!(matches!(
         store
             .accept_turn_steer(
@@ -604,19 +726,19 @@ async fn turn_steer_application_enforces_fifo_and_message_sequence_on_timestamp_
     let applied_at = Utc::now();
     assert_eq!(
         store
-            .apply_turn_steer(turn.id, lease, high_id, 1, None, applied_at)
+            .apply_turn_steer(turn.id, lease, high_id, 1, None, &[], applied_at)
             .await
             .unwrap(),
         None
     );
     let low = store
-        .apply_turn_steer(turn.id, lease, low_id, 1, None, applied_at)
+        .apply_turn_steer(turn.id, lease, low_id, 1, None, &[], applied_at)
         .await
         .unwrap()
         .unwrap();
     assert!(matches!(low.outcome, ApplyTurnSteerOutcome::Applied(_)));
     let high = store
-        .apply_turn_steer(turn.id, lease, high_id, 2, None, applied_at)
+        .apply_turn_steer(turn.id, lease, high_id, 2, None, &[], applied_at)
         .await
         .unwrap()
         .unwrap();
@@ -681,7 +803,7 @@ async fn concurrent_apply_and_completion_leave_no_pending_steer() {
     let apply = tokio::spawn(async move {
         apply_barrier.wait().await;
         apply_store
-            .apply_turn_steer(turn.id, lease_token, steer_id, 1, None, Utc::now())
+            .apply_turn_steer(turn.id, lease_token, steer_id, 1, None, &[], Utc::now())
             .await
             .unwrap()
     });
@@ -882,7 +1004,7 @@ async fn concurrent_message_and_steer_reserve_one_shared_identity() {
         AcceptTurnSteerOutcome::Accepted(_) => {
             assert!(message.is_err());
             let applied = store
-                .apply_turn_steer(steer_turn.id, lease, shared_id, 1, None, Utc::now())
+                .apply_turn_steer(steer_turn.id, lease, shared_id, 1, None, &[], Utc::now())
                 .await
                 .unwrap()
                 .unwrap();
@@ -1193,7 +1315,7 @@ async fn failed_steer_message_insert_rolls_back_the_application_receipt() {
     .await
     .unwrap();
     assert!(store
-        .apply_turn_steer(turn.id, lease, steer_id, 1, None, Utc::now())
+        .apply_turn_steer(turn.id, lease, steer_id, 1, None, &[], Utc::now())
         .await
         .is_err());
     let pending = existing_steer(
@@ -1247,7 +1369,7 @@ async fn failed_steer_event_insert_rolls_back_message_receipt_and_revision() {
         .unwrap();
 
     assert!(store
-        .apply_turn_steer(turn.id, lease, steer_id, 1, None, Utc::now())
+        .apply_turn_steer(turn.id, lease, steer_id, 1, None, &[], Utc::now())
         .await
         .is_err());
 

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -69,6 +69,25 @@ id_type!(
     ChunkId
 );
 
+id_type!(
+    /// Opaque renderer identity for one assistant-message citation.
+    AssistantCitationId
+);
+
+impl AssistantCitationId {
+    const NAMESPACE: Uuid = Uuid::from_u128(0x2b74_9531_8d6e_4e11_a80b_8f50_413e_927c);
+
+    /// Derive one stable citation identity from its message and one-based ordinal.
+    #[must_use]
+    pub fn derive(message_id: MessageId, ordinal: u16) -> Self {
+        let message_namespace = Uuid::new_v5(&Self::NAMESPACE, message_id.as_uuid().as_bytes());
+        Self(Uuid::new_v5(
+            &message_namespace,
+            ordinal.to_string().as_bytes(),
+        ))
+    }
+}
+
 impl ChunkId {
     const NAMESPACE: Uuid = Uuid::from_u128(0x9f8d_2c31_5b47_4e6a_a1c2_d3e4_f506_1728);
 

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod approval;
 #[cfg(feature = "blob-fs")]
 pub mod blob;
 pub mod cancel;
+pub mod citation;
 pub mod client_tools;
 pub mod config;
 pub mod context;
@@ -53,6 +54,11 @@ pub use approval::{
 #[cfg(feature = "blob-fs")]
 pub use blob::FsBlobStore;
 pub use cancel::{CancelToken, Cancelled};
+pub use citation::{
+    format_source_reference, parse_assistant_citations, AssistantCitationReference,
+    AssistantCitationSnapshot, ParsedAssistantCitations, MAX_ASSISTANT_CITATIONS,
+    MAX_CITATION_EXCERPT_CHARS, MAX_CITATION_HEADING_CHARS, MAX_CITATION_PAGES,
+};
 pub use client_tools::{
     list_connected_folders_tool_spec, list_folder_tool_spec, read_connected_file_tool_spec,
     request_folder_access_tool_spec, sandbox_folder_access_proposal_tool_spec,
@@ -69,9 +75,9 @@ pub use db::DbStore;
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{
-    AgentRunId, CallId, ChatId, ChunkId, DocumentId, DocumentJobId, HostRootId, HostRootIdError,
-    MessageId, ProjectId, RootAttachmentChangeId, RootAttachmentChangeIdError, StepId, TurnId,
-    TurnSteerId,
+    AgentRunId, AssistantCitationId, CallId, ChatId, ChunkId, DocumentId, DocumentJobId,
+    HostRootId, HostRootIdError, MessageId, ProjectId, RootAttachmentChangeId,
+    RootAttachmentChangeIdError, StepId, TurnId, TurnSteerId,
 };
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -672,6 +672,8 @@ pub enum RetrievalEvidenceSource {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RetrievalEvidenceInput {
     pub rank: u16,
+    /// Random opaque identity shown to the model instead of database keys.
+    pub source_token: Uuid,
     pub document_id: DocumentId,
     pub generation: DocumentGeneration,
     pub chunk_id: ChunkId,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -48,6 +48,8 @@ pub const MAX_PENDING_ROOT_ATTACHMENT_CHANGES: u64 = 256;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatTranscriptSnapshot {
     pub messages: Vec<Message>,
+    /// Ordered renderer-safe sources keyed to their assistant message.
+    pub citations: Vec<crate::AssistantCitationSnapshot>,
     /// A renderer-safe historical projection. It contains fixed titles and
     /// lifecycle timestamps only; canonical tool records never leave storage.
     pub tool_activity: Vec<ChatToolActivitySnapshot>,
@@ -1595,6 +1597,7 @@ pub trait Store: Send + Sync {
     /// ordinal return [`ApplyTurnSteerOutcome::Existing`] with the same journal
     /// row even after the turn advances. A stale lease, rejected steer, or
     /// different winning lease returns `None`.
+    #[allow(clippy::too_many_arguments)]
     async fn apply_turn_steer(
         &self,
         _turn_id: TurnId,
@@ -1602,6 +1605,7 @@ pub trait Store: Send + Sync {
         _steer_id: TurnSteerId,
         _attempt_event_ordinal: i32,
         _preceding_assistant: Option<&Message>,
+        _preceding_citations: &[crate::AssistantCitationReference],
         _now: chrono::DateTime<chrono::Utc>,
     ) -> Result<Option<JournaledTurnSteerOutcome>> {
         turn_storage_unavailable()
@@ -1648,6 +1652,38 @@ pub trait Store: Send + Sync {
         _stop_reason: StopReason,
     ) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
         turn_storage_unavailable()
+    }
+
+    /// Complete one claimed turn with ordered evidence-backed assistant sources.
+    ///
+    /// The clean message, resolved same-turn citations, terminal transition, and
+    /// journal event commit together. Unknown opaque references are ignored.
+    #[allow(clippy::too_many_arguments)]
+    async fn complete_turn_run_with_citations_and_append_event(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
+        now: chrono::DateTime<chrono::Utc>,
+        output: &Message,
+        citations: &[crate::AssistantCitationReference],
+        usage: Usage,
+        stop_reason: StopReason,
+    ) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
+        if citations.is_empty() {
+            self.complete_turn_run_and_append_event(
+                id,
+                lease_token,
+                expected_steer_revision,
+                now,
+                output,
+                usage,
+                stop_reason,
+            )
+            .await
+        } else {
+            turn_storage_unavailable()
+        }
     }
 
     /// Atomically record a failure for one exact live claimed attempt.
@@ -1791,6 +1827,21 @@ pub trait Store: Send + Sync {
 
     /// Append a message to its chat.
     async fn append_message(&self, message: &Message) -> Result<()>;
+
+    /// Atomically append a clean assistant message and its exact evidence-backed sources.
+    async fn append_assistant_message_with_citations(
+        &self,
+        message: &Message,
+        references: &[crate::AssistantCitationReference],
+    ) -> Result<()> {
+        if references.is_empty() {
+            self.append_message(message).await
+        } else {
+            Err(AgentError::Store(
+                "assistant citation storage is not implemented by this Store".into(),
+            ))
+        }
+    }
 
     /// List a chat's messages in creation order.
     async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>>;
@@ -2039,6 +2090,28 @@ pub trait Store: Send + Sync {
         _event: &AgentEvent,
     ) -> Result<Option<SequencedEvent>> {
         turn_storage_unavailable()
+    }
+
+    /// Recover a completed turn only when its output, ordered citations, and
+    /// terminal event match the exact request whose response was ambiguous.
+    ///
+    /// Stores without structured citation support retain the legacy recovery
+    /// path for citation-free outputs. Citation-aware stores must override this
+    /// method so a matching message identity cannot conceal different sources.
+    async fn recover_exact_completed_turn_event(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        _output: &Message,
+        citations: &[crate::AssistantCitationReference],
+        event: &AgentEvent,
+    ) -> Result<Option<SequencedEvent>> {
+        if citations.is_empty() {
+            self.recover_exact_turn_terminal_event(turn_id, lease_token, event)
+                .await
+        } else {
+            turn_storage_unavailable()
+        }
     }
 
     /// List a chat's journaled events with `seq` greater than `after`, in

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -1352,6 +1352,7 @@ impl Store for MemStore {
             .unwrap_or(0);
         Ok(Some(ChatTranscriptSnapshot {
             messages: Vec::new(),
+            citations: Vec::new(),
             tool_activity: Vec::new(),
             last_event_seq,
         }))

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -310,6 +310,7 @@ mod tests {
         let output =
             ToolOutput::text("ok").with_private_evidence(vec![crate::RetrievalEvidenceInput {
                 rank: 1,
+                source_token: uuid::Uuid::new_v4(),
                 document_id,
                 generation: crate::DocumentGeneration {
                     content_revision: 1,

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -6,20 +6,184 @@ use chrono::{Duration, Utc};
 use openwave_core::{
     AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
     AgentEvent, AgentRunExecution, AgentRunId, AgentRunStatus, ApplyTurnSteerOutcome,
-    BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome, CallId, Chat, ChatId,
-    ChatRootAttachment, ClaimClientToolCallOutcome, ClientToolCallRequest, CompleteTurnRunOutcome,
-    DbStore, FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
+    AssistantCitationReference, BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome,
+    ByteSpan, CallId, Chat, ChatId, ChatRootAttachment, ChunkId, ClaimClientToolCallOutcome,
+    ClientToolCallRequest, CompleteTurnRunOutcome, DbStore, DocumentGeneration, DocumentId,
+    FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, HostRootId, Message, MessageId,
     ParkTurnForClientCallOutcome, Project, ProjectId, RecordTurnFailureOutcome,
     RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, ResolveToolCallOutcome,
-    Role, RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentChangeTerminal,
-    RootAttachmentOrigin, StopReason, Store, SubmitAgentRunResultOutcome, ToolCallExecution,
-    ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnCheckpointProgress, TurnFailureRetry,
-    TurnId, TurnRunStatus, TurnSteerId, TurnSteerStatus, Usage,
+    RetrievalEvidenceInput, RetrievalEvidenceSource, Role, RootAttachmentChangeAction,
+    RootAttachmentChangeId, RootAttachmentChangeTerminal, RootAttachmentOrigin, StopReason, Store,
+    SubmitAgentRunResultOutcome, ToolCallExecution, ToolCallRecord, ToolCallResolution,
+    ToolCallStatus, TurnCheckpointProgress, TurnFailureRetry, TurnId, TurnRunStatus, TurnSteerId,
+    TurnSteerStatus, Usage,
 };
 use sea_orm::{ConnectionTrait, Database, DatabaseBackend, Statement, TransactionTrait};
 
 static POSTGRES_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+#[tokio::test]
+async fn postgres_terminal_citations_are_atomic_and_exactly_recoverable() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let nanosecond_created_at =
+        chrono::DateTime::<Utc>::from_timestamp(1_810_000_000, 123_456_789).unwrap();
+    let standalone = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        role: Role::Assistant,
+        content: "standalone".into(),
+        created_at: nanosecond_created_at,
+    };
+    store
+        .append_assistant_message_with_citations(&standalone, &[])
+        .await
+        .unwrap();
+    store
+        .append_assistant_message_with_citations(&standalone, &[])
+        .await
+        .unwrap();
+    let turn_id = TurnId::new();
+    assert!(matches!(
+        store
+            .accept_turn(turn_id, chat.id, "gpt-5", "cite")
+            .await
+            .unwrap(),
+        AcceptTurnOutcome::Accepted(_)
+    ));
+    let claimed_at = utc_now_at_postgres_precision();
+    let lease = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(lease, claimed_at, claimed_at + Duration::minutes(1))
+        .await
+        .unwrap();
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id,
+        provider_id: "pg_search".into(),
+        name: "search".into(),
+        arguments: serde_json::json!({"query": "fact"}),
+        execution: ToolCallExecution::Server,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: claimed_at,
+        resolved_at: None,
+    };
+    store.accept_tool_call(&call).await.unwrap();
+    let document_id = DocumentId::new();
+    let span = ByteSpan::new(0, 4);
+    let source_token = uuid::Uuid::new_v4();
+    store
+        .resolve_server_tool_call_with_evidence(
+            call.id,
+            &ToolCallResolution::Completed {
+                result: "fact".into(),
+            },
+            claimed_at + Duration::milliseconds(1),
+            &[RetrievalEvidenceInput {
+                rank: 1,
+                source_token,
+                document_id,
+                generation: DocumentGeneration {
+                    content_revision: 1,
+                    revision_token: uuid::Uuid::new_v4(),
+                },
+                chunk_id: ChunkId::derive(document_id, span.start, span.end),
+                span,
+                snippet: "fact".into(),
+                heading_path: Vec::new(),
+                source_regions: Vec::new(),
+                source: RetrievalEvidenceSource::Inline,
+            }],
+        )
+        .await
+        .unwrap();
+    let completed_at = utc_now_at_postgres_precision();
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "answer".into(),
+        created_at: completed_at,
+    };
+    let citation = AssistantCitationReference { source_token };
+    assert!(matches!(
+        store
+            .complete_turn_run_with_citations_and_append_event(
+                turn_id,
+                lease,
+                0,
+                completed_at,
+                &output,
+                &[citation],
+                Usage::default(),
+                StopReason::EndTurn,
+            )
+            .await
+            .unwrap()
+            .unwrap()
+            .outcome,
+        CompleteTurnRunOutcome::Completed(_)
+    ));
+    assert!(matches!(
+        store
+            .complete_turn_run_with_citations_and_append_event(
+                turn_id,
+                lease,
+                0,
+                utc_now_at_postgres_precision(),
+                &output,
+                &[citation],
+                Usage::default(),
+                StopReason::EndTurn,
+            )
+            .await
+            .unwrap()
+            .unwrap()
+            .outcome,
+        CompleteTurnRunOutcome::Existing(_)
+    ));
+    assert!(store
+        .complete_turn_run_with_citations_and_append_event(
+            turn_id,
+            lease,
+            0,
+            utc_now_at_postgres_precision(),
+            &output,
+            &[],
+            Usage::default(),
+            StopReason::EndTurn,
+        )
+        .await
+        .is_err());
+    assert_eq!(
+        store
+            .get_chat_transcript(chat.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .citations
+            .len(),
+        1
+    );
+}
 
 fn utc_now_at_postgres_precision() -> chrono::DateTime<Utc> {
     chrono::DateTime::<Utc>::from_timestamp_micros(Utc::now().timestamp_micros()).unwrap()
@@ -1235,6 +1399,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
             steer_id,
             1,
             Some(&preceding),
+            &[],
             Utc::now(),
         )
         .await
@@ -1305,6 +1470,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
             second_steer_id,
             2,
             None,
+            &[],
             Utc::now(),
         )
         .await
@@ -1340,6 +1506,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
             steer_id,
             1,
             Some(&preceding),
+            &[],
             Utc::now(),
         )
         .await

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use openwave_core::{
-    ApprovalClass, Result, RetrievalEvidenceInput, RetrievalEvidenceSource, Tool, ToolCtx,
-    ToolOutput, ToolSpec,
+    format_source_reference, ApprovalClass, AssistantCitationReference, Result,
+    RetrievalEvidenceInput, RetrievalEvidenceSource, Tool, ToolCtx, ToolOutput, ToolSpec,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -77,12 +77,19 @@ fn parse_args<T: for<'de> Deserialize<'de>>(args: Value) -> std::result::Result<
 }
 
 /// Render citations into a compact, model-readable listing.
-fn render(citations: &[Citation]) -> String {
+fn render(citations: &[Citation], source_tokens: &[uuid::Uuid]) -> String {
+    debug_assert_eq!(citations.len(), source_tokens.len());
     let plural = if citations.len() == 1 { "" } else { "s" };
-    let mut out = format!("Found {} passage{plural}:", citations.len());
+    let mut out = format!(
+        "Found {} passage{plural}. To cite a passage, copy its opaque source reference exactly into the answer:",
+        citations.len()
+    );
     for (i, c) in citations.iter().enumerate() {
+        let reference = format_source_reference(AssistantCitationReference {
+            source_token: source_tokens[i],
+        });
         out.push_str(&format!(
-            "\n\n{}. [score {:.3}] document {} (bytes {}..{}){}{}\n{}",
+            "\n\n{}. Source reference: {reference}\n[score {:.3}] document {} (bytes {}..{}){}{}\n{}",
             i + 1,
             c.score,
             c.document_id,
@@ -204,12 +211,17 @@ impl Tool for SearchTool {
         if citations.is_empty() {
             return Ok(ToolOutput::text("No matching passages found."));
         }
+        let mut source_tokens = citations
+            .iter()
+            .map(|_| uuid::Uuid::new_v4())
+            .collect::<Vec<_>>();
         let content = loop {
-            let content = render(&citations);
+            let content = render(&citations, &source_tokens);
             if content.len() <= openwave_core::ToolCallRecord::MAX_RESULT_BYTES {
                 break content;
             }
             citations.pop();
+            source_tokens.pop();
             if citations.is_empty() {
                 return Ok(ToolOutput::error(
                     "search results exceed the tool result budget",
@@ -227,6 +239,7 @@ impl Tool for SearchTool {
                 };
                 Ok(RetrievalEvidenceInput {
                     rank: u16::try_from(index + 1).expect("search result limit fits u16"),
+                    source_token: source_tokens[index],
                     document_id: citation.document_id,
                     generation,
                     chunk_id: citation.chunk_id,
@@ -460,7 +473,7 @@ mod tests {
             score: 0.5,
         });
 
-        let output = render(std::slice::from_ref(&citation));
+        let output = render(std::slice::from_ref(&citation), &[uuid::Uuid::new_v4()]);
 
         assert!(output.contains("Section: Guide > Setup"));
         assert!(output.ends_with("body"));
@@ -485,7 +498,7 @@ mod tests {
             generation: None,
             score: 0.5,
         });
-        assert!(render(&[single]).contains("\nPage: 7\nbody"));
+        assert!(render(&[single], &[uuid::Uuid::new_v4()]).contains("\nPage: 7\nbody"));
 
         let mut multi = Chunk::new(document_id, 0, ByteSpan::new(0, 4), "body");
         multi.source_regions = vec![page(0, 2, 7), page(2, 4, 8)];
@@ -495,7 +508,7 @@ mod tests {
             generation: None,
             score: 0.5,
         });
-        assert!(render(&[multi]).contains("\nPages: 7, 8\nbody"));
+        assert!(render(&[multi], &[uuid::Uuid::new_v4()]).contains("\nPages: 7, 8\nbody"));
     }
 
     #[test]
@@ -507,7 +520,7 @@ mod tests {
             score: 0.5,
         });
 
-        let output = render(&[citation]);
+        let output = render(&[citation], &[uuid::Uuid::new_v4()]);
 
         assert!(!output.contains("Section:"));
         assert!(output.ends_with("body"));
@@ -540,6 +553,11 @@ mod tests {
         assert_eq!(out.private_evidence.len(), 1);
         assert!(out.private_evidence[0].snippet.contains("Jupiter"));
         assert_eq!(out.private_evidence[0].rank, 1);
+        assert!(out
+            .content
+            .contains(&format_source_reference(AssistantCitationReference {
+                source_token: out.private_evidence[0].source_token,
+            })));
         assert_eq!(out.private_evidence[0].generation.content_revision, 1);
     }
 

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -507,6 +507,7 @@ pub struct ChatMessageSnapshot {
     pub role: Role,
     pub content: String,
     pub created_at: chrono::DateTime<Utc>,
+    pub citations: Vec<openwave_core::AssistantCitationSnapshot>,
 }
 
 /// One visible transcript plus the durable journal watermark that produced it.
@@ -528,6 +529,7 @@ impl From<StoredMessage> for ChatMessageSnapshot {
             role: message.role,
             content: message.content,
             created_at: message.created_at,
+            citations: Vec::new(),
         }
     }
 }
@@ -544,11 +546,24 @@ pub async fn list_chat_messages(
         .get_chat_transcript(id)
         .await?
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
+    let mut citations_by_message = std::collections::HashMap::new();
+    for citation in transcript.citations {
+        citations_by_message
+            .entry(citation.message_id)
+            .or_insert_with(Vec::new)
+            .push(citation);
+    }
     let messages = transcript
         .messages
         .into_iter()
         .filter(|message| matches!(message.role, Role::User | Role::Assistant))
-        .map(ChatMessageSnapshot::from)
+        .map(|message| {
+            let mut snapshot = ChatMessageSnapshot::from(message);
+            snapshot.citations = citations_by_message
+                .remove(&snapshot.id)
+                .unwrap_or_default();
+            snapshot
+        })
         .collect();
     Ok(Json(ChatTranscript {
         messages,

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -9,15 +9,15 @@ use axum::http::{header, Request, StatusCode};
 use futures::stream::{self, BoxStream, StreamExt};
 // Tests use the in-memory store; production wires LanceDB in `bind`.
 use openwave_core::{
-    AcceptAgentRunOutcome, AgentErrorInfo, AgentEvent, AgentRunExecution, AgentRunId,
-    AgentRunInboxStatus, AgentRunStatus, ApprovalClass, BeginRootAttachmentChange, BlobStore,
-    CallId, Chat, ChatId, ChatRequest, ChatRootAttachment, ClientToolCallRequest, ContentBlock,
-    HostRootId, Message, MessageId, ModelProvider, ParkSandboxToolCallOutcome,
-    ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent, ProviderId, Role,
-    RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentOrigin,
+    AcceptAgentRunOutcome, Agent, AgentConfig, AgentErrorInfo, AgentEvent, AgentRunExecution,
+    AgentRunId, AgentRunInboxStatus, AgentRunStatus, ApprovalClass, BeginRootAttachmentChange,
+    BlobStore, CallId, Chat, ChatId, ChatRequest, ChatRootAttachment, ClaimedAgentEvent,
+    ClientToolCallRequest, ContentBlock, HostRootId, Message, MessageId, ModelProvider,
+    ParkSandboxToolCallOutcome, ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent,
+    ProviderId, Role, RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentOrigin,
     SandboxToolCallRequest, SecretProvider, SequencedEvent, StopReason, Tool, ToolCallExecution,
-    ToolCallRecord, ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput, ToolSpec,
-    TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
+    ToolCallRecord, ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput, ToolRegistry,
+    ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
 };
 use openwave_retrieval::{
     Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
@@ -30,6 +30,308 @@ use tower::ServiceExt;
 use crate::event_projection::{RendererAgentEvent, RendererSequencedEvent};
 
 mod root_attachment;
+
+#[test]
+fn transcript_citation_json_is_closed_and_renderer_bounded() {
+    let message_id = MessageId::new();
+    let snapshot = crate::routes::ChatMessageSnapshot {
+        id: message_id,
+        role: Role::Assistant,
+        content: "answer".into(),
+        created_at: chrono::Utc::now(),
+        citations: vec![openwave_core::AssistantCitationSnapshot {
+            id: openwave_core::AssistantCitationId::derive(message_id, 1),
+            message_id,
+            ordinal: 1,
+            excerpt: "x".repeat(openwave_core::MAX_CITATION_EXCERPT_CHARS),
+            heading: Some("h".repeat(openwave_core::MAX_CITATION_HEADING_CHARS)),
+            pages: (1..=u32::try_from(openwave_core::MAX_CITATION_PAGES).unwrap()).collect(),
+        }],
+    };
+    let json = serde_json::to_value(snapshot).unwrap();
+    let citation = &json["citations"][0];
+    assert_eq!(
+        citation
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>(),
+        ["excerpt", "heading", "id", "ordinal", "pages"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect()
+    );
+    let encoded = serde_json::to_string(&json).unwrap();
+    for private in [
+        "document_id",
+        "source_token",
+        "call_id",
+        "rank",
+        "revision",
+        "generation",
+        "span",
+        "chunk",
+        "source_uri",
+        "tool",
+    ] {
+        assert!(!encoded.contains(private), "leaked private field {private}");
+    }
+}
+
+struct AmbiguousCitationTool {
+    source_token: uuid::Uuid,
+}
+
+#[async_trait]
+impl Tool for AmbiguousCitationTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "search".into(),
+            description: "return evidence".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, _args: serde_json::Value) -> Result<ToolOutput> {
+        let document_id = openwave_core::DocumentId::new();
+        let span = openwave_core::ByteSpan::new(0, 8);
+        Ok(
+            ToolOutput::text("evidence result").with_private_evidence(vec![
+                openwave_core::RetrievalEvidenceInput {
+                    rank: 1,
+                    source_token: self.source_token,
+                    document_id,
+                    generation: openwave_core::DocumentGeneration {
+                        content_revision: 1,
+                        revision_token: uuid::Uuid::new_v4(),
+                    },
+                    chunk_id: openwave_core::ChunkId::derive(document_id, span.start, span.end),
+                    span,
+                    snippet: "evidence".into(),
+                    heading_path: vec!["Facts".into()],
+                    source_regions: Vec::new(),
+                    source: openwave_core::RetrievalEvidenceSource::Inline,
+                },
+            ]),
+        )
+    }
+}
+
+struct ContinuationProbe;
+
+#[async_trait]
+impl Tool for ContinuationProbe {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec {
+            name: "continuation_probe".into(),
+            description: "prove continuation".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        }
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, _args: serde_json::Value) -> Result<ToolOutput> {
+        Ok(ToolOutput::text("continued"))
+    }
+}
+
+struct AmbiguousCitationProvider {
+    calls: AtomicUsize,
+    marker: String,
+}
+
+#[async_trait]
+impl ModelProvider for AmbiguousCitationProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("ambiguous-citation")
+    }
+
+    async fn stream(&self, _request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let events = match self.calls.fetch_add(1, Ordering::SeqCst) {
+            0 => vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "search_1".into(),
+                    name: "search".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{}".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ],
+            1 => {
+                let mut events = format!("intermediate {}", self.marker)
+                    .chars()
+                    .map(|character| ProviderEvent::TextDelta {
+                        text: character.to_string(),
+                    })
+                    .collect::<Vec<_>>();
+                events.extend([
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "probe_1".into(),
+                        name: "continuation_probe".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: "{}".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]);
+                events
+            }
+            _ => "final [[ow-source:abcdef"
+                .chars()
+                .map(|character| ProviderEvent::TextDelta {
+                    text: character.to_string(),
+                })
+                .chain(std::iter::once(ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                }))
+                .collect(),
+        };
+        Ok(stream::iter(events).boxed())
+    }
+}
+
+#[tokio::test]
+async fn assistant_retry_and_stream_redaction_survive_durable_replay() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("citation-retry.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let chat = Chat {
+        id: ChatId::new(),
+        project_id: None,
+        title: None,
+        model: None,
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
+        created_at: chrono::Utc::now(),
+    };
+    database.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    database
+        .accept_turn(turn_id, chat.id, "test", "question")
+        .await
+        .unwrap();
+    let claimed_at = chrono::Utc::now();
+    let lease_token = uuid::Uuid::new_v4();
+    database
+        .claim_turn_run(
+            lease_token,
+            claimed_at,
+            claimed_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap();
+
+    let injected = Arc::new(PauseTerminalStore::new(
+        database.clone(),
+        Arc::new(Notify::new()),
+        Arc::new(Notify::new()),
+    ));
+    injected.do_not_pause_terminal();
+    injected.fail_after_next_assistant_commit();
+    let source_token = uuid::Uuid::new_v4();
+    let marker =
+        openwave_core::format_source_reference(openwave_core::AssistantCitationReference {
+            source_token,
+        });
+    let agent = Agent::new(
+        Arc::new(AmbiguousCitationProvider {
+            calls: AtomicUsize::new(0),
+            marker: marker.clone(),
+        }),
+        Arc::new(
+            ToolRegistry::new()
+                .with(Box::new(AmbiguousCitationTool { source_token }))
+                .with(Box::new(ContinuationProbe)),
+        ),
+        injected.clone(),
+        AgentConfig {
+            model: "test".into(),
+            ..AgentConfig::default()
+        },
+    )
+    .with_durable_steer(lease_token);
+    let (tx, rx) = futures::channel::mpsc::unbounded();
+    let outcome = agent
+        .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
+        .await
+        .unwrap();
+    drop(tx);
+    let output = match outcome {
+        openwave_core::AgentTurnOutcome::Completed { output, .. } => output,
+        other => panic!("unexpected agent outcome: {other:?}"),
+    };
+    assert_eq!(output.content, "final [[ow-source:abcdef");
+    assert_eq!(injected.assistant_append_calls(), 2);
+
+    let emissions = rx.collect::<Vec<_>>().await;
+    for emission in emissions {
+        let ClaimedAgentEvent::Pending { ordinal, event } = emission else {
+            panic!("unexpected non-pending agent emission");
+        };
+        database
+            .append_turn_event(
+                chat.id,
+                turn_id,
+                lease_token,
+                ordinal,
+                chrono::Utc::now(),
+                &event,
+            )
+            .await
+            .unwrap()
+            .expect("live claimed event should append");
+    }
+    let replay = database.list_events(chat.id, 0).await.unwrap();
+    let replayed_text = replay
+        .iter()
+        .filter_map(|event| match &event.event {
+            AgentEvent::TextDelta { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<String>();
+    assert_eq!(replayed_text, "intermediate final [[ow-source:abcdef");
+    assert!(!replayed_text.contains(&marker));
+    assert!(!replayed_text.contains(&source_token.simple().to_string()));
+
+    let transcript = database
+        .get_chat_transcript(chat.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let intermediate = transcript
+        .messages
+        .iter()
+        .find(|message| message.content == "intermediate ")
+        .expect("one clean intermediate assistant message");
+    assert_eq!(transcript.citations.len(), 1);
+    assert_eq!(transcript.citations[0].message_id, intermediate.id);
+    let calls = database.list_tool_calls(chat.id).await.unwrap();
+    assert_eq!(calls.len(), 2);
+    assert!(calls.iter().all(|call| call.status.is_terminal()));
+}
 
 /// A provider that answers with a one-line completion and no tool calls.
 struct FakeProvider;
@@ -412,6 +714,8 @@ struct PauseTerminalStore {
     pause_after_claim_commit: std::sync::atomic::AtomicBool,
     fail_after_heartbeat_commit: std::sync::atomic::AtomicBool,
     fail_after_completion_commit: std::sync::atomic::AtomicBool,
+    fail_after_assistant_commit: std::sync::atomic::AtomicBool,
+    assistant_append_calls: AtomicUsize,
     fail_after_park_commit: std::sync::atomic::AtomicBool,
     fail_after_apply_steer_commit: std::sync::atomic::AtomicBool,
     cancel_after_apply_steer_commit: std::sync::atomic::AtomicBool,
@@ -438,6 +742,8 @@ impl PauseTerminalStore {
             pause_after_claim_commit: std::sync::atomic::AtomicBool::new(false),
             fail_after_heartbeat_commit: std::sync::atomic::AtomicBool::new(false),
             fail_after_completion_commit: std::sync::atomic::AtomicBool::new(false),
+            fail_after_assistant_commit: std::sync::atomic::AtomicBool::new(false),
+            assistant_append_calls: AtomicUsize::new(0),
             fail_after_park_commit: std::sync::atomic::AtomicBool::new(false),
             fail_after_apply_steer_commit: std::sync::atomic::AtomicBool::new(false),
             cancel_after_apply_steer_commit: std::sync::atomic::AtomicBool::new(false),
@@ -473,6 +779,15 @@ impl PauseTerminalStore {
     fn fail_after_next_completion_commit(&self) {
         self.fail_after_completion_commit
             .store(true, Ordering::SeqCst);
+    }
+
+    fn fail_after_next_assistant_commit(&self) {
+        self.fail_after_assistant_commit
+            .store(true, Ordering::SeqCst);
+    }
+
+    fn assistant_append_calls(&self) -> usize {
+        self.assistant_append_calls.load(Ordering::SeqCst)
     }
 
     fn fail_after_next_park_commit(&self) {
@@ -844,6 +1159,7 @@ impl Store for PauseTerminalStore {
         steer_id: TurnSteerId,
         attempt_event_ordinal: i32,
         preceding_assistant: Option<&Message>,
+        preceding_citations: &[openwave_core::AssistantCitationReference],
         now: chrono::DateTime<chrono::Utc>,
     ) -> Result<Option<openwave_core::JournaledTurnSteerOutcome>> {
         let applied = self
@@ -854,6 +1170,7 @@ impl Store for PauseTerminalStore {
                 steer_id,
                 attempt_event_ordinal,
                 preceding_assistant,
+                preceding_citations,
                 now,
             )
             .await?;
@@ -1102,8 +1419,45 @@ impl Store for PauseTerminalStore {
             .recover_exact_turn_terminal_event(turn_id, lease_token, event)
             .await
     }
+    async fn recover_exact_completed_turn_event(
+        &self,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        output: &Message,
+        citations: &[openwave_core::AssistantCitationReference],
+        event: &AgentEvent,
+    ) -> Result<Option<SequencedEvent>> {
+        self.terminal_recovery_calls.fetch_add(1, Ordering::SeqCst);
+        if self.fail_terminal_recovery.swap(false, Ordering::SeqCst) {
+            return Err(AgentError::Store(
+                "injected transient terminal recovery failure".into(),
+            ));
+        }
+        self.inner
+            .recover_exact_completed_turn_event(turn_id, lease_token, output, citations, event)
+            .await
+    }
     async fn append_message(&self, message: &Message) -> Result<()> {
         self.inner.append_message(message).await
+    }
+    async fn append_assistant_message_with_citations(
+        &self,
+        message: &Message,
+        citations: &[openwave_core::AssistantCitationReference],
+    ) -> Result<()> {
+        self.assistant_append_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner
+            .append_assistant_message_with_citations(message, citations)
+            .await?;
+        if self
+            .fail_after_assistant_commit
+            .swap(false, Ordering::SeqCst)
+        {
+            return Err(AgentError::Store(
+                "injected ambiguous assistant append response".into(),
+            ));
+        }
+        Ok(())
     }
     async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>> {
         self.inner.list_messages(chat_id).await
@@ -1147,6 +1501,17 @@ impl Store for PauseTerminalStore {
     ) -> Result<openwave_core::ResolveToolCallOutcome> {
         self.inner
             .resolve_server_tool_call(id, resolution, resolved_at)
+            .await
+    }
+    async fn resolve_server_tool_call_with_evidence(
+        &self,
+        id: openwave_core::CallId,
+        resolution: &openwave_core::ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+        evidence: &[openwave_core::RetrievalEvidenceInput],
+    ) -> Result<openwave_core::ResolveToolCallOutcome> {
+        self.inner
+            .resolve_server_tool_call_with_evidence(id, resolution, resolved_at, evidence)
             .await
     }
     async fn resolve_client_tool_call_and_append_event(

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -166,7 +166,8 @@ enum ResolutionState {
 
 enum TerminalIdentity<'a> {
     Completed {
-        output_message_id: MessageId,
+        output: &'a openwave_core::Message,
+        citations: &'a [openwave_core::AssistantCitationReference],
         event: &'a AgentEvent,
     },
     Failed {
@@ -198,9 +199,7 @@ impl TerminalIdentity<'_> {
 
     fn matches_turn(&self, turn: &TurnRun) -> bool {
         match self {
-            Self::Completed {
-                output_message_id, ..
-            } => turn.output_message_id == Some(*output_message_id),
+            Self::Completed { output, .. } => turn.output_message_id == Some(output.id),
             Self::Failed { code, detail, .. } => {
                 turn.last_error_code.as_deref() == Some(*code)
                     && turn.last_error_detail.as_deref() == Some(*detail)
@@ -649,6 +648,7 @@ impl TurnWorker {
             match drive_result {
                 Ok(AgentTurnOutcome::Completed {
                     output,
+                    citations,
                     usage,
                     stop_reason,
                     steer_revision,
@@ -724,12 +724,13 @@ impl TurnWorker {
                     let continue_after_steer = loop {
                         match self
                             .store
-                            .complete_turn_run_and_append_event(
+                            .complete_turn_run_with_citations_and_append_event(
                                 turn.id,
                                 lease_token,
                                 expected_steer_revision,
                                 Utc::now(),
                                 &output,
+                                &citations,
                                 total_usage,
                                 stop_reason,
                             )
@@ -772,7 +773,8 @@ impl TurnWorker {
                                         &turn,
                                         lease_token,
                                         TerminalIdentity::Completed {
-                                            output_message_id: output.id,
+                                            output: &output,
+                                            citations: &citations,
                                             event: &terminal_event,
                                         },
                                     )
@@ -1528,15 +1530,34 @@ impl TurnWorker {
                         if !terminal.matches_turn(&current) {
                             return ResolutionState::Lost;
                         }
-                        return match self
-                            .store
-                            .recover_exact_turn_terminal_event(
-                                turn.id,
-                                lease_token,
-                                terminal.event(),
-                            )
-                            .await
-                        {
+                        let recovered = match &terminal {
+                            TerminalIdentity::Completed {
+                                output,
+                                citations,
+                                event,
+                            } => {
+                                self.store
+                                    .recover_exact_completed_turn_event(
+                                        turn.id,
+                                        lease_token,
+                                        output,
+                                        citations,
+                                        event,
+                                    )
+                                    .await
+                            }
+                            TerminalIdentity::Failed { .. }
+                            | TerminalIdentity::Cancelled { .. } => {
+                                self.store
+                                    .recover_exact_turn_terminal_event(
+                                        turn.id,
+                                        lease_token,
+                                        terminal.event(),
+                                    )
+                                    .await
+                            }
+                        };
+                        return match recovered {
                             Ok(Some(event)) => ResolutionState::Resolved(event),
                             Ok(None) => ResolutionState::Lost,
                             Err(error) => {


### PR DESCRIPTION
## Summary
- add opaque source references and immutable assistant citation relations over exact retrieval evidence
- persist clean assistant text and ordered citations atomically at intermediate, steer, and terminal boundaries
- expose only bounded historical excerpt, heading, and page snapshots in chat transcripts
- preserve exact ambiguous-retry, chat/turn ownership, deletion, and document-generation semantics on SQLite and PostgreSQL

## Validation
- workspace all-target check
- bw Rust lint check
- core library suite (309 tests) and focused citation/parser/steer tests
- focused server and retrieval tests
- PostgreSQL citation and timestamp exact-retry coverage
- git diff --check

## Development note
- the pre-v1 baseline migration is updated in place; reset existing development databases