### PR TITLE
Add foreground working indicator

### DIFF
--- a/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
@@ -1,0 +1,136 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AssistantWorkingIndicator } from "./AssistantWorkingIndicator";
+import {
+  shouldShowAssistantWorking,
+  type ChatMessage,
+} from "./MessageList";
+
+describe("AssistantWorkingIndicator", () => {
+  it("renders fixed visible copy as one polite atomic status", () => {
+    const markup = renderToStaticMarkup(<AssistantWorkingIndicator />);
+
+    expect(markup).toContain("Working");
+    expect(markup).toContain('role="status"');
+    expect(markup).toContain('aria-live="polite"');
+    expect(markup).toContain('aria-atomic="true"');
+    expect(markup).toContain('aria-hidden="true"');
+  });
+
+  it("shows while an open turn has no more specific live status", () => {
+    const messages: ChatMessage[] = [
+      { id: "user", role: "user", text: "Question" },
+      { id: "assistant", role: "assistant", text: "", sources: [] },
+    ];
+
+    expect(shouldShowAssistantWorking(messages, true, 0)).toBe(true);
+    expect(
+      shouldShowAssistantWorking(
+        [{ id: "user-only", role: "user", text: "Submitted question" }],
+        true,
+        0,
+      ),
+    ).toBe(true);
+    expect(shouldShowAssistantWorking(messages, false, 0)).toBe(false);
+  });
+
+  it("does not compete with a partial assistant response", () => {
+    expect(
+      shouldShowAssistantWorking(
+        [
+          {
+            id: "assistant-streaming",
+            role: "assistant",
+            text: "Partial response",
+            sources: [],
+          },
+        ],
+        true,
+        0,
+      ),
+    ).toBe(false);
+    expect(
+      shouldShowAssistantWorking(
+        [
+          {
+            id: "assistant-sourced",
+            role: "assistant",
+            text: "",
+            sources: [
+              {
+                id: "source",
+                ordinal: 1,
+                excerpt: "Visible evidence",
+                heading: null,
+                pages: [],
+              },
+            ],
+          },
+        ],
+        true,
+        0,
+      ),
+    ).toBe(false);
+  });
+
+  it("defers to active tool and user-action statuses", () => {
+    const runningTool: ChatMessage = {
+      id: "tool",
+      role: "tool",
+      callId: "call",
+      name: "web_search",
+      status: "running",
+    };
+    const approval: ChatMessage = {
+      id: "approval",
+      role: "approval",
+      callId: "call",
+      summary: "Safe approval copy",
+      canApprove: true,
+    };
+
+    expect(shouldShowAssistantWorking([runningTool], true, 0)).toBe(false);
+    expect(shouldShowAssistantWorking([approval], true, 0)).toBe(false);
+    expect(shouldShowAssistantWorking([], true, 1)).toBe(false);
+    expect(
+      shouldShowAssistantWorking(
+        [
+          {
+            ...runningTool,
+            status: "future-private-status" as "running",
+          },
+        ],
+        true,
+        0,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns after a terminal tool phase before the next assistant segment", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "assistant-before-tool",
+        role: "assistant",
+        text: "I will check that.",
+        sources: [],
+      },
+      {
+        id: "tool",
+        role: "tool",
+        callId: "call",
+        name: "private-provider-tool-name",
+        status: "completed",
+      },
+      {
+        id: "approval",
+        role: "approval",
+        callId: "call",
+        summary: "private-provider-diagnostic",
+        canApprove: false,
+        resolved: true,
+      },
+    ];
+
+    expect(shouldShowAssistantWorking(messages, true, 0)).toBe(true);
+  });
+});

