### PR TITLE
Render delegated file activity safely

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -615,6 +615,7 @@ fn tool_activity_from_call(call: ToolCallRecord) -> ChatToolActivitySnapshot {
 fn historical_tool_title(name: &str) -> &'static str {
     match name {
         "web_search" => "Search the web",
+        crate::SANDBOX_READ_DELEGATED_FILE_TOOL => "Read a delegated file",
         "read_file" | "read_connected_file" => "Read a file",
         "list_dir" => "Browse files",
         "write_file" => "Update a file",
@@ -624,6 +625,20 @@ fn historical_tool_title(name: &str) -> &'static str {
         "spawn_sandbox_agent" => "Delegate a task",
         "wait_for_agents" => "Wait for background agents",
         _ => "Use a tool",
+    }
+}
+
+#[cfg(test)]
+mod historical_tool_title_tests {
+    use super::historical_tool_title;
+
+    #[test]
+    fn delegated_file_reads_have_a_fixed_renderer_title() {
+        assert_eq!(
+            historical_tool_title(crate::SANDBOX_READ_DELEGATED_FILE_TOOL),
+            "Read a delegated file"
+        );
+        assert_eq!(historical_tool_title("private_read_variant"), "Use a tool");
     }
 }
 

--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.test.tsx
@@ -96,6 +96,32 @@ describe("AgentActivityPanel", () => {
     expect(markup).not.toContain("Reading a file");
   });
 
