### PR TITLE
Wire assistant sources into chat

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -30,7 +30,6 @@ import {
   toolApprovalPresentation,
   type ToolCallStatus,
 } from "./ToolCallCard";
-import { hydrateTranscriptHistory } from "./TranscriptHistory";
 import { useChatEventStream } from "./ChatEventStream";
 import { isNearBottom, scrollToLatest } from "./ChatScroll";
 import { DocumentsView } from "./DocumentsView";
@@ -39,6 +38,11 @@ import {
   upsertPendingApprovalCard,
 } from "./ApprovalHistory";
 import { loadChatApprovalHydration } from "./ChatApprovalHydration";
+import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
+import {
+  loadCurrentTerminalTranscript,
+  presentChatTranscript,
+} from "./ChatTranscriptPresentation";
 
 type Msg = ChatMessage;
 
@@ -97,6 +101,10 @@ export default function App() {
   const hydratedMessageIdsRef = useRef<Set<string>>(new Set());
   const lastSeqRef = useRef(0);
   const assistantBufRef = useRef("");
+  const assistantMarkerScrubberRef = useRef(
+    new AssistantSourceMarkerStreamScrubber(),
+  );
+  const terminalHydrationGenerationRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const followsLatestRef = useRef(true);
   const refreshFolderAccessRef = useRef<(() => void) | null>(null);
@@ -122,6 +130,7 @@ export default function App() {
     })();
     return () => {
       cancelled = true;
+      terminalHydrationGenerationRef.current += 1;
     };
   }, []);
 
