### PR TITLE
Activate background agent orchestration

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -27,7 +27,10 @@ use futures::StreamExt;
 use futures_timer::Delay;
 use serde_json::Value;
 
-use crate::agent_tools::{validate_spawn_sandbox_agent_arguments, SpawnSandboxAgentArgs};
+use crate::agent_tools::{
+    validate_spawn_sandbox_agent_arguments, validate_wait_for_agents_arguments,
+    SpawnSandboxAgentArgs, WaitForAgentsArgs,
+};
 use crate::approval::{
     ApprovalDecision, ApprovalGate, ApprovalJournalIdentity, ApprovalRequest,
     ApprovalRequiredPublication, RefuseGate, ToolApprovalKind,
@@ -67,9 +70,16 @@ enum RegisteredTool {
         spec: ToolSpec,
         validate_arguments: Option<fn(&Value) -> bool>,
     },
-    ForegroundSandboxSpawn {
+    ForegroundOrchestration {
         spec: ToolSpec,
+        kind: ForegroundOrchestrationKind,
     },
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ForegroundOrchestrationKind {
+    Spawn,
+    Wait,
 }
 
 impl ToolRegistry {
@@ -111,19 +121,27 @@ impl ToolRegistry {
         );
     }
 
-    /// Register the prepared foreground-only sandbox delegation contract.
+    /// Register the closed foreground-only spawn and ordered-wait contracts.
     ///
-    /// This integration seam is intentionally not enabled by the production
-    /// registry until a sandbox executor can claim and complete the child. A
-    /// claimed foreground worker must opt in before it is advertised, then
-    /// atomically parks its exact turn with durable child admission. Sandboxed
-    /// workers never opt in.
-    pub fn register_foreground_sandbox_spawn(&mut self) {
-        let spec = crate::spawn_sandbox_agent_tool_spec();
-        self.tools.insert(
-            spec.name.clone(),
-            RegisteredTool::ForegroundSandboxSpawn { spec },
-        );
+    /// A claimed foreground worker must still opt in before either definition
+    /// is advertised. Sandboxed workers never opt in, keeping delegation depth
+    /// bounded at one.
+    pub fn register_foreground_agent_orchestration(&mut self) {
+        for (spec, kind) in [
+            (
+                crate::spawn_sandbox_agent_tool_spec(),
+                ForegroundOrchestrationKind::Spawn,
+            ),
+            (
+                crate::wait_for_agents_tool_spec(),
+                ForegroundOrchestrationKind::Wait,
+            ),
+        ] {
+            self.tools.insert(
+                spec.name.clone(),
+                RegisteredTool::ForegroundOrchestration { spec, kind },
+            );
+        }
     }
 
     /// Builder-style [`register`](Self::register).
@@ -139,7 +157,7 @@ impl ToolRegistry {
         match self.tools.get(name) {
             Some(RegisteredTool::Server(tool)) => Some(tool.as_ref()),
             Some(RegisteredTool::Client { .. })
-            | Some(RegisteredTool::ForegroundSandboxSpawn { .. })
+            | Some(RegisteredTool::ForegroundOrchestration { .. })
             | None => None,
         }
     }
@@ -150,7 +168,7 @@ impl ToolRegistry {
         Some(match self.tools.get(name)? {
             RegisteredTool::Server(_) => ToolCallExecution::Server,
             RegisteredTool::Client { .. } => ToolCallExecution::Client,
-            RegisteredTool::ForegroundSandboxSpawn { .. } => return None,
+            RegisteredTool::ForegroundOrchestration { .. } => return None,
         })
     }
 
@@ -165,16 +183,18 @@ impl ToolRegistry {
     /// The foreground coordinator may opt into the sandbox control tool. All
     /// other contexts receive the ordinary server/client tool set only.
     #[must_use]
-    pub fn specs_for_foreground(&self, allow_sandbox_spawn: bool) -> Vec<ToolSpec> {
+    pub fn specs_for_foreground(&self, allow_agent_orchestration: bool) -> Vec<ToolSpec> {
         self.tools
             .values()
             .filter_map(|tool| match tool {
                 RegisteredTool::Server(tool) => Some(tool.spec()),
                 RegisteredTool::Client { spec, .. } => Some(spec.clone()),
-                RegisteredTool::ForegroundSandboxSpawn { spec } if allow_sandbox_spawn => {
+                RegisteredTool::ForegroundOrchestration { spec, .. }
+                    if allow_agent_orchestration =>
+                {
                     Some(spec.clone())
                 }
-                RegisteredTool::ForegroundSandboxSpawn { .. } => None,
+                RegisteredTool::ForegroundOrchestration { .. } => None,
             })
             .collect()
     }
@@ -192,7 +212,7 @@ impl ToolRegistry {
                 ..
             }) => true,
             Some(RegisteredTool::Server(_))
-            | Some(RegisteredTool::ForegroundSandboxSpawn { .. })
+            | Some(RegisteredTool::ForegroundOrchestration { .. })
             | None => false,
         }
     }
@@ -202,7 +222,10 @@ impl ToolRegistry {
     pub fn is_foreground_sandbox_spawn(&self, name: &str) -> bool {
         matches!(
             self.tools.get(name),
-            Some(RegisteredTool::ForegroundSandboxSpawn { .. })
+            Some(RegisteredTool::ForegroundOrchestration {
+                kind: ForegroundOrchestrationKind::Spawn,
+                ..
+            })
         )
     }
 
@@ -217,6 +240,29 @@ impl ToolRegistry {
         serde_json::from_value::<SpawnSandboxAgentArgs>(arguments.clone())
             .ok()
             .map(|arguments| arguments.task)
+    }
+
+    /// Whether `name` identifies the foreground-only ordered wait tool.
+    #[must_use]
+    pub fn is_foreground_agent_wait(&self, name: &str) -> bool {
+        matches!(
+            self.tools.get(name),
+            Some(RegisteredTool::ForegroundOrchestration {
+                kind: ForegroundOrchestrationKind::Wait,
+                ..
+            })
+        )
+    }
+
+    /// Parse and validate one ordered foreground child wait.
+    #[must_use]
+    pub fn wait_for_agent_ids(&self, name: &str, arguments: &Value) -> Option<Vec<AgentRunId>> {
+        if !self.is_foreground_agent_wait(name) || !validate_wait_for_agents_arguments(arguments) {
+            return None;
+        }
+        serde_json::from_value::<WaitForAgentsArgs>(arguments.clone())
+            .ok()
+            .map(|arguments| arguments.agent_ids)
     }
 
     /// Whether no tools are registered.
@@ -317,11 +363,22 @@ pub enum AgentTurnOutcome {
     /// The foreground model requested one durable sandbox child.
     ///
     /// The foreground worker validates this exact request and invokes
-    /// [`Store::accept_sandbox_agent_run_and_park_turn`] with its live lease,
-    /// steering epoch, and accumulated checkpoint totals.
+    /// [`Store::checkpoint_sandbox_spawn`] with its live lease, steering epoch,
+    /// and accumulated checkpoint totals before yielding into `resuming`.
     SandboxAgentSpawn {
         /// Canonical child identity and bounded task derived from the tool call.
         request: SandboxAgentSpawnRequest,
+        /// Provider usage incurred in this agent invocation.
+        usage: Usage,
+        /// Durable steering epoch captured before the producing model call.
+        steer_revision: i64,
+        /// Model-call steps consumed in this agent invocation.
+        model_steps: usize,
+    },
+    /// The foreground model requested an ordered wait for sandbox children.
+    WaitForAgents {
+        /// Canonical wait identity and ordered child set.
+        request: ForegroundAgentWaitRequest,
         /// Provider usage incurred in this agent invocation.
         usage: Usage,
         /// Durable steering epoch captured before the producing model call.
@@ -345,10 +402,14 @@ pub enum AgentTurnOutcome {
 pub struct SandboxAgentSpawnRequest {
     /// Stable call identity emitted by the model stream.
     pub call_id: CallId,
+    /// Provider-facing tool-use identity retained for transcript reconstruction.
+    pub provider_id: String,
     /// Deterministic sandbox child identity derived from [`Self::call_id`].
     pub child_run_id: AgentRunId,
     /// Bounded, self-contained child input.
     pub task: String,
+    /// Canonical closed arguments emitted by the provider.
+    pub arguments: Value,
 }
 
 impl SandboxAgentSpawnRequest {
@@ -357,9 +418,39 @@ impl SandboxAgentSpawnRequest {
     pub fn is_well_formed(&self) -> bool {
         self.call_id.0 != uuid::Uuid::nil()
             && self.child_run_id == AgentRunId::sandbox_for_spawn_call(self.call_id)
-            && validate_spawn_sandbox_agent_arguments(&serde_json::json!({
-                "task": self.task,
-            }))
+            && !self.provider_id.is_empty()
+            && !self.provider_id.contains('\0')
+            && self.provider_id.len() <= ToolCallRecord::MAX_LABEL_LEN
+            && validate_spawn_sandbox_agent_arguments(&self.arguments)
+            && serde_json::from_value::<SpawnSandboxAgentArgs>(self.arguments.clone())
+                .is_ok_and(|arguments| arguments.task == self.task)
+    }
+}
+
+/// One model proposal to wait for an ordered set of admitted sandbox children.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForegroundAgentWaitRequest {
+    /// Stable model tool-call identity.
+    pub call_id: CallId,
+    /// Provider-facing tool-use identity retained for transcript reconstruction.
+    pub provider_id: String,
+    /// Ordered child identities requested by the model.
+    pub child_run_ids: Vec<AgentRunId>,
+    /// Canonical closed arguments emitted by the provider.
+    pub arguments: Value,
+}
+
+impl ForegroundAgentWaitRequest {
+    /// Whether immutable provider output agrees with the closed wait contract.
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        self.call_id.0 != uuid::Uuid::nil()
+            && !self.provider_id.is_empty()
+            && !self.provider_id.contains('\0')
+            && self.provider_id.len() <= ToolCallRecord::MAX_LABEL_LEN
+            && validate_wait_for_agents_arguments(&self.arguments)
+            && serde_json::from_value::<WaitForAgentsArgs>(self.arguments.clone())
+                .is_ok_and(|arguments| arguments.agent_ids == self.child_run_ids)
     }
 }
 
@@ -631,7 +722,8 @@ pub struct Agent {
     cancel: CancelToken,
     steer: SteerInbox,
     durable_steer_lease: Option<uuid::Uuid>,
-    sandbox_spawns_enabled: bool,
+    agent_orchestration_enabled: bool,
+    continuation_instruction: Option<String>,
 }
 
 /// A tool call accumulated from the provider stream.
@@ -667,7 +759,8 @@ impl Agent {
             cancel: CancelToken::new(),
             steer: SteerInbox::new(),
             durable_steer_lease: None,
-            sandbox_spawns_enabled: false,
+            agent_orchestration_enabled: false,
+            continuation_instruction: None,
         }
     }
 
@@ -701,18 +794,25 @@ impl Agent {
         self
     }
 
-    /// Advertise and accept the foreground-only sandbox delegation tool.
+    /// Advertise and accept foreground-only spawn and ordered-wait tools.
     ///
     /// This is intentionally opt-in: sandbox workers must not set it, keeping
     /// the v1 hierarchy at a single child depth.
     #[must_use]
-    pub fn with_foreground_sandbox_spawns(mut self) -> Self {
-        self.sandbox_spawns_enabled = true;
+    pub fn with_foreground_agent_orchestration(mut self) -> Self {
+        self.agent_orchestration_enabled = true;
         self
     }
 
-    fn sandbox_spawns_active(&self) -> bool {
-        self.sandbox_spawns_enabled && self.durable_steer_lease.is_some()
+    /// Add a fixed runtime correction before the next provider invocation.
+    #[must_use]
+    pub fn with_continuation_instruction(mut self, instruction: Option<String>) -> Self {
+        self.continuation_instruction = instruction;
+        self
+    }
+
+    fn agent_orchestration_active(&self) -> bool {
+        self.agent_orchestration_enabled && self.durable_steer_lease.is_some()
     }
 
     /// Run one turn: submit `user_input`, drive the loop to a final answer,
@@ -854,6 +954,9 @@ impl Agent {
         // The provider transcript for this turn: prior stored text + the blocks
         // we build up as the loop runs.
         let mut transcript = self.load_transcript(chat.id).await?;
+        if let Some(instruction) = self.continuation_instruction.as_ref() {
+            transcript.push(ChatMessage::text(Role::System, instruction.clone()));
+        }
         let mut total_usage = Usage::default();
         self.resume_pending_server_calls(chat, turn_id, events, &mut transcript)
             .await?;
@@ -883,7 +986,7 @@ impl Agent {
                     messages: fitted,
                     tools: self
                         .tools
-                        .specs_for_foreground(self.sandbox_spawns_active()),
+                        .specs_for_foreground(self.agent_orchestration_active()),
                     max_tokens: self.config.max_tokens,
                     temperature: self.config.temperature,
                 };
@@ -1071,7 +1174,7 @@ impl Agent {
             let sandbox_spawns = calls
                 .iter()
                 .filter(|call| {
-                    self.sandbox_spawns_active()
+                    self.agent_orchestration_active()
                         && self.tools.is_foreground_sandbox_spawn(&call.name)
                 })
                 .collect::<Vec<_>>();
@@ -1120,8 +1223,65 @@ impl Agent {
                 return Ok(AgentTurnOutcome::SandboxAgentSpawn {
                     request: SandboxAgentSpawnRequest {
                         call_id: call.call_id,
+                        provider_id: call.provider_id.clone(),
                         child_run_id: AgentRunId::sandbox_for_spawn_call(call.call_id),
                         task,
+                        arguments,
+                    },
+                    usage: total_usage,
+                    steer_revision,
+                    model_steps: step + 1,
+                });
+            }
+
+            let agent_waits = calls
+                .iter()
+                .filter(|call| {
+                    self.agent_orchestration_active()
+                        && self.tools.is_foreground_agent_wait(&call.name)
+                })
+                .collect::<Vec<_>>();
+            if !agent_waits.is_empty() {
+                if calls.len() != 1 || agent_waits.len() != 1 || !text.is_empty() {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage::text(
+                        Role::User,
+                        "wait_for_agents must be requested alone, without assistant text or sibling tool calls. Retry the request in that form.",
+                    ));
+                    continue;
+                }
+                let call = agent_waits[0];
+                let Some(arguments) = parse_client_args(&call.args) else {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage::text(
+                        Role::User,
+                        "The wait_for_agents arguments were not valid JSON. Retry with one complete ordered agent_ids value.",
+                    ));
+                    continue;
+                };
+                let Some(child_run_ids) = self.tools.wait_for_agent_ids(&call.name, &arguments)
+                else {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage::text(
+                        Role::User,
+                        "wait_for_agents requires one non-empty, bounded, unique agent_ids list with no extra properties.",
+                    ));
+                    continue;
+                };
+                let Some(steer_revision) = generation_steer_revision else {
+                    events.send(AgentEvent::StreamInterrupted);
+                    transcript.push(ChatMessage::text(
+                        Role::User,
+                        "wait_for_agents is available only from a durably claimed foreground turn.",
+                    ));
+                    continue;
+                };
+                return Ok(AgentTurnOutcome::WaitForAgents {
+                    request: ForegroundAgentWaitRequest {
+                        call_id: call.call_id,
+                        provider_id: call.provider_id.clone(),
+                        child_run_ids,
+                        arguments,
                     },
                     usage: total_usage,
                     steer_revision,
@@ -1964,7 +2124,9 @@ impl Agent {
             self.config.context_window,
             reduction_level,
             self.config.system_prompt.as_deref(),
-            &self.tools.specs(),
+            &self
+                .tools
+                .specs_for_foreground(self.agent_orchestration_active()),
         );
         let floor = context::content_floor_for_level(reduction_level);
         context::fit_to_budget(transcript, budget, floor)
@@ -2735,11 +2897,19 @@ mod tests {
             .unwrap();
 
         let mut registry = ToolRegistry::new();
-        registry.register_foreground_sandbox_spawn();
+        registry.register_foreground_agent_orchestration();
         assert!(registry.specs().is_empty());
+        let advertised = registry
+            .specs_for_foreground(true)
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect::<std::collections::HashSet<_>>();
         assert_eq!(
-            registry.specs_for_foreground(true)[0].name,
-            crate::SPAWN_SANDBOX_AGENT_TOOL
+            advertised,
+            [crate::SPAWN_SANDBOX_AGENT_TOOL, crate::WAIT_FOR_AGENTS_TOOL]
+                .into_iter()
+                .map(str::to_owned)
+                .collect()
         );
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
@@ -2755,7 +2925,7 @@ mod tests {
             },
         )
         .with_durable_steer(lease_token)
-        .with_foreground_sandbox_spawns();
+        .with_foreground_agent_orchestration();
         let (tx, rx) = unbounded();
         let outcome = agent
             .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
@@ -2788,6 +2958,92 @@ mod tests {
             AgentEvent::ToolCallStarted { name, .. }
                 if name == crate::SPAWN_SANDBOX_AGENT_TOOL
         )));
+    }
+
+    #[tokio::test]
+    async fn claimed_foreground_agent_returns_exact_ordered_wait_checkpoint() {
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("wait.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "fake", "wait for both")
+            .await
+            .unwrap();
+        let lease_token = uuid::Uuid::new_v4();
+        let claimed_at = Utc::now();
+        store
+            .claim_turn_run(
+                lease_token,
+                claimed_at,
+                claimed_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.register_foreground_agent_orchestration();
+        let arguments = r#"{"agent_ids":["00000000-0000-0000-0000-000000000002","00000000-0000-0000-0000-000000000001"]}"#;
+        let agent = Agent::new(
+            Arc::new(ClientToolProvider {
+                assistant_text: false,
+                name: crate::WAIT_FOR_AGENTS_TOOL,
+                arguments,
+            }),
+            Arc::new(registry),
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        )
+        .with_durable_steer(lease_token)
+        .with_foreground_agent_orchestration();
+        let (tx, _rx) = unbounded();
+        let outcome = agent
+            .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
+            .await
+            .unwrap();
+        let AgentTurnOutcome::WaitForAgents {
+            request,
+            steer_revision,
+            model_steps,
+            ..
+        } = outcome
+        else {
+            panic!("foreground agent should return an ordered wait checkpoint");
+        };
+        assert_eq!(request.provider_id, "native_1");
+        assert_eq!(
+            request.arguments,
+            serde_json::from_str::<Value>(arguments).unwrap()
+        );
+        assert_eq!(
+            request.child_run_ids,
+            [
+                "00000000-0000-0000-0000-000000000002",
+                "00000000-0000-0000-0000-000000000001",
+            ]
+            .map(|id| AgentRunId(uuid::Uuid::parse_str(id).unwrap()))
+        );
+        assert!(request.is_well_formed());
+        assert_eq!(steer_revision, 0);
+        assert_eq!(model_steps, 1);
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -3,8 +3,7 @@
 //! These are prepared control-flow proposals, not generic server-executed
 //! tools. The foreground turn worker owns the corresponding durable transition
 //! so the model can never bypass its lease, steer, or accounting fences. The
-//! production registry deliberately keeps this definition disabled until a
-//! sandbox executor can claim and complete the child.
+//! production registry exposes them only to durably claimed foreground turns.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -57,7 +56,7 @@ pub struct SpawnSandboxAgentArgs {
 ///
 /// This deliberately excludes scheduler state and lease identities. The
 /// foreground model needs only the stable child identity it may later pass to
-/// [`WAIT_FOR_AGENTS_TOOL`]. The current runtime does not emit this result yet.
+/// [`WAIT_FOR_AGENTS_TOOL`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct SpawnSandboxAgentResult {
     /// Stable identity of the admitted depth-one child.
@@ -220,13 +219,14 @@ pub fn validate_wait_for_agents_arguments(arguments: &Value) -> bool {
 /// Foreground-only model tool contract for delegating one bounded task.
 ///
 /// The worker derives the durable child identity from the model tool call and
-/// atomically parks the foreground turn. Sandboxed agents never receive this
-/// definition, so the v1 hierarchy cannot recurse past depth one.
+/// atomically checkpoints the result before continuing the foreground turn.
+/// Sandboxed agents never receive this definition, so the v1 hierarchy cannot
+/// recurse past depth one.
 #[must_use]
 pub fn spawn_sandbox_agent_tool_spec() -> ToolSpec {
     ToolSpec {
         name: SPAWN_SANDBOX_AGENT_TOOL.into(),
-        description: "Delegate one self-contained task to an isolated background agent. The conversation will pause until that agent returns. Use this only when independent work is useful; do not ask it to spawn more agents.".into(),
+        description: "Delegate one self-contained task to an isolated background agent and continue immediately. Save every returned agent_id. Before final completion, include every spawned agent_id in a wait_for_agents call; batch independent IDs into one wait, and do not ask it to spawn more agents.".into(),
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
@@ -245,9 +245,8 @@ pub fn spawn_sandbox_agent_tool_spec() -> ToolSpec {
 
 /// Prepared foreground-only contract for waiting on depth-one children.
 ///
-/// This definition is intentionally not registered yet. Advertising it is
-/// safe only after non-blocking spawn and durable multi-child resume are wired
-/// together in the foreground runtime.
+/// It is advertised only with the matching non-blocking spawn contract from a
+/// durably claimed foreground turn.
 #[must_use]
 pub fn wait_for_agents_tool_spec() -> ToolSpec {
     ToolSpec {

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -39,7 +39,8 @@ pub mod tool;
 pub mod tools;
 
 pub use agent::{
-    Agent, AgentConfig, AgentTurnOutcome, ClaimedAgentEvent, SandboxAgentSpawnRequest, ToolRegistry,
+    Agent, AgentConfig, AgentTurnOutcome, ClaimedAgentEvent, ForegroundAgentWaitRequest,
+    SandboxAgentSpawnRequest, ToolRegistry,
 };
 pub use agent_tools::{
     sandbox_web_search_tool_spec, spawn_sandbox_agent_tool_spec,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1337,8 +1337,8 @@ pub trait Store: Send + Sync {
     /// parent, child, and immutable admission receipt commit together under the
     /// chat/turn write lock. Existing exact receipts are recovered before the
     /// bounded outstanding-child check, making an ambiguous commit retry safe.
-    /// This is a persistence primitive only; the foreground agent does not yet
-    /// expose non-blocking fan-out behavior.
+    /// The stronger checkpoint boundary below composes this admission with the
+    /// foreground transcript, progress, event, and immediate continuation.
     #[allow(clippy::too_many_arguments)]
     async fn admit_sandbox_agent_run(
         &self,
@@ -1360,7 +1360,8 @@ pub trait Store: Send + Sync {
     /// A successful transition writes one terminal, non-executable
     /// orchestration tool call and its `ToolCallCompleted` event, applies one
     /// progress delta, then moves `running` to `resuming` with no live lease.
-    /// This storage primitive is deliberately not advertised to models yet.
+    /// Foreground orchestration advertises this together with the explicit
+    /// ordered wait boundary; sandbox agents receive neither contract.
     async fn checkpoint_sandbox_spawn(
         &self,
         _request: &crate::model::SandboxSpawnCheckpointRequest,

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -530,10 +530,10 @@ fn agent_deps(
         read_connected_file_tool_spec(),
         validate_read_connected_file_arguments,
     );
-    // The foreground worker parks atomically with child acceptance, and the
-    // bounded sandbox worker is started from the same state below. Sandboxed
-    // requests deliberately never receive this foreground-only definition.
-    tools.register_foreground_sandbox_spawn();
+    // Foreground spawn checkpoints child acceptance and immediately resumes;
+    // an explicit ordered wait parks only when results are needed. The bounded
+    // sandbox worker below never receives either orchestration definition.
+    tools.register_foreground_agent_orchestration();
     let tools = Arc::new(tools);
     let model = std::env::var("OPENWAVE_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string());
     let agent_config = AgentConfig {

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -357,13 +357,13 @@ impl ModelProvider for FakeProvider {
     }
 }
 
-/// Drives the complete foreground-child-foreground round trip. The sandbox
-/// request is identified by its absence of the foreground delegation contract;
-/// its fixed web-search capability is deliberately separate.
+/// Drives non-blocking spawn, premature completion correction, ordered wait,
+/// and final foreground completion. The sandbox surface remains independent.
 #[derive(Default)]
 struct SandboxRoundTripProvider {
     foreground_calls: AtomicUsize,
     requests: std::sync::Mutex<Vec<ChatRequest>>,
+    second_child_started: tokio::sync::Notify,
 }
 
 #[async_trait]
@@ -373,44 +373,127 @@ impl ModelProvider for SandboxRoundTripProvider {
     }
 
     async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
-        let sandbox = !request
-            .tools
-            .iter()
-            .any(|tool| tool.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL);
+        let sandbox = !request.tools.iter().any(|tool| {
+            matches!(
+                tool.name.as_str(),
+                openwave_core::SPAWN_SANDBOX_AGENT_TOOL | openwave_core::WAIT_FOR_AGENTS_TOOL
+            )
+        });
+        let delegated_task = sandbox.then(|| {
+            request
+                .messages
+                .first()
+                .and_then(|message| message.content.first())
+                .and_then(|block| match block {
+                    ContentBlock::Text { text } => Some(text.clone()),
+                    _ => None,
+                })
+                .unwrap_or_default()
+        });
         self.requests.lock().unwrap().push(request);
         let events = if sandbox {
+            let first = delegated_task
+                .as_deref()
+                .is_some_and(|task| task.contains("first child"));
+            if first {
+                self.second_child_started.notified().await;
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            } else {
+                self.second_child_started.notify_one();
+            }
             vec![
                 ProviderEvent::TextDelta {
-                    text: "child result".into(),
+                    text: if first {
+                        "first child result".into()
+                    } else {
+                        "second child result".into()
+                    },
                 },
                 ProviderEvent::Stop {
                     reason: StopReason::EndTurn,
-                },
-            ]
-        } else if self.foreground_calls.fetch_add(1, Ordering::SeqCst) == 0 {
-            vec![
-                ProviderEvent::ToolCallStarted {
-                    index: 0,
-                    id: "delegate-1".into(),
-                    name: openwave_core::SPAWN_SANDBOX_AGENT_TOOL.into(),
-                },
-                ProviderEvent::ToolCallArgsDelta {
-                    index: 0,
-                    fragment: r#"{"task":"Return a concise child result."}"#.into(),
-                },
-                ProviderEvent::Stop {
-                    reason: StopReason::ToolUse,
                 },
             ]
         } else {
-            vec![
-                ProviderEvent::TextDelta {
-                    text: "parent resumed".into(),
-                },
-                ProviderEvent::Stop {
-                    reason: StopReason::EndTurn,
-                },
-            ]
+            let foreground_call = self.foreground_calls.fetch_add(1, Ordering::SeqCst);
+            match foreground_call {
+                0 => vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "delegate-1".into(),
+                        name: openwave_core::SPAWN_SANDBOX_AGENT_TOOL.into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: r#"{"task":"Return the first child result."}"#.into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ],
+                1 => vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "delegate-2".into(),
+                        name: openwave_core::SPAWN_SANDBOX_AGENT_TOOL.into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: r#"{"task":"Return the second child result."}"#.into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ],
+                // The worker must reject this terminal answer while children
+                // remains unsettled, then inject a fixed wait correction.
+                2 => vec![
+                    ProviderEvent::TextDelta {
+                        text: "premature parent answer".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ],
+                3 => {
+                    let request = self.requests.lock().unwrap().last().unwrap().clone();
+                    let agent_ids = request
+                        .messages
+                        .iter()
+                        .flat_map(|message| &message.content)
+                        .filter_map(|block| match block {
+                            ContentBlock::ToolResult { content, .. } => {
+                                serde_json::from_str::<serde_json::Value>(content)
+                                    .ok()
+                                    .and_then(|value| value["agent_id"].as_str().map(str::to_owned))
+                            }
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>();
+                    assert_eq!(agent_ids.len(), 2);
+                    vec![
+                        ProviderEvent::ToolCallStarted {
+                            index: 0,
+                            id: "wait-1".into(),
+                            name: openwave_core::WAIT_FOR_AGENTS_TOOL.into(),
+                        },
+                        ProviderEvent::ToolCallArgsDelta {
+                            index: 0,
+                            fragment: serde_json::json!({"agent_ids":agent_ids}).to_string(),
+                        },
+                        ProviderEvent::Stop {
+                            reason: StopReason::ToolUse,
+                        },
+                    ]
+                }
+                _ => vec![
+                    ProviderEvent::TextDelta {
+                        text: "parent completed after ordered wait".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ],
+            }
         };
         Ok(stream::iter(events).boxed())
     }
@@ -5823,7 +5906,7 @@ async fn root_search_never_returns_project_owned_vectors() {
 }
 
 #[test]
-fn agent_deps_registers_server_tools_and_the_foreground_sandbox_contract() {
+fn agent_deps_registers_server_tools_and_closed_foreground_orchestration() {
     let (_retrieval, tools, _config) = agent_deps(
         Arc::new(HashEmbedder::default()),
         Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
@@ -5837,19 +5920,23 @@ fn agent_deps_registers_server_tools_and_the_foreground_sandbox_contract() {
         names.iter().any(|n| n == "read_file"),
         "file tools still present"
     );
-    assert!(
-        !names
-            .iter()
-            .any(|name| name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL),
-        "the sandbox contract must only be advertised to a claimed foreground turn"
-    );
-    assert!(
-        tools
-            .specs_for_foreground(true)
-            .iter()
-            .any(|spec| spec.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL),
-        "foreground turns must expose the durable sandbox delegation contract"
-    );
+    assert!([
+        openwave_core::SPAWN_SANDBOX_AGENT_TOOL,
+        openwave_core::WAIT_FOR_AGENTS_TOOL,
+    ]
+    .iter()
+    .all(|orchestration| !names.iter().any(|name| name == orchestration)));
+    let foreground = tools
+        .specs_for_foreground(true)
+        .into_iter()
+        .map(|spec| spec.name)
+        .collect::<std::collections::HashSet<_>>();
+    assert!([
+        openwave_core::SPAWN_SANDBOX_AGENT_TOOL,
+        openwave_core::WAIT_FOR_AGENTS_TOOL,
+    ]
+    .iter()
+    .all(|name| foreground.contains(*name)));
     assert_eq!(
         tools.execution(openwave_core::REQUEST_FOLDER_ACCESS_TOOL),
         Some(ToolCallExecution::Client)
@@ -8556,7 +8643,7 @@ async fn post_message_runs_a_turn_and_journals_its_events() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn foreground_sandbox_spawn_parks_executes_delivers_and_resumes() {
+async fn foreground_spawn_is_nonblocking_and_ordered_wait_resumes_with_child_result() {
     let dir = tempfile::tempdir().unwrap();
     let store: Arc<dyn Store> = Arc::new(
         DbStore::connect(&format!(
@@ -8568,7 +8655,7 @@ async fn foreground_sandbox_spawn_parks_executes_delivers_and_resumes() {
     );
     let provider = Arc::new(SandboxRoundTripProvider::default());
     let mut tools = ToolRegistry::new();
-    tools.register_foreground_sandbox_spawn();
+    tools.register_foreground_agent_orchestration();
     let state = AppState::new(
         Config::desktop(dir.path()),
         store.clone(),
@@ -8611,57 +8698,146 @@ async fn foreground_sandbox_spawn_parks_executes_delivers_and_resumes() {
         events.last().map(|event| &event.event),
         Some(AgentEvent::TurnCompleted { .. })
     ));
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event.event, AgentEvent::ToolCallCompleted { .. }))
+            .count(),
+        3
+    );
+    assert!(events
+        .iter()
+        .any(|event| matches!(event.event, AgentEvent::StreamInterrupted)));
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event.event, AgentEvent::TurnFailed { .. })));
 
     let runs = store.list_agent_runs(chat.id).await.unwrap();
-    let child = runs
+    let children = runs
         .iter()
-        .find(|run| run.parent_id.is_some())
-        .expect("foreground delegation should durably create one child");
-    assert_eq!(child.status, AgentRunStatus::Completed);
+        .filter(|run| run.parent_id.is_some())
+        .collect::<Vec<_>>();
+    assert_eq!(children.len(), 2);
+    assert!(children
+        .iter()
+        .all(|child| child.status == AgentRunStatus::Completed));
     let parent = openwave_core::AgentRunId::foreground_for_chat(chat.id);
     let inbox = store.list_agent_run_inbox(parent).await.unwrap();
-    assert_eq!(inbox.len(), 1);
-    assert_eq!(inbox[0].child_run_id, child.id);
-    assert_eq!(inbox[0].result.text, "child result");
-    assert_eq!(inbox[0].status, AgentRunInboxStatus::Consumed);
-    assert_eq!(inbox[0].claim_count, 1);
-    assert!(inbox[0].consumed_lease_token.is_some());
+    assert_eq!(inbox.len(), 2);
+    assert!(inbox.iter().all(|entry| {
+        entry.status == AgentRunInboxStatus::Consumed
+            && entry.claim_count == 1
+            && entry.consumed_lease_token.is_some()
+    }));
+    assert!(inbox
+        .iter()
+        .any(|entry| entry.result.text == "first child result"));
+    assert!(inbox
+        .iter()
+        .any(|entry| entry.result.text == "second child result"));
+    let first_delivery = inbox
+        .iter()
+        .find(|entry| entry.result.text == "first child result")
+        .unwrap()
+        .delivered_at;
+    let second_delivery = inbox
+        .iter()
+        .find(|entry| entry.result.text == "second child result")
+        .unwrap()
+        .delivered_at;
+    assert!(second_delivery < first_delivery);
 
     let turn = store.list_turn_runs(chat.id).await.unwrap().pop().unwrap();
     assert_eq!(turn.status, TurnRunStatus::Completed);
     assert_eq!(
-        turn.claim_count, 2,
-        "the resumed turn requires a fresh lease"
+        turn.claim_count, 4,
+        "two spawn continuations and ordered wait each require a fresh lease"
     );
     let requests = provider.requests.lock().unwrap();
-    assert_eq!(requests.len(), 3);
-    assert!(requests[0]
+    assert_eq!(requests.len(), 7);
+    let foreground = requests
+        .iter()
+        .filter(|request| {
+            request
+                .tools
+                .iter()
+                .any(|tool| tool.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL)
+        })
+        .collect::<Vec<_>>();
+    let sandbox = requests
+        .iter()
+        .filter(|request| {
+            request
+                .tools
+                .iter()
+                .any(|tool| tool.name == openwave_core::SANDBOX_WEB_SEARCH_TOOL)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(foreground.len(), 5);
+    assert_eq!(sandbox.len(), 2);
+    assert!(foreground.iter().all(|request| request
         .tools
         .iter()
-        .any(|tool| tool.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL));
+        .any(|tool| tool.name == openwave_core::WAIT_FOR_AGENTS_TOOL)));
+    assert!(sandbox
+        .iter()
+        .all(|request| request.tools.iter().all(|tool| {
+            !matches!(
+                tool.name.as_str(),
+                openwave_core::SPAWN_SANDBOX_AGENT_TOOL | openwave_core::WAIT_FOR_AGENTS_TOOL
+            )
+        })));
     assert!(
-        requests[1]
-            .tools
-            .iter()
-            .any(|tool| tool.name == openwave_core::SANDBOX_WEB_SEARCH_TOOL),
-        "sandbox receives only the fixed web-search tool surface"
-    );
-    assert!(
-        requests[2].messages.iter().any(|message| {
-            message.role == Role::System
-                && message.content
-                    == vec![ContentBlock::Text {
-                        text:
-                            "Sandbox agent completed. Its exact final result follows:\nchild result"
-                                .into(),
-                    }]
+        foreground[3].messages.iter().any(|message| {
+            message.role == Role::System && message.content.iter().any(|block| {
+                matches!(
+                    block,
+                    ContentBlock::Text { text }
+                        if text.contains("cannot finish yet") && text.contains("wait_for_agents")
+                )
+            })
         }),
-        "the resumed foreground request must receive the durable child result"
+        "premature completion must produce a fixed wait correction"
     );
-    assert!(requests[2]
-        .tools
+    assert!(foreground[4].messages.iter().any(|message| {
+        message.content.iter().any(|block| {
+            matches!(
+                block,
+            ContentBlock::ToolResult { content, .. }
+                if content.contains("first child result") && content.contains("second child result")
+            )
+        })
+    }));
+    drop(requests);
+    let calls = store.list_tool_calls(chat.id).await.unwrap();
+    assert_eq!(calls.len(), 3);
+    assert!(calls.iter().all(|call| {
+        call.execution == openwave_core::ToolCallExecution::Orchestration
+            && call.status == openwave_core::ToolCallStatus::Completed
+    }));
+    assert!(calls
         .iter()
-        .any(|tool| tool.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL));
+        .any(|call| call.name == openwave_core::SPAWN_SANDBOX_AGENT_TOOL));
+    assert!(calls
+        .iter()
+        .any(|call| call.name == openwave_core::WAIT_FOR_AGENTS_TOOL));
+    let wait_result = calls
+        .iter()
+        .find(|call| call.name == openwave_core::WAIT_FOR_AGENTS_TOOL)
+        .and_then(|call| call.result.as_deref())
+        .expect("ordered wait should persist its bounded result");
+    assert!(
+        wait_result.find("first child result").unwrap()
+            < wait_result.find("second child result").unwrap(),
+        "wait result must preserve spawn/request order despite reverse completion"
+    );
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert!(messages
+        .iter()
+        .any(|message| message.content == "parent completed after ordered wait"));
+    assert!(!messages
+        .iter()
+        .any(|message| message.content.contains("premature parent answer")));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -15,11 +15,13 @@ use chrono::Utc;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::StreamExt;
 use openwave_core::{
-    AcceptSandboxAgentRunAndParkTurnOutcome, Agent, AgentConfig, AgentError, AgentEvent,
-    AgentTurnOutcome, ClaimedAgentEvent, CompleteTurnRunOutcome, MessageId,
-    ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, Result, SandboxAgentSpawnRequest,
-    SequencedEvent, Store, ToolRegistry, ToolScratch, TurnCheckpointProgress, TurnFailureRetry,
-    TurnId, TurnRun, TurnRunStatus, SPAWN_SANDBOX_AGENT_TOOL,
+    Agent, AgentConfig, AgentError, AgentEvent, AgentRunWaitCondition,
+    AgentRunWaitSetCheckpointRequest, AgentTurnOutcome, CheckpointSandboxSpawnOutcome,
+    ClaimedAgentEvent, CompleteTurnRunOutcome, ForegroundAgentWaitRequest, MessageId,
+    ParkTurnForAgentRunWaitSetOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
+    Result, SandboxAgentSpawnRequest, SandboxSpawnCheckpointRequest, SequencedEvent, Store,
+    ToolRegistry, ToolScratch, TurnCheckpointProgress, TurnFailureRetry, TurnId, TurnRun,
+    TurnRunStatus, SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL,
 };
 use tokio::sync::Notify;
 
@@ -58,6 +60,7 @@ pub(crate) enum TurnWorkerOutcome {
     Completed(TurnId),
     WaitingForClient(TurnId),
     WaitingForAgentRun(TurnId),
+    Resuming(TurnId),
     Cancelled(TurnId),
     Failed(TurnId),
     LeaseLost(TurnId),
@@ -142,6 +145,17 @@ fn sandbox_spawn_checkpoint_is_valid(
                 &serde_json::json!({"task": request.task}),
             )
             .is_some_and(|task| task == request.task)
+}
+
+fn agent_wait_checkpoint_is_valid(
+    tools: &ToolRegistry,
+    request: &ForegroundAgentWaitRequest,
+) -> bool {
+    request.is_well_formed()
+        && tools.is_foreground_agent_wait(WAIT_FOR_AGENTS_TOOL)
+        && tools
+            .wait_for_agent_ids(WAIT_FOR_AGENTS_TOOL, &request.arguments)
+            .is_some_and(|ids| ids == request.child_run_ids)
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -386,6 +400,7 @@ impl TurnWorker {
         let mut total_usage = turn.usage;
         let mut checkpoint_usage = openwave_core::Usage::default();
         let mut checkpoint_steps = 0_usize;
+        let mut continuation_instruction = None;
         if remaining_steps == 0 {
             return self
                 .record_failure(
@@ -485,7 +500,8 @@ impl TurnWorker {
                 .with_cancel(cancel.clone())
                 .with_steer(steer.clone())
                 .with_durable_steer(lease_token)
-                .with_foreground_sandbox_spawns();
+                .with_foreground_agent_orchestration()
+                .with_continuation_instruction(continuation_instruction.clone());
             let chat = chat.clone();
             let (events_tx, mut events_rx) = unbounded();
             let mut drive = AbortOnDrop(tokio::spawn(async move {
@@ -627,6 +643,7 @@ impl TurnWorker {
                         | Ok(AgentTurnOutcome::Cancelled { usage, .. })
                         | Ok(AgentTurnOutcome::ClientToolCall { usage, .. })
                         | Ok(AgentTurnOutcome::SandboxAgentSpawn { usage, .. })
+                        | Ok(AgentTurnOutcome::WaitForAgents { usage, .. })
                         | Ok(AgentTurnOutcome::Failed { usage, .. }) => *usage,
                         Err(_) => openwave_core::Usage::default(),
                     };
@@ -752,11 +769,11 @@ impl TurnWorker {
                                     child_run_ids,
                                     ..
                                 } => {
-                                    return Err(AgentError::msg(format!(
-                                        "turn {} attempted to complete with {} unsettled sandbox children",
-                                        turn.id,
-                                        child_run_ids.len()
-                                    )));
+                                    continuation_instruction = Some(format!(
+                                        "You cannot finish yet because background agents are still unsettled. Call wait_for_agents exactly once with this complete agent_ids list, preserving this order: {}",
+                                        serde_json::to_string(&child_run_ids)?
+                                    ));
+                                    break true;
                                 }
                             },
                             Ok(None) => {
@@ -1160,22 +1177,26 @@ impl TurnWorker {
                         })?,
                         usage: checkpoint_usage,
                     };
+                    let checkpoint = SandboxSpawnCheckpointRequest {
+                        origin_turn_id: turn.id,
+                        lease_token,
+                        expected_steer_revision: steer_revision,
+                        call_id: request.call_id,
+                        provider_id: request.provider_id.clone(),
+                        arguments: request.arguments.clone(),
+                        result: serde_json::to_string(&openwave_core::SpawnSandboxAgentResult {
+                            agent_id: request.child_run_id,
+                        })?,
+                        event_ordinal: ordinal,
+                        progress,
+                    };
                     let mut checkpoint_heartbeat = AbortOnDrop(tokio::spawn(
                         self.clone()
                             .heartbeat_lease(turn.clone(), lease_token, cancel.clone()),
                     ));
                     loop {
                         let park_result = tokio::select! {
-                            result = self.store.accept_sandbox_agent_run_and_park_turn(
-                                request.child_run_id,
-                                turn.id,
-                                request.call_id,
-                                &request.task,
-                                lease_token,
-                                steer_revision,
-                                progress,
-                                Utc::now(),
-                            ) => result,
+                            result = self.store.checkpoint_sandbox_spawn(&checkpoint, Utc::now()) => result,
                             result = &mut checkpoint_heartbeat.0 => {
                                 match result {
                                     Ok(HeartbeatOutcome::Cancelling) => {
@@ -1195,44 +1216,39 @@ impl TurnWorker {
                             }
                         };
                         match park_result {
-                            Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::Parked {
-                                ..
-                            }))
-                            | Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::Existing {
-                                ..
+                            Ok(Some(CheckpointSandboxSpawnOutcome::Checkpointed {
+                                event, ..
                             })) => {
                                 checkpoint_heartbeat.abort_and_wait().await;
-                                // The child and parent wait state are now one
-                                // durable transaction. This is intentionally
-                                // only a latency hint: the sandbox worker's
-                                // durable claim scan remains the correctness
-                                // source if the notification is lost.
+                                self.publish(turn.chat_id, event);
                                 self.sandbox_agent_wake.notify_one();
-                                return Ok(TurnWorkerOutcome::WaitingForAgentRun(turn.id));
+                                self.wake.notify_one();
+                                return Ok(TurnWorkerOutcome::Resuming(turn.id));
                             }
-                            Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::SteerPending(_)))
-                            | Ok(Some(
-                                AcceptSandboxAgentRunAndParkTurnOutcome::OutputSuperseded(_),
-                            )) => {
+                            Ok(Some(CheckpointSandboxSpawnOutcome::Existing { event, .. })) => {
+                                checkpoint_heartbeat.abort_and_wait().await;
+                                // Exact recovery can be the first successful
+                                // response observed after an ambiguous commit.
+                                // Re-publishing the same durable sequence is
+                                // safe for cursor-deduplicating clients.
+                                self.publish(turn.chat_id, event);
+                                self.sandbox_agent_wake.notify_one();
+                                self.wake.notify_one();
+                                return Ok(TurnWorkerOutcome::Resuming(turn.id));
+                            }
+                            Ok(Some(CheckpointSandboxSpawnOutcome::SteerPending(_)))
+                            | Ok(Some(CheckpointSandboxSpawnOutcome::OutputSuperseded(_))) => {
                                 break;
                             }
-                            Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::AtCapacity)) => {
-                                checkpoint_heartbeat.abort_and_wait().await;
-                                return self
-                                    .record_failure(
-                                        &turn,
-                                        lease_token,
-                                        total_model_steps,
-                                        total_usage,
-                                        "sandbox_agent_capacity_exceeded",
-                                        "sandbox delegation exceeds the bounded outstanding-child limit",
-                                    )
-                                    .await;
+                            Ok(Some(CheckpointSandboxSpawnOutcome::AtCapacity)) => {
+                                continuation_instruction = Some(
+                                    "The background-agent capacity is full. Do not spawn another agent. Call wait_for_agents with previously returned agent IDs before trying to delegate more work."
+                                        .into(),
+                                );
+                                break;
                             }
-                            Ok(Some(AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict))
-                            | Ok(Some(
-                                AcceptSandboxAgentRunAndParkTurnOutcome::ParentUnavailable,
-                            )) => {
+                            Ok(Some(CheckpointSandboxSpawnOutcome::IdentityConflict))
+                            | Ok(Some(CheckpointSandboxSpawnOutcome::ParentUnavailable)) => {
                                 checkpoint_heartbeat.abort_and_wait().await;
                                 return self
                                     .record_failure(
@@ -1244,6 +1260,26 @@ impl TurnWorker {
                                         "sandbox delegation conflicts with its durable receipt",
                                     )
                                     .await;
+                            }
+                            Ok(Some(CheckpointSandboxSpawnOutcome::LeaseLost)) => {
+                                match self.live_turn_state_retry(&turn, lease_token).await {
+                                    LiveTurnState::Running => tokio::task::yield_now().await,
+                                    LiveTurnState::Cancelling => {
+                                        checkpoint_heartbeat.abort_and_wait().await;
+                                        drop(active);
+                                        return self
+                                            .acknowledge_cancellation(
+                                                &turn,
+                                                lease_token,
+                                                total_usage,
+                                            )
+                                            .await;
+                                    }
+                                    LiveTurnState::Lost => {
+                                        checkpoint_heartbeat.abort_and_wait().await;
+                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    }
+                                }
                             }
                             Ok(None) => {
                                 match self.live_turn_state_retry(&turn, lease_token).await {
@@ -1285,6 +1321,207 @@ impl TurnWorker {
                             )
                             .await;
                     }
+                    let mut continuation_heartbeat = AbortOnDrop(tokio::spawn(
+                        self.clone()
+                            .heartbeat_lease(turn.clone(), lease_token, cancel.clone()),
+                    ));
+                    match self
+                        .append_event(&turn, lease_token, ordinal, &AgentEvent::StreamInterrupted)
+                        .await?
+                    {
+                        EventAppend::Committed => {
+                            ordinal = ordinal.checked_add(1).ok_or_else(|| {
+                                AgentError::msg(format!("turn {} event ordinal exhausted", turn.id))
+                            })?;
+                        }
+                        EventAppend::Cancelling => {
+                            cancel.cancel();
+                            drop(active);
+                            return self
+                                .acknowledge_cancellation(&turn, lease_token, total_usage)
+                                .await;
+                        }
+                        EventAppend::LeaseLost => {
+                            return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                        }
+                    }
+                    continuation_heartbeat.abort_and_wait().await;
+                    continue;
+                }
+                Ok(AgentTurnOutcome::WaitForAgents {
+                    request,
+                    usage,
+                    steer_revision,
+                    model_steps,
+                }) => {
+                    if model_steps == 0 || model_steps > remaining_steps {
+                        return Err(AgentError::msg(format!(
+                            "turn {} returned an invalid model-step count {model_steps}",
+                            turn.id
+                        )));
+                    }
+                    remaining_steps -= model_steps;
+                    total_model_steps = checked_model_step_sum(total_model_steps, model_steps)?;
+                    total_usage = match checked_usage_sum(total_usage, usage) {
+                        Ok(total) => total,
+                        Err(_) => {
+                            return self
+                                .record_failure(
+                                    &turn,
+                                    lease_token,
+                                    total_model_steps,
+                                    total_usage,
+                                    "usage_overflow",
+                                    "provider usage exceeded the supported turn total",
+                                )
+                                .await;
+                        }
+                    };
+                    if remaining_steps == 0 {
+                        drop(active);
+                        return self
+                            .record_failure(
+                                &turn,
+                                lease_token,
+                                total_model_steps,
+                                total_usage,
+                                "max_steps_exceeded",
+                                "max steps per turn exceeded before waiting for background agents",
+                            )
+                            .await;
+                    }
+                    if !agent_wait_checkpoint_is_valid(self.tools.as_ref(), &request) {
+                        drop(active);
+                        return self
+                            .record_failure(
+                                &turn,
+                                lease_token,
+                                total_model_steps,
+                                total_usage,
+                                "invalid_agent_wait",
+                                "agent returned an invalid background-agent wait checkpoint",
+                            )
+                            .await;
+                    }
+                    checkpoint_usage = match checked_usage_sum(checkpoint_usage, usage) {
+                        Ok(total) => total,
+                        Err(_) => {
+                            return self
+                                .record_failure(
+                                    &turn,
+                                    lease_token,
+                                    total_model_steps,
+                                    total_usage,
+                                    "usage_overflow",
+                                    "provider usage exceeded the supported checkpoint total",
+                                )
+                                .await;
+                        }
+                    };
+                    checkpoint_steps =
+                        checkpoint_steps.checked_add(model_steps).ok_or_else(|| {
+                            AgentError::msg(format!(
+                                "turn {} checkpoint model-step count overflowed",
+                                turn.id
+                            ))
+                        })?;
+                    let progress = TurnCheckpointProgress {
+                        model_steps: i32::try_from(checkpoint_steps).map_err(|_| {
+                            AgentError::msg(format!(
+                                "turn {} checkpoint model-step count is too large",
+                                turn.id
+                            ))
+                        })?,
+                        usage: checkpoint_usage,
+                    };
+                    let checkpoint = AgentRunWaitSetCheckpointRequest {
+                        call_id: request.call_id,
+                        origin_turn_id: turn.id,
+                        child_run_ids: request.child_run_ids.clone(),
+                        condition: AgentRunWaitCondition::All,
+                        lease_token,
+                        expected_steer_revision: steer_revision,
+                        provider_id: request.provider_id.clone(),
+                        arguments: request.arguments.clone(),
+                        event_ordinal: ordinal,
+                        progress,
+                    };
+                    let mut checkpoint_heartbeat = AbortOnDrop(tokio::spawn(
+                        self.clone()
+                            .heartbeat_lease(turn.clone(), lease_token, cancel.clone()),
+                    ));
+                    loop {
+                        let park_result = tokio::select! {
+                            result = self.store.park_turn_for_agent_run_wait_set(&checkpoint, Utc::now()) => result,
+                            result = &mut checkpoint_heartbeat.0 => {
+                                match result {
+                                    Ok(HeartbeatOutcome::Cancelling) => {
+                                        drop(active);
+                                        return self
+                                            .acknowledge_cancellation(
+                                                &turn,
+                                                lease_token,
+                                                total_usage,
+                                            )
+                                            .await;
+                                    }
+                                    Ok(HeartbeatOutcome::LeaseLost) | Err(_) => {
+                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    }
+                                }
+                            }
+                        };
+                        match park_result {
+                            Ok(Some(ParkTurnForAgentRunWaitSetOutcome::Parked { .. }))
+                            | Ok(Some(ParkTurnForAgentRunWaitSetOutcome::Existing { .. })) => {
+                                checkpoint_heartbeat.abort_and_wait().await;
+                                // This also drives the durable ready-set scan
+                                // when every child completed before the park.
+                                self.sandbox_agent_wake.notify_one();
+                                return Ok(TurnWorkerOutcome::WaitingForAgentRun(turn.id));
+                            }
+                            Ok(Some(ParkTurnForAgentRunWaitSetOutcome::SteerPending(_)))
+                            | Ok(Some(ParkTurnForAgentRunWaitSetOutcome::OutputSuperseded(_))) => {
+                                break;
+                            }
+                            Ok(Some(ParkTurnForAgentRunWaitSetOutcome::IdentityConflict)) => {
+                                continuation_instruction = Some(
+                                    "That background-agent wait was invalid. Use only unique agent IDs returned by spawn_sandbox_agent in this turn, and include every unsettled child before finishing."
+                                        .into(),
+                                );
+                                break;
+                            }
+                            Ok(None) => {
+                                match self.live_turn_state_retry(&turn, lease_token).await {
+                                    LiveTurnState::Running => tokio::task::yield_now().await,
+                                    LiveTurnState::Cancelling => {
+                                        checkpoint_heartbeat.abort_and_wait().await;
+                                        drop(active);
+                                        return self
+                                            .acknowledge_cancellation(
+                                                &turn,
+                                                lease_token,
+                                                total_usage,
+                                            )
+                                            .await;
+                                    }
+                                    LiveTurnState::Lost => {
+                                        checkpoint_heartbeat.abort_and_wait().await;
+                                        return Ok(TurnWorkerOutcome::LeaseLost(turn.id));
+                                    }
+                                }
+                            }
+                            Err(error) => {
+                                self.retry_after(
+                                    "background-agent wait checkpoint",
+                                    turn.id,
+                                    &error,
+                                )
+                                .await;
+                            }
+                        }
+                    }
+                    checkpoint_heartbeat.abort_and_wait().await;
                     let mut continuation_heartbeat = AbortOnDrop(tokio::spawn(
                         self.clone()
                             .heartbeat_lease(turn.clone(), lease_token, cancel.clone()),
@@ -2059,12 +2296,14 @@ mod committed_event_drain_tests {
     #[test]
     fn sandbox_spawn_checkpoint_fence_requires_the_registered_foreground_contract() {
         let mut tools = ToolRegistry::new();
-        tools.register_foreground_sandbox_spawn();
+        tools.register_foreground_agent_orchestration();
         let call_id = openwave_core::CallId::new();
         let request = SandboxAgentSpawnRequest {
             call_id,
+            provider_id: "provider-call".into(),
             child_run_id: openwave_core::AgentRunId::sandbox_for_spawn_call(call_id),
             task: "Research the error handling options.".into(),
+            arguments: serde_json::json!({"task":"Research the error handling options."}),
         };
         assert!(sandbox_spawn_checkpoint_is_valid(&tools, &request));
 


### PR DESCRIPTION
## Summary

- expose closed foreground-only `spawn_sandbox_agent` and `wait_for_agents` contracts together
- checkpoint non-blocking child admission and ordered waits through the durable turn worker
- keep premature completion and capacity pressure as model-correctable continuation states
- prove two-child fan-out, reverse completion, ordered result delivery, and sandbox tool isolation end to end

## Validation

- `cargo test -p openwave-core --lib` (357 tests)
- `cargo test -p openwave-server --lib` (239 tests before the independently merged recovery test)
- focused post-rebase core, registry, and two-child runtime tests
- `cargo check --workspace --all-targets --locked`
- `cargo fmt --all --check`
- `bw dev lint --rust --check`
