### PR TITLE
Document background agent orchestration

### DIFF
--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -298,7 +298,7 @@ The implementation is intentionally incremental:
     receipt-backed model resume. *(Shipped.)*
 11. Let a sandbox relay a typed folder-consent proposal to its foreground
     parent, without host access or a picker. *(Shipped.)*
-12. Add a fenced read-only proxy for roots the foreground chat already
+12. Add fenced read-only tools to the foreground turn for roots its chat already
     attached; sandbox broker access remains deferred. *(Shipped.)*
 13. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work, including exact sandbox stop controls. *(Shipped.)*

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -54,7 +54,7 @@ differ:
 | --- | --- |
 | Responds directly in the chat | Works on one delegated task |
 | Final assistant text completes a turn | An explicit result submission completes the run |
-| Uses conversation-facing tools | Starts with no tools or shared conversation context |
+| Uses conversation-facing tools | May make at most one web-search or folder-access proposal call; has no shared conversation context |
 | Usually short-lived work | May park and resume over a longer period |
 | Streams answer content | Publishes bounded progress and a final result |
 
@@ -248,6 +248,12 @@ provider identifiers, executor leases, and raw failures remain server-side.
 New tools are invisible to the renderer until they receive their own safe
 activity projection.
 
+The desktop Agent activity panel turns that projection into foreground and
+background status rows. It offers Stop only for sandbox states that can still
+be cancelled, binds each request to the exact chat and run, and keeps a pending
+or retryable error state until polling confirms the durable transition. The
+panel never receives a worker lease or direct scheduler control.
+
 ## Reliability contract
 
 The agent hierarchy preserves the runtime's existing rules:
@@ -293,9 +299,9 @@ The implementation is intentionally incremental:
 11. Let a sandbox relay a typed folder-consent proposal to its foreground
     parent, without host access or a picker. *(Shipped.)*
 12. Add a fenced read-only proxy for roots the foreground chat already
-    attached; sandbox broker access remains deferred.
+    attached; sandbox broker access remains deferred. *(Shipped.)*
 13. Add desktop surfaces for queued, running, waiting, failed, and completed
-   background work.
+   background work, including exact sandbox stop controls. *(Shipped.)*
 14. Persist the non-blocking spawn checkpoint and ordered wait receipts.
     *(Shipped.)*
 15. Activate non-blocking spawn and ordered multi-agent waits together.

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -70,8 +70,8 @@ spawn:
 2. The tool-call identity is stored as the child's unique spawn identity, so an
    ambiguous retry recovers the original run instead of creating a duplicate.
 3. A bounded scheduler claims the child with an exact renewable lease.
-4. The scheduler gives the child private scratch and advances its isolated
-   no-tools task loop.
+4. The scheduler gives the child private scratch and advances its isolated task
+   loop with only the narrow sandbox-safe tool surface.
 5. The child submits an immutable terminal result. Provider failures leave the
    exact lease for the bounded scheduler retry/reap path; they do not create an
    unfenced executor-side failure transition.

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -10,10 +10,18 @@ The initial design is deliberately bounded:
 - the foreground agent may start background agents;
 - every background agent runs in a sandbox;
 - background agents cannot start more agents (`depth <= 1`);
-- configurable global and per-chat limits bound queued and running agents.
+- at most four children from one foreground turn may remain unsettled;
+- configurable global and per-chat limits bound actively running agents.
 
 This is enough for useful parallel research and production work without needing
 a recursive fleet scheduler.
+
+From the user's point of view, the foreground assistant can hand several
+independent jobs to background workers, continue organizing the task, and then
+pause at one explicit join point. Results return together in the order the
+assistant requested, even if the workers actually finished in another order.
+Closing the app or restarting the server does not lose the accepted jobs or
+their place in the conversation.
 
 ## The execution hierarchy
 
@@ -71,38 +79,54 @@ spawn:
    together. A later wait transition may consume that entry and wake a parent.
 
 The bounded `spawn_sandbox_agent` contract is available only to a durably
