### PR TITLE
Refresh agent activity after tool completion

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentRunRefresh.test.ts
+++ b/crates/openwave-desktop/ui/src/AgentRunRefresh.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "./api";
+import { shouldRefreshAgentRunsAfterToolEvent } from "./AgentRunRefresh";
+
+describe("agent-run tool refresh boundary", () => {
+  it("refreshes after durable tool completion, not speculative tool start", () => {
+    const started: AgentEvent = {
+      type: "tool_call_started",
+      call_id: "call-1",
+      name: "spawn_sandbox_agent",
+    };
+    const completed: AgentEvent = {
+      type: "tool_call_completed",
+      call_id: "call-1",
+      status: "completed",
+    };
+
+    expect(shouldRefreshAgentRunsAfterToolEvent(started)).toBe(false);
+    expect(shouldRefreshAgentRunsAfterToolEvent(completed)).toBe(true);
+    expect(
+      shouldRefreshAgentRunsAfterToolEvent({
+        ...completed,
+        status: "failed",
+      }),
+    ).toBe(true);
+  });
+});

--- a/crates/openwave-desktop/ui/src/AgentRunRefresh.ts
+++ b/crates/openwave-desktop/ui/src/AgentRunRefresh.ts
@@ -1,0 +1,11 @@
+import type { AgentEvent } from "./api";
+
+/**
+ * Agent-run mutations performed by tools are query-visible at the durable
+ * completion boundary, not when the provider first announces the call.
+ */
+export function shouldRefreshAgentRunsAfterToolEvent(
+  event: AgentEvent,
+): boolean {
+  return event.type === "tool_call_completed";
+}

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -49,6 +49,7 @@ import {
   presentChatTranscript,
 } from "./ChatTranscriptPresentation";
 import { AgentActivityPanel, agentRunsForChat } from "./AgentActivityPanel";
+import { shouldRefreshAgentRunsAfterToolEvent } from "./AgentRunRefresh";
 import {
   SandboxAgentStopFence,
   canStopSandboxAgentRun,
@@ -429,6 +430,10 @@ export default function App() {
     lastSeqRef.current = framed.seq;
     const event = framed.event;
 
+    if (shouldRefreshAgentRunsAfterToolEvent(event)) {
+      refreshAgentRunsRef.current?.();
+    }
+
     if (event.type === "turn_started") {
       const startsDifferentTurn = activeTurnIdRef.current !== event.turn_id;
       refreshAgentRunsRef.current?.();
@@ -504,7 +509,6 @@ export default function App() {
         assistantMarkerScrubberRef.current =
           new AssistantSourceMarkerStreamScrubber();
       }
-      refreshAgentRunsRef.current?.();
       if (event.name === "request_folder_access") {
         refreshFolderAccessRef.current?.();
       }


### PR DESCRIPTION
## Summary

- refresh agent activity when a tool call reaches its durable completion event
- stop querying at the speculative tool-start boundary where a spawned child may not be visible yet
- cover the event-to-refresh policy while retaining active-child polling

## Validation

- `pnpm test` (130 tests)
- `pnpm build`
