### PR TITLE
Add durable sandbox admission ownership

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -365,6 +365,27 @@ pub mod agent_run {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod sandbox_agent_admission {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "sandbox_agent_admission")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub child_run_id: Uuid,
+        pub parent_run_id: Uuid,
+        pub origin_turn_id: Uuid,
+        pub chat_id: Uuid,
+        pub spawn_call_id: Uuid,
+        pub admitted_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod agent_run_claim {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -344,6 +344,19 @@ async fn create_agent_run_table(manager: &SchemaManager<'_>) -> Result<(), DbErr
     manager
         .create_index(
             Index::create()
+                .name("idx_agent_run_admission_identity")
+                .table(AgentRun::Table)
+                .col(AgentRun::Id)
+                .col(AgentRun::ParentId)
+                .col(AgentRun::ChatId)
+                .col(AgentRun::SpawnCallId)
+                .unique()
+                .to_owned(),
+        )
+        .await?;
+    manager
+        .create_index(
+            Index::create()
                 .name("idx_agent_run_spawn_call")
                 .table(AgentRun::Table)
                 .col(AgentRun::SpawnCallId)
@@ -1052,7 +1065,6 @@ impl MigrationTrait for Init {
                     .to_owned(),
             )
             .await?;
-
         manager
             .create_table(
                 Table::create()
@@ -1598,6 +1610,98 @@ impl MigrationTrait for Init {
                     .to_owned(),
             )
             .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_turn_run_admission_owner")
+                    .table(TurnRun::Table)
+                    .col(TurnRun::Id)
+                    .col(TurnRun::ChatId)
+                    .col(TurnRun::AgentRunId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(SandboxAgentAdmission::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(SandboxAgentAdmission::ChildRunId)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(SandboxAgentAdmission::ParentRunId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SandboxAgentAdmission::OriginTurnId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SandboxAgentAdmission::ChatId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(SandboxAgentAdmission::SpawnCallId)
+                            .uuid()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(
+                        ColumnDef::new(SandboxAgentAdmission::AdmittedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_sandbox_agent_admission_child")
+                            .from_tbl(SandboxAgentAdmission::Table)
+                            .from_col(SandboxAgentAdmission::ChildRunId)
+                            .from_col(SandboxAgentAdmission::ParentRunId)
+                            .from_col(SandboxAgentAdmission::ChatId)
+                            .from_col(SandboxAgentAdmission::SpawnCallId)
+                            .to_tbl(AgentRun::Table)
+                            .to_col(AgentRun::Id)
+                            .to_col(AgentRun::ParentId)
+                            .to_col(AgentRun::ChatId)
+                            .to_col(AgentRun::SpawnCallId)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_sandbox_agent_admission_origin_turn")
+                            .from_tbl(SandboxAgentAdmission::Table)
+                            .from_col(SandboxAgentAdmission::OriginTurnId)
+                            .from_col(SandboxAgentAdmission::ChatId)
+                            .from_col(SandboxAgentAdmission::ParentRunId)
+                            .to_tbl(TurnRun::Table)
+                            .to_col(TurnRun::Id)
+                            .to_col(TurnRun::ChatId)
+                            .to_col(TurnRun::AgentRunId)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_sandbox_agent_admission_outstanding")
+                    .table(SandboxAgentAdmission::Table)
+                    .col(SandboxAgentAdmission::OriginTurnId)
+                    .col(SandboxAgentAdmission::AdmittedAt)
+                    .col(SandboxAgentAdmission::ChildRunId)
+                    .to_owned(),
+            )
+            .await?;
 
         manager
             .create_table(
@@ -2035,6 +2139,9 @@ impl MigrationTrait for Init {
             .await?;
         manager
             .drop_table(Table::drop().table(TurnAgentRunWait::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(SandboxAgentAdmission::Table).to_owned())
             .await?;
         manager
             .drop_table(Table::drop().table(TurnRun::Table).to_owned())
@@ -4250,6 +4357,17 @@ enum AgentRun {
     LastErrorDetail,
     CreatedAt,
     UpdatedAt,
+}
+
+#[derive(DeriveIden)]
+enum SandboxAgentAdmission {
+    Table,
+    ChildRunId,
+    ParentRunId,
+    OriginTurnId,
+    ChatId,
+    SpawnCallId,
+    AdmittedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -41,12 +41,13 @@ use crate::model::{
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
     AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, AcceptToolCallOutcome,
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, BeginRootAttachmentChangeOutcome,
-    ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome, ClaimSandboxToolCallOutcome,
-    ClaimTurnRunOutcome, CompleteTurnRunOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
-    ConsumeAgentRunInboxOutcome, DecideToolApprovalOutcome, DeleteChatOutcome,
-    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
-    FailAgentRunOutcome, FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, AdmitSandboxAgentRunOutcome,
+    BeginRootAttachmentChangeOutcome, ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome,
+    ClaimSandboxToolCallOutcome, ClaimTurnRunOutcome, CompleteTurnRunOutcome,
+    ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
+    DecideToolApprovalOutcome, DeleteChatOutcome, DocumentIndexJobReason,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FailAgentRunOutcome,
+    FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
     JournaledToolApprovalOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
     ParkSandboxToolCallOutcome, ParkTurnForAgentRunInboxOutcome, ParkTurnForClientCallOutcome,
@@ -1774,6 +1775,37 @@ impl Store for DbStore {
             input,
         )
         .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn admit_sandbox_agent_run(
+        &self,
+        origin_turn_id: TurnId,
+        spawn_call_id: CallId,
+        input: &str,
+        lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
+        max_outstanding_children: u32,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
+        ops::agent_run::admit_sandbox_agent_run(
+            self,
+            origin_turn_id,
+            spawn_call_id,
+            input,
+            lease_token,
+            expected_steer_revision,
+            max_outstanding_children,
+            now,
+        )
+        .await
+    }
+
+    async fn get_sandbox_agent_admission(
+        &self,
+        child_run_id: AgentRunId,
+    ) -> Result<Option<crate::model::SandboxAgentAdmission>> {
+        ops::agent_run::get_sandbox_agent_admission(self, child_run_id).await
     }
 
     #[allow(clippy::too_many_arguments)] // Mirrors the Store checkpoint contract.

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1,20 +1,22 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, DatabaseBackend, EntityTrait, QueryFilter,
-    QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, Condition, DatabaseBackend, EntityTrait, PaginatorTrait,
+    QueryFilter, QueryOrder, QuerySelect, QueryTrait, Set, Statement, TransactionTrait,
 };
 
 use crate::error::{AgentError, Result};
 use crate::id::{AgentRunId, CallId, ChatId, MessageId, TurnId};
 use crate::model::{
     AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunInboxStatus, AgentRunResult,
-    AgentRunResultPayload, AgentRunStatus, TurnRun,
+    AgentRunResultPayload, AgentRunStatus, SandboxAgentAdmission, TurnRun, TurnRunStatus,
+    TurnSteerStatus,
 };
 use crate::storage::{
-    AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, ClaimAgentRunInboxOutcome,
-    ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome, FailAgentRunOutcome,
-    FinishAgentRunCancellationOutcome, ParkTurnForAgentRunInboxOutcome,
-    RequestAgentRunCancellationOutcome, SubmitAgentRunResultOutcome,
+    AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, AdmitSandboxAgentRunOutcome,
+    ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
+    ConsumeAgentRunInboxOutcome, FailAgentRunOutcome, FinishAgentRunCancellationOutcome,
+    ParkTurnForAgentRunInboxOutcome, RequestAgentRunCancellationOutcome,
+    SubmitAgentRunResultOutcome,
 };
 use crate::{RequestFolderAccessArgs, RequestedFolderHint};
 
@@ -92,6 +94,11 @@ pub(in crate::db) async fn accept_agent_run(
     execution: AgentRunExecution,
     input: Option<&str>,
 ) -> Result<AcceptAgentRunOutcome> {
+    if execution == AgentRunExecution::Sandbox {
+        return Err(AgentError::Store(
+            "sandbox agent runs require exact turn-bound admission".into(),
+        ));
+    }
     validate_request(id, parent_id, spawn_call_id, execution, input)?;
 
     let transaction = store.conn.begin().await.map_err(store_err)?;
@@ -236,116 +243,161 @@ pub(in crate::db) async fn accept_agent_run(
     Ok(AcceptAgentRunOutcome::Accepted(run))
 }
 
-/// Accept one sandbox child and park its exact foreground turn in the same
-/// transaction. The sandbox parent comes from the locked turn, which binds
-/// child hierarchy and checkpoint scope without trusting a caller-supplied
-/// parent id.
-#[allow(clippy::too_many_arguments)] // Atomic checkpoint inputs form the durable receipt identity.
-pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
+#[allow(clippy::too_many_arguments)]
+pub(in crate::db) async fn admit_sandbox_agent_run(
     store: &DbStore,
-    child_run_id: AgentRunId,
-    turn_id: TurnId,
+    origin_turn_id: TurnId,
     spawn_call_id: CallId,
     input: &str,
     lease_token: uuid::Uuid,
     expected_steer_revision: i64,
-    progress: crate::TurnCheckpointProgress,
+    max_outstanding_children: u32,
     now: chrono::DateTime<Utc>,
-) -> Result<Option<AcceptSandboxAgentRunAndParkTurnOutcome>> {
-    validate_agent_run_inbox_park_request(turn_id, child_run_id, lease_token, progress)?;
-    let now = canonical_db_timestamp(now)?;
-    let Some(scope) = entities::turn_run::Entity::find_by_id(turn_id.0)
+) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
+    validate_admission_request(
+        origin_turn_id,
+        spawn_call_id,
+        input,
+        lease_token,
+        max_outstanding_children,
+    )?;
+    // Validate the caller timestamp at the boundary, but never use a value
+    // captured before lock acquisition to fence a live lease.
+    canonical_db_timestamp(now)?;
+    let Some(scope) = entities::turn_run::Entity::find_by_id(origin_turn_id.0)
         .one(&store.conn)
         .await
         .map_err(store_err)?
     else {
         return Ok(None);
     };
-
     let transaction = store.conn.begin().await.map_err(store_err)?;
     if !acquire_chat_write_lock(&transaction, ChatId(scope.chat_id)).await?
-        || !acquire_turn_write_lock(&transaction, turn_id).await?
+        || !acquire_turn_write_lock(&transaction, origin_turn_id).await?
     {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
-    let turn = entities::turn_run::Entity::find_by_id(turn_id.0)
+    let turn = entities::turn_run::Entity::find_by_id(origin_turn_id.0)
         .one(&transaction)
         .await
         .map_err(store_err)?
         .expect("locked turn exists");
+    let now = database_now(&transaction).await?;
+    let outcome = admit_sandbox_agent_run_on(
+        &transaction,
+        &turn,
+        spawn_call_id,
+        input,
+        lease_token,
+        expected_steer_revision,
+        max_outstanding_children,
+        now,
+    )
+    .await;
+    match outcome {
+        Ok(outcome) => {
+            transaction.commit().await.map_err(store_err)?;
+            Ok(Some(outcome))
+        }
+        Err(error) => {
+            // PostgreSQL aborts the transaction after a unique-key race. Roll
+            // it back before resolving the immutable identity on a fresh
+            // connection; this also covers an ambiguous insert result.
+            transaction.rollback().await.map_err(store_err)?;
+            if let Some(outcome) = resolve_existing_sandbox_admission_on(
+                &store.conn,
+                origin_turn_id,
+                ChatId(turn.chat_id),
+                AgentRunId(turn.agent_run_id),
+                spawn_call_id,
+                input,
+            )
+            .await?
+            {
+                Ok(Some(outcome))
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+
+pub(in crate::db) async fn get_sandbox_agent_admission(
+    store: &DbStore,
+    child_run_id: AgentRunId,
+) -> Result<Option<SandboxAgentAdmission>> {
+    entities::sandbox_agent_admission::Entity::find_by_id(child_run_id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(sandbox_agent_admission_from_model)
+        .transpose()
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn admit_sandbox_agent_run_on<C>(
+    conn: &C,
+    turn: &entities::turn_run::Model,
+    spawn_call_id: CallId,
+    input: &str,
+    lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
+    max_outstanding_children: u32,
+    now: chrono::DateTime<Utc>,
+) -> Result<AdmitSandboxAgentRunOutcome>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let origin_turn_id = TurnId(turn.id);
     let chat_id = ChatId(turn.chat_id);
     let parent_id = AgentRunId(turn.agent_run_id);
-    validate_request(
-        child_run_id,
-        Some(parent_id),
-        Some(spawn_call_id),
-        AgentRunExecution::Sandbox,
-        Some(input),
-    )?;
+    let child_run_id = AgentRunId::sandbox_for_spawn_call(spawn_call_id);
 
-    let existing = match find_by_id_on(&transaction, child_run_id).await? {
-        Some(existing) => Some(existing),
-        None => find_by_spawn_call_on(&transaction, spawn_call_id).await?,
-    };
-    if let Some(existing) = existing {
-        let canonical_child_run_id = AgentRunId(existing.id);
-        let exact = matches!(
-            existing_request_outcome(
-                existing.clone(),
-                chat_id,
-                Some(parent_id),
-                Some(spawn_call_id),
-                AgentRunExecution::Sandbox,
-                Some(input),
-            )?,
-            AcceptAgentRunOutcome::Existing(_)
-        );
-        if !exact {
-            transaction.commit().await.map_err(store_err)?;
-            return Ok(Some(
-                AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
-            ));
-        }
-        // A child accepted outside this operation must never be retrofitted
-        // into a foreground checkpoint. A committed checkpoint is the only
-        // durable proof that this is an exact retry of the combined action.
-        let atomic_wait =
-            entities::turn_agent_run_wait::Entity::find_by_id(canonical_child_run_id.0)
-                .one(&transaction)
-                .await
-                .map_err(store_err)?;
-        if !atomic_wait.is_some_and(|wait| wait.atomic_admission) {
-            transaction.commit().await.map_err(store_err)?;
-            return Ok(Some(
-                AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
-            ));
-        }
-        let outcome = park_turn_for_agent_run_inbox_on(
-            &transaction,
-            turn_id,
-            canonical_child_run_id,
-            lease_token,
-            expected_steer_revision,
-            progress,
-            now,
-            true,
-        )
-        .await?;
-        transaction.commit().await.map_err(store_err)?;
-        return Ok(Some(match outcome {
-            Some(ParkTurnForAgentRunInboxOutcome::Existing { turn, wait }) => {
-                AcceptSandboxAgentRunAndParkTurnOutcome::Existing {
-                    child: agent_run_from_model(existing)?,
-                    turn,
-                    wait,
-                }
-            }
-            _ => AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
-        }));
+    if let Some(outcome) = resolve_existing_sandbox_admission_on(
+        conn,
+        origin_turn_id,
+        chat_id,
+        parent_id,
+        spawn_call_id,
+        input,
+    )
+    .await?
+    {
+        return Ok(outcome);
     }
 
-    let parent = find_by_id_on(&transaction, parent_id).await?;
+    if find_by_id_on(conn, child_run_id).await?.is_some()
+        || find_by_spawn_call_on(conn, spawn_call_id).await?.is_some()
+    {
+        return Ok(AdmitSandboxAgentRunOutcome::IdentityConflict);
+    }
+
+    if turn.status != TurnRunStatus::Running.as_str()
+        || turn.lease_token != Some(lease_token)
+        || turn
+            .lease_expires_at
+            .is_none_or(|lease_expires_at| lease_expires_at <= now)
+        || turn.updated_at > now
+    {
+        return Ok(AdmitSandboxAgentRunOutcome::LeaseLost);
+    }
+    let steer_pending = entities::turn_steer::Entity::find()
+        .filter(entities::turn_steer::Column::TurnId.eq(origin_turn_id.0))
+        .filter(entities::turn_steer::Column::Status.eq(TurnSteerStatus::Pending.as_str()))
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .is_some();
+    if steer_pending || turn.steer_revision != expected_steer_revision {
+        let turn = super::turn::turn_run_from_model(turn.clone())?;
+        return Ok(if steer_pending {
+            AdmitSandboxAgentRunOutcome::SteerPending(turn)
+        } else {
+            AdmitSandboxAgentRunOutcome::OutputSuperseded(turn)
+        });
+    }
+    let parent = find_by_id_on(conn, parent_id).await?;
     let parent_available = parent.is_some_and(|parent| {
         parent.chat_id == chat_id.0
             && parent.parent_id.is_none()
@@ -354,14 +406,36 @@ pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
             && parent.status == AgentRunStatus::Active.as_str()
     });
     if !parent_available {
-        transaction.commit().await.map_err(store_err)?;
-        return Ok(Some(
-            AcceptSandboxAgentRunAndParkTurnOutcome::ParentUnavailable,
-        ));
+        return Ok(AdmitSandboxAgentRunOutcome::ParentUnavailable);
     }
 
-    let created_at = database_now(&transaction).await?;
-    let model = entities::agent_run::ActiveModel {
+    let outstanding = entities::agent_run::Entity::find()
+        .filter(
+            entities::agent_run::Column::Id.in_subquery(
+                entities::sandbox_agent_admission::Entity::find()
+                    .select_only()
+                    .column(entities::sandbox_agent_admission::Column::ChildRunId)
+                    .filter(
+                        entities::sandbox_agent_admission::Column::OriginTurnId
+                            .eq(origin_turn_id.0),
+                    )
+                    .into_query(),
+            ),
+        )
+        .filter(entities::agent_run::Column::Status.is_not_in([
+            AgentRunStatus::Completed.as_str(),
+            AgentRunStatus::Failed.as_str(),
+            AgentRunStatus::Cancelled.as_str(),
+        ]))
+        .count(conn)
+        .await
+        .map_err(store_err)?;
+    if outstanding >= u64::from(max_outstanding_children) {
+        return Ok(AdmitSandboxAgentRunOutcome::AtCapacity);
+    }
+
+    let created_at = database_now(conn).await?;
+    let child = entities::agent_run::ActiveModel {
         id: Set(child_run_id.0),
         chat_id: Set(chat_id.0),
         parent_id: Set(Some(parent_id.0)),
@@ -385,10 +459,210 @@ pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
         created_at: Set(created_at),
         updated_at: Set(created_at),
     }
-    .insert(&transaction)
+    .insert(conn)
     .await
     .map_err(store_err)?;
-    let child = agent_run_from_model(model)?;
+    let admission = entities::sandbox_agent_admission::ActiveModel {
+        child_run_id: Set(child_run_id.0),
+        parent_run_id: Set(parent_id.0),
+        origin_turn_id: Set(origin_turn_id.0),
+        chat_id: Set(chat_id.0),
+        spawn_call_id: Set(spawn_call_id.0),
+        admitted_at: Set(created_at),
+    }
+    .insert(conn)
+    .await
+    .map_err(store_err)?;
+    Ok(AdmitSandboxAgentRunOutcome::Accepted {
+        child: agent_run_from_model(child)?,
+        admission: sandbox_agent_admission_from_model(admission)?,
+    })
+}
+
+async fn resolve_existing_sandbox_admission_on<C>(
+    conn: &C,
+    origin_turn_id: TurnId,
+    chat_id: ChatId,
+    parent_id: AgentRunId,
+    spawn_call_id: CallId,
+    input: &str,
+) -> Result<Option<AdmitSandboxAgentRunOutcome>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let child_run_id = AgentRunId::sandbox_for_spawn_call(spawn_call_id);
+    let existing_admission = entities::sandbox_agent_admission::Entity::find()
+        .filter(
+            Condition::any()
+                .add(entities::sandbox_agent_admission::Column::ChildRunId.eq(child_run_id.0))
+                .add(entities::sandbox_agent_admission::Column::SpawnCallId.eq(spawn_call_id.0)),
+        )
+        .one(conn)
+        .await
+        .map_err(store_err)?;
+    if let Some(admission) = existing_admission {
+        let child = find_by_id_on(conn, AgentRunId(admission.child_run_id)).await?;
+        let exact = admission.child_run_id == child_run_id.0
+            && admission.parent_run_id == parent_id.0
+            && admission.origin_turn_id == origin_turn_id.0
+            && admission.chat_id == chat_id.0
+            && admission.spawn_call_id == spawn_call_id.0
+            && child.as_ref().is_some_and(|child| {
+                child.chat_id == chat_id.0
+                    && child.parent_id == Some(parent_id.0)
+                    && child.spawn_call_id == Some(spawn_call_id.0)
+                    && child.execution == AgentRunExecution::Sandbox.as_str()
+                    && child.input.as_deref() == Some(input)
+            });
+        return Ok(Some(if exact {
+            AdmitSandboxAgentRunOutcome::Existing {
+                child: agent_run_from_model(child.expect("exact admission has child"))?,
+                admission: sandbox_agent_admission_from_model(admission)?,
+            }
+        } else {
+            AdmitSandboxAgentRunOutcome::IdentityConflict
+        }));
+    }
+    Ok(None)
+}
+
+/// Accept one sandbox child and park its exact foreground turn in the same
+/// transaction. The sandbox parent comes from the locked turn, which binds
+/// child hierarchy and checkpoint scope without trusting a caller-supplied
+/// parent id.
+#[allow(clippy::too_many_arguments)] // Atomic checkpoint inputs form the durable receipt identity.
+pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
+    store: &DbStore,
+    child_run_id: AgentRunId,
+    turn_id: TurnId,
+    spawn_call_id: CallId,
+    input: &str,
+    lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
+    progress: crate::TurnCheckpointProgress,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<AcceptSandboxAgentRunAndParkTurnOutcome>> {
+    validate_agent_run_inbox_park_request(turn_id, child_run_id, lease_token, progress)?;
+    // Validate the API value, then take authoritative time after acquiring the
+    // same locks that protect the lease transition.
+    canonical_db_timestamp(now)?;
+    let Some(scope) = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(None);
+    };
+
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, ChatId(scope.chat_id)).await?
+        || !acquire_turn_write_lock(&transaction, turn_id).await?
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let turn = entities::turn_run::Entity::find_by_id(turn_id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .expect("locked turn exists");
+    let now = database_now(&transaction).await?;
+    if child_run_id != AgentRunId::sandbox_for_spawn_call(spawn_call_id) {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(
+            AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
+        ));
+    }
+    validate_admission_request(
+        turn_id,
+        spawn_call_id,
+        input,
+        lease_token,
+        AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
+    )?;
+    let admission_outcome = admit_sandbox_agent_run_on(
+        &transaction,
+        &turn,
+        spawn_call_id,
+        input,
+        lease_token,
+        expected_steer_revision,
+        AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
+        now,
+    )
+    .await;
+    let admission_outcome = match admission_outcome {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            let chat_id = ChatId(turn.chat_id);
+            let parent_id = AgentRunId(turn.agent_run_id);
+            transaction.rollback().await.map_err(store_err)?;
+            if resolve_existing_sandbox_admission_on(
+                &store.conn,
+                turn_id,
+                chat_id,
+                parent_id,
+                spawn_call_id,
+                input,
+            )
+            .await?
+            .is_some()
+            {
+                return Ok(Some(
+                    AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
+                ));
+            }
+            return Err(error);
+        }
+    };
+    let (child, existing) = match admission_outcome {
+        AdmitSandboxAgentRunOutcome::Accepted { child, .. } => (child, false),
+        AdmitSandboxAgentRunOutcome::Existing { child, .. } => {
+            let atomic_wait = entities::turn_agent_run_wait::Entity::find_by_id(child.id.0)
+                .one(&transaction)
+                .await
+                .map_err(store_err)?;
+            if !atomic_wait.is_some_and(|wait| wait.atomic_admission) {
+                transaction.commit().await.map_err(store_err)?;
+                return Ok(Some(
+                    AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
+                ));
+            }
+            (child, true)
+        }
+        AdmitSandboxAgentRunOutcome::IdentityConflict => {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(
+                AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
+            ));
+        }
+        AdmitSandboxAgentRunOutcome::ParentUnavailable => {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(
+                AcceptSandboxAgentRunAndParkTurnOutcome::ParentUnavailable,
+            ));
+        }
+        AdmitSandboxAgentRunOutcome::LeaseLost => {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(None);
+        }
+        AdmitSandboxAgentRunOutcome::AtCapacity => {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::AtCapacity));
+        }
+        AdmitSandboxAgentRunOutcome::SteerPending(turn) => {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::SteerPending(
+                turn,
+            )));
+        }
+        AdmitSandboxAgentRunOutcome::OutputSuperseded(turn) => {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(
+                AcceptSandboxAgentRunAndParkTurnOutcome::OutputSuperseded(turn),
+            ));
+        }
+    };
 
     let outcome = park_turn_for_agent_run_inbox_on(
         &transaction,
@@ -408,6 +682,9 @@ pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
     let outcome = match outcome {
         ParkTurnForAgentRunInboxOutcome::Parked { turn, wait } => {
             AcceptSandboxAgentRunAndParkTurnOutcome::Parked { child, turn, wait }
+        }
+        ParkTurnForAgentRunInboxOutcome::Existing { turn, wait } if existing => {
+            AcceptSandboxAgentRunAndParkTurnOutcome::Existing { child, turn, wait }
         }
         ParkTurnForAgentRunInboxOutcome::SteerPending(turn) => {
             transaction.rollback().await.map_err(store_err)?;
@@ -476,10 +753,16 @@ pub(in crate::db) async fn claim_agent_run(
                 transaction.commit().await.map_err(store_err)?;
                 return Ok(None);
             };
+            let admitted = entities::sandbox_agent_admission::Entity::find_by_id(agent_run_id)
+                .one(&transaction)
+                .await
+                .map_err(store_err)?
+                .is_some();
             let existing = find_by_id_on(&transaction, AgentRunId(agent_run_id))
                 .await?
                 .filter(|run| {
-                    run.execution == AgentRunExecution::Sandbox.as_str()
+                    admitted
+                        && run.execution == AgentRunExecution::Sandbox.as_str()
                         && matches!(run.status.as_str(), "running" | "cancelling")
                         && Some(run.attempt_count) == receipt.attempt_count
                         && Some(run.claim_count) == receipt.claim_count
@@ -538,6 +821,7 @@ pub(in crate::db) async fn claim_agent_run(
 
         let live = entities::agent_run::Entity::find()
             .filter(entities::agent_run::Column::Execution.eq(AgentRunExecution::Sandbox.as_str()))
+            .filter(entities::agent_run::Column::Id.in_subquery(admitted_child_id_subquery()))
             .filter(entities::agent_run::Column::Status.is_in([
                 AgentRunStatus::Running.as_str(),
                 AgentRunStatus::Cancelling.as_str(),
@@ -2003,10 +2287,13 @@ where
 {
     let backend = conn.get_database_backend();
     // PostgreSQL's CURRENT_TIMESTAMP is fixed at transaction start. Claimers
-    // can wait on the scheduler lock, so use its statement-time clock there;
-    // SQLite's CURRENT_TIMESTAMP already has the desired statement semantics.
+    // can wait on a lock, so use statement-time clocks. SQLite's bare
+    // CURRENT_TIMESTAMP loses fractional seconds; use the end of its current
+    // clock millisecond so application-authored microsecond timestamps from
+    // that same millisecond never appear to come from the future.
     let clock_sql = match backend {
         DatabaseBackend::Postgres => "SELECT clock_timestamp() AS now",
+        DatabaseBackend::Sqlite => "SELECT (strftime('%Y-%m-%dT%H:%M:%f', 'now') || '999Z') AS now",
         _ => "SELECT CURRENT_TIMESTAMP AS now",
     };
     let statement = Statement::from_string(backend, clock_sql);
@@ -2051,6 +2338,7 @@ where
 {
     entities::agent_run::Entity::find()
         .filter(entities::agent_run::Column::Execution.eq(AgentRunExecution::Sandbox.as_str()))
+        .filter(entities::agent_run::Column::Id.in_subquery(admitted_child_id_subquery()))
         .filter(entities::agent_run::Column::Status.is_in([
             AgentRunStatus::Queued.as_str(),
             AgentRunStatus::Running.as_str(),
@@ -2082,6 +2370,7 @@ where
     loop {
         let page = entities::agent_run::Entity::find()
             .filter(entities::agent_run::Column::Execution.eq(AgentRunExecution::Sandbox.as_str()))
+            .filter(entities::agent_run::Column::Id.in_subquery(admitted_child_id_subquery()))
             .filter(
                 sea_orm::Condition::any()
                     .add(
@@ -2137,6 +2426,7 @@ where
 {
     entities::agent_run::Entity::find()
         .filter(entities::agent_run::Column::Execution.eq(AgentRunExecution::Sandbox.as_str()))
+        .filter(entities::agent_run::Column::Id.in_subquery(admitted_child_id_subquery()))
         .filter(
             sea_orm::Condition::any()
                 .add(entities::agent_run::Column::Status.eq(AgentRunStatus::Cancelling.as_str()))
@@ -2164,6 +2454,13 @@ where
         .one(conn)
         .await
         .map_err(store_err)
+}
+
+fn admitted_child_id_subquery() -> sea_orm::sea_query::SelectStatement {
+    sea_orm::sea_query::Query::select()
+        .column(entities::sandbox_agent_admission::Column::ChildRunId)
+        .from(entities::sandbox_agent_admission::Entity)
+        .to_owned()
 }
 
 async fn fail_candidate_on<C>(
@@ -2421,6 +2718,34 @@ fn validate_request(
     }
 }
 
+fn validate_admission_request(
+    origin_turn_id: TurnId,
+    spawn_call_id: CallId,
+    input: &str,
+    lease_token: uuid::Uuid,
+    max_outstanding_children: u32,
+) -> Result<()> {
+    if origin_turn_id.0.is_nil() || spawn_call_id.0.is_nil() || lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "sandbox admission identities must not be nil".into(),
+        ));
+    }
+    if max_outstanding_children == 0 || max_outstanding_children > AgentRun::MAX_CONCURRENCY_LIMIT {
+        return Err(AgentError::Store(format!(
+            "sandbox outstanding-child limit must be in 1..={}",
+            AgentRun::MAX_CONCURRENCY_LIMIT
+        )));
+    }
+    let input_len = input.chars().count();
+    if input_len == 0 || input_len > AgentRun::MAX_INPUT_LEN {
+        return Err(AgentError::Store(format!(
+            "sandbox agent-run task must contain 1..={} characters",
+            AgentRun::MAX_INPUT_LEN
+        )));
+    }
+    Ok(())
+}
+
 pub(in crate::db) fn agent_run_from_model(model: entities::agent_run::Model) -> Result<AgentRun> {
     let execution = match model.execution.as_str() {
         "foreground" => AgentRunExecution::Foreground,
@@ -2457,6 +2782,29 @@ pub(in crate::db) fn agent_run_from_model(model: entities::agent_run::Model) -> 
         created_at: model.created_at,
         updated_at: model.updated_at,
     })
+}
+
+fn sandbox_agent_admission_from_model(
+    model: entities::sandbox_agent_admission::Model,
+) -> Result<SandboxAgentAdmission> {
+    let admission = SandboxAgentAdmission {
+        child_run_id: AgentRunId(model.child_run_id),
+        parent_run_id: AgentRunId(model.parent_run_id),
+        origin_turn_id: TurnId(model.origin_turn_id),
+        chat_id: ChatId(model.chat_id),
+        spawn_call_id: CallId(model.spawn_call_id),
+        admitted_at: model.admitted_at,
+    };
+    if admission.child_run_id != AgentRunId::sandbox_for_spawn_call(admission.spawn_call_id)
+        || admission.parent_run_id.0.is_nil()
+        || admission.origin_turn_id.0.is_nil()
+        || admission.chat_id.0.is_nil()
+    {
+        return Err(AgentError::Store(
+            "invalid stored sandbox agent admission".into(),
+        ));
+    }
+    Ok(admission)
 }
 
 fn agent_run_status_from_db(value: &str) -> Result<AgentRunStatus> {

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -878,7 +878,7 @@ where
     })
 }
 
-fn turn_run_from_model(model: entities::turn_run::Model) -> Result<TurnRun> {
+pub(in crate::db) fn turn_run_from_model(model: entities::turn_run::Model) -> Result<TurnRun> {
     let usage = usage_from_turn_model(&model)?;
     Ok(TurnRun {
         id: TurnId(model.id),

--- a/crates/openwave-core/src/db/ops/turn/agent_run_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/agent_run_wait.rs
@@ -12,6 +12,7 @@ use crate::storage::ParkTurnForAgentRunInboxOutcome;
 use crate::{AgentRunId, TurnId, TurnRun};
 
 use super::super::super::{entities, store_err, DbStore};
+use super::super::agent_run::database_now;
 use super::super::{acquire_chat_write_lock, acquire_turn_write_lock};
 use super::{canonical_db_timestamp, turn_run_from_model};
 
@@ -25,7 +26,7 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<ParkTurnForAgentRunInboxOutcome>> {
     validate_agent_run_inbox_park_request(turn_id, child_run_id, lease_token, progress)?;
-    let now = canonical_db_timestamp(now)?;
+    canonical_db_timestamp(now)?;
     let Some(scope) = entities::turn_run::Entity::find_by_id(turn_id.0)
         .one(&store.conn)
         .await
@@ -40,6 +41,7 @@ pub(in crate::db) async fn park_turn_for_agent_run_inbox(
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }
+    let now = database_now(&transaction).await?;
 
     let outcome = park_turn_for_agent_run_inbox_on(
         &transaction,
@@ -86,7 +88,18 @@ where
                     "agent-run checkpoint for child {child_run_id} is missing its turn"
                 ))
             })?;
-        let exact = wait.turn_id == turn_id.0
+        let admission = entities::sandbox_agent_admission::Entity::find_by_id(child_run_id.0)
+            .one(conn)
+            .await
+            .map_err(store_err)?;
+        let exact_admission = admission.is_some_and(|admission| {
+            admission.child_run_id == child_run_id.0
+                && admission.origin_turn_id == turn_id.0
+                && admission.parent_run_id == turn.agent_run_id
+                && admission.chat_id == turn.chat_id
+        });
+        let exact = exact_admission
+            && wait.turn_id == turn_id.0
             && wait.parent_run_id == turn.agent_run_id
             && wait.chat_id == turn.chat_id
             && wait.park_lease_token == lease_token
@@ -136,8 +149,17 @@ where
         .one(conn)
         .await
         .map_err(store_err)?;
-    let valid_child = child.is_some_and(|child| {
-        child.chat_id == turn.chat_id
+    let admission = entities::sandbox_agent_admission::Entity::find_by_id(child_run_id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?;
+    let valid_child = child.zip(admission).is_some_and(|(child, admission)| {
+        admission.child_run_id == child.id
+            && admission.origin_turn_id == turn_id.0
+            && admission.parent_run_id == turn.agent_run_id
+            && admission.chat_id == turn.chat_id
+            && child.spawn_call_id == Some(admission.spawn_call_id)
+            && child.chat_id == turn.chat_id
             && child.parent_id == Some(turn.agent_run_id)
             && child.depth == 1
             && child.execution == AgentRunExecution::Sandbox.as_str()
@@ -148,7 +170,7 @@ where
             )
     });
     if !valid_child {
-        return Ok(None);
+        return Ok(Some(ParkTurnForAgentRunInboxOutcome::IdentityConflict));
     }
     let totals = checked_checkpoint_totals(&turn, progress)?;
     let wait = entities::turn_agent_run_wait::ActiveModel {

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -14,21 +14,76 @@ use chrono::{Duration, Utc};
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 
 async fn accepted_sandbox_for_tool_test(store: &DbStore, chat_id: ChatId) -> AgentRun {
-    match store
-        .accept_agent_run(
-            AgentRunId::new(),
+    admit_sandbox_for_test(store, chat_id, "Use the durable sandbox tool checkpoint").await
+}
+
+async fn live_turn_for_sandbox_test(
+    store: &DbStore,
+    chat_id: ChatId,
+) -> (crate::TurnRun, uuid::Uuid) {
+    if let Some(turn) = store
+        .list_turn_runs(chat_id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|turn| turn.status == TurnRunStatus::Running)
+    {
+        return (
+            turn.clone(),
+            turn.lease_token.expect("running turn has lease"),
+        );
+    }
+    let turn_id = TurnId::new();
+    store
+        .accept_turn(
+            turn_id,
             chat_id,
-            Some(AgentRunId::foreground_for_chat(chat_id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("Use the durable sandbox tool checkpoint"),
+            "sandbox-test-model",
+            "sandbox test admission",
+        )
+        .await
+        .unwrap();
+    let lease = uuid::Uuid::new_v4();
+    let now = Utc::now();
+    let turn = store
+        .claim_turn_run(lease, now, now + Duration::hours(1))
+        .await
+        .unwrap()
+        .turn
+        .expect("sandbox test turn should claim");
+    assert_eq!(turn.id, turn_id);
+    (turn, lease)
+}
+
+async fn admit_sandbox_call_for_test(
+    store: &DbStore,
+    chat_id: ChatId,
+    call_id: CallId,
+    input: &str,
+) -> AgentRun {
+    let (turn, lease) = live_turn_for_sandbox_test(store, chat_id).await;
+    match store
+        .admit_sandbox_agent_run(
+            turn.id,
+            call_id,
+            input,
+            lease,
+            turn.steer_revision,
+            AgentRun::MAX_CONCURRENCY_LIMIT,
+            Utc::now(),
         )
         .await
         .unwrap()
+        .expect("sandbox test admission should resolve")
     {
-        AcceptAgentRunOutcome::Accepted(run) => run,
-        outcome => panic!("unexpected sandbox acceptance: {outcome:?}"),
+        crate::AdmitSandboxAgentRunOutcome::Accepted { child, .. }
+        | crate::AdmitSandboxAgentRunOutcome::Existing { child, .. } => child,
+        outcome => panic!("unexpected sandbox test admission: {outcome:?}"),
     }
+}
+
+async fn admit_sandbox_for_test(store: &DbStore, chat_id: ChatId, input: &str) -> AgentRun {
+    admit_sandbox_call_for_test(store, chat_id, CallId::new(), input).await
 }
 
 async fn force_expired_agent_lease(store: &DbStore, id: AgentRunId) {
@@ -76,18 +131,7 @@ async fn submit_sandbox_result(
     input: &str,
     text: &str,
 ) -> (AgentRunId, crate::AgentRunResult) {
-    let child_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            child_id,
-            chat_id,
-            Some(AgentRunId::foreground_for_chat(chat_id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some(input),
-        )
-        .await
-        .unwrap();
+    let child_id = admit_sandbox_for_test(store, chat_id, input).await.id;
     let lease_token = uuid::Uuid::new_v4();
     let claimed = store
         .claim_agent_run(lease_token, Duration::minutes(1), 1, 1)
@@ -112,23 +156,7 @@ async fn park_foreground_turn_on_child(
     chat_id: ChatId,
     child_run_id: AgentRunId,
 ) -> crate::TurnRun {
-    let queued = match store
-        .accept_turn(TurnId::new(), chat_id, "gpt-5", "wait for the child")
-        .await
-        .unwrap()
-    {
-        AcceptTurnOutcome::Accepted(turn) => turn,
-        outcome => panic!("unexpected turn acceptance: {outcome:?}"),
-    };
-    let lease_token = uuid::Uuid::new_v4();
-    let now = Utc::now();
-    let running = store
-        .claim_turn_run(lease_token, now, now + Duration::minutes(5))
-        .await
-        .unwrap()
-        .turn
-        .expect("foreground turn should claim");
-    assert_eq!(running.id, queued.id);
+    let (running, lease_token) = live_turn_for_sandbox_test(store, chat_id).await;
     let progress = TurnCheckpointProgress {
         model_steps: 1,
         usage: Usage {
@@ -178,8 +206,8 @@ async fn sandbox_spawn_and_foreground_checkpoint_commit_as_one_exact_transition(
         .turn
         .expect("foreground turn should claim");
     assert_eq!(running.id, queued.id);
-    let child_run_id = AgentRunId::new();
     let spawn_call_id = CallId::new();
+    let child_run_id = AgentRunId::sandbox_for_spawn_call(spawn_call_id);
     let progress = TurnCheckpointProgress {
         model_steps: 1,
         usage: Usage {
@@ -227,7 +255,7 @@ async fn sandbox_spawn_and_foreground_checkpoint_commit_as_one_exact_transition(
     assert!(matches!(
         store
             .accept_sandbox_agent_run_and_park_turn(
-                child_run_id,
+                AgentRunId::new(),
                 running.id,
                 spawn_call_id,
                 "research the question",
@@ -238,13 +266,20 @@ async fn sandbox_spawn_and_foreground_checkpoint_commit_as_one_exact_transition(
             )
             .await
             .unwrap(),
-        Some(AcceptSandboxAgentRunAndParkTurnOutcome::Existing { child, turn, wait })
-            if child == parked.0 && turn == parked.1 && wait == parked.2
+        Some(AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict)
     ));
+    let admission = store
+        .get_sandbox_agent_admission(child_run_id)
+        .await
+        .unwrap()
+        .expect("sandbox child should retain its exact origin ownership");
+    assert_eq!(admission.child_run_id, child_run_id);
+    assert_eq!(admission.origin_turn_id, running.id);
+    assert_eq!(admission.spawn_call_id, spawn_call_id);
     assert!(matches!(
         store
             .accept_sandbox_agent_run_and_park_turn(
-                AgentRunId::new(),
+                child_run_id,
                 running.id,
                 spawn_call_id,
                 "research the question",
@@ -292,12 +327,13 @@ async fn sandbox_spawn_checkpoint_rolls_back_when_foreground_lease_or_steer_is_s
         model_steps: 1,
         usage: Usage::default(),
     };
-    let stale_child_id = AgentRunId::new();
+    let stale_call_id = CallId::new();
+    let stale_child_id = AgentRunId::sandbox_for_spawn_call(stale_call_id);
     assert!(store
         .accept_sandbox_agent_run_and_park_turn(
             stale_child_id,
             running.id,
-            CallId::new(),
+            stale_call_id,
             "this child must roll back",
             uuid::Uuid::new_v4(),
             running.steer_revision,
@@ -309,13 +345,14 @@ async fn sandbox_spawn_checkpoint_rolls_back_when_foreground_lease_or_steer_is_s
         .is_none());
     assert!(store.get_agent_run(stale_child_id).await.unwrap().is_none());
 
-    let superseded_child_id = AgentRunId::new();
+    let superseded_call_id = CallId::new();
+    let superseded_child_id = AgentRunId::sandbox_for_spawn_call(superseded_call_id);
     assert!(matches!(
         store
             .accept_sandbox_agent_run_and_park_turn(
                 superseded_child_id,
                 running.id,
-                CallId::new(),
+                superseded_call_id,
                 "this child must not survive a stale model output",
                 lease_token,
                 running.steer_revision + 1,
@@ -366,19 +403,21 @@ async fn sandbox_spawn_checkpoint_never_retrofits_a_separately_accepted_child() 
         .turn
         .expect("foreground turn should claim");
     assert_eq!(running.id, queued.id);
-    let child_run_id = AgentRunId::new();
     let spawn_call_id = CallId::new();
+    let child_run_id = AgentRunId::sandbox_for_spawn_call(spawn_call_id);
     store
-        .accept_agent_run(
-            child_run_id,
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(spawn_call_id),
-            AgentRunExecution::Sandbox,
-            Some("accepted by an older boundary"),
+        .admit_sandbox_agent_run(
+            running.id,
+            spawn_call_id,
+            "accepted by an older boundary",
+            lease_token,
+            running.steer_revision,
+            AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
+            Utc::now(),
         )
         .await
-        .unwrap();
+        .unwrap()
+        .expect("standalone admission should resolve");
     let progress = TurnCheckpointProgress {
         model_steps: 1,
         usage: Usage::default(),
@@ -405,7 +444,7 @@ async fn sandbox_spawn_checkpoint_never_retrofits_a_separately_accepted_child() 
     assert!(matches!(
         store
             .accept_sandbox_agent_run_and_park_turn(
-                AgentRunId::new(),
+                child_run_id,
                 running.id,
                 spawn_call_id,
                 "accepted by an older boundary",
@@ -423,6 +462,336 @@ async fn sandbox_spawn_checkpoint_never_retrofits_a_separately_accepted_child() 
         Some(legacy_parked.0)
     );
     assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn sandbox_admission_is_exact_bounded_and_releases_terminal_capacity() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let first_call = CallId::new();
+    let first = store
+        .admit_sandbox_agent_run(
+            turn.id,
+            first_call,
+            "first bounded child",
+            lease,
+            turn.steer_revision,
+            1,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let first_child = match first {
+        crate::AdmitSandboxAgentRunOutcome::Accepted { child, admission } => {
+            assert_eq!(admission.origin_turn_id, turn.id);
+            assert_eq!(admission.parent_run_id, turn.agent_run_id);
+            assert_eq!(admission.spawn_call_id, first_call);
+            child
+        }
+        outcome => panic!("unexpected admission outcome: {outcome:?}"),
+    };
+    assert_eq!(
+        first_child.id,
+        AgentRunId::sandbox_for_spawn_call(first_call)
+    );
+    assert!(matches!(
+        store
+            .admit_sandbox_agent_run(
+                turn.id,
+                first_call,
+                "first bounded child",
+                lease,
+                turn.steer_revision,
+                1,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(crate::AdmitSandboxAgentRunOutcome::Existing { child, .. })
+            if child == first_child
+    ));
+
+    let second_call = CallId::new();
+    assert!(matches!(
+        store
+            .admit_sandbox_agent_run(
+                turn.id,
+                second_call,
+                "second bounded child",
+                lease,
+                turn.steer_revision,
+                1,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(crate::AdmitSandboxAgentRunOutcome::AtCapacity)
+    ));
+
+    let finished_at = Utc::now();
+    crate::db::entities::agent_run::Entity::update_many()
+        .col_expr(
+            crate::db::entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunStatus::Cancelled.as_str()),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::FinishedAt,
+            sea_orm::sea_query::Expr::value(Some(finished_at)),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(finished_at),
+        )
+        .filter(crate::db::entities::agent_run::Column::Id.eq(first_child.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert!(store
+        .get_sandbox_agent_admission(first_child.id)
+        .await
+        .unwrap()
+        .is_some());
+    assert!(matches!(
+        store
+            .admit_sandbox_agent_run(
+                turn.id,
+                second_call,
+                "second bounded child",
+                lease,
+                turn.steer_revision,
+                1,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(crate::AdmitSandboxAgentRunOutcome::Accepted { child, .. })
+            if child.id == AgentRunId::sandbox_for_spawn_call(second_call)
+    ));
+}
+
+#[tokio::test]
+async fn concurrent_sandbox_admission_never_oversubscribes_origin_turn() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let store = std::sync::Arc::new(store);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for index in 0..8 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .admit_sandbox_agent_run(
+                    turn.id,
+                    CallId::new(),
+                    &format!("concurrent child {index}"),
+                    lease,
+                    turn.steer_revision,
+                    2,
+                    Utc::now(),
+                )
+                .await
+                .unwrap()
+                .unwrap()
+        }));
+    }
+    let outcomes = futures::future::join_all(tasks).await;
+    let accepted = outcomes
+        .into_iter()
+        .map(Result::unwrap)
+        .filter(|outcome| matches!(outcome, crate::AdmitSandboxAgentRunOutcome::Accepted { .. }))
+        .count();
+    assert_eq!(accepted, 2);
+    assert_eq!(
+        store
+            .list_agent_runs(chat.id)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|run| run.execution == AgentRunExecution::Sandbox)
+            .count(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn concurrent_exact_sandbox_admission_converges_on_one_receipt() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let call = CallId::new();
+    let store = std::sync::Arc::new(store);
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let mut tasks = Vec::new();
+    for _ in 0..2 {
+        let store = store.clone();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .admit_sandbox_agent_run(
+                    turn.id,
+                    call,
+                    "the same concurrent child",
+                    lease,
+                    turn.steer_revision,
+                    2,
+                    Utc::now(),
+                )
+                .await
+                .unwrap()
+                .unwrap()
+        }));
+    }
+    let outcomes = futures::future::join_all(tasks).await;
+    let accepted = outcomes
+        .iter()
+        .filter(|outcome| {
+            matches!(
+                outcome.as_ref().unwrap(),
+                crate::AdmitSandboxAgentRunOutcome::Accepted { .. }
+            )
+        })
+        .count();
+    let existing = outcomes
+        .iter()
+        .filter(|outcome| {
+            matches!(
+                outcome.as_ref().unwrap(),
+                crate::AdmitSandboxAgentRunOutcome::Existing { .. }
+            )
+        })
+        .count();
+    assert_eq!((accepted, existing), (1, 1));
+    assert_eq!(
+        store
+            .list_agent_runs(chat.id)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|run| run.execution == AgentRunExecution::Sandbox)
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn sandbox_child_cannot_park_a_different_origin_turn() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (first_turn, first_lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let child = match store
+        .admit_sandbox_agent_run(
+            first_turn.id,
+            CallId::new(),
+            "owned by only the first turn",
+            first_lease,
+            first_turn.steer_revision,
+            2,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        crate::AdmitSandboxAgentRunOutcome::Accepted { child, .. } => child,
+        outcome => panic!("unexpected first admission: {outcome:?}"),
+    };
+    let cancelled_at = Utc::now();
+    store
+        .request_turn_cancellation(first_turn.id, cancelled_at)
+        .await
+        .unwrap();
+    store
+        .finish_turn_cancellation(first_turn.id, first_lease, Utc::now())
+        .await
+        .unwrap();
+
+    let (second_turn, second_lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    assert_ne!(second_turn.id, first_turn.id);
+    assert!(matches!(
+        store
+            .park_turn_for_agent_run_inbox(
+                second_turn.id,
+                child.id,
+                second_lease,
+                second_turn.steer_revision,
+                TurnCheckpointProgress {
+                    model_steps: 1,
+                    usage: Usage::default(),
+                },
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(ParkTurnForAgentRunInboxOutcome::IdentityConflict)
+    ));
+    assert_eq!(
+        store.get_turn_run(second_turn.id).await.unwrap(),
+        Some(second_turn)
+    );
+}
+
+#[tokio::test]
+async fn sandbox_admission_rejects_cross_turn_identity_and_fk_corruption() {
+    let (_dir, store) = temp_store().await;
+    let first_chat = sample_chat();
+    let second_chat = sample_chat();
+    store.create_chat(&first_chat).await.unwrap();
+    store.create_chat(&second_chat).await.unwrap();
+    let (first_turn, first_lease) = live_turn_for_sandbox_test(&store, first_chat.id).await;
+    let (second_turn, second_lease) = live_turn_for_sandbox_test(&store, second_chat.id).await;
+    let call = CallId::new();
+    let child = match store
+        .admit_sandbox_agent_run(
+            first_turn.id,
+            call,
+            "owned by the first turn",
+            first_lease,
+            first_turn.steer_revision,
+            2,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        crate::AdmitSandboxAgentRunOutcome::Accepted { child, .. } => child,
+        outcome => panic!("unexpected admission outcome: {outcome:?}"),
+    };
+    assert!(matches!(
+        store
+            .admit_sandbox_agent_run(
+                second_turn.id,
+                call,
+                "owned by the first turn",
+                second_lease,
+                second_turn.steer_revision,
+                2,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(crate::AdmitSandboxAgentRunOutcome::IdentityConflict)
+    ));
+
+    let malformed = crate::db::entities::sandbox_agent_admission::ActiveModel {
+        child_run_id: Set(child.id.0),
+        parent_run_id: Set(second_turn.agent_run_id.0),
+        origin_turn_id: Set(second_turn.id.0),
+        chat_id: Set(second_chat.id.0),
+        spawn_call_id: Set(CallId::new().0),
+        admitted_at: Set(Utc::now()),
+    };
+    assert!(malformed.insert(&store.conn).await.is_err());
 }
 
 #[tokio::test]
@@ -464,23 +833,15 @@ async fn foreground_and_sandbox_runs_roundtrip_with_exact_idempotency() {
         AcceptAgentRunOutcome::Existing(existing) if existing == foreground
     ));
 
-    let sandbox_id = AgentRunId::new();
     let spawn_call_id = CallId::new();
-    let sandbox = match store
-        .accept_agent_run(
-            sandbox_id,
-            chat.id,
-            Some(foreground_id),
-            Some(spawn_call_id),
-            AgentRunExecution::Sandbox,
-            Some("Inspect the selected documents"),
-        )
-        .await
-        .unwrap()
-    {
-        AcceptAgentRunOutcome::Accepted(run) => run,
-        outcome => panic!("unexpected sandbox outcome: {outcome:?}"),
-    };
+    let sandbox = admit_sandbox_call_for_test(
+        &store,
+        chat.id,
+        spawn_call_id,
+        "Inspect the selected documents",
+    )
+    .await;
+    let sandbox_id = AgentRunId::sandbox_for_spawn_call(spawn_call_id);
     assert_eq!(sandbox.parent_id, Some(foreground_id));
     assert_eq!(sandbox.spawn_call_id, Some(spawn_call_id));
     assert_eq!(sandbox.depth, 1);
@@ -499,46 +860,29 @@ async fn foreground_and_sandbox_runs_roundtrip_with_exact_idempotency() {
     );
 
     assert!(matches!(
-        store
-            .accept_agent_run(
-                sandbox_id,
-                chat.id,
-                Some(foreground_id),
-                Some(spawn_call_id),
-                AgentRunExecution::Sandbox,
-                Some("Inspect the selected documents"),
-            )
-            .await
-            .unwrap(),
-        AcceptAgentRunOutcome::Existing(existing) if existing == sandbox
+        admit_sandbox_call_for_test(
+            &store,
+            chat.id,
+            spawn_call_id,
+            "Inspect the selected documents",
+        ).await,
+        existing if existing == sandbox
     ));
+    let (turn, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
     assert!(matches!(
         store
-            .accept_agent_run(
-                AgentRunId::new(),
-                chat.id,
-                Some(foreground_id),
-                Some(spawn_call_id),
-                AgentRunExecution::Sandbox,
-                Some("Inspect the selected documents"),
+            .admit_sandbox_agent_run(
+                turn.id,
+                spawn_call_id,
+                "Changed delegated task",
+                lease,
+                turn.steer_revision,
+                AgentRun::MAX_CONCURRENCY_LIMIT,
+                Utc::now(),
             )
             .await
             .unwrap(),
-        AcceptAgentRunOutcome::Existing(existing) if existing == sandbox
-    ));
-    assert!(matches!(
-        store
-            .accept_agent_run(
-                AgentRunId::new(),
-                chat.id,
-                Some(foreground_id),
-                Some(spawn_call_id),
-                AgentRunExecution::Sandbox,
-                Some("Changed delegated task"),
-            )
-            .await
-            .unwrap(),
-        AcceptAgentRunOutcome::IdentityConflict
+        Some(crate::AdmitSandboxAgentRunOutcome::IdentityConflict)
     ));
     assert_eq!(
         store.get_agent_run(sandbox_id).await.unwrap(),
@@ -571,52 +915,27 @@ async fn agent_run_acceptance_enforces_one_foreground_and_depth_one_children() {
         AcceptAgentRunOutcome::ForegroundExists(existing) if existing.id == foreground_id
     ));
 
-    let child_id = AgentRunId::new();
-    assert!(matches!(
-        store
-            .accept_agent_run(
-                child_id,
-                chat.id,
-                Some(foreground_id),
-                Some(CallId::new()),
-                AgentRunExecution::Sandbox,
-                Some("first child"),
-            )
-            .await
-            .unwrap(),
-        AcceptAgentRunOutcome::Accepted(_)
-    ));
-    assert!(matches!(
-        store
-            .accept_agent_run(
-                AgentRunId::new(),
-                chat.id,
-                Some(child_id),
-                Some(CallId::new()),
-                AgentRunExecution::Sandbox,
-                Some("forbidden grandchild"),
-            )
-            .await
-            .unwrap(),
-        AcceptAgentRunOutcome::ParentUnavailable
-    ));
+    let child_id = admit_sandbox_for_test(&store, chat.id, "first child")
+        .await
+        .id;
+    assert_eq!(
+        store.get_agent_run(child_id).await.unwrap().unwrap().depth,
+        AgentRun::MAX_DEPTH
+    );
 
     let other_chat = sample_chat();
     store.create_chat(&other_chat).await.unwrap();
-    assert!(matches!(
-        store
-            .accept_agent_run(
-                AgentRunId::new(),
-                other_chat.id,
-                Some(foreground_id),
-                Some(CallId::new()),
-                AgentRunExecution::Sandbox,
-                Some("cross-chat child"),
-            )
-            .await
-            .unwrap(),
-        AcceptAgentRunOutcome::ParentUnavailable
-    ));
+    assert!(store
+        .accept_agent_run(
+            AgentRunId::new(),
+            other_chat.id,
+            Some(foreground_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("cross-chat child"),
+        )
+        .await
+        .is_err());
 }
 
 #[tokio::test]
@@ -682,20 +1001,17 @@ async fn agent_run_acceptance_rejects_invalid_shapes_and_identity_reuse() {
         .await
         .is_err());
 
-    assert!(matches!(
-        store
-            .accept_agent_run(
-                foreground_id,
-                chat.id,
-                Some(foreground_id),
-                Some(CallId::new()),
-                AgentRunExecution::Sandbox,
-                Some("different immutable request"),
-            )
-            .await
-            .unwrap(),
-        AcceptAgentRunOutcome::IdentityConflict
-    ));
+    assert!(store
+        .accept_agent_run(
+            foreground_id,
+            chat.id,
+            Some(foreground_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("different immutable request"),
+        )
+        .await
+        .is_err());
     assert!(store
         .list_agent_runs(ChatId::new())
         .await
@@ -751,27 +1067,112 @@ async fn agent_run_schema_rejects_cross_chat_parentage() {
 }
 
 #[tokio::test]
+async fn scheduler_never_claims_a_sandbox_row_without_an_admission_receipt() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let parent_id = AgentRunId::foreground_for_chat(chat.id);
+    let spawn_call_id = CallId::new();
+    let child_id = AgentRunId::sandbox_for_spawn_call(spawn_call_id);
+    let now = Utc::now();
+    crate::db::entities::agent_run::ActiveModel {
+        id: Set(child_id.0),
+        chat_id: Set(chat.id.0),
+        parent_id: Set(Some(parent_id.0)),
+        parent_depth: Set(Some(0)),
+        spawn_call_id: Set(Some(spawn_call_id.0)),
+        execution: Set(AgentRunExecution::Sandbox.as_str().into()),
+        depth: Set(1),
+        status: Set(AgentRunStatus::Queued.as_str().into()),
+        input: Set(Some("receiptless corruption".into())),
+        attempt_count: Set(0),
+        max_attempts: Set(AgentRun::DEFAULT_MAX_ATTEMPTS),
+        claim_count: Set(0),
+        available_at: Set(now),
+        deadline_at: Set(Some(now + AgentRun::DEFAULT_MAX_DURATION)),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        started_at: Set(None),
+        finished_at: Set(None),
+        last_error_code: Set(None),
+        last_error_detail: Set(None),
+        created_at: Set(now),
+        updated_at: Set(now),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+
+    assert!(store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 4, 2)
+        .await
+        .unwrap()
+        .is_none());
+    let receiptless = store.get_agent_run(child_id).await.unwrap().unwrap();
+    assert_eq!(receiptless.status, AgentRunStatus::Queued);
+    assert_eq!(receiptless.claim_count, 0);
+
+    let claim_token = uuid::Uuid::new_v4();
+    let lease_expires_at = Utc::now() + Duration::minutes(5);
+    crate::db::entities::agent_run_claim::ActiveModel {
+        token: Set(claim_token),
+        agent_run_id: Set(Some(child_id.0)),
+        attempt_count: Set(Some(1)),
+        claim_count: Set(Some(1)),
+        claimed_at: Set(now),
+        lease_expires_at: Set(Some(lease_expires_at)),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+    crate::db::entities::agent_run::Entity::update_many()
+        .col_expr(
+            crate::db::entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunStatus::Running.as_str()),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::AttemptCount,
+            sea_orm::sea_query::Expr::value(1),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::ClaimCount,
+            sea_orm::sea_query::Expr::value(1),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Some(claim_token)),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Some(lease_expires_at)),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::StartedAt,
+            sea_orm::sea_query::Expr::value(Some(now)),
+        )
+        .col_expr(
+            crate::db::entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(crate::db::entities::agent_run::Column::Id.eq(child_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert!(store
+        .claim_agent_run(claim_token, Duration::minutes(1), 4, 2)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
 async fn sandbox_claims_are_exact_reclaimable_and_heartbeatable() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let foreground_id = AgentRunId::foreground_for_chat(chat.id);
-    let child_id = AgentRunId::new();
-    let _child = match store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(foreground_id),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("claim and heartbeat"),
-        )
+    let child_id = admit_sandbox_for_test(&store, chat.id, "claim and heartbeat")
         .await
-        .unwrap()
-    {
-        AcceptAgentRunOutcome::Accepted(run) => run,
-        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
-    };
+        .id;
 
     let first_token = uuid::Uuid::new_v4();
     let first = store
@@ -802,7 +1203,7 @@ async fn sandbox_claims_are_exact_reclaimable_and_heartbeatable() {
         .await
         .unwrap());
     assert!(!store
-        .heartbeat_agent_run(child_id, first_token, Duration::minutes(2))
+        .heartbeat_agent_run(child_id, first_token, Duration::minutes(1))
         .await
         .unwrap());
     assert!(!store
@@ -853,17 +1254,7 @@ async fn sandbox_claims_are_exact_reclaimable_and_heartbeatable() {
 
     let later_chat = sample_chat();
     store.create_chat(&later_chat).await.unwrap();
-    store
-        .accept_agent_run(
-            AgentRunId::new(),
-            later_chat.id,
-            Some(AgentRunId::foreground_for_chat(later_chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("later work"),
-        )
-        .await
-        .unwrap();
+    admit_sandbox_for_test(&store, later_chat.id, "later work").await;
     assert!(store
         .claim_agent_run(exhausted_scan, Duration::minutes(1), 2, 1)
         .await
@@ -876,18 +1267,9 @@ async fn sandbox_result_submission_is_fenced_and_idempotent() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let child_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("return a concise result"),
-        )
+    let child_id = admit_sandbox_for_test(&store, chat.id, "return a concise result")
         .await
-        .unwrap();
+        .id;
     let lease_token = uuid::Uuid::new_v4();
     store
         .claim_agent_run(lease_token, Duration::minutes(1), 1, 1)
@@ -954,18 +1336,9 @@ async fn sandbox_folder_proposal_is_typed_fenced_and_idempotent() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let child_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("ask the parent about folder consent"),
-        )
+    let child_id = admit_sandbox_for_test(&store, chat.id, "ask the parent about folder consent")
         .await
-        .unwrap();
+        .id;
     let lease_token = uuid::Uuid::new_v4();
     store
         .claim_agent_run(lease_token, Duration::minutes(1), 1, 1)
@@ -1148,18 +1521,9 @@ async fn child_inbox_consumption_atomically_wakes_a_parked_foreground_turn() {
         .turn
         .expect("foreground turn should claim");
     assert_eq!(running.id, queued.id);
-    let child_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(parent_id),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("research the question"),
-        )
+    let child_id = admit_sandbox_for_test(&store, chat.id, "research the question")
         .await
-        .unwrap();
+        .id;
     let progress = TurnCheckpointProgress {
         model_steps: 1,
         usage: Usage {
@@ -1272,19 +1636,10 @@ async fn parked_parent_cancellation_retires_a_delivered_child_without_an_orphan_
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
 
-    let child_id = AgentRunId::new();
     let parent_id = AgentRunId::foreground_for_chat(chat.id);
-    store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(parent_id),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("finish before the parent is cancelled"),
-        )
+    let child_id = admit_sandbox_for_test(&store, chat.id, "finish before the parent is cancelled")
         .await
-        .unwrap();
+        .id;
     let parked = park_foreground_turn_on_child(&store, chat.id, child_id).await;
     let child_lease = uuid::Uuid::new_v4();
     assert_eq!(
@@ -1335,18 +1690,13 @@ async fn parked_parent_cancellation_cascades_to_an_unclaimed_sandbox_child() {
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
 
-    let child_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("this work should be fenced before it starts"),
-        )
-        .await
-        .unwrap();
+    let child_id = admit_sandbox_for_test(
+        &store,
+        chat.id,
+        "this work should be fenced before it starts",
+    )
+    .await
+    .id;
     let parked = park_foreground_turn_on_child(&store, chat.id, child_id).await;
     assert!(matches!(
         store
@@ -1380,19 +1730,10 @@ async fn failed_child_result_is_persisted_in_the_resumed_parent_transcript() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let child_id = AgentRunId::new();
     let parent_id = AgentRunId::foreground_for_chat(chat.id);
-    store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(parent_id),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("this task will fail"),
-        )
+    let child_id = admit_sandbox_for_test(&store, chat.id, "this task will fail")
         .await
-        .unwrap();
+        .id;
     crate::db::entities::agent_run::Entity::update_many()
         .col_expr(
             crate::db::entities::agent_run::Column::MaxAttempts,
@@ -1558,18 +1899,9 @@ async fn sandbox_cancellation_fences_running_work_and_recovers_exact_acknowledge
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let queued_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            queued_id,
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("cancel before claim"),
-        )
+    let queued_id = admit_sandbox_for_test(&store, chat.id, "cancel before claim")
         .await
-        .unwrap();
+        .id;
     assert!(matches!(
         store.request_agent_run_cancellation(queued_id).await.unwrap(),
         Some(RequestAgentRunCancellationOutcome::Cancelled(run)) if run.status == AgentRunStatus::Cancelled
@@ -1584,18 +1916,9 @@ async fn sandbox_cancellation_fences_running_work_and_recovers_exact_acknowledge
         .unwrap()
         .is_none());
 
-    let running_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            running_id,
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("cancel while running"),
-        )
+    let running_id = admit_sandbox_for_test(&store, chat.id, "cancel while running")
         .await
-        .unwrap();
+        .id;
     let lease_token = uuid::Uuid::new_v4();
     store
         .claim_agent_run(lease_token, Duration::minutes(1), 1, 1)
@@ -1643,20 +1966,10 @@ async fn expired_sandbox_cancellation_is_terminal_and_cannot_fake_worker_acknowl
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let parent_id = AgentRunId::foreground_for_chat(chat.id);
-
-    let expired_before_request = AgentRunId::new();
-    store
-        .accept_agent_run(
-            expired_before_request,
-            chat.id,
-            Some(parent_id),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("cancel after lease expiry"),
-        )
-        .await
-        .unwrap();
+    let expired_before_request =
+        admit_sandbox_for_test(&store, chat.id, "cancel after lease expiry")
+            .await
+            .id;
     store
         .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 1, 1)
         .await
@@ -1677,18 +1990,10 @@ async fn expired_sandbox_cancellation_is_terminal_and_cannot_fake_worker_acknowl
         .unwrap()
         .is_none());
 
-    let expired_after_request = AgentRunId::new();
-    store
-        .accept_agent_run(
-            expired_after_request,
-            chat.id,
-            Some(parent_id),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("expire after cancellation request"),
-        )
-        .await
-        .unwrap();
+    let expired_after_request =
+        admit_sandbox_for_test(&store, chat.id, "expire after cancellation request")
+            .await
+            .id;
     let lease_token = uuid::Uuid::new_v4();
     store
         .claim_agent_run(lease_token, Duration::minutes(1), 1, 1)
@@ -1719,36 +2024,18 @@ async fn unavailable_parent_rejects_result_without_holding_the_scheduler_lock() 
     let other_chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
     store.create_chat(&other_chat).await.unwrap();
-    let child_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("parent may finish first"),
-        )
+    let child_id = admit_sandbox_for_test(&store, chat.id, "parent may finish first")
         .await
-        .unwrap();
+        .id;
     let lease_token = uuid::Uuid::new_v4();
     store
         .claim_agent_run(lease_token, Duration::minutes(1), 2, 1)
         .await
         .unwrap()
         .unwrap();
-    let other_child_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            other_child_id,
-            other_chat.id,
-            Some(AgentRunId::foreground_for_chat(other_chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("scheduler remains usable"),
-        )
+    let other_child_id = admit_sandbox_for_test(&store, other_chat.id, "scheduler remains usable")
         .await
-        .unwrap();
+        .id;
     let now = Utc::now();
     crate::db::entities::agent_run::Entity::update_many()
         .col_expr(
@@ -1799,21 +2086,7 @@ async fn sandbox_claims_enforce_global_and_per_chat_limits() {
         (first_chat.id, "first-b"),
         (second_chat.id, "second-a"),
     ] {
-        let run = match store
-            .accept_agent_run(
-                AgentRunId::new(),
-                chat_id,
-                Some(AgentRunId::foreground_for_chat(chat_id)),
-                Some(CallId::new()),
-                AgentRunExecution::Sandbox,
-                Some(task),
-            )
-            .await
-            .unwrap()
-        {
-            AcceptAgentRunOutcome::Accepted(run) => run,
-            outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
-        };
+        let run = admit_sandbox_for_test(&store, chat_id, task).await;
         accepted.push(run);
     }
 
@@ -1840,22 +2113,8 @@ async fn sandbox_claim_terminalizes_expired_deadlines() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let child_id = AgentRunId::new();
-    let child = match store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("deadline"),
-        )
-        .await
-        .unwrap()
-    {
-        AcceptAgentRunOutcome::Accepted(run) => run,
-        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
-    };
+    let child = admit_sandbox_for_test(&store, chat.id, "deadline").await;
+    let child_id = child.id;
     force_expired_agent_deadline(&store, child.id).await;
     assert!(store
         .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 1, 1)
@@ -1882,35 +2141,18 @@ async fn expired_cancelling_sandbox_run_is_reaped_and_releases_capacity() {
     let other_chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
     store.create_chat(&other_chat).await.unwrap();
-    let child_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("cancellation reaper"),
-        )
+    let child_id = admit_sandbox_for_test(&store, chat.id, "cancellation reaper")
         .await
-        .unwrap();
+        .id;
     store
         .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
         .await
         .unwrap()
         .unwrap();
-    let other_child_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            other_child_id,
-            other_chat.id,
-            Some(AgentRunId::foreground_for_chat(other_chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("capacity-consuming live worker"),
-        )
-        .await
-        .unwrap();
+    let other_child_id =
+        admit_sandbox_for_test(&store, other_chat.id, "capacity-consuming live worker")
+            .await
+            .id;
     let other = store
         .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
         .await
@@ -1947,21 +2189,7 @@ async fn concurrent_sandbox_claimers_respect_both_limits() {
     store.create_chat(&first_chat).await.unwrap();
     store.create_chat(&second_chat).await.unwrap();
     for chat_id in [first_chat.id, first_chat.id, second_chat.id, second_chat.id] {
-        let _accepted = match store
-            .accept_agent_run(
-                AgentRunId::new(),
-                chat_id,
-                Some(AgentRunId::foreground_for_chat(chat_id)),
-                Some(CallId::new()),
-                AgentRunExecution::Sandbox,
-                Some("concurrent claim"),
-            )
-            .await
-            .unwrap()
-        {
-            AcceptAgentRunOutcome::Accepted(run) => run,
-            outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
-        };
+        let _accepted = admit_sandbox_for_test(&store, chat_id, "concurrent claim").await;
     }
 
     let store = std::sync::Arc::new(store);

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -91,9 +91,9 @@ pub use model::{
     Message, Project, RetrievalEvidence, RetrievalEvidenceInput, RetrievalEvidenceSource, Role,
     RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
     RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
-    RootAttachmentSubjectKind, SandboxToolCall, SandboxToolCallReceipt, SandboxToolCallRequest,
-    SandboxToolCallStatus, SourceLocation, SourceRegion, ToolCallExecution, ToolCallRecord,
-    ToolCallResolution, ToolCallStatus, TurnAgentRunWait, TurnAgentRunWaitStatus,
+    RootAttachmentSubjectKind, SandboxAgentAdmission, SandboxToolCall, SandboxToolCallReceipt,
+    SandboxToolCallRequest, SandboxToolCallStatus, SourceLocation, SourceRegion, ToolCallExecution,
+    ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnAgentRunWait, TurnAgentRunWaitStatus,
     TurnCheckpointProgress, TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt,
     TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus, MAX_ATTACHMENT_REVISION,
     MAX_ROOT_ATTACHMENTS,
@@ -105,7 +105,7 @@ pub use provider::{
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
     AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, AcceptToolCallOutcome,
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, ApplyTurnSteerOutcome,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, AdmitSandboxAgentRunOutcome, ApplyTurnSteerOutcome,
     BeginRootAttachmentChangeOutcome, BlobStore, ChatToolActivitySnapshot, ChatToolActivityStatus,
     ChatTranscriptSnapshot, ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome,
     ClaimSandboxToolCallOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1180,12 +1180,37 @@ impl AgentRun {
     pub const DEFAULT_MAX_DURATION: chrono::Duration = chrono::Duration::hours(1);
     /// Largest accepted scheduler concurrency bound.
     pub const MAX_CONCURRENCY_LIMIT: u32 = 1_024;
+    /// Default maximum children from one foreground turn that may remain
+    /// nonterminal at once. Admission enforces this independently from worker
+    /// concurrency so queued work is bounded before it reaches the scheduler.
+    pub const DEFAULT_MAX_OUTSTANDING_CHILDREN: u32 = 4;
     /// Maximum stable failure-category length.
     pub const MAX_ERROR_CODE_LEN: usize = 128;
     /// Maximum persisted diagnostic-detail length.
     pub const MAX_ERROR_DETAIL_LEN: usize = 4_096;
     /// Maximum final text stored in an immutable sandbox result receipt.
     pub const MAX_RESULT_LEN: usize = 65_536;
+}
+
+/// Immutable ownership receipt for one admitted sandbox child.
+///
+/// The origin turn is intentionally distinct from the long-lived foreground
+/// coordinator. A foreground run can span many turns, while every sandbox
+/// child belongs to the exact turn and model call that delegated its task.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxAgentAdmission {
+    /// Deterministic child identity derived from [`Self::spawn_call_id`].
+    pub child_run_id: crate::id::AgentRunId,
+    /// Foreground coordinator that owned the origin turn.
+    pub parent_run_id: crate::id::AgentRunId,
+    /// Exact foreground turn that admitted the child.
+    pub origin_turn_id: crate::id::TurnId,
+    /// Conversation shared by the origin turn, parent, and child.
+    pub chat_id: ChatId,
+    /// Exact model call that requested the child.
+    pub spawn_call_id: crate::id::CallId,
+    /// Database time at which admission committed.
+    pub admitted_at: DateTime<Utc>,
 }
 
 /// Immutable final text submitted by one exact sandbox worker lease.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -220,6 +220,33 @@ pub enum AcceptAgentRunOutcome {
     ParentUnavailable,
 }
 
+/// Result of transactionally admitting one bounded sandbox child.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdmitSandboxAgentRunOutcome {
+    /// The child and immutable origin ownership were committed together.
+    Accepted {
+        child: AgentRun,
+        admission: crate::model::SandboxAgentAdmission,
+    },
+    /// An exact ambiguous retry recovered the committed child and ownership.
+    Existing {
+        child: AgentRun,
+        admission: crate::model::SandboxAgentAdmission,
+    },
+    /// The child or spawn-call identity is bound to different immutable input.
+    IdentityConflict,
+    /// The origin turn does not have an eligible foreground coordinator.
+    ParentUnavailable,
+    /// The origin turn is not owned by the supplied live worker lease.
+    LeaseLost,
+    /// This origin turn already owns the configured number of nonterminal children.
+    AtCapacity,
+    /// A durable steer won the admission race and must be applied first.
+    SteerPending(TurnRun),
+    /// The request came from provider output generated before an applied steer.
+    OutputSuperseded(TurnRun),
+}
+
 /// Result of atomically parking a sandbox run on immutable tool work.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParkSandboxToolCallOutcome {
@@ -276,6 +303,8 @@ pub enum AcceptSandboxAgentRunAndParkTurnOutcome {
     /// The turn's foreground coordinator is no longer an eligible sandbox
     /// parent.
     ParentUnavailable,
+    /// The origin turn already owns the configured number of nonterminal children.
+    AtCapacity,
     /// A durable steer won the checkpoint race and must be applied first.
     SteerPending(TurnRun),
     /// The request came from provider output generated before an applied steer.
@@ -1201,6 +1230,37 @@ pub trait Store: Send + Sync {
         _execution: AgentRunExecution,
         _input: Option<&str>,
     ) -> Result<AcceptAgentRunOutcome> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Admit one depth-one sandbox child without advancing its origin turn.
+    ///
+    /// The child id is derived from `spawn_call_id`; callers cannot choose a
+    /// second identity for the same model request. The origin turn, foreground
+    /// parent, child, and immutable admission receipt commit together under the
+    /// chat/turn write lock. Existing exact receipts are recovered before the
+    /// bounded outstanding-child check, making an ambiguous commit retry safe.
+    /// This is a persistence primitive only; the foreground agent does not yet
+    /// expose non-blocking fan-out behavior.
+    #[allow(clippy::too_many_arguments)]
+    async fn admit_sandbox_agent_run(
+        &self,
+        _origin_turn_id: TurnId,
+        _spawn_call_id: CallId,
+        _input: &str,
+        _lease_token: uuid::Uuid,
+        _expected_steer_revision: i64,
+        _max_outstanding_children: u32,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Fetch immutable origin ownership for an admitted sandbox child.
+    async fn get_sandbox_agent_admission(
+        &self,
+        _child_run_id: AgentRunId,
+    ) -> Result<Option<crate::model::SandboxAgentAdmission>> {
         agent_run_storage_unavailable()
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -4,8 +4,8 @@ use std::{sync::Arc, time::Duration as StdDuration};
 
 use chrono::{Duration, Utc};
 use openwave_core::{
-    AcceptAgentRunOutcome, AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome,
-    AgentEvent, AgentRunExecution, AgentRunId, AgentRunStatus, ApplyTurnSteerOutcome,
+    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentEvent,
+    AgentRunExecution, AgentRunId, AgentRunStatus, ApplyTurnSteerOutcome,
     AssistantCitationReference, BeginRootAttachmentChange, BeginRootAttachmentChangeOutcome,
     ByteSpan, CallId, Chat, ChatId, ChatRootAttachment, ChunkId, ClaimClientToolCallOutcome,
     ClientToolCallRequest, CompleteTurnRunOutcome, DbStore, DocumentGeneration, DocumentId,
@@ -201,6 +201,70 @@ fn sample_chat() -> Chat {
     }
 }
 
+async fn postgres_live_turn(
+    store: &DbStore,
+    chat_id: ChatId,
+) -> (openwave_core::TurnRun, uuid::Uuid) {
+    if let Some(turn) = store
+        .list_turn_runs(chat_id)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|turn| turn.status == TurnRunStatus::Running)
+    {
+        return (
+            turn.clone(),
+            turn.lease_token.expect("running turn has lease"),
+        );
+    }
+    let turn_id = TurnId::new();
+    store
+        .accept_turn(
+            turn_id,
+            chat_id,
+            "postgres-sandbox-test",
+            "sandbox admission",
+        )
+        .await
+        .unwrap();
+    let lease = uuid::Uuid::new_v4();
+    let now = utc_now_at_postgres_precision();
+    let turn = store
+        .claim_turn_run(lease, now, now + Duration::hours(1))
+        .await
+        .unwrap()
+        .turn
+        .expect("postgres sandbox test turn should claim");
+    (turn, lease)
+}
+
+async fn postgres_admit_sandbox(
+    store: &DbStore,
+    chat_id: ChatId,
+    call: CallId,
+    input: &str,
+) -> openwave_core::AgentRun {
+    let (turn, lease) = postgres_live_turn(store, chat_id).await;
+    match store
+        .admit_sandbox_agent_run(
+            turn.id,
+            call,
+            input,
+            lease,
+            turn.steer_revision,
+            openwave_core::AgentRun::MAX_CONCURRENCY_LIMIT,
+            utc_now_at_postgres_precision(),
+        )
+        .await
+        .unwrap()
+        .expect("postgres sandbox admission should resolve")
+    {
+        openwave_core::AdmitSandboxAgentRunOutcome::Accepted { child, .. }
+        | openwave_core::AdmitSandboxAgentRunOutcome::Existing { child, .. } => child,
+        outcome => panic!("unexpected postgres sandbox admission: {outcome:?}"),
+    }
+}
+
 #[tokio::test]
 async fn postgres_agent_runs_enforce_foreground_parentage_and_idempotency() {
     let _guard = POSTGRES_TEST_LOCK.lock().await;
@@ -223,53 +287,26 @@ async fn postgres_agent_runs_enforce_foreground_parentage_and_idempotency() {
     assert_eq!(foreground.depth, 0);
     assert_eq!(foreground.status, AgentRunStatus::Active);
 
-    let child_id = AgentRunId::new();
     let spawn_call_id = CallId::new();
-    let child = match store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(foreground_id),
-            Some(spawn_call_id),
-            AgentRunExecution::Sandbox,
-            Some("postgres child"),
-        )
-        .await
-        .unwrap()
-    {
-        AcceptAgentRunOutcome::Accepted(run) => run,
-        outcome => panic!("unexpected sandbox outcome: {outcome:?}"),
-    };
+    let child = postgres_admit_sandbox(&store, chat.id, spawn_call_id, "postgres child").await;
+    let child_id = child.id;
     assert_eq!(child.depth, 1);
     assert_eq!(child.status, AgentRunStatus::Queued);
-    assert!(matches!(
-        store
-            .accept_agent_run(
-                child_id,
-                chat.id,
-                Some(foreground_id),
-                Some(spawn_call_id),
-                AgentRunExecution::Sandbox,
-                Some("postgres child"),
-            )
-            .await
-            .unwrap(),
-        AcceptAgentRunOutcome::Existing(existing) if existing == child
-    ));
-    assert!(matches!(
-        store
-            .accept_agent_run(
-                AgentRunId::new(),
-                chat.id,
-                Some(child_id),
-                Some(CallId::new()),
-                AgentRunExecution::Sandbox,
-                Some("forbidden grandchild"),
-            )
-            .await
-            .unwrap(),
-        AcceptAgentRunOutcome::ParentUnavailable
-    ));
+    assert_eq!(
+        postgres_admit_sandbox(&store, chat.id, spawn_call_id, "postgres child").await,
+        child
+    );
+    assert!(store
+        .accept_agent_run(
+            AgentRunId::new(),
+            chat.id,
+            Some(child_id),
+            Some(CallId::new()),
+            AgentRunExecution::Sandbox,
+            Some("forbidden grandchild"),
+        )
+        .await
+        .is_err());
 }
 
 #[tokio::test]
@@ -287,28 +324,25 @@ async fn postgres_agent_run_identity_collision_recovers_exactly_across_chats() {
     let second_chat = sample_chat();
     store.create_chat(&first_chat).await.unwrap();
     store.create_chat(&second_chat).await.unwrap();
-    let first_parent = AgentRunId::foreground_for_chat(first_chat.id);
-    let second_parent = AgentRunId::foreground_for_chat(second_chat.id);
-
-    let collision_id = AgentRunId::new();
+    let (first_turn, first_lease) = postgres_live_turn(&store, first_chat.id).await;
+    let (second_turn, second_lease) = postgres_live_turn(&store, second_chat.id).await;
+    let collision_call = CallId::new();
     let barrier = Arc::new(tokio::sync::Barrier::new(2));
     let mut tasks = Vec::new();
-    for (chat_id, parent_id) in [
-        (first_chat.id, first_parent),
-        (second_chat.id, second_parent),
-    ] {
+    for (turn, lease) in [(first_turn, first_lease), (second_turn, second_lease)] {
         let store = store.clone();
         let barrier = barrier.clone();
         tasks.push(tokio::spawn(async move {
             barrier.wait().await;
             store
-                .accept_agent_run(
-                    collision_id,
-                    chat_id,
-                    Some(parent_id),
-                    Some(CallId::new()),
-                    AgentRunExecution::Sandbox,
-                    Some("colliding child"),
+                .admit_sandbox_agent_run(
+                    turn.id,
+                    collision_call,
+                    "colliding child",
+                    lease,
+                    turn.steer_revision,
+                    1,
+                    utc_now_at_postgres_precision(),
                 )
                 .await
         }));
@@ -317,12 +351,200 @@ async fn postgres_agent_run_identity_collision_recovers_exactly_across_chats() {
     let mut conflicted = 0;
     for task in tasks {
         match task.await.unwrap() {
-            Ok(AcceptAgentRunOutcome::Accepted(_)) => accepted += 1,
-            Ok(AcceptAgentRunOutcome::IdentityConflict) => conflicted += 1,
+            Ok(Some(openwave_core::AdmitSandboxAgentRunOutcome::Accepted { .. })) => accepted += 1,
+            Ok(Some(openwave_core::AdmitSandboxAgentRunOutcome::IdentityConflict)) => {
+                conflicted += 1
+            }
             outcome => panic!("unexpected cross-chat collision outcome: {outcome:?}"),
         }
     }
     assert_eq!((accepted, conflicted), (1, 1));
+}
+
+#[tokio::test]
+async fn postgres_concurrent_sandbox_admission_respects_origin_turn_cap() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = postgres_live_turn(&store, chat.id).await;
+    let barrier = Arc::new(tokio::sync::Barrier::new(8));
+    let mut tasks = Vec::new();
+    for index in 0..8 {
+        let contender = DbStore::connect(&url).await.unwrap();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            contender
+                .admit_sandbox_agent_run(
+                    turn.id,
+                    CallId::new(),
+                    &format!("postgres concurrent admission {index}"),
+                    lease,
+                    turn.steer_revision,
+                    2,
+                    utc_now_at_postgres_precision(),
+                )
+                .await
+                .unwrap()
+                .unwrap()
+        }));
+    }
+    let outcomes = futures::future::join_all(tasks).await;
+    let accepted = outcomes
+        .into_iter()
+        .map(Result::unwrap)
+        .filter(|outcome| {
+            matches!(
+                outcome,
+                openwave_core::AdmitSandboxAgentRunOutcome::Accepted { .. }
+            )
+        })
+        .count();
+    assert_eq!(accepted, 2);
+    let sandbox_runs = store
+        .list_agent_runs(chat.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|run| run.execution == AgentRunExecution::Sandbox)
+        .collect::<Vec<_>>();
+    assert_eq!(sandbox_runs.len(), 2);
+    for run in sandbox_runs {
+        store.request_agent_run_cancellation(run.id).await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn postgres_concurrent_exact_sandbox_admission_converges() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = postgres_live_turn(&store, chat.id).await;
+    let call = CallId::new();
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let mut tasks = Vec::new();
+    for _ in 0..2 {
+        let contender = DbStore::connect(&url).await.unwrap();
+        let barrier = barrier.clone();
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            contender
+                .admit_sandbox_agent_run(
+                    turn.id,
+                    call,
+                    "same postgres child",
+                    lease,
+                    turn.steer_revision,
+                    2,
+                    utc_now_at_postgres_precision(),
+                )
+                .await
+                .unwrap()
+                .unwrap()
+        }));
+    }
+    let outcomes = futures::future::join_all(tasks).await;
+    let accepted = outcomes
+        .iter()
+        .filter(|outcome| {
+            matches!(
+                outcome.as_ref().unwrap(),
+                openwave_core::AdmitSandboxAgentRunOutcome::Accepted { .. }
+            )
+        })
+        .count();
+    let existing = outcomes
+        .iter()
+        .filter(|outcome| {
+            matches!(
+                outcome.as_ref().unwrap(),
+                openwave_core::AdmitSandboxAgentRunOutcome::Existing { .. }
+            )
+        })
+        .count();
+    assert_eq!((accepted, existing), (1, 1));
+}
+
+#[tokio::test]
+async fn postgres_sandbox_admission_checks_lease_time_after_lock_wait() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = postgres_live_turn(&store, chat.id).await;
+    let setup_connection = Database::connect(&url).await.unwrap();
+    setup_connection
+        .execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!(
+                "UPDATE turn_run SET lease_expires_at = clock_timestamp() + interval '200 milliseconds' WHERE id = '{}'",
+                turn.id.0
+            ),
+        ))
+        .await
+        .unwrap();
+
+    let blocker_connection = Database::connect(&url).await.unwrap();
+    let blocker = blocker_connection.begin().await.unwrap();
+    blocker
+        .execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            format!("UPDATE chat SET title = title WHERE id = '{}'", chat.id.0),
+        ))
+        .await
+        .unwrap();
+
+    let contender = store.clone();
+    let call = CallId::new();
+    let stale_caller_now = utc_now_at_postgres_precision();
+    let admission = tokio::spawn(async move {
+        contender
+            .admit_sandbox_agent_run(
+                turn.id,
+                call,
+                "must not cross an expired lease",
+                lease,
+                turn.steer_revision,
+                2,
+                stale_caller_now,
+            )
+            .await
+    });
+    tokio::time::sleep(StdDuration::from_millis(350)).await;
+    blocker.commit().await.unwrap();
+
+    assert!(matches!(
+        admission.await.unwrap().unwrap(),
+        Some(openwave_core::AdmitSandboxAgentRunOutcome::LeaseLost)
+    ));
+    assert!(store
+        .get_agent_run(AgentRunId::sandbox_for_spawn_call(call))
+        .await
+        .unwrap()
+        .is_none());
 }
 
 #[tokio::test]
@@ -341,21 +563,13 @@ async fn postgres_concurrent_sandbox_claims_respect_global_and_per_chat_limits()
     store.create_chat(&first_chat).await.unwrap();
     store.create_chat(&second_chat).await.unwrap();
     for chat_id in [first_chat.id, first_chat.id, second_chat.id, second_chat.id] {
-        let _accepted = match store
-            .accept_agent_run(
-                AgentRunId::new(),
-                chat_id,
-                Some(AgentRunId::foreground_for_chat(chat_id)),
-                Some(CallId::new()),
-                AgentRunExecution::Sandbox,
-                Some("postgres concurrent claim"),
-            )
-            .await
-            .unwrap()
-        {
-            AcceptAgentRunOutcome::Accepted(run) => run,
-            outcome => panic!("unexpected sandbox outcome: {outcome:?}"),
-        };
+        let _accepted = postgres_admit_sandbox(
+            store.as_ref(),
+            chat_id,
+            CallId::new(),
+            "postgres concurrent claim",
+        )
+        .await;
     }
     let barrier = Arc::new(tokio::sync::Barrier::new(8));
     let mut claimers = Vec::new();
@@ -395,18 +609,14 @@ async fn postgres_sandbox_claim_uses_statement_time_after_scheduler_lock_wait() 
     let store = DbStore::connect(&url).await.unwrap();
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let child_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            child_id,
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("scheduler lock clock regression"),
-        )
-        .await
-        .unwrap();
+    let child_id = postgres_admit_sandbox(
+        &store,
+        chat.id,
+        CallId::new(),
+        "scheduler lock clock regression",
+    )
+    .await
+    .id;
 
     let blocker = Database::connect(&url).await.unwrap();
     blocker
@@ -490,18 +700,10 @@ async fn postgres_sandbox_terminal_transitions_are_exact_and_fenced() {
     store.create_chat(&chat).await.unwrap();
     let parent_id = AgentRunId::foreground_for_chat(chat.id);
 
-    let completed_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            completed_id,
-            chat.id,
-            Some(parent_id),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("postgres terminal result"),
-        )
-        .await
-        .unwrap();
+    let completed_id =
+        postgres_admit_sandbox(&store, chat.id, CallId::new(), "postgres terminal result")
+            .await
+            .id;
     let prioritizer = Database::connect(&url).await.unwrap();
     prioritizer
         .execute(Statement::from_string(
@@ -544,18 +746,10 @@ async fn postgres_sandbox_terminal_transitions_are_exact_and_fenced() {
         Some(SubmitAgentRunResultOutcome::Existing(_))
     ));
 
-    let cancelling_id = AgentRunId::new();
-    store
-        .accept_agent_run(
-            cancelling_id,
-            chat.id,
-            Some(parent_id),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("postgres cancellation"),
-        )
-        .await
-        .unwrap();
+    let cancelling_id =
+        postgres_admit_sandbox(&store, chat.id, CallId::new(), "postgres cancellation")
+            .await
+            .id;
     prioritizer
         .execute(Statement::from_string(
             DatabaseBackend::Postgres,

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -737,11 +737,12 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
+    use chrono::Utc;
     use futures::stream::{self, BoxStream};
     use openwave_core::{
-        AcceptAgentRunOutcome, AcceptTurnOutcome, AgentRunExecution, AgentRunInboxStatus, CallId,
-        Chat, ChatId, ChatRequest, DbStore, ModelProvider, ProviderId, Role, Store,
-        ToolCallResolution, TurnCheckpointProgress, TurnId, TurnRunStatus, Usage,
+        AcceptTurnOutcome, AgentRunInboxStatus, CallId, Chat, ChatId, ChatRequest, DbStore,
+        ModelProvider, ProviderId, Role, Store, ToolCallResolution, TurnCheckpointProgress, TurnId,
+        TurnRunStatus, Usage,
     };
 
     use super::*;
@@ -916,26 +917,74 @@ mod tests {
         (worker, store, provider, chat, dir)
     }
 
+    async fn admit_sandbox(
+        store: &Arc<dyn Store>,
+        chat_id: openwave_core::ChatId,
+        call: CallId,
+        input: &str,
+    ) -> openwave_core::AgentRun {
+        let running = store
+            .list_turn_runs(chat_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|turn| turn.status == openwave_core::TurnRunStatus::Running);
+        let (turn, lease) = if let Some(turn) = running {
+            let lease = turn.lease_token.expect("running test turn has lease");
+            (turn, lease)
+        } else {
+            let turn_id = openwave_core::TurnId::new();
+            store
+                .accept_turn(
+                    turn_id,
+                    chat_id,
+                    "sandbox-test-model",
+                    "sandbox test admission",
+                )
+                .await
+                .unwrap();
+            let lease = uuid::Uuid::new_v4();
+            let now = Utc::now();
+            let turn = store
+                .claim_turn_run(lease, now, now + chrono::Duration::hours(1))
+                .await
+                .unwrap()
+                .turn
+                .expect("sandbox test turn should claim");
+            (turn, lease)
+        };
+        match store
+            .admit_sandbox_agent_run(
+                turn.id,
+                call,
+                input,
+                lease,
+                turn.steer_revision,
+                openwave_core::AgentRun::MAX_CONCURRENCY_LIMIT,
+                Utc::now(),
+            )
+            .await
+            .unwrap()
+            .expect("sandbox test admission should resolve")
+        {
+            openwave_core::AdmitSandboxAgentRunOutcome::Accepted { child, .. }
+            | openwave_core::AdmitSandboxAgentRunOutcome::Existing { child, .. } => child,
+            outcome => panic!("unexpected sandbox admission: {outcome:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn completes_a_claimed_run_with_a_no_tools_private_request() {
         let (worker, store, provider, chat, dir) = fixture().await;
         let call = CallId::new();
         let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
         let parent = openwave_core::AgentRunId::foreground_for_chat(chat.id);
-        assert!(matches!(
-            store
-                .accept_agent_run(
-                    id,
-                    chat.id,
-                    Some(parent),
-                    Some(call),
-                    AgentRunExecution::Sandbox,
-                    Some("Investigate this in isolation."),
-                )
+        assert_eq!(
+            admit_sandbox(&store, chat.id, call, "Investigate this in isolation.")
                 .await
-                .unwrap(),
-            AcceptAgentRunOutcome::Accepted(_)
-        ));
+                .id,
+            id
+        );
 
         assert_eq!(
             worker.run_once().await.unwrap(),
@@ -1012,17 +1061,7 @@ mod tests {
         );
         let spawn = CallId::new();
         let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
-        store
-            .accept_agent_run(
-                id,
-                chat.id,
-                Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
-                Some(spawn),
-                AgentRunExecution::Sandbox,
-                Some("Research this."),
-            )
-            .await
-            .unwrap();
+        admit_sandbox(&store, chat.id, spawn, "Research this.").await;
 
         let call_id = match worker.run_once().await.unwrap() {
             SandboxAgentRunWorkerOutcome::ToolCheckpointed(call_id) => call_id,
@@ -1141,17 +1180,7 @@ mod tests {
         let (worker, store, _provider, chat, _dir) = fixture().await;
         let spawn = CallId::new();
         let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
-        store
-            .accept_agent_run(
-                id,
-                chat.id,
-                Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
-                Some(spawn),
-                AgentRunExecution::Sandbox,
-                Some("Research this."),
-            )
-            .await
-            .unwrap();
+        admit_sandbox(&store, chat.id, spawn, "Research this.").await;
         let lease = uuid::Uuid::new_v4();
         let run = store
             .claim_agent_run(lease, chrono::Duration::minutes(1), 4, 2)
@@ -1371,20 +1400,12 @@ mod tests {
         store.create_chat(&chat).await.unwrap();
         let call = CallId::new();
         let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
-        assert!(matches!(
-            store
-                .accept_agent_run(
-                    id,
-                    chat.id,
-                    Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
-                    Some(call),
-                    AgentRunExecution::Sandbox,
-                    Some("Wait until cancelled."),
-                )
+        assert_eq!(
+            admit_sandbox(&store, chat.id, call, "Wait until cancelled.")
                 .await
-                .unwrap(),
-            AcceptAgentRunOutcome::Accepted(_)
-        ));
+                .id,
+            id
+        );
         let started = Arc::new(Notify::new());
         let worker = SandboxAgentRunWorker::new(
             store.clone(),
@@ -1443,17 +1464,7 @@ mod tests {
             async move {
                 let call = CallId::new();
                 let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
-                store
-                    .accept_agent_run(
-                        id,
-                        chat.id,
-                        Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
-                        Some(call),
-                        AgentRunExecution::Sandbox,
-                        Some(&task),
-                    )
-                    .await
-                    .unwrap();
+                admit_sandbox(&store, chat.id, call, &task).await;
                 id
             }
         };
@@ -1522,17 +1533,7 @@ mod tests {
         let (_unused, store, provider, chat, _dir) = fixture().await;
         let call = CallId::new();
         let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
-        store
-            .accept_agent_run(
-                id,
-                chat.id,
-                Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
-                Some(call),
-                AgentRunExecution::Sandbox,
-                Some("do not call provider"),
-            )
-            .await
-            .unwrap();
+        admit_sandbox(&store, chat.id, call, "do not call provider").await;
         let entered = Arc::new(Notify::new());
         let release = Arc::new(Notify::new());
         let worker = SandboxAgentRunWorker::new(
@@ -1574,18 +1575,7 @@ mod tests {
     async fn resolver_delay_past_the_database_lease_prevents_provider_egress() {
         let (_unused, store, provider, chat, _dir) = fixture().await;
         let call = CallId::new();
-        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
-        store
-            .accept_agent_run(
-                id,
-                chat.id,
-                Some(openwave_core::AgentRunId::foreground_for_chat(chat.id)),
-                Some(call),
-                AgentRunExecution::Sandbox,
-                Some("do not call provider after expiry"),
-            )
-            .await
-            .unwrap();
+        admit_sandbox(&store, chat.id, call, "do not call provider after expiry").await;
         let entered = Arc::new(Notify::new());
         let release = Arc::new(Notify::new());
         let worker = SandboxAgentRunWorker::new(

--- a/crates/openwave-server/src/sandbox_web_search_worker.rs
+++ b/crates/openwave-server/src/sandbox_web_search_worker.rs
@@ -360,9 +360,9 @@ mod tests {
     use std::sync::Mutex;
 
     use openwave_core::{
-        AcceptAgentRunOutcome, AgentRunExecution, AgentRunId, AgentRunStatus, CallId, Chat, ChatId,
-        ClaimSandboxToolCallOutcome, DbStore, ParkSandboxToolCallOutcome,
-        RequestAgentRunCancellationOutcome, SandboxToolCallRequest, Store,
+        AgentRunStatus, CallId, Chat, ChatId, ClaimSandboxToolCallOutcome, DbStore,
+        ParkSandboxToolCallOutcome, RequestAgentRunCancellationOutcome, SandboxToolCallRequest,
+        Store,
     };
     use openwave_web_search::{WebSearchProviderKind, WebSearchResult};
 
@@ -430,19 +430,40 @@ mod tests {
             created_at: Utc::now(),
         };
         store.create_chat(&chat).await.unwrap();
-        let run = match store
-            .accept_agent_run(
-                AgentRunId::new(),
+        let turn_id = openwave_core::TurnId::new();
+        store
+            .accept_turn(
+                turn_id,
                 chat.id,
-                Some(AgentRunId::foreground_for_chat(chat.id)),
-                Some(CallId::new()),
-                AgentRunExecution::Sandbox,
-                Some("search"),
+                "sandbox-test-model",
+                "sandbox search test",
+            )
+            .await
+            .unwrap();
+        let turn_lease = uuid::Uuid::new_v4();
+        let now = Utc::now();
+        let turn = store
+            .claim_turn_run(turn_lease, now, now + chrono::Duration::hours(1))
+            .await
+            .unwrap()
+            .turn
+            .unwrap();
+        let call = CallId::new();
+        let run = match store
+            .admit_sandbox_agent_run(
+                turn.id,
+                call,
+                "search",
+                turn_lease,
+                turn.steer_revision,
+                1,
+                Utc::now(),
             )
             .await
             .unwrap()
+            .unwrap()
         {
-            AcceptAgentRunOutcome::Accepted(run) => run,
+            openwave_core::AdmitSandboxAgentRunOutcome::Accepted { child, .. } => child,
             outcome => panic!("unexpected sandbox admission: {outcome:?}"),
         };
         let worker_lease = uuid::Uuid::new_v4();

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -9,15 +9,15 @@ use axum::http::{header, Request, StatusCode};
 use futures::stream::{self, BoxStream, StreamExt};
 // Tests use the in-memory store; production wires LanceDB in `bind`.
 use openwave_core::{
-    AcceptAgentRunOutcome, Agent, AgentConfig, AgentErrorInfo, AgentEvent, AgentRunExecution,
-    AgentRunId, AgentRunInboxStatus, AgentRunStatus, ApprovalClass, BeginRootAttachmentChange,
-    BlobStore, CallId, Chat, ChatId, ChatRequest, ChatRootAttachment, ClaimedAgentEvent,
-    ClientToolCallRequest, ContentBlock, HostRootId, Message, MessageId, ModelProvider,
-    ParkSandboxToolCallOutcome, ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent,
-    ProviderId, Role, RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentOrigin,
-    SandboxToolCallRequest, SecretProvider, SequencedEvent, StopReason, Tool, ToolCallExecution,
-    ToolCallRecord, ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput, ToolRegistry,
-    ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
+    Agent, AgentConfig, AgentErrorInfo, AgentEvent, AgentRunInboxStatus, AgentRunStatus,
+    ApprovalClass, BeginRootAttachmentChange, BlobStore, CallId, Chat, ChatId, ChatRequest,
+    ChatRootAttachment, ClaimedAgentEvent, ClientToolCallRequest, ContentBlock, HostRootId,
+    Message, MessageId, ModelProvider, ParkSandboxToolCallOutcome, ParkTurnForClientCallOutcome,
+    Project, ProjectId, ProviderEvent, ProviderId, Role, RootAttachmentChangeAction,
+    RootAttachmentChangeId, RootAttachmentOrigin, SandboxToolCallRequest, SecretProvider,
+    SequencedEvent, StopReason, Tool, ToolCallExecution, ToolCallRecord, ToolCallResolution,
+    ToolCallStatus, ToolCtx, ToolOutput, ToolRegistry, ToolSpec, TurnCheckpointProgress, TurnId,
+    TurnRunStatus, TurnSteerId, Usage,
 };
 use openwave_retrieval::{
     Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
@@ -1795,6 +1795,48 @@ fn spawn_turn_worker_with_config(state: &AppState, config: turn_worker::TurnWork
 
 async fn test_app() -> (Router, Arc<str>, Arc<dyn Store>, tempfile::TempDir) {
     test_app_with(Arc::new(FakeProvider)).await
+}
+
+async fn admit_sandbox_for_test(
+    store: &Arc<dyn Store>,
+    chat_id: ChatId,
+    input: &str,
+) -> openwave_core::AgentRun {
+    let turn_id = TurnId::new();
+    store
+        .accept_turn(
+            turn_id,
+            chat_id,
+            "sandbox-test-model",
+            "sandbox server test",
+        )
+        .await
+        .unwrap();
+    let turn_lease = uuid::Uuid::new_v4();
+    let now = chrono::Utc::now();
+    let turn = store
+        .claim_turn_run(turn_lease, now, now + chrono::Duration::hours(1))
+        .await
+        .unwrap()
+        .turn
+        .expect("sandbox test turn should claim");
+    match store
+        .admit_sandbox_agent_run(
+            turn.id,
+            CallId::new(),
+            input,
+            turn_lease,
+            turn.steer_revision,
+            1,
+            chrono::Utc::now(),
+        )
+        .await
+        .unwrap()
+        .expect("sandbox test admission should resolve")
+    {
+        openwave_core::AdmitSandboxAgentRunOutcome::Accepted { child, .. } => child,
+        outcome => panic!("unexpected sandbox test admission: {outcome:?}"),
+    }
 }
 
 /// A normal authenticated local API plus a handle to its test-only secret
@@ -6157,21 +6199,7 @@ async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
         json_body(response).await
     };
 
-    let run = match store
-        .accept_agent_run(
-            AgentRunId::new(),
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("research"),
-        )
-        .await
-        .unwrap()
-    {
-        AcceptAgentRunOutcome::Accepted(run) => run,
-        outcome => panic!("unexpected sandbox admission: {outcome:?}"),
-    };
+    let run = admit_sandbox_for_test(&store, chat.id, "research").await;
     let worker_lease = uuid::Uuid::new_v4();
     assert_eq!(
         store
@@ -6463,21 +6491,7 @@ async fn agent_run_snapshots_omit_persisted_raw_failure_detail() {
     assert_eq!(response.status(), StatusCode::CREATED);
     let chat: Chat = json_body(response).await;
 
-    let run = match store
-        .accept_agent_run(
-            AgentRunId::new(),
-            chat.id,
-            Some(AgentRunId::foreground_for_chat(chat.id)),
-            Some(CallId::new()),
-            AgentRunExecution::Sandbox,
-            Some("research"),
-        )
-        .await
-        .unwrap()
-    {
-        AcceptAgentRunOutcome::Accepted(run) => run,
-        outcome => panic!("unexpected sandbox admission: {outcome:?}"),
-    };
+    let run = admit_sandbox_for_test(&store, chat.id, "research").await;
     let lease_token = uuid::Uuid::new_v4();
     assert_eq!(
         store

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -1206,6 +1206,19 @@ impl TurnWorker {
                             )) => {
                                 break;
                             }
+                            Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::AtCapacity)) => {
+                                checkpoint_heartbeat.abort_and_wait().await;
+                                return self
+                                    .record_failure(
+                                        &turn,
+                                        lease_token,
+                                        total_model_steps,
+                                        total_usage,
+                                        "sandbox_agent_capacity_exceeded",
+                                        "sandbox delegation exceeds the bounded outstanding-child limit",
+                                    )
+                                    .await;
+                            }
                             Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict))
                             | Ok(Some(
                                 AcceptSandboxAgentRunAndParkTurnOutcome::ParentUnavailable,


### PR DESCRIPTION
## Summary

- bind every sandbox child to its exact foreground turn and spawn call with an immutable admission receipt
- enforce deterministic child identity, depth-one ownership, and bounded outstanding admission in the same transaction
- require receipt-backed scheduler claims and exact origin ownership when parking a foreground turn
- add SQLite and PostgreSQL coverage for concurrency caps, exact retries, lease races, foreign-key integrity, and corrupted receiptless rows

## Validation

- `bw dev lint --rust --check`
- `cargo check --workspace --all-targets`
- `cargo check -p openwave-core --all-targets --features postgres`
- `cargo test -p openwave-core --features sqlite` (316 passed)
- `cargo test -p openwave-server` (222 passed)
- PostgreSQL test target feature-compiles; runtime database was not configured locally