-claimed foreground turn. It is a wait-form tool: one bounded `task` derives a
-child identity from its exact tool call, then commits the queued child, durable
-wait, and release of the foreground lease in one transaction. Only after that
-commit does the server wake the bounded sandbox worker. The notification is a
-latency hint, not a correctness dependency: the worker polls durable child and
-inbox state, so a missed wake or restart cannot lose accepted work. A sandbox
-result is delivered, claimed under an exact continuation lease, consumed, and
-turns the parked foreground turn into a fresh durably claimable `resuming`
-attempt. The tool is never advertised to sandbox workers, and the store
-independently enforces depth one. A later non-blocking spawn tool can let the
-foreground continue after spawning, but must earn the same checkpoint and
-replay rules.
+claimed foreground turn. One bounded `task` derives a child identity from its
+exact tool call. In one transaction, OpenWave admits the queued child, records
+the completed orchestration tool result containing its opaque `agent_id`,
+journals that completion, applies model progress once, and releases the
+foreground lease into `resuming`. The foreground can therefore be reclaimed
+and continue while the child runs. Only after the commit does the server wake
+the foreground and sandbox workers. Those notifications reduce latency; their
+durable scans remain the correctness path after a missed wake or restart.
 
-Core now prepares, but does not advertise, the typed boundary for that later
-cutover. Its inactive non-blocking spawn checkpoint atomically binds child
-admission, the completed orchestration tool history, one journal event, exact
-usage progress, and release of the foreground lease. Ambiguous retries recover
-that immutable receipt before consulting mutable turn state. The model-facing
-spawn result contains only the stable opaque child agent ID.
+Each spawn call is made alone and returns one ID for the foreground agent to
+retain. Up to four children from the exact origin turn may be unsettled at once.
+"Unsettled" includes both live work and a terminal result that has not yet been
+consumed, so finishing quickly does not accidentally open an unbounded queue.
+A consumed result, or one explicitly retired by cancellation, releases its
+slot. Sandbox workers never receive either orchestration tool, and storage also
+enforces depth one.
 
 The paired `wait_for_agents` call accepts one to four unique child IDs in caller
-order and has only `All` completion semantics; its result contains each typed
-terminal child payload in that same order. Durable runtime validation must still
-prove every ID is a depth-one child owned by the exact origin turn. No scheduler
-lease, executor identity, or continuation token crosses this model-facing
-boundary. The non-blocking spawn behavior and `wait_for_agents` tool remain
-inactive until the ordered wait owns the same atomic tool-history boundary.
+order and has only `All` completion semantics. The call is also made alone. Its
+park transaction proves every ID belongs to the exact origin turn, records the
+pending orchestration tool call and ordered membership, applies model progress
+once, and moves the foreground turn to `waiting_for_agent_run`. Scheduler
+leases, executor identities, and continuation tokens never cross this
+model-facing boundary.
 
-The current serial single-child wait also carries an immutable atomic-admission
-marker. Only that receipt allows a later retry to recover the combined
-transition; an older path that accepted a child and parked a turn in separate
-commits is never mistaken for proof that both effects committed together.
+When every child has a terminal inbox delivery, one resume transaction consumes
+all of them exactly once, completes the same tool call with typed results in
+request order, appends the exact `ToolCallCompleted` journal event, and changes
+the foreground turn to `resuming`. A child may finish before the wait is parked;
+the durable readiness scan still finds it. If a steer interrupts an open wait,
+the wait call closes but the children and their deliveries remain available for
+a later wait. Parent cancellation instead fences its owned children and retires
+unconsumed delivery.
+
+Foreground completion has a final storage guard. If the model tries to return a
+final answer while any admitted child remains unsettled, the completion does
+not commit. The worker continues with the complete ordered ID list and directs
+the model to issue one valid wait. This prevents a prompt mistake or premature
+provider response from orphaning background work.
+
+Ambiguous responses keep the original identity. Spawn recovery reads its
+immutable checkpoint before mutable lease or steer state, so a lost response
+cannot create a second child or apply usage twice. Ordered-wait recovery keeps
+one resume token across transient adapter errors; if the first response was
+lost after commit, the exact retry recovers the already-consumed results and
+the same journal event. That event may be published live again, but it retains
+its durable sequence number. Reconnecting clients replay the journal, and live
+clients deduplicate by sequence cursor.
 
 ## One continuation model
 
@@ -122,11 +146,13 @@ notification may reduce latency, but it is never the source of truth.
 
 ## Sandbox and host-access boundary
 
-A background agent has private runtime scratch, but the initial executor has no
-tools and cannot access that scratch, projects, host folders, the network, or
-the parent conversation. Foreground chats may inspect already attached roots,
-but sandbox agents do not receive the broker transport or these tool contracts.
-Future sandbox folder access must use the parent-mediated consent and
+A background agent has private runtime scratch but cannot access that scratch,
+projects, host folders, the general network, or the parent conversation. Its
+current narrow exceptions are one checkpointed public web search or a typed
+folder-access proposal that grants no access. It never receives the foreground
+spawn/wait or broker tool contracts. Foreground chats may inspect already
+attached roots, but sandbox agents do not receive the broker transport. Future
+sandbox folder access must use the parent-mediated consent and
 durable-receipt protocol described in [Host access and connected folders](host-access.md),
 never absolute paths.
 
