### PR TITLE
Add sandbox agent cancellation API

### DIFF
--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -197,6 +197,10 @@ pub fn app(state: AppState) -> Router {
         .route("/chats/{id}/messages", get(routes::list_chat_messages))
         .route("/chats/{id}/agent-runs", get(routes::list_agent_runs))
         .route(
+            "/chats/{chat_id}/agent-runs/{run_id}/cancel",
+            post(routes::cancel_agent_run),
+        )
+        .route(
             "/settings/api-key",
             axum::routing::put(routes::put_api_key).delete(routes::delete_api_key),
         )

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -15,9 +15,9 @@ use tokio::sync::broadcast::error::RecvError;
 use openwave_core::{
     AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunExecution, AgentRunStatus,
     ApprovalDecision, CallId, Chat, ChatId, DeleteChatOutcome, Message as StoredMessage, MessageId,
-    Project, ProjectId, RequestTurnCancellationOutcome, Role, SandboxToolCall,
-    SandboxToolCallStatus, SecretProvider, SequencedEvent, Store, ToolCallExecution,
-    ToolCallRecord, ToolCallStatus, TurnId, TurnSteer, TurnSteerId,
+    Project, ProjectId, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, Role,
+    SandboxToolCall, SandboxToolCallStatus, SecretProvider, SequencedEvent, Store,
+    ToolCallExecution, ToolCallRecord, ToolCallStatus, TurnId, TurnSteer, TurnSteerId,
 };
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
@@ -768,6 +768,101 @@ pub async fn list_agent_runs(
         snapshots.push(AgentRunSnapshot::from_run(run, activity));
     }
     Ok(Json(snapshots))
+}
+
+/// Renderer-safe result of requesting cancellation for one sandbox run.
+///
+/// The command can expose only the two states it successfully produces or
+/// recovers. Worker leases, delegated input, retry budgets, and diagnostics
+/// remain behind the server boundary.
+#[derive(Debug, Serialize)]
+pub struct AgentRunCancellationSnapshot {
+    pub id: openwave_core::AgentRunId,
+    pub status: AgentRunCancellationStatus,
+}
+
+/// Closed renderer vocabulary for a successful sandbox cancellation request.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRunCancellationStatus {
+    Cancelling,
+    Cancelled,
+}
+
+/// `POST /chats/{chat_id}/agent-runs/{run_id}/cancel` — durably cancel one
+/// chat-owned sandbox run.
+///
+/// Unclaimed work becomes terminal immediately. A live worker retains its
+/// exact lease and acknowledges the `cancelling` state before quiescing.
+/// Exact retries of either state return the same renderer-safe result.
+pub async fn cancel_agent_run(
+    State(state): State<AppState>,
+    Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
+) -> Result<(StatusCode, Json<AgentRunCancellationSnapshot>), ServerError> {
+    state
+        .store
+        .get_chat(chat_id)
+        .await?
+        .ok_or_else(|| ServerError::not_found(format!("chat {chat_id} not found")))?;
+
+    loop {
+        let run = state
+            .store
+            .get_agent_run(run_id)
+            .await?
+            .ok_or_else(|| ServerError::not_found(format!("agent run {run_id} not found")))?;
+        if run.chat_id != chat_id {
+            return Err(ServerError::conflict_kind(
+                "agent_run_chat_mismatch",
+                format!("agent run {run_id} does not belong to chat {chat_id}"),
+            ));
+        }
+        if run.execution != AgentRunExecution::Sandbox {
+            return Err(ServerError::conflict_kind(
+                "agent_run_not_cancellable",
+                format!("agent run {run_id} is not a sandbox run"),
+            ));
+        }
+
+        let Some(outcome) = state.store.request_agent_run_cancellation(run_id).await? else {
+            // A claim or heartbeat may win after the ownership read. Retry the
+            // same idempotent command; the store serializes the next attempt
+            // against that lifecycle transition.
+            tokio::task::yield_now().await;
+            continue;
+        };
+        let (run, status) = match outcome {
+            RequestAgentRunCancellationOutcome::Cancelled(run) => {
+                (run, AgentRunCancellationStatus::Cancelled)
+            }
+            RequestAgentRunCancellationOutcome::Requested(run) => {
+                (run, AgentRunCancellationStatus::Cancelling)
+            }
+            RequestAgentRunCancellationOutcome::Existing(run) => {
+                let status = match run.status {
+                    AgentRunStatus::Cancelling => AgentRunCancellationStatus::Cancelling,
+                    AgentRunStatus::Cancelled => AgentRunCancellationStatus::Cancelled,
+                    _ => {
+                        return Err(ServerError::internal(
+                            "agent-run cancellation recovered an invalid state",
+                        ));
+                    }
+                };
+                (run, status)
+            }
+            RequestAgentRunCancellationOutcome::AlreadyTerminal(run) => {
+                return Err(ServerError::conflict_kind(
+                    "agent_run_already_terminal",
+                    format!("agent run {} already finished before cancellation", run.id),
+                ));
+            }
+        };
+        state.agent_run_wake.notify_one();
+        return Ok((
+            StatusCode::ACCEPTED,
+            Json(AgentRunCancellationSnapshot { id: run.id, status }),
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1839,6 +1839,26 @@ async fn admit_sandbox_for_test(
     }
 }
 
+async fn cancel_sandbox_run(
+    router: &Router,
+    bearer: &str,
+    chat_id: ChatId,
+    run_id: openwave_core::AgentRunId,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/chats/{chat_id}/agent-runs/{run_id}/cancel"))
+                .header(header::AUTHORIZATION, bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
 /// A normal authenticated local API plus a handle to its test-only secret
 /// store, for asserting web-search credential routes never touch other keys.
 async fn test_app_with_web_search_secrets() -> (Router, Arc<str>, Arc<MemSecrets>, tempfile::TempDir)
@@ -6293,6 +6313,162 @@ async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
         snapshot.get("activity"),
         Some(&serde_json::json!({"kind": "web_search", "status": "running"}))
     );
+}
+
+#[tokio::test]
+async fn queued_sandbox_cancellation_is_immediate_and_exact_retries_are_closed() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let run = admit_sandbox_for_test(&store, chat.id, "private delegated task").await;
+
+    for _ in 0..2 {
+        let response = cancel_sandbox_run(&router, &bearer, chat.id, run.id).await;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let body: serde_json::Value = json_body(response).await;
+        assert_eq!(
+            body,
+            serde_json::json!({"id": run.id, "status": "cancelled"})
+        );
+        let encoded = serde_json::to_string(&body).unwrap();
+        for forbidden in ["private delegated task", "lease", "diagnostic", "input"] {
+            assert!(!encoded.contains(forbidden), "response leaked {forbidden}");
+        }
+    }
+    assert_eq!(
+        store.get_agent_run(run.id).await.unwrap().unwrap().status,
+        AgentRunStatus::Cancelled
+    );
+}
+
+#[tokio::test]
+async fn running_sandbox_cancellation_returns_cancelling_on_exact_retry() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let run = admit_sandbox_for_test(&store, chat.id, "research").await;
+    let lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(lease, chrono::Duration::minutes(5), 1, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        run.id
+    );
+
+    for _ in 0..2 {
+        let response = cancel_sandbox_run(&router, &bearer, chat.id, run.id).await;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let body: serde_json::Value = json_body(response).await;
+        assert_eq!(
+            body,
+            serde_json::json!({"id": run.id, "status": "cancelling"})
+        );
+        assert_eq!(body.as_object().unwrap().len(), 2);
+    }
+    let persisted = store.get_agent_run(run.id).await.unwrap().unwrap();
+    assert_eq!(persisted.status, AgentRunStatus::Cancelling);
+    assert_eq!(persisted.lease_token, Some(lease));
+}
+
+#[tokio::test]
+async fn sandbox_cancellation_rejects_unknown_cross_chat_and_foreground_targets() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let owner = make_chat(&router, &bearer).await;
+    let other = make_chat(&router, &bearer).await;
+    let run = admit_sandbox_for_test(&store, owner.id, "research").await;
+
+    let missing_chat = cancel_sandbox_run(
+        &router,
+        &bearer,
+        ChatId::new(),
+        openwave_core::AgentRunId::new(),
+    )
+    .await;
+    assert_eq!(missing_chat.status(), StatusCode::NOT_FOUND);
+    let missing_chat: AgentErrorInfo = json_body(missing_chat).await;
+    assert_eq!(missing_chat.kind, "not_found");
+
+    let missing_run =
+        cancel_sandbox_run(&router, &bearer, owner.id, openwave_core::AgentRunId::new()).await;
+    assert_eq!(missing_run.status(), StatusCode::NOT_FOUND);
+    let missing_run: AgentErrorInfo = json_body(missing_run).await;
+    assert_eq!(missing_run.kind, "not_found");
+
+    let cross_chat = cancel_sandbox_run(&router, &bearer, other.id, run.id).await;
+    assert_eq!(cross_chat.status(), StatusCode::CONFLICT);
+    let cross_chat: AgentErrorInfo = json_body(cross_chat).await;
+    assert_eq!(cross_chat.kind, "agent_run_chat_mismatch");
+
+    let foreground = cancel_sandbox_run(
+        &router,
+        &bearer,
+        owner.id,
+        openwave_core::AgentRunId::foreground_for_chat(owner.id),
+    )
+    .await;
+    assert_eq!(foreground.status(), StatusCode::CONFLICT);
+    let foreground: AgentErrorInfo = json_body(foreground).await;
+    assert_eq!(foreground.kind, "agent_run_not_cancellable");
+
+    assert_eq!(
+        store.get_agent_run(run.id).await.unwrap().unwrap().status,
+        AgentRunStatus::Queued
+    );
+}
+
+#[tokio::test]
+async fn sandbox_cancellation_rejects_a_completed_run() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let run = admit_sandbox_for_test(&store, chat.id, "research").await;
+    let lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(lease, chrono::Duration::minutes(5), 1, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        run.id
+    );
+    assert!(matches!(
+        store
+            .submit_agent_run_result(run.id, lease, "done")
+            .await
+            .unwrap(),
+        Some(openwave_core::SubmitAgentRunResultOutcome::Completed(_))
+    ));
+
+    let response = cancel_sandbox_run(&router, &bearer, chat.id, run.id).await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let error: AgentErrorInfo = json_body(response).await;
+    assert_eq!(error.kind, "agent_run_already_terminal");
+    assert!(!error.message.contains("done"));
+}
+
+#[tokio::test]
+async fn sandbox_cancellation_requires_authentication() {
+    let (router, _token, _store, _dir) = test_app().await;
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/chats/{}/agent-runs/{}/cancel",
+                    ChatId::new(),
+                    openwave_core::AgentRunId::new()
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add authenticated chat-scoped cancellation for individual sandbox agent runs
- return a closed renderer-safe cancellation status without executor-private fields
- reject unknown, cross-chat, foreground, and already-finished targets with stable errors

## Verification
- `cargo test -p openwave-server`
- `bw dev lint --rust --check`
- `git diff --check`