### PR TITLE
Add active turn steering control

### DIFF
--- a/crates/openwave-desktop/ui/src/ActiveTurnSteer.test.ts
+++ b/crates/openwave-desktop/ui/src/ActiveTurnSteer.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ActiveTurnSteerFence,
+  canBeginActiveTurnSteer,
+  MAX_STEER_CHARACTERS,
+  shouldClearAcceptedSteerDraft,
+} from "./ActiveTurnSteer";
+
+const target = { chatId: "chat-1", turnId: "turn-1", selection: 4 };
+
+describe("ActiveTurnSteerFence", () => {
+  it("rejects steer admission synchronously once cancellation starts", () => {
+    expect(
+      canBeginActiveTurnSteer({
+        busy: true,
+        turnId: "turn-1",
+        cancelRequestTurnId: "turn-1",
+        deletionInFlight: false,
+      }),
+    ).toBe(false);
+    expect(
+      canBeginActiveTurnSteer({
+        busy: true,
+        turnId: "turn-1",
+        cancelRequestTurnId: null,
+        deletionInFlight: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("creates one stable identity and fences a duplicate submission", () => {
+    const createId = vi.fn(() => "steer-1");
+    const fence = new ActiveTurnSteerFence();
+
+    const request = fence.begin(target, "  change course  ", createId);
+
+    expect(request).toEqual({
+      ...target,
+      content: "change course",
+      draftSnapshot: "  change course  ",
+      steerId: "steer-1",
+    });
+    expect(fence.begin(target, "another direction", createId)).toBeNull();
+    expect(createId).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses the exact identity when unchanged guidance is retried", () => {
+    const createId = vi.fn(() => "steer-1");
+    const fence = new ActiveTurnSteerFence();
+    const first = fence.begin(target, "change course", createId)!;
+    fence.fail(first);
+
+    const retry = fence.begin(target, "  change course  ", createId)!;
+
+    expect(retry.steerId).toBe(first.steerId);
+    expect(retry.content).toBe(first.content);
+    expect(retry.draftSnapshot).toBe("  change course  ");
+    expect(createId).toHaveBeenCalledTimes(1);
+  });
+
+  it("allocates a new identity when failed guidance changes", () => {
+    const createId = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("steer-1")
+      .mockReturnValueOnce("steer-2");
+    const fence = new ActiveTurnSteerFence();
+    const first = fence.begin(target, "change course", createId)!;
+    fence.fail(first);
+
+    expect(fence.begin(target, "different course", createId)?.steerId).toBe(
+      "steer-2",
+    );
+  });
+
+  it("accepts a response only for the exact selected chat and active turn", () => {
+    const fence = new ActiveTurnSteerFence();
+    const request = fence.begin(target, "change course", () => "steer-1")!;
+
+    expect(fence.canApplyResponse(request, target)).toBe(true);
+    expect(
+      fence.canApplyResponse(request, { ...target, chatId: "chat-2" }),
+    ).toBe(false);
+    expect(
+      fence.canApplyResponse(request, { ...target, turnId: "turn-2" }),
+    ).toBe(false);
+    expect(
+      fence.canApplyResponse(request, { ...target, selection: 5 }),
+    ).toBe(false);
+
+  });
+
+  it.each(["terminal event", "chat switch", "unmount"])(
+    "rejects a response after %s invalidates the request",
+    () => {
+      const fence = new ActiveTurnSteerFence();
+      const request = fence.begin(target, "change course", () => "steer-1")!;
+
+      fence.invalidate();
+
+      expect(fence.canApplyResponse(request, target)).toBe(false);
+    },
+  );
+
+  it("rejects malformed or oversized guidance before allocating an identity", () => {
+    const createId = vi.fn(() => "steer-1");
+    const fence = new ActiveTurnSteerFence();
+
+    expect(fence.begin(target, "  ", createId)).toBeNull();
+    expect(fence.begin(target, "bad\0input", createId)).toBeNull();
+    expect(
+      fence.begin(target, "x".repeat(MAX_STEER_CHARACTERS + 1), createId),
+    ).toBeNull();
+    expect(createId).not.toHaveBeenCalled();
+  });
+
+  it("measures the server bound in Unicode scalars rather than UTF-16 units", () => {
+    const fence = new ActiveTurnSteerFence();
+
+    expect(
+      fence.begin(
+        target,
+        "🌊".repeat(MAX_STEER_CHARACTERS),
+        () => "steer-1",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("clears only the accepted snapshot and preserves a newer draft", () => {
+    const fence = new ActiveTurnSteerFence();
+    const request = fence.begin(target, "first direction", () => "steer-1")!;
+
+    expect(shouldClearAcceptedSteerDraft(request, "first direction")).toBe(true);
+    expect(shouldClearAcceptedSteerDraft(request, "next direction")).toBe(false);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ActiveTurnSteer.ts
+++ b/crates/openwave-desktop/ui/src/ActiveTurnSteer.ts
@@ -1,0 +1,105 @@
+export const MAX_STEER_CHARACTERS = 65_536;
+
+export type ActiveTurnTarget = {
+  chatId: string;
+  turnId: string;
+  selection: number;
+};
+
+export type ActiveTurnSteerRequest = ActiveTurnTarget & {
+  content: string;
+  draftSnapshot: string;
+  steerId: string;
+};
+
+export function canBeginActiveTurnSteer(input: {
+  busy: boolean;
+  turnId: string | null;
+  cancelRequestTurnId: string | null;
+  deletionInFlight: boolean;
+}): input is typeof input & { turnId: string } {
+  return (
+    input.busy &&
+    input.turnId !== null &&
+    input.cancelRequestTurnId === null &&
+    !input.deletionInFlight
+  );
+}
+
+function sameTarget(
+  left: ActiveTurnTarget,
+  right: ActiveTurnTarget,
+): boolean {
+  return (
+    left.chatId === right.chatId &&
+    left.turnId === right.turnId &&
+    left.selection === right.selection
+  );
+}
+
+export class ActiveTurnSteerFence {
+  private pending: ActiveTurnSteerRequest | null = null;
+  private retryable: ActiveTurnSteerRequest | null = null;
+
+  begin(
+    target: ActiveTurnTarget,
+    draft: string,
+    createId: () => string,
+  ): ActiveTurnSteerRequest | null {
+    const content = draft.trim();
+    if (
+      this.pending ||
+      !content ||
+      content.includes("\0") ||
+      [...content].length > MAX_STEER_CHARACTERS
+    ) {
+      return null;
+    }
+
+    const request =
+      this.retryable &&
+      sameTarget(this.retryable, target) &&
+      this.retryable.content === content
+        ? { ...this.retryable, draftSnapshot: draft }
+        : {
+            ...target,
+            content,
+            draftSnapshot: draft,
+            steerId: createId(),
+          };
+    this.retryable = null;
+    this.pending = request;
+    return request;
+  }
+
+  canApplyResponse(
+    request: ActiveTurnSteerRequest,
+    currentTarget: ActiveTurnTarget,
+  ): boolean {
+    return this.pending === request && sameTarget(request, currentTarget);
+  }
+
+  finish(request: ActiveTurnSteerRequest): void {
+    if (this.pending !== request) return;
+    this.pending = null;
+    this.retryable = null;
+  }
+
+  fail(request: ActiveTurnSteerRequest): void {
+    if (this.pending !== request) return;
+    this.pending = null;
+    this.retryable = request;
+  }
+
+  invalidate(): void {
+    this.pending = null;
+    this.retryable = null;
+  }
+}
+
+export function shouldClearAcceptedSteerDraft(
+  request: ActiveTurnSteerRequest,
+  currentDraft: string,
+): boolean {
+  return request.draftSnapshot === currentDraft;
+}

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -40,6 +40,11 @@ import {
 import { loadChatApprovalHydration } from "./ChatApprovalHydration";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
 import {
+  ActiveTurnSteerFence,
+  canBeginActiveTurnSteer,
+  shouldClearAcceptedSteerDraft,
+} from "./ActiveTurnSteer";
+import {
   loadCurrentTerminalTranscript,
   presentChatTranscript,
 } from "./ChatTranscriptPresentation";
@@ -84,6 +89,11 @@ export default function App() {
     null,
   );
   const [cancelError, setCancelError] = useState<string | null>(null);
+  const [steerPendingTurnId, setSteerPendingTurnId] = useState<string | null>(
+    null,
+  );
+  const [steerError, setSteerError] = useState<string | null>(null);
+  const [steerStatus, setSteerStatus] = useState<string | null>(null);
   const [creatingChat, setCreatingChat] = useState(false);
   const [deletingChatId, setDeletingChatId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState(false);
@@ -112,6 +122,10 @@ export default function App() {
   const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
   const visibleFolderCallIdsRef = useRef<Set<string>>(new Set());
   const cancelRequestTurnRef = useRef<string | null>(null);
+  const activeTurnIdRef = useRef<string | null>(null);
+  const draftRef = useRef("");
+  const selectedChatIdRef = useRef<string | null>(null);
+  const steerFenceRef = useRef(new ActiveTurnSteerFence());
   const provisionalToolCallIdsRef = useRef<Set<string>>(new Set());
   const deletionInFlightRef = useRef(false);
 
@@ -131,6 +145,7 @@ export default function App() {
     return () => {
       cancelled = true;
       terminalHydrationGenerationRef.current += 1;
+      steerFenceRef.current.invalidate();
     };
   }, []);
 
@@ -187,7 +202,7 @@ export default function App() {
           reconcilePendingApprovalCards(presented.messages, pendingApprovals),
         );
         const pendingTurnId = pendingApprovals[0]?.turnId ?? null;
-        setActiveTurnId(pendingTurnId);
+        setCurrentActiveTurnId(pendingTurnId);
         setBusy(pendingTurnId !== null);
         setHydratedChatId(chat.id);
       } catch (err) {
@@ -343,6 +358,7 @@ export default function App() {
     const event = framed.event;
 
     if (event.type === "turn_started") {
+      const startsDifferentTurn = activeTurnIdRef.current !== event.turn_id;
       refreshAgentRunsRef.current?.();
       terminalHydrationGenerationRef.current += 1;
       assistantBufRef.current = "";
@@ -350,10 +366,11 @@ export default function App() {
         new AssistantSourceMarkerStreamScrubber();
       provisionalToolCallIdsRef.current = new Set();
       setBusy(true);
-      setActiveTurnId(event.turn_id);
+      setCurrentActiveTurnId(event.turn_id);
       setCancelPendingTurnId(null);
       setCancelError(null);
       cancelRequestTurnRef.current = null;
+      if (startsDifferentTurn) clearSteerRequestState();
       setMessages((prev) => [
         ...prev,
         { id: nextId(), role: "assistant", text: "", sources: [] },
@@ -562,10 +579,34 @@ export default function App() {
 
   function resolveActiveTurn() {
     setBusy(false);
-    setActiveTurnId(null);
+    setCurrentActiveTurnId(null);
     setCancelPendingTurnId(null);
     setCancelError(null);
     cancelRequestTurnRef.current = null;
+    clearSteerRequestState();
+  }
+
+  function setCurrentActiveTurnId(turnId: string | null) {
+    activeTurnIdRef.current = turnId;
+    setActiveTurnId(turnId);
+  }
+
+  function setComposerDraft(nextDraft: string) {
+    draftRef.current = nextDraft;
+    setDraft(nextDraft);
+  }
+
+  function clearSteerRequestState() {
+    steerFenceRef.current.invalidate();
+    setSteerPendingTurnId(null);
+    setSteerError(null);
+    setSteerStatus(null);
+  }
+
+  function onComposerDraftChange(nextDraft: string) {
+    setComposerDraft(nextDraft);
+    setSteerError(null);
+    setSteerStatus(null);
   }
 
   async function refreshCatalog() {
@@ -585,10 +626,10 @@ export default function App() {
     const content = draft.trim();
     const turnId = crypto.randomUUID();
     terminalHydrationGenerationRef.current += 1;
-    setDraft("");
+    setComposerDraft("");
     setMessages((prev) => [...prev, { id: nextId(), role: "user", text: content }]);
     setBusy(true);
-    setActiveTurnId(turnId);
+    setCurrentActiveTurnId(turnId);
     setCancelPendingTurnId(null);
     setCancelError(null);
     try {
@@ -602,6 +643,79 @@ export default function App() {
         ...prev,
         { id: nextId(), role: "error", text: String(err) },
       ]);
+    }
+  }
+
+  async function onSteerActiveTurn() {
+    const admission = {
+      busy,
+      turnId: activeTurnIdRef.current,
+      cancelRequestTurnId: cancelRequestTurnRef.current,
+      deletionInFlight: deletionInFlightRef.current,
+    };
+    if (
+      !client ||
+      !chat ||
+      !canBeginActiveTurnSteer(admission)
+    ) {
+      return;
+    }
+    const turnId = admission.turnId;
+
+    const request = steerFenceRef.current.begin(
+      {
+        chatId: chat.id,
+        turnId,
+        selection: chatSelectionRef.current,
+      },
+      draftRef.current,
+      () => crypto.randomUUID(),
+    );
+    if (!request) return;
+
+    setSteerPendingTurnId(turnId);
+    setSteerError(null);
+    setSteerStatus("Sending guidance…");
+    setCancelError(null);
+    try {
+      await client.steer(
+        request.chatId,
+        request.turnId,
+        request.steerId,
+        request.content,
+        true,
+      );
+      if (
+        !steerFenceRef.current.canApplyResponse(request, {
+          chatId: selectedChatIdRef.current ?? "",
+          turnId: activeTurnIdRef.current ?? "",
+          selection: chatSelectionRef.current,
+        })
+      ) {
+        return;
+      }
+
+      steerFenceRef.current.finish(request);
+      setSteerPendingTurnId(null);
+      if (shouldClearAcceptedSteerDraft(request, draftRef.current)) {
+        setComposerDraft("");
+      }
+      setSteerStatus("Guidance sent");
+    } catch (err) {
+      if (
+        !steerFenceRef.current.canApplyResponse(request, {
+          chatId: selectedChatIdRef.current ?? "",
+          turnId: activeTurnIdRef.current ?? "",
+          selection: chatSelectionRef.current,
+        })
+      ) {
+        return;
+      }
+
+      steerFenceRef.current.fail(request);
+      setSteerPendingTurnId(null);
+      setSteerStatus(null);
+      setSteerError(String(err));
     }
   }
 
@@ -658,12 +772,13 @@ export default function App() {
       setAgentRunsError(null);
       setFolderAccessRequests([]);
       setFolderAccessErrors({});
-      setDraft("");
+      setComposerDraft("");
       setBusy(false);
-      setActiveTurnId(null);
+      setCurrentActiveTurnId(null);
       setCancelPendingTurnId(null);
       setCancelError(null);
       cancelRequestTurnRef.current = null;
+      clearSteerRequestState();
       activateChat(created);
       setChats((current) => [created, ...current]);
       setChatsError(null);
@@ -695,6 +810,7 @@ export default function App() {
       // This invalidates callbacks that captured the deleted selection. The
       // ref update also gates sends before the disabled composer renders.
       chatSelectionRef.current += 1;
+      clearSteerRequestState();
     }
     try {
       await client.deleteChat(target.id);
@@ -722,6 +838,7 @@ export default function App() {
   function activateChat(next: Chat) {
     chatSelectionRef.current += 1;
     terminalHydrationGenerationRef.current += 1;
+    selectedChatIdRef.current = next.id;
     assistantMarkerScrubberRef.current =
       new AssistantSourceMarkerStreamScrubber();
     setChat(next);
@@ -746,12 +863,13 @@ export default function App() {
     setAgentRunsError(null);
     setFolderAccessRequests([]);
     setFolderAccessErrors({});
-    setDraft("");
+    setComposerDraft("");
     setBusy(false);
-    setActiveTurnId(null);
+    setCurrentActiveTurnId(null);
     setCancelPendingTurnId(null);
     setCancelError(null);
     cancelRequestTurnRef.current = null;
+    clearSteerRequestState();
     setEditingTitle(false);
     activateChat(next);
     setStatus(`chat ${next.id.slice(0, 8)}…`);
@@ -1200,10 +1318,16 @@ export default function App() {
             }
             disabled={deletingChatId !== null}
             draft={draft}
-            onDraftChange={setDraft}
+            onDraftChange={onComposerDraftChange}
             onSend={onSend}
+            onSteer={onSteerActiveTurn}
             onStop={onCancelActiveTurn}
             resetKey={chat?.id ?? "no-chat"}
+            steerError={steerError}
+            steerPending={
+              activeTurnId !== null && steerPendingTurnId === activeTurnId
+            }
+            steerStatus={steerStatus}
           />
         </section>
 

--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -88,18 +88,126 @@ describe("Composer", () => {
         draft="A later draft"
         onDraftChange={vi.fn()}
         onSend={noop}
+        onSteer={noop}
         onStop={noop}
         resetKey="chat-1"
+        steerError={null}
+        steerPending={false}
+        steerStatus={null}
       />,
     );
 
     expect(markup).toContain('class="composer-actions"');
-    expect(markup).toContain("Stop");
-    expect(markup).not.toContain(">Send<");
+    expect(markup).toContain("Redirect");
+    expect(markup).toContain(">Stop<");
+    expect(markup).toContain('aria-label="Redirect active response"');
     expect(markup).toContain('aria-label="Stop response"');
     expect(markup).toContain('aria-label="Message"');
-    expect(markup).toContain('disabled=""');
+    expect(markup).not.toContain('<textarea disabled=""');
     expect(markup).toContain('role="status"');
+  });
+
+  it("keeps Stop available for an active turn until the user types", () => {
+    const markup = renderToStaticMarkup(
+      <Composer
+        activeTurnId="turn-1"
+        busy
+        cancelError={null}
+        cancelPending={false}
+        disabled={false}
+        draft=""
+        onDraftChange={vi.fn()}
+        onSend={noop}
+        onSteer={noop}
+        onStop={noop}
+        resetKey="chat-1"
+        steerError={null}
+        steerPending={false}
+        steerStatus={null}
+      />,
+    );
+
+    expect(markup).toContain(">Stop<");
+    expect(markup).toContain('aria-label="Stop response"');
+    expect(markup).toContain("Guide the active response…");
+    expect(markup).not.toContain('<textarea disabled=""');
+  });
+
+  it("keeps the draft editable while fencing an in-flight steer", () => {
+    const markup = renderToStaticMarkup(
+      <Composer
+        activeTurnId="turn-1"
+        busy
+        cancelError={null}
+        cancelPending={false}
+        disabled={false}
+        draft="change course"
+        onDraftChange={vi.fn()}
+        onSend={noop}
+        onSteer={noop}
+        onStop={noop}
+        resetKey="chat-1"
+        steerError={null}
+        steerPending
+        steerStatus="Sending guidance…"
+      />,
+    );
+
+    expect(markup).toContain(">Sending…<");
+    expect(markup).toContain(">Stop<");
+    expect(markup).toContain('aria-label="Redirect active response"');
+    expect(markup).not.toContain('<textarea disabled=""');
+    expect(markup).toContain("Sending guidance…");
+  });
+
+  it("keeps Stop available but fences Redirect while cancellation is pending", () => {
+    const markup = renderToStaticMarkup(
+      <Composer
+        activeTurnId="turn-1"
+        busy
+        cancelError={null}
+        cancelPending
+        disabled={false}
+        draft="change course"
+        onDraftChange={vi.fn()}
+        onSend={noop}
+        onSteer={noop}
+        onStop={noop}
+        resetKey="chat-1"
+        steerError={null}
+        steerPending={false}
+        steerStatus={null}
+      />,
+    );
+
+    expect(markup).toContain(">Redirect<");
+    expect(markup).toContain(">Stopping…<");
+    expect(markup.match(/disabled=""/g)).toHaveLength(2);
+  });
+
+  it("surfaces unsupported active-turn guidance instead of silently ignoring it", () => {
+    const markup = renderToStaticMarkup(
+      <Composer
+        activeTurnId="turn-1"
+        busy
+        cancelError={null}
+        cancelPending={false}
+        disabled={false}
+        draft={"change\0course"}
+        onDraftChange={vi.fn()}
+        onSend={noop}
+        onSteer={noop}
+        onStop={noop}
+        resetKey="chat-1"
+        steerError={null}
+        steerPending={false}
+        steerStatus={null}
+      />,
+    );
+
+    expect(markup).toContain("Guidance contains an unsupported character.");
+    expect(markup).toContain('aria-label="Redirect active response"');
+    expect(markup.match(/disabled=""/g)).toHaveLength(1);
   });
 
   it("disables an empty draft without hiding the send control", () => {
@@ -113,8 +221,12 @@ describe("Composer", () => {
         draft="   "
         onDraftChange={vi.fn()}
         onSend={noop}
+        onSteer={noop}
         onStop={noop}
         resetKey="chat-1"
+        steerError={null}
+        steerPending={false}
+        steerStatus={null}
       />,
     );
 

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -4,6 +4,7 @@ import {
   useLayoutEffect,
   useRef,
 } from "react";
+import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
 
 const MIN_COMPOSER_LINES = 1;
 export const MAX_COMPOSER_LINES = 6;
@@ -77,8 +78,12 @@ export type ComposerProps = {
   draft: string;
   onDraftChange: (draft: string) => void;
   onSend: () => Promise<void>;
+  onSteer: () => Promise<void>;
   onStop: () => Promise<void>;
   resetKey: string;
+  steerError: string | null;
+  steerPending: boolean;
+  steerStatus: string | null;
 };
 
 export function Composer({
@@ -90,14 +95,30 @@ export function Composer({
   draft,
   onDraftChange,
   onSend,
+  onSteer,
   onStop,
   resetKey,
+  steerError,
+  steerPending,
+  steerStatus,
 }: ComposerProps) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const latestResetKeyRef = useRef(resetKey);
   latestResetKeyRef.current = resetKey;
-  const inputDisabled = disabled || busy;
-  const canSend = !inputDisabled && Boolean(draft.trim());
+  const inputDisabled = disabled;
+  const active = busy && activeTurnId !== null;
+  const hasDraft = Boolean(draft.trim());
+  const steerHasUnsupportedCharacter = active && draft.includes("\0");
+  const steerTooLong =
+    active && [...draft.trim()].length > MAX_STEER_CHARACTERS;
+  const canSubmit =
+    !inputDisabled &&
+    !steerPending &&
+    !cancelPending &&
+    hasDraft &&
+    !steerHasUnsupportedCharacter &&
+    !steerTooLong &&
+    (!busy || active);
 
   useLayoutEffect(() => {
     const textarea = textareaRef.current;
@@ -105,13 +126,12 @@ export function Composer({
   }, [draft, resetKey]);
 
   async function submit(): Promise<void> {
-    if (!canSend) return;
+    if (!canSubmit) return;
     const submissionKey = resetKey;
-    await onSend();
+    await (active ? onSteer() : onSend());
 
-    // A successful send enters a running turn and keeps the input disabled.
-    // If the request fails, the input becomes available again and returns focus
-    // so the user can continue without another click.
+    // Restore focus after accepted guidance or a failed request. A new chat or
+    // disabled composer must never receive focus from an older submission.
     window.requestAnimationFrame(() => {
       const textarea = textareaRef.current;
       if (
@@ -142,7 +162,9 @@ export function Composer({
       <textarea
         ref={textareaRef}
         value={draft}
-        placeholder="Message OpenWave…"
+        placeholder={
+          active ? "Guide the active response…" : "Message OpenWave…"
+        }
         aria-label="Message"
         disabled={inputDisabled}
         onChange={onChange}
@@ -153,21 +175,35 @@ export function Composer({
         }}
       />
       <div className="composer-actions">
-        {busy && activeTurnId ? (
-          <button
-            type="button"
-            className="btn btn-stop"
-            aria-label={cancelPending ? "Stopping response" : "Stop response"}
-            disabled={disabled || cancelPending}
-            onClick={() => void onStop()}
-          >
-            {cancelPending ? "Stopping…" : "Stop"}
-          </button>
+        {active ? (
+          <>
+            {(hasDraft || steerPending) && (
+              <button
+                type="submit"
+                className="btn btn-primary"
+                aria-label="Redirect active response"
+                disabled={!canSubmit}
+              >
+                {steerPending ? "Sending…" : "Redirect"}
+              </button>
+            )}
+            <button
+              type="button"
+              className="btn btn-stop"
+              aria-label={
+                cancelPending ? "Stopping response" : "Stop response"
+              }
+              disabled={disabled || cancelPending}
+              onClick={() => void onStop()}
+            >
+              {cancelPending ? "Stopping…" : "Stop"}
+            </button>
+          </>
         ) : (
           <button
             type="submit"
             className="btn btn-primary"
-            disabled={!canSend}
+            disabled={!canSubmit}
           >
             Send
           </button>
@@ -179,6 +215,26 @@ export function Composer({
       {cancelError && (
         <span className="composer-turn-error" role="status">
           Couldn’t stop turn: {cancelError}
+        </span>
+      )}
+      {steerError && (
+        <span className="composer-turn-error" role="alert">
+          Couldn’t redirect: {steerError}
+        </span>
+      )}
+      {steerStatus && !steerError && (
+        <span className="composer-turn-status" role="status">
+          {steerStatus}
+        </span>
+      )}
+      {steerTooLong && (
+        <span className="composer-turn-error" role="alert">
+          Guidance is too long.
+        </span>
+      )}
+      {steerHasUnsupportedCharacter && (
+        <span className="composer-turn-error" role="alert">
+          Guidance contains an unsupported character.
         </span>
       )}
     </form>

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -144,3 +144,30 @@ describe("pending approval recovery", () => {
     }
   });
 });
+
+describe("active turn steering", () => {
+  it("posts an interrupt against the exact chat, turn, and stable identity", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await client.steer(
+      "chat-1",
+      "turn-1",
+      "steer-1",
+      "change course",
+      true,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1/chats/chat-1/steer");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      steer_id: "steer-1",
+      turn_id: "turn-1",
+      content: "change course",
+      interrupt: true,
+    });
+  });
+});

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1099,6 +1099,7 @@ button {
 .composer-actions {
   display: flex;
   align-items: center;
+  gap: 0.45rem;
 }
 
 .composer-actions .btn {
@@ -1121,6 +1122,12 @@ button {
   color: var(--danger);
   font-size: 0.78rem;
   overflow-wrap: anywhere;
+}
+
+.composer-turn-status {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 0.78rem;
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- keep the composer editable during an active foreground turn while preserving an independent Stop action
- submit bounded interrupt guidance against the exact active turn with stable retry identity and stale-response fencing
- preserve drafts across failures and concurrent edits, gate cancel/redirect admission races, and provide accessible status and validation feedback

## Validation
- `pnpm test` (78 tests)
- `pnpm build`
- `git diff --check`