### PR TITLE
Use neutral audit test path

### DIFF
--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -580,7 +580,7 @@ mod tests {
 
     #[test]
     fn audit_targets_never_include_an_absolute_path() {
-        let target = AuditTarget::selected_folder(Path::new("/Users/thet/Documents/private"));
+        let target = AuditTarget::selected_folder(Path::new("/fixtures/private"));
         let encoded = serde_json::to_string(&event(target)).unwrap();
         assert!(encoded.contains("private"));
         assert!(!encoded.contains("Users"));


### PR DESCRIPTION
## Summary

- replace a developer-specific absolute path in the audit redaction test
- retain the same basename-redaction coverage with a neutral fixture path

## Validation

- `cargo fmt --all --check`
- `bw dev lint --rust --check`
- `cargo test -p openwave-host-broker audit_targets_never_include_an_absolute_path --lib`
