### PR TITLE
Add message copy and timestamps

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -376,7 +376,13 @@ export default function App() {
       if (startsDifferentTurn) clearSteerRequestState();
       setMessages((prev) => [
         ...prev,
-        { id: nextId(), role: "assistant", text: "", sources: [] },
+        {
+          id: nextId(),
+          role: "assistant",
+          text: "",
+          sources: [],
+          createdAt: new Date().toISOString(),
+        },
       ]);
       return;
     }
@@ -392,7 +398,13 @@ export default function App() {
         if (last?.role === "assistant") {
           copy[copy.length - 1] = { ...last, text };
         } else {
-          copy.push({ id: nextId(), role: "assistant", text, sources: [] });
+          copy.push({
+            id: nextId(),
+            role: "assistant",
+            text,
+            sources: [],
+            createdAt: new Date().toISOString(),
+          });
         }
         return copy;
       });
@@ -488,7 +500,12 @@ export default function App() {
       hydratedMessageIdsRef.current.add(event.message_id);
       setMessages((prev) => [
         ...prev,
-        { id: event.message_id, role: "user", text: event.text },
+        {
+          id: event.message_id,
+          role: "user",
+          text: event.text,
+          createdAt: new Date().toISOString(),
+        },
       ]);
       return;
     }
@@ -547,7 +564,13 @@ export default function App() {
       if (last?.role === "assistant") {
         copy[copy.length - 1] = { ...last, text };
       } else {
-        copy.push({ id: nextId(), role: "assistant", text, sources: [] });
+        copy.push({
+          id: nextId(),
+          role: "assistant",
+          text,
+          sources: [],
+          createdAt: new Date().toISOString(),
+        });
       }
       return copy;
     });