--- a/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.tsx
@@ -1,0 +1,16 @@
+import { Logomark } from "./Logomark";
+
+/** One fixed, renderer-owned status for an open foreground turn. */
+export function AssistantWorkingIndicator() {
+  return (
+    <div
+      className="assistant-working"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <Logomark className="assistant-working-mark" />
+      <span>Working</span>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -33,7 +33,7 @@ describe("MessageBubble", () => {
     expect(assistant).not.toContain("bubble");
   });
 
-  it("keeps tool cards, approvals, and active streaming placeholders in sequence", () => {
+  it("keeps tool cards and approvals in sequence without a duplicate worker status", () => {
     const messages: ChatMessage[] = [
       { id: "tool-1", role: "tool", callId: "call-1", name: "web_search", status: "running" },
       {
@@ -66,7 +66,33 @@ describe("MessageBubble", () => {
       markup.indexOf("Approval needed"),
     );
     expect(markup).toContain("message-approval");
-    expect(markup).toContain('aria-label="Thinking"');
+    expect(markup).not.toContain("Working");
+    expect(markup).toContain('aria-live="polite"');
+  });
+
+  it("replaces an empty active assistant placeholder with one worker status", () => {
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={[
+          { id: "assistant-active", role: "assistant", text: "", sources: [] },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        busy
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup.match(/>Working</g)).toHaveLength(1);
+    expect(markup).not.toContain('aria-label="Assistant"');
+    expect(markup).not.toContain("message-stream-placeholder");
   });
 
   it("does not offer approval for an action without a safe description", () => {

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode, RefObject, UIEvent } from "react";
 import type { PendingFolderAccessRequest } from "./api";
+import { AssistantWorkingIndicator } from "./AssistantWorkingIndicator";
 import { FolderAccessCard } from "./FolderAccessCard";
 import type { FolderAccessDecision } from "./host";
 import { MessageMarkdown } from "./MessageMarkdown";
@@ -91,6 +92,11 @@ export function MessageList({
           onCancel={() => onFolderAccessCancel(request.callId, request.turnId)}
         />
       ))}
+      {shouldShowAssistantWorking(
+        messages,
+        busy,
+        folderAccessRequests.length,
+      ) && <AssistantWorkingIndicator />}
     </div>
   );
 }
@@ -231,15 +237,11 @@ export function MessageBubble({
   }
 
   if (message.role === "assistant") {
+    if (!message.text && message.sources.length === 0) return null;
+
     return (
       <article className="message message-assistant" aria-label="Assistant">
-        {message.text ? (
-          <MessageMarkdown>{message.text}</MessageMarkdown>
-        ) : busy ? (
-          <span className="message-stream-placeholder" aria-label="Thinking">
-            …
-          </span>
-        ) : null}
+        {message.text && <MessageMarkdown>{message.text}</MessageMarkdown>}
         <AssistantSources sources={message.sources} />
         <MessageFooter
           role="assistant"
@@ -274,4 +276,32 @@ export function MessageBubble({
       {message.text}
     </div>
   );
+}
+
+/**
+ * The generic worker indicator fills only gaps where no more specific live or
+ * user-action status is already visible. All copy remains renderer-owned.
+ */
+export function shouldShowAssistantWorking(
+  messages: readonly ChatMessage[],
+  busy: boolean,
+  pendingFolderAccessCount: number,
+): boolean {
+  if (!busy || pendingFolderAccessCount > 0) return false;
+  const hasSpecificPendingStatus = messages.some(
+    (message) =>
+      (message.role === "tool" &&
+        message.status !== "completed" &&
+        message.status !== "failed" &&
+        message.status !== "cancelled") ||
+      (message.role === "approval" && !message.resolved),
+  );
+  if (hasSpecificPendingStatus) return false;
+
+  const latest = messages[messages.length - 1];
+  if (latest?.role === "assistant") {
+    return latest.text.trim().length === 0 && latest.sources.length === 0;
+  }
+  if (latest?.role === "system" || latest?.role === "error") return false;
+  return true;
 }

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -812,11 +812,37 @@ button {
   text-align: left;
 }
 
-.message-stream-placeholder {
-  display: inline-block;
-  min-width: 1.2rem;
+.assistant-working {
+  display: flex;
+  width: fit-content;
+  max-width: 100%;
+  align-self: flex-start;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.2rem 0;
   color: var(--muted);
-  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+  font-weight: 550;
+}
+
+.assistant-working-mark {
+  width: 1rem;
+  height: auto;
+  transform-origin: center;
+  animation: assistant-working-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes assistant-working-pulse {
+  0%,
+  100% {
+    opacity: 0.38;
+    transform: scale(0.92);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 .message-approval {
@@ -1185,9 +1211,15 @@ button {
   .tool-call-spinner,
   .assistant-sources-chevron,
   .message-footer,
-  .tool-activity-group-chevron {
+  .tool-activity-group-chevron,
+  .assistant-working-mark {
     animation: none;
     transition: none;
+  }
+
+  .assistant-working-mark {
+    opacity: 0.72;
+    transform: none;
   }
 }
 


### PR DESCRIPTION
## Summary

- replace the empty response placeholder with a compact foreground working indicator
- defer to streamed content, active tools, approvals, and folder access states
- include accessible live status and reduced-motion behavior

## Validation

- 105 desktop UI tests
- production UI build
- React/TypeScript lint check