### PR TITLE
Refine background activity panel

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.test.tsx
@@ -1,0 +1,139 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentRun } from "./api";
+import { AgentActivityPanel, agentRunsForChat } from "./AgentActivityPanel";
+
+function run(overrides: Partial<AgentRun>): AgentRun {
+  return {
+    id: "run-1",
+    parent_id: null,
+    execution: "sandbox",
+    status: "running",
+    started_at: "2026-07-19T12:00:00Z",
+    finished_at: null,
+    last_error_code: null,
+    activity: null,
+    created_at: "2026-07-19T12:00:00Z",
+    updated_at: "2026-07-19T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("AgentActivityPanel", () => {
+  it("shows snapshots only for the conversation that owns them", () => {
+    const runs = [run({ id: "chat-a-run" })];
+
+    expect(agentRunsForChat("chat-a", "chat-a", runs)).toBe(runs);
+    expect(agentRunsForChat("chat-a", "chat-b", runs)).toEqual([]);
+    expect(agentRunsForChat(null, "chat-a", runs)).toEqual([]);
+  });
+
+  it("groups live and recent background work with a focused live region", () => {
+    const markup = renderToStaticMarkup(
+      <AgentActivityPanel
+        runs={[
+          run({ id: "foreground", execution: "foreground", status: "active" }),
+          run({ id: "live", status: "running" }),
+          run({
+            id: "search",
+            status: "waiting",
+            activity: { kind: "web_search", status: "running" },
+          }),
+          run({ id: "complete", status: "completed", updated_at: "2026-07-19T12:03:00Z" }),
+          run({ id: "failed", status: "failed", updated_at: "2026-07-19T12:02:00Z" }),
+          run({ id: "old", status: "cancelled", updated_at: "2026-07-19T12:01:00Z" }),
+        ]}
+        loading={false}
+        error={null}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Active background tasks"');
+    expect(markup).toContain('aria-label="Recent background tasks"');
+    expect(markup).toContain('aria-live="polite"');
+    expect(markup).toContain(
+      '<strong aria-live="polite" aria-atomic="true" aria-label="Background task 1: running">running</strong>',
+    );
+    expect(markup).not.toContain('aria-label="Conversation: active"');
+    expect(markup).toContain("2 background tasks");
+    expect(markup).toContain("Searching the web");
+    expect(markup).toContain("1 earlier result");
+    expect(markup).not.toContain('aria-live="polite" aria-label="Agent activity"');
+  });
+
+  it("renders only generic safe copy instead of run identifiers or diagnostics", () => {
+    const markup = renderToStaticMarkup(
+      <AgentActivityPanel
+        runs={[
+          run({
+            id: "private-run-identity",
+            parent_id: "private-parent-identity",
+            status: "failed",
+            last_error_code: "private_provider_diagnostic",
+            activity: { kind: "read_connected_file", status: "running" },
+          }),
+        ]}
+        loading={false}
+        error={null}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Background task 1");
+    expect(markup).toContain("Could not finish");
+    expect(markup).not.toContain("private-run-identity");
+    expect(markup).not.toContain("private-parent-identity");
+    expect(markup).not.toContain("private_provider_diagnostic");
+    expect(markup).not.toContain("Reading a file");
+  });
+
+  it("falls back safely for malformed future activity projections", () => {
+    const malformedRuns = [
+      run({
+        id: "unknown-kind",
+        activity: { kind: "future_private_tool", status: "running" } as never,
+      }),
+      run({
+        id: "unknown-status",
+        activity: { kind: "web_search", status: "future_status" } as never,
+      }),
+    ];
+
+    const markup = renderToStaticMarkup(
+      <AgentActivityPanel
+        runs={malformedRuns}
+        loading={false}
+        error={null}
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Background task 1");
+    expect(markup).toContain("Background task 2");
+    expect(markup).toContain("Working in the background");
+    expect(markup).not.toContain("future_private_tool");
+    expect(markup).not.toContain("future_status");
+  });
+
+  it("keeps load and retry states compact and accessible", () => {
+    expect(
+      renderToStaticMarkup(
+        <AgentActivityPanel runs={[]} loading error={null} onRetry={vi.fn()} />,
+      ),
+    ).toContain("Loading activity…");
+
+    const failure = renderToStaticMarkup(
+      <AgentActivityPanel
+        runs={[]}
+        loading={false}
+        error="private network detail"
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(failure).toContain('role="status"');
+    expect(failure).toContain("Activity unavailable");
+    expect(failure).toContain("Retry");
+    expect(failure).not.toContain("private network detail");
+  });
+});

--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
@@ -1,0 +1,255 @@
+import type { ReactNode } from "react";
+import type { AgentRun } from "./api";
+
+const MAX_RECENT_TERMINAL_SANDBOX_RUNS = 2;
+
+export function agentRunsForChat(
+  ownerChatId: string | null,
+  selectedChatId: string | null,
+  runs: AgentRun[],
+): AgentRun[] {
+  return ownerChatId !== null && ownerChatId === selectedChatId ? runs : [];
+}
+
+export function AgentActivityPanel({
+  runs,
+  loading,
+  error,
+  onRetry,
+}: {
+  runs: AgentRun[];
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  if (loading) {
+    return <div className="agent-activity-state">Loading activity…</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="agent-activity-state is-error" role="status">
+        Activity unavailable
+        <button type="button" className="agent-activity-retry" onClick={onRetry}>
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const foreground = runs.find((run) => run.execution === "foreground");
+  const sandboxes = runs.filter((run) => run.execution === "sandbox");
+  if (!foreground && sandboxes.length === 0) return null;
+
+  const activeSandboxes = sandboxes.filter((run) =>
+    isActiveAgentRunStatus(run.status),
+  );
+  const terminalSandboxes = sandboxes
+    .filter((run) => !isActiveAgentRunStatus(run.status))
+    .sort((left, right) => right.updated_at.localeCompare(left.updated_at));
+  const recentTerminalSandboxes = terminalSandboxes.slice(
+    0,
+    MAX_RECENT_TERMINAL_SANDBOX_RUNS,
+  );
+  const hiddenTerminalCount = terminalSandboxes.length - recentTerminalSandboxes.length;
+
+  return (
+    <section className="agent-activity" aria-label="Agent activity">
+      <div className="agent-activity-heading">
+        <span>Activity</span>
+        <span className="agent-activity-summary" aria-live="polite" aria-atomic="true">
+          {backgroundSummary(activeSandboxes.length, recentTerminalSandboxes.length)}
+        </span>
+      </div>
+
+      {foreground && (
+        <ul className="agent-activity-list" aria-label="Conversation activity">
+          <AgentActivityItem run={foreground} label="Conversation" />
+        </ul>
+      )}
+
+      {activeSandboxes.length > 0 && (
+        <ActivityGroup label="Active" count={activeSandboxes.length} active>
+          {activeSandboxes.map((run, index) => (
+            <AgentActivityItem
+              key={run.id}
+              run={run}
+              label={`Background task ${index + 1}`}
+              announce
+            />
+          ))}
+        </ActivityGroup>
+      )}
+
+      {recentTerminalSandboxes.length > 0 && (
+        <ActivityGroup label="Recent" count={terminalSandboxes.length}>
+          {recentTerminalSandboxes.map((run, index) => (
+            <AgentActivityItem
+              key={run.id}
+              run={run}
+              label={`Background task ${index + 1}`}
+            />
+          ))}
+        </ActivityGroup>
+      )}
+
+      {hiddenTerminalCount > 0 && (
+        <p className="agent-activity-history">
+          {hiddenTerminalCount} earlier {hiddenTerminalCount === 1 ? "result" : "results"}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function ActivityGroup({
+  label,
+  count,
+  active = false,
+  children,
+}: {
+  label: string;
+  count: number;
+  active?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <section className="agent-activity-group" aria-label={`${label} background tasks`}>
+      <div className="agent-activity-group-heading">
+        <span className={`agent-activity-group-indicator${active ? " is-active" : ""}`} aria-hidden="true" />
+        <span>{label}</span>
+        <span className="agent-activity-group-count">{count}</span>
+      </div>
+      <ul className="agent-activity-list">{children}</ul>
+    </section>
+  );
+}
+
+function AgentActivityItem({
+  run,
+  label,
+  announce = false,
+}: {
+  run: AgentRun;
+  label: string;
+  announce?: boolean;
+}) {
+  const activity = isActiveAgentRunStatus(run.status)
+    ? agentActivityPresentation(run.activity)
+    : null;
+  const status = activity?.status ?? readableAgentRunStatus(run.status);
+  return (
+    <li
+      className={`agent-activity-item is-${run.status}${activity ? ` is-activity-${activity.sourceStatus}` : ""}`}
+    >
+      <span className="agent-activity-indicator" aria-hidden="true" />
+      <span className="agent-activity-item-copy">
+        <span>{activity?.label ?? label}</span>
+        <span className="agent-activity-detail">
+          {activity?.detail ?? agentRunStatusDescription(run.status)}
+        </span>
+      </span>
+      <strong
+        aria-live={announce ? "polite" : undefined}
+        aria-atomic={announce ? "true" : undefined}
+        aria-label={announce ? `${activity?.label ?? label}: ${status}` : undefined}
+      >
+        {status}
+      </strong>
+    </li>
+  );
+}
+
+function backgroundSummary(activeCount: number, recentCount: number): string {
+  if (activeCount > 0) {
+    return `${activeCount} background ${activeCount === 1 ? "task" : "tasks"}`;
+  }
+  return recentCount > 0 ? "Recent background work" : "No background work";
+}
+
+function agentActivityPresentation(
+  activity: AgentRun["activity"],
+): { label: string; detail: string; status: string; sourceStatus: string } | null {
+  if (!activity) return null;
+
+  const presentations = {
+    web_search: {
+      label: "Web search",
+      waiting: "Waiting to search",
+      running: "Searching the web",
+      activeStatus: "searching",
+    },
+    list_connected_folders: {
+      label: "Connected folders",
+      waiting: "Waiting to check connected folders",
+      running: "Checking connected folders",
+      activeStatus: "checking",
+    },
+    list_folder: {
+      label: "Folder",
+      waiting: "Waiting to list a folder",
+      running: "Listing a folder",
+      activeStatus: "listing",
+    },
+    read_connected_file: {
+      label: "File",
+      waiting: "Waiting to read a file",
+      running: "Reading a file",
+      activeStatus: "reading",
+    },
+  } as const;
+  const presentation = presentations[activity.kind as keyof typeof presentations];
+  if (
+    !presentation ||
+    (activity.status !== "waiting" && activity.status !== "running")
+  ) {
+    return null;
+  }
+
+  return {
+    label: presentation.label,
+    detail: presentation[activity.status],
+    status: activity.status === "running" ? presentation.activeStatus : "waiting",
+    sourceStatus: activity.status,
+  };
+}
+
+function readableAgentRunStatus(status: AgentRun["status"]): string {
+  switch (status) {
+    case "retry_wait":
+      return "retrying";
+    case "cancelling":
+      return "stopping";
+    default:
+      return status;
+  }
+}
+
+function isActiveAgentRunStatus(status: AgentRun["status"]): boolean {
+  return ["active", "queued", "running", "cancelling", "waiting", "retry_wait"].includes(
+    status,
+  );
+}
+
+function agentRunStatusDescription(status: AgentRun["status"]): string {
+  switch (status) {
+    case "active":
+      return "Ready for this conversation";
+    case "queued":
+      return "Queued to start";
+    case "running":
+      return "Working in the background";
+    case "cancelling":
+      return "Stopping";
+    case "waiting":
+      return "Waiting to continue";
+    case "retry_wait":
+      return "Waiting to retry";
+    case "completed":
+      return "Finished";
+    case "failed":
+      return "Could not finish";
+    case "cancelled":
+      return "Stopped";
+  }
+}

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -48,11 +48,11 @@ import {
   loadCurrentTerminalTranscript,
   presentChatTranscript,
 } from "./ChatTranscriptPresentation";
+import { AgentActivityPanel, agentRunsForChat } from "./AgentActivityPanel";
 
 type Msg = ChatMessage;
 
 let msgSeq = 0;
-const MAX_RECENT_TERMINAL_SANDBOX_RUNS = 2;
 
 function nextId(): string {
   msgSeq += 1;
@@ -71,6 +71,7 @@ export default function App() {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [messages, setMessages] = useState<Msg[]>([]);
   const [agentRuns, setAgentRuns] = useState<AgentRun[]>([]);
+  const [agentRunsChatId, setAgentRunsChatId] = useState<string | null>(null);
   const [agentRunsLoading, setAgentRunsLoading] = useState(false);
   const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
   const [folderAccessRequests, setFolderAccessRequests] = useState<
@@ -262,6 +263,7 @@ export default function App() {
     };
 
     setAgentRuns([]);
+    setAgentRunsChatId(chat.id);
     setAgentRunsError(null);
     setAgentRunsLoading(true);
     refreshAgentRunsRef.current = () => void refresh();
@@ -275,7 +277,8 @@ export default function App() {
     };
   }, [client, chat?.id]);
 
-  const hasActiveSandboxRun = agentRuns.some(
+  const visibleAgentRuns = agentRunsForChat(agentRunsChatId, chat?.id ?? null, agentRuns);
+  const hasActiveSandboxRun = visibleAgentRuns.some(
     (run) =>
       run.execution === "sandbox" &&
       ["queued", "running", "cancelling", "waiting", "retry_wait"].includes(
@@ -1264,9 +1267,9 @@ export default function App() {
               }}
             />
             <AgentActivityPanel
-              runs={agentRuns}
-              loading={agentRunsLoading}
-              error={agentRunsError}
+              runs={visibleAgentRuns}
+              loading={agentRunsChatId === chat.id ? agentRunsLoading : true}
+              error={agentRunsChatId === chat.id ? agentRunsError : null}
               onRetry={() => refreshAgentRunsRef.current?.()}
             />
           </div>
@@ -1425,226 +1428,6 @@ function discardToolCalls(messages: Msg[], callIds: Set<string>): Msg[] {
 
 function withoutConnectionState(status: string): string {
   return status.replace(/ · (?:live|reconnecting)$/, "");
-}
-
-function AgentActivityPanel({
-  runs,
-  loading,
-  error,
-  onRetry,
-}: {
-  runs: AgentRun[];
-  loading: boolean;
-  error: string | null;
-  onRetry: () => void;
-}) {
-  if (loading) {
-    return <div className="agent-activity-state">Loading activity…</div>;
-  }
-
-  if (error) {
-    return (
-      <div className="agent-activity-state is-error" role="status">
-        Activity unavailable
-        <button type="button" className="agent-activity-retry" onClick={onRetry}>
-          Retry
-        </button>
-      </div>
-    );
-  }
-
-  const foreground = runs.find((run) => run.execution === "foreground");
-  const sandboxes = runs.filter((run) => run.execution === "sandbox");
-  if (!foreground && sandboxes.length === 0) return null;
-
-  const activeSandboxes = sandboxes.filter((run) =>
-    isActiveAgentRunStatus(run.status),
-  );
-  const terminalSandboxes = sandboxes
-    .filter((run) => !isActiveAgentRunStatus(run.status))
-    .sort((left, right) => right.updated_at.localeCompare(left.updated_at));
-  const recentTerminalSandboxes = terminalSandboxes.slice(
-    0,
-    MAX_RECENT_TERMINAL_SANDBOX_RUNS,
-  );
-  const hiddenTerminalCount = terminalSandboxes.length - recentTerminalSandboxes.length;
-  const active = runs.some((run) => isActiveAgentRunStatus(run.status));
-  return (
-    <section
-      className="agent-activity"
-      aria-label="Agent activity"
-      aria-live={active ? "polite" : "off"}
-    >
-      <div className="agent-activity-heading">
-        <span>Activity</span>
-        <span className="agent-activity-summary">
-          {activeSandboxes.length > 0
-            ? `${activeSandboxes.length} background ${activeSandboxes.length === 1 ? "task" : "tasks"}`
-            : recentTerminalSandboxes.length > 0
-              ? "Recent background work"
-              : "No background work"}
-        </span>
-      </div>
-      <ul className="agent-activity-list">
-        {foreground && <AgentActivityItem run={foreground} label="Conversation" />}
-        {activeSandboxes.map((run, index) => (
-          <AgentActivityItem
-            key={run.id}
-            run={run}
-            label={`Background task ${index + 1}`}
-          />
-        ))}
-        {recentTerminalSandboxes.map((run, index) => (
-          <AgentActivityItem
-            key={run.id}
-            run={run}
-            label={`Recent background task ${index + 1}`}
-          />
-        ))}
-      </ul>
-      {hiddenTerminalCount > 0 && (
-        <p className="agent-activity-history">
-          {hiddenTerminalCount} earlier {hiddenTerminalCount === 1 ? "result" : "results"}
-        </p>
-      )}
-    </section>
-  );
-}
-
-function AgentActivityItem({ run, label }: { run: AgentRun; label: string }) {
-  const activity = agentActivityPresentation(run.activity);
-  const status = activity?.status ?? readableAgentRunStatus(run.status);
-  return (
-    <li
-      className={`agent-activity-item is-${run.status}${activity ? ` is-activity-${activity.sourceStatus}` : ""}`}
-    >
-      <span className="agent-activity-indicator" aria-hidden="true" />
-      <span className="agent-activity-item-copy">
-        <span>{activity?.label ?? label}</span>
-        <span className="agent-activity-detail">
-          {activity?.detail ?? agentRunStatusDescription(run.status)}
-        </span>
-      </span>
-      <strong>{status}</strong>
-    </li>
-  );
-}
-
-function agentActivityPresentation(
-  activity: AgentRun["activity"],
-): { label: string; detail: string; status: string; sourceStatus: string } | null {
-  if (!activity) return null;
-
-  switch (activity.kind) {
-    case "web_search":
-      switch (activity.status) {
-        case "waiting":
-          return {
-            label: "Web search",
-            detail: "Waiting to search",
-            status: "waiting",
-            sourceStatus: "waiting",
-          };
-        case "running":
-          return {
-            label: "Web search",
-            detail: "Searching the web",
-            status: "searching",
-            sourceStatus: "running",
-          };
-      }
-    case "list_connected_folders":
-      switch (activity.status) {
-        case "waiting":
-          return {
-            label: "Connected folders",
-            detail: "Waiting to check connected folders",
-            status: "waiting",
-            sourceStatus: "waiting",
-          };
-        case "running":
-          return {
-            label: "Connected folders",
-            detail: "Checking connected folders",
-            status: "checking",
-            sourceStatus: "running",
-          };
-      }
-    case "list_folder":
-      switch (activity.status) {
-        case "waiting":
-          return {
-            label: "Folder",
-            detail: "Waiting to list a folder",
-            status: "waiting",
-            sourceStatus: "waiting",
-          };
-        case "running":
-          return {
-            label: "Folder",
-            detail: "Listing a folder",
-            status: "listing",
-            sourceStatus: "running",
-          };
-      }
-    case "read_connected_file":
-      switch (activity.status) {
-        case "waiting":
-          return {
-            label: "File",
-            detail: "Waiting to read a file",
-            status: "waiting",
-            sourceStatus: "waiting",
-          };
-        case "running":
-          return {
-            label: "File",
-            detail: "Reading a file",
-            status: "reading",
-            sourceStatus: "running",
-          };
-      }
-  }
-}
-
-function readableAgentRunStatus(status: AgentRun["status"]): string {
-  switch (status) {
-    case "retry_wait":
-      return "retrying";
-    case "cancelling":
-      return "stopping";
-    default:
-      return status;
-  }
-}
-
-function isActiveAgentRunStatus(status: AgentRun["status"]): boolean {
-  return ["active", "queued", "running", "cancelling", "waiting", "retry_wait"].includes(
-    status,
-  );
-}
-
-function agentRunStatusDescription(status: AgentRun["status"]): string {
-  switch (status) {
-    case "active":
-      return "Ready for this conversation";
-    case "queued":
-      return "Queued to start";
-    case "running":
-      return "Working in the background";
-    case "cancelling":
-      return "Stopping";
-    case "waiting":
-      return "Waiting to continue";
-    case "retry_wait":
-      return "Waiting to retry";
-    case "completed":
-      return "Finished";
-    case "failed":
-      return "Could not finish";
-    case "cancelled":
-      return "Stopped";
-  }
 }
 
 function FoldersPanel({ chat }: { chat: Chat }) {

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -438,6 +438,44 @@ button {
   list-style: none;
 }
 
+.agent-activity-group {
+  display: grid;
+  gap: 0.15rem;
+  border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+}
+
+.agent-activity-group-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding-top: 0.35rem;
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-weight: 620;
+}
+
+.agent-activity-group-indicator {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted) 45%, var(--line));
+}
+
+.agent-activity-group-indicator.is-active {
+  background: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.agent-activity-group-count {
+  min-width: 1.1rem;
+  border-radius: 999px;
+  padding: 0.02rem 0.3rem;
+  background: color-mix(in srgb, var(--line) 55%, transparent);
+  text-align: center;
+  font-size: 0.66rem;
+  font-variant-numeric: tabular-nums;
+}
+
 .agent-activity-history {
   margin: 0;
   padding-top: 0.15rem;
@@ -451,7 +489,7 @@ button {
   gap: 0.45rem;
   min-width: 0;
   padding: 0.3rem 0;
-  border-top: 1px solid color-mix(in srgb, var(--line) 72%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--line) 54%, transparent);
   font-size: 0.77rem;
 }
 


### PR DESCRIPTION
## Summary
- extract the agent activity panel into a focused desktop UI component
- group active and recent sandbox work with compact status counts
- limit live announcements to changing summaries and statuses
- keep run identities, diagnostics, and stale terminal activity out of renderer copy

## Verification
- `pnpm test` (81 tests)
- `pnpm build`
- `git diff --check`