@@ -630,7 +653,15 @@ export default function App() {
     const turnId = crypto.randomUUID();
     terminalHydrationGenerationRef.current += 1;
     setComposerDraft("");
-    setMessages((prev) => [...prev, { id: nextId(), role: "user", text: content }]);
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: nextId(),
+        role: "user",
+        text: content,
+        createdAt: new Date().toISOString(),
+      },
+    ]);
     setBusy(true);
     setCurrentActiveTurnId(turnId);
     setCancelPendingTurnId(null);

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -43,6 +43,7 @@ describe("terminal transcript presentation", () => {
         id: "assistant-durable",
         role: "assistant",
         text: "Clean durable answer",
+        createdAt: "2026-07-19T10:00:00Z",
         sources: [
           {
             id: "citation-private-id",
@@ -143,6 +144,7 @@ describe("terminal transcript presentation", () => {
         id: "assistant-durable",
         role: "assistant",
         text: "Clean durable answer",
+        createdAt: "2026-07-19T10:00:00Z",
         sources: [],
       },
     ]);

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -44,11 +44,13 @@ export function presentChatTranscript(
             role: "assistant",
             text: entry.text,
             sources: entry.sources,
+            createdAt: entry.createdAt,
           }
         : {
             id: entry.id,
             role: "user",
             text: entry.text,
+            createdAt: entry.createdAt,
           },
   );
 

--- a/crates/openwave-desktop/ui/src/MessageFooter.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageFooter.test.tsx
@@ -1,0 +1,68 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  copyMessageText,
+  formatMessageTimestamp,
+  MessageFooter,
+} from "./MessageFooter";
+
+describe("MessageFooter", () => {
+  it("renders copy and a machine-readable timestamp for a settled assistant message", () => {
+    const markup = renderToStaticMarkup(
+      <MessageFooter
+        role="assistant"
+        text="## Finished answer"
+        createdAt="2026-07-20T10:00:00Z"
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Copy"');
+    expect(markup).toContain('dateTime="2026-07-20T10:00:00Z"');
+    expect(markup).toContain('aria-live="polite"');
+  });
+
+  it("does not expose actions or time for an unsettled assistant response", () => {
+    const markup = renderToStaticMarkup(
+      <MessageFooter
+        role="assistant"
+        text="Partial answer"
+        createdAt="2026-07-20T10:00:00Z"
+        settled={false}
+      />,
+    );
+
+    expect(markup).toBe("");
+  });
+
+  it("does not render a timestamp-only footer for an empty settled assistant", () => {
+    const markup = renderToStaticMarkup(
+      <MessageFooter
+        role="assistant"
+        text="  "
+        createdAt="2026-07-20T10:00:00Z"
+      />,
+    );
+
+    expect(markup).toBe("");
+  });
+
+  it("copies the exact plain Markdown source", async () => {
+    const writeText = vi.fn(async () => undefined);
+
+    await copyMessageText("## Answer\n\n- one", { writeText });
+
+    expect(writeText).toHaveBeenCalledWith("## Answer\n\n- one");
+  });
+
+  it("keeps clipboard failures available to the component error state", async () => {
+    await expect(copyMessageText("Answer", undefined)).rejects.toThrow(
+      "Clipboard access is unavailable",
+    );
+  });
+
+  it("rejects malformed durable timestamps instead of rendering bad text", () => {
+    expect(
+      formatMessageTimestamp("not-a-date", new Date("2026-07-20T12:00:00Z")),
+    ).toBeNull();
+  });
+});

--- a/crates/openwave-desktop/ui/src/MessageFooter.tsx
+++ b/crates/openwave-desktop/ui/src/MessageFooter.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react";
+
+type MessageFooterProps = {
+  role: "user" | "assistant";
+  text: string;
+  createdAt?: string;
+  settled?: boolean;
+};
+
+type ClipboardWriter = {
+  writeText(text: string): Promise<void>;
+};
+
+type CopyState = "idle" | "copied" | "failed";
+
+const COPY_STATE_RESET_MS = 3_000;
+
+export function MessageFooter({
+  role,
+  text,
+  createdAt,
+  settled = true,
+}: MessageFooterProps) {
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const hasContent = text.trim().length > 0;
+  const timestamp = createdAt && (role === "user" || (settled && hasContent))
+    ? formatMessageTimestamp(createdAt, new Date())
+    : null;
+  const canCopy = role === "assistant" && settled && hasContent;
+
+  useEffect(() => {
+    if (copyState === "idle") return;
+    const timeout = window.setTimeout(
+      () => setCopyState("idle"),
+      COPY_STATE_RESET_MS,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [copyState]);
+
+  if (!canCopy && !timestamp) return null;
+
+  async function onCopy() {
+    try {
+      await copyMessageText(text);
+      setCopyState("copied");
+    } catch {
+      setCopyState("failed");
+    }
+  }
+
+  const copyLabel =
+    copyState === "copied"
+      ? "Copied"
+      : copyState === "failed"
+        ? "Copy failed"
+        : "Copy";
+
+  return (
+    <footer className="message-footer">
+      {canCopy && (
+        <button
+          type="button"
+          className="message-copy"
+          aria-label={copyLabel}
+          title={copyLabel}
+          onClick={() => void onCopy()}
+        >
+          <span aria-hidden="true">{copyState === "copied" ? "✓" : "⧉"}</span>
+          <span>{copyLabel}</span>
+        </button>
+      )}
+      <span className="message-footer-spacer" />
+      {timestamp && (
+        <time dateTime={createdAt} title={timestamp.full}>
+          {timestamp.short}
+        </time>
+      )}
+      <span className="sr-only" role="status" aria-live="polite">
+        {copyState === "copied"
+          ? "Message copied to clipboard."
+          : copyState === "failed"
+            ? "Message could not be copied."
+            : ""}
+      </span>
+    </footer>
+  );
+}
+
+export async function copyMessageText(
+  text: string,
+  clipboard: ClipboardWriter | undefined = globalThis.navigator?.clipboard,
+): Promise<void> {
+  if (!clipboard?.writeText) {
+    throw new Error("Clipboard access is unavailable");
+  }
+  await clipboard.writeText(text);
+}
+
+export function formatMessageTimestamp(
+  createdAt: string,
+  now: Date,
+): { short: string; full: string } | null {
+  const created = new Date(createdAt);
+  if (Number.isNaN(created.getTime())) return null;
+
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(created);
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  );
+  const startOfCreatedDay = new Date(
+    created.getFullYear(),
+    created.getMonth(),
+    created.getDate(),
+  );
+  const dayDifference = Math.round(
+    (startOfToday.getTime() - startOfCreatedDay.getTime()) / 86_400_000,
+  );
+
+  let short: string;
+  if (dayDifference === 0) {
+    short = time;
+  } else if (dayDifference === 1) {
+    short = `Yesterday, ${time}`;
+  } else {
+    short = new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      year: created.getFullYear() === now.getFullYear() ? undefined : "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(created);
+  }
+
+  return {
+    short,
+    full: new Intl.DateTimeFormat(undefined, {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(created),
+  };
+}

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -242,4 +242,121 @@ describe("MessageBubble", () => {
     expect(markup).not.toContain("private-citation-id");
     expect(markup).not.toContain("ow-source");
   });
+
+  it("shows settled message actions without treating the active response as finished", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        text: "Earlier question",
+        createdAt: "2026-07-20T10:00:00Z",
+      },
+      {
+        id: "assistant-settled",
+        role: "assistant",
+        text: "Earlier answer",
+        sources: [],
+        createdAt: "2026-07-20T10:00:01Z",
+      },
+      {
+        id: "assistant-streaming",
+        role: "assistant",
+        text: "Partial answer",
+        sources: [],
+        createdAt: "2026-07-20T10:01:00Z",
+      },
+    ];
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={messages}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        busy
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup.match(/aria-label="Copy"/g)).toHaveLength(1);
+    expect(markup.match(/class="message-footer"/g)).toHaveLength(2);
+    expect(markup).toContain('class="message-user-frame"');
+    expect(markup).not.toContain('dateTime="2026-07-20T10:01:00Z"');
+  });
+
+  it("does not add message actions to tool, system, or error rows", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "tool-1",
+        role: "tool",
+        callId: "call-1",
+        name: "read_file",
+        status: "running",
+      },
+      { id: "system-1", role: "system", text: "turn cancelled" },
+      { id: "error-1", role: "error", text: "could not complete" },
+    ];
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={messages}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup).not.toContain("message-footer");
+    expect(markup).not.toContain("Copy");
+  });
+
+  it("keeps the previous assistant settled while a submitted user message awaits turn start", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "assistant-settled",
+        role: "assistant",
+        text: "Previous answer",
+        sources: [],
+        createdAt: "2026-07-20T10:00:00Z",
+      },
+      {
+        id: "user-optimistic",
+        role: "user",
+        text: "Next question",
+        createdAt: "2026-07-20T10:01:00Z",
+      },
+    ];
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={messages}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        busy
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Copy"');
+    expect(markup).toContain('dateTime="2026-07-20T10:00:00Z"');
+    expect(markup).toContain('dateTime="2026-07-20T10:01:00Z"');
+  });
 });

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -3,17 +3,19 @@ import type { PendingFolderAccessRequest } from "./api";
 import { FolderAccessCard } from "./FolderAccessCard";
 import type { FolderAccessDecision } from "./host";
 import { MessageMarkdown } from "./MessageMarkdown";