@@ -141,8 +167,9 @@ keeping one chat from monopolizing it, and preventing an agent from creating an
 unbounded queue. The scheduler therefore applies configurable limits to:
 
 - background agents running across the installation;
-- running and outstanding children per chat or foreground run;
-- total children created by one foreground run;
+- running children per chat;
+- four unsettled children per foreground turn, including delivered results
+  that have not yet been consumed;
 - wall-clock time, model steps, tool calls, and other resource budgets.
 
 When a running slot is unavailable, accepted work remains durably queued. A
@@ -174,34 +201,28 @@ host path, root identity, broker grant, or client-call identity; it only tells
 the foreground parent to decide whether the existing foreground consent tool is
 appropriate. The receipt, `completed` state, and one parent inbox entry commit
 together, so an ambiguous worker retry can recover its original result but
-cannot overwrite or double-deliver it. Each inbox entry
-then advances through its own fenced continuation state machine:
-`pending -> claimed -> consumed` (or `cancelled` when its parked parent is
-cancelled). A parent continuation claims one exact child
-result only after the matching foreground checkpoint has committed, with a
-database-clock lease, and only that live lease can consume it. A result that
-arrives first remains pending; it is never leased merely because a process saw
-it before the parent reached its durable boundary.
-An expired claim can be reclaimed; a consumed entry retains the exact consuming
-lease as an immutable receipt, so an ambiguous consume retry recovers the same
-boundary without processing the child result twice. Consumption also persists
-the exact terminal child text as a deterministic system transcript message, so
-the resumed model request sees it after a restart. A foreground worker can
-checkpoint its exact turn against a known child, releasing its turn lease and
-preserving model progress. Consumption then closes that checkpoint and moves
-the turn to `resuming` in the same transaction. `resuming` is the durable wake
-signal: any worker can claim it after restart, without relying on an in-memory
-notification. Queued, waiting,
-and retry-wait work cancels
-immediately; a running worker first enters `cancelling` and must acknowledge its
-exact live lease. That acknowledgement writes its own immutable receipt, so only
-the worker that actually committed terminal cancellation can recover an
-ambiguous retry. An expired running lease is cancelled immediately on request
-rather than reclaimed. Cancelling a parked parent fences its owned sandbox
-child in the same durable transition: queued work is cancelled, running work
-is asked to acknowledge cancellation, and a delivered inbox receipt is retired.
-Parent inbox delivery is intentionally the next transition, not a process-local
+cannot overwrite or double-deliver it. Each inbox entry advances through a
+fenced lifecycle: `pending -> consumed`, with a stable resume token proving the
+consumer, or `cancelled` when the parent retires the delivery. The ordered wait
+consumes all named entries in one transaction only after the matching
+foreground checkpoint exists. A result that arrives first remains pending; it
+is never treated as parent-visible merely because a process noticed it early.
+
+The completed wait tool result is the model-facing delivery. It contains each
+typed child result in the caller's original order and is reconstructed from the
+same immutable receipts after restart. `resuming` is the durable wake signal:
+any foreground worker can claim it without relying on an in-memory
 notification.
+
+Queued, waiting, and retry-wait child work cancels immediately. A running child
+first enters `cancelling` and must acknowledge its exact live lease. That
+acknowledgement writes its own immutable receipt, so only the worker that
+committed terminal cancellation can recover an ambiguous retry. An expired
+running lease is cancelled immediately on request rather than reclaimed.
+Cancelling a foreground turn fences its owned children in the same ordered
+transition: queued work is cancelled, running work is asked to acknowledge,
+and delivered inbox receipts are retired. Inbox delivery and consumption are
+always durable state transitions, never process-local notifications.
 
 ## Observing execution
 
@@ -239,11 +260,11 @@ The agent hierarchy preserves the runtime's existing rules:
 5. Waits release workers and resume from committed checkpoints.
 6. Steering and cancellation are resolved at explicit boundaries.
 7. A final result, terminal run state, and immutable parent inbox entry are
