### PR TITLE
Document exact sandbox file delegation

### DIFF
--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -54,7 +54,7 @@ differ:
 | --- | --- |
 | Responds directly in the chat | Works on one delegated task |
 | Final assistant text completes a turn | An explicit result submission completes the run |
-| Uses conversation-facing tools | May make at most one web-search or folder-access proposal call; has no shared conversation context |
+| Uses conversation-facing tools | May make at most one sandbox-safe tool call; has no shared conversation context |
 | Usually short-lived work | May park and resume over a longer period |
 | Streams answer content | Publishes bounded progress and a final result |
 
@@ -87,6 +87,13 @@ foreground lease into `resuming`. The foreground can therefore be reclaimed
 and continue while the child runs. Only after the commit does the server wake
 the foreground and sandbox workers. Those notifications reduce latency; their
 durable scans remain the correctness path after a missed wake or restart.
+
+A spawn may also delegate one exact file as an opaque root ID plus a non-empty
+root-relative path. Admission verifies that the root is attached to the
+foreground chat and stores the resource immutably with that child. This does
+not grant a folder, expose a host path, or let the child choose another target;
+it only makes the argument-free desktop read described below eligible while
+the same attachment remains current.
 
 Each spawn call is made alone and returns one ID for the foreground agent to
 retain. Up to four children from the exact origin turn may be unsettled at once.
@@ -147,14 +154,24 @@ notification may reduce latency, but it is never the source of truth.
 ## Sandbox and host-access boundary
 
 A background agent has private runtime scratch but cannot access that scratch,
-projects, host folders, the general network, or the parent conversation. Its
-current narrow exceptions are one checkpointed public web search or a typed
-folder-access proposal that grants no access. It never receives the foreground
-spawn/wait or broker tool contracts. Foreground chats may inspect already
-attached roots, but sandbox agents do not receive the broker transport. Future
-sandbox folder access must use the parent-mediated consent and
-durable-receipt protocol described in [Host access and connected folders](host-access.md),
-never absolute paths.
+projects, general host folders, the general network, or the parent
+conversation. Its narrow exceptions share one total tool-call budget: a
+checkpointed public web search, a typed folder-access proposal that grants no
+access, or—only in the embedded desktop—one exact file named by its immutable
+admission. The read tool takes no arguments. A native executor revalidates the
+current chat attachment immediately before the host broker performs a bounded
+UTF-8 read, persists private no-replay recovery state, and publishes only
+bounded content or a neutral failure. Headless workers never advertise the
+read. Sandboxes do not receive foreground spawn/wait or broker transport
+contracts, and absolute paths never cross into provider context. See
+[Host access and connected folders](host-access.md).
+
+This is intentionally not chat-wide or root-wide access. A sandbox cannot list
+roots or directories, open a picker, request a different file, write, run a
+shell command, or use a general filesystem API. A detach can revoke the exact
+read before claim, at the final pre-dispatch heartbeat, or at resolution; if
+content arrived after authority was lost, it is discarded rather than returned
+to the model.
 
 The sandbox boundary should remain useful outside the desktop product. A local
 process sandbox is the first execution adapter; self-hosted and managed profiles
@@ -299,12 +316,15 @@ The implementation is intentionally incremental:
 11. Let a sandbox relay a typed folder-consent proposal to its foreground
     parent, without host access or a picker. *(Shipped.)*
 12. Add fenced read-only tools to the foreground turn for roots its chat already
-    attached; sandbox broker access remains deferred. *(Shipped.)*
+    attached. *(Shipped.)*
 13. Add desktop surfaces for queued, running, waiting, failed, and completed
    background work, including exact sandbox stop controls. *(Shipped.)*
 14. Persist the non-blocking spawn checkpoint and ordered wait receipts.
     *(Shipped.)*
 15. Activate non-blocking spawn and ordered multi-agent waits together.
     *(Shipped.)*
