### PR TITLE
Prepare multi-agent tool contracts

### DIFF
--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -8,12 +8,16 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashSet;
 
-use crate::model::AgentRun;
+use crate::id::AgentRunId;
+use crate::model::{AgentRun, AgentRunResultPayload, TurnAgentRunWaitSet};
 use crate::tool::ToolSpec;
 
 /// Stable name for the foreground-only sandbox delegation tool.
 pub const SPAWN_SANDBOX_AGENT_TOOL: &str = "spawn_sandbox_agent";
+/// Stable name for the prepared foreground-only multi-child wait tool.
+pub const WAIT_FOR_AGENTS_TOOL: &str = "wait_for_agents";
 /// The only tool a depth-one sandbox may receive.
 pub const SANDBOX_WEB_SEARCH_TOOL: &str = "web_search";
 
@@ -22,6 +26,8 @@ pub const SANDBOX_WEB_SEARCH_TOOL: &str = "web_search";
 /// The persisted byte limit remains [`AgentRun::MAX_INPUT_LEN`]; this lower
 /// character cap ensures even four-byte UTF-8 input fits that durable bound.
 pub const MAX_SANDBOX_AGENT_TASK_CHARS: usize = 16_000;
+/// Maximum number of depth-one children in one foreground wait request.
+pub const MAX_WAIT_FOR_AGENTS_CHILDREN: usize = TurnAgentRunWaitSet::MAX_CHILDREN;
 
 /// Canonical model proposal for one isolated sandbox task.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -29,6 +35,64 @@ pub const MAX_SANDBOX_AGENT_TASK_CHARS: usize = 16_000;
 pub struct SpawnSandboxAgentArgs {
     /// A self-contained task for the isolated child. It cannot spawn children.
     pub task: String,
+}
+
+/// Closed model-facing acknowledgement for a non-blocking sandbox spawn.
+///
+/// This deliberately excludes scheduler state and lease identities. The
+/// foreground model needs only the stable child identity it may later pass to
+/// [`WAIT_FOR_AGENTS_TOOL`]. The current runtime does not emit this result yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct SpawnSandboxAgentResult {
+    /// Stable identity of the admitted depth-one child.
+    pub agent_id: AgentRunId,
+}
+
+/// Canonical model proposal to wait for an ordered set of sandbox children.
+///
+/// Completion always means `All`: the foreground turn resumes only after
+/// every listed child has delivered an immutable result. The durable runtime
+/// additionally verifies that each id belongs to a depth-one child owned by
+/// the exact foreground turn; UUID shape alone cannot prove that authority.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WaitForAgentsArgs {
+    /// Unique child identities in the order their results must be returned.
+    pub agent_ids: Vec<AgentRunId>,
+}
+
+impl WaitForAgentsArgs {
+    /// Whether this proposal has a non-empty, bounded, unique list of IDs.
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        if self.agent_ids.is_empty()
+            || self.agent_ids.len() > MAX_WAIT_FOR_AGENTS_CHILDREN
+            || self.agent_ids.iter().any(|id| id.0.is_nil())
+        {
+            return false;
+        }
+
+        self.agent_ids.iter().copied().collect::<HashSet<_>>().len() == self.agent_ids.len()
+    }
+}
+
+/// One closed, model-facing child result returned by [`WAIT_FOR_AGENTS_TOOL`].
+///
+/// Operational fencing data from the durable result receipt is intentionally
+/// absent. Results remain in the caller's requested order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WaitForAgentResult {
+    /// Child whose immutable result was delivered.
+    pub agent_id: AgentRunId,
+    /// Typed terminal payload produced by that child.
+    pub result: AgentRunResultPayload,
+}
+
+/// Closed model-facing result for one all-children wait.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WaitForAgentsResult {
+    /// One result per requested child, in the exact request order.
+    pub results: Vec<WaitForAgentResult>,
 }
 
 impl SpawnSandboxAgentArgs {
@@ -46,6 +110,13 @@ impl SpawnSandboxAgentArgs {
 #[must_use]
 pub fn validate_spawn_sandbox_agent_arguments(arguments: &Value) -> bool {
     serde_json::from_value::<SpawnSandboxAgentArgs>(arguments.clone())
+        .is_ok_and(|arguments| arguments.is_well_formed())
+}
+
+/// Validate one canonical ordered all-children wait proposal.
+#[must_use]
+pub fn validate_wait_for_agents_arguments(arguments: &Value) -> bool {
+    serde_json::from_value::<WaitForAgentsArgs>(arguments.clone())
         .is_ok_and(|arguments| arguments.is_well_formed())
 }
 
@@ -70,6 +141,34 @@ pub fn spawn_sandbox_agent_tool_spec() -> ToolSpec {
                 }
             },
             "required": ["task"],
+            "additionalProperties": false
+        }),
+    }
+}
+
+/// Prepared foreground-only contract for waiting on depth-one children.
+///
+/// This definition is intentionally not registered yet. Advertising it is
+/// safe only after non-blocking spawn and durable multi-child resume are wired
+/// together in the foreground runtime.
+#[must_use]
+pub fn wait_for_agents_tool_spec() -> ToolSpec {
+    ToolSpec {
+        name: WAIT_FOR_AGENTS_TOOL.into(),
+        description: "Wait until all specified background agents finish, then return their results in the same order. Use only depth-one agent IDs returned by spawn_sandbox_agent.".into(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "agent_ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": MAX_WAIT_FOR_AGENTS_CHILDREN,
+                    "uniqueItems": true,
+                    "items": { "type": "string", "format": "uuid" },
+                    "description": "Opaque depth-one child agent IDs, in the order their results should be returned."
+                }
+            },
+            "required": ["agent_ids"],
             "additionalProperties": false
         }),
     }