-   committed atomically. A foreground turn may checkpoint against one exact
-   inbox delivery. When the child is spawned from a wait boundary, that
-   checkpoint commits with child admission and releases the foreground lease;
-   consuming the delivery under an exact expiring continuation lease also wakes
-   the checkpointed turn to `resuming`, with exact retry recovery.
+   committed atomically. Spawn separately commits child admission with its
+   completed orchestration result and foreground `resuming` transition. An
+   ordered wait checkpoints one to four exact child IDs; consuming all matching
+   deliveries completes that same tool call and wakes the foreground turn to
+   `resuming`, with exact retry recovery at both boundaries.
 8. Clients recover from a durable snapshot plus ordered event replay.
 
 Until a tool satisfies the side-effect receipt contract, OpenWave continues to
@@ -265,9 +286,8 @@ The implementation is intentionally incremental:
    durable `resuming` wake signal. *(Shipped.)*
 8. Run isolated sandbox tasks with no shared conversation context, over the
    durable lease/result boundary. *(Shipped.)*
-9. Enable the bounded foreground-only `spawn_sandbox_agent` contract, wake the
-   sandbox worker after its atomic checkpoint, and resume the parked turn from
-   the already-delivered inbox receipt. *(Shipped.)*
+9. Prove the bounded foreground-only spawn path with atomic child admission,
+   sandbox wake-up, immutable delivery, and parent resume. *(Shipped.)*
 10. Add the one-call sandbox `web_search` checkpoint, host executor, and
     receipt-backed model resume. *(Shipped.)*
 11. Let a sandbox relay a typed folder-consent proposal to its foreground
@@ -276,7 +296,9 @@ The implementation is intentionally incremental:
     attached; sandbox broker access remains deferred.
 13. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work.
-14. Persist the non-blocking spawn checkpoint without advertising it. *(Shipped.)*
+14. Persist the non-blocking spawn checkpoint and ordered wait receipts.
+    *(Shipped.)*
 15. Activate non-blocking spawn and ordered multi-agent waits together.
+    *(Shipped.)*
 16. Add richer context lifecycle, parallel-safe tool groups, and further
    orchestration only after these recovery boundaries are proven.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -594,24 +594,28 @@ The browser-facing API is not exposed on a public network interface.
 The current UI is a workspace-style conversation shell, not the complete
 product. It reopens durable chats and supports conversation create/list/switch/
 rename/delete, transcript hydration, Markdown messages, live and historical
-tool activity, reconnectable streaming, provider and web-search setup, model
-selection, a foreground-turn stop control, approval prompts, native
-connected-folder pick/list/revoke, and a concise foreground/background
-agent-status surface. The stop control sends cancellation for the exact active
-turn, prevents duplicate requests, and stays in a pending state until an
-authoritative terminal event arrives; it never treats a request as a locally
-completed cancellation.
+tool-call rendering, reconnectable streaming, provider and web-search setup,
+model selection, a foreground-turn stop control, approval prompts, native
+connected-folder pick/list/revoke, and a dedicated foreground/background agent
+activity panel. That panel renders safe lifecycle and activity status and can
+stop an eligible sandbox task through its exact run identity. The foreground
+stop control sends cancellation for the exact active turn, prevents duplicate
+requests, and stays in a pending state until an authoritative terminal event
+arrives; neither control treats a request as a locally completed cancellation.
 That surface reads a redacted durable snapshot and is only an observer: worker
 leases, delegated inputs, and scheduler control remain server-private.
 OpenWave's operational scratch stays in private app storage; user-selected paths
 cross only the native host-to-broker control boundary, while the renderer sees
 opaque folder summaries. Projects and chats store only ordered opaque root IDs
-and attachment revisions—never host paths or grants. Built-in agent file tools
-still use a server-derived per-chat private scratch directory and are not yet
-routed through connected roots; that scratch path is neither persisted nor
-returned to the renderer. The UI does not yet provide projects or steer
-controls. Completed assistant messages render the closed structured source cards
-described above. The Documents surface derives scope from the
+and attachment revisions—never host paths or grants. Built-in scratch tools
+remain confined to a server-derived per-chat directory whose path is neither
+persisted nor returned to the renderer. Foreground agents separately have a
+fenced read-only proxy for roots already attached to the chat:
+`list_connected_folders`, `list_folder`, and `read_connected_file` carry only
+opaque root IDs and bounded relative paths through the trusted native broker.
+The UI does not yet provide projects or steer controls. Completed assistant
+messages render the closed structured source cards described above. The
+Documents surface derives scope from the
 authoritative current chat: project chats use that project's corpus and loose
 chats use the unscoped corpus. It lists the catalog, imports a user-picked text
 or Markdown file, polls durable processing status, and searches ready passages.