-16. Add richer context lifecycle, parallel-safe tool groups, and further
-   orchestration only after these recovery boundaries are proven.
+16. Add the desktop-only, argument-free read of one exact file immutably
+    delegated at spawn, with native claim/revalidation, broker authorization,
+    revocation fencing, and crash-safe no-replay recovery. *(Shipped.)*
+17. Add richer context lifecycle, parallel-safe tool groups, and further
+    orchestration only after these recovery boundaries are proven.

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -100,7 +100,9 @@ A runnable sidecar exposes the same core over bounded, strict JSONL stdio,
 resynchronizes after oversized input, and protects its own app-data directory
 from ever becoming a connected root. The Tauri host owns its lifecycle and
 native folder consent behind narrow pick/list/revoke commands; the renderer sees
-only opaque summaries. Existing agent file tools do not use this boundary yet.
+only opaque summaries. Foreground connected-folder tools and the desktop-only
+sandbox read of one exact delegated file use this operation boundary; private
+scratch tools remain separate and confined to app storage.
 See [Host access and connected folders](host-access.md).
 
 **Depends on:** no OpenWave client crate.
@@ -151,7 +153,10 @@ that mounts external MCP servers remains planned.
 
 The Tauri application: it compiles the server in-process, hosts the chat UI, and
 talks to it over an ephemeral loopback HTTP/WebSocket surface. This is the
-primary way most people will run OpenWave. See
+primary way most people will run OpenWave. Its private native executor also
+recovers exact delegated-file checkpoints, revalidates product attachment
+authority, and sends one bounded read through the host broker without exposing
+the target or executor credentials to the renderer. See
 [`crates/openwave-desktop/README.md`](../crates/openwave-desktop/README.md) for
 local run instructions.
 
@@ -168,6 +173,12 @@ Client-owned tool work is exposed through authenticated per-chat polling,
 claim, heartbeat, and resolution routes. General records show visible lease
 metadata but never the secret claim token; only the claim response returns that
 receipt.
+
+The embedded-desktop profile additionally enables the argument-free
+`read_delegated_file` checkpoint for a depth-one child with one immutable exact
+file delegation. Native-only pending/claim/heartbeat/resolve routes drive it;
+the headless profile does not advertise the tool because it has no embedded
+executor.
 
 **Depends on:** `openwave-core`, `openwave-router`, `openwave-retrieval`.
 

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -85,6 +85,57 @@ or detach identity only when it is unknown, and then supplies the terminal
 observation to the product state machine. Startup recovery is sequential and
 bounded to 64 oldest pending changes per pass.
 
