### PR TITLE
Present background agent waits in the desktop

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -622,6 +622,7 @@ fn historical_tool_title(name: &str) -> &'static str {
         "connect_folder" => "Connect a folder",
         "list_connected_folders" => "Check connected folders",
         "spawn_sandbox_agent" => "Delegate a task",
+        "wait_for_agents" => "Wait for background agents",
         _ => "Use a tool",
     }
 }

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -95,6 +95,37 @@ describe("MessageBubble", () => {
     expect(markup).not.toContain("message-stream-placeholder");
   });
 
+  it("shows a specific background wait instead of the generic worker status", () => {
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={[
+          {
+            id: "wait-1",
+            role: "tool",
+            callId: "call-1",
+            name: "wait_for_agents",
+            status: "running",
+          },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        busy
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup).toContain("Waiting for background agents");
+    expect(markup).not.toContain(">Working<");
+    expect(markup).not.toContain("call-1");
+  });
+
   it("does not offer approval for an action without a safe description", () => {
     const markup = renderToStaticMarkup(
       <MessageBubble

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.test.tsx
@@ -50,6 +50,20 @@ describe("ToolActivityGroup", () => {
     });
   });
 
+  it("uses the dedicated active copy while background agents are pending", () => {
+    expect(
+      toolActivityGroupPresentation([
+        { name: "spawn_sandbox_agent", status: "completed" },
+        { name: "wait_for_agents", status: "running" },
+      ]),
+    ).toEqual({
+      phase: "active",
+      tone: "running",
+      icon: "↗",
+      label: "Waiting for background agents",
+    });
+  });
+
   it("renders a native disclosure with a hidden ordered timeline", () => {
     const markup = renderToStaticMarkup(
       <ToolActivityGroup

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -41,6 +41,35 @@ describe("ToolCallCard", () => {
     expect(markup).toContain("Document search complete");
   });
 
+  it("distinguishes delegation from waiting for the child results", () => {
+    const delegated = renderToStaticMarkup(
+      <ToolCallCard name="spawn_sandbox_agent" status="completed" />,
+    );
+    const waiting = renderToStaticMarkup(
+      <ToolCallCard name="wait_for_agents" status="running" />,
+    );
+    const finished = renderToStaticMarkup(
+      <ToolCallCard name="wait_for_agents" status="completed" />,
+    );
+
+    expect(delegated).toContain("Task delegated");
+    expect(delegated).not.toContain("task complete");
+    expect(waiting).toContain("Waiting for background agents");
+    expect(finished).toContain("Background agents finished");
+  });
+
+  it("uses fixed terminal failure copy for background-agent waits", () => {
+    const failed = renderToStaticMarkup(
+      <ToolCallCard name="wait_for_agents" status="failed" />,
+    );
+    const cancelled = renderToStaticMarkup(
+      <ToolCallCard name="wait_for_agents" status="cancelled" />,
+    );
+
+    expect(failed).toContain("Tool could not complete");
+    expect(cancelled).toContain("Not run");
+  });
+
   it("degrades an unknown runtime status without using it as copy or a class", () => {
     const markup = renderToStaticMarkup(
       <ToolCallCard

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -97,8 +97,14 @@ const TOOL_PRESENTATIONS: Record<string, ToolPresentation> = {
   spawn_sandbox_agent: {
     label: "Delegate a task",
     active: "Delegating a task",
-    complete: "Delegated task complete",
-    settled: "Delegated a task",
+    complete: "Task delegated",
+    settled: "Task delegated",
+  },
+  wait_for_agents: {
+    label: "Wait for background agents",
+    active: "Waiting for background agents",
+    complete: "Background agents finished",
+    settled: "Background agents finished",
   },
 };
 

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
@@ -42,6 +42,29 @@ describe("hydrateTranscriptHistory", () => {
     ]);
   });
 
+  it("hydrates background delegation and wait activity with fixed tool kinds", () => {
+    const entries = hydrateTranscriptHistory([], [
+      {
+        title: "Delegate a task",
+        status: "completed",
+        started_at: "2026-07-16T10:00:00Z",
+        finished_at: "2026-07-16T10:00:00Z",
+      },
+      {
+        title: "Wait for background agents",
+        status: "completed",
+        started_at: "2026-07-16T10:00:01Z",
+        finished_at: "2026-07-16T10:00:02Z",
+      },
+    ]);
+
+    expect(entries).toEqual([
+      expect.objectContaining({ name: "spawn_sandbox_agent" }),
+      expect.objectContaining({ name: "wait_for_agents" }),
+    ]);
+    expect(JSON.stringify(entries)).not.toContain("finished_at");
+  });
+
   it("attaches sources only to their exact owning assistant message", () => {
     const entries = hydrateTranscriptHistory(
       [

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -31,6 +31,7 @@ const HISTORY_TOOL_NAMES: Record<ChatToolActivity["title"], string> = {
   "Connect a folder": "connect_folder",
   "Check connected folders": "list_connected_folders",
   "Delegate a task": "spawn_sandbox_agent",
+  "Wait for background agents": "wait_for_agents",
   "Use a tool": "historical_unknown_tool",
 };
 

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -122,6 +122,25 @@ describe("pending approval recovery", () => {
     expect(parsePendingToolApproval({ ...safe, action: "private_plugin" })).toBeNull();
   });
 
+  it("recognizes the fixed background wait name without accepting extensions", () => {
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "wait_for_agents",
+        approval: "unsupported",
+        can_approve: false,
+      }),
+    ).toMatchObject({ action: "wait_for_agents", canApprove: false });
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "wait_for_agents_with_private_results",
+        approval: "unsupported",
+        can_approve: false,
+      }),
+    ).toBeNull();
+  });
+
   it("fails closed on malformed, duplicate, or cross-turn pages", async () => {
     const client = new ApiClient("http://127.0.0.1", "token");
     for (const body of [

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -78,6 +78,7 @@ export type ChatToolActivity = {
     | "Connect a folder"
     | "Check connected folders"
     | "Delegate a task"
+    | "Wait for background agents"
     | "Use a tool";
   status: "completed" | "failed" | "cancelled";
   started_at: string;
@@ -178,6 +179,7 @@ export type RendererToolName =
   | "list_folder"
   | "read_connected_file"
   | "spawn_sandbox_agent"
+  | "wait_for_agents"
   | "other";
 
 export type RendererApprovalKind =
@@ -603,6 +605,7 @@ function isRendererToolName(value: unknown): value is RendererToolName {
     value === "list_folder" ||
     value === "read_connected_file" ||
     value === "spawn_sandbox_agent" ||
+    value === "wait_for_agents" ||
     value === "other"
   );
 }

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -81,6 +81,7 @@ pub(crate) enum RendererToolName {
     ListFolder,
     ReadConnectedFile,
     SpawnSandboxAgent,
+    WaitForAgents,
     Other,
 }
 
@@ -105,6 +106,7 @@ impl From<&str> for RendererToolName {
             "list_folder" => Self::ListFolder,
             "read_connected_file" => Self::ReadConnectedFile,
             "spawn_sandbox_agent" => Self::SpawnSandboxAgent,
+            "wait_for_agents" => Self::WaitForAgents,
             _ => Self::Other,
         }
     }
@@ -314,5 +316,23 @@ mod tests {
         assert!(json.contains("search_may_share_query_and_excerpts"));
         assert!(!json.contains("private query"));
         assert!(!json.contains("document title"));
+    }
+
+    #[test]
+    fn background_agent_tools_use_fixed_renderer_names() {
+        for (name, expected) in [
+            ("spawn_sandbox_agent", r#""name":"spawn_sandbox_agent""#),
+            ("wait_for_agents", r#""name":"wait_for_agents""#),
+        ] {
+            let projected = RendererSequencedEvent::from(&SequencedEvent {
+                seq: 1,
+                event: AgentEvent::ToolCallStarted {
+                    call_id: CallId::new(),
+                    name: name.into(),
+                },
+            });
+            let json = serde_json::to_string(&projected).unwrap();
+            assert!(json.contains(expected));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- recognize `wait_for_agents` across the renderer-safe live and history projections
- distinguish delegated work from completed background work in tool cards
- keep active waits visible instead of showing the generic assistant status

## Validation

- desktop UI test suite (129 tests)
- desktop production build
- focused server projection test
- Rust formatting and lint