@@ -717,21 +721,18 @@ document pipeline, generation-aware Lance publication, durable turn acceptance
 and ownership, atomic client-wait checkpoints, terminal turn commits,
 cancellation, reconnectable event stream, durable foreground/sandbox agent-run
 leases and result delivery, bounded non-blocking child admission, ordered
-multi-child waits, the foreground terminal guard, and fail-closed provider
-routing.
+multi-child waits, the foreground terminal guard, Markdown and tool-call
+transcript rendering, the agent activity/status-and-stop surface, and
+fail-closed provider routing.
 
 The main next steps are:
 
-- surface the activated non-blocking spawn and ordered wait lifecycle clearly
-  in desktop message history and background-agent status/cancel views;
 - extend the bounded depth-one hierarchy with carefully scoped sandbox-safe
   capabilities without widening its spawn or host-access authority;
 - continue unifying client execution, folder consent, user questions, and
   resource waits around durable continuations that release workers;
 - persist model/tool step boundaries and side-effect receipts so sandbox and
   foreground runs can resume safely after process loss;
-- route built-in file tools through explicit broker roots while keeping private
-  per-chat scratch separate;
 - add resumable checkpoints and explicit idempotency policy around remaining
   server-side tool effects;
 - expose the remaining backend capabilities through the desktop information

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -716,20 +716,18 @@ The strongest parts today are the core seams, database constraints, durable
 document pipeline, generation-aware Lance publication, durable turn acceptance
 and ownership, atomic client-wait checkpoints, terminal turn commits,
 cancellation, reconnectable event stream, durable foreground/sandbox agent-run
-leases and result delivery, and fail-closed provider routing.
+leases and result delivery, bounded non-blocking child admission, ordered
+multi-child waits, the foreground terminal guard, and fail-closed provider
+routing.
 
 The main next steps are:
 
-- split sandbox delegation into exact non-blocking child admission followed by
-  a durable multi-child wait, so one depth-zero coordinator can fan out bounded
-  parallel work without allowing recursive agents;
-- enforce transactional outstanding-child caps and origin-turn ownership in
-  addition to the existing global/per-chat running caps;
-- extend the resulting durable agent-run hierarchy with carefully scoped
-  sandbox-safe capabilities and small UI status/cancel surfaces;
-- unify client execution, folder consent, user questions, resource waits, and
-  child-agent waits with the durable approval pattern as continuations that
-  release workers;
+- surface the activated non-blocking spawn and ordered wait lifecycle clearly
+  in desktop message history and background-agent status/cancel views;
+- extend the bounded depth-one hierarchy with carefully scoped sandbox-safe
+  capabilities without widening its spawn or host-access authority;
+- continue unifying client execution, folder consent, user questions, and
+  resource waits around durable continuations that release workers;
 - persist model/tool step boundaries and side-effect receipts so sandbox and
   foreground runs can resume safely after process loss;
 - route built-in file tools through explicit broker roots while keeping private

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,7 +7,7 @@ identity.
 
 ## What exists today
 
-The current foreground agent surface contains nine tools:
+The current foreground agent surface contains ten tools:
 
 | Tool | Purpose | Execution boundary |
 | --- | --- | --- |
@@ -19,14 +19,14 @@ The current foreground agent surface contains nine tools:
 | `list_connected_folders` | List roots already attached to this chat | Native client continuation |
 | `list_folder` | List one directory below an attached root | Native client continuation |
 | `read_connected_file` | Read bounded UTF-8 text below an attached root | Native client continuation |
-| `spawn_sandbox_agent` | Delegate one bounded task and wait for its durable result | Foreground-only durable continuation |
+| `spawn_sandbox_agent` | Start one isolated background task and immediately continue | Foreground-only durable checkpoint |
+| `wait_for_agents` | Wait for one to four spawned agents and return their results in request order | Foreground-only durable continuation |
 
-The core also contains an inactive `wait_for_agents` definition for the next
-orchestration cutover. It accepts one to four unique depth-one child agent IDs,
-waits for all of them, and preserves request order in its result. The strict
-arguments and closed spawn/wait result shapes are prepared now so the runtime
-does not invent ad hoc JSON later, but neither the wait definition nor the
-future non-blocking spawn wording is advertised yet.
+The two background-agent tools are a closed pair. A spawn returns only an opaque
+`agent_id`; a wait accepts one to four unique IDs returned by spawns from the
+same foreground turn. Both calls must be made alone, without assistant text or
+sibling tool calls. Sandbox agents receive neither definition, so they cannot
+create or wait on other agents.
 
 The connected-folder calls are foreground-only. Their arguments contain only
 an opaque root ID and a bounded root-relative path; native code recovers the
