### PR TITLE
Bind exact files to sandbox admissions

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1205,7 +1205,7 @@ impl Agent {
                     transcript.push(ChatMessage {
                         role: Role::User,
                         content: vec![ContentBlock::Text {
-                            text: "The sandbox task must be one non-empty, bounded `task` field with no extra properties. Retry with that exact shape.".into(),
+                            text: "The sandbox task needs one non-empty, bounded `task`. It may also include one `resource` object containing only `root_id` and `relative_path`; omit `resource` entirely when unused rather than sending null. Retry with that exact shape.".into(),
                         }],
                     });
                     continue;
@@ -2455,6 +2455,10 @@ mod tests {
         arguments: &'static str,
     }
 
+    struct SandboxCorrectionProvider {
+        calls: AtomicUsize,
+    }
+
     struct ContextRecordingTool {
         observed_project: Arc<Mutex<Option<Option<ProjectId>>>>,
     }
@@ -2729,6 +2733,46 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl ModelProvider for SandboxCorrectionProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("sandbox-correction")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let first = self.calls.fetch_add(1, Ordering::SeqCst) == 0;
+            let arguments = if first {
+                r#"{"task":"Research the error handling options.","resource":null}"#
+            } else {
+                r#"{"task":"Research the error handling options."}"#
+            };
+            Ok(stream::iter(vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: if first {
+                        "sandbox_null".into()
+                    } else {
+                        "sandbox_omitted".into()
+                    },
+                    name: crate::SPAWN_SANDBOX_AGENT_TOOL.into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: arguments.into(),
+                },
+                ProviderEvent::Usage(Usage {
+                    input_tokens: 5,
+                    output_tokens: 2,
+                    ..Usage::default()
+                }),
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ])
+            .boxed())
+        }
+    }
+
     #[tokio::test]
     async fn claimed_agent_returns_a_client_tool_checkpoint_without_executing_it() {
         let db = tempfile::tempdir().unwrap();
@@ -2958,6 +3002,49 @@ mod tests {
             AgentEvent::ToolCallStarted { name, .. }
                 if name == crate::SPAWN_SANDBOX_AGENT_TOOL
         )));
+
+        let mut correction_registry = ToolRegistry::new();
+        correction_registry.register_foreground_agent_orchestration();
+        let correction_provider = Arc::new(SandboxCorrectionProvider {
+            calls: AtomicUsize::new(0),
+        });
+        let correction_agent = Agent::new(
+            correction_provider.clone(),
+            Arc::new(correction_registry),
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        )
+        .with_durable_steer(lease_token)
+        .with_foreground_agent_orchestration();
+        let (correction_tx, correction_rx) = unbounded();
+        let corrected = correction_agent
+            .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &correction_tx)
+            .await
+            .unwrap();
+        drop(correction_tx);
+        let correction_events = emitted_events(correction_rx.collect().await);
+        let AgentTurnOutcome::SandboxAgentSpawn {
+            request,
+            model_steps,
+            ..
+        } = corrected
+        else {
+            panic!("foreground agent should correct a noncanonical sandbox resource");
+        };
+        assert_eq!(correction_provider.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(model_steps, 2);
+        assert_eq!(
+            request.arguments,
+            serde_json::json!({"task": "Research the error handling options."})
+        );
+        assert!(request.is_well_formed());
+        assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
+        assert!(correction_events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::StreamInterrupted)));
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use std::collections::HashSet;
 
 use crate::error::{AgentError, Result};
-use crate::id::AgentRunId;
+use crate::id::{AgentRunId, HostRootId};
 use crate::model::{
     AgentRun, AgentRunInboxEntry, AgentRunResultPayload, ToolCallRecord, TurnAgentRunWaitSet,
 };
@@ -50,6 +50,30 @@ pub(crate) const WAIT_CANCELLED_WITH_TURN_RESULT: &str =
 pub struct SpawnSandboxAgentArgs {
     /// A self-contained task for the isolated child. It cannot spawn children.
     pub task: String,
+    /// Optional exact file the child may receive through a later capability.
+    ///
+    /// Persisting this delegation grants no file access by itself. The initial
+    /// runtime deliberately advertises no sandbox file-read tool.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<SandboxAgentFileResource>,
+}
+
+/// One exact, pathless-root file identity delegated to a sandbox child.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SandboxAgentFileResource {
+    /// Opaque host-broker root identity attached to the foreground chat.
+    pub root_id: HostRootId,
+    /// Nonempty path relative to that root; absolute and parent paths are invalid.
+    pub relative_path: String,
+}
+
+impl SandboxAgentFileResource {
+    /// Whether this is a bounded, canonical root-relative file identity.
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        crate::client_tools::valid_connected_folder_path(&self.relative_path, false)
+    }
 }
 
 /// Closed model-facing acknowledgement for a non-blocking sandbox spawn.
