### PR TITLE
Fix hosted Clippy regressions

### DIFF
--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -109,6 +109,7 @@ pub(crate) struct SandboxAgentRunWorker {
 
 impl SandboxAgentRunWorker {
     #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         store: Arc<dyn Store>,
         resolver: Arc<dyn ProviderResolver>,

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -8753,7 +8753,7 @@ async fn foreground_spawn_is_nonblocking_and_ordered_wait_resumes_with_child_res
         turn.claim_count, 4,
         "two spawn continuations and ordered wait each require a fresh lease"
     );
-    let requests = provider.requests.lock().unwrap();
+    let requests = provider.requests.lock().unwrap().clone();
     assert_eq!(requests.len(), 7);
     let foreground = requests
         .iter()
@@ -8808,7 +8808,6 @@ async fn foreground_spawn_is_nonblocking_and_ordered_wait_resumes_with_child_res
             )
         })
     }));
-    drop(requests);
     let calls = store.list_tool_calls(chat.id).await.unwrap();
     assert_eq!(calls.len(), 3);
     assert!(calls.iter().all(|call| {


### PR DESCRIPTION
## Summary

- allow the intentionally wide test-only sandbox worker constructor
- snapshot provider requests before later asynchronous store reads
- restore clean hosted Clippy checks on the background-agent integration test

## Validation

- `cargo fmt --all --check`
- `bw dev lint --rust --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p openwave-server foreground_spawn_is_nonblocking_and_ordered_wait_resumes_with_child_result --lib`
