### PR TITLE
Bound unsettled sandbox admissions

### DIFF
--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, DatabaseBackend, EntityTrait, PaginatorTrait,
-    QueryFilter, QueryOrder, QuerySelect, QueryTrait, Set, Statement, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, Condition, DatabaseBackend, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
 };
 
 use crate::error::{AgentError, Result};
@@ -278,6 +278,10 @@ pub(in crate::db) async fn admit_sandbox_agent_run(
         return Ok(None);
     };
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    // Admission and terminal child delivery share the scheduler lock before
+    // chat and turn ownership. This gives the unsettled-child classifier one
+    // stable snapshot and preserves the global scheduler -> chat -> turn order.
+    acquire_agent_run_claim_lock(&transaction).await?;
     if !acquire_chat_write_lock(&transaction, ChatId(scope.chat_id)).await?
         || !acquire_turn_write_lock(&transaction, origin_turn_id).await?
     {
@@ -415,28 +419,14 @@ where
         return Ok(AdmitSandboxAgentRunOutcome::ParentUnavailable);
     }
 
-    let outstanding = entities::agent_run::Entity::find()
-        .filter(
-            entities::agent_run::Column::Id.in_subquery(
-                entities::sandbox_agent_admission::Entity::find()
-                    .select_only()
-                    .column(entities::sandbox_agent_admission::Column::ChildRunId)
-                    .filter(
-                        entities::sandbox_agent_admission::Column::OriginTurnId
-                            .eq(origin_turn_id.0),
-                    )
-                    .into_query(),
-            ),
-        )
-        .filter(entities::agent_run::Column::Status.is_not_in([
-            AgentRunStatus::Completed.as_str(),
-            AgentRunStatus::Failed.as_str(),
-            AgentRunStatus::Cancelled.as_str(),
-        ]))
-        .count(conn)
-        .await
-        .map_err(store_err)?;
-    if outstanding >= u64::from(max_outstanding_children) {
+    // A terminal child remains outstanding until its immutable delivery has
+    // been consumed or explicitly retired. Counting only live run rows would
+    // let fast children fall out of this bound before the foreground model can
+    // wait on them, eventually producing more IDs than one ordered wait can
+    // consume. The shared classifier also validates admission and terminal
+    // receipt provenance before capacity can be released.
+    let outstanding = unsettled_sandbox_children_for_origin_turn_on(conn, turn).await?;
+    if outstanding.len() >= max_outstanding_children as usize {
         return Ok(AdmitSandboxAgentRunOutcome::AtCapacity);
     }
 
@@ -561,6 +551,9 @@ pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
     };
 
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    // Legacy atomic spawn uses the same scheduler -> chat -> turn order as the
+    // nonblocking checkpoint so the shared unsettled classifier is stable.
+    acquire_agent_run_claim_lock(&transaction).await?;
     if !acquire_chat_write_lock(&transaction, ChatId(scope.chat_id)).await?
         || !acquire_turn_write_lock(&transaction, turn_id).await?
     {

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -19,7 +19,10 @@ use crate::{AgentRunId, ChatId, ToolOutput};
 use super::super::super::{entities, store_err, DbStore};
 use super::super::{
     acquire_chat_write_lock,
-    agent_run::{admit_sandbox_agent_run_on, agent_run_from_model, database_now},
+    agent_run::{
+        acquire_agent_run_claim_lock, admit_sandbox_agent_run_on, agent_run_from_model,
+        database_now,
+    },
     client_execution::tool_call_from_model,
     conversation::append_event_on,
     next_tool_history_order_on,
@@ -53,6 +56,10 @@ pub(in crate::db) async fn checkpoint_sandbox_spawn(
         return Ok(None);
     };
     let transaction = store.conn.begin().await.map_err(store_err)?;
+    // Match every child terminal/delivery path: scheduler first, then chat and
+    // turn. The exact checkpoint recovery above intentionally remains before
+    // these mutable locks.
+    acquire_agent_run_claim_lock(&transaction).await?;
     if !acquire_chat_write_lock(&transaction, ChatId(scope.chat_id)).await?
         || !super::super::acquire_turn_write_lock(&transaction, request.origin_turn_id).await?
     {

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -465,7 +465,7 @@ async fn sandbox_spawn_checkpoint_never_retrofits_a_separately_accepted_child() 
 }
 
 #[tokio::test]
-async fn sandbox_admission_is_exact_bounded_and_releases_terminal_capacity() {
+async fn sandbox_admission_is_exact_bounded_and_releases_consumed_terminal_capacity() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
@@ -531,24 +531,37 @@ async fn sandbox_admission_is_exact_bounded_and_releases_terminal_capacity() {
         Some(crate::AdmitSandboxAgentRunOutcome::AtCapacity)
     ));
 
-    let finished_at = Utc::now();
-    crate::db::entities::agent_run::Entity::update_many()
-        .col_expr(
-            crate::db::entities::agent_run::Column::Status,
-            sea_orm::sea_query::Expr::value(AgentRunStatus::Cancelled.as_str()),
-        )
-        .col_expr(
-            crate::db::entities::agent_run::Column::FinishedAt,
-            sea_orm::sea_query::Expr::value(Some(finished_at)),
-        )
-        .col_expr(
-            crate::db::entities::agent_run::Column::UpdatedAt,
-            sea_orm::sea_query::Expr::value(finished_at),
-        )
-        .filter(crate::db::entities::agent_run::Column::Id.eq(first_child.id.0))
-        .exec(&store.conn)
+    let child_lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(child_lease, Duration::minutes(1), 1, 1)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        first_child.id
+    );
+    store
+        .submit_agent_run_result(first_child.id, child_lease, "first child finished")
         .await
+        .unwrap()
         .unwrap();
+    assert!(matches!(
+        store
+            .admit_sandbox_agent_run(
+                turn.id,
+                first_call,
+                "first bounded child",
+                lease,
+                turn.steer_revision,
+                1,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
+        Some(crate::AdmitSandboxAgentRunOutcome::Existing { child, .. })
+            if child.id == first_child.id
+    ));
     assert!(store
         .get_sandbox_agent_admission(first_child.id)
         .await
@@ -567,9 +580,116 @@ async fn sandbox_admission_is_exact_bounded_and_releases_terminal_capacity() {
             )
             .await
             .unwrap(),
+        Some(crate::AdmitSandboxAgentRunOutcome::AtCapacity)
+    ));
+
+    let parked = park_foreground_turn_on_child(&store, chat.id, first_child.id).await;
+    assert_eq!(parked.id, turn.id);
+    let continuation = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run_inbox_entry(
+            turn.agent_run_id,
+            first_child.id,
+            continuation,
+            Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .consume_agent_run_inbox_entry_and_resume_turn(
+            turn.agent_run_id,
+            first_child.id,
+            continuation,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let resumed_lease = uuid::Uuid::new_v4();
+    let resumed = store
+        .claim_turn_run(resumed_lease, Utc::now(), Utc::now() + Duration::minutes(5))
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(resumed.id, turn.id);
+    assert!(matches!(
+        store
+            .admit_sandbox_agent_run(
+                resumed.id,
+                second_call,
+                "second bounded child",
+                resumed_lease,
+                resumed.steer_revision,
+                1,
+                Utc::now(),
+            )
+            .await
+            .unwrap(),
         Some(crate::AdmitSandboxAgentRunOutcome::Accepted { child, .. })
             if child.id == AgentRunId::sandbox_for_spawn_call(second_call)
     ));
+}
+
+#[tokio::test]
+async fn sandbox_admission_fails_closed_on_a_terminal_child_without_delivery() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = live_turn_for_sandbox_test(&store, chat.id).await;
+    let first_call = CallId::new();
+    let first_child = match store
+        .admit_sandbox_agent_run(
+            turn.id,
+            first_call,
+            "first bounded child",
+            lease,
+            turn.steer_revision,
+            1,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        crate::AdmitSandboxAgentRunOutcome::Accepted { child, .. } => child,
+        outcome => panic!("unexpected admission outcome: {outcome:?}"),
+    };
+    let child_lease = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(child_lease, Duration::minutes(1), 1, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    store
+        .submit_agent_run_result(first_child.id, child_lease, "first child finished")
+        .await
+        .unwrap()
+        .unwrap();
+    crate::db::entities::agent_run_inbox::Entity::delete_by_id(first_child.id.0)
+        .exec(&store.conn)
+        .await
+        .unwrap();
+
+    let second_call = CallId::new();
+    let error = store
+        .admit_sandbox_agent_run(
+            turn.id,
+            second_call,
+            "second bounded child",
+            lease,
+            turn.steer_revision,
+            1,
+            Utc::now(),
+        )
+        .await
+        .expect_err("missing terminal delivery must fail closed");
+    assert!(matches!(error, crate::AgentError::Store(_)));
+    assert!(store
+        .get_agent_run(AgentRunId::sandbox_for_spawn_call(second_call))
+        .await
+        .unwrap()
+        .is_none());
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1180,9 +1180,12 @@ impl AgentRun {
     pub const DEFAULT_MAX_DURATION: chrono::Duration = chrono::Duration::hours(1);
     /// Largest accepted scheduler concurrency bound.
     pub const MAX_CONCURRENCY_LIMIT: u32 = 1_024;
-    /// Default maximum children from one foreground turn that may remain
-    /// nonterminal at once. Admission enforces this independently from worker
-    /// concurrency so queued work is bounded before it reaches the scheduler.
+    /// Default maximum unsettled children from one foreground turn.
+    ///
+    /// A child remains unsettled while it is running or while its terminal
+    /// delivery is still pending or claimed. Admission enforces this
+    /// independently from worker concurrency so both queued work and unread
+    /// results stay bounded.
     pub const DEFAULT_MAX_OUTSTANDING_CHILDREN: u32 = 4;
     /// Maximum stable failure-category length.
     pub const MAX_ERROR_CODE_LEN: usize = 128;
@@ -1864,8 +1867,9 @@ pub struct AgentRunWaitSetCandidate {
 }
 
 impl TurnAgentRunWaitSet {
-    /// The admission layer already caps outstanding children at four. Keeping
-    /// the wait bound equal prevents an oversized continuation checkpoint.
+    /// The admission layer caps unsettled children at four, including terminal
+    /// deliveries that have not been consumed or retired. Keeping the wait
+    /// bound equal prevents an oversized continuation checkpoint.
     pub const MAX_CHILDREN: usize = AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN as usize;
 }
 


### PR DESCRIPTION
## Summary

- count sandbox children as unsettled until their terminal delivery is consumed or retired
- serialize admission with terminal delivery under the scheduler-first lock order
- fail closed when terminal result or inbox provenance is incomplete

## Validation

- `cargo test -p openwave-core --lib` (356 tests)
- `cargo check --workspace --all-targets --locked`
- `cargo fmt --all --check`
- `bw dev lint --rust --check`
