### PR TITLE
Box spawn checkpoint turn payload

### DIFF
--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -340,7 +340,7 @@ where
     let checkpoint = checkpoint_from_model(checkpoint_model)?;
     Ok(CheckpointSandboxSpawnOutcome::Checkpointed {
         child,
-        turn: turn_run_from_model(turn)?,
+        turn: Box::new(turn_run_from_model(turn)?),
         call,
         checkpoint,
         event: SequencedEvent {

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -255,7 +255,7 @@ pub enum CheckpointSandboxSpawnOutcome {
     /// committed together.
     Checkpointed {
         child: AgentRun,
-        turn: TurnRun,
+        turn: Box<TurnRun>,
         call: ToolCallRecord,
         checkpoint: crate::model::SandboxSpawnCheckpoint,
         event: SequencedEvent,


### PR DESCRIPTION
## Summary

- box the yielded turn payload in the spawn checkpoint outcome
- keep the durable checkpoint behavior and public result shape otherwise unchanged
- satisfy the hosted Rust lint size check with a narrow allocation boundary

## Validation

- `cargo fmt --all --check`
- `bw dev lint --rust --check`
- `cargo test -p openwave-core nonblocking_spawn_commits_one_atomic_yield_and_exact_retry_survives_reclaim --lib`
