### PR TITLE
Execute exact delegated file reads on desktop

### DIFF
--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -20,13 +20,9 @@ use crate::tool::ToolSpec;
 pub const SPAWN_SANDBOX_AGENT_TOOL: &str = "spawn_sandbox_agent";
 /// Stable name for the prepared foreground-only multi-child wait tool.
 pub const WAIT_FOR_AGENTS_TOOL: &str = "wait_for_agents";
-/// The only tool a depth-one sandbox may receive.
+/// Public-web tool a depth-one sandbox may receive.
 pub const SANDBOX_WEB_SEARCH_TOOL: &str = "web_search";
-/// Stable name for the future native-executed delegated file read.
-///
-/// The primitive is intentionally not included in the sandbox provider tool
-/// list yet. It exists so the durable checkpoint and trusted-host control
-/// plane can be built and tested before a broker executor is wired in.
+/// Stable name for the native-executed exact delegated file read.
 pub const SANDBOX_READ_DELEGATED_FILE_TOOL: &str = "read_delegated_file";
 
 /// Maximum task length in Unicode scalar values advertised to a model.
@@ -56,10 +52,11 @@ pub(crate) const WAIT_CANCELLED_WITH_TURN_RESULT: &str =
 pub struct SpawnSandboxAgentArgs {
     /// A self-contained task for the isolated child. It cannot spawn children.
     pub task: String,
-    /// Optional exact file the child may receive through a later capability.
+    /// Optional exact file a compatible native executor may make available.
     ///
-    /// Persisting this delegation grants no file access by itself. The initial
-    /// runtime deliberately advertises no sandbox file-read tool.
+    /// Persisting this delegation grants no file access by itself. A compatible
+    /// executor advertises the read only while the root remains attached, then
+    /// revalidates authority with the host broker before bytes move.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource: Option<SandboxAgentFileResource>,
 }
