### PR TITLE
Add sandbox task stop controls

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.test.tsx
@@ -19,6 +19,12 @@ function run(overrides: Partial<AgentRun>): AgentRun {
   };
 }
 
+const noStops = {
+  stoppingRunIds: new Set<string>(),
+  stopErrorRunIds: new Set<string>(),
+  onStop: vi.fn(),
+};
+
 describe("AgentActivityPanel", () => {
   it("shows snapshots only for the conversation that owns them", () => {
     const runs = [run({ id: "chat-a-run" })];
@@ -46,6 +52,7 @@ describe("AgentActivityPanel", () => {
         loading={false}
         error={null}
         onRetry={vi.fn()}
+        {...noStops}
       />,
     );
 
@@ -77,6 +84,7 @@ describe("AgentActivityPanel", () => {
         loading={false}
         error={null}
         onRetry={vi.fn()}
+        {...noStops}
       />,
     );
 
@@ -106,6 +114,7 @@ describe("AgentActivityPanel", () => {
         loading={false}
         error={null}
         onRetry={vi.fn()}
+        {...noStops}
       />,
     );
 
@@ -119,7 +128,13 @@ describe("AgentActivityPanel", () => {
   it("keeps load and retry states compact and accessible", () => {
     expect(
       renderToStaticMarkup(
-        <AgentActivityPanel runs={[]} loading error={null} onRetry={vi.fn()} />,
+        <AgentActivityPanel
+          runs={[]}
+          loading
+          error={null}
+          onRetry={vi.fn()}
+          {...noStops}
+        />,
       ),
     ).toContain("Loading activity…");
 
@@ -129,11 +144,57 @@ describe("AgentActivityPanel", () => {
         loading={false}
         error="private network detail"
         onRetry={vi.fn()}
+        {...noStops}
       />,
     );
     expect(failure).toContain('role="status"');
     expect(failure).toContain("Activity unavailable");
     expect(failure).toContain("Retry");
     expect(failure).not.toContain("private network detail");
+  });
+
+  it("offers exact active sandbox stops with safe pending and error copy", () => {
+    const markup = renderToStaticMarkup(
+      <AgentActivityPanel
+        runs={[
+          run({ id: "running" }),
+          run({ id: "pending", status: "waiting" }),
+          run({ id: "stopping", status: "cancelling" }),
+          run({ id: "recent", status: "completed" }),
+          run({ id: "foreground", execution: "foreground", status: "active" }),
+        ]}
+        loading={false}
+        error={null}
+        onRetry={vi.fn()}
+        stoppingRunIds={new Set(["pending"])}
+        stopErrorRunIds={new Set(["running"])}
+        onStop={vi.fn()}
+      />,
+    );
+
+    expect(markup.match(/>Stop<\/button>/g)).toHaveLength(1);
+    expect(markup).toContain("Stopping…");
+    expect(markup).toContain("disabled=\"\"");
+    expect(markup).toContain('role="status"');
+    expect(markup).toContain("Could not stop this task. Try again.");
+    expect(markup).not.toContain("private");
+  });
+
+  it("suppresses an ambiguous request error once polling confirms stopping", () => {
+    const markup = renderToStaticMarkup(
+      <AgentActivityPanel
+        runs={[run({ id: "stopping", status: "cancelling" })]}
+        loading={false}
+        error={null}
+        onRetry={vi.fn()}
+        stoppingRunIds={new Set()}
+        stopErrorRunIds={new Set(["stopping"])}
+        onStop={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Stopping");
+    expect(markup).not.toContain("Could not stop");
+    expect(markup).not.toContain(">Stop</button>");
   });
 });

--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { AgentRun } from "./api";
+import { canStopSandboxAgentRun } from "./SandboxAgentStop";
 
 const MAX_RECENT_TERMINAL_SANDBOX_RUNS = 2;
 
@@ -16,11 +17,17 @@ export function AgentActivityPanel({
   loading,
   error,
   onRetry,
+  stoppingRunIds,
+  stopErrorRunIds,
+  onStop,
 }: {
   runs: AgentRun[];
   loading: boolean;
   error: string | null;
   onRetry: () => void;
+  stoppingRunIds: ReadonlySet<string>;
+  stopErrorRunIds: ReadonlySet<string>;
+  onStop: (runId: string) => void;
 }) {
   if (loading) {
     return <div className="agent-activity-state">Loading activity…</div>;
@@ -76,6 +83,9 @@ export function AgentActivityPanel({
               run={run}
               label={`Background task ${index + 1}`}
               announce
+              stopping={stoppingRunIds.has(run.id)}
+              stopError={stopErrorRunIds.has(run.id)}
+              onStop={onStop}
             />
           ))}
         </ActivityGroup>
@@ -129,10 +139,16 @@ function AgentActivityItem({
   run,
   label,
   announce = false,
+  stopping = false,
+  stopError = false,
+  onStop,
 }: {
   run: AgentRun;
   label: string;
   announce?: boolean;
+  stopping?: boolean;
+  stopError?: boolean;
+  onStop?: (runId: string) => void;
 }) {
   const activity = isActiveAgentRunStatus(run.status)
     ? agentActivityPresentation(run.activity)
@@ -148,14 +164,32 @@ function AgentActivityItem({
         <span className="agent-activity-detail">
           {activity?.detail ?? agentRunStatusDescription(run.status)}
         </span>
+        {stopError && canStopSandboxAgentRun(run) && (
+          <span className="agent-activity-stop-error" role="status">
+            Could not stop this task. Try again.
+          </span>
+        )}
       </span>
-      <strong
-        aria-live={announce ? "polite" : undefined}
-        aria-atomic={announce ? "true" : undefined}
-        aria-label={announce ? `${activity?.label ?? label}: ${status}` : undefined}
-      >
-        {status}
-      </strong>
+      <span className="agent-activity-item-actions">
+        <strong
+          aria-live={announce ? "polite" : undefined}
+          aria-atomic={announce ? "true" : undefined}
+          aria-label={announce ? `${activity?.label ?? label}: ${status}` : undefined}
+        >
+          {status}
+        </strong>
+        {onStop && canStopSandboxAgentRun(run) && (
+          <button
+            type="button"
+            className="agent-activity-stop"
+            disabled={stopping}
+            aria-label={`Stop ${label.toLowerCase()}`}
+            onClick={() => onStop(run.id)}
+          >
+            {stopping ? "Stopping…" : "Stop"}
+          </button>
+        )}
+      </span>
     </li>
   );
 }

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -49,6 +49,12 @@ import {
   presentChatTranscript,
 } from "./ChatTranscriptPresentation";
 import { AgentActivityPanel, agentRunsForChat } from "./AgentActivityPanel";
+import {
+  SandboxAgentStopFence,
+  canStopSandboxAgentRun,
+  reconcileSandboxAgentCancellation,
+  sandboxAgentStopKey,
+} from "./SandboxAgentStop";
 
 type Msg = ChatMessage;
 
@@ -74,6 +80,12 @@ export default function App() {
   const [agentRunsChatId, setAgentRunsChatId] = useState<string | null>(null);
   const [agentRunsLoading, setAgentRunsLoading] = useState(false);
   const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
+  const [stoppingSandboxRunKeys, setStoppingSandboxRunKeys] = useState<Set<string>>(
+    new Set(),
+  );
+  const [sandboxStopErrorKeys, setSandboxStopErrorKeys] = useState<Set<string>>(
+    new Set(),
+  );
   const [folderAccessRequests, setFolderAccessRequests] = useState<
     PendingFolderAccessRequest[]
   >([]);
@@ -127,6 +139,7 @@ export default function App() {
   const draftRef = useRef("");
   const selectedChatIdRef = useRef<string | null>(null);
   const steerFenceRef = useRef(new ActiveTurnSteerFence());
+  const sandboxStopFenceRef = useRef(new SandboxAgentStopFence());
   const provisionalToolCallIdsRef = useRef<Set<string>>(new Set());
   const deletionInFlightRef = useRef(false);
 
@@ -147,6 +160,7 @@ export default function App() {
       cancelled = true;
       terminalHydrationGenerationRef.current += 1;
       steerFenceRef.current.invalidate();
+      sandboxStopFenceRef.current.invalidate();
     };
   }, []);
 
@@ -278,6 +292,20 @@ export default function App() {
   }, [client, chat?.id]);
 
   const visibleAgentRuns = agentRunsForChat(agentRunsChatId, chat?.id ?? null, agentRuns);
+  const visibleStoppingSandboxRunIds = new Set(
+    visibleAgentRuns
+      .filter((run) =>
+        stoppingSandboxRunKeys.has(sandboxAgentStopKey(chat?.id ?? "", run.id)),
+      )
+      .map((run) => run.id),
+  );
+  const visibleSandboxStopErrorRunIds = new Set(
+    visibleAgentRuns
+      .filter((run) =>
+        sandboxStopErrorKeys.has(sandboxAgentStopKey(chat?.id ?? "", run.id)),
+      )
+      .map((run) => run.id),
+  );
   const hasActiveSandboxRun = visibleAgentRuns.some(
     (run) =>
       run.execution === "sandbox" &&
@@ -294,6 +322,47 @@ export default function App() {
     );
     return () => window.clearInterval(interval);
   }, [hasActiveSandboxRun]);
+
+  async function onStopSandboxAgentRun(runId: string) {
+    if (!client || !chat || deletionInFlightRef.current) return;
+    const target = visibleAgentRuns.find((run) => run.id === runId);
+    if (!target || !canStopSandboxAgentRun(target)) return;
+
+    const chatId = chat.id;
+    const request = sandboxStopFenceRef.current.begin(chatId, runId);
+    if (!request) return;
+    const key = sandboxAgentStopKey(chatId, runId);
+    setStoppingSandboxRunKeys((current) => new Set(current).add(key));
+    setSandboxStopErrorKeys((current) => {
+      const next = new Set(current);
+      next.delete(key);
+      return next;
+    });
+
+    try {
+      const cancellation = await client.cancelAgentRun(chatId, runId);
+      if (!sandboxStopFenceRef.current.isCurrent(request, selectedChatIdRef.current)) {
+        return;
+      }
+      setAgentRuns((current) =>
+        reconcileSandboxAgentCancellation(current, cancellation),
+      );
+      refreshAgentRunsRef.current?.();
+    } catch {
+      if (!sandboxStopFenceRef.current.isCurrent(request, selectedChatIdRef.current)) {
+        return;
+      }
+      setSandboxStopErrorKeys((current) => new Set(current).add(key));
+    } finally {
+      if (sandboxStopFenceRef.current.finish(request, selectedChatIdRef.current)) {
+        setStoppingSandboxRunKeys((current) => {
+          const next = new Set(current);
+          next.delete(key);
+          return next;
+        });
+      }
+    }
+  }
 
   useEffect(() => {
     if (!client || !chat) return;
@@ -845,6 +914,9 @@ export default function App() {
       // ref update also gates sends before the disabled composer renders.
       chatSelectionRef.current += 1;
       clearSteerRequestState();
+      sandboxStopFenceRef.current.invalidate();
+      setStoppingSandboxRunKeys(new Set());
+      setSandboxStopErrorKeys(new Set());
     }
     try {
       await client.deleteChat(target.id);
@@ -873,6 +945,9 @@ export default function App() {
     chatSelectionRef.current += 1;
     terminalHydrationGenerationRef.current += 1;
     selectedChatIdRef.current = next.id;
+    sandboxStopFenceRef.current.invalidate();
+    setStoppingSandboxRunKeys(new Set());
+    setSandboxStopErrorKeys(new Set());
     assistantMarkerScrubberRef.current =
       new AssistantSourceMarkerStreamScrubber();
     setChat(next);
@@ -1302,6 +1377,9 @@ export default function App() {
               loading={agentRunsChatId === chat.id ? agentRunsLoading : true}
               error={agentRunsChatId === chat.id ? agentRunsError : null}
               onRetry={() => refreshAgentRunsRef.current?.()}
+              stoppingRunIds={visibleStoppingSandboxRunIds}
+              stopErrorRunIds={visibleSandboxStopErrorRunIds}
+              onStop={(runId) => void onStopSandboxAgentRun(runId)}
             />
           </div>
 

--- a/crates/openwave-desktop/ui/src/SandboxAgentStop.test.ts
+++ b/crates/openwave-desktop/ui/src/SandboxAgentStop.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { AgentRun } from "./api";
+import {
+  SandboxAgentStopFence,
+  canStopSandboxAgentRun,
+  reconcileSandboxAgentCancellation,
+  sandboxAgentStopKey,
+} from "./SandboxAgentStop";
+
+function run(overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    id: "run-1",
+    parent_id: null,
+    execution: "sandbox",
+    status: "running",
+    started_at: null,
+    finished_at: null,
+    last_error_code: null,
+    activity: { kind: "web_search", status: "running" },
+    created_at: "2026-07-20T12:00:00Z",
+    updated_at: "2026-07-20T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("SandboxAgentStopFence", () => {
+  it("deduplicates an exact request while allowing independent sandbox children", () => {
+    const fence = new SandboxAgentStopFence();
+    const first = fence.begin("chat-a", "run-1");
+
+    expect(first).not.toBeNull();
+    expect(fence.begin("chat-a", "run-1")).toBeNull();
+    expect(fence.begin("chat-a", "run-2")).not.toBeNull();
+    expect(fence.begin("chat-b", "run-1")).not.toBeNull();
+    expect(sandboxAgentStopKey("a:b", "c")).not.toBe(
+      sandboxAgentStopKey("a", "b:c"),
+    );
+  });
+
+  it("prevents a stale completion from painting after chat switch or unmount", () => {
+    const fence = new SandboxAgentStopFence();
+    const switched = fence.begin("chat-a", "run-1");
+    expect(switched && fence.isCurrent(switched, "chat-b")).toBe(false);
+
+    const unmounted = fence.begin("chat-a", "run-2");
+    fence.invalidate();
+    expect(unmounted && fence.isCurrent(unmounted, "chat-a")).toBe(false);
+    expect(unmounted && fence.finish(unmounted, "chat-a")).toBe(false);
+  });
+
+  it("releases only the current exact request so a failed stop can retry", () => {
+    const fence = new SandboxAgentStopFence();
+    const request = fence.begin("chat-a", "run-1");
+    expect(request && fence.finish(request, "chat-a")).toBe(true);
+    expect(fence.begin("chat-a", "run-1")).not.toBeNull();
+  });
+});
+
+describe("sandbox stop presentation state", () => {
+  it("offers stop only for cancellable sandbox lifecycle states", () => {
+    for (const status of ["queued", "running", "waiting", "retry_wait"] as const) {
+      expect(canStopSandboxAgentRun(run({ status }))).toBe(true);
+    }
+    for (const status of [
+      "active",
+      "cancelling",
+      "completed",
+      "failed",
+      "cancelled",
+    ] as const) {
+      expect(canStopSandboxAgentRun(run({ status }))).toBe(false);
+    }
+    expect(
+      canStopSandboxAgentRun(run({ execution: "foreground", status: "running" })),
+    ).toBe(false);
+  });
+
+  it("reconciles only the exact sandbox child and clears stale activity", () => {
+    const untouched = run({ id: "run-2" });
+    const foreground = run({ id: "run-1", execution: "foreground" });
+    const runs = [run(), untouched, foreground];
+
+    const reconciled = reconcileSandboxAgentCancellation(runs, {
+      id: "run-1",
+      status: "cancelled",
+    });
+
+    expect(reconciled[0]).toMatchObject({ id: "run-1", status: "cancelled", activity: null });
+    expect(reconciled[1]).toBe(untouched);
+    expect(reconciled[2]).toBe(foreground);
+  });
+
+  it("does not let a delayed acknowledgement regress authoritative terminal state", () => {
+    for (const status of ["completed", "failed", "cancelled"] as const) {
+      const authoritative = run({ status, activity: null });
+      const reconciled = reconcileSandboxAgentCancellation([authoritative], {
+        id: authoritative.id,
+        status: "cancelling",
+      });
+      expect(reconciled[0]).toBe(authoritative);
+    }
+
+    expect(
+      reconcileSandboxAgentCancellation([run({ status: "cancelling" })], {
+        id: "run-1",
+        status: "cancelled",
+      })[0],
+    ).toMatchObject({ status: "cancelled", activity: null });
+  });
+});

--- a/crates/openwave-desktop/ui/src/SandboxAgentStop.ts
+++ b/crates/openwave-desktop/ui/src/SandboxAgentStop.ts
@@ -1,0 +1,67 @@
+import type { AgentRun, SandboxAgentCancellation } from "./api";
+
+export type SandboxAgentStopToken = Readonly<{
+  chatId: string;
+  runId: string;
+  generation: number;
+  request: number;
+}>;
+
+/**
+ * Keeps async stop completions tied to one exact chat selection and sandbox
+ * run. Invalidating the fence makes every in-flight completion stale.
+ */
+export class SandboxAgentStopFence {
+  private generation = 0;
+  private request = 0;
+  private readonly active = new Map<string, number>();
+
+  begin(chatId: string, runId: string): SandboxAgentStopToken | null {
+    const key = sandboxAgentStopKey(chatId, runId);
+    if (this.active.has(key)) return null;
+    const request = ++this.request;
+    this.active.set(key, request);
+    return { chatId, runId, generation: this.generation, request };
+  }
+
+  isCurrent(token: SandboxAgentStopToken, selectedChatId: string | null): boolean {
+    return (
+      token.generation === this.generation &&
+      token.chatId === selectedChatId &&
+      this.active.get(sandboxAgentStopKey(token.chatId, token.runId)) === token.request
+    );
+  }
+
+  finish(token: SandboxAgentStopToken, selectedChatId: string | null): boolean {
+    if (!this.isCurrent(token, selectedChatId)) return false;
+    this.active.delete(sandboxAgentStopKey(token.chatId, token.runId));
+    return true;
+  }
+
+  invalidate(): void {
+    this.generation += 1;
+    this.active.clear();
+  }
+}
+
+export function sandboxAgentStopKey(chatId: string, runId: string): string {
+  return JSON.stringify([chatId, runId]);
+}
+
+export function canStopSandboxAgentRun(run: AgentRun): boolean {
+  return (
+    run.execution === "sandbox" &&
+    ["queued", "running", "waiting", "retry_wait"].includes(run.status)
+  );
+}
+
+export function reconcileSandboxAgentCancellation(
+  runs: AgentRun[],
+  cancellation: SandboxAgentCancellation,
+): AgentRun[] {
+  return runs.map((run) => {
+    if (run.id !== cancellation.id || run.execution !== "sandbox") return run;
+    if (["completed", "failed", "cancelled"].includes(run.status)) return run;
+    return { ...run, status: cancellation.status, activity: null };
+  });
+}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -3,6 +3,7 @@ import {
   ApiClient,
   parseFolderAccessRequest,
   parsePendingToolApproval,
+  parseSandboxAgentCancellation,
 } from "./api";
 
 afterEach(() => {
@@ -169,5 +170,78 @@ describe("active turn steering", () => {
       content: "change course",
       interrupt: true,
     });
+  });
+});
+
+describe("sandbox agent cancellation", () => {
+  it("accepts only the closed cancellation projection", () => {
+    expect(
+      parseSandboxAgentCancellation({ id: "run-1", status: "cancelling" }),
+    ).toEqual({ id: "run-1", status: "cancelling" });
+    expect(
+      parseSandboxAgentCancellation({ id: "run-1", status: "cancelled" }),
+    ).toEqual({ id: "run-1", status: "cancelled" });
+
+    for (const body of [
+      { id: "run-1", status: "running" },
+      { id: "", status: "cancelled" },
+      { id: "run-1", status: "cancelled", lease_token: "private" },
+      { id: "run-1", status: "cancelled", executor_id: "private" },
+      { id: "run-1", status: "cancelled", diagnostic: "private" },
+    ]) {
+      expect(parseSandboxAgentCancellation(body)).toBeNull();
+    }
+  });
+
+  it("posts to the exact encoded run route and parses a 202 response body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "run/1", status: "cancelling" }), {
+        status: 202,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await expect(client.cancelAgentRun("chat/1", "run/1")).resolves.toEqual({
+      id: "run/1",
+      status: "cancelling",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1/chats/chat%2F1/agent-runs/run%2F1/cancel",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("fails closed when the server returns another run identity", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: "run-2", status: "cancelled" }), {
+          status: 202,
+        }),
+      ),
+    );
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await expect(client.cancelAgentRun("chat-1", "run-1")).rejects.toThrow(
+      "sandbox cancellation response is invalid",
+    );
+  });
+
+  it("rejects a valid projection returned with a status other than 202", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: "run-1", status: "cancelled" }), {
+          status: 200,
+        }),
+      ),
+    );
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await expect(client.cancelAgentRun("chat-1", "run-1")).rejects.toThrow(
+      "expected 202, received 200",
+    );
   });
 });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -114,6 +114,12 @@ export type AgentRun = {
   updated_at: string;
 };
 
+/** The complete renderer projection returned by one sandbox stop request. */
+export type SandboxAgentCancellation = {
+  id: string;
+  status: "cancelling" | "cancelled";
+};
+
 /**
  * Live agent activity is intentionally a closed vocabulary. The server never
  * sends tool inputs, results, host paths, grants, executor identities, leases,
@@ -219,7 +225,11 @@ export class ApiClient {
     return headers;
   }
 
-  private async json<T>(path: string, init?: RequestInit): Promise<T> {
+  private async json<T>(
+    path: string,
+    init?: RequestInit,
+    expectedStatus?: number,
+  ): Promise<T> {
     const response = await fetch(`${this.baseUrl}${path}`, init);
     if (!response.ok) {
       let detail = response.statusText;
@@ -231,7 +241,12 @@ export class ApiClient {
       }
       throw new Error(`${response.status}: ${detail}`);
     }
-    if (response.status === 204 || response.status === 202) return undefined as T;
+    if (expectedStatus !== undefined && response.status !== expectedStatus) {
+      throw new Error(
+        `unexpected response status: expected ${expectedStatus}, received ${response.status}`,
+      );
+    }
+    if (response.status === 204) return undefined as T;
     const text = await response.text();
     if (!text) return undefined as T;
     return JSON.parse(text) as T;
@@ -353,6 +368,25 @@ export class ApiClient {
     return this.json(`/chats/${chatId}/agent-runs`, {
       headers: this.headers(),
     });
+  }
+
+  async cancelAgentRun(
+    chatId: string,
+    runId: string,
+  ): Promise<SandboxAgentCancellation> {
+    const body = await this.json<unknown>(
+      `/chats/${encodeURIComponent(chatId)}/agent-runs/${encodeURIComponent(runId)}/cancel`,
+      {
+        method: "POST",
+        headers: this.headers(),
+      },
+      202,
+    );
+    const cancellation = parseSandboxAgentCancellation(body);
+    if (!cancellation || cancellation.id !== runId) {
+      throw new Error("sandbox cancellation response is invalid");
+    }
+    return cancellation;
   }
 
   postMessage(chatId: string, turnId: string, content: string): Promise<void> {
@@ -499,6 +533,22 @@ export function parseFolderAccessRequest(
     folderHint,
     claimedByDesktop: value.claimed,
   };
+}
+
+export function parseSandboxAgentCancellation(
+  value: unknown,
+): SandboxAgentCancellation | null {
+  if (!isRecord(value)) return null;
+  const keys = Object.keys(value);
+  if (
+    keys.some((key) => key !== "id" && key !== "status") ||
+    typeof value.id !== "string" ||
+    value.id.length === 0 ||
+    (value.status !== "cancelling" && value.status !== "cancelled")
+  ) {
+    return null;
+  }
+  return { id: value.id, status: value.status };
 }
 
 export function parsePendingToolApproval(

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -512,6 +512,39 @@ button {
   text-transform: capitalize;
 }
 
+.agent-activity-item-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.agent-activity-stop {
+  border: 1px solid color-mix(in srgb, var(--line) 84%, transparent);
+  border-radius: 5px;
+  padding: 0.14rem 0.38rem;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--bg-elevated) 88%, var(--sidebar));
+  font: inherit;
+  font-size: 0.68rem;
+  font-weight: 620;
+}
+
+.agent-activity-stop:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--danger) 42%, var(--line));
+  color: var(--danger);
+}
+
+.agent-activity-stop:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.agent-activity-stop-error {
+  color: var(--danger);
+  font-size: 0.68rem;
+}
+
 .agent-activity-indicator {
   width: 0.5rem;
   height: 0.5rem;


### PR DESCRIPTION
## Summary

- add an accessible Stop action for active sandbox tasks in the activity panel
- scope pending, error, and async completion state to the exact chat and run
- reconcile accepted cancellation monotonically and refresh authoritative activity
- validate the endpoint's exact `202` closed response without exposing worker details

## Validation

- `pnpm test --run` (123 passed)
- `pnpm build`
- `bw dev lint --react --check`