@@ -66,27 +66,39 @@ The foreground coordinator needs tools for:
 - web search and page retrieval;
 - connected-root list/read/import and explicit export;
 - asking the user a structured question;
-- spawning, inspecting, messaging, waiting for, cancelling, and reviewing
-  depth-one sandbox agents.
+- spawning and waiting for depth-one sandbox agents.
 
-`spawn_sandbox_agent` is enabled only for a claimed foreground turn. It
-atomically admits a depth-one child and parks that turn; the child result is
-persisted as a system transcript message before the parent can resume. Sandbox
-agents never receive this tool.
+`spawn_sandbox_agent` and `wait_for_agents` are enabled only for a durably
+claimed foreground turn. A spawn atomically admits the depth-one child,
+records the completed tool result containing its `agent_id`, journals that
+completion, applies model usage once, and moves the foreground turn to
+`resuming`. A fresh worker claim then continues the conversation while the
+child runs independently. The notification that wakes each worker is only a
+latency hint; the committed state is sufficient after a restart.
 
-That first implementation is durable but serial: spawning one child immediately
-parks the parent, so the coordinator cannot launch a group and then wait for the
-group. The next runtime sequence separates those concerns. Core now has an
-inactive atomic checkpoint for non-blocking spawn: it admits the exact child,
-commits completed orchestration tool history and a journal event, applies usage
-once, and releases the foreground lease for a normal durable reclaim. A
-separate `wait_for_agents` continuation will then park on an explicit bounded
-set and consume their immutable results in stable order. The model surface stays
-unchanged until both halves are available; this avoids advertising fan-out that
-cannot recover correctly after restart.
+One foreground turn may have at most four unsettled children. A child remains
+unsettled while it is still running or while its terminal delivery is waiting
+to be consumed. The model can launch independent tasks one at a time, retaining
+each returned ID, and then make one ordered `wait_for_agents` call. That call
+uses `All` semantics: it atomically records the pending tool call and exact
+ordered child set, applies progress once, and releases the foreground lease.
+After every child has a terminal delivery, recovery consumes all deliveries,
+completes the same tool call with results in request order, journals the exact
+completion event, and moves the turn to `resuming`.
 
-A background sandbox has no shared conversation, filesystem, network, or
-host-folder access. It receives one bounded task and may be offered exactly
+The foreground turn cannot silently finish while one of its children is still
+unsettled. If the model tries, the completion boundary keeps the turn alive and
+gives the next model call the complete ordered ID list it must wait for. This is
+a storage-backed correctness guard, not merely a prompt convention.
+
+All orchestration identities are stable across ambiguous responses. An exact
+spawn or wait retry recovers its prior receipt rather than creating another
+child or consuming a result twice. Live event delivery uses the exact journaled
+sequence; reconnecting clients replay the journal, and cursor-based consumers
+can ignore a repeated live publication after commit-response loss.
+
+A background sandbox has no shared conversation, filesystem, general network,
+or host-folder access. It receives one bounded task and may be offered exactly
 one tool call: `web_search` when its remaining model-step budget can also
 consume the result, or a sandbox-only `request_folder_access` proposal. The
 proposal is a typed terminal child result, not a client call: it cannot open a
@@ -97,7 +109,7 @@ atomically parks only web search under its exact lease; a separate host-owned
 executor performs that bounded search and writes an immutable receipt. On a
 later claim, the sandbox reconstructs the matching `ToolUse`/`ToolResult` from
 that receipt before it can finalize. Sandboxes do not receive
-`spawn_sandbox_agent` and cannot create further agents.
+`spawn_sandbox_agent` or `wait_for_agents` and cannot create further agents.
 
 Future sandbox-safe capabilities, such as broker-mediated folder reads, must
 be added one at a time behind the same durable continuation and consent


### PR DESCRIPTION
## Summary

- explain non-blocking background-agent spawn and ordered multi-agent waits
- document depth-one and four-unsettled-child bounds in user-facing terms
- describe terminal completion guards, sandbox isolation, and restart recovery

## Validation

- Markdown diff and whitespace checks
- stale blocking-spawn and inactive-wait claim audit
- public-reference and attribution hygiene scan