@@ -199,14 +223,25 @@ impl SpawnSandboxAgentArgs {
             && !self.task.contains('\0')
             && self.task.chars().count() <= MAX_SANDBOX_AGENT_TASK_CHARS
             && self.task.len() <= AgentRun::MAX_INPUT_LEN
+            && self
+                .resource
+                .as_ref()
+                .is_none_or(SandboxAgentFileResource::is_well_formed)
     }
 }
 
 /// Validate one canonical model payload before the foreground worker parks.
 #[must_use]
 pub fn validate_spawn_sandbox_agent_arguments(arguments: &Value) -> bool {
-    serde_json::from_value::<SpawnSandboxAgentArgs>(arguments.clone())
-        .is_ok_and(|arguments| arguments.is_well_formed())
+    parse_canonical_spawn_sandbox_agent_arguments(arguments).is_some()
+}
+
+pub(crate) fn parse_canonical_spawn_sandbox_agent_arguments(
+    arguments: &Value,
+) -> Option<SpawnSandboxAgentArgs> {
+    let decoded = serde_json::from_value::<SpawnSandboxAgentArgs>(arguments.clone()).ok()?;
+    (decoded.is_well_formed() && serde_json::to_value(&decoded).ok().as_ref() == Some(arguments))
+        .then_some(decoded)
 }
 
 /// Validate one canonical ordered all-children wait proposal.
@@ -235,6 +270,21 @@ pub fn spawn_sandbox_agent_tool_spec() -> ToolSpec {
                     "minLength": 1,
                     "maxLength": MAX_SANDBOX_AGENT_TASK_CHARS,
                     "description": "A concise, self-contained task for one isolated background agent."
+                },
+                "resource": {
+                    "type": "object",
+                    "description": "Optional exact file identity within a folder already connected to this conversation. This delegates only its identity; the sandbox currently has no file-read tool.",
+                    "properties": {
+                        "root_id": { "type": "string", "format": "uuid" },
+                        "relative_path": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": crate::client_tools::MAX_CONNECTED_FOLDER_PATH_BYTES,
+                            "description": "Nonempty root-relative file path."
+                        }
+                    },
+                    "required": ["root_id", "relative_path"],
+                    "additionalProperties": false
                 }
             },
             "required": ["task"],
