### PR TITLE
Refine tool activity history

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -1307,6 +1307,7 @@ export default function App() {
 
           <div className="message-view">
             <MessageList
+              key={chat.id}
               messages={messages}
               folderAccessRequests={folderAccessRequests}
               nativeHost={hasNativeHost()}

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -118,13 +118,15 @@ describe("MessageBubble", () => {
       />,
     );
 
-    expect(markup).toContain('class="tool-activity-group"');
+    expect(markup).toContain('class="tool-activity-group is-settled"');
     expect(markup).toContain('aria-expanded="false"');
     expect(markup).toContain('aria-controls="tool-activity-group-0"');
     expect(markup).toContain('id="tool-activity-group-0" hidden=""');
-    expect(markup).toContain("2 tool activities");
-    expect(markup).toContain("Search the web: Web search complete");
-    expect(markup).toContain("Read a file: Tool could not complete");
+    expect(markup).toContain(
+      "2 tool activities · 1 completed · 1 failed",
+    );
+    expect(markup).toContain("Web search complete");
+    expect(markup).toContain("Tool could not complete");
     expect(markup.indexOf("Web search complete")).toBeLessThan(
       markup.indexOf("Done"),
     );
@@ -188,7 +190,9 @@ describe("MessageBubble", () => {
       />,
     );
 
-    expect(markup).toContain("Use a tool: Tool complete");
+    expect(markup).toContain("Used a tool and searched the web");
+    expect(markup).toContain("Use a tool");
+    expect(markup).toContain("Tool complete");
     expect(markup).not.toContain("private_server");
     expect(markup).not.toContain("sensitive_path");
   });

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -178,7 +178,7 @@ export function groupMessageItems(
 
     items.push(
       <ToolActivityGroup
-        key={activities[0].id}
+        key={`tool-activity-group-${groupIndex}`}
         activities={activities}
         groupIndex={groupIndex}
       />,

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.test.tsx
@@ -1,0 +1,108 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  ToolActivityGroup,
+  toolActivityGroupPresentation,
+  type ToolActivity,
+} from "./ToolActivityGroup";
+
+describe("ToolActivityGroup", () => {
+  it("summarizes a small completed phase with semantic allowlisted copy", () => {
+    expect(
+      toolActivityGroupPresentation([
+        { name: "web_search", status: "completed" },
+        { name: "read_file", status: "completed" },
+      ]),
+    ).toEqual({
+      phase: "settled",
+      tone: "completed",
+      icon: "✓",
+      label: "Searched the web and read a file",
+    });
+  });
+
+  it("summarizes mixed terminal outcomes without provider details", () => {
+    expect(
+      toolActivityGroupPresentation([
+        { name: "web_search", status: "completed" },
+        { name: "write_file", status: "failed" },
+        { name: "list_dir", status: "cancelled" },
+      ]),
+    ).toEqual({
+      phase: "settled",
+      tone: "failed",
+      icon: "!",
+      label: "3 tool activities · 1 completed · 1 failed · 1 not run",
+    });
+  });
+
+  it("keeps an active phase distinct from settled history", () => {
+    expect(
+      toolActivityGroupPresentation([
+        { name: "read_file", status: "completed" },
+        { name: "list_dir", status: "running" },
+      ]),
+    ).toEqual({
+      phase: "active",
+      tone: "running",
+      icon: "↗",
+      label: "Browsing files",
+    });
+  });
+
+  it("renders a native disclosure with a hidden ordered timeline", () => {
+    const markup = renderToStaticMarkup(
+      <ToolActivityGroup
+        groupIndex={3}
+        activities={[
+          { name: "web_search", status: "completed" },
+          { name: "read_file", status: "failed" },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain('aria-controls="tool-activity-group-3"');
+    expect(markup).toContain(
+      'id="tool-activity-group-3" hidden="" class="tool-activity-group-list" role="list"',
+    );
+    expect(markup.match(/role="listitem"/g)).toHaveLength(2);
+    expect(markup).not.toContain("tool-call-card");
+    expect(markup).not.toContain('aria-live="polite"');
+  });
+
+  it("uses fixed fallback copy for unknown names and malformed statuses", () => {
+    const markup = renderToStaticMarkup(
+      <ToolActivityGroup
+        groupIndex={0}
+        activities={[
+          {
+            id: "private-call-id",
+            name: "private_provider_tool_name",
+            status: "private-provider-diagnostic" as "completed",
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("1 tool activity · 1 unavailable");
+    expect(markup).toContain("Use a tool");
+    expect(markup).toContain("Status unavailable");
+    expect(markup).not.toContain("private_provider_tool_name");
+    expect(markup).not.toContain("private-provider-diagnostic");
+    expect(markup).not.toContain("private-call-id");
+  });
+
+  it("does not render a broken disclosure for an invalid activity list", () => {
+    const markup = renderToStaticMarkup(
+      <ToolActivityGroup
+        groupIndex={0}
+        activities={undefined as unknown as ToolActivity[]}
+      />,
+    );
+
+    expect(markup).toContain("Tool activity unavailable");
+    expect(markup).not.toContain("aria-controls");
+    expect(markup).not.toContain("role=\"list\"");
+  });
+});

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
@@ -1,12 +1,11 @@
 import { useState } from "react";
 import {
-  ToolCallCard,
   toolCallPresentation,
   type ToolCallStatus,
 } from "./ToolCallCard";
 
-type ToolActivity = {
-  id: string;
+export type ToolActivity = {
+  id?: string;
   name: string;
   status: ToolCallStatus;
 };
@@ -22,14 +21,26 @@ export function ToolActivityGroup({
 }: ToolActivityGroupProps) {
   const [expanded, setExpanded] = useState(false);
   const contentId = `tool-activity-group-${groupIndex}`;
-  const summary = activities
-    .map((activity) => toolCallPresentation(activity.name, activity.status))
-    .map(({ label, statusLabel }) => `${label}: ${statusLabel}`)
-    .join(" · ");
-  const actionLabel = `${activities.length} tool activities`;
+  const safeActivities = normalizeActivities(activities);
+  const summary = toolActivityGroupPresentation(safeActivities);
+
+  if (safeActivities.length === 0) {
+    return (
+      <p className="tool-activity-unavailable" role="status">
+        Tool activity unavailable
+      </p>
+    );
+  }
 
   return (
-    <section className="tool-activity-group" aria-label="Tool activity">
+    <section
+      className={`tool-activity-group is-${summary.phase}`}
+      aria-label={
+        summary.phase === "settled"
+          ? "Completed tool activity"
+          : "Active tool activity"
+      }
+    >
       <button
         type="button"
         className="tool-activity-group-toggle"
@@ -37,27 +48,162 @@ export function ToolActivityGroup({
         aria-controls={contentId}
         onClick={() => setExpanded((current) => !current)}
       >
-        <span className="tool-activity-group-icon" aria-hidden="true">
-          {expanded ? "⌄" : "›"}
+        <span
+          className={`tool-activity-group-status is-${summary.tone}`}
+          aria-hidden="true"
+        >
+          {summary.icon}
         </span>
-        <span className="tool-activity-group-copy">
-          <strong>{actionLabel}</strong>
-          <span>{summary}</span>
+        <span className="tool-activity-group-label">{summary.label}</span>
+        <span
+          className={`tool-activity-group-chevron${expanded ? " is-expanded" : ""}`}
+          aria-hidden="true"
+        >
+          ›
         </span>
       </button>
       <div
         id={contentId}
         hidden={!expanded}
         className="tool-activity-group-list"
+        role="list"
       >
-        {activities.map((activity) => (
-          <ToolCallCard
-            key={activity.id}
-            name={activity.name}
-            status={activity.status}
-          />
-        ))}
+        {safeActivities.map((activity, index) => {
+          const presentation = toolCallPresentation(
+            activity.name,
+            activity.status,
+          );
+          return (
+            <div
+              className={`tool-activity-timeline-item is-${presentation.tone}`}
+              role="listitem"
+              key={index}
+            >
+              <span className="tool-activity-timeline-marker" aria-hidden="true">
+                {presentation.icon}
+              </span>
+              <span className="tool-activity-timeline-copy">
+                <strong>{presentation.label}</strong>
+                <span>{presentation.statusLabel}</span>
+              </span>
+            </div>
+          );
+        })}
       </div>
     </section>
   );
+}
+
+export type ToolActivityGroupPresentation = {
+  phase: "active" | "settled";
+  tone: "running" | "completed" | "failed" | "cancelled" | "unknown";
+  icon: string;
+  label: string;
+};
+
+export function toolActivityGroupPresentation(
+  activities: readonly ToolActivity[],
+): ToolActivityGroupPresentation {
+  if (activities.length === 0) {
+    return {
+      phase: "settled",
+      tone: "unknown",
+      icon: "?",
+      label: "Tool activity unavailable",
+    };
+  }
+
+  const presentations = activities.map((activity) =>
+    toolCallPresentation(activity.name, activity.status),
+  );
+  const active = presentations.filter(
+    ({ tone }) => tone === "running" || tone === "waiting_approval",
+  );
+  if (active.length > 0) {
+    const latest = active[active.length - 1]!;
+    return {
+      phase: "active",
+      tone: "running",
+      icon: latest.icon,
+      label: latest.statusLabel,
+    };
+  }
+
+  const completed = presentations.filter(({ tone }) => tone === "completed");
+  const failed = presentations.filter(({ tone }) => tone === "failed");
+  const cancelled = presentations.filter(({ tone }) => tone === "cancelled");
+  const unknown = presentations.filter(({ tone }) => tone === "unknown");
+
+  if (completed.length === presentations.length && completed.length <= 2) {
+    return {
+      phase: "settled",
+      tone: "completed",
+      icon: "✓",
+      label: completed
+        .map(({ settledLabel }, index) =>
+          index === 0 ? settledLabel : lowercaseFirst(settledLabel),
+        )
+        .join(" and "),
+    };
+  }
+
+  const counts = [
+    countLabel(completed.length, "completed"),
+    countLabel(failed.length, "failed"),
+    countLabel(cancelled.length, "not run"),
+    countLabel(unknown.length, "unavailable"),
+  ].filter((label): label is string => label !== null);
+  const tone =
+    failed.length > 0
+      ? "failed"
+      : unknown.length > 0
+        ? "unknown"
+        : cancelled.length > 0
+          ? "cancelled"
+          : "completed";
+
+  return {
+    phase: "settled",
+    tone,
+    icon:
+      tone === "failed"
+        ? "!"
+        : tone === "cancelled"
+          ? "–"
+          : tone === "unknown"
+            ? "?"
+            : "✓",
+    label: `${activities.length} tool ${
+      activities.length === 1 ? "activity" : "activities"
+    }${counts.length > 0 ? ` · ${counts.join(" · ")}` : ""}`,
+  };
+}
+
+function countLabel(count: number, label: string): string | null {
+  return count > 0 ? `${count} ${label}` : null;
+}
+
+function normalizeActivities(activities: unknown): ToolActivity[] {
+  if (!Array.isArray(activities)) return [];
+  return activities.flatMap((activity) => {
+    const candidate = activity as Record<string, unknown> | null;
+    if (
+      candidate === null ||
+      typeof candidate !== "object" ||
+      typeof candidate.name !== "string" ||
+      typeof candidate.status !== "string"
+    ) {
+      return [];
+    }
+    return [
+      {
+        name: candidate.name,
+        status: candidate.status as ToolCallStatus,
+      },
+    ];
+  });
+}
+
+function lowercaseFirst(value: string): string {
+  return value.length === 0 ? value : value[0]!.toLowerCase() + value.slice(1);
 }

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -41,6 +41,19 @@ describe("ToolCallCard", () => {
     expect(markup).toContain("Document search complete");
   });
 
+  it("degrades an unknown runtime status without using it as copy or a class", () => {
+    const markup = renderToStaticMarkup(
+      <ToolCallCard
+        name="web_search"
+        status={"private-provider-diagnostic" as "completed"}
+      />,
+    );
+
+    expect(markup).toContain("Status unavailable");
+    expect(markup).toContain("is-unknown");
+    expect(markup).not.toContain("private-provider-diagnostic");
+  });
+
   it("allows approval only for a fixed action description", () => {
     expect(toolApprovalPresentation("search_may_share_query_and_excerpts")).toEqual({
       summary:

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -14,11 +14,20 @@ type ToolPresentation = {
   label: string;
   active: string;
   complete: string;
+  settled: string;
 };
 
 export type ToolCallPresentation = {
   label: string;
   statusLabel: string;
+  settledLabel: string;
+  tone:
+    | "running"
+    | "waiting_approval"
+    | "completed"
+    | "failed"
+    | "cancelled"
+    | "unknown";
 };
 
 export type ToolApprovalPresentation = {
@@ -35,51 +44,61 @@ const TOOL_PRESENTATIONS: Record<string, ToolPresentation> = {
     label: "Search documents",
     active: "Searching documents",
     complete: "Document search complete",
+    settled: "Searched documents",
   },
   web_search: {
     label: "Search the web",
     active: "Searching the web",
     complete: "Web search complete",
+    settled: "Searched the web",
   },
   read_file: {
     label: "Read a file",
     active: "Reading a file",
     complete: "File read complete",
+    settled: "Read a file",
   },
   list_dir: {
     label: "Browse files",
     active: "Browsing files",
     complete: "File browse complete",
+    settled: "Browsed files",
   },
   write_file: {
     label: "Update a file",
     active: "Updating a file",
     complete: "File update complete",
+    settled: "Updated a file",
   },
   request_folder_access: {
     label: "Request folder access",
     active: "Requesting folder access",
     complete: "Folder access request complete",
+    settled: "Requested folder access",
   },
   connect_folder: {
     label: "Connect a folder",
     active: "Connecting a folder",
     complete: "Folder connected",
+    settled: "Connected a folder",
   },
   list_connected_folders: {
     label: "Check connected folders",
     active: "Checking connected folders",
     complete: "Connected folders checked",
+    settled: "Checked connected folders",
   },
   read_connected_file: {
     label: "Read a connected file",
     active: "Reading a connected file",
     complete: "Connected file read complete",
+    settled: "Read a connected file",
   },
   spawn_sandbox_agent: {
     label: "Delegate a task",
     active: "Delegating a task",
     complete: "Delegated task complete",
+    settled: "Delegated a task",
   },
 };
 
@@ -87,6 +106,7 @@ const FALLBACK_TOOL: ToolPresentation = {
   label: "Use a tool",
   active: "Using a tool",
   complete: "Tool complete",
+  settled: "Used a tool",
 };
 
 export function ToolCallCard({ name, status }: ToolCallCardProps) {
@@ -94,7 +114,7 @@ export function ToolCallCard({ name, status }: ToolCallCardProps) {
 
   return (
     <section
-      className={`tool-call-card is-${status}`}
+      className={`tool-call-card is-${presentation.tone}`}
       aria-label={`${presentation.label}: ${presentation.statusLabel}`}
       role="status"
       aria-live="polite"
@@ -107,7 +127,7 @@ export function ToolCallCard({ name, status }: ToolCallCardProps) {
         <strong>{presentation.label}</strong>
         <span>{presentation.statusLabel}</span>
       </div>
-      {status === "running" && (
+      {presentation.tone === "running" && (
         <span className="tool-call-spinner" aria-hidden="true" />
       )}
     </section>
@@ -127,6 +147,8 @@ export function toolCallPresentation(
   return {
     label: tool.label,
     statusLabel: statusPresentationResult.label,
+    settledLabel: tool.settled,
+    tone: statusPresentationResult.tone,
     icon: statusPresentationResult.icon,
   };
 }
@@ -150,14 +172,31 @@ export function toolApprovalPresentation(
 function statusPresentation(tool: ToolPresentation, status: ToolCallStatus) {
   switch (status) {
     case "waiting_approval":
-      return { icon: "…", label: "Waiting for approval" };
+      return {
+        icon: "…",
+        label: "Waiting for approval",
+        tone: "waiting_approval" as const,
+      };
     case "completed":
-      return { icon: "✓", label: tool.complete };
+      return {
+        icon: "✓",
+        label: tool.complete,
+        tone: "completed" as const,
+      };
     case "failed":
-      return { icon: "!", label: "Tool could not complete" };
+      return {
+        icon: "!",
+        label: "Tool could not complete",
+        tone: "failed" as const,
+      };
     case "cancelled":
-      return { icon: "–", label: "Not run" };
+      return { icon: "–", label: "Not run", tone: "cancelled" as const };
     case "running":
-      return { icon: "↗", label: tool.active };
+      return { icon: "↗", label: tool.active, tone: "running" as const };
   }
+
+  // Renderer projections are a closed vocabulary, but a future or malformed
+  // payload must degrade to fixed copy rather than reaching a dynamic class or
+  // throwing while conversation history renders.
+  return { icon: "?", label: "Status unavailable", tone: "unknown" as const };
 }

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1042,19 +1042,17 @@ button {
 .tool-activity-group {
   width: min(100%, 31rem);
   align-self: flex-start;
-  border: 1px solid var(--line);
-  border-radius: 9px;
-  background: color-mix(in srgb, var(--bg-elevated) 88%, var(--sidebar));
 }
 
 .tool-activity-group-toggle {
   display: flex;
-  width: 100%;
+  width: fit-content;
+  max-width: 100%;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.42rem;
   border: 0;
-  border-radius: 8px;
-  padding: 0.6rem 0.65rem;
+  border-radius: 6px;
+  padding: 0.24rem 0.32rem;
   color: var(--muted);
   background: transparent;
   text-align: left;
@@ -1062,49 +1060,119 @@ button {
 
 .tool-activity-group-toggle:hover,
 .tool-activity-group-toggle:focus-visible {
-  background: color-mix(in srgb, var(--sidebar-active) 65%, transparent);
-}
-
-.tool-activity-group-icon {
-  width: 1.15rem;
-  flex: 0 0 auto;
   color: var(--ink);
-  font-size: 1.3rem;
-  line-height: 1;
-  text-align: center;
+  background: color-mix(in srgb, var(--sidebar-active) 58%, transparent);
 }
 
-.tool-activity-group-copy {
+.tool-activity-group-status {
   display: grid;
-  min-width: 0;
-  gap: 0.04rem;
+  width: 1.15rem;
+  height: 1.15rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--ink);
+  background: var(--user-bg);
+  font-size: 0.7rem;
+  font-weight: 650;
+  line-height: 1;
 }
 
-.tool-activity-group-copy strong,
-.tool-activity-group-copy span {
+.tool-activity-group-status.is-completed {
+  color: oklch(0.42 0.13 150);
+  background: oklch(0.95 0.035 150);
+}
+
+.tool-activity-group-status.is-failed,
+.tool-activity-group-status.is-unknown {
+  color: var(--danger);
+  background: oklch(0.97 0.01 25);
+}
+
+.tool-activity-group-label {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.tool-activity-group-copy strong {
-  color: var(--ink);
   font-size: 0.82rem;
-  font-weight: 600;
+  font-weight: 550;
 }
 
-.tool-activity-group-copy span {
-  font-size: 0.75rem;
+.tool-activity-group-chevron {
+  flex: 0 0 auto;
+  font-size: 1rem;
+  line-height: 1;
+  transition: transform 120ms ease;
+}
+
+.tool-activity-group-chevron.is-expanded {
+  transform: rotate(90deg);
 }
 
 .tool-activity-group-list {
   display: grid;
-  gap: 0.45rem;
-  padding: 0 0.65rem 0.65rem;
+  gap: 0.7rem;
+  margin: 0.35rem 0 0 0.86rem;
+  border-left: 1px solid var(--line);
+  padding: 0.3rem 0 0.25rem 1rem;
 }
 
-.tool-activity-group-list .tool-call-card {
-  width: 100%;
+.tool-activity-timeline-item {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 0.55rem;
+  color: var(--muted);
+}
+
+.tool-activity-timeline-marker {
+  position: absolute;
+  left: -1.04rem;
+  display: grid;
+  width: 1rem;
+  height: 1rem;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--ink);
+  background: var(--bg);
+  font-size: 0.67rem;
+  font-weight: 650;
+  line-height: 1;
+  transform: translateX(-50%);
+}
+
+.tool-activity-timeline-item.is-completed .tool-activity-timeline-marker {
+  color: oklch(0.42 0.13 150);
+}
+
+.tool-activity-timeline-item.is-failed .tool-activity-timeline-marker,
+.tool-activity-timeline-item.is-unknown .tool-activity-timeline-marker {
+  color: var(--danger);
+}
+
+.tool-activity-timeline-copy {
+  display: grid;
+  min-width: 0;
+  gap: 0.05rem;
+}
+
+.tool-activity-timeline-copy strong {
+  color: var(--ink);
+  font-size: 0.8rem;
+  font-weight: 550;
+}
+
+.tool-activity-timeline-copy span {
+  font-size: 0.74rem;
+}
+
+.tool-activity-unavailable {
+  width: fit-content;
+  max-width: 100%;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
 }
 
 @keyframes tool-call-spin {
@@ -1116,7 +1184,8 @@ button {
 @media (prefers-reduced-motion: reduce) {
   .tool-call-spinner,
   .assistant-sources-chevron,
-  .message-footer {
+  .message-footer,
+  .tool-activity-group-chevron {
     animation: none;
     transition: none;
   }


### PR DESCRIPTION
## Summary

- replace terminal tool cards with compact semantic activity summaries
- show expanded history as an accessible vertical timeline
- keep active work separate and harden fallback rendering for malformed projections

## Validation

- 99 desktop UI tests
- production UI build
- React/TypeScript lint check