### PR TITLE
Add Markdown table copy action

### DIFF
--- a/crates/openwave-desktop/ui/src/ClipboardCopyButton.test.tsx
+++ b/crates/openwave-desktop/ui/src/ClipboardCopyButton.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ClipboardCopyButton,
+  COPY_STATE_RESET_MS,
+  copyPlainText,
+  scheduleCopyStateReset,
+} from "./ClipboardCopyButton";
+
+describe("ClipboardCopyButton", () => {
+  it("renders a named action with a polite result status", () => {
+    const markup = renderToStaticMarkup(
+      <ClipboardCopyButton
+        value="Visible text"
+        label="Copy table contents"
+        copiedAnnouncement="Table copied to clipboard."
+        failedAnnouncement="Table could not be copied."
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Copy table contents"');
+    expect(markup).toContain('title="Copy table contents"');
+    expect(markup).toContain('role="status"');
+    expect(markup).toContain('aria-live="polite"');
+  });
+
+  it("copies exact plain text and reports unavailable clipboard access", async () => {
+    const writeText = vi.fn(async () => undefined);
+
+    await copyPlainText("Name\tValue\nAlpha\t1\n", { writeText });
+
+    expect(writeText).toHaveBeenCalledWith("Name\tValue\nAlpha\t1\n");
+    await expect(copyPlainText("text", undefined)).rejects.toThrow(
+      "Clipboard access is unavailable",
+    );
+  });
+
+  it("resets after the bounded success or failure interval and cleans up", () => {
+    let callback: (() => void) | undefined;
+    const reset = vi.fn();
+    const clearTimeout = vi.fn();
+    const setTimeout = vi.fn((next: () => void, delayMs: number) => {
+      callback = next;
+      expect(delayMs).toBe(COPY_STATE_RESET_MS);
+      return 42;
+    });
+
+    const cleanup = scheduleCopyStateReset(reset, {
+      setTimeout,
+      clearTimeout,
+    });
+    callback?.();
+    cleanup();
+
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(clearTimeout).toHaveBeenCalledWith(42);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ClipboardCopyButton.tsx
+++ b/crates/openwave-desktop/ui/src/ClipboardCopyButton.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+
+export type ClipboardWriter = {
+  writeText(text: string): Promise<void>;
+};
+
+type CopyState = "idle" | "copied" | "failed";
+
+type TimerApi = {
+  setTimeout(callback: () => void, delayMs: number): number;
+  clearTimeout(id: number): void;
+};
+
+type ClipboardCopyButtonProps = {
+  value: string;
+  label: string;
+  copiedAnnouncement: string;
+  failedAnnouncement: string;
+  className?: string;
+};
+
+export const COPY_STATE_RESET_MS = 3_000;
+
+export function ClipboardCopyButton({
+  value,
+  label,
+  copiedAnnouncement,
+  failedAnnouncement,
+  className,
+}: ClipboardCopyButtonProps) {
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+
+  useEffect(() => {
+    if (copyState === "idle") return;
+    return scheduleCopyStateReset(() => setCopyState("idle"));
+  }, [copyState]);
+
+  async function onCopy() {
+    try {
+      await copyPlainText(value);
+      setCopyState("copied");
+    } catch {
+      setCopyState("failed");
+    }
+  }
+
+  const visibleLabel =
+    copyState === "copied"
+      ? "Copied"
+      : copyState === "failed"
+        ? "Copy failed"
+        : label;
+
+  return (
+    <>
+      <button
+        type="button"
+        className={className}
+        aria-label={visibleLabel}
+        title={visibleLabel}
+        onClick={() => void onCopy()}
+      >
+        <span aria-hidden="true">{copyState === "copied" ? "✓" : "⧉"}</span>
+        <span>{visibleLabel}</span>
+      </button>
+      <span className="sr-only" role="status" aria-live="polite">
+        {copyState === "copied"
+          ? copiedAnnouncement
+          : copyState === "failed"
+            ? failedAnnouncement
+            : ""}
+      </span>
+    </>
+  );
+}
+
+export async function copyPlainText(
+  text: string,
+  clipboard: ClipboardWriter | undefined = globalThis.navigator?.clipboard,
+): Promise<void> {
+  if (!clipboard?.writeText) {
+    throw new Error("Clipboard access is unavailable");
+  }
+  await clipboard.writeText(text);
+}
+
+export function scheduleCopyStateReset(
+  reset: () => void,
+  timers: TimerApi = window,
+): () => void {
+  const timeout = timers.setTimeout(reset, COPY_STATE_RESET_MS);
+  return () => timers.clearTimeout(timeout);
+}

--- a/crates/openwave-desktop/ui/src/MarkdownTable.test.tsx
+++ b/crates/openwave-desktop/ui/src/MarkdownTable.test.tsx
@@ -1,0 +1,77 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  copyMarkdownTable,
+  MarkdownTable,
+  markdownTablePlainText,
+} from "./MarkdownTable";
+
+const table = (
+  <>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>
+          <strong>Value</strong>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr data-private-id="row-private-id">
+        <td>
+          Alpha <code>one</code>
+        </td>
+        <td>
+          <a href="https://example.com/private-target">1</a>
+        </td>
+      </tr>
+    </tbody>
+  </>
+);
+
+describe("MarkdownTable", () => {
+  it("renders a keyboard-accessible action below the scrollable table", () => {
+    const markup = renderToStaticMarkup(<MarkdownTable>{table}</MarkdownTable>);
+
+    expect(markup).toContain('class="markdown-table-frame"');
+    expect(markup).toContain('class="markdown-table-wrap"');
+    expect(markup).toContain('aria-label="Copy table contents"');
+    expect(markup.indexOf("<table>")).toBeLessThan(
+      markup.indexOf("Copy table contents"),
+    );
+  });
+
+  it("serializes only visible cell text as spreadsheet-friendly TSV", () => {
+    const plainText = markdownTablePlainText(table);
+
+    expect(plainText).toBe("Name\tValue\nAlpha one\t1\n");
+    expect(plainText).not.toContain("row-private-id");
+    expect(plainText).not.toContain("private-target");
+  });
+
+  it("copies the exact TSV and propagates clipboard failure", async () => {
+    const writeText = vi.fn(async () => undefined);
+
+    await copyMarkdownTable(table, { writeText });
+    expect(writeText).toHaveBeenCalledWith("Name\tValue\nAlpha one\t1\n");
+
+    await expect(copyMarkdownTable(table, undefined)).rejects.toThrow(
+      "Clipboard access is unavailable",
+    );
+  });
+
+  it("does not render a copy action for a table without visible rows", () => {
+    const markup = renderToStaticMarkup(
+      <MarkdownTable>
+        <tbody>
+          <tr>
+            <td> </td>
+          </tr>
+        </tbody>
+      </MarkdownTable>,
+    );
+
+    expect(markup).toContain("<table>");
+    expect(markup).not.toContain("Copy table contents");
+  });
+});

--- a/crates/openwave-desktop/ui/src/MarkdownTable.tsx
+++ b/crates/openwave-desktop/ui/src/MarkdownTable.tsx
@@ -1,0 +1,95 @@
+import {
+  Children,
+  isValidElement,
+  type PropsWithChildren,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+import { ClipboardCopyButton, copyPlainText } from "./ClipboardCopyButton";
+
+export function MarkdownTable({ children }: PropsWithChildren) {
+  const plainText = markdownTablePlainText(children);
+
+  return (
+    <div className="markdown-table-frame">
+      <div className="markdown-table-wrap">
+        <table>{children}</table>
+      </div>
+      {plainText && (
+        <div className="markdown-table-actions">
+          <ClipboardCopyButton
+            value={plainText}
+            label="Copy table contents"
+            copiedAnnouncement="Table copied to clipboard."
+            failedAnnouncement="Table could not be copied."
+            className="markdown-table-copy"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function markdownTablePlainText(children: ReactNode): string {
+  const rows: string[] = [];
+  collectRows(children, rows);
+  return rows.length > 0 ? `${rows.join("\n")}\n` : "";
+}
+
+export async function copyMarkdownTable(
+  children: ReactNode,
+  clipboard: Parameters<typeof copyPlainText>[1],
+): Promise<void> {
+  const text = markdownTablePlainText(children);
+  if (!text) throw new Error("Table has no visible text");
+  await copyPlainText(text, clipboard);
+}
+
+function collectRows(node: ReactNode, rows: string[]): void {
+  Children.forEach(node, (child) => {
+    if (!isValidElement(child)) return;
+    const element = child as ReactElement<PropsWithChildren>;
+    if (element.type === "tr") {
+      const cells: string[] = [];
+      collectCells(element.props.children, cells);
+      if (cells.some((cell) => cell.length > 0)) rows.push(cells.join("\t"));
+      return;
+    }
+    collectRows(element.props.children, rows);
+  });
+}
+
+function collectCells(node: ReactNode, cells: string[]): void {
+  Children.forEach(node, (child) => {
+    if (!isValidElement(child)) return;
+    const element = child as ReactElement<PropsWithChildren>;
+    if (element.type === "th" || element.type === "td") {
+      cells.push(normalizeCellText(visibleText(element.props.children)));
+      return;
+    }
+    collectCells(element.props.children, cells);
+  });
+}
+
+function visibleText(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (!node || typeof node === "boolean") return "";
+
+  let text = "";
+  Children.forEach(node, (child) => {
+    if (typeof child === "string" || typeof child === "number") {
+      text += String(child);
+      return;
+    }
+    if (!isValidElement(child)) return;
+    const element = child as ReactElement<PropsWithChildren>;
+    text += element.type === "br" ? " " : visibleText(element.props.children);
+  });
+  return text;
+}
+
+function normalizeCellText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}

--- a/crates/openwave-desktop/ui/src/MessageFooter.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageFooter.test.tsx
@@ -1,10 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
-import {
-  copyMessageText,
-  formatMessageTimestamp,
-  MessageFooter,
-} from "./MessageFooter";
+import { describe, expect, it } from "vitest";
+import { formatMessageTimestamp, MessageFooter } from "./MessageFooter";
 
 describe("MessageFooter", () => {
   it("renders copy and a machine-readable timestamp for a settled assistant message", () => {
@@ -44,20 +40,6 @@ describe("MessageFooter", () => {
     );
 
     expect(markup).toBe("");
-  });
-
-  it("copies the exact plain Markdown source", async () => {
-    const writeText = vi.fn(async () => undefined);
-
-    await copyMessageText("## Answer\n\n- one", { writeText });
-
-    expect(writeText).toHaveBeenCalledWith("## Answer\n\n- one");
-  });
-
-  it("keeps clipboard failures available to the component error state", async () => {
-    await expect(copyMessageText("Answer", undefined)).rejects.toThrow(
-      "Clipboard access is unavailable",
-    );
   });
 
   it("rejects malformed durable timestamps instead of rendering bad text", () => {

--- a/crates/openwave-desktop/ui/src/MessageFooter.tsx
+++ b/crates/openwave-desktop/ui/src/MessageFooter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { ClipboardCopyButton } from "./ClipboardCopyButton";
 
 type MessageFooterProps = {
   role: "user" | "assistant";
@@ -7,67 +7,30 @@ type MessageFooterProps = {
   settled?: boolean;
 };
 
-type ClipboardWriter = {
-  writeText(text: string): Promise<void>;
-};
-
-type CopyState = "idle" | "copied" | "failed";
-
-const COPY_STATE_RESET_MS = 3_000;
-
 export function MessageFooter({
   role,
   text,
   createdAt,
   settled = true,
 }: MessageFooterProps) {
-  const [copyState, setCopyState] = useState<CopyState>("idle");
   const hasContent = text.trim().length > 0;
   const timestamp = createdAt && (role === "user" || (settled && hasContent))
     ? formatMessageTimestamp(createdAt, new Date())
     : null;
   const canCopy = role === "assistant" && settled && hasContent;
 
-  useEffect(() => {
-    if (copyState === "idle") return;
-    const timeout = window.setTimeout(
-      () => setCopyState("idle"),
-      COPY_STATE_RESET_MS,
-    );
-    return () => window.clearTimeout(timeout);
-  }, [copyState]);
-
   if (!canCopy && !timestamp) return null;
-
-  async function onCopy() {
-    try {
-      await copyMessageText(text);
-      setCopyState("copied");
-    } catch {
-      setCopyState("failed");
-    }
-  }
-
-  const copyLabel =
-    copyState === "copied"
-      ? "Copied"
-      : copyState === "failed"
-        ? "Copy failed"
-        : "Copy";
 
   return (
     <footer className="message-footer">
       {canCopy && (
-        <button
-          type="button"
+        <ClipboardCopyButton
+          value={text}
+          label="Copy"
+          copiedAnnouncement="Message copied to clipboard."
+          failedAnnouncement="Message could not be copied."
           className="message-copy"
-          aria-label={copyLabel}
-          title={copyLabel}
-          onClick={() => void onCopy()}
-        >
-          <span aria-hidden="true">{copyState === "copied" ? "✓" : "⧉"}</span>
-          <span>{copyLabel}</span>
-        </button>
+        />
       )}
       <span className="message-footer-spacer" />
       {timestamp && (
@@ -75,25 +38,8 @@ export function MessageFooter({
           {timestamp.short}
         </time>
       )}
-      <span className="sr-only" role="status" aria-live="polite">
-        {copyState === "copied"
-          ? "Message copied to clipboard."
-          : copyState === "failed"
-            ? "Message could not be copied."
-            : ""}
-      </span>
     </footer>
   );
-}
-
-export async function copyMessageText(
-  text: string,
-  clipboard: ClipboardWriter | undefined = globalThis.navigator?.clipboard,
-): Promise<void> {
-  if (!clipboard?.writeText) {
-    throw new Error("Clipboard access is unavailable");
-  }
-  await clipboard.writeText(text);
 }
 
 export function formatMessageTimestamp(

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
@@ -31,4 +31,17 @@ describe("MessageMarkdown", () => {
     expect(markup).not.toContain("<iframe");
     expect(markup).not.toContain("javascript:");
   });
+
+  it("adds a table-level copy action without exposing Markdown attributes", () => {
+    const markup = renderToStaticMarkup(
+      <MessageMarkdown>
+        {"| Name | Value |\n| --- | --- |\n| Alpha | **1** |"}
+      </MessageMarkdown>,
+    );
+
+    expect(markup).toContain("<table>");
+    expect(markup).toContain('aria-label="Copy table contents"');
+    expect(markup).toContain("Alpha");
+    expect(markup).toContain("<strong>1</strong>");
+  });
 });

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { MarkdownTable } from "./MarkdownTable";
 
 /**
  * Keep model-generated navigation deliberately narrow. `react-markdown` does
@@ -47,11 +48,7 @@ const components: Components = {
   code: ({ children }) => <code>{children}</code>,
   pre: ({ children }) => <pre>{children}</pre>,
   blockquote: ({ children }) => <blockquote>{children}</blockquote>,
-  table: ({ children }) => (
-    <div className="markdown-table-wrap">
-      <table>{children}</table>
-    </div>
-  ),
+  table: ({ children }) => <MarkdownTable>{children}</MarkdownTable>,
 };
 
 interface MessageMarkdownProps {

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -880,7 +880,7 @@ button {
 .message-markdown ol,
 .message-markdown pre,
 .message-markdown blockquote,
-.message-markdown .markdown-table-wrap {
+.message-markdown .markdown-table-frame {
   margin: 0 0 0.7rem;
 }
 
@@ -967,6 +967,12 @@ button {
   border-top: 1px solid var(--line);
 }
 
+.markdown-table-frame {
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+}
+
 .markdown-table-wrap {
   overflow-x: auto;
 }
@@ -987,6 +993,32 @@ button {
 
 .message-markdown th {
   font-weight: 650;
+}
+
+.markdown-table-actions {
+  display: flex;
+  justify-content: flex-end;
+  border-top: 1px solid var(--line);
+  padding: 0.25rem;
+  background: color-mix(in srgb, var(--sidebar) 45%, transparent);
+}
+
+.markdown-table-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: 0;
+  border-radius: 5px;
+  padding: 0.2rem 0.38rem;
+  color: var(--muted);
+  background: transparent;
+  font-size: 0.72rem;
+}
+
+.markdown-table-copy:hover,
+.markdown-table-copy:focus-visible {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--sidebar-active) 60%, transparent);
 }
 
 .markdown-image-omitted {


### PR DESCRIPTION
## Summary

- add a keyboard-accessible copy action beneath rendered Markdown tables
- export only visible cell text as plain TSV for spreadsheet-friendly paste
- share bounded success and failure handling with message copy actions

## Validation

- 111 desktop UI tests
- production UI build
- React/TypeScript lint check