### PR TITLE
Add bounded project rename

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -170,6 +170,19 @@ impl Store for DbStore {
         Ok(projects)
     }
 
+    async fn update_project_title(&self, id: ProjectId, title: Option<String>) -> Result<bool> {
+        let result = entities::project::Entity::update_many()
+            .set(entities::project::ActiveModel {
+                title: Set(title),
+                ..Default::default()
+            })
+            .filter(entities::project::Column::Id.eq(id.0))
+            .exec(&self.conn)
+            .await
+            .map_err(store_err)?;
+        Ok(result.rows_affected == 1)
+    }
+
     async fn create_document(&self, document: &DocumentRecord) -> Result<()> {
         validate_document_source_regions(&document.canonical_text, &document.source_regions)?;
         let source_byte_len = document

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -446,6 +446,38 @@ async fn list_projects_is_newest_first() {
 }
 
 #[tokio::test]
+async fn project_title_update_sets_clears_and_reports_missing_identity() {
+    let (_dir, store) = temp_store().await;
+    let project = sample_project();
+    store.create_project(&project).await.unwrap();
+
+    assert!(store
+        .update_project_title(project.id, Some("Renamed".into()))
+        .await
+        .unwrap());
+    assert_eq!(
+        store
+            .get_project(project.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .title
+            .as_deref(),
+        Some("Renamed")
+    );
+
+    assert!(store.update_project_title(project.id, None).await.unwrap());
+    assert_eq!(
+        store.get_project(project.id).await.unwrap().unwrap().title,
+        None
+    );
+    assert!(!store
+        .update_project_title(ProjectId::new(), Some("missing".into()))
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
 async fn documents_roundtrip_and_list_by_corpus_scope() {
     let (_dir, store) = temp_store().await;
     let project_a = sample_project();

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -815,6 +815,16 @@ pub trait Store: Send + Sync {
     /// List projects, most-recently-created first.
     async fn list_projects(&self) -> Result<Vec<Project>>;
 
+    /// Replace one project's human-facing title.
+    ///
+    /// Returns `false` when the project does not exist. Product adapters own
+    /// title normalization and bounds before calling this storage primitive.
+    async fn update_project_title(&self, _id: ProjectId, _title: Option<String>) -> Result<bool> {
+        Err(AgentError::Store(
+            "project metadata storage is not implemented by this Store".into(),
+        ))
+    }
+
     /// Persist a new authoritative document record.
     ///
     /// `project_id`, when present, must identify an existing project. The default

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -1005,6 +1005,27 @@ export default function App() {
     }
   }
 
+  async function onRenameProject(
+    projectId: string,
+    title: string | null,
+  ): Promise<boolean> {
+    if (!client) return false;
+    setProjectsError(null);
+    try {
+      const updated = await client.patchProjectTitle(projectId, title);
+      if (updated.id !== projectId) {
+        throw new Error("project rename response has the wrong identity");
+      }
+      setProjects((current) =>
+        current.map((project) => (project.id === updated.id ? updated : project)),
+      );
+      return true;
+    } catch (err) {
+      setProjectsError(`Could not rename project: ${String(err)}`);
+      return false;
+    }
+  }
+
   async function onDeleteChat(target: Chat) {
     if (!client || deletionInFlightRef.current || creationInFlightRef.current) return;
     const label = target.title?.trim() || "this conversation";
@@ -1262,6 +1283,7 @@ export default function App() {
           error={projectsError}
           onSelect={(projectId) => void onSelectProject(projectId)}
           onCreate={onCreateProject}
+          onRename={onRenameProject}
         />
 
         {hasNativeHost() && (

--- a/crates/openwave-desktop/ui/src/ProjectNavigation.test.tsx
+++ b/crates/openwave-desktop/ui/src/ProjectNavigation.test.tsx
@@ -23,6 +23,7 @@ describe("ProjectNavigation", () => {
         error={null}
         onSelect={vi.fn()}
         onCreate={vi.fn()}
+        onRename={vi.fn()}
       />,
     );
 
@@ -32,6 +33,7 @@ describe("ProjectNavigation", () => {
     expect(markup).toContain("Untitled project");
     expect(markup).toContain('aria-current="page"');
     expect(markup.match(/aria-current="page"/g)).toHaveLength(1);
+    expect(markup).toContain('aria-label="Rename Research"');
   });
 
   it("keeps project failures bounded to the sidebar", () => {
@@ -43,6 +45,7 @@ describe("ProjectNavigation", () => {
         error="Could not load projects."
         onSelect={vi.fn()}
         onCreate={vi.fn()}
+        onRename={vi.fn()}
       />,
     );
 

--- a/crates/openwave-desktop/ui/src/ProjectNavigation.tsx
+++ b/crates/openwave-desktop/ui/src/ProjectNavigation.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import type { Project } from "./api";
 
 type Props = {
@@ -8,6 +8,7 @@ type Props = {
   error: string | null;
   onSelect: (projectId: string | null) => void;
   onCreate: (title: string) => Promise<boolean>;
+  onRename: (projectId: string, title: string | null) => Promise<boolean>;
 };
 
 export function ProjectNavigation({
@@ -17,9 +18,23 @@ export function ProjectNavigation({
   error,
   onSelect,
   onCreate,
+  onRename,
 }: Props) {
   const [adding, setAdding] = useState(false);
   const [title, setTitle] = useState("");
+  const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
+  const [renameTitle, setRenameTitle] = useState("");
+  const [savingRename, setSavingRename] = useState(false);
+  const renameInFlightRef = useRef(false);
+  const renameActionRefs = useRef(new Map<string, HTMLButtonElement>());
+  const renaming = editingProjectId !== null;
+
+  useEffect(() => {
+    if (editingProjectId !== null && editingProjectId !== selectedProjectId) {
+      setEditingProjectId(null);
+      setRenameTitle("");
+    }
+  }, [editingProjectId, selectedProjectId]);
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -31,6 +46,29 @@ export function ProjectNavigation({
     }
   }
 
+  async function submitRename(
+    event: FormEvent<HTMLFormElement>,
+    projectId: string,
+  ) {
+    event.preventDefault();
+    const trimmed = renameTitle.trim();
+    if (disabled || renameInFlightRef.current) return;
+    renameInFlightRef.current = true;
+    setSavingRename(true);
+    try {
+      if (await onRename(projectId, trimmed || null)) finishRename(projectId);
+    } finally {
+      renameInFlightRef.current = false;
+      setSavingRename(false);
+    }
+  }
+
+  function finishRename(projectId: string) {
+    setEditingProjectId(null);
+    setRenameTitle("");
+    requestAnimationFrame(() => renameActionRefs.current.get(projectId)?.focus());
+  }
+
   return (
     <section className="project-navigation" aria-label="Projects">
       <div className="sidebar-section-heading">
@@ -40,7 +78,7 @@ export function ProjectNavigation({
           className="sidebar-add"
           aria-label="Create project"
           title="Create project"
-          disabled={disabled}
+          disabled={disabled || renaming}
           onClick={() => setAdding((current) => !current)}
         >
           +
@@ -86,18 +124,81 @@ export function ProjectNavigation({
         <ProjectButton
           title="Loose chats"
           selected={selectedProjectId === null}
-          disabled={disabled}
+          disabled={disabled || renaming}
           onClick={() => onSelect(null)}
         />
-        {projects.map((project) => (
-          <ProjectButton
-            key={project.id}
-            title={project.title?.trim() || "Untitled project"}
-            selected={selectedProjectId === project.id}
-            disabled={disabled}
-            onClick={() => onSelect(project.id)}
-          />
-        ))}
+        {projects.map((project) => {
+          const projectTitle = project.title?.trim() || "Untitled project";
+          const selected = selectedProjectId === project.id;
+          if (editingProjectId === project.id && selected) {
+            return (
+              <form
+                key={project.id}
+                className="project-rename"
+                onSubmit={(event) => void submitRename(event, project.id)}
+              >
+                <input
+                  autoFocus
+                  aria-label="Project name"
+                  placeholder="Untitled project"
+                  value={renameTitle}
+                  maxLength={120}
+                  disabled={disabled || savingRename}
+                  onChange={(event) => setRenameTitle(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Escape") {
+                      finishRename(project.id);
+                    }
+                  }}
+                />
+                <button
+                  type="submit"
+                  aria-label="Save project name"
+                  disabled={disabled || savingRename}
+                >
+                  ✓
+                </button>
+                <button
+                  type="button"
+                  aria-label="Cancel project rename"
+                  disabled={disabled || savingRename}
+                  onClick={() => finishRename(project.id)}
+                >
+                  ×
+                </button>
+              </form>
+            );
+          }
+          return (
+            <div key={project.id} className={`project-row${selected ? " is-active" : ""}`}>
+              <ProjectButton
+                title={projectTitle}
+                selected={selected}
+                disabled={disabled || savingRename || renaming}
+                onClick={() => onSelect(project.id)}
+              />
+              {selected && (
+                <button
+                  type="button"
+                  className="project-rename-action"
+                  ref={(element) => {
+                    if (element) renameActionRefs.current.set(project.id, element);
+                    else renameActionRefs.current.delete(project.id);
+                  }}
+                  aria-label={`Rename ${projectTitle}`}
+                  title="Rename project"
+                  disabled={disabled || savingRename || adding}
+                  onClick={() => {
+                    setEditingProjectId(project.id);
+                    setRenameTitle(project.title ?? "");
+                  }}
+                >
+                  ···
+                </button>
+              )}
+            </div>
+          );
+        })}
       </div>
       {error && <p className="sidebar-error">{error}</p>}
     </section>

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -288,6 +288,33 @@ describe("project-scoped conversation API", () => {
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(JSON.parse(String(init.body))).toEqual({});
   });
+
+  it("renames the exact project with a bounded metadata patch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "project-1",
+          title: "Renamed",
+          attachment_revision: 0,
+          root_attachments: [],
+          created_at: "2026-07-21T12:00:00Z",
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await client.patchProjectTitle("project-1", "Renamed");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1/projects/project-1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ title: "Renamed" }),
+      }),
+    );
+  });
 });
 
 describe("sandbox agent cancellation", () => {

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -348,6 +348,14 @@ export class ApiClient {
     return this.json("/projects", { headers: this.headers() });
   }
 
+  patchProjectTitle(projectId: string, title: string | null): Promise<Project> {
+    return this.json(`/projects/${encodeURIComponent(projectId)}`, {
+      method: "PATCH",
+      headers: this.headers(true),
+      body: JSON.stringify({ title }),
+    });
+  }
+
   createChat(model?: string, projectId?: string | null): Promise<Chat> {
     return this.json("/chats", {
       method: "POST",

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -166,6 +166,70 @@ button {
   text-align: left;
 }
 
+.project-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  border-radius: 7px;
+}
+
+.project-row .project-item {
+  flex: 1 1 auto;
+}
+
+.project-row.is-active {
+  background: var(--sidebar-active);
+}
+
+.project-rename-action {
+  width: 1.8rem;
+  height: 1.65rem;
+  flex: 0 0 auto;
+  margin-right: 0.2rem;
+  border: 0;
+  border-radius: 5px;
+  color: var(--muted);
+  background: transparent;
+  line-height: 1;
+}
+
+.project-rename-action:hover:not(:disabled) {
+  color: var(--ink);
+  background: var(--bg-elevated);
+}
+
+.project-rename {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 0.25rem;
+  align-items: center;
+  padding: 0.15rem 0.2rem;
+}
+
+.project-rename input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 0.35rem 0.4rem;
+  background: var(--bg-elevated);
+  font-size: 0.8rem;
+}
+
+.project-rename button {
+  width: 1.6rem;
+  height: 1.6rem;
+  border: 0;
+  border-radius: 5px;
+  color: var(--muted);
+  background: transparent;
+}
+
+.project-rename button:hover:not(:disabled) {
+  color: var(--ink);
+  background: var(--sidebar-active);
+}
+
 .project-item:hover:not(:disabled),
 .project-item.is-active {
   color: var(--ink);

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -178,9 +178,20 @@ pub fn app(state: AppState) -> Router {
         )
         .route(
             "/projects",
-            post(routes::create_project).get(routes::list_projects),
+            post(routes::create_project)
+                .get(routes::list_projects)
+                .layer(DefaultBodyLimit::max(
+                    routes::MAX_PROJECT_METADATA_BODY_BYTES,
+                )),
         )
-        .route("/projects/{id}", get(routes::get_project))
+        .route(
+            "/projects/{id}",
+            get(routes::get_project)
+                .patch(routes::patch_project)
+                .layer(DefaultBodyLimit::max(
+                    routes::MAX_PROJECT_METADATA_BODY_BYTES,
+                )),
+        )
         .route("/models", get(routes::list_models))
         .route(
             "/web-search",

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -43,6 +43,11 @@ pub use root_attachment::*;
 /// The store-settings key for the selected model.
 const MODEL_SETTING: &str = "model";
 
+/// Product-facing project names stay compact across desktop and API clients.
+pub const MAX_PROJECT_TITLE_CHARS: usize = 120;
+/// Project metadata requests need only a compact JSON object.
+pub const MAX_PROJECT_METADATA_BODY_BYTES: usize = 1_024;
+
 /// Runtime settings a client can read. The API key itself is never returned —
 /// it lives in the `SecretProvider`, not the store — only whether one is set.
 #[derive(Debug, Serialize, Deserialize)]
@@ -363,6 +368,30 @@ pub struct CreateProject {
     pub title: Option<String>,
 }
 
+/// Body of `PATCH /projects/{id}`. An explicit `null` clears the title, while
+/// an absent field leaves it unchanged.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectUpdate {
+    #[serde(default, deserialize_with = "double_option")]
+    pub title: Option<Option<String>>,
+}
+
+fn normalize_project_title(title: Option<String>) -> Result<Option<String>, ServerError> {
+    let title = title
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty());
+    if title
+        .as_ref()
+        .is_some_and(|value| value.chars().count() > MAX_PROJECT_TITLE_CHARS)
+    {
+        return Err(ServerError::bad_request(format!(
+            "project title must not exceed {MAX_PROJECT_TITLE_CHARS} characters"
+        )));
+    }
+    Ok(title)
+}
+
 /// `POST /projects` — create a project and return it (`201 Created`).
 pub async fn create_project(
     State(state): State<AppState>,
@@ -370,13 +399,33 @@ pub async fn create_project(
 ) -> Result<impl IntoResponse, ServerError> {
     let project = Project {
         id: ProjectId::new(),
-        title: body.title,
+        title: normalize_project_title(body.title)?,
         attachment_revision: 0,
         root_attachments: Vec::new(),
         created_at: Utc::now(),
     };
     state.store.create_project(&project).await?;
     Ok((StatusCode::CREATED, Json(project)))
+}
+
+/// `PATCH /projects/{id}` — update bounded human-facing project metadata.
+pub async fn patch_project(
+    State(state): State<AppState>,
+    Path(id): Path<ProjectId>,
+    Json(body): Json<ProjectUpdate>,
+) -> Result<Json<Project>, ServerError> {
+    let title = body.title.map(normalize_project_title).transpose()?;
+    if let Some(title) = title {
+        if !state.store.update_project_title(id, title).await? {
+            return Err(ServerError::not_found(format!("project {id} not found")));
+        }
+    }
+    state
+        .store
+        .get_project(id)
+        .await?
+        .map(Json)
+        .ok_or_else(|| ServerError::not_found(format!("project {id} not found")))
 }
 
 /// `GET /projects` — list projects, most-recently-created first.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -7340,6 +7340,102 @@ async fn project_create_get_and_list() {
     assert_eq!(listed, vec![created]);
 }
 
+async fn patch_project(
+    router: &Router,
+    bearer: &str,
+    project: ProjectId,
+    body: serde_json::Value,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/projects/{project}"))
+                .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn project_title_patch_is_trimmed_bounded_and_clearable() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let project = make_project(&router, &bearer).await;
+
+    let oversized_create = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/projects")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"title": "x".repeat(121)}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(oversized_create.status(), StatusCode::BAD_REQUEST);
+
+    let renamed = patch_project(
+        &router,
+        &bearer,
+        project.id,
+        serde_json::json!({"title": "  Research workspace  "}),
+    )
+    .await;
+    assert_eq!(renamed.status(), StatusCode::OK);
+    assert_eq!(
+        json_body::<Project>(renamed).await.title.as_deref(),
+        Some("Research workspace")
+    );
+
+    let oversized = patch_project(
+        &router,
+        &bearer,
+        project.id,
+        serde_json::json!({"title": "x".repeat(121)}),
+    )
+    .await;
+    assert_eq!(oversized.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        store
+            .get_project(project.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .title
+            .as_deref(),
+        Some("Research workspace")
+    );
+
+    let cleared = patch_project(
+        &router,
+        &bearer,
+        project.id,
+        serde_json::json!({"title": null}),
+    )
+    .await;
+    assert_eq!(cleared.status(), StatusCode::OK);
+    assert_eq!(json_body::<Project>(cleared).await.title, None);
+
+    let missing = patch_project(
+        &router,
+        &bearer,
+        ProjectId::new(),
+        serde_json::json!({"title": "missing"}),
+    )
+    .await;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+}
+
 #[tokio::test]
 async fn chat_can_be_filed_under_a_project() {
     let (router, token, _store, _dir) = test_app().await;


### PR DESCRIPTION
## Summary

- add a bounded project-title storage and HTTP update path
- trim and cap project names consistently on create and rename
- expose an inline project rename control in desktop navigation
- fence duplicate submissions and validate the exact project response identity

## Validation

- `cargo test --workspace`
- `bw dev lint --rust`
- `cargo fmt --all --check`
- `pnpm --dir crates/openwave-desktop/ui test`
- `pnpm --dir crates/openwave-desktop/ui build`
- repeated ambiguous-steer regression: 5/5 clean