@@ -335,7 +385,35 @@ mod tests {
         assert!(validate_spawn_sandbox_agent_arguments(&valid));
         assert!(!validate_spawn_sandbox_agent_arguments(
             &serde_json::json!({
+                "task": "Research without a delegated file.",
+                "resource": null
+            })
+        ));
+        assert!(validate_spawn_sandbox_agent_arguments(&serde_json::json!({
+            "task": "Inspect the exact report.",
+            "resource": {
+                "root_id": uuid::Uuid::new_v4(),
+                "relative_path": "reports/summary.md"
+            }
+        })));
+        assert!(!validate_spawn_sandbox_agent_arguments(
+            &serde_json::json!({
                 "task": "",
+            })
+        ));
+        assert!(!validate_spawn_sandbox_agent_arguments(
+            &serde_json::json!({
+                "task": "Escape the connected root.",
+                "resource": {
+                    "root_id": uuid::Uuid::new_v4(),
+                    "relative_path": "../private.txt"
+                }
+            })
+        ));
+        assert!(!validate_spawn_sandbox_agent_arguments(
+            &serde_json::json!({
+                "task": "Use a partial resource.",
+                "resource": { "root_id": uuid::Uuid::new_v4() }
             })
         ));
         assert!(!validate_spawn_sandbox_agent_arguments(
@@ -358,6 +436,10 @@ mod tests {
         assert_eq!(spec.input_schema["additionalProperties"], false);
         assert_eq!(spec.input_schema["required"], serde_json::json!(["task"]));
         assert_eq!(spec.input_schema["properties"]["task"]["maxLength"], 16_000);
+        assert_eq!(
+            spec.input_schema["properties"]["resource"]["required"],
+            serde_json::json!(["root_id", "relative_path"])
+        );
         assert!(spec.description.contains("do not ask it to spawn"));
     }
 

--- a/crates/openwave-core/src/client_tools.rs
+++ b/crates/openwave-core/src/client_tools.rs
@@ -276,7 +276,7 @@ pub fn read_connected_file_tool_spec() -> ToolSpec {
     }
 }
 
-fn valid_connected_folder_path(path: &str, allow_root: bool) -> bool {
+pub(crate) fn valid_connected_folder_path(path: &str, allow_root: bool) -> bool {
     if path.len() > MAX_CONNECTED_FOLDER_PATH_BYTES
         || path.contains('\0')
         || path.contains('\\')

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -377,6 +377,8 @@ pub mod sandbox_agent_admission {
         pub origin_turn_id: Uuid,
         pub chat_id: Uuid,
         pub spawn_call_id: Uuid,
+        pub delegated_root_id: Option<Uuid>,
+        pub delegated_relative_path: Option<String>,
         pub admitted_at: DateTimeUtc,
     }
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -2034,6 +2034,8 @@ impl MigrationTrait for Init {
                             .not_null()
                             .unique_key(),
                     )
+                    .col(ColumnDef::new(SandboxAgentAdmission::DelegatedRootId).uuid())
+                    .col(ColumnDef::new(SandboxAgentAdmission::DelegatedRelativePath).text())
                     .col(
                         ColumnDef::new(SandboxAgentAdmission::AdmittedAt)
                             .timestamp_with_time_zone()
@@ -2066,6 +2068,17 @@ impl MigrationTrait for Init {
                             .to_col(TurnRun::ChatId)
                             .to_col(TurnRun::AgentRunId)
                             .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .check(
+                        Expr::col(SandboxAgentAdmission::DelegatedRootId)
+                            .is_null()
+                            .and(Expr::col(SandboxAgentAdmission::DelegatedRelativePath).is_null())
+                            .or(Expr::col(SandboxAgentAdmission::DelegatedRootId)
+                                .is_not_null()
+                                .and(
+                                    Expr::col(SandboxAgentAdmission::DelegatedRelativePath)
+                                        .is_not_null(),
+                                )),
                     )
                     .to_owned(),
             )
@@ -5011,6 +5024,8 @@ enum SandboxAgentAdmission {
     OriginTurnId,
     ChatId,
     SpawnCallId,
+    DelegatedRootId,
+    DelegatedRelativePath,
     AdmittedAt,
 }
 

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -4,6 +4,7 @@ use sea_orm::{
     QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
 };
 
+use crate::agent_tools::SandboxAgentFileResource;
 use crate::error::{AgentError, Result};
 use crate::id::{AgentRunId, CallId, ChatId, MessageId, TurnId};
 use crate::model::{
@@ -299,6 +300,7 @@ pub(in crate::db) async fn admit_sandbox_agent_run(
         &turn,
         spawn_call_id,
         input,
+        None,
         lease_token,
         expected_steer_revision,
         max_outstanding_children,
@@ -322,6 +324,7 @@ pub(in crate::db) async fn admit_sandbox_agent_run(
                 AgentRunId(turn.agent_run_id),
                 spawn_call_id,
                 input,
+                None,
             )
             .await?
             {
@@ -351,6 +354,7 @@ pub(in crate::db) async fn admit_sandbox_agent_run_on<C>(
     turn: &entities::turn_run::Model,
     spawn_call_id: CallId,
     input: &str,
+    resource: Option<&SandboxAgentFileResource>,
     lease_token: uuid::Uuid,
     expected_steer_revision: i64,
     max_outstanding_children: u32,
@@ -371,6 +375,7 @@ where
         parent_id,
         spawn_call_id,
         input,
+        resource,
     )
     .await?
     {
@@ -418,6 +423,19 @@ where
     if !parent_available {
         return Ok(AdmitSandboxAgentRunOutcome::ParentUnavailable);
     }
+    if let Some(resource) = resource {
+        let attached = entities::chat_root_attachment::Entity::find_by_id((
+            chat_id.0,
+            *resource.root_id.as_uuid(),
+        ))
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .is_some();
+        if !attached {
+            return Ok(AdmitSandboxAgentRunOutcome::DelegatedResourceUnavailable);
+        }
+    }
 
     // A terminal child remains outstanding until its immutable delivery has
     // been consumed or explicitly retired. Counting only live run rows would
@@ -464,6 +482,8 @@ where
         origin_turn_id: Set(origin_turn_id.0),
         chat_id: Set(chat_id.0),
         spawn_call_id: Set(spawn_call_id.0),
+        delegated_root_id: Set(resource.map(|resource| *resource.root_id.as_uuid())),
+        delegated_relative_path: Set(resource.map(|resource| resource.relative_path.clone())),
         admitted_at: Set(created_at),
     }
     .insert(conn)
@@ -482,6 +502,7 @@ async fn resolve_existing_sandbox_admission_on<C>(
     parent_id: AgentRunId,
     spawn_call_id: CallId,
     input: &str,
+    resource: Option<&SandboxAgentFileResource>,
 ) -> Result<Option<AdmitSandboxAgentRunOutcome>>
 where
     C: sea_orm::ConnectionTrait,
@@ -503,6 +524,9 @@ where
             && admission.origin_turn_id == origin_turn_id.0
             && admission.chat_id == chat_id.0
             && admission.spawn_call_id == spawn_call_id.0
+            && admission.delegated_root_id == resource.map(|resource| *resource.root_id.as_uuid())
+            && admission.delegated_relative_path.as_deref()
+                == resource.map(|resource| resource.relative_path.as_str())
             && child.as_ref().is_some_and(|child| {
                 child.chat_id == chat_id.0
                     && child.parent_id == Some(parent_id.0)
@@ -584,6 +608,7 @@ pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
         &turn,
         spawn_call_id,
         input,
+        None,
         lease_token,
         expected_steer_revision,
         AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
@@ -603,6 +628,7 @@ pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
                 parent_id,
                 spawn_call_id,
                 input,
+                None,
             )
             .await?
             .is_some()
@@ -639,6 +665,12 @@ pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
             transaction.commit().await.map_err(store_err)?;
             return Ok(Some(
                 AcceptSandboxAgentRunAndParkTurnOutcome::ParentUnavailable,
+            ));
+        }
+        AdmitSandboxAgentRunOutcome::DelegatedResourceUnavailable => {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(Some(
+                AcceptSandboxAgentRunAndParkTurnOutcome::IdentityConflict,
             ));
         }
         AdmitSandboxAgentRunOutcome::LeaseLost => {
@@ -2409,18 +2441,37 @@ pub(in crate::db) fn agent_run_from_model(model: entities::agent_run::Model) -> 
 fn sandbox_agent_admission_from_model(
     model: entities::sandbox_agent_admission::Model,
 ) -> Result<SandboxAgentAdmission> {
+    let resource = match (model.delegated_root_id, model.delegated_relative_path) {
+        (Some(root_id), Some(relative_path)) => Some(SandboxAgentFileResource {
+            root_id: crate::HostRootId::from_uuid(root_id).map_err(|error| {
+                AgentError::Store(format!("invalid delegated root id: {error}"))
+            })?,
+            relative_path,
+        }),
+        (None, None) => None,
+        _ => {
+            return Err(AgentError::Store(
+                "stored sandbox delegation has a partial file identity".into(),
+            ));
+        }
+    };
     let admission = SandboxAgentAdmission {
         child_run_id: AgentRunId(model.child_run_id),
         parent_run_id: AgentRunId(model.parent_run_id),
         origin_turn_id: TurnId(model.origin_turn_id),
         chat_id: ChatId(model.chat_id),
         spawn_call_id: CallId(model.spawn_call_id),
+        resource,
         admitted_at: model.admitted_at,
     };
     if admission.child_run_id != AgentRunId::sandbox_for_spawn_call(admission.spawn_call_id)
         || admission.parent_run_id.0.is_nil()
         || admission.origin_turn_id.0.is_nil()
         || admission.chat_id.0.is_nil()
+        || admission
+            .resource
+            .as_ref()
+            .is_some_and(|resource| !resource.is_well_formed())
     {
         return Err(AgentError::Store(
             "invalid stored sandbox agent admission".into(),

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -5,7 +5,8 @@ use sea_orm::{
 };
 
 use crate::agent_tools::{
-    SpawnSandboxAgentArgs, SpawnSandboxAgentResult, SPAWN_SANDBOX_AGENT_TOOL,
+    parse_canonical_spawn_sandbox_agent_arguments, SpawnSandboxAgentArgs, SpawnSandboxAgentResult,
+    SPAWN_SANDBOX_AGENT_TOOL,
 };
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
@@ -167,12 +168,13 @@ where
         return Ok(CheckpointSandboxSpawnOutcome::IdentityConflict);
     }
 
-    let task = canonical_task(request)?;
+    let arguments = canonical_arguments(request)?;
     let admission = admit_sandbox_agent_run_on(
         conn,
         turn,
         request.call_id,
-        &task,
+        &arguments.task,
+        arguments.resource.as_ref(),
         request.lease_token,
         request.expected_steer_revision,
         AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
@@ -189,6 +191,9 @@ where
         }
         AdmitSandboxAgentRunOutcome::ParentUnavailable => {
             return Ok(CheckpointSandboxSpawnOutcome::ParentUnavailable)
+        }
+        AdmitSandboxAgentRunOutcome::DelegatedResourceUnavailable => {
+            return Ok(CheckpointSandboxSpawnOutcome::DelegatedResourceUnavailable)
         }
         AdmitSandboxAgentRunOutcome::LeaseLost => {
             return Ok(CheckpointSandboxSpawnOutcome::LeaseLost)
@@ -402,7 +407,7 @@ where
         output: ToolOutput::text(checkpoint.result.clone()),
     };
     let stored_event: AgentEvent = serde_json::from_value(event.payload)?;
-    let task = canonical_task(request)?;
+    let arguments = canonical_arguments(request)?;
     let raw_call_valid = call_model.error_code.is_none()
         && call_model.error_detail.is_none()
         && call_model.approval_status.is_none()
@@ -430,7 +435,17 @@ where
         || child.spawn_call_id != Some(checkpoint.call_id.0)
         || child.execution != crate::AgentRunExecution::Sandbox.as_str()
         || child.depth != i16::from(AgentRun::MAX_DEPTH)
-        || child.input.as_deref() != Some(task.as_str())
+        || child.input.as_deref() != Some(arguments.task.as_str())
+        || admission.delegated_root_id
+            != arguments
+                .resource
+                .as_ref()
+                .map(|resource| *resource.root_id.as_uuid())
+        || admission.delegated_relative_path.as_deref()
+            != arguments
+                .resource
+                .as_ref()
+                .map(|resource| resource.relative_path.as_str())
         || child.created_at > checkpoint.committed_at
         || call.id != checkpoint.call_id
         || call.chat_id != checkpoint.chat_id
@@ -487,18 +502,13 @@ fn validate_request(request: &SandboxSpawnCheckpointRequest) -> Result<()> {
             "invalid non-blocking sandbox spawn checkpoint".into(),
         ));
     }
-    canonical_task(request)?;
+    canonical_arguments(request)?;
     Ok(())
 }
 
-fn canonical_task(request: &SandboxSpawnCheckpointRequest) -> Result<String> {
-    let arguments: SpawnSandboxAgentArgs = serde_json::from_value(request.arguments.clone())
-        .map_err(|_| AgentError::Store("invalid sandbox spawn arguments".into()))?;
-    if !arguments.is_well_formed() || serde_json::to_value(&arguments)? != request.arguments {
-        return Err(AgentError::Store(
-            "sandbox spawn arguments are not canonical".into(),
-        ));
-    }
+fn canonical_arguments(request: &SandboxSpawnCheckpointRequest) -> Result<SpawnSandboxAgentArgs> {
+    let arguments = parse_canonical_spawn_sandbox_agent_arguments(&request.arguments)
+        .ok_or_else(|| AgentError::Store("sandbox spawn arguments are not canonical".into()))?;
     let child_run_id = AgentRunId::sandbox_for_spawn_call(request.call_id);
     let canonical_result = serde_json::to_string(&SpawnSandboxAgentResult {
         agent_id: child_run_id,
@@ -508,7 +518,7 @@ fn canonical_task(request: &SandboxSpawnCheckpointRequest) -> Result<String> {
             "sandbox spawn result is not canonical".into(),
         ));
     }
-    Ok(arguments.task)
+    Ok(arguments)
 }
 
 struct CheckpointTotals {

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -909,6 +909,8 @@ async fn sandbox_admission_rejects_cross_turn_identity_and_fk_corruption() {
         origin_turn_id: Set(second_turn.id.0),
         chat_id: Set(second_chat.id.0),
         spawn_call_id: Set(CallId::new().0),
+        delegated_root_id: Set(None),
+        delegated_relative_path: Set(None),
         admitted_at: Set(Utc::now()),
     };
     assert!(malformed.insert(&store.conn).await.is_err());

--- a/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
@@ -1,10 +1,14 @@
 use super::{sample_chat, temp_store};
-use crate::agent_tools::{SpawnSandboxAgentResult, SPAWN_SANDBOX_AGENT_TOOL};
+use crate::agent_tools::{
+    SandboxAgentFileResource, SpawnSandboxAgentResult, SPAWN_SANDBOX_AGENT_TOOL,
+};
 use crate::provider::ContentBlock;
 use crate::{
-    AgentEvent, AgentRun, AgentRunId, AgentRunStatus, CallId, CheckpointSandboxSpawnOutcome,
-    ResolveToolCallOutcome, SandboxSpawnCheckpointRequest, Store, ToolCallExecution,
-    ToolCallRecord, ToolCallStatus, TurnCheckpointProgress, TurnId, TurnRunStatus, Usage,
+    AgentEvent, AgentRun, AgentRunId, AgentRunStatus, CallId, ChatRootAttachment,
+    CheckpointSandboxSpawnOutcome, HostRootId, ResolveToolCallOutcome, RootAttachmentChangeAction,
+    RootAttachmentChangeId, RootAttachmentChangeTerminal, RootAttachmentOrigin,
+    SandboxSpawnCheckpointRequest, Store, ToolCallExecution, ToolCallRecord, ToolCallStatus,
+    TurnCheckpointProgress, TurnId, TurnRunStatus, Usage,
 };
 use chrono::{Duration, Utc};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
@@ -68,6 +72,21 @@ fn request(
     }
 }
 
+fn resource_request(
+    turn: &crate::TurnRun,
+    lease_token: uuid::Uuid,
+    call_id: CallId,
+    task: &str,
+    resource: &SandboxAgentFileResource,
+) -> SandboxSpawnCheckpointRequest {
+    let mut request = request(turn, lease_token, call_id, task, 2, progress());
+    request.arguments = serde_json::json!({
+        "task": task,
+        "resource": resource,
+    });
+    request
+}
+
 fn progress() -> TurnCheckpointProgress {
     TurnCheckpointProgress {
         model_steps: 1,
@@ -78,6 +97,47 @@ fn progress() -> TurnCheckpointProgress {
             cache_creation_input_tokens: 2,
         },
     }
+}
+
+async fn detach_conversation_root(
+    store: &crate::DbStore,
+    chat_id: crate::ChatId,
+    root_id: HostRootId,
+) {
+    let executor_id = uuid::Uuid::new_v4();
+    let created_at =
+        chrono::DateTime::from_timestamp_micros(Utc::now().timestamp_micros()).unwrap();
+    let change_id = RootAttachmentChangeId::new();
+    let revision = store
+        .get_chat(chat_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .attachment_revision;
+    store
+        .begin_root_attachment_change(&crate::BeginRootAttachmentChange {
+            id: change_id,
+            chat_id,
+            executor_id,
+            root_id,
+            action: RootAttachmentChangeAction::Detach,
+            expected_attachment_revision: revision,
+            created_at,
+        })
+        .await
+        .unwrap();
+    store
+        .finish_root_attachment_change(
+            change_id,
+            executor_id,
+            &RootAttachmentChangeTerminal::Completed {
+                broker_changed: true,
+                broker_currently_attached: false,
+            },
+            created_at + Duration::seconds(1),
+        )
+        .await
+        .unwrap();
 }
 
 #[tokio::test]
@@ -197,6 +257,220 @@ async fn nonblocking_spawn_commits_one_atomic_yield_and_exact_retry_survives_rec
     assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 2);
     assert_eq!(store.list_tool_calls(chat.id).await.unwrap(), vec![call]);
     assert_eq!(store.list_events(chat.id, 0).await.unwrap().len(), 2);
+    assert_eq!(
+        store
+            .get_sandbox_agent_admission(child.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .resource,
+        None
+    );
+}
+
+#[tokio::test]
+async fn exact_file_delegation_commits_with_admission_and_fences_retries() {
+    let (_dir, store) = temp_store().await;
+    let resource = SandboxAgentFileResource {
+        root_id: HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+        relative_path: "reports/summary.md".into(),
+    };
+    let mut chat = sample_chat();
+    chat.attachment_revision = 1;
+    chat.root_attachments.push(ChatRootAttachment {
+        root_id: resource.root_id,
+        origin: RootAttachmentOrigin::Conversation,
+    });
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = running_turn(&store, chat.id).await;
+    let request = resource_request(&turn, lease, CallId::new(), "inspect one report", &resource);
+
+    let child = match store
+        .checkpoint_sandbox_spawn(&request, Utc::now())
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        CheckpointSandboxSpawnOutcome::Checkpointed { child, .. } => child,
+        outcome => panic!("unexpected resource spawn outcome: {outcome:?}"),
+    };
+    assert_eq!(
+        store
+            .get_sandbox_agent_admission(child.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .resource,
+        Some(resource.clone())
+    );
+    detach_conversation_root(&store, chat.id, resource.root_id).await;
+    assert!(matches!(
+        store
+            .checkpoint_sandbox_spawn(&request, Utc::now())
+            .await
+            .unwrap(),
+        Some(CheckpointSandboxSpawnOutcome::Existing { child: existing, .. }) if existing == child
+    ));
+
+    let mut changed = request;
+    changed.arguments["resource"]["relative_path"] = serde_json::json!("reports/other.md");
+    assert!(matches!(
+        store
+            .checkpoint_sandbox_spawn(&changed, Utc::now())
+            .await
+            .unwrap(),
+        Some(CheckpointSandboxSpawnOutcome::IdentityConflict)
+    ));
+    assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 2);
+    assert_eq!(store.list_tool_calls(chat.id).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn unattached_file_delegation_rejects_without_partial_writes() {
+    let (_dir, store) = temp_store().await;
+    let resource = SandboxAgentFileResource {
+        root_id: HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+        relative_path: "reports/missing.md".into(),
+    };
+    let mut chat = sample_chat();
+    chat.attachment_revision = 1;
+    chat.root_attachments.push(ChatRootAttachment {
+        root_id: resource.root_id,
+        origin: RootAttachmentOrigin::Conversation,
+    });
+    store.create_chat(&chat).await.unwrap();
+    detach_conversation_root(&store, chat.id, resource.root_id).await;
+    assert!(store
+        .get_chat(chat.id)
+        .await
+        .unwrap()
+        .unwrap()
+        .root_attachments
+        .is_empty());
+
+    let (turn, lease) = running_turn(&store, chat.id).await;
+    let request = resource_request(
+        &turn,
+        lease,
+        CallId::new(),
+        "inspect a detached report",
+        &resource,
+    );
+
+    assert!(matches!(
+        store
+            .checkpoint_sandbox_spawn(&request, Utc::now())
+            .await
+            .unwrap(),
+        Some(CheckpointSandboxSpawnOutcome::DelegatedResourceUnavailable)
+    ));
+    assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 1);
+    assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
+    assert_eq!(store.list_events(chat.id, 0).await.unwrap().len(), 1);
+    assert_eq!(
+        store.get_turn_run(turn.id).await.unwrap().unwrap().status,
+        TurnRunStatus::Running
+    );
+}
+
+#[tokio::test]
+async fn concurrent_detach_and_file_delegation_serialize_to_one_coherent_snapshot() {
+    let (_dir, store) = temp_store().await;
+    let resource = SandboxAgentFileResource {
+        root_id: HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap(),
+        relative_path: "reports/race.md".into(),
+    };
+    let mut chat = sample_chat();
+    chat.attachment_revision = 1;
+    chat.root_attachments.push(ChatRootAttachment {
+        root_id: resource.root_id,
+        origin: RootAttachmentOrigin::Conversation,
+    });
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = running_turn(&store, chat.id).await;
+    let request = resource_request(
+        &turn,
+        lease,
+        CallId::new(),
+        "inspect while the root detaches",
+        &resource,
+    );
+
+    let executor_id = uuid::Uuid::new_v4();
+    let change_id = RootAttachmentChangeId::new();
+    let created_at =
+        chrono::DateTime::from_timestamp_micros(Utc::now().timestamp_micros()).unwrap();
+    store
+        .begin_root_attachment_change(&crate::BeginRootAttachmentChange {
+            id: change_id,
+            chat_id: chat.id,
+            executor_id,
+            root_id: resource.root_id,
+            action: RootAttachmentChangeAction::Detach,
+            expected_attachment_revision: 1,
+            created_at,
+        })
+        .await
+        .unwrap();
+
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(2));
+    let spawn_store = store.clone();
+    let spawn_barrier = barrier.clone();
+    let spawn = tokio::spawn(async move {
+        spawn_barrier.wait().await;
+        spawn_store
+            .checkpoint_sandbox_spawn(&request, Utc::now())
+            .await
+            .unwrap()
+            .unwrap()
+    });
+    let detach_store = store.clone();
+    let detach = tokio::spawn(async move {
+        barrier.wait().await;
+        detach_store
+            .finish_root_attachment_change(
+                change_id,
+                executor_id,
+                &RootAttachmentChangeTerminal::Completed {
+                    broker_changed: true,
+                    broker_currently_attached: false,
+                },
+                created_at + Duration::seconds(1),
+            )
+            .await
+            .unwrap();
+    });
+    let (spawn, detach) = tokio::join!(spawn, detach);
+    let spawn = spawn.expect("concurrent spawn task panicked");
+    detach.expect("concurrent detach task panicked");
+
+    assert!(store
+        .get_chat(chat.id)
+        .await
+        .unwrap()
+        .unwrap()
+        .root_attachments
+        .is_empty());
+    match spawn {
+        CheckpointSandboxSpawnOutcome::Checkpointed { child, .. } => {
+            assert_eq!(
+                store
+                    .get_sandbox_agent_admission(child.id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .resource,
+                Some(resource)
+            );
+            assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 2);
+            assert_eq!(store.list_tool_calls(chat.id).await.unwrap().len(), 1);
+        }
+        CheckpointSandboxSpawnOutcome::DelegatedResourceUnavailable => {
+            assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 1);
+            assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
+        }
+        outcome => panic!("unexpected concurrent delegation outcome: {outcome:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -45,10 +45,10 @@ pub use agent::{
 pub use agent_tools::{
     sandbox_web_search_tool_spec, spawn_sandbox_agent_tool_spec,
     validate_spawn_sandbox_agent_arguments, validate_wait_for_agents_arguments,
-    wait_for_agents_tool_spec, SpawnSandboxAgentArgs, SpawnSandboxAgentResult, WaitForAgentResult,
-    WaitForAgentsArgs, WaitForAgentsResult, MAX_SANDBOX_AGENT_TASK_CHARS,
-    MAX_WAIT_FOR_AGENTS_CHILDREN, SANDBOX_WEB_SEARCH_TOOL, SPAWN_SANDBOX_AGENT_TOOL,
-    WAIT_FOR_AGENTS_TOOL,
+    wait_for_agents_tool_spec, SandboxAgentFileResource, SpawnSandboxAgentArgs,
+    SpawnSandboxAgentResult, WaitForAgentResult, WaitForAgentsArgs, WaitForAgentsResult,
+    MAX_SANDBOX_AGENT_TASK_CHARS, MAX_WAIT_FOR_AGENTS_CHILDREN, SANDBOX_WEB_SEARCH_TOOL,
+    SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL,
 };
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1212,6 +1212,11 @@ pub struct SandboxAgentAdmission {
     pub chat_id: ChatId,
     /// Exact model call that requested the child.
     pub spawn_call_id: crate::id::CallId,
+    /// Optional exact file identity delegated only to this child.
+    ///
+    /// This immutable receipt is not host authority and does not imply that a
+    /// sandbox file-read capability exists.
+    pub resource: Option<crate::agent_tools::SandboxAgentFileResource>,
     /// Database time at which admission committed.
     pub admitted_at: DateTime<Utc>,
 }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -238,6 +238,8 @@ pub enum AdmitSandboxAgentRunOutcome {
     IdentityConflict,
     /// The origin turn does not have an eligible foreground coordinator.
     ParentUnavailable,
+    /// The delegated file root is not attached to the foreground chat.
+    DelegatedResourceUnavailable,
     /// The origin turn is not owned by the supplied live worker lease.
     LeaseLost,
     /// This origin turn already owns the configured number of nonterminal children.
@@ -272,6 +274,8 @@ pub enum CheckpointSandboxSpawnOutcome {
     IdentityConflict,
     /// The origin turn does not have an eligible foreground coordinator.
     ParentUnavailable,
+    /// The delegated file root is not attached to the foreground chat.
+    DelegatedResourceUnavailable,
     /// The exact foreground claim is missing, stale, or no longer live.
     LeaseLost,
     /// Four nonterminal children already belong to this origin turn.
@@ -1337,6 +1341,9 @@ pub trait Store: Send + Sync {
     /// parent, child, and immutable admission receipt commit together under the
     /// chat/turn write lock. Existing exact receipts are recovered before the
     /// bounded outstanding-child check, making an ambiguous commit retry safe.
+    /// A non-blocking checkpoint may additionally bind one exact root-relative
+    /// file identity after validating its root against the locked chat
+    /// attachment projection; the receipt itself grants no host authority.
     /// The stronger checkpoint boundary below composes this admission with the
     /// foreground transcript, progress, event, and immediate continuation.
     #[allow(clippy::too_many_arguments)]

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -1247,6 +1247,15 @@ impl TurnWorker {
                                 );
                                 break;
                             }
+                            Ok(Some(
+                                CheckpointSandboxSpawnOutcome::DelegatedResourceUnavailable,
+                            )) => {
+                                continuation_instruction = Some(
+                                    "That delegated file is no longer connected to this conversation. Continue without it or choose a currently connected file."
+                                        .into(),
+                                );
+                                break;
+                            }
                             Ok(Some(CheckpointSandboxSpawnOutcome::IdentityConflict))
                             | Ok(Some(CheckpointSandboxSpawnOutcome::ParentUnavailable)) => {
                                 checkpoint_heartbeat.abort_and_wait().await;


### PR DESCRIPTION
## Summary

- extend foreground sandbox spawn arguments with an optional exact file identity under an opaque connected root
- validate the root attachment and persist the immutable child-scoped delegation in the same transaction as admission and checkpointing
- recover exact retries after detachment, reject conflicting or unavailable delegations without partial writes, and keep sandbox file access disabled

## Validation

- `cargo fmt --all --check`
- `bw dev lint --rust --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p openwave-core --lib` (360 passed)
- concurrent detach/spawn serialization and exact retry/conflict/rollback coverage