@@ -172,32 +181,10 @@ export default function App() {
         if (!hydration) return;
         const { transcript, pendingApprovals } = hydration;
         lastSeqRef.current = transcript.last_event_seq;
-        const hydrated = hydrateTranscriptHistory(
-          transcript.messages,
-          transcript.tool_activity,
-        );
-        hydratedMessageIdsRef.current = new Set(
-          hydrated
-            .filter((entry) => entry.kind === "message")
-            .map((entry) => entry.id),
-        );
-        const transcriptMessages: Msg[] = hydrated.map((entry) =>
-          entry.kind === "tool"
-            ? {
-                id: entry.id,
-                role: "tool",
-                callId: entry.id,
-                name: entry.name,
-                status: entry.status,
-              }
-            : {
-                id: entry.id,
-                role: entry.role,
-                text: entry.text,
-              },
-        );
+        const presented = presentChatTranscript(transcript);
+        hydratedMessageIdsRef.current = presented.messageIds;
         setMessages(
-          reconcilePendingApprovalCards(transcriptMessages, pendingApprovals),
+          reconcilePendingApprovalCards(presented.messages, pendingApprovals),
         );
         const pendingTurnId = pendingApprovals[0]?.turnId ?? null;
         setActiveTurnId(pendingTurnId);
@@ -357,7 +344,10 @@ export default function App() {
 
     if (event.type === "turn_started") {
       refreshAgentRunsRef.current?.();
+      terminalHydrationGenerationRef.current += 1;
       assistantBufRef.current = "";
+      assistantMarkerScrubberRef.current =
+        new AssistantSourceMarkerStreamScrubber();
       provisionalToolCallIdsRef.current = new Set();
       setBusy(true);
       setActiveTurnId(event.turn_id);
@@ -366,21 +356,23 @@ export default function App() {
       cancelRequestTurnRef.current = null;
       setMessages((prev) => [
         ...prev,
-        { id: nextId(), role: "assistant", text: "" },
+        { id: nextId(), role: "assistant", text: "", sources: [] },
       ]);
       return;
     }
 
     if (event.type === "text_delta") {
-      assistantBufRef.current += event.text;
+      assistantBufRef.current += assistantMarkerScrubberRef.current.push(
+        event.text,
+      );
       const text = assistantBufRef.current;
       setMessages((prev) => {
         const copy = [...prev];
         const last = copy[copy.length - 1];
         if (last?.role === "assistant") {
-          copy[copy.length - 1] = { id: last.id, role: "assistant", text };
+          copy[copy.length - 1] = { ...last, text };
         } else {
-          copy.push({ id: nextId(), role: "assistant", text });
+          copy.push({ id: nextId(), role: "assistant", text, sources: [] });
         }
         return copy;
       });
@@ -388,6 +380,9 @@ export default function App() {
     }
 
     if (event.type === "stream_interrupted") {
+      // The whole optimistic candidate is invalidated at this boundary. Finish
+      // clears any withheld marker-like tail before the replacement starts.
+      assistantMarkerScrubberRef.current.finish();
       assistantBufRef.current = "";
       const provisionalCallIds = provisionalToolCallIdsRef.current;
       provisionalToolCallIdsRef.current = new Set();
@@ -402,6 +397,12 @@ export default function App() {
     }
 
     if (event.type === "tool_call_started") {
+      flushAssistantMarkerTail();
+      if (provisionalToolCallIdsRef.current.size === 0) {
+        assistantBufRef.current = "";
+        assistantMarkerScrubberRef.current =
+          new AssistantSourceMarkerStreamScrubber();
+      }
       refreshAgentRunsRef.current?.();
       if (event.name === "request_folder_access") {
         refreshFolderAccessRef.current?.();
@@ -473,13 +474,21 @@ export default function App() {
     }
 
     if (event.type === "turn_completed") {
+      flushAssistantMarkerTail();
       provisionalToolCallIdsRef.current = new Set();
       resolveActiveTurn();
       refreshAgentRunsRef.current?.();
+      const selection = chatSelectionRef.current;
+      const generation = ++terminalHydrationGenerationRef.current;
+      if (chat) {
+        void refreshTerminalTranscript(chat.id, selection, generation);
+      }
       return;
     }
 
     if (event.type === "turn_cancelled") {
+      flushAssistantMarkerTail();
+      terminalHydrationGenerationRef.current += 1;
       provisionalToolCallIdsRef.current = new Set();
       resolveActiveTurn();
       refreshAgentRunsRef.current?.();
@@ -491,6 +500,8 @@ export default function App() {
     }
 
     if (event.type === "turn_failed") {
+      flushAssistantMarkerTail();
+      terminalHydrationGenerationRef.current += 1;
       provisionalToolCallIdsRef.current = new Set();
       resolveActiveTurn();
       refreshAgentRunsRef.current?.();
@@ -502,6 +513,50 @@ export default function App() {
           text: "The turn could not be completed.",
         },
       ]);
+    }
+  }
+
+  function flushAssistantMarkerTail() {
+    const tail = assistantMarkerScrubberRef.current.finish();
+    if (!tail) return;
+    assistantBufRef.current += tail;
+    const text = assistantBufRef.current;
+    setMessages((previous) => {
+      const copy = [...previous];
+      const last = copy[copy.length - 1];
+      if (last?.role === "assistant") {
+        copy[copy.length - 1] = { ...last, text };
+      } else {
+        copy.push({ id: nextId(), role: "assistant", text, sources: [] });
+      }
+      return copy;
+    });
+  }
+
+  async function refreshTerminalTranscript(
+    chatId: string,
+    selection: number,
+    generation: number,
+  ) {
+    if (!client) return;
+    try {
+      const presented = await loadCurrentTerminalTranscript(
+        client,
+        chatId,
+        () =>
+          chatSelectionRef.current === selection &&
+          terminalHydrationGenerationRef.current === generation,
+      );
+      if (!presented) return;
+      lastSeqRef.current = Math.max(
+        lastSeqRef.current,
+        presented.lastEventSeq,
+      );
+      hydratedMessageIdsRef.current = presented.messageIds;
+      setMessages(presented.messages);
+    } catch {
+      // The scrubbed optimistic response remains safe and visible. Reopening
+      // the conversation will load a fresh authoritative snapshot.
     }
   }
 
@@ -529,6 +584,7 @@ export default function App() {
     const selection = chatSelectionRef.current;
     const content = draft.trim();
     const turnId = crypto.randomUUID();
+    terminalHydrationGenerationRef.current += 1;
     setDraft("");
     setMessages((prev) => [...prev, { id: nextId(), role: "user", text: content }]);
     setBusy(true);
@@ -590,6 +646,8 @@ export default function App() {
       socketRef.current?.close();
       socketRef.current = null;
       assistantBufRef.current = "";
+      assistantMarkerScrubberRef.current =
+        new AssistantSourceMarkerStreamScrubber();
       provisionalToolCallIdsRef.current = new Set();
       lastSeqRef.current = 0;
       followsLatestRef.current = true;
@@ -663,6 +721,9 @@ export default function App() {
 
   function activateChat(next: Chat) {
     chatSelectionRef.current += 1;
+    terminalHydrationGenerationRef.current += 1;
+    assistantMarkerScrubberRef.current =
+      new AssistantSourceMarkerStreamScrubber();
     setChat(next);
   }
 
@@ -674,6 +735,8 @@ export default function App() {
     socketRef.current?.close();
     socketRef.current = null;
     assistantBufRef.current = "";
+    assistantMarkerScrubberRef.current =
+      new AssistantSourceMarkerStreamScrubber();
     lastSeqRef.current = 0;
     followsLatestRef.current = true;
     setHasUnreadActivity(false);

--- a/crates/openwave-desktop/ui/src/AssistantSourceMarkerStream.test.ts
+++ b/crates/openwave-desktop/ui/src/AssistantSourceMarkerStream.test.ts
@@ -80,4 +80,14 @@ describe("AssistantSourceMarkerStreamScrubber", () => {
     expect(scrubber.finish()).toBe("[[ow-source:01234567");
     expect(scrubber.finish()).toBe("");
   });
+
+  it("flushes malformed interruption prose but never releases a valid marker", () => {
+    const interrupted = new AssistantSourceMarkerStreamScrubber();
+    expect(interrupted.push("Answer [[ow-source:01234567")).toBe("Answer ");
+    expect(interrupted.finish()).toBe("[[ow-source:01234567");
+
+    const completedMarker = new AssistantSourceMarkerStreamScrubber();
+    expect(completedMarker.push(`Answer ${MARKER}`)).toBe("Answer ");
+    expect(completedMarker.finish()).toBe("");
+  });
 });

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChatTranscript } from "./api";
+import {
+  loadCurrentTerminalTranscript,
+  presentChatTranscript,
+} from "./ChatTranscriptPresentation";
+
+const transcript: ChatTranscript = {
+  messages: [
+    {
+      id: "assistant-durable",
+      role: "assistant",
+      content: "Clean durable answer",
+      created_at: "2026-07-19T10:00:00Z",
+      citations: [
+        {
+          id: "citation-private-id",
+          message_id: "assistant-durable",
+          ordinal: 1,
+          excerpt: "Bounded source excerpt",
+          heading: null,
+          pages: [],
+        },
+      ],
+    },
+  ],
+  tool_activity: [],
+  last_event_seq: 12,
+};
+
+describe("terminal transcript presentation", () => {
+  it("replaces optimistic text with authoritative content and sources", async () => {
+    const listChatMessages = vi.fn(async () => transcript);
+    const presented = await loadCurrentTerminalTranscript(
+      { listChatMessages },
+      "chat-current",
+      () => true,
+    );
+
+    expect(listChatMessages).toHaveBeenCalledWith("chat-current");
+    expect(presented?.messages).toEqual([
+      {
+        id: "assistant-durable",
+        role: "assistant",
+        text: "Clean durable answer",
+        sources: [
+          {
+            id: "citation-private-id",
+            ordinal: 1,
+            excerpt: "Bounded source excerpt",
+            heading: null,
+            pages: [],
+          },
+        ],
+      },
+    ]);
+    expect(presented?.lastEventSeq).toBe(12);
+  });
+
+  it("drops a terminal response after the selected chat changes", async () => {
+    let resolveRequest: ((value: ChatTranscript) => void) | undefined;
+    const listChatMessages = vi.fn(
+      () =>
+        new Promise<ChatTranscript>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+    let current = true;
+    const pending = loadCurrentTerminalTranscript(
+      { listChatMessages },
+      "chat-old",
+      () => current,
+    );
+
+    current = false;
+    resolveRequest?.(transcript);
+
+    await expect(pending).resolves.toBeNull();
+  });
+
+  it("retries a transient terminal fetch and returns the durable sources", async () => {
+    const listChatMessages = vi
+      .fn<() => Promise<ChatTranscript>>()
+      .mockRejectedValueOnce(new Error("daemon briefly unavailable"))
+      .mockResolvedValueOnce(transcript);
+    const wait = vi.fn(async () => undefined);
+
+    const presented = await loadCurrentTerminalTranscript(
+      { listChatMessages },
+      "chat-current",
+      () => true,
+      { retryDelaysMs: [25], wait },
+    );
+
+    expect(listChatMessages).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledWith(25);
+    expect(presented?.messages[0]).toMatchObject({
+      id: "assistant-durable",
+      sources: [{ excerpt: "Bounded source excerpt" }],
+    });
+  });
+
+  it("cancels delayed retries after unmount or another generation invalidation", async () => {
+    const listChatMessages = vi.fn(async () => {
+      throw new Error("daemon briefly unavailable");
+    });
+    let current = true;
+    const wait = vi.fn(async () => {
+      current = false;
+    });
+
+    const presented = await loadCurrentTerminalTranscript(
+      { listChatMessages },
+      "chat-old",
+      () => current,
+      { retryDelaysMs: [25, 50], wait },
+    );
+
+    expect(presented).toBeNull();
+    expect(listChatMessages).toHaveBeenCalledTimes(1);
+    expect(wait).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not carry nested citations across message ownership", () => {
+    const presented = presentChatTranscript({
+      ...transcript,
+      messages: [
+        {
+          ...transcript.messages[0],
+          citations: [
+            {
+              ...transcript.messages[0].citations![0],
+              message_id: "a-different-message",
+              excerpt: "cross-message private excerpt",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(presented.messages).toEqual([
+      {
+        id: "assistant-durable",
+        role: "assistant",
+        text: "Clean durable answer",
+        sources: [],
+      },
+    ]);
+    expect(JSON.stringify(presented?.messages)).not.toContain(
+      "cross-message private excerpt",
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -1,0 +1,93 @@
+import type { ApiClient, ChatTranscript } from "./api";
+import type { ChatMessage } from "./MessageList";
+import { hydrateTranscriptHistory } from "./TranscriptHistory";
+
+type TranscriptClient = Pick<ApiClient, "listChatMessages">;
+type RetryOptions = {
+  retryDelaysMs?: readonly number[];
+  wait?: (delayMs: number) => Promise<void>;
+};
+
+const TERMINAL_TRANSCRIPT_RETRY_DELAYS_MS = [100, 300] as const;
+
+export type PresentedTranscript = {
+  lastEventSeq: number;
+  messages: ChatMessage[];
+  messageIds: Set<string>;
+};
+
+/** Convert one durable snapshot into the renderer's closed message model. */
+export function presentChatTranscript(
+  transcript: ChatTranscript,
+): PresentedTranscript {
+  const hydrated = hydrateTranscriptHistory(
+    transcript.messages,
+    transcript.tool_activity,
+  );
+  const messageIds = new Set(
+    hydrated
+      .filter((entry) => entry.kind === "message")
+      .map((entry) => entry.id),
+  );
+  const messages: ChatMessage[] = hydrated.map((entry) =>
+    entry.kind === "tool"
+      ? {
+          id: entry.id,
+          role: "tool",
+          callId: entry.id,
+          name: entry.name,
+          status: entry.status,
+        }
+      : entry.role === "assistant"
+        ? {
+            id: entry.id,
+            role: "assistant",
+            text: entry.text,
+            sources: entry.sources,
+          }
+        : {
+            id: entry.id,
+            role: "user",
+            text: entry.text,
+          },
+  );
+
+  return {
+    lastEventSeq: transcript.last_event_seq,
+    messages,
+    messageIds,
+  };
+}
+
+/**
+ * Re-fetch a terminal turn from durable state, but return nothing after the
+ * caller's chat/generation fence has gone stale.
+ */
+export async function loadCurrentTerminalTranscript(
+  client: TranscriptClient,
+  chatId: string,
+  isCurrent: () => boolean,
+  options: RetryOptions = {},
+): Promise<PresentedTranscript | null> {
+  const retryDelaysMs =
+    options.retryDelaysMs ?? TERMINAL_TRANSCRIPT_RETRY_DELAYS_MS;
+  const wait = options.wait ?? waitForRetry;
+
+  for (let attempt = 0; ; attempt += 1) {
+    if (!isCurrent()) return null;
+    try {
+      const transcript = await client.listChatMessages(chatId);
+      if (!isCurrent()) return null;
+      return presentChatTranscript(transcript);
+    } catch (error) {
+      if (!isCurrent()) return null;
+      const retryDelay = retryDelaysMs[attempt];
+      if (retryDelay === undefined) throw error;
+      await wait(retryDelay);
+    }
+  }
+}
+
+function waitForRetry(delayMs: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, delayMs));
+}

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -15,7 +15,12 @@ describe("MessageBubble", () => {
     );
     const assistant = renderToStaticMarkup(
       <MessageBubble
-        message={{ id: "assistant-1", role: "assistant", text: "## Answer" }}
+        message={{
+          id: "assistant-1",
+          role: "assistant",
+          text: "## Answer",
+          sources: [],
+        }}
         busy={false}
         onApproval={noop}
       />,
@@ -38,7 +43,7 @@ describe("MessageBubble", () => {
         summary: "Search a site",
         canApprove: true,
       },
-      { id: "assistant-2", role: "assistant", text: "" },
+      { id: "assistant-2", role: "assistant", text: "", sources: [] },
     ];
     const markup = renderToStaticMarkup(
       <MessageList
@@ -88,7 +93,12 @@ describe("MessageBubble", () => {
     const messages: ChatMessage[] = [
       { id: "tool-1", role: "tool", callId: "call-1", name: "web_search", status: "completed" },
       { id: "tool-2", role: "tool", callId: "call-2", name: "read_file", status: "failed" },
-      { id: "assistant-1", role: "assistant", text: "Done" },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        text: "Done",
+        sources: [],
+      },
       { id: "tool-3", role: "tool", callId: "call-3", name: "list_dir", status: "cancelled" },
     ];
     const markup = renderToStaticMarkup(
@@ -181,5 +191,55 @@ describe("MessageBubble", () => {
     expect(markup).toContain("Use a tool: Tool complete");
     expect(markup).not.toContain("private_server");
     expect(markup).not.toContain("sensitive_path");
+  });
+
+  it("renders each source beneath only its owning assistant message", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        text: "First answer",
+        sources: [
+          {
+            id: "private-citation-id",
+            ordinal: 1,
+            excerpt: "First source excerpt",
+            heading: "First source",
+            pages: [4],
+          },
+        ],
+      },
+      {
+        id: "assistant-2",
+        role: "assistant",
+        text: "Second answer",
+        sources: [],
+      },
+    ];
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={messages}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup.indexOf("First answer")).toBeLessThan(
+      markup.indexOf("First source excerpt"),
+    );
+    expect(markup.indexOf("First source excerpt")).toBeLessThan(
+      markup.indexOf("Second answer"),
+    );
+    expect(markup).not.toContain("private-citation-id");
+    expect(markup).not.toContain("ow-source");
   });
 });

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -3,12 +3,18 @@ import type { PendingFolderAccessRequest } from "./api";
 import { FolderAccessCard } from "./FolderAccessCard";
 import type { FolderAccessDecision } from "./host";
 import { MessageMarkdown } from "./MessageMarkdown";
+import { AssistantSources, type AssistantSource } from "./AssistantSources";
 import { ToolCallCard, type ToolCallStatus } from "./ToolCallCard";
 import { ToolActivityGroup } from "./ToolActivityGroup";
 
 export type ChatMessage =
   | { id: string; role: "user"; text: string }
-  | { id: string; role: "assistant"; text: string }
+  | {
+      id: string;
+      role: "assistant";
+      text: string;
+      sources: AssistantSource[];
+    }
   | { id: string; role: "system"; text: string }
   | {
       id: string;
@@ -215,6 +221,7 @@ export function MessageBubble({
             …
           </span>
         ) : null}
+        <AssistantSources sources={message.sources} />
       </article>
     );
   }

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
@@ -10,12 +10,14 @@ describe("hydrateTranscriptHistory", () => {
           role: "user",
           content: "find this",
           created_at: "2026-07-16T10:00:00Z",
+          citations: [],
         },
         {
           id: "assistant-1",
           role: "assistant",
           content: "done",
           created_at: "2026-07-16T10:00:02Z",
+          citations: [],
         },
       ],
       [
@@ -38,6 +40,72 @@ describe("hydrateTranscriptHistory", () => {
       }),
       expect.objectContaining({ id: "assistant-1", kind: "message" }),
     ]);
+  });
+
+  it("attaches sources only to their exact owning assistant message", () => {
+    const entries = hydrateTranscriptHistory(
+      [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "first",
+          created_at: "2026-07-16T10:00:00Z",
+          citations: [
+            {
+              id: "citation-1",
+              message_id: "assistant-1",
+              ordinal: 1,
+              excerpt: "safe excerpt",
+              heading: "Safe heading",
+              pages: [2],
+            },
+            {
+              id: "citation-crossed",
+              message_id: "assistant-2",
+              ordinal: 2,
+              excerpt: "must not cross messages",
+              heading: null,
+              pages: [],
+            },
+          ],
+        },
+        {
+          id: "assistant-2",
+          role: "assistant",
+          content: "second",
+          created_at: "2026-07-16T10:00:01Z",
+          citations: [],
+        },
+      ],
+      [],
+    );
+
+    expect(entries[0]).toMatchObject({
+      id: "assistant-1",
+      sources: [{ id: "citation-1", excerpt: "safe excerpt" }],
+    });
+    expect(entries[1]).toMatchObject({ id: "assistant-2", sources: [] });
+    expect(JSON.stringify(entries)).not.toContain("must not cross messages");
+  });
+
+  it("treats citations omitted from a partial response as an empty source list", () => {
+    const [entry] = hydrateTranscriptHistory(
+      [
+        {
+          id: "assistant-legacy",
+          role: "assistant",
+          content: "still readable",
+          created_at: "2026-07-16T10:00:00Z",
+        },
+      ],
+      [],
+    );
+
+    expect(entry).toMatchObject({
+      id: "assistant-legacy",
+      text: "still readable",
+      sources: [],
+    });
   });
 
   it("keeps the server's generic historical title on the generic card path", () => {

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage, ChatToolActivity } from "./api";
+import type { AssistantSource } from "./AssistantSources";
 import type { ToolCallStatus } from "./ToolCallCard";
 
 export type HydratedTranscriptEntry =
@@ -7,6 +8,7 @@ export type HydratedTranscriptEntry =
       kind: "message";
       role: ChatMessage["role"];
       text: string;
+      sources: AssistantSource[];
       createdAt: string;
     }
   | {
@@ -43,6 +45,18 @@ export function hydrateTranscriptHistory(
       kind: "message" as const,
       role: message.role,
       text: message.content,
+      sources:
+        message.role === "assistant"
+          ? (message.citations ?? [])
+              .filter((citation) => citation.message_id === message.id)
+              .map(({ id, ordinal, excerpt, heading, pages }) => ({
+                id,
+                ordinal,
+                excerpt,
+                heading,
+                pages,
+              }))
+          : [],
       createdAt: message.created_at,
     })),
     ...toolActivity.map((activity, index) => ({

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -53,6 +53,18 @@ export type ChatMessage = {
   role: "user" | "assistant";
   content: string;
   created_at: string;
+  /** Optional so a partial renderer-boundary response remains non-fatal. */
+  citations?: ChatMessageCitation[];
+};
+
+/** A bounded, renderer-safe evidence snapshot owned by one assistant message. */
+export type ChatMessageCitation = {
+  id: string;
+  message_id: string;
+  ordinal: number;
+  excerpt: string;
+  heading: string | null;
+  pages: number[];
 };
 
 /** A fixed, terminal tool-card projection with no canonical tool data. */


### PR DESCRIPTION
## Summary
- render durable sources beneath the exact owning assistant message
- scrub opaque source markers across fragmented live text deltas
- rehydrate authoritative transcript content and citations after terminal completion
- fence retries across chat changes, newer turns, and component teardown

## Validation
- desktop UI suite (62 tests)
- TypeScript check and Vite production build
- three adversarial review passes
- git diff --check

## Merge order
- merge after #244 adds the durable transcript citation projection