### PR TITLE
Guard parent turn terminalization

### DIFF
--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -1282,6 +1282,7 @@ async fn create_agent_run_cancellation_table(manager: &SchemaManager<'_>) -> Res
                 .check(Expr::col(AgentRunCancellation::Reason).is_in([
                     crate::model::AgentRunCancellationReason::Requested.as_str(),
                     crate::model::AgentRunCancellationReason::ParentTurnCancelled.as_str(),
+                    crate::model::AgentRunCancellationReason::ParentTurnFailed.as_str(),
                 ]))
                 .to_owned(),
         )

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -35,6 +35,7 @@ mod cancellation;
 pub(in crate::db) use cancellation::{
     cancel_sandbox_children_for_origin_turn_on, finish_agent_run_cancellation,
     get_agent_run_cancellation_signal, request_agent_run_cancellation,
+    unsettled_sandbox_children_for_origin_turn_on,
 };
 
 pub(in crate::db) async fn insert_foreground_agent_run_on<C>(
@@ -2584,6 +2585,9 @@ fn agent_run_result_display_text(payload: &AgentRunResultPayload) -> String {
             AgentRunCancellationReason::Requested => "Sandbox task was cancelled.".to_owned(),
             AgentRunCancellationReason::ParentTurnCancelled => {
                 "Sandbox task was cancelled because its parent turn was cancelled.".to_owned()
+            }
+            AgentRunCancellationReason::ParentTurnFailed => {
+                "Sandbox task was cancelled because its parent turn failed.".to_owned()
             }
         },
     }

--- a/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
@@ -16,7 +16,7 @@ use super::{
     acquire_agent_run_claim_lock, agent_run_from_model, agent_run_result_display_text,
     agent_run_result_from_model, agent_run_result_payload_json, agent_run_result_payload_kind,
     agent_run_status_from_db, database_now, find_agent_run_inbox_on, find_by_id_on,
-    load_agent_run_inbox_entry_on,
+    load_agent_run_inbox_by_ids_on, load_agent_run_inbox_entry_on,
 };
 
 #[derive(Clone, Copy)]
@@ -246,6 +246,7 @@ pub(in crate::db) async fn cancel_sandbox_children_for_origin_turn_on<C>(
     conn: &C,
     turn: &entities::turn_run::Model,
     now: chrono::DateTime<Utc>,
+    reason: AgentRunCancellationReason,
 ) -> Result<bool>
 where
     C: sea_orm::ConnectionTrait,
@@ -279,27 +280,21 @@ where
                 "sandbox child {child_id} does not match its admission"
             )));
         }
+        agent_run_from_model(child.clone())?;
         match agent_run_status_from_db(&child.status)? {
             AgentRunStatus::Completed | AgentRunStatus::Failed => {
-                retire_inbox_on(conn, turn.agent_run_id, child.id).await?;
+                retire_inbox_on(conn, turn.agent_run_id, &child).await?;
             }
             AgentRunStatus::Cancelled => {
                 validate_cancellation_delivery_on(conn, &child, None).await?;
-                retire_inbox_on(conn, turn.agent_run_id, child.id).await?;
+                retire_inbox_on(conn, turn.agent_run_id, &child).await?;
             }
             AgentRunStatus::Running
                 if child.lease_expires_at.is_some_and(|expiry| expiry > now)
                     && child.deadline_at.is_some_and(|deadline| deadline > now) =>
             {
                 let identity = cancellation_identity_on(conn, &child, now).await?;
-                insert_cancellation_request_on(
-                    conn,
-                    &child,
-                    identity,
-                    AgentRunCancellationReason::ParentTurnCancelled,
-                    now,
-                )
-                .await?;
+                insert_cancellation_request_on(conn, &child, identity, reason, now).await?;
                 if !mark_live_run_cancelling_on(conn, &child, now).await? {
                     return Ok(false);
                 }
@@ -319,7 +314,7 @@ where
                     conn,
                     &child,
                     now,
-                    AgentRunCancellationReason::ParentTurnCancelled,
+                    reason,
                     AgentRunInboxStatus::Cancelled,
                 )
                 .await?
@@ -335,6 +330,131 @@ where
         }
     }
     Ok(true)