+### Exact files delegated to a background agent
+
+Foreground folder tools can browse roots already attached to their chat. A
+background sandbox receives a much narrower capability: when spawning the
+child, the foreground agent may name one already attached opaque root ID and
+one root-relative file path. That exact pair is stored immutably in the child's
+admission. It does not attach a root, create a broker grant, or expose a host
+path.
+
+Only the embedded desktop advertises `read_delegated_file`, and only to the
+depth-one child whose admission has that exact resource while the root remains
+attached. The tool takes an empty argument object, so the child cannot replace
+the target or discover other roots and files. It shares the sandbox's one total
+tool-call budget with web search and the typed folder-access proposal. It is not
+a picker, directory listing, write, shell, or general filesystem capability.
+
+The read crosses the trust boundaries as a durable continuation:
+
+1. The sandbox parks one argument-free call and releases its worker lease.
+2. The desktop polls a native-only pending route that reveals only call IDs.
+   Pending, claim, heartbeat, and resolve require both the ordinary loopback
+   bearer and a separate native-executor credential withheld from the renderer.
+3. Claim installs an exact executor lease and revalidates the immutable child
+   admission plus the chat's current attachment before returning the opaque
+   root and relative path to native code.
+4. Native code durably records a private dispatch fence, then sends a final
+   specialized heartbeat. That heartbeat revalidates the admission and
+   attachment immediately before broker admission.
+5. The host broker performs one bounded UTF-8 `ReadFile` under the
+   server-derived conversation context. It checks its own live attachment and
+   grant and reauthorizes before releasing bytes.
+6. Resolve revalidates the executor lease and current product attachment before
+   committing bounded content. If a detach or cancellation won the race, the
+   content is discarded and the sandbox resumes with a neutral terminal result.
+
+The app-private recovery receipt contains the call identity, stable executor,
+secret lease, dispatch phase, and bounded terminal resolution, but not the root
+or relative path. A receipt recorded after dispatch began is never dispatched
+again after a crash: if no terminal result was durably stored, recovery resolves
+the call as unavailable. This conservative no-replay rule treats even a
+privacy-sensitive read as an effect whose ambiguous dispatch must not be
+repeated. An expired claim whose private receipt was lost is likewise
+cleanup-only, never authority for another read. A target that cannot be
+represented by the broker's stricter relative-path contract fails neutrally
+before host I/O.
+
+The headless server does not have the embedded native executor or its stable
+private credential, so it never advertises this tool. Future self-hosted or
+managed deployments will need an equivalent explicitly trusted host executor;
+the current implementation does not claim that support.
+
 ## The four layers
 
 ```text

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -196,9 +196,17 @@ The built-in server registry currently contains:
   from stored state, persists its bounded result, and never exposes host paths
   or broker diagnostics to the renderer or model.
 
-Today these file tools still operate inside a server-derived, pinned per-chat
-scratch capability. Its path is neither persisted on the chat nor returned by
-the product API. The desktop can connect, list, and revoke multiple folders
+Depth-one sandbox agents have a separate, smaller surface and one total tool
+call. Besides web search or a typed folder-access proposal, an embedded-desktop
+child may receive `read_delegated_file` when its foreground spawn immutably
+named one exact attached root and relative path. The tool accepts no arguments;
+it cannot browse, choose a path, open a picker, write, or run commands. The
+headless server does not advertise it.
+
+The built-in `read_file`, `list_dir`, and `write_file` tools operate only inside
+a server-derived, pinned per-chat scratch capability. Its path is neither
+persisted on the chat nor returned by the product API. The desktop can connect,
+list, and revoke multiple folders
 through a native picker and capability-gated host-broker sidecar; it exposes only
 opaque root IDs and display names to the renderer. Foreground tool calls can now
 list/read roots already attached to their stored chat context. An approved
@@ -215,6 +223,15 @@ folder picker, claim the request, and ask the broker to register the selected
 folder. The selected path never enters the renderer or product HTTP API. The
 secret claim token is never renderer-visible; native code sends it only through
 the separately credentialed loopback client-execution API.
+Delegated sandbox reads use a parallel native-only continuation. Pending
+discovery reveals only a call ID; claim recovers the server-owned exact target
+after checking the immutable admission and current chat attachment. Native code
+then persists a no-replay dispatch fence, performs a final authority-checking
+heartbeat, and asks the host broker for one bounded UTF-8 read. The broker
+independently reauthorizes its live grant. Resolve checks attachment authority
+again, which discards content if a detach won while the read was in flight. A
+crash after possible broker dispatch becomes a safe unavailable result instead
+of another read.
 The model router supports Anthropic, OpenAI, and OpenAI-compatible endpoints. It
 fails closed: if no enabled provider with a usable credential can serve the
 selected model, no model request is sent.
@@ -640,6 +657,11 @@ persisted nor returned to the renderer. Foreground agents separately have a
 fenced read-only proxy for roots already attached to the chat:
 `list_connected_folders`, `list_folder`, and `read_connected_file` carry only
 opaque root IDs and bounded relative paths through the trusted native broker.
+An admitted depth-one child can instead read only the single exact file its
+foreground spawn delegated. It receives an argument-free tool, while the native
+executor privately performs claim, final attachment revalidation, one broker
+read, and fenced resolution. The renderer never receives that target or the
+file contents from the executor control plane.
 The UI does not yet provide projects or steer controls. Completed assistant
 messages render the closed structured source cards described above. The
 Documents surface derives scope from the
@@ -755,7 +777,7 @@ fail-closed provider routing.
 The main next steps are:
 
 - extend the bounded depth-one hierarchy with carefully scoped sandbox-safe
-  capabilities without widening its spawn or host-access authority;
+  capabilities without widening the exact delegated-file or spawn authority;
 - continue unifying client execution, folder consent, user questions, and
   resource waits around durable continuations that release workers;
 - persist model/tool step boundaries and side-effect receipts so sandbox and

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -97,23 +97,39 @@ child or consuming a result twice. Live event delivery uses the exact journaled
 sequence; reconnecting clients replay the journal, and cursor-based consumers
 can ignore a repeated live publication after commit-response loss.
 
-A background sandbox has no shared conversation, filesystem, general network,
-or host-folder access. It receives one bounded task and may be offered exactly
-one tool call: `web_search` when its remaining model-step budget can also
-consume the result, or a sandbox-only `request_folder_access` proposal. The
-proposal is a typed terminal child result, not a client call: it cannot open a
+A background sandbox has no shared conversation, general filesystem, general
+network, or broad host-folder access. It receives one bounded task and has one
+total tool-call budget. Depending on its remaining model-step budget and exact
+admission, it may be offered `web_search`, a sandbox-only
+`request_folder_access` proposal, or the desktop-only
+`read_delegated_file`. The delegated read is available only when the foreground
+spawn named one exact `{root_id, relative_path}` that was attached to the chat
+and remains attached. It accepts no model arguments: the sandbox cannot choose
+a root or path, discover neighboring files, or broaden the delegation.
+
+The desktop executor discovers only the parked call identity. Its native-only
+claim recovers the server-owned chat, root, and relative path after revalidating
+the immutable child admission and current attachment. Immediately before one
+bounded UTF-8 broker read, it performs a final authority-checking heartbeat;
+the broker independently reauthorizes the chat context and root. Resolution
+checks the same authority again, so a detach that wins while bytes are in
+flight discards the content and resumes the child with a neutral failure.
+Headless servers have no embedded native executor and never advertise this
+tool.
+
+The folder-access proposal is a typed terminal child result, not a client call:
+it cannot open a
 picker, name a root, expose a path, or grant access. Its foreground parent
 receives deterministic system context and independently decides whether to
 issue the ordinary foreground `request_folder_access` client tool. The worker
-atomically parks only web search under its exact lease; a separate host-owned
-executor performs that bounded search and writes an immutable receipt. On a
-later claim, the sandbox reconstructs the matching `ToolUse`/`ToolResult` from
-that receipt before it can finalize. Sandboxes do not receive
+atomically parks web search or the delegated read under its exact lease; a
+separate host-owned executor performs the bounded operation and writes a
+durable receipt. The desktop also persists an app-private delegated-read
+receipt before broker dispatch. If a crash makes dispatch ambiguous, recovery
+publishes a safe failure instead of reading the file again. On a later claim,
+the sandbox reconstructs the matching `ToolUse`/`ToolResult` from the terminal
+receipt before it can finalize. Sandboxes do not receive
 `spawn_sandbox_agent` or `wait_for_agents` and cannot create further agents.
-
-Future sandbox-safe capabilities, such as broker-mediated folder reads, must
-be added one at a time behind the same durable continuation and consent
-boundaries.
 
 Later additions may include a scratchpad, pinned context, plan/execution modes,
 deliverable export, clipboard operations, generated images, and connected apps.


### PR DESCRIPTION
## Summary
- explain the foreground-to-sandbox exact file delegation boundary
- document native claim, final heartbeat, broker authorization, and resolution fencing
- describe desktop-only activation, one-call budgeting, and conservative crash recovery
- refresh crate and maintainer guides where the brokered read was still described as deferred

## Validation
- `bw dev lint --check --rust --repo-root /private/tmp/openwave-delegated-read-docs`
- `git diff --check`
- local Markdown link target validation