@@ -104,6 +203,10 @@ pub fn sandbox_web_search_tool_spec() -> ToolSpec {
 mod tests {
     use super::*;
 
+    fn child_ids(count: usize) -> Vec<AgentRunId> {
+        (0..count).map(|_| AgentRunId::new()).collect()
+    }
+
     #[test]
     fn sandbox_spawn_contract_is_strict_and_bounded() {
         let valid = serde_json::json!({"task": "Research the error handling approach."});
@@ -134,5 +237,96 @@ mod tests {
         assert_eq!(spec.input_schema["required"], serde_json::json!(["task"]));
         assert_eq!(spec.input_schema["properties"]["task"]["maxLength"], 16_000);
         assert!(spec.description.contains("do not ask it to spawn"));
+    }
+
+    #[test]
+    fn wait_for_agents_contract_accepts_an_ordered_bounded_unique_list() {
+        let ids = child_ids(MAX_WAIT_FOR_AGENTS_CHILDREN);
+        let arguments = serde_json::json!({"agent_ids": ids});
+
+        assert!(validate_wait_for_agents_arguments(&arguments));
+        let decoded: WaitForAgentsArgs = serde_json::from_value(arguments).unwrap();
+        assert_eq!(decoded.agent_ids, ids);
+    }
+
+    #[test]
+    fn wait_for_agents_contract_rejects_empty_duplicate_nil_and_oversized_lists() {
+        let duplicate = AgentRunId::new();
+        let oversized = child_ids(MAX_WAIT_FOR_AGENTS_CHILDREN + 1);
+
+        for invalid in [
+            serde_json::json!({"agent_ids": []}),
+            serde_json::json!({"agent_ids": [duplicate, duplicate]}),
+            serde_json::json!({"agent_ids": [uuid::Uuid::nil()]}),
+            serde_json::json!({"agent_ids": oversized}),
+        ] {
+            assert!(!validate_wait_for_agents_arguments(&invalid), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn wait_for_agents_contract_rejects_malformed_and_noncanonical_payloads() {
+        let id = AgentRunId::new();
+
+        for invalid in [
+            serde_json::json!({}),
+            serde_json::json!({"agent_ids": [id], "condition": "all"}),
+            serde_json::json!({"agent_ids": "not-an-array"}),
+            serde_json::json!({"agent_ids": ["not-a-uuid"]}),
+            serde_json::json!({"agent_ids": [id, 42]}),
+            serde_json::Value::Null,
+        ] {
+            assert!(!validate_wait_for_agents_arguments(&invalid), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn wait_for_agents_spec_encodes_all_semantics_and_matches_validation_bound() {
+        let spec = wait_for_agents_tool_spec();
+
+        assert_eq!(spec.name, WAIT_FOR_AGENTS_TOOL);
+        assert_eq!(spec.input_schema["additionalProperties"], false);
+        assert_eq!(
+            spec.input_schema["required"],
+            serde_json::json!(["agent_ids"])
+        );
+        assert_eq!(spec.input_schema["properties"]["agent_ids"]["minItems"], 1);
+        assert_eq!(
+            spec.input_schema["properties"]["agent_ids"]["maxItems"],
+            MAX_WAIT_FOR_AGENTS_CHILDREN
+        );
+        assert_eq!(
+            spec.input_schema["properties"]["agent_ids"]["uniqueItems"],
+            true
+        );
+        assert!(spec.description.contains("all specified"));
+        assert!(spec.description.contains("same order"));
+    }
+
+    #[test]
+    fn prepared_orchestration_results_have_closed_model_facing_shapes() {
+        let agent_id = AgentRunId::new();
+        let spawn = SpawnSandboxAgentResult { agent_id };
+        assert_eq!(
+            serde_json::to_value(spawn).unwrap(),
+            serde_json::json!({"agent_id": agent_id})
+        );
+        let wait = WaitForAgentsResult {
+            results: vec![WaitForAgentResult {
+                agent_id,
+                result: AgentRunResultPayload::FinalText {
+                    text: "finished".into(),
+                },
+            }],
+        };
+        assert_eq!(
+            serde_json::to_value(&wait).unwrap(),
+            serde_json::json!({
+                "results": [{
+                    "agent_id": agent_id,
+                    "result": {"kind": "final_text", "text": "finished"},
+                }],
+            })
+        );
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -43,8 +43,11 @@ pub use agent::{
 };
 pub use agent_tools::{
     sandbox_web_search_tool_spec, spawn_sandbox_agent_tool_spec,
-    validate_spawn_sandbox_agent_arguments, SpawnSandboxAgentArgs, MAX_SANDBOX_AGENT_TASK_CHARS,
-    SANDBOX_WEB_SEARCH_TOOL, SPAWN_SANDBOX_AGENT_TOOL,
+    validate_spawn_sandbox_agent_arguments, validate_wait_for_agents_arguments,
+    wait_for_agents_tool_spec, SpawnSandboxAgentArgs, SpawnSandboxAgentResult, WaitForAgentResult,
+    WaitForAgentsArgs, WaitForAgentsResult, MAX_SANDBOX_AGENT_TASK_CHARS,
+    MAX_WAIT_FOR_AGENTS_CHILDREN, SANDBOX_WEB_SEARCH_TOOL, SPAWN_SANDBOX_AGENT_TOOL,
+    WAIT_FOR_AGENTS_TOOL,
 };
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -84,10 +84,19 @@ independently enforces depth one. A later non-blocking spawn tool can let the
 foreground continue after spawning, but must earn the same checkpoint and
 replay rules.
 
-The wait also carries an immutable atomic-admission marker. Only that receipt
-allows a later retry to recover the combined transition; an older path that
-accepted a child and parked a turn in separate commits is never mistaken for
-proof that both effects committed together.
+Core now prepares, but does not advertise, the typed boundary for that later
+cutover. A non-blocking spawn will return only its stable opaque child agent
+ID. The paired `wait_for_agents` call accepts one to four unique child IDs in
+caller order and has only `All` completion semantics; its result contains each
+typed terminal child payload in that same order. Durable runtime validation
+must still prove every ID is a depth-one child owned by the exact origin turn. No
+scheduler lease, executor identity, or continuation token crosses this
+model-facing boundary.
+
+The current serial single-child wait also carries an immutable atomic-admission
+marker. Only that receipt allows a later retry to recover the combined
+transition; an older path that accepted a child and parked a turn in separate
+commits is never mistaken for proof that both effects committed together.
 
 ## One continuation model
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -21,6 +21,13 @@ The current foreground agent surface contains nine tools:
 | `read_connected_file` | Read bounded UTF-8 text below an attached root | Native client continuation |
 | `spawn_sandbox_agent` | Delegate one bounded task and wait for its durable result | Foreground-only durable continuation |
 
+The core also contains an inactive `wait_for_agents` definition for the next
+orchestration cutover. It accepts one to four unique depth-one child agent IDs,
+waits for all of them, and preserves request order in its result. The strict
+arguments and closed spawn/wait result shapes are prepared now so the runtime
+does not invent ad hoc JSON later, but neither the wait definition nor the
+future non-blocking spawn wording is advertised yet.
+
 The connected-folder calls are foreground-only. Their arguments contain only
 an opaque root ID and a bounded root-relative path; native code recovers the
 stored chat context, reauthorizes with the broker, and persists the exact


### PR DESCRIPTION
## Summary

- define an inactive, foreground-only `wait_for_agents` contract with ordered All semantics
- validate one to four unique opaque child agent IDs with a closed schema
- add closed model-facing spawn and ordered wait result envelopes
- document the prepared boundary without changing the current runtime behavior

## Validation

- `cargo test -p openwave-core` (333 passed)
- `cargo fmt --all -- --check`
- `bw dev lint --rust --check`