+}
+
+/// Validate every child admitted by one exact foreground turn and return the
+/// ones whose terminal delivery is not yet consumed or explicitly retired.
+///
+/// The caller holds the scheduler, chat, and turn locks in that order. Stable
+/// admission ordering makes the typed completion fence deterministic across
+/// retries and database backends.
+pub(in crate::db) async fn unsettled_sandbox_children_for_origin_turn_on<C>(
+    conn: &C,
+    turn: &entities::turn_run::Model,
+) -> Result<Vec<AgentRunId>>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    let parent_id = AgentRunId(turn.agent_run_id);
+    let parent = find_by_id_on(conn, parent_id).await?.ok_or_else(|| {
+        AgentError::Store(format!(
+            "origin turn {} is missing its foreground agent",
+            turn.id
+        ))
+    })?;
+    if parent.id != turn.agent_run_id
+        || parent.chat_id != turn.chat_id
+        || parent.execution != AgentRunExecution::Foreground.as_str()
+        || parent.depth != 0
+        || parent.parent_id.is_some()
+    {
+        return Err(AgentError::Store(format!(
+            "origin turn {} does not match its foreground agent",
+            turn.id
+        )));
+    }
+
+    let admissions = entities::sandbox_agent_admission::Entity::find()
+        .filter(entities::sandbox_agent_admission::Column::OriginTurnId.eq(turn.id))
+        .order_by_asc(entities::sandbox_agent_admission::Column::AdmittedAt)
+        .order_by_asc(entities::sandbox_agent_admission::Column::ChildRunId)
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    let mut unsettled = Vec::with_capacity(admissions.len());
+    for admission in admissions {
+        if admission.parent_run_id != turn.agent_run_id
+            || admission.chat_id != turn.chat_id
+            || AgentRunId(admission.child_run_id)
+                != AgentRunId::sandbox_for_spawn_call(crate::CallId(admission.spawn_call_id))
+        {
+            return Err(AgentError::Store(format!(
+                "sandbox admission {} does not match origin turn {}",
+                admission.child_run_id, turn.id
+            )));
+        }
+        let child_id = AgentRunId(admission.child_run_id);
+        let child = find_by_id_on(conn, child_id).await?.ok_or_else(|| {
+            AgentError::Store(format!(
+                "sandbox admission references missing child {child_id}"
+            ))
+        })?;
+        if child.parent_id != Some(turn.agent_run_id)
+            || child.chat_id != turn.chat_id
+            || child.execution != AgentRunExecution::Sandbox.as_str()
+            || child.depth != 1
+            || child.spawn_call_id != Some(admission.spawn_call_id)
+        {
+            return Err(AgentError::Store(format!(
+                "sandbox child {child_id} does not match its admission"
+            )));
+        }
+        agent_run_from_model(child.clone())?;
+
+        let status = agent_run_status_from_db(&child.status)?;
+        if !status.is_terminal() {
+            if find_agent_run_inbox_on(conn, parent_id, child_id)
+                .await?
+                .is_some()
+            {
+                return Err(AgentError::Store(format!(
+                    "nonterminal sandbox child {child_id} has a terminal inbox delivery"
+                )));
+            }
+            unsettled.push(child_id);
+            continue;
+        }
+
+        if status == AgentRunStatus::Cancelled {
+            validate_cancellation_delivery_on(conn, &child, None).await?;
+        }
+        let inbox = load_agent_run_inbox_by_ids_on(conn, parent_id, child_id)
+            .await?
+            .ok_or_else(|| {
+                AgentError::Store(format!(
+                    "terminal sandbox child {child_id} is missing its inbox delivery"
+                ))
+            })?;
+        let result_claim = entities::agent_run_claim::Entity::find_by_id(inbox.result.lease_token)
+            .one(conn)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| {
+                AgentError::Store(format!(
+                    "terminal sandbox child {child_id} result is missing claim provenance"
+                ))
+            })?;
+        if inbox.chat_id != ChatId(turn.chat_id)
+            || inbox.result.agent_run_id != child_id
+            || (status != AgentRunStatus::Cancelled
+                && (inbox.result.attempt_count != child.attempt_count
+                    || inbox.result.claim_count != child.claim_count
+                    || result_claim.agent_run_id != Some(child.id)
+                    || result_claim.attempt_count != Some(child.attempt_count)
+                    || result_claim.claim_count != Some(child.claim_count)))
+        {
+            return Err(AgentError::Store(format!(
+                "terminal sandbox child {child_id} has mismatched result provenance"
+            )));
+        }
+        if !matches!(
+            inbox.status,
+            AgentRunInboxStatus::Consumed | AgentRunInboxStatus::Cancelled
+        ) {
+            unsettled.push(child_id);
+        }
+    }
+    Ok(unsettled)
 }
 
 pub(super) async fn reap_expired_cancelling_on<C>(
@@ -670,6 +790,7 @@ where
         turn.status.as_str(),
         "cancelling" | "cancelling_client" | "cancelled"
     );
+    let parent_failed = turn.status == "failed";
     let parent_usable = !matches!(
         turn.status.as_str(),
         "cancelling" | "cancelling_client" | "cancelled" | "completed" | "failed"
@@ -677,6 +798,8 @@ where
     Ok((
         if parent_cancelled {
             AgentRunCancellationReason::ParentTurnCancelled
+        } else if parent_failed {
+            AgentRunCancellationReason::ParentTurnFailed
         } else {
             AgentRunCancellationReason::Requested
         },
@@ -688,11 +811,54 @@ where
     ))
 }
 
-async fn retire_inbox_on<C>(conn: &C, parent_id: uuid::Uuid, child_id: uuid::Uuid) -> Result<()>
+async fn retire_inbox_on<C>(
+    conn: &C,
+    parent_id: uuid::Uuid,
+    child: &entities::agent_run::Model,
+) -> Result<()>
 where
     C: sea_orm::ConnectionTrait,
 {
-    entities::agent_run_inbox::Entity::update_many()
+    let child_id = AgentRunId(child.id);
+    let inbox = load_agent_run_inbox_by_ids_on(conn, AgentRunId(parent_id), child_id)
+        .await?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "terminal sandbox child {child_id} is missing its inbox delivery"
+            ))
+        })?;
+    let result_claim = entities::agent_run_claim::Entity::find_by_id(inbox.result.lease_token)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .ok_or_else(|| {
+            AgentError::Store(format!(
+                "terminal sandbox child {child_id} result is missing claim provenance"
+            ))
+        })?;
+    if inbox.parent_run_id != AgentRunId(parent_id)
+        || inbox.child_run_id != child_id
+        || inbox.chat_id != ChatId(child.chat_id)
+        || inbox.result.agent_run_id != child_id
+        || (child.status != AgentRunStatus::Cancelled.as_str()
+            && (inbox.result.attempt_count != child.attempt_count
+                || inbox.result.claim_count != child.claim_count
+                || result_claim.agent_run_id != Some(child.id)
+                || result_claim.attempt_count != Some(child.attempt_count)
+                || result_claim.claim_count != Some(child.claim_count)))
+    {
+        return Err(AgentError::Store(format!(
+            "terminal sandbox child {child_id} has mismatched delivery provenance"
+        )));
+    }
+    let status = inbox.status;
+    if matches!(
+        status,
+        AgentRunInboxStatus::Consumed | AgentRunInboxStatus::Cancelled
+    ) {
+        return Ok(());
+    }
+    let updated = entities::agent_run_inbox::Entity::update_many()
         .col_expr(
             entities::agent_run_inbox::Column::Status,
             sea_orm::sea_query::Expr::value(AgentRunInboxStatus::Cancelled.as_str()),
@@ -705,15 +871,18 @@ where
             entities::agent_run_inbox::Column::LeaseExpiresAt,
             sea_orm::sea_query::Expr::value(Option::<chrono::DateTime<Utc>>::None),
         )
