### PR TITLE
Add desktop project navigation

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -5,6 +5,7 @@ import {
   type Chat,
   type ModelInfo,
   type PendingFolderAccessRequest,
+  type Project,
   type ProviderInfo,
   type ProviderKind,
   type SequencedEvent,
@@ -56,6 +57,7 @@ import {
   reconcileSandboxAgentCancellation,
   sandboxAgentStopKey,
 } from "./SandboxAgentStop";
+import { ProjectNavigation } from "./ProjectNavigation";
 
 type Msg = ChatMessage;
 
@@ -74,6 +76,10 @@ export default function App() {
   const [hydratedChatId, setHydratedChatId] = useState<string | null>(null);
   const [chats, setChats] = useState<Chat[]>([]);
   const [chatsError, setChatsError] = useState<string | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [projectsLoading, setProjectsLoading] = useState(true);
+  const [projectsError, setProjectsError] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [messages, setMessages] = useState<Msg[]>([]);
@@ -109,6 +115,7 @@ export default function App() {
   const [steerError, setSteerError] = useState<string | null>(null);
   const [steerStatus, setSteerStatus] = useState<string | null>(null);
   const [creatingChat, setCreatingChat] = useState(false);
+  const [creatingProject, setCreatingProject] = useState(false);
   const [deletingChatId, setDeletingChatId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState("");
@@ -142,6 +149,7 @@ export default function App() {
   const steerFenceRef = useRef(new ActiveTurnSteerFence());
   const sandboxStopFenceRef = useRef(new SandboxAgentStopFence());
   const provisionalToolCallIdsRef = useRef<Set<string>>(new Set());
+  const creationInFlightRef = useRef(false);
   const deletionInFlightRef = useRef(false);
 
   useEffect(() => {
@@ -170,6 +178,16 @@ export default function App() {
     let cancelled = false;
     (async () => {
       try {
+        void (async () => {
+          try {
+            const existingProjects = await client.listProjects();
+            if (!cancelled) setProjects(existingProjects);
+          } catch {
+            if (!cancelled) setProjectsError("Could not load projects.");
+          } finally {
+            if (!cancelled) setProjectsLoading(false);
+          }
+        })();
         const [catalog, providerList, existingChats] = await Promise.all([
           client.listModels(),
           client.listProviders(),
@@ -858,38 +876,16 @@ export default function App() {
   }
 
   async function onNewChat() {
-    if (!client || creatingChat || deletionInFlightRef.current) return;
+    if (!client || creationInFlightRef.current || deletionInFlightRef.current) return;
+    creationInFlightRef.current = true;
     setCreatingChat(true);
     setPrimaryView("chat");
     try {
-      const created = await client.createChat(chat?.model ?? models[0]?.id);
-      socketGenerationRef.current += 1;
-      socketRef.current?.close();
-      socketRef.current = null;
-      assistantBufRef.current = "";
-      assistantMarkerScrubberRef.current =
-        new AssistantSourceMarkerStreamScrubber();
-      provisionalToolCallIdsRef.current = new Set();
-      lastSeqRef.current = 0;
-      followsLatestRef.current = true;
-      setHasUnreadActivity(false);
-      setMessages([]);
-      hydratedMessageIdsRef.current = new Set();
-      setAgentRuns([]);
-      setAgentRunsError(null);
-      setFolderAccessRequests([]);
-      setFolderAccessErrors({});
-      setComposerDraft("");
-      setBusy(false);
-      setCurrentActiveTurnId(null);
-      setCancelPendingTurnId(null);
-      setCancelError(null);
-      cancelRequestTurnRef.current = null;
-      clearSteerRequestState();
-      activateChat(created);
-      setChats((current) => [created, ...current]);
-      setChatsError(null);
-      setStatus(`chat ${created.id.slice(0, 8)}…`);
+      const created = await client.createChat(
+        chat?.model ?? models[0]?.id,
+        selectedProjectId,
+      );
+      openCreatedChat(created);
     } catch (err) {
       setMessages((prev) => [
         ...prev,
@@ -900,12 +896,117 @@ export default function App() {
         },
       ]);
     } finally {
+      creationInFlightRef.current = false;
       setCreatingChat(false);
     }
   }
 
+  function openCreatedChat(created: Chat) {
+    setPrimaryView("chat");
+    socketGenerationRef.current += 1;
+    socketRef.current?.close();
+    socketRef.current = null;
+    assistantBufRef.current = "";
+    assistantMarkerScrubberRef.current =
+      new AssistantSourceMarkerStreamScrubber();
+    provisionalToolCallIdsRef.current = new Set();
+    lastSeqRef.current = 0;
+    followsLatestRef.current = true;
+    setHasUnreadActivity(false);
+    setMessages([]);
+    hydratedMessageIdsRef.current = new Set();
+    setAgentRuns([]);
+    setAgentRunsError(null);
+    setFolderAccessRequests([]);
+    setFolderAccessErrors({});
+    setComposerDraft("");
+    setBusy(false);
+    setCurrentActiveTurnId(null);
+    setCancelPendingTurnId(null);
+    setCancelError(null);
+    cancelRequestTurnRef.current = null;
+    clearSteerRequestState();
+    activateChat(created);
+    setChats((current) => [created, ...current]);
+    setChatsError(null);
+    setProjectsError(null);
+    setStatus(`chat ${created.id.slice(0, 8)}…`);
+  }
+
+  async function onSelectProject(projectId: string | null) {
+    if (
+      !client ||
+      projectsLoading ||
+      creationInFlightRef.current ||
+      deletionInFlightRef.current
+    ) {
+      return;
+    }
+    const existing = chats.find((item) => item.project_id === projectId);
+    if (existing) {
+      setProjectsError(null);
+      selectChat(existing);
+      return;
+    }
+
+    creationInFlightRef.current = true;
+    setCreatingChat(true);
+    setProjectsError(null);
+    try {
+      const created = await client.createChat(
+        chat?.model ?? models[0]?.id,
+        projectId,
+      );
+      openCreatedChat(created);
+    } catch (err) {
+      setProjectsError(`Could not open project: ${String(err)}`);
+    } finally {
+      creationInFlightRef.current = false;
+      setCreatingChat(false);
+    }
+  }
+
+  async function onCreateProject(title: string): Promise<boolean> {
+    if (
+      !client ||
+      projectsLoading ||
+      creationInFlightRef.current ||
+      deletionInFlightRef.current
+    ) {
+      return false;
+    }
+    creationInFlightRef.current = true;
+    setCreatingProject(true);
+    setProjectsError(null);
+    let project: Project;
+    try {
+      project = await client.createProject(title);
+      setProjects((current) => [project, ...current]);
+    } catch (err) {
+      setProjectsError(`Could not create project: ${String(err)}`);
+      creationInFlightRef.current = false;
+      setCreatingProject(false);
+      return false;
+    }
+
+    try {
+      const created = await client.createChat(
+        chat?.model ?? models[0]?.id,
+        project.id,
+      );
+      openCreatedChat(created);
+      return true;
+    } catch (err) {
+      setProjectsError(`Project created, but its first chat could not start: ${String(err)}`);
+      return true;
+    } finally {
+      creationInFlightRef.current = false;
+      setCreatingProject(false);
+    }
+  }
+
   async function onDeleteChat(target: Chat) {
-    if (!client || deletionInFlightRef.current || creatingChat) return;
+    if (!client || deletionInFlightRef.current || creationInFlightRef.current) return;
     const label = target.title?.trim() || "this conversation";
     if (!window.confirm(`Delete ${label}? This cannot be undone.`)) return;
 
@@ -930,9 +1031,9 @@ export default function App() {
         return;
       }
 
-      let next = refreshed[0];
+      let next = refreshed.find((item) => item.project_id === target.project_id);
       if (!next) {
-        next = await client.createChat(models[0]?.id);
+        next = await client.createChat(models[0]?.id, target.project_id);
         refreshed = await client.listChats();
       }
       setChats(refreshed);
@@ -955,12 +1056,19 @@ export default function App() {
     assistantMarkerScrubberRef.current =
       new AssistantSourceMarkerStreamScrubber();
     setChat(next);
+    setSelectedProjectId(next.project_id);
   }
 
   function selectChat(next: Chat, force = false) {
     setPrimaryView("chat");
     setSettingsPanel(null);
-    if (next.id === chat?.id || creatingChat || (!force && deletionInFlightRef.current)) return;
+    if (
+      next.id === chat?.id ||
+      creatingChat ||
+      (!force && (creationInFlightRef.current || deletionInFlightRef.current))
+    ) {
+      return;
+    }
     socketGenerationRef.current += 1;
     socketRef.current?.close();
     socketRef.current = null;
@@ -1120,6 +1228,13 @@ export default function App() {
     );
   }
 
+  const visibleChats = chats.filter(
+    (item) => item.project_id === selectedProjectId,
+  );
+  const activeProject = selectedProjectId
+    ? projects.find((project) => project.id === selectedProjectId) ?? null
+    : null;
+
   return (
     <div className="app-shell">
       <aside className="sidebar">
@@ -1132,11 +1247,22 @@ export default function App() {
           type="button"
           className="new-chat"
           onClick={() => void onNewChat()}
-          disabled={creatingChat || deletingChatId !== null}
+          disabled={creatingChat || creatingProject || deletingChatId !== null}
         >
           <span aria-hidden="true">+</span>
           {creatingChat ? "Starting…" : deletingChatId ? "Deleting…" : "New chat"}
         </button>
+
+        <ProjectNavigation
+          projects={projects}
+          selectedProjectId={selectedProjectId}
+          disabled={
+            projectsLoading || creatingChat || creatingProject || deletingChatId !== null
+          }
+          error={projectsError}
+          onSelect={(projectId) => void onSelectProject(projectId)}
+          onCreate={onCreateProject}
+        />
 
         {hasNativeHost() && (
           <button
@@ -1155,7 +1281,7 @@ export default function App() {
         <div className="sidebar-section">
           <span className="sidebar-label">Conversations</span>
           <div className="conversation-list" aria-label="Conversations">
-            {chats.map((item) => (
+            {visibleChats.map((item) => (
               <div
                 key={item.id}
                 className={`conversation-row${primaryView === "chat" && item.id === chat.id ? " is-active" : ""}`}
@@ -1164,7 +1290,7 @@ export default function App() {
                   type="button"
                   className="conversation-item"
                   aria-current={primaryView === "chat" && item.id === chat.id ? "page" : undefined}
-                  disabled={deletingChatId !== null || creatingChat}
+                  disabled={deletingChatId !== null || creatingChat || creatingProject}
                   onClick={() => selectChat(item)}
                 >
                   <span className="conversation-dot" aria-hidden="true" />
@@ -1175,7 +1301,7 @@ export default function App() {
                   className="conversation-delete"
                   aria-label={`Delete ${item.title?.trim() || "conversation"}`}
                   title="Delete conversation"
-                  disabled={deletingChatId !== null || creatingChat}
+                  disabled={deletingChatId !== null || creatingChat || creatingProject}
                   onClick={() => void onDeleteChat(item)}
                 >
                   ×
@@ -1238,7 +1364,10 @@ export default function App() {
         <section className="chat-pane">
           <header className="conversation-header">
             <div>
-              <p className="eyebrow">Conversation</p>
+              <p className="eyebrow">
+                {activeProject?.title?.trim() ||
+                  (selectedProjectId ? "Untitled project" : "Loose conversation")}
+              </p>
               {editingTitle ? (
                 <form
                   className="conversation-title-editor"

--- a/crates/openwave-desktop/ui/src/ProjectNavigation.test.tsx
+++ b/crates/openwave-desktop/ui/src/ProjectNavigation.test.tsx
@@ -1,0 +1,52 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { Project } from "./api";
+import { ProjectNavigation } from "./ProjectNavigation";
+
+function project(id: string, title: string | null): Project {
+  return {
+    id,
+    title,
+    attachment_revision: 0,
+    root_attachments: [],
+    created_at: "2026-07-21T12:00:00Z",
+  };
+}
+
+describe("ProjectNavigation", () => {
+  it("renders loose and project scopes with one selected scope", () => {
+    const markup = renderToStaticMarkup(
+      <ProjectNavigation
+        projects={[project("project-a", "Research"), project("project-b", null)]}
+        selectedProjectId="project-a"
+        disabled={false}
+        error={null}
+        onSelect={vi.fn()}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Projects"');
+    expect(markup).toContain("Loose chats");
+    expect(markup).toContain("Research");
+    expect(markup).toContain("Untitled project");
+    expect(markup).toContain('aria-current="page"');
+    expect(markup.match(/aria-current="page"/g)).toHaveLength(1);
+  });
+
+  it("keeps project failures bounded to the sidebar", () => {
+    const markup = renderToStaticMarkup(
+      <ProjectNavigation
+        projects={[]}
+        selectedProjectId={null}
+        disabled
+        error="Could not load projects."
+        onSelect={vi.fn()}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Could not load projects.");
+    expect(markup).toContain("disabled");
+  });
+});

--- a/crates/openwave-desktop/ui/src/ProjectNavigation.tsx
+++ b/crates/openwave-desktop/ui/src/ProjectNavigation.tsx
@@ -1,0 +1,132 @@
+import { useState, type FormEvent } from "react";
+import type { Project } from "./api";
+
+type Props = {
+  projects: Project[];
+  selectedProjectId: string | null;
+  disabled: boolean;
+  error: string | null;
+  onSelect: (projectId: string | null) => void;
+  onCreate: (title: string) => Promise<boolean>;
+};
+
+export function ProjectNavigation({
+  projects,
+  selectedProjectId,
+  disabled,
+  error,
+  onSelect,
+  onCreate,
+}: Props) {
+  const [adding, setAdding] = useState(false);
+  const [title, setTitle] = useState("");
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = title.trim();
+    if (!trimmed || disabled) return;
+    if (await onCreate(trimmed)) {
+      setTitle("");
+      setAdding(false);
+    }
+  }
+
+  return (
+    <section className="project-navigation" aria-label="Projects">
+      <div className="sidebar-section-heading">
+        <span className="sidebar-label">Projects</span>
+        <button
+          type="button"
+          className="sidebar-add"
+          aria-label="Create project"
+          title="Create project"
+          disabled={disabled}
+          onClick={() => setAdding((current) => !current)}
+        >
+          +
+        </button>
+      </div>
+
+      {adding && (
+        <form className="project-create" onSubmit={(event) => void submit(event)}>
+          <input
+            autoFocus
+            aria-label="Project name"
+            placeholder="Project name"
+            value={title}
+            maxLength={120}
+            disabled={disabled}
+            onChange={(event) => setTitle(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                setTitle("");
+                setAdding(false);
+              }
+            }}
+          />
+          <div className="project-create-actions">
+            <button type="submit" disabled={disabled || !title.trim()}>
+              Create
+            </button>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => {
+                setTitle("");
+                setAdding(false);
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      <div className="project-list">
+        <ProjectButton
+          title="Loose chats"
+          selected={selectedProjectId === null}
+          disabled={disabled}
+          onClick={() => onSelect(null)}
+        />
+        {projects.map((project) => (
+          <ProjectButton
+            key={project.id}
+            title={project.title?.trim() || "Untitled project"}
+            selected={selectedProjectId === project.id}
+            disabled={disabled}
+            onClick={() => onSelect(project.id)}
+          />
+        ))}
+      </div>
+      {error && <p className="sidebar-error">{error}</p>}
+    </section>
+  );
+}
+
+function ProjectButton({
+  title,
+  selected,
+  disabled,
+  onClick,
+}: {
+  title: string;
+  selected: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`project-item${selected ? " is-active" : ""}`}
+      aria-current={selected ? "page" : undefined}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <span className="project-icon" aria-hidden="true">
+        {selected ? "◆" : "◇"}
+      </span>
+      <span>{title}</span>
+    </button>
+  );
+}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -211,6 +211,85 @@ describe("active turn steering", () => {
   });
 });
 
+describe("project-scoped conversation API", () => {
+  it("creates a named project and a chat in that exact scope", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "project-1",
+            title: "Research",
+            attachment_revision: 0,
+            root_attachments: [],
+            created_at: "2026-07-21T12:00:00Z",
+          }),
+          { status: 201 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: "chat-1",
+            title: null,
+            model: "model-1",
+            attachment_revision: 0,
+            root_attachments: [],
+            project_id: "project-1",
+            created_at: "2026-07-21T12:00:00Z",
+          }),
+          { status: 201 },
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await client.createProject("Research");
+    await client.createChat("model-1", "project-1");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "http://127.0.0.1/projects",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ title: "Research" }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "http://127.0.0.1/chats",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ model: "model-1", project_id: "project-1" }),
+      }),
+    );
+  });
+
+  it("keeps a loose chat explicitly outside project scope", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "chat-1",
+          title: null,
+          model: null,
+          attachment_revision: 0,
+          root_attachments: [],
+          project_id: null,
+          created_at: "2026-07-21T12:00:00Z",
+        }),
+        { status: 201 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await client.createChat(undefined, null);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({});
+  });
+});
+
 describe("sandbox agent cancellation", () => {
   it("accepts only the closed cancellation projection", () => {
     expect(

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -18,6 +18,14 @@ export type ModelInfo = {
   provider: string;
 };
 
+export type Project = {
+  id: string;
+  title: string | null;
+  attachment_revision: number;
+  root_attachments: string[];
+  created_at: string;
+};
+
 /** The fixed, host-owned search providers supported by this build. */
 export type WebSearchProviderKind = "exa" | "tavily";
 
@@ -328,11 +336,26 @@ export class ApiClient {
     });
   }
 
-  createChat(model?: string): Promise<Chat> {
+  createProject(title: string): Promise<Project> {
+    return this.json("/projects", {
+      method: "POST",
+      headers: this.headers(true),
+      body: JSON.stringify({ title }),
+    });
+  }
+
+  listProjects(): Promise<Project[]> {
+    return this.json("/projects", { headers: this.headers() });
+  }
+
+  createChat(model?: string, projectId?: string | null): Promise<Chat> {
     return this.json("/chats", {
       method: "POST",
       headers: this.headers(true),
-      body: JSON.stringify({ model: model || undefined }),
+      body: JSON.stringify({
+        model: model || undefined,
+        project_id: projectId || undefined,
+      }),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -59,7 +59,7 @@ button {
   display: flex;
   min-width: 0;
   flex-direction: column;
-  gap: 1.4rem;
+  gap: 1rem;
   padding: 1rem 0.75rem 0.75rem;
   border-right: 1px solid var(--line);
   background: var(--sidebar);
@@ -109,13 +109,121 @@ button {
 
 .sidebar-section {
   display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  flex: 1 1 auto;
   gap: 0.45rem;
   min-height: 0;
+  overflow: hidden;
+}
+
+.project-navigation {
+  display: grid;
+  min-height: 0;
+  gap: 0.4rem;
+}
+
+.sidebar-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.sidebar-add {
+  width: 1.6rem;
+  height: 1.6rem;
+  border: 0;
+  border-radius: 5px;
+  color: var(--muted);
+  background: transparent;
+  line-height: 1;
+}
+
+.sidebar-add:hover:not(:disabled) {
+  color: var(--ink);
+  background: var(--sidebar-active);
+}
+
+.project-list {
+  display: grid;
+  max-height: min(20vh, 12rem);
+  gap: 0.12rem;
+  overflow-y: auto;
+}
+
+.project-item {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  gap: 0.55rem;
+  border: 0;
+  border-radius: 7px;
+  padding: 0.48rem 0.55rem;
+  color: var(--muted);
+  background: transparent;
+  font-size: 0.84rem;
+  text-align: left;
+}
+
+.project-item:hover:not(:disabled),
+.project-item.is-active {
+  color: var(--ink);
+  background: var(--sidebar-active);
+}
+
+.project-item > span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-icon {
+  width: 0.75rem;
+  flex: 0 0 auto;
+  color: var(--accent);
+  text-align: center;
+  font-size: 0.58rem;
+}
+
+.project-create {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0 0.25rem 0.3rem;
+}
+
+.project-create input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0.4rem 0.48rem;
+  background: var(--bg-elevated);
+  font-size: 0.8rem;
+}
+
+.project-create-actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.project-create-actions button {
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 0.22rem 0.45rem;
+  background: var(--bg-elevated);
+  font-size: 0.72rem;
+}
+
+.project-create-actions button:first-child:not(:disabled) {
+  border-color: var(--ink);
+  color: var(--bg);
+  background: var(--ink);
 }
 
 .conversation-list {
   display: grid;
-  max-height: min(46vh, 32rem);
+  max-height: none;
   gap: 0.12rem;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary

- add project and loose-chat scopes to desktop navigation
- create the first project-scoped conversation with a new project
- keep new and replacement conversations in the selected project scope
- isolate project navigation in a focused, tested component

## Validation

- `pnpm --dir crates/openwave-desktop/ui test`
- `pnpm --dir crates/openwave-desktop/ui build`
- `cargo test --workspace`
- `bw dev lint --rust`
- `cargo fmt --all --check`