@@ -279,7 +276,7 @@ pub fn spawn_sandbox_agent_tool_spec() -> ToolSpec {
                 },
                 "resource": {
                     "type": "object",
-                    "description": "Optional exact file identity within a folder already connected to this conversation. This delegates only its identity; the sandbox currently has no file-read tool.",
+                    "description": "Optional exact file identity within a folder already connected to this conversation. This delegates only its identity; a compatible native executor must revalidate current access before any read.",
                     "properties": {
                         "root_id": { "type": "string", "format": "uuid" },
                         "relative_path": {

--- a/crates/openwave-desktop/src/broker.rs
+++ b/crates/openwave-desktop/src/broker.rs
@@ -10,8 +10,8 @@ use std::{
 
 use openwave_host_broker::{
     sidecar::{SidecarRequest, SidecarResponse, MAX_REQUEST_BYTES, MAX_RESPONSE_BYTES},
-    ControlEnvelope, ControlRequest, ControlResult, OperationEnvelope, OperationResult, RequestId,
-    Response, PROTOCOL_VERSION,
+    ControlEnvelope, ControlRequest, ControlResult, ErrorCode, OperationEnvelope, OperationResult,
+    RequestId, Response, PROTOCOL_VERSION,
 };
 use tauri::{async_runtime::JoinHandle, AppHandle};
 use tauri_plugin_shell::ShellExt;
@@ -421,6 +421,7 @@ fn decode_response(
             match envelope.response {
                 Response::Ok(result) => Ok(ExchangeResult::Control(result)),
                 Response::Error(error) => Err(BrokerClientError::Broker {
+                    code: error.code,
                     message: error.message,
                     retryable: error.retryable,
                 }),
@@ -431,6 +432,7 @@ fn decode_response(
             match envelope.response {
                 Response::Ok(result) => Ok(ExchangeResult::Operation(result)),
                 Response::Error(error) => Err(BrokerClientError::Broker {
+                    code: error.code,
                     message: error.message,
                     retryable: error.retryable,
                 }),
@@ -518,7 +520,11 @@ pub(crate) enum BrokerClientError {
     #[error("host broker transport error: {0}")]
     Transport(String),
     #[error("{message}")]
-    Broker { message: String, retryable: bool },
+    Broker {
+        code: ErrorCode,
+        message: String,
+        retryable: bool,
+    },
 }
 
 impl BrokerClientError {

--- a/crates/openwave-desktop/src/client_execution.rs
+++ b/crates/openwave-desktop/src/client_execution.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 use crate::host_access::{pick_folder, AuthoritativeContext, HostAccess};
 
 mod control_plane;
+pub(crate) mod delegated_file_read;
 pub(crate) mod folder_operations;
 mod product_sync;
 mod receipt_store;
@@ -32,8 +33,10 @@ pub(crate) use control_plane::ControlPlaneClient;
 use control_plane::ControlPlaneError;
 pub(crate) use receipt_store::ReceiptStore;
 use receipt_store::{
-    FolderAccessIntent, FolderAccessReceipt, FolderOperationPhase, FolderOperationReceipt,
-    ManualFolderConnectReceipt, ProductRootAttachmentSync, RegistrationPhase, StoredResolution,
+    delegated_file_content_fits_server, DelegatedFileFailureReason, DelegatedFileReadReceipt,
+    DelegatedFileResolution, FolderAccessIntent, FolderAccessReceipt, FolderOperationPhase,
+    FolderOperationReceipt, ManualFolderConnectReceipt, ProductRootAttachmentSync,
+    RegistrationPhase, StoredResolution,
 };
 
 const RECOVERY_IDLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);

--- a/crates/openwave-desktop/src/client_execution/control_plane.rs
+++ b/crates/openwave-desktop/src/client_execution/control_plane.rs
@@ -11,7 +11,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 
-use super::receipt_store::StoredResolution;
+use super::receipt_store::{DelegatedFileResolution, StoredResolution};
 
 const MAX_EXACT_ATTEMPTS: usize = 3;
 const CLIENT_EXECUTOR_HEADER: &str = "x-openwave-client-executor";
@@ -82,6 +82,56 @@ struct BeginRootAttachmentRequest {
 #[derive(Serialize)]
 struct FinishRootAttachmentRequest<'a> {
     terminal: &'a RootAttachmentChangeTerminal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub(super) struct PendingDelegatedFileRead {
+    pub(super) call_id: CallId,
+    pub(super) claimed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum DelegatedFileClaimDisposition {
+    Claimed,
+    Existing,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ClaimedDelegatedFileRead {
+    pub(super) disposition: DelegatedFileClaimDisposition,
+    pub(super) call_id: CallId,
+    pub(super) chat_id: ChatId,
+    pub(super) root_id: HostRootId,
+    pub(super) relative_path: String,
+}
+
+#[derive(Serialize)]
+struct DelegatedFileLeaseRequest {
+    lease_token: Uuid,
+}
+
+#[derive(Serialize)]
+struct ResolveDelegatedFileReadRequest<'a> {
+    lease_token: Uuid,
+    resolution: &'a DelegatedFileResolution,
+}
+
+#[derive(Deserialize)]
+struct DelegatedFileHeartbeat {
+    extended: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DelegatedFileResolutionDisposition {
+    Resolved,
+    Existing,
+}
+
+#[derive(Deserialize)]
+struct ResolvedDelegatedFileRead {
+    disposition: DelegatedFileResolutionDisposition,
 }
 
 #[derive(Debug, Deserialize)]
@@ -183,6 +233,62 @@ impl ControlPlaneClient {
     ) -> Result<Vec<ToolCallRecord>, ControlPlaneError> {
         self.get(&format!("/chats/{chat_id}/client-executions/pending/raw"))
             .await
+    }
+
+    pub(super) async fn pending_delegated_file_reads(
+        &self,
+    ) -> Result<Vec<PendingDelegatedFileRead>, ControlPlaneError> {
+        self.get("/sandbox-file-reads/pending").await
+    }
+
+    pub(super) async fn claim_delegated_file_read(
+        &self,
+        call_id: CallId,
+        lease_token: Uuid,
+    ) -> Result<ClaimedDelegatedFileRead, ControlPlaneError> {
+        self.post(
+            &format!("/sandbox-file-reads/{call_id}/claim"),
+            &DelegatedFileLeaseRequest { lease_token },
+        )
+        .await
+    }
+
+    pub(super) async fn heartbeat_delegated_file_read(
+        &self,
+        call_id: CallId,
+        lease_token: Uuid,
+    ) -> Result<(), ControlPlaneError> {
+        let heartbeat: DelegatedFileHeartbeat = self
+            .post(
+                &format!("/sandbox-file-reads/{call_id}/heartbeat"),
+                &DelegatedFileLeaseRequest { lease_token },
+            )
+            .await?;
+        if !heartbeat.extended {
+            return Err(ControlPlaneError::Protocol);
+        }
+        Ok(())
+    }
+
+    pub(super) async fn resolve_delegated_file_read(
+        &self,
+        call_id: CallId,
+        lease_token: Uuid,
+        resolution: &DelegatedFileResolution,
+    ) -> Result<(), ControlPlaneError> {
+        let response: ResolvedDelegatedFileRead = self
+            .post(
+                &format!("/sandbox-file-reads/{call_id}/resolve"),
+                &ResolveDelegatedFileReadRequest {
+                    lease_token,
+                    resolution,
+                },
+            )
+            .await?;
+        match response.disposition {
+            DelegatedFileResolutionDisposition::Resolved
+            | DelegatedFileResolutionDisposition::Existing => Ok(()),
+        }
     }
 
     pub(super) async fn heartbeat(

--- a/crates/openwave-desktop/src/client_execution/delegated_file_read.rs
+++ b/crates/openwave-desktop/src/client_execution/delegated_file_read.rs
@@ -1,0 +1,416 @@
+//! Native executor for exact files delegated to depth-one sandbox agents.
+//!
+//! Discovery reveals only a call identity. The native claim supplies the
+//! server-owned root/path pair after revalidating the immutable admission and
+//! current attachment. Neither value is persisted or exposed to the renderer.
+
+use std::collections::HashSet;
+
+use openwave_core::CallId;
+use openwave_host_broker::{
+    ErrorCode, OperationEnvelope, OperationRequest, OperationResult, PathRequest, RelativePath,
+    RootId, PROTOCOL_VERSION,
+};
+use tauri::Manager;
+
+use crate::{broker::BrokerClientError, host_access::HostAccess};
+
+use super::{
+    control_plane, control_plane_error, delegated_file_content_fits_server, private_receipt_error,
+    DelegatedFileFailureReason, DelegatedFileReadReceipt, DelegatedFileResolution,
+    FolderOperationPhase,
+};
+
+const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaimConflictDisposition {
+    Defer,
+    Retire,
+}
+
+pub(crate) async fn recover_delegated_file_read(app: tauri::AppHandle) {
+    loop {
+        if recover_once(&app).await {
+            eprintln!("openwave-desktop: delegated-file executor deferred work");
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+async fn recover_once(app: &tauri::AppHandle) -> bool {
+    let state = app.state::<HostAccess>();
+    let receipts = match state.receipts.load_delegated_file_reads() {
+        Ok(receipts) => receipts,
+        Err(_) => return true,
+    };
+    let recovered: HashSet<CallId> = receipts.iter().map(|receipt| receipt.call_id).collect();
+    let mut failed = false;
+    for receipt in receipts {
+        if execute_receipt(&state, receipt).await.is_err() {
+            failed = true;
+        }
+    }
+
+    let client = match control_plane(&state) {
+        Ok(client) => client,
+        Err(_) => return true,
+    };
+    let pending = match client.pending_delegated_file_reads().await {
+        Ok(pending) => pending,
+        Err(_) => return true,
+    };
+    for candidate in pending
+        .into_iter()
+        .filter(|candidate| should_discover(candidate.call_id, &recovered))
+    {
+        let receipt =
+            DelegatedFileReadReceipt::new(candidate.call_id, state.receipts.executor_id());
+        if state.receipts.save_delegated_file_read(&receipt).is_err()
+            || execute_receipt(&state, receipt).await.is_err()
+        {
+            failed = true;
+        }
+    }
+    failed
+}
+
+async fn execute_receipt(
+    state: &HostAccess,
+    mut receipt: DelegatedFileReadReceipt,
+) -> Result<(), String> {
+    if receipt.executor_id != state.receipts.executor_id() {
+        return Err("delegated-file receipt has the wrong native executor".to_owned());
+    }
+    if let Some(resolution) = receipt.resolution.clone() {
+        return publish_resolution(state, &receipt, &resolution).await;
+    }
+    if receipt.phase == FolderOperationPhase::DispatchStarted {
+        receipt.resolution = Some(interrupted_resolution());
+        state
+            .receipts
+            .save_delegated_file_read(&receipt)
+            .map_err(private_receipt_error)?;
+        return publish_resolution(
+            state,
+            &receipt,
+            receipt.resolution.as_ref().expect("stored above"),
+        )
+        .await;
+    }
+
+    // The receipt and exact lease exist durably before the claim. Losing the
+    // claim response therefore never loses the only authority that may recover
+    // it, and no host I/O has happened yet.
+    state
+        .receipts
+        .save_delegated_file_read(&receipt)
+        .map_err(private_receipt_error)?;
+    let client = control_plane(state)?;
+    let claim = match client
+        .claim_delegated_file_read(receipt.call_id, receipt.lease_token)
+        .await
+    {
+        Ok(claim) => claim,
+        Err(error) if error.is_conflict() => {
+            let pending = client
+                .pending_delegated_file_reads()
+                .await
+                .map_err(control_plane_error)?;
+            match claim_conflict_disposition(receipt.call_id, &pending) {
+                ClaimConflictDisposition::Defer => {
+                    return Err("delegated-file claim could not be recovered yet".to_owned());
+                }
+                ClaimConflictDisposition::Retire => {}
+            }
+            return state
+                .receipts
+                .remove_delegated_file_read(receipt.call_id)
+                .map_err(private_receipt_error);
+        }
+        Err(error) => return Err(control_plane_error(error)),
+    };
+    if claim.call_id != receipt.call_id {
+        return Err("local control plane returned an invalid delegated-file claim".to_owned());
+    }
+    let _ = claim.disposition;
+
+    // Resolve all native inputs before entering the no-replay dispatch fence.
+    let context = match state.context(claim.chat_id.0).await {
+        Ok(context) => context,
+        Err(_) => return terminalize_without_dispatch(state, &mut receipt).await,
+    };
+    let (root_id, relative_path) = match broker_resource(claim.root_id, &claim.relative_path) {
+        Ok(resource) => resource,
+        Err(()) => return terminalize_without_dispatch(state, &mut receipt).await,
+    };
+    let operation = OperationEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: openwave_host_broker::RequestId::new(),
+        context: context.execution,
+        request: OperationRequest::ReadFile(PathRequest {
+            root_id,
+            path: relative_path,
+        }),
+    };
+
+    // Persist ambiguity before the final authority check. A crash from this
+    // point onward terminalizes the call and never replays a possible read.
+    receipt.phase = FolderOperationPhase::DispatchStarted;
+    state
+        .receipts
+        .save_delegated_file_read(&receipt)
+        .map_err(private_receipt_error)?;
+    client
+        .heartbeat_delegated_file_read(receipt.call_id, receipt.lease_token)
+        .await
+        .map_err(control_plane_error)?;
+
+    // No await that can alter product authority sits between the specialized
+    // heartbeat/revalidation and broker admission.
+    let resolution = match state.broker.operation(operation).await {
+        Ok(OperationResult::ReadFile(file)) => content_resolution(file.content),
+        Ok(_) => failed(DelegatedFileFailureReason::Unavailable),
+        Err(error) => broker_failure(&error),
+    };
+    receipt.set_bounded_resolution(resolution);
+    state
+        .receipts
+        .save_delegated_file_read(&receipt)
+        .map_err(private_receipt_error)?;
+    publish_resolution(
+        state,
+        &receipt,
+        receipt.resolution.as_ref().expect("stored above"),
+    )
+    .await
+}
+
+async fn terminalize_without_dispatch(
+    state: &HostAccess,
+    receipt: &mut DelegatedFileReadReceipt,
+) -> Result<(), String> {
+    // No broker operation was attempted. Reuse the conservative terminal phase
+    // so a crash can only recover toward a neutral result, never toward I/O.
+    receipt.phase = FolderOperationPhase::DispatchStarted;
+    receipt.set_bounded_resolution(failed(DelegatedFileFailureReason::Unavailable));
+    state
+        .receipts
+        .save_delegated_file_read(receipt)
+        .map_err(private_receipt_error)?;
+    publish_resolution(
+        state,
+        receipt,
+        receipt.resolution.as_ref().expect("stored above"),
+    )
+    .await
+}
+
+fn broker_resource(
+    root_id: openwave_core::HostRootId,
+    relative_path: &str,
+) -> Result<(RootId, RelativePath), ()> {
+    let root_id = RootId::from_uuid(*root_id.as_uuid()).map_err(|_| ())?;
+    let relative_path = RelativePath::parse(relative_path).map_err(|_| ())?;
+    if relative_path.is_root() {
+        return Err(());
+    }
+    Ok((root_id, relative_path))
+}
+
+fn should_discover(call_id: CallId, recovered: &HashSet<CallId>) -> bool {
+    !recovered.contains(&call_id)
+}
+
+fn claim_conflict_disposition(
+    call_id: CallId,
+    pending: &[super::control_plane::PendingDelegatedFileRead],
+) -> ClaimConflictDisposition {
+    if pending.iter().any(|candidate| candidate.call_id == call_id) {
+        ClaimConflictDisposition::Defer
+    } else {
+        ClaimConflictDisposition::Retire
+    }
+}
+
+fn content_resolution(content: String) -> DelegatedFileResolution {
+    if content.contains('\0') {
+        return failed(DelegatedFileFailureReason::NotUtf8);
+    }
+    let resolution = DelegatedFileResolution::Completed { content };
+    let server_result_fits = match &resolution {
+        DelegatedFileResolution::Completed { content } => {
+            delegated_file_content_fits_server(content)
+        }
+        _ => unreachable!(),
+    };
+    if server_result_fits {
+        resolution
+    } else {
+        failed(DelegatedFileFailureReason::TooLarge)
+    }
+}
+
+fn broker_failure(error: &BrokerClientError) -> DelegatedFileResolution {
+    let reason = match error {
+        BrokerClientError::Broker {
+            code: ErrorCode::Denied | ErrorCode::InvalidRoot,
+            ..
+        } => DelegatedFileFailureReason::PermissionDenied,
+        BrokerClientError::Broker {
+            code: ErrorCode::TooLarge,
+            ..
+        } => DelegatedFileFailureReason::TooLarge,
+        BrokerClientError::Broker {
+            code: ErrorCode::UnsupportedContent,
+            ..
+        } => DelegatedFileFailureReason::NotUtf8,
+        _ => DelegatedFileFailureReason::Unavailable,
+    };
+    failed(reason)
+}
+
+fn failed(reason: DelegatedFileFailureReason) -> DelegatedFileResolution {
+    DelegatedFileResolution::Failed { reason }
+}
+
+fn interrupted_resolution() -> DelegatedFileResolution {
+    failed(DelegatedFileFailureReason::Unavailable)
+}
+
+async fn publish_resolution(
+    state: &HostAccess,
+    receipt: &DelegatedFileReadReceipt,
+    resolution: &DelegatedFileResolution,
+) -> Result<(), String> {
+    let client = control_plane(state)?;
+    match client
+        .resolve_delegated_file_read(receipt.call_id, receipt.lease_token, resolution)
+        .await
+    {
+        Ok(()) => state
+            .receipts
+            .remove_delegated_file_read(receipt.call_id)
+            .map_err(private_receipt_error),
+        Err(error) if error.is_conflict() => {
+            // Specialized resolve revalidates attachment authority. If a
+            // detach terminalized the call while bytes were in flight, the
+            // content is discarded here and the private receipt is retired.
+            let still_pending = client
+                .pending_delegated_file_reads()
+                .await
+                .map_err(control_plane_error)?
+                .into_iter()
+                .any(|candidate| candidate.call_id == receipt.call_id);
+            if still_pending {
+                Err("delegated-file result no longer owns the pending request".to_owned())
+            } else {
+                state
+                    .receipts
+                    .remove_delegated_file_read(receipt.call_id)
+                    .map_err(private_receipt_error)
+            }
+        }
+        Err(error) => Err(control_plane_error(error)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_and_failure_results_are_bounded_and_path_free() {
+        assert_eq!(
+            content_resolution("x".repeat(openwave_core::SandboxToolCall::MAX_RESULT_BYTES)),
+            failed(DelegatedFileFailureReason::TooLarge)
+        );
+        assert_eq!(
+            content_resolution("contains\0null".to_owned()),
+            failed(DelegatedFileFailureReason::NotUtf8)
+        );
+        let encoded = serde_json::to_string(&interrupted_resolution()).unwrap();
+        assert!(!encoded.contains("/Users/"));
+        assert!(!encoded.contains("relative_path"));
+    }
+
+    #[test]
+    fn broker_failures_map_to_closed_safe_categories() {
+        let denied = BrokerClientError::Broker {
+            code: ErrorCode::Denied,
+            message: "/private/secret".to_owned(),
+            retryable: false,
+        };
+        assert_eq!(
+            broker_failure(&denied),
+            failed(DelegatedFileFailureReason::PermissionDenied)
+        );
+        assert!(!serde_json::to_string(&broker_failure(&denied))
+            .unwrap()
+            .contains("secret"));
+    }
+
+    #[test]
+    fn dispatch_fence_forces_terminal_recovery_without_another_read() {
+        let mut receipt = DelegatedFileReadReceipt::new(CallId::new(), uuid::Uuid::new_v4());
+        assert_eq!(receipt.phase, FolderOperationPhase::NotStarted);
+        receipt.phase = FolderOperationPhase::DispatchStarted;
+        assert!(receipt.resolution.is_none());
+    }
+
+    #[test]
+    fn claimed_candidates_are_recovered_instead_of_ignored() {
+        let candidate = super::super::control_plane::PendingDelegatedFileRead {
+            call_id: CallId::new(),
+            claimed: true,
+        };
+        let recovered = HashSet::new();
+        assert!(should_discover(candidate.call_id, &recovered));
+        // Discovery deliberately does not filter on `claimed`: attempting the
+        // specialized claim terminalizes an expired orphan without dispatch.
+        assert!(candidate.claimed);
+        assert_eq!(
+            claim_conflict_disposition(candidate.call_id, &[]),
+            ClaimConflictDisposition::Retire
+        );
+        assert_eq!(
+            claim_conflict_disposition(candidate.call_id, &[candidate]),
+            ClaimConflictDisposition::Defer
+        );
+    }
+
+    #[test]
+    fn exact_server_and_private_receipt_bounds_cover_json_escaping() {
+        let control_heavy = "\u{0001}".repeat(64 * 1024);
+        let resolution = content_resolution(control_heavy);
+        let mut receipt = DelegatedFileReadReceipt::new(CallId::new(), uuid::Uuid::new_v4());
+        receipt.phase = FolderOperationPhase::DispatchStarted;
+        receipt.set_bounded_resolution(resolution);
+        let encoded = serde_json::to_vec(&receipt).unwrap();
+        assert!(encoded.len() <= 128 * 1024);
+        assert_eq!(
+            receipt.resolution,
+            Some(failed(DelegatedFileFailureReason::TooLarge))
+        );
+
+        let ascii = content_resolution("x".repeat(64 * 1024));
+        if let DelegatedFileResolution::Completed { content } = &ascii {
+            let server = serde_json::json!({"content": content}).to_string();
+            assert!(server.len() <= openwave_core::SandboxToolCall::MAX_RESULT_BYTES);
+        }
+    }
+
+    #[test]
+    fn broker_incompatible_delegated_paths_terminalize_neutrally() {
+        let root_id = openwave_core::HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+        for path in ["report?.md", "CON", "report. "] {
+            assert!(broker_resource(root_id, path).is_err(), "{path}");
+        }
+        assert!(broker_resource(root_id, "reports/summary.md").is_ok());
+        let resolution = failed(DelegatedFileFailureReason::Unavailable);
+        let encoded = serde_json::to_string(&resolution).unwrap();
+        assert!(!encoded.contains("report?"));
+        assert!(!encoded.contains("CON"));
+        assert!(!encoded.contains(root_id.as_uuid().to_string().as_str()));
+    }
+}

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -24,6 +24,7 @@ const MAX_EXECUTOR_BYTES: usize = 128;
 const MAX_RECEIPT_BYTES: usize = 128 * 1024;
 const MAX_RECEIPTS: usize = 1_024;
 const FOLDER_OPERATION_PREFIX: &str = "folder-operation-";
+const DELEGATED_FILE_READ_PREFIX: &str = "delegated-file-read-";
 const MANUAL_FOLDER_CONNECT_PREFIX: &str = "manual-folder-connect-";
 const MAX_SAFE_ROOT_DISPLAY_BYTES: usize = 1_024;
 
@@ -67,6 +68,41 @@ pub(super) struct FolderOperationReceipt {
     pub(super) phase: FolderOperationPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) resolution: Option<StoredResolution>,
+}
+
+/// Native-only recovery state for one exact sandbox delegated-file read.
+///
+/// Host root and relative path are deliberately absent. They are returned only
+/// by the native claim and are revalidated again by the final heartbeat.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub(super) struct DelegatedFileReadReceipt {
+    version: u32,
+    pub(super) call_id: CallId,
+    pub(super) executor_id: Uuid,
+    pub(super) lease_token: Uuid,
+    #[serde(default)]
+    pub(super) phase: FolderOperationPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) resolution: Option<DelegatedFileResolution>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum DelegatedFileFailureReason {
+    NotFound,
+    NotUtf8,
+    TooLarge,
+    PermissionDenied,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub(super) enum DelegatedFileResolution {
+    Completed { content: String },
+    Failed { reason: DelegatedFileFailureReason },
+    Cancelled,
 }
 
 /// App-private recovery state for a folder selected from the manual connected
@@ -195,6 +231,23 @@ impl std::fmt::Debug for FolderOperationReceipt {
             .field("lease_token", &"[redacted]")
             .field("phase", &self.phase)
             .field("resolution", &self.resolution)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for DelegatedFileReadReceipt {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DelegatedFileReadReceipt")
+            .field("version", &self.version)
+            .field("call_id", &self.call_id)
+            .field("executor_id", &self.executor_id)
+            .field("lease_token", &"[redacted]")
+            .field("phase", &self.phase)
+            .field(
+                "resolution",
+                &self.resolution.as_ref().map(|_| "[redacted]"),
+            )
             .finish()
     }
 }
@@ -374,6 +427,54 @@ impl FolderOperationReceipt {
     }
 }
 
+impl DelegatedFileReadReceipt {
+    pub(super) fn new(call_id: CallId, executor_id: Uuid) -> Self {
+        Self {
+            version: RECEIPT_VERSION,
+            call_id,
+            executor_id,
+            lease_token: Uuid::new_v4(),
+            phase: FolderOperationPhase::NotStarted,
+            resolution: None,
+        }
+    }
+
+    fn validate(&self) -> io::Result<()> {
+        if self.version != RECEIPT_VERSION
+            || self.call_id.0.is_nil()
+            || self.executor_id.is_nil()
+            || self.lease_token.is_nil()
+            || matches!(
+                &self.resolution,
+                Some(DelegatedFileResolution::Completed { content })
+                    if !delegated_file_content_fits_server(content)
+            )
+            || (self.resolution.is_some() && self.phase != FolderOperationPhase::DispatchStarted)
+        {
+            return Err(invalid_data("invalid delegated-file receipt"));
+        }
+        Ok(())
+    }
+
+    pub(super) fn set_bounded_resolution(&mut self, resolution: DelegatedFileResolution) {
+        self.resolution = Some(resolution);
+        let fits = serde_json::to_vec(self)
+            .map(|bytes| bytes.len() <= MAX_RECEIPT_BYTES)
+            .unwrap_or(false);
+        if !fits {
+            self.resolution = Some(DelegatedFileResolution::Failed {
+                reason: DelegatedFileFailureReason::TooLarge,
+            });
+        }
+    }
+}
+
+pub(super) fn delegated_file_content_fits_server(content: &str) -> bool {
+    !content.contains('\0')
+        && serde_json::to_string(&serde_json::json!({"content": content}))
+            .is_ok_and(|encoded| encoded.len() <= openwave_core::SandboxToolCall::MAX_RESULT_BYTES)
+}
+
 impl ReceiptStore {
     pub(crate) fn open(data_dir: &Path) -> io::Result<Self> {
         let directory = data_dir.join(RECEIPT_DIRECTORY);
@@ -416,6 +517,9 @@ impl ReceiptStore {
             _lock: lock,
         };
         store.load_all()?;
+        store.load_operations()?;
+        store.load_delegated_file_reads()?;
+        store.load_manual_connects()?;
         Ok(store)
     }
 
@@ -441,6 +545,22 @@ impl ReceiptStore {
         write_atomically(
             &self.directory,
             &self.operation_receipt_path(receipt.call_id),
+            &bytes,
+        )
+    }
+
+    pub(super) fn save_delegated_file_read(
+        &self,
+        receipt: &DelegatedFileReadReceipt,
+    ) -> io::Result<()> {
+        receipt.validate()?;
+        let bytes = serde_json::to_vec(receipt).map_err(invalid_data)?;
+        if bytes.len() > MAX_RECEIPT_BYTES {
+            return Err(invalid_data("delegated-file receipt is too large"));
+        }
+        write_atomically(
+            &self.directory,
+            &self.delegated_file_read_receipt_path(receipt.call_id),
             &bytes,
         )
     }
@@ -477,6 +597,14 @@ impl ReceiptStore {
         }
     }
 
+    pub(super) fn remove_delegated_file_read(&self, call_id: CallId) -> io::Result<()> {
+        match fs::remove_file(self.delegated_file_read_receipt_path(call_id)) {
+            Ok(()) => sync_directory(&self.directory),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
     pub(super) fn remove_manual_connect(
         &self,
         change_id: RootAttachmentChangeId,
@@ -500,6 +628,9 @@ impl ReceiptStore {
                 continue;
             }
             if file_name.starts_with(FOLDER_OPERATION_PREFIX) {
+                continue;
+            }
+            if file_name.starts_with(DELEGATED_FILE_READ_PREFIX) {
                 continue;
             }
             if file_name.starts_with(MANUAL_FOLDER_CONNECT_PREFIX) {
@@ -583,6 +714,48 @@ impl ReceiptStore {
         Ok(receipts)
     }
 
+    pub(super) fn load_delegated_file_reads(&self) -> io::Result<Vec<DelegatedFileReadReceipt>> {
+        let mut receipts = Vec::new();
+        let mut call_ids = HashSet::new();
+        for entry in fs::read_dir(&self.directory)? {
+            let entry = entry?;
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                return Err(invalid_data("invalid client-execution receipt name"));
+            };
+            let Some(call_id) = file_name
+                .strip_prefix(DELEGATED_FILE_READ_PREFIX)
+                .and_then(|name| name.strip_suffix(".json"))
+            else {
+                continue;
+            };
+            if receipts.len() >= MAX_RECEIPTS {
+                return Err(invalid_data("too many pending delegated-file receipts"));
+            }
+            let call_id = call_id
+                .parse::<Uuid>()
+                .map(CallId::from)
+                .map_err(invalid_data)?;
+            validate_private_file(&entry.path(), MAX_RECEIPT_BYTES)?;
+            let mut bytes = Vec::new();
+            File::open(entry.path())?
+                .take((MAX_RECEIPT_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)?;
+            if bytes.len() > MAX_RECEIPT_BYTES {
+                return Err(invalid_data("delegated-file receipt is too large"));
+            }
+            let receipt: DelegatedFileReadReceipt =
+                serde_json::from_slice(&bytes).map_err(invalid_data)?;
+            receipt.validate()?;
+            if receipt.call_id != call_id || !call_ids.insert(call_id) {
+                return Err(invalid_data("delegated-file receipt identity mismatch"));
+            }
+            receipts.push(receipt);
+        }
+        receipts.sort_by_key(|receipt| receipt.call_id.to_string());
+        Ok(receipts)
+    }
+
     pub(super) fn load_manual_connects(&self) -> io::Result<Vec<ManualFolderConnectReceipt>> {
         let mut receipts = Vec::new();
         let mut change_ids = HashSet::new();
@@ -634,6 +807,11 @@ impl ReceiptStore {
     fn operation_receipt_path(&self, call_id: CallId) -> PathBuf {
         self.directory
             .join(format!("{FOLDER_OPERATION_PREFIX}{call_id}.json"))
+    }
+
+    fn delegated_file_read_receipt_path(&self, call_id: CallId) -> PathBuf {
+        self.directory
+            .join(format!("{DELEGATED_FILE_READ_PREFIX}{call_id}.json"))
     }
 
     fn manual_connect_receipt_path(&self, change_id: RootAttachmentChangeId) -> PathBuf {
@@ -806,6 +984,29 @@ mod tests {
 
         let reopened = ReceiptStore::open(temp.path()).unwrap();
         assert_eq!(reopened.executor_id(), executor_id);
+    }
+
+    #[test]
+    fn delegated_file_receipts_are_pathless_private_and_never_log_content() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(temp.path()).unwrap();
+        let mut receipt = DelegatedFileReadReceipt::new(CallId::new(), store.executor_id());
+        store.save_delegated_file_read(&receipt).unwrap();
+        assert_eq!(
+            store.load_delegated_file_reads().unwrap(),
+            vec![receipt.clone()]
+        );
+
+        receipt.phase = FolderOperationPhase::DispatchStarted;
+        receipt.resolution = Some(DelegatedFileResolution::Completed {
+            content: "private-content-sentinel".to_owned(),
+        });
+        store.save_delegated_file_read(&receipt).unwrap();
+        let debug = format!("{receipt:?}");
+        assert!(!debug.contains("private-content-sentinel"));
+        assert!(!debug.contains("relative_path"));
+        store.remove_delegated_file_read(receipt.call_id).unwrap();
+        assert!(store.load_delegated_file_reads().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -146,12 +146,10 @@ async fn boot_server(
     data_dir: PathBuf,
 ) -> Result<(), String> {
     let client_executor_id = app.state::<host_access::HostAccess>().client_executor_id();
-    let server = openwave_server::bind_with_client_executor_id(
-        Config::desktop(data_dir),
-        client_executor_id,
-    )
-    .await
-    .map_err(|e| e.to_string())?;
+    let server =
+        openwave_server::bind_with_desktop_executor(Config::desktop(data_dir), client_executor_id)
+            .await
+            .map_err(|e| e.to_string())?;
     app.state::<host_access::HostAccess>()
         .initialize_store(server.store())?;
     let base_url = format!("http://{}", server.local_addr());
@@ -175,6 +173,11 @@ async fn boot_server(
             folder_operation_app,
         )
         .await;
+    });
+    let delegated_file_app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        client_execution::delegated_file_read::recover_delegated_file_read(delegated_file_app)
+            .await;
     });
     let root_attachment_app = app.clone();
     tauri::async_runtime::spawn(async move {

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -376,7 +376,7 @@ pub async fn bind(config: Config) -> Result<Server> {
 ///
 /// The desktop persists this identity outside renderer-visible state so pending
 /// attachment work remains recoverable across launches.
-pub async fn bind_with_client_executor_id(
+pub async fn bind_with_desktop_executor(
     config: Config,
     client_executor_id: Uuid,
 ) -> Result<Server> {
@@ -465,6 +465,8 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
         Some(state.config.data_dir.join("scratch")),
         turn_worker::TurnWorkerConfig::default(),
     );
+    let sandbox_worker_config = sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default()
+        .with_delegated_file_executor(client_executor_id.is_some());
     let sandbox_agent_run_worker = sandbox_agent_run_worker::SandboxAgentRunWorker::with_attempts(
         state.store.clone(),
         state.resolver.clone(),
@@ -474,7 +476,7 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
         state.sandbox_attempts.clone(),
         state.agent_config.clone(),
         Some(state.config.data_dir.join("scratch")),
-        sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default(),
+        sandbox_worker_config,
     );
     let sandbox_web_search_worker =
         sandbox_web_search_worker::SandboxWebSearchWorker::with_attempts(

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -16,7 +16,8 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use openwave_core::{
-    sandbox_folder_access_proposal_tool_spec, sandbox_web_search_tool_spec, AgentConfig,
+    sandbox_folder_access_proposal_tool_spec, sandbox_read_delegated_file_tool_spec,
+    sandbox_web_search_tool_spec, validate_sandbox_read_delegated_file_arguments, AgentConfig,
     AgentError, AgentRun, AgentRunInboxEntry, AgentRunStatus, CallId, ChatMessage, ChatRequest,
     ClaimAgentRunInboxOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome, ContentBlock,
     FailAgentRunOutcome, ModelProvider, ParkSandboxToolCallOutcome, ProviderEvent,
@@ -36,7 +37,8 @@ use crate::state::SandboxAttemptGuard;
 /// interactive tools or conversation-wide responsibilities that are outside a
 /// depth-one child run's authority.
 const SANDBOX_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below and return a concise, self-contained result for your parent agent. You cannot access the conversation, filesystem, connected folders, or other agents. You may use at most one tool: web_search when current public-web information is necessary, or request_folder_access only to propose that your foreground parent decide whether to ask the user. The proposal grants no access and cannot open a picker. Otherwise finish directly.";
-const SANDBOX_WEB_SEARCH_TOOL_LIMIT: usize = 1;
+const SANDBOX_DELEGATED_FILE_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below and return a concise, self-contained result for your parent agent. You cannot access the conversation, filesystem, connected folders, or other agents except for the one exact file explicitly delegated to this run. You may use at most one tool: read_delegated_file to read that exact file, web_search when current public-web information is necessary, or request_folder_access only to propose that your foreground parent decide whether to ask the user. The proposal grants no access and cannot open a picker. Otherwise finish directly.";
+const SANDBOX_TOOL_LIMIT: usize = 1;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SandboxAgentRunWorkerConfig {
@@ -48,6 +50,7 @@ pub(crate) struct SandboxAgentRunWorkerConfig {
     max_concurrency: usize,
     max_running_global: u32,
     max_running_per_chat: u32,
+    delegated_file_executor_enabled: bool,
     #[cfg(test)]
     suppress_resolver_heartbeats: bool,
 }
@@ -63,9 +66,18 @@ impl Default for SandboxAgentRunWorkerConfig {
             max_concurrency: 4,
             max_running_global: 4,
             max_running_per_chat: 2,
+            delegated_file_executor_enabled: false,
             #[cfg(test)]
             suppress_resolver_heartbeats: false,
         }
+    }
+}
+
+impl SandboxAgentRunWorkerConfig {
+    #[must_use]
+    pub(crate) const fn with_delegated_file_executor(mut self, enabled: bool) -> Self {
+        self.delegated_file_executor_enabled = enabled;
+        self
     }
 }
 
@@ -454,8 +466,27 @@ impl SandboxAgentRunWorker {
             .store
             .list_sandbox_tool_calls_for_agent_run(run.id)
             .await?;
-        let request =
-            sandbox_request(&self.agent_config, task, &previous_calls, &*self.store).await?;
+        let delegated_file_available = if self.config.delegated_file_executor_enabled {
+            match (
+                self.store.get_sandbox_agent_admission(run.id).await?,
+                self.store.get_chat(run.chat_id).await?,
+            ) {
+                (Some(admission), Some(chat)) => {
+                    delegated_file_admission_matches(&run, &admission, &chat)
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+        let request = sandbox_request(
+            &self.agent_config,
+            task,
+            &previous_calls,
+            &*self.store,
+            delegated_file_available,
+        )
+        .await?;
         let Some(provider) = self.resolve_provider(run.id, lease_token, &cancel).await? else {
             // `resolve_provider` has returned and dropped its resolver future
             // before this durable acknowledgement can terminalize the run.
@@ -521,6 +552,13 @@ impl SandboxAgentRunWorker {
             }
             Ok(SandboxCompletion::FolderAccessProposal { request }) => {
                 self.submit_folder_access_proposal(run.id, lease_token, request)
+                    .await
+            }
+            Ok(SandboxCompletion::DelegatedFileRead {
+                provider_id,
+                arguments,
+            }) => {
+                self.park_delegated_file_read(run, lease_token, provider_id, arguments)
                     .await
             }
             Err(error) => self.record_failure(run.id, lease_token, error).await,
@@ -710,6 +748,75 @@ impl SandboxAgentRunWorker {
         }
     }
 
+    async fn park_delegated_file_read(
+        &self,
+        run: AgentRun,
+        lease_token: uuid::Uuid,
+        provider_id: String,
+        arguments: serde_json::Value,
+    ) -> Result<SandboxAgentRunWorkerOutcome> {
+        let call = SandboxToolCallRequest {
+            id: CallId::new(),
+            agent_run_id: run.id,
+            chat_id: run.chat_id,
+            provider_id,
+            name: openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL.into(),
+            arguments,
+        };
+        let outcome = match self
+            .store
+            .park_agent_run_for_sandbox_tool_call(run.id, lease_token, &call)
+            .await
+        {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                let recovered = self
+                    .store
+                    .list_sandbox_tool_calls_for_agent_run(run.id)
+                    .await?
+                    .into_iter()
+                    .find(|existing| {
+                        existing.park_lease_token == lease_token
+                            && existing.provider_id == call.provider_id
+                            && existing.name == call.name
+                            && existing.arguments == call.arguments
+                    });
+                if let Some(call) = recovered {
+                    self.wake.notify_one();
+                    return Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id));
+                }
+                return Err(error);
+            }
+        };
+        match outcome {
+            ParkSandboxToolCallOutcome::Parked { call, .. }
+            | ParkSandboxToolCallOutcome::Existing { call, .. } => {
+                self.wake.notify_one();
+                Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id))
+            }
+            ParkSandboxToolCallOutcome::IdentityConflict => {
+                self.record_failure(
+                    run.id,
+                    lease_token,
+                    AgentError::msg("sandbox delegated-file checkpoint identity conflict"),
+                )
+                .await
+            }
+            ParkSandboxToolCallOutcome::DelegatedResourceUnavailable => {
+                self.record_failure(
+                    run.id,
+                    lease_token,
+                    AgentError::msg("sandbox delegated resource is unavailable"),
+                )
+                .await
+            }
+            ParkSandboxToolCallOutcome::LeaseLost => {
+                self.acknowledge_cancellation_or_lease_loss(run.id, lease_token)
+                    .await
+            }
+        }
+    }
+
     async fn acknowledge_cancellation_or_lease_loss(
         &self,
         id: openwave_core::AgentRunId,
@@ -758,21 +865,44 @@ impl SandboxAgentRunWorker {
     }
 }
 
+fn delegated_file_admission_matches(
+    run: &AgentRun,
+    admission: &openwave_core::SandboxAgentAdmission,
+    chat: &openwave_core::Chat,
+) -> bool {
+    admission.child_run_id == run.id
+        && admission.chat_id == run.chat_id
+        && chat.id == run.chat_id
+        && admission.resource.as_ref().is_some_and(|resource| {
+            resource.is_well_formed()
+                && chat
+                    .root_attachments
+                    .iter()
+                    .any(|attachment| attachment.root_id == resource.root_id)
+        })
+}
+
 async fn sandbox_request(
     config: &AgentConfig,
     task: String,
     calls: &[SandboxToolCall],
     store: &dyn Store,
+    delegated_file_available: bool,
 ) -> Result<ChatRequest> {
-    if calls.len() > SANDBOX_WEB_SEARCH_TOOL_LIMIT {
-        return Err(AgentError::msg("sandbox web-search tool budget exceeded"));
+    if calls.len() > SANDBOX_TOOL_LIMIT {
+        return Err(AgentError::msg("sandbox tool budget exceeded"));
     }
     if config.max_steps == 0 || calls.len().saturating_add(1) > config.max_steps {
         return Err(AgentError::msg("sandbox model-step budget exceeded"));
     }
     let mut messages = vec![ChatMessage::text(Role::User, task)];
     for call in calls {
-        if call.name != openwave_core::SANDBOX_WEB_SEARCH_TOOL || !call.status.is_terminal() {
+        if !matches!(
+            call.name.as_str(),
+            openwave_core::SANDBOX_WEB_SEARCH_TOOL
+                | openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
+        ) || !call.status.is_terminal()
+        {
             return Err(AgentError::msg("sandbox checkpoint cannot be resumed"));
         }
         let receipt = store
@@ -798,7 +928,14 @@ async fn sandbox_request(
     }
     Ok(ChatRequest {
         model: config.model.clone(),
-        system: Some(SANDBOX_SYSTEM_PROMPT.into()),
+        system: Some(
+            if delegated_file_available {
+                SANDBOX_DELEGATED_FILE_SYSTEM_PROMPT
+            } else {
+                SANDBOX_SYSTEM_PROMPT
+            }
+            .into(),
+        ),
         messages,
         // Once a receipt exists, omit the tool definition. This makes the
         // depth-one sandbox's one-call budget visible to the model and turns a
@@ -807,10 +944,14 @@ async fn sandbox_request(
         // completion. Never advertise work that the remaining model budget
         // cannot consume after its durable receipt arrives.
         tools: if calls.is_empty() && config.max_steps >= 2 {
-            vec![
+            let mut tools = vec![
                 sandbox_web_search_tool_spec(),
                 sandbox_folder_access_proposal_tool_spec(),
-            ]
+            ];
+            if delegated_file_available {
+                tools.push(sandbox_read_delegated_file_tool_spec());
+            }
+            tools
         } else if calls.is_empty() && config.max_steps >= 1 {
             vec![sandbox_folder_access_proposal_tool_spec()]
         } else {
@@ -830,6 +971,10 @@ enum SandboxCompletion {
     FolderAccessProposal {
         request: RequestFolderAccessArgs,
     },
+    DelegatedFileRead {
+        provider_id: String,
+        arguments: serde_json::Value,
+    },
 }
 
 async fn complete_sandbox_task(
@@ -844,6 +989,10 @@ async fn complete_sandbox_task(
         .tools
         .iter()
         .any(|tool| tool.name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL);
+    let delegated_file_advertised = request
+        .tools
+        .iter()
+        .any(|tool| tool.name == openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL);
     let mut stream = provider.stream(request).await?;
     let mut text = String::new();
     let mut calls = std::collections::BTreeMap::<u32, (String, String, String)>::new();
@@ -920,6 +1069,24 @@ async fn complete_sandbox_task(
                             ));
                         }
                         return Ok(SandboxCompletion::FolderAccessProposal { request });
+                    }
+                    if name == openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
+                        && delegated_file_advertised
+                    {
+                        let arguments = serde_json::from_str(&arguments).map_err(|_| {
+                            AgentError::msg(
+                                "sandbox agent emitted invalid delegated-file arguments",
+                            )
+                        })?;
+                        if !validate_sandbox_read_delegated_file_arguments(&arguments) {
+                            return Err(AgentError::msg(
+                                "sandbox agent emitted invalid delegated-file arguments",
+                            ));
+                        }
+                        return Ok(SandboxCompletion::DelegatedFileRead {
+                            provider_id,
+                            arguments,
+                        });
                     }
                     return Err(AgentError::msg(
                         "sandbox agent requested an unadvertised tool",
@@ -2342,6 +2509,7 @@ mod tests {
             "task".into(),
             &[],
             &store,
+            false,
         )
         .await
         .unwrap();
@@ -2377,6 +2545,7 @@ mod tests {
             "task".into(),
             &[],
             &store,
+            false,
         )
         .await
         .unwrap();
@@ -2399,6 +2568,241 @@ mod tests {
             },
         ]));
         assert!(complete_sandbox_task(provider, request).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn desktop_delegation_advertises_one_canonical_file_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap();
+        let request = sandbox_request(
+            &AgentConfig {
+                model: "m".into(),
+                ..AgentConfig::default()
+            },
+            "task".into(),
+            &[],
+            &store,
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            request.system.as_deref(),
+            Some(SANDBOX_DELEGATED_FILE_SYSTEM_PROMPT)
+        );
+        assert_eq!(
+            request
+                .tools
+                .iter()
+                .filter(|tool| tool.name == openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL)
+                .count(),
+            1
+        );
+
+        let provider = Arc::new(EventProvider(vec![
+            ProviderEvent::ToolCallStarted {
+                index: 0,
+                id: "read_1".into(),
+                name: openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL.into(),
+            },
+            ProviderEvent::ToolCallArgsDelta {
+                index: 0,
+                fragment: "{}".into(),
+            },
+            ProviderEvent::Stop {
+                reason: StopReason::ToolUse,
+            },
+        ]));
+        assert!(matches!(
+            complete_sandbox_task(provider, request).await.unwrap(),
+            SandboxCompletion::DelegatedFileRead { arguments, .. }
+                if arguments == serde_json::json!({})
+        ));
+    }
+
+    #[tokio::test]
+    async fn delegated_file_read_rejects_nonempty_arguments() {
+        let request = ChatRequest {
+            model: "m".into(),
+            system: Some(SANDBOX_DELEGATED_FILE_SYSTEM_PROMPT.into()),
+            messages: vec![ChatMessage::text(Role::User, "task")],
+            tools: vec![sandbox_read_delegated_file_tool_spec()],
+            max_tokens: Some(100),
+            temperature: Some(0.0),
+        };
+        let provider = Arc::new(EventProvider(vec![
+            ProviderEvent::ToolCallStarted {
+                index: 0,
+                id: "read_1".into(),
+                name: openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL.into(),
+            },
+            ProviderEvent::ToolCallArgsDelta {
+                index: 0,
+                fragment: r#"{"path":"secret"}"#.into(),
+            },
+            ProviderEvent::Stop {
+                reason: StopReason::ToolUse,
+            },
+        ]));
+        assert!(complete_sandbox_task(provider, request).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn delegated_file_advertisement_requires_exact_current_attachment() {
+        let (_worker, store, _provider, mut chat, _dir) = fixture().await;
+        let run = admit_sandbox(&store, chat.id, CallId::new(), "inspect file").await;
+        let mut admission = store
+            .get_sandbox_agent_admission(run.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!delegated_file_admission_matches(&run, &admission, &chat));
+
+        let root_id = openwave_core::HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+        admission.resource = Some(openwave_core::SandboxAgentFileResource {
+            root_id,
+            relative_path: "reports/summary.md".into(),
+        });
+        assert!(!delegated_file_admission_matches(&run, &admission, &chat));
+        chat.root_attachments
+            .push(openwave_core::ChatRootAttachment {
+                root_id,
+                origin: openwave_core::RootAttachmentOrigin::Conversation,
+            });
+        assert!(delegated_file_admission_matches(&run, &admission, &chat));
+
+        admission.chat_id = ChatId::new();
+        assert!(!delegated_file_admission_matches(&run, &admission, &chat));
+    }
+
+    #[tokio::test]
+    async fn desktop_worker_checkpoints_one_exact_delegated_file_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let root_id = openwave_core::HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+        let mut chat = sandbox_chat();
+        chat.attachment_revision = 1;
+        chat.root_attachments
+            .push(openwave_core::ChatRootAttachment {
+                root_id,
+                origin: openwave_core::RootAttachmentOrigin::Conversation,
+            });
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "model", "spawn delegated child")
+            .await
+            .unwrap();
+        let foreground_lease = uuid::Uuid::new_v4();
+        let now = Utc::now();
+        let turn = store
+            .claim_turn_run(foreground_lease, now, now + chrono::Duration::minutes(1))
+            .await
+            .unwrap()
+            .turn
+            .unwrap();
+        store
+            .append_turn_event(
+                chat.id,
+                turn.id,
+                foreground_lease,
+                1,
+                Utc::now(),
+                &openwave_core::AgentEvent::TurnStarted { turn_id: turn.id },
+            )
+            .await
+            .unwrap();
+        let spawn_call_id = CallId::new();
+        let child_id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn_call_id);
+        let outcome = store
+            .checkpoint_sandbox_spawn(
+                &openwave_core::SandboxSpawnCheckpointRequest {
+                    origin_turn_id: turn.id,
+                    lease_token: foreground_lease,
+                    expected_steer_revision: turn.steer_revision,
+                    call_id: spawn_call_id,
+                    provider_id: "spawn_1".into(),
+                    arguments: serde_json::json!({
+                        "task": "inspect the report",
+                        "resource": {
+                            "root_id": root_id,
+                            "relative_path": "reports/summary.md"
+                        }
+                    }),
+                    result: serde_json::to_string(&openwave_core::SpawnSandboxAgentResult {
+                        agent_id: child_id,
+                    })
+                    .unwrap(),
+                    event_ordinal: 2,
+                    progress: TurnCheckpointProgress {
+                        model_steps: 1,
+                        usage: Usage::default(),
+                    },
+                },
+                Utc::now(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            openwave_core::CheckpointSandboxSpawnOutcome::Checkpointed { .. }
+                | openwave_core::CheckpointSandboxSpawnOutcome::Existing { .. }
+        ));
+
+        let provider = Arc::new(EventProvider(vec![
+            ProviderEvent::ToolCallStarted {
+                index: 0,
+                id: "read_1".into(),
+                name: openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL.into(),
+            },
+            ProviderEvent::ToolCallArgsDelta {
+                index: 0,
+                fragment: "{}".into(),
+            },
+            ProviderEvent::Stop {
+                reason: StopReason::ToolUse,
+            },
+        ]));
+        let worker = SandboxAgentRunWorker::new(
+            store.clone(),
+            Arc::new(FixedResolver(provider)),
+            Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
+            Arc::new(EventBus::default()),
+            AgentConfig {
+                model: "model".into(),
+                ..AgentConfig::default()
+            },
+            Some(dir.path().join("scratch")),
+            SandboxAgentRunWorkerConfig::default().with_delegated_file_executor(true),
+        );
+        assert!(matches!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::ToolCheckpointed(_)
+        ));
+        let calls = store
+            .list_sandbox_tool_calls_for_agent_run(child_id)
+            .await
+            .unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].name,
+            openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
+        );
+        assert_eq!(calls[0].arguments, serde_json::json!({}));
     }
 
     fn sandbox_chat() -> Chat {


### PR DESCRIPTION
## Summary
- advertise `read_delegated_file` only for embedded desktop sandbox runs with an exact currently attached resource
- execute one bounded broker read behind native claim, heartbeat, resolve, and private no-replay recovery receipts
- recover expired claims and invalid portable paths to neutral terminal results without replaying host I/O

## Validation
- `bw dev lint --rust --check`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p openwave-server` (259 passed)
- `cargo test -p openwave-desktop` (42 passed)