-        .filter(entities::agent_run_inbox::Column::ChildRunId.eq(child_id))
+        .filter(entities::agent_run_inbox::Column::ChildRunId.eq(child.id))
         .filter(entities::agent_run_inbox::Column::ParentRunId.eq(parent_id))
-        .filter(entities::agent_run_inbox::Column::Status.is_in([
-            AgentRunInboxStatus::Pending.as_str(),
-            AgentRunInboxStatus::Claimed.as_str(),
-        ]))
+        .filter(entities::agent_run_inbox::Column::Status.eq(status.as_str()))
         .exec(conn)
         .await
         .map_err(store_err)?;
+    if updated.rows_affected != 1 {
+        return Err(AgentError::Store(format!(
+            "terminal sandbox child {child_id} inbox retirement changed {} rows",
+            updated.rows_affected
+        )));
+    }
     Ok(())
 }
 
@@ -868,7 +1037,8 @@ where
     })?;
     let inbox = load_agent_run_inbox_entry_on(conn, inbox_model).await?;
     let inbox_lifecycle_valid = match reason {
-        AgentRunCancellationReason::ParentTurnCancelled => {
+        AgentRunCancellationReason::ParentTurnCancelled
+        | AgentRunCancellationReason::ParentTurnFailed => {
             inbox.status == AgentRunInboxStatus::Cancelled
         }
         // A direct cancellation may be delivered while its origin is live and

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -13,7 +13,7 @@ use crate::storage::{AcceptTurnOutcome, ClaimScanTerminalEvent, ClaimTurnRunOutc
 
 use super::super::{entities, store_err, DbStore};
 use super::{
-    acquire_chat_write_lock,
+    acquire_chat_write_lock, acquire_turn_write_lock,
     agent_run::find_foreground_agent_run_on,
     conversation::{
         append_event_on, next_message_seq_on, reserve_message_identity_on,
@@ -431,11 +431,61 @@ pub(in crate::db) async fn claim_turn_run(
         let reclaiming = candidate.status == TurnRunStatus::Running.as_str();
         if reclaiming && candidate.attempt_count >= candidate.max_attempts {
             let chat_id = ChatId(candidate.chat_id);
+            // Final lease exhaustion shares the terminal lock order with
+            // explicit completion and failure: sandbox scheduler, chat, turn.
+            super::agent_run::acquire_agent_run_claim_lock(&transaction).await?;
             if !acquire_chat_write_lock(&transaction, chat_id).await? {
                 return Err(AgentError::Store(format!(
                     "turn {} references missing chat {chat_id}",
                     TurnId(candidate.id)
                 )));
+            }
+            if !acquire_turn_write_lock(&transaction, TurnId(candidate.id)).await? {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+            let Some(locked_candidate) = entities::turn_run::Entity::find_by_id(candidate.id)
+                .one(&transaction)
+                .await
+                .map_err(store_err)?
+            else {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            };
+            if locked_candidate.status != TurnRunStatus::Running.as_str()
+                || locked_candidate.chat_id != candidate.chat_id
+                || locked_candidate.agent_run_id != candidate.agent_run_id
+                || locked_candidate.attempt_count != candidate.attempt_count
+                || locked_candidate.max_attempts != candidate.max_attempts
+                || locked_candidate.claim_count != candidate.claim_count
+                || locked_candidate.lease_token != candidate.lease_token
+                || locked_candidate.lease_expires_at != candidate.lease_expires_at
+                || locked_candidate.updated_at != candidate.updated_at
+            {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+            let candidate = locked_candidate;
+            let terminal_now =
+                std::cmp::max(now, super::agent_run::database_now(&transaction).await?);
+            if candidate
+                .lease_expires_at
+                .is_none_or(|expires_at| expires_at > terminal_now)
+                || candidate.updated_at > terminal_now
+            {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
+            }
+            if !super::agent_run::cancel_sandbox_children_for_origin_turn_on(
+                &transaction,
+                &candidate,
+                terminal_now,
+                crate::model::AgentRunCancellationReason::ParentTurnFailed,
+            )
+            .await?
+            {
+                transaction.rollback().await.map_err(store_err)?;
+                continue;
             }
             let failed = entities::turn_run::Entity::update_many()
                 .col_expr(
@@ -452,7 +502,7 @@ pub(in crate::db) async fn claim_turn_run(
                 )
                 .col_expr(
                     entities::turn_run::Column::FinishedAt,
-                    sea_orm::sea_query::Expr::value(Some(now)),
+                    sea_orm::sea_query::Expr::value(Some(terminal_now)),
                 )
                 .col_expr(
                     entities::turn_run::Column::LastErrorCode,
@@ -464,7 +514,7 @@ pub(in crate::db) async fn claim_turn_run(
                 )
                 .col_expr(
                     entities::turn_run::Column::UpdatedAt,
-                    sea_orm::sea_query::Expr::value(now),
+                    sea_orm::sea_query::Expr::value(terminal_now),
                 )
                 .filter(entities::turn_run::Column::Id.eq(candidate.id))
                 .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Running.as_str()))
@@ -479,7 +529,8 @@ pub(in crate::db) async fn claim_turn_run(
                 transaction.rollback().await.map_err(store_err)?;
                 continue;
             }
-            steer::reject_pending_turn_steers_on(&transaction, TurnId(candidate.id), now).await?;
+            steer::reject_pending_turn_steers_on(&transaction, TurnId(candidate.id), terminal_now)
+                .await?;
             let event = AgentEvent::TurnFailed {
                 error: AgentErrorInfo {
                     kind: "lease_expired".into(),
@@ -504,7 +555,7 @@ pub(in crate::db) async fn claim_turn_run(
                 requested_retry_at: Set(None),
                 error_code: Set("lease_expired".into()),
                 error_detail: Set(Some("final worker lease expired".into())),
-                resolved_at: Set(now),
+                resolved_at: Set(terminal_now),
                 result_status: Set(TurnRunStatus::Failed.as_str().into()),
             }
             .insert(&transaction)

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -135,18 +135,17 @@ async fn complete_turn_run_inner(
 ) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
     validate_turn_output(id, lease_token, output)?;
     super::super::citation::validate_assistant_message(output, citations)?;
-    let now = canonical_db_timestamp(now)?;
+    let requested_at = canonical_db_timestamp(now)?;
     let output_created_at = canonical_db_timestamp(output.created_at)?;
-    if output_created_at > now {
-        return Err(AgentError::Store(
-            "turn output timestamp must not be after completion time".into(),
-        ));
-    }
 
     let Some(journal_chat_id) = journal_chat_id(store, id, true).await? else {
         return Ok(None);
     };
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    // Sandbox scheduling and foreground terminalization share one lock order:
+    // scheduler, chat, then turn. This makes child admission, result delivery,
+    // and the parent terminal decision one serial boundary.
+    super::super::agent_run::acquire_agent_run_claim_lock(&transaction).await?;
     if !acquire_chat_write_lock(&transaction, journal_chat_id).await? {
         return Err(AgentError::Store(format!(
             "turn {id} references missing chat {journal_chat_id}"
@@ -155,6 +154,17 @@ async fn complete_turn_run_inner(
     if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
+    }
+    // Caller time records intent. Lock acquisition can wait behind a child
+    // transition, so take an authoritative clock after all terminal locks.
+    let now = std::cmp::max(
+        requested_at,
+        super::super::agent_run::database_now(&transaction).await?,
+    );
+    if output_created_at > now {
+        return Err(AgentError::Store(
+            "turn output timestamp must not be after completion time".into(),
+        ));
     }
     let Some(receipt) = entities::turn_claim::Entity::find_by_id(lease_token)
         .one(&transaction)
@@ -230,6 +240,23 @@ async fn complete_turn_run_inner(
                 CompleteTurnRunOutcome::SteerPending(existing)
             } else {
                 CompleteTurnRunOutcome::OutputSuperseded(existing)
+            },
+            terminal_event: None,
+        }));
+    }
+
+    let outstanding = super::super::agent_run::unsettled_sandbox_children_for_origin_turn_on(
+        &transaction,
+        &existing,
+    )
+    .await?;
+    if !outstanding.is_empty() {
+        let turn = turn_run_from_model(existing)?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(Some(JournaledTurnOutcome {
+            outcome: CompleteTurnRunOutcome::ChildrenOutstanding {
+                turn,
+                child_run_ids: outstanding,
             },
             terminal_event: None,
         }));
@@ -443,7 +470,7 @@ async fn record_turn_run_failure_inner(
     terminal_event: Option<&AgentEvent>,
 ) -> Result<Option<JournaledTurnOutcome<RecordTurnFailureOutcome>>> {
     validate_turn_failure(lease_token, error_code, error_detail)?;
-    let now = canonical_db_timestamp(now)?;
+    let requested_at = canonical_db_timestamp(now)?;
     let requested_retry_at = match retry {
         TurnFailureRetry::Permanent => None,
         TurnFailureRetry::RetryAt(retry_at) => Some(canonical_db_timestamp(retry_at)?),
@@ -474,17 +501,20 @@ async fn record_turn_run_failure_inner(
             terminal_event: sequenced_event,
         }));
     }
-    if requested_retry_at.is_some_and(|retry_at| retry_at <= now) {
+    if requested_retry_at.is_some_and(|retry_at| retry_at <= requested_at) {
         return Err(AgentError::Store(
             "turn retry time must be after failure resolution time".into(),
         ));
     }
 
-    let journal_chat_id = journal_chat_id(store, id, terminal_event.is_some()).await?;
-    if terminal_event.is_some() && journal_chat_id.is_none() {
+    let journal_chat_id = journal_chat_id(store, id, true).await?;
+    if journal_chat_id.is_none() {
         return Ok(None);
     }
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    // Keep foreground failure serial with sandbox claims, cancellation, and
+    // result delivery: scheduler, chat, then turn.
+    super::super::agent_run::acquire_agent_run_claim_lock(&transaction).await?;
     if let Some(chat_id) = journal_chat_id {
         if !acquire_chat_write_lock(&transaction, chat_id).await? {
             return Err(AgentError::Store(format!(
@@ -495,6 +525,15 @@ async fn record_turn_run_failure_inner(
     if !acquire_turn_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
+    }
+    let now = std::cmp::max(
+        requested_at,
+        super::super::agent_run::database_now(&transaction).await?,
+    );
+    if requested_retry_at.is_some_and(|retry_at| retry_at <= now) {
+        return Err(AgentError::Store(
+            "turn retry time must be after failure resolution time".into(),
+        ));
     }
     if let Some(existing) = exact_turn_failure_on(
         &transaction,
@@ -580,6 +619,17 @@ async fn record_turn_run_failure_inner(
         TurnRunStatus::Failed
     };
     if result_status == TurnRunStatus::Failed {
+        if !super::super::agent_run::cancel_sandbox_children_for_origin_turn_on(
+            &transaction,
+            &turn,
+            now,
+            crate::model::AgentRunCancellationReason::ParentTurnFailed,
+        )
+        .await?
+        {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(None);
+        }
         super::super::approval::close_pending_for_terminal_turn_on(&transaction, id, now).await?;
     }
     let receipt = entities::turn_failure::ActiveModel {

--- a/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
@@ -112,6 +112,7 @@ async fn request_turn_cancellation_inner(
         &transaction,
         &turn,
         now,
+        crate::model::AgentRunCancellationReason::ParentTurnCancelled,
     )
     .await?
     {

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -12,6 +12,7 @@ use chrono::{DateTime, Utc};
 
 mod agent_run;
 mod multi_agent_wait;
+mod parent_terminal_guard;
 mod root_attachment;
 mod sandbox_spawn_checkpoint;
 mod turn_steer;

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -2050,7 +2050,7 @@ async fn direct_cancellation_reason_wins_a_later_parent_cancellation() {
 }
 
 #[tokio::test]
-async fn cancellation_retry_survives_later_origin_completion() {
+async fn cancellation_retry_remains_pending_while_parent_completion_is_fenced() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
@@ -2075,7 +2075,8 @@ async fn cancellation_retry_survives_later_origin_completion() {
             .complete_turn_run(origin.id, origin_lease, 0, completed_at, &output)
             .await
             .unwrap(),
-        Some(crate::CompleteTurnRunOutcome::Completed(_))
+        Some(crate::CompleteTurnRunOutcome::ChildrenOutstanding { child_run_ids, .. })
+            if child_run_ids == vec![child.id]
     ));
     assert!(matches!(
         store.request_agent_run_cancellation(child.id).await.unwrap(),

--- a/crates/openwave-core/src/db/tests/parent_terminal_guard.rs
+++ b/crates/openwave-core/src/db/tests/parent_terminal_guard.rs
@@ -1,0 +1,347 @@
+use super::{sample_chat, temp_store};
+use crate::db::tests::agent_run::{admit_sandbox_call_for_test, live_turn_for_sandbox_test};
+use crate::{
+    AgentRunCancellationReason, AgentRunId, AgentRunInboxStatus, AgentRunStatus, CallId,
+    CompleteTurnRunOutcome, Message, MessageId, RecordTurnFailureOutcome,
+    RequestAgentRunCancellationOutcome, Role, Store, SubmitAgentRunResultOutcome, TurnFailureRetry,
+    TurnRunStatus, Usage,
+};
+use chrono::{Duration, Utc};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+async fn complete_child(store: &crate::DbStore, chat_id: crate::ChatId, task: &str) -> AgentRunId {
+    let child = admit_sandbox_call_for_test(store, chat_id, CallId::new(), task).await;
+    let lease = uuid::Uuid::new_v4();
+    let claimed = store
+        .claim_agent_run(lease, Duration::minutes(5), 1, 1)
+        .await
+        .unwrap()
+        .expect("child should claim");
+    assert_eq!(claimed.id, child.id);
+    assert!(matches!(
+        store
+            .submit_agent_run_result(child.id, lease, "finished")
+            .await
+            .unwrap(),
+        Some(SubmitAgentRunResultOutcome::Completed(_))
+    ));
+    child.id
+}
+
+async fn consume_child(store: &crate::DbStore, chat_id: crate::ChatId, child: AgentRunId) {
+    let parent = AgentRunId::foreground_for_chat(chat_id);
+    let lease = uuid::Uuid::new_v4();
+    let delivered = store
+        .list_agent_run_inbox(parent)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.child_run_id == child)
+        .expect("terminal inbox should exist")
+        .delivered_at;
+    let updated = crate::db::entities::agent_run_inbox::Entity::update_many()
+        .col_expr(
+            crate::db::entities::agent_run_inbox::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunInboxStatus::Consumed.as_str()),
+        )
+        .col_expr(
+            crate::db::entities::agent_run_inbox::Column::ClaimCount,
+            sea_orm::sea_query::Expr::value(1),
+        )
+        .col_expr(
+            crate::db::entities::agent_run_inbox::Column::ConsumedLeaseToken,
+            sea_orm::sea_query::Expr::value(Some(lease)),
+        )
+        .col_expr(
+            crate::db::entities::agent_run_inbox::Column::ConsumedAt,
+            sea_orm::sea_query::Expr::value(Some(delivered)),
+        )
+        .filter(crate::db::entities::agent_run_inbox::Column::ChildRunId.eq(child.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert_eq!(updated.rows_affected, 1);
+}
+
+fn output_for(turn: &crate::TurnRun, chat_id: crate::ChatId) -> Message {
+    Message {
+        id: MessageId::new(),
+        chat_id,
+        turn_id: turn.id,
+        role: Role::Assistant,
+        content: "foreground answer".into(),
+        created_at: Utc::now().max(turn.updated_at),
+    }
+}
+
+#[tokio::test]
+async fn completion_fences_children_in_stable_order_without_writing_output() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let first = admit_sandbox_call_for_test(&store, chat.id, CallId::new(), "first").await;
+    let second = admit_sandbox_call_for_test(&store, chat.id, CallId::new(), "second").await;
+    let output = output_for(&turn, chat.id);
+
+    let fenced = store
+        .complete_turn_run(turn.id, lease, 0, Utc::now(), &output)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        fenced,
+        CompleteTurnRunOutcome::ChildrenOutstanding { child_run_ids, .. }
+            if child_run_ids == vec![first.id, second.id]
+    ));
+    assert_eq!(
+        store.get_turn_run(turn.id).await.unwrap().unwrap().status,
+        TurnRunStatus::Running
+    );
+    assert!(!store
+        .list_messages(chat.id)
+        .await
+        .unwrap()
+        .iter()
+        .any(|message| message.id == output.id));
+    assert!(store.list_events(chat.id, 0).await.unwrap().is_empty());
+
+    let first_lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(first_lease, Duration::minutes(5), 1, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        first.id
+    );
+    store
+        .submit_agent_run_result(first.id, first_lease, "first result")
+        .await
+        .unwrap()
+        .unwrap();
+    let still_fenced = store
+        .complete_turn_run(turn.id, lease, 0, Utc::now(), &output)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        still_fenced,
+        CompleteTurnRunOutcome::ChildrenOutstanding { child_run_ids, .. }
+            if child_run_ids == vec![first.id, second.id]
+    ));
+    consume_child(&store, chat.id, first.id).await;
+
+    assert!(matches!(
+        store
+            .request_agent_run_cancellation(second.id)
+            .await
+            .unwrap(),
+        Some(RequestAgentRunCancellationOutcome::Cancelled(_))
+    ));
+    assert!(matches!(
+        store
+            .complete_turn_run(turn.id, lease, 0, Utc::now(), &output)
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::ChildrenOutstanding { child_run_ids, .. })
+            if child_run_ids == vec![second.id]
+    ));
+    consume_child(&store, chat.id, second.id).await;
+    assert!(matches!(
+        store
+            .complete_turn_run(turn.id, lease, 0, Utc::now(), &output)
+            .await
+            .unwrap(),
+        Some(CompleteTurnRunOutcome::Completed(_))
+    ));
+}
+
+#[tokio::test]
+async fn permanent_failure_fences_live_children_and_retires_only_unconsumed_deliveries() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, turn_lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let pending = complete_child(&store, chat.id, "pending result").await;
+    let consumed = complete_child(&store, chat.id, "consumed result").await;
+    consume_child(&store, chat.id, consumed).await;
+    let running = admit_sandbox_call_for_test(&store, chat.id, CallId::new(), "running").await;
+    let running_lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(running_lease, Duration::minutes(5), 1, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        running.id
+    );
+    let queued = admit_sandbox_call_for_test(&store, chat.id, CallId::new(), "queued").await;
+
+    let failure = store
+        .record_turn_run_failure(
+            turn.id,
+            turn_lease,
+            Utc::now(),
+            TurnFailureRetry::Permanent,
+            0,
+            Usage::default(),
+            "provider_failed",
+            Some("provider failed permanently"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(failure, RecordTurnFailureOutcome::Recorded(_)));
+    assert_eq!(
+        store.get_turn_run(turn.id).await.unwrap().unwrap().status,
+        TurnRunStatus::Failed
+    );
+    assert_eq!(
+        store
+            .get_agent_run(running.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        AgentRunStatus::Cancelling
+    );
+    assert_eq!(
+        store
+            .get_agent_run(queued.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        AgentRunStatus::Cancelled
+    );
+
+    let inbox = store
+        .list_agent_run_inbox(AgentRunId::foreground_for_chat(chat.id))
+        .await
+        .unwrap();
+    assert_eq!(
+        inbox
+            .iter()
+            .find(|entry| entry.child_run_id == pending)
+            .unwrap()
+            .status,
+        AgentRunInboxStatus::Cancelled
+    );
+    assert_eq!(
+        inbox
+            .iter()
+            .find(|entry| entry.child_run_id == consumed)
+            .unwrap()
+            .status,
+        AgentRunInboxStatus::Consumed
+    );
+    let queued_inbox = inbox
+        .iter()
+        .find(|entry| entry.child_run_id == queued.id)
+        .unwrap();
+    assert_eq!(queued_inbox.status, AgentRunInboxStatus::Cancelled);
+    assert!(matches!(
+        queued_inbox.result.payload,
+        crate::AgentRunResultPayload::Cancelled {
+            reason: AgentRunCancellationReason::ParentTurnFailed
+        }
+    ));
+
+    store
+        .finish_agent_run_cancellation(running.id, running_lease)
+        .await
+        .unwrap()
+        .unwrap();
+    let inbox = store
+        .list_agent_run_inbox(AgentRunId::foreground_for_chat(chat.id))
+        .await
+        .unwrap();
+    let running_inbox = inbox
+        .iter()
+        .find(|entry| entry.child_run_id == running.id)
+        .unwrap();
+    assert_eq!(running_inbox.status, AgentRunInboxStatus::Cancelled);
+    assert!(matches!(
+        running_inbox.result.payload,
+        crate::AgentRunResultPayload::Cancelled {
+            reason: AgentRunCancellationReason::ParentTurnFailed
+        }
+    ));
+}
+
+#[tokio::test]
+async fn terminal_child_missing_its_inbox_is_corruption_not_a_silent_retirement() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let child = complete_child(&store, chat.id, "corrupt delivery").await;
+    crate::db::entities::agent_run_inbox::Entity::delete_many()
+        .filter(crate::db::entities::agent_run_inbox::Column::ChildRunId.eq(child.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let output = output_for(&turn, chat.id);
+    assert!(store
+        .complete_turn_run(turn.id, lease, 0, Utc::now(), &output)
+        .await
+        .is_err());
+    assert!(store
+        .record_turn_run_failure(
+            turn.id,
+            lease,
+            Utc::now(),
+            TurnFailureRetry::Permanent,
+            0,
+            Usage::default(),
+            "failed",
+            None,
+        )
+        .await
+        .is_err());
+    assert_eq!(
+        store.get_turn_run(turn.id).await.unwrap().unwrap().status,
+        TurnRunStatus::Running
+    );
+}
+
+#[tokio::test]
+async fn terminal_child_corrupt_result_is_not_retired_by_parent_failure() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let child = complete_child(&store, chat.id, "corrupt result").await;
+    let updated = crate::db::entities::agent_run_result::Entity::update_many()
+        .col_expr(
+            crate::db::entities::agent_run_result::Column::PayloadJson,
+            sea_orm::sea_query::Expr::value("{not-json}"),
+        )
+        .filter(crate::db::entities::agent_run_result::Column::AgentRunId.eq(child.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert_eq!(updated.rows_affected, 1);
+
+    assert!(store
+        .record_turn_run_failure(
+            turn.id,
+            lease,
+            Utc::now(),
+            TurnFailureRetry::Permanent,
+            0,
+            Usage::default(),
+            "failed",
+            None,
+        )
+        .await
+        .is_err());
+    assert_eq!(
+        store.get_turn_run(turn.id).await.unwrap().unwrap().status,
+        TurnRunStatus::Running
+    );
+}

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1312,6 +1312,8 @@ pub enum AgentRunCancellationReason {
     Requested,
     /// The exact foreground turn that admitted the child was cancelled.
     ParentTurnCancelled,
+    /// The exact foreground turn that admitted the child failed permanently.
+    ParentTurnFailed,
 }
 
 /// Immutable executor identity retained by a sandbox cancellation request.
@@ -1332,6 +1334,7 @@ impl AgentRunCancellationReason {
         match self {
             Self::Requested => "requested",
             Self::ParentTurnCancelled => "parent_turn_cancelled",
+            Self::ParentTurnFailed => "parent_turn_failed",
         }
     }
 
@@ -1339,6 +1342,7 @@ impl AgentRunCancellationReason {
         match value {
             "requested" => Some(Self::Requested),
             "parent_turn_cancelled" => Some(Self::ParentTurnCancelled),
+            "parent_turn_failed" => Some(Self::ParentTurnFailed),
             _ => None,
         }
     }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -469,6 +469,14 @@ pub enum CompleteTurnRunOutcome {
     Completed(TurnRun),
     /// This exact completion was already committed by an earlier call.
     Existing(TurnRun),
+    /// Completion was fenced until every child admitted by this turn has a
+    /// consumed or explicitly retired terminal delivery.
+    ChildrenOutstanding {
+        /// The still-live foreground turn.
+        turn: TurnRun,
+        /// Stable admission-order identities that still need settlement.
+        child_run_ids: Vec<crate::id::AgentRunId>,
+    },
     /// Completion was fenced because an accepted steer still needs application.
     SteerPending(TurnRun),
     /// The output was generated from an older steer revision and must be regenerated.

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -794,6 +794,211 @@ async fn postgres_parent_cancellation_and_first_child_claim_converge_without_ide
 }
 
 #[tokio::test]
+async fn postgres_parent_completion_and_child_admission_form_one_terminal_boundary() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = Arc::new(DbStore::connect(&url).await.unwrap());
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = postgres_live_turn(store.as_ref(), chat.id).await;
+    let call = CallId::new();
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: turn.id,
+        role: Role::Assistant,
+        content: "race-safe terminal answer".into(),
+        created_at: utc_now_at_postgres_precision().max(turn.updated_at),
+    };
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let admission = {
+        let store = Arc::clone(&store);
+        let barrier = Arc::clone(&barrier);
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .admit_sandbox_agent_run(
+                    turn.id,
+                    call,
+                    "race parent completion",
+                    lease,
+                    turn.steer_revision,
+                    openwave_core::AgentRun::MAX_CONCURRENCY_LIMIT,
+                    utc_now_at_postgres_precision(),
+                )
+                .await
+                .unwrap()
+                .unwrap()
+        })
+    };
+    let completion = {
+        let store = Arc::clone(&store);
+        let barrier = Arc::clone(&barrier);
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .complete_turn_run(
+                    turn.id,
+                    lease,
+                    turn.steer_revision,
+                    utc_now_at_postgres_precision(),
+                    &output,
+                )
+                .await
+                .unwrap()
+                .unwrap()
+        })
+    };
+    let admission = admission.await.unwrap();
+    let completion = completion.await.unwrap();
+    let parent = store.get_turn_run(turn.id).await.unwrap().unwrap();
+    let children = store
+        .list_agent_runs(chat.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|run| run.execution == AgentRunExecution::Sandbox)
+        .collect::<Vec<_>>();
+    match completion {
+        CompleteTurnRunOutcome::Completed(_) => {
+            assert!(matches!(
+                admission,
+                openwave_core::AdmitSandboxAgentRunOutcome::ParentUnavailable
+                    | openwave_core::AdmitSandboxAgentRunOutcome::LeaseLost
+            ));
+            assert_eq!(parent.status, TurnRunStatus::Completed);
+            assert!(children.is_empty());
+        }
+        CompleteTurnRunOutcome::ChildrenOutstanding { child_run_ids, .. } => {
+            assert!(matches!(
+                admission,
+                openwave_core::AdmitSandboxAgentRunOutcome::Accepted { .. }
+            ));
+            assert_eq!(parent.status, TurnRunStatus::Running);
+            assert_eq!(children.len(), 1);
+            assert_eq!(child_run_ids, vec![children[0].id]);
+        }
+        outcome => panic!("unexpected completion/admission race outcome: {outcome:?}"),
+    }
+    cleanup_postgres_sandbox_chat(store.as_ref(), chat.id).await;
+}
+
+#[tokio::test]
+async fn postgres_permanent_parent_failure_and_child_result_cannot_orphan_delivery() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = Arc::new(DbStore::connect(&url).await.unwrap());
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, turn_lease) = postgres_live_turn(store.as_ref(), chat.id).await;
+    let child = postgres_admit_sandbox(
+        store.as_ref(),
+        chat.id,
+        CallId::new(),
+        "race parent failure",
+    )
+    .await;
+    let child_lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(child_lease, Duration::minutes(5), 4, 4)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        child.id
+    );
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let submission = {
+        let store = Arc::clone(&store);
+        let barrier = Arc::clone(&barrier);
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .submit_agent_run_result(child.id, child_lease, "terminal child result")
+                .await
+                .unwrap()
+        })
+    };
+    let failure = {
+        let store = Arc::clone(&store);
+        let barrier = Arc::clone(&barrier);
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .record_turn_run_failure(
+                    turn.id,
+                    turn_lease,
+                    utc_now_at_postgres_precision(),
+                    TurnFailureRetry::Permanent,
+                    0,
+                    Usage::default(),
+                    "provider_failed",
+                    Some("provider failed permanently"),
+                )
+                .await
+                .unwrap()
+                .unwrap()
+        })
+    };
+    let submission = submission.await.unwrap();
+    assert!(matches!(
+        failure.await.unwrap(),
+        RecordTurnFailureOutcome::Recorded(_)
+    ));
+    let parent = store.get_turn_run(turn.id).await.unwrap().unwrap();
+    let child = store.get_agent_run(child.id).await.unwrap().unwrap();
+    assert_eq!(parent.status, TurnRunStatus::Failed);
+    match child.status {
+        AgentRunStatus::Completed => {
+            assert!(matches!(
+                submission,
+                Some(SubmitAgentRunResultOutcome::Completed(_))
+            ));
+            let inbox = store
+                .list_agent_run_inbox(AgentRunId::foreground_for_chat(chat.id))
+                .await
+                .unwrap();
+            assert_eq!(inbox.len(), 1);
+            assert_eq!(inbox[0].status, AgentRunInboxStatus::Cancelled);
+        }
+        AgentRunStatus::Cancelling => {
+            assert!(submission.is_none());
+            store
+                .finish_agent_run_cancellation(child.id, child_lease)
+                .await
+                .unwrap()
+                .unwrap();
+            let inbox = store
+                .list_agent_run_inbox(AgentRunId::foreground_for_chat(chat.id))
+                .await
+                .unwrap();
+            assert!(matches!(
+                inbox[0].result.payload,
+                AgentRunResultPayload::Cancelled {
+                    reason: AgentRunCancellationReason::ParentTurnFailed
+                }
+            ));
+            assert_eq!(inbox[0].status, AgentRunInboxStatus::Cancelled);
+        }
+        status => panic!("unexpected child status after permanent parent failure: {status:?}"),
+    }
+    cleanup_postgres_sandbox_chat(store.as_ref(), chat.id).await;
+}
+
+#[tokio::test]
 async fn postgres_parent_cancellation_uses_time_after_admission_and_heartbeat_lock_waits() {
     let _guard = POSTGRES_TEST_LOCK.lock().await;
     let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
@@ -1570,15 +1775,16 @@ async fn postgres_sandbox_claim_uses_statement_time_after_scheduler_lock_wait() 
     // intentionally short lease has expired; the regression this test guards
     // is whether the lease was based on the pre-wait transaction timestamp.
     assert!(claimed.lease_expires_at.unwrap() > lock_released_at);
-    // The integration suite shares an isolated database, so leave no live
-    // scheduler capacity behind for its independent concurrency cases.
+    // Restore a cancellable nonterminal shape before shared cleanup. Forging a
+    // terminal child without its immutable result/inbox would now correctly
+    // be treated as corruption by the parent terminal guard.
     blocker
         .execute(Statement::from_string(
             DatabaseBackend::Postgres,
             format!(
                 "UPDATE agent_run \
-                 SET status = 'completed', lease_token = NULL, lease_expires_at = NULL, \
-                     finished_at = clock_timestamp(), updated_at = clock_timestamp() \
+                 SET status = 'queued', lease_token = NULL, lease_expires_at = NULL, \
+                     finished_at = NULL, updated_at = clock_timestamp() \
                  WHERE id = '{}'",
                 child_id.0
             ),

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -748,6 +748,16 @@ impl TurnWorker {
                                 | CompleteTurnRunOutcome::OutputSuperseded(_) => {
                                     break true;
                                 }
+                                CompleteTurnRunOutcome::ChildrenOutstanding {
+                                    child_run_ids,
+                                    ..
+                                } => {
+                                    return Err(AgentError::msg(format!(
+                                        "turn {} attempted to complete with {} unsettled sandbox children",
+                                        turn.id,
+                                        child_run_ids.len()
+                                    )));
+                                }
                             },
                             Ok(None) => {
                                 // A concurrent durable admission can advance


### PR DESCRIPTION
## Summary

- fence successful foreground completion while any admitted sandbox child remains unsettled
- atomically cancel or retire child work when a parent fails permanently or exhausts its final lease
- validate terminal inbox, result, and claim provenance before allowing parent terminalization
- preserve retry-wait children and existing cancellation precedence

## Validation

- `cargo test -p openwave-core --lib` (355 passed)
- `cargo test -p openwave-server --lib` (238 passed)
- `cargo test -p openwave-core --no-default-features --features postgres --test postgres_turn_state --locked` (24 passed on an isolated PostgreSQL instance)
- `cargo check --workspace --all-targets`
- `cargo fmt --all --check`
- `bw dev lint --rust --check`