+  it("uses fixed waiting and running copy for delegated file reads", () => {
+    const markup = renderToStaticMarkup(
+      <AgentActivityPanel
+        runs={[
+          run({
+            id: "waiting-read",
+            activity: { kind: "read_delegated_file", status: "waiting" },
+          }),
+          run({
+            id: "running-read",
+            activity: { kind: "read_delegated_file", status: "running" },
+          }),
+        ]}
+        loading={false}
+        error={null}
+        onRetry={vi.fn()}
+        {...noStops}
+      />,
+    );
+
+    expect(markup).toContain("Waiting to read a delegated file");
+    expect(markup).toContain("Reading a delegated file");
+    expect(markup).not.toContain("waiting-read");
+    expect(markup).not.toContain("running-read");
+  });
+
   it("falls back safely for malformed future activity projections", () => {
     const malformedRuns = [
       run({

--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
@@ -213,6 +213,12 @@ function agentActivityPresentation(
       running: "Searching the web",
       activeStatus: "searching",
     },
+    read_delegated_file: {
+      label: "Delegated file",
+      waiting: "Waiting to read a delegated file",
+      running: "Reading a delegated file",
+      activeStatus: "reading",
+    },
     list_connected_folders: {
       label: "Connected folders",
       waiting: "Waiting to check connected folders",

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -41,6 +41,17 @@ describe("ToolCallCard", () => {
     expect(markup).toContain("Document search complete");
   });
 
+  it("renders a fixed delegated-file presentation without resource details", () => {
+    const markup = renderToStaticMarkup(
+      <ToolCallCard name="read_delegated_file" status="running" />,
+    );
+
+    expect(markup).toContain("Read a delegated file");
+    expect(markup).toContain("Reading a delegated file");
+    expect(markup).not.toContain("path");
+    expect(markup).not.toContain("root");
+  });
+
   it("distinguishes delegation from waiting for the child results", () => {
     const delegated = renderToStaticMarkup(
       <ToolCallCard name="spawn_sandbox_agent" status="completed" />,

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -52,6 +52,12 @@ const TOOL_PRESENTATIONS: Record<string, ToolPresentation> = {
     complete: "Web search complete",
     settled: "Searched the web",
   },
+  read_delegated_file: {
+    label: "Read a delegated file",
+    active: "Reading a delegated file",
+    complete: "Delegated file read complete",
+    settled: "Read a delegated file",
+  },
   read_file: {
     label: "Read a file",
     active: "Reading a file",

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
@@ -65,6 +65,22 @@ describe("hydrateTranscriptHistory", () => {
     expect(JSON.stringify(entries)).not.toContain("finished_at");
   });
 
+  it("hydrates delegated file reads as their fixed presentation kind", () => {
+    const entries = hydrateTranscriptHistory([], [
+      {
+        title: "Read a delegated file",
+        status: "completed",
+        started_at: "2026-07-16T10:00:00Z",
+        finished_at: "2026-07-16T10:00:01Z",
+      },
+    ]);
+
+    expect(entries).toEqual([
+      expect.objectContaining({ name: "read_delegated_file" }),
+    ]);
+    expect(JSON.stringify(entries)).not.toContain("finished_at");
+  });
+
   it("attaches sources only to their exact owning assistant message", () => {
     const entries = hydrateTranscriptHistory(
       [

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -24,6 +24,7 @@ export type HydratedTranscriptEntry =
 // cannot become a display path for provider names, arguments, or output.
 const HISTORY_TOOL_NAMES: Record<ChatToolActivity["title"], string> = {
   "Search the web": "web_search",
+  "Read a delegated file": "read_delegated_file",
   "Read a file": "read_file",
   "Browse files": "list_dir",
   "Update a file": "write_file",

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -141,6 +141,25 @@ describe("pending approval recovery", () => {
     ).toBeNull();
   });
 
+  it("recognizes only the fixed delegated-file renderer name", () => {
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "read_delegated_file",
+        approval: "unsupported",
+        can_approve: false,
+      }),
+    ).toMatchObject({ action: "read_delegated_file", canApprove: false });
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "read_delegated_file:/Users/private/document.txt",
+        approval: "unsupported",
+        can_approve: false,
+      }),
+    ).toBeNull();
+  });
+
   it("fails closed on malformed, duplicate, or cross-turn pages", async () => {
     const client = new ApiClient("http://127.0.0.1", "token");
     for (const body of [

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -71,6 +71,7 @@ export type ChatMessageCitation = {
 export type ChatToolActivity = {
   title:
     | "Search the web"
+    | "Read a delegated file"
     | "Read a file"
     | "Browse files"
     | "Update a file"
@@ -129,6 +130,7 @@ export type SandboxAgentCancellation = {
 export type AgentActivity = {
   kind:
     | "web_search"
+    | "read_delegated_file"
     | "list_connected_folders"
     | "list_folder"
     | "read_connected_file";
@@ -170,6 +172,7 @@ export type AgentEvent =
 export type RendererToolName =
   | "search"
   | "web_search"
+  | "read_delegated_file"
   | "read_file"
   | "list_dir"
   | "write_file"
@@ -596,6 +599,7 @@ function isRendererToolName(value: unknown): value is RendererToolName {
   return (
     value === "search" ||
     value === "web_search" ||
+    value === "read_delegated_file" ||
     value === "read_file" ||
     value === "list_dir" ||
     value === "write_file" ||

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -72,6 +72,7 @@ pub(crate) enum RendererAgentEvent {
 pub(crate) enum RendererToolName {
     Search,
     WebSearch,
+    ReadDelegatedFile,
     ReadFile,
     ListDir,
     WriteFile,
@@ -97,6 +98,7 @@ impl From<&str> for RendererToolName {
         match name {
             "search" => Self::Search,
             "web_search" => Self::WebSearch,
+            openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL => Self::ReadDelegatedFile,
             "read_file" => Self::ReadFile,
             "list_dir" => Self::ListDir,
             "write_file" => Self::WriteFile,
@@ -323,6 +325,10 @@ mod tests {
         for (name, expected) in [
             ("spawn_sandbox_agent", r#""name":"spawn_sandbox_agent""#),
             ("wait_for_agents", r#""name":"wait_for_agents""#),
+            (
+                openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL,
+                r#""name":"read_delegated_file""#,
+            ),
         ] {
             let projected = RendererSequencedEvent::from(&SequencedEvent {
                 seq: 1,


### PR DESCRIPTION
## Summary
- add a fixed renderer projection for delegated file reads
- show safe delegated-read copy in tool cards and background activity
- preserve the fixed presentation in durable transcript history

## Validation
- `bw dev lint --react --check`
- `bw dev lint --rust --check`
- `cargo test -p openwave-core delegated_file_reads_have_a_fixed_renderer_title`
- `cargo test -p openwave-server event_projection::tests::background_agent_tools_use_fixed_renderer_names`
- `pnpm --dir crates/openwave-desktop/ui test -- ToolCallCard.test.tsx AgentActivityPanel.test.tsx TranscriptHistory.test.ts api.test.ts`
- `pnpm --dir crates/openwave-desktop/ui build`