+import { MessageFooter } from "./MessageFooter";
 import { AssistantSources, type AssistantSource } from "./AssistantSources";
 import { ToolCallCard, type ToolCallStatus } from "./ToolCallCard";
 import { ToolActivityGroup } from "./ToolActivityGroup";
 
 export type ChatMessage =
-  | { id: string; role: "user"; text: string }
+  | { id: string; role: "user"; text: string; createdAt?: string }
   | {
       id: string;
       role: "assistant";
       text: string;
       sources: AssistantSource[];
+      createdAt?: string;
     }
   | { id: string; role: "system"; text: string }
   | {
@@ -116,6 +118,23 @@ export function groupMessageItems(
   const items: ReactNode[] = [];
   let index = 0;
   let groupIndex = 0;
+  let streamingAssistantId: string | undefined;
+  if (busy) {
+    for (
+      let messageIndex = messages.length - 1;
+      messageIndex >= 0;
+      messageIndex -= 1
+    ) {
+      const candidate = messages[messageIndex];
+      if (candidate?.role === "assistant") {
+        streamingAssistantId = candidate.id;
+        break;
+      }
+      // A newly submitted user message is busy before its turn-start event
+      // arrives. Do not make the preceding completed assistant look live.
+      if (candidate?.role === "user") break;
+    }
+  }
 
   while (index < messages.length) {
     const message = messages[index];
@@ -125,7 +144,7 @@ export function groupMessageItems(
         <MessageBubble
           key={message.id}
           message={message}
-          busy={busy}
+          busy={message.id === streamingAssistantId}
           onApproval={onApproval}
         />,
       );
@@ -150,7 +169,7 @@ export function groupMessageItems(
         <MessageBubble
           key={message.id}
           message={message}
-          busy={busy}
+          busy={message.id === streamingAssistantId}
           onApproval={onApproval}
         />,
       );
@@ -222,15 +241,28 @@ export function MessageBubble({
           </span>
         ) : null}
         <AssistantSources sources={message.sources} />
+        <MessageFooter
+          role="assistant"
+          text={message.text}
+          createdAt={message.createdAt}
+          settled={!busy}
+        />
       </article>
     );
   }
 
   if (message.role === "user") {
     return (
-      <article className="message message-user" aria-label="You">
-        <MessageMarkdown>{message.text}</MessageMarkdown>
-      </article>
+      <div className="message-user-frame">
+        <article className="message message-user" aria-label="You">
+          <MessageMarkdown>{message.text}</MessageMarkdown>
+        </article>
+        <MessageFooter
+          role="user"
+          text={message.text}
+          createdAt={message.createdAt}
+        />
+      </div>
     );
   }
 

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -604,10 +604,14 @@ button {
   overflow-wrap: anywhere;
 }
 
-.message-user {
+.message-user-frame {
   width: fit-content;
   max-width: min(80%, 38rem);
   align-self: flex-end;
+}
+
+.message-user {
+  width: 100%;
   border-radius: 15px 15px 4px 15px;
   padding: 0.52rem 0.78rem;
   background: color-mix(in srgb, var(--sidebar-active) 84%, var(--bg-elevated));
@@ -618,6 +622,62 @@ button {
   align-self: flex-start;
   padding: 0.1rem 0;
   background: transparent;
+}
+
+.message-footer {
+  display: flex;
+  min-height: 1.7rem;
+  align-items: center;
+  gap: 0.35rem;
+  padding-top: 0.25rem;
+  color: var(--muted);
+  font-size: 0.72rem;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.message-user-frame .message-footer {
+  padding-inline: 0.3rem;
+}
+
+.message-assistant:hover .message-footer,
+.message-assistant:focus-within .message-footer,
+.message-user-frame:hover .message-footer,
+.message-user-frame:focus-within .message-footer {
+  opacity: 1;
+}
+
+.message-footer-spacer {
+  flex: 1 1 auto;
+}
+
+.message-footer time {
+  cursor: default;
+  white-space: nowrap;
+}
+
+.message-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  border: 0;
+  border-radius: 5px;
+  padding: 0.18rem 0.32rem;
+  color: var(--muted);
+  background: transparent;
+  font-size: 0.72rem;
+}
+
+.message-copy:hover,
+.message-copy:focus-visible {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--sidebar-active) 60%, transparent);
+}
+
+@media (hover: none) {
+  .message-footer {
+    opacity: 1;
+  }
 }
 
 .assistant-sources {
@@ -1055,7 +1115,8 @@ button {
 
 @media (prefers-reduced-motion: reduce) {
   .tool-call-spinner,
-  .assistant-sources-chevron {
+  .assistant-sources-chevron,
+  .message-footer {
     animation: none;
     transition: none;
   }


### PR DESCRIPTION
## Summary

- preserve durable message timestamps through transcript presentation
- add quiet copy and timestamp footers for completed messages
- keep active and empty assistant placeholders free of finished-message actions

## Validation

- 92 desktop UI tests
- production UI build
- React/TypeScript lint check