### PR TITLE
Add fail-closed project deletion

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -46,11 +46,12 @@ use crate::storage::{
     ClaimClientToolCallOutcome, ClaimDelegatedFileReadOutcome, ClaimSandboxToolCallOutcome,
     ClaimTurnRunOutcome, CompleteTurnRunOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
     ConsumeAgentRunInboxOutcome, DecideToolApprovalOutcome, DeleteChatOutcome,
-    DocumentIndexJobReason, EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome,
-    FailAgentRunOutcome, FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
-    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
-    JournaledToolApprovalOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
-    ParkSandboxToolCallOutcome, ParkTurnForAgentRunInboxOutcome, ParkTurnForAgentRunWaitSetOutcome,
+    DeleteProjectOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
+    EnsureDocumentParseJobOutcome, FailAgentRunOutcome, FinishAgentRunCancellationOutcome,
+    FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
+    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledToolApprovalOutcome,
+    JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkSandboxToolCallOutcome,
+    ParkTurnForAgentRunInboxOutcome, ParkTurnForAgentRunWaitSetOutcome,
     ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
     RequestToolApprovalOutcome, RequestTurnCancellationOutcome, ResolveSandboxToolCallOutcome,
     ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, Store,
@@ -183,6 +184,50 @@ impl Store for DbStore {
         Ok(result.rows_affected == 1)
     }
 
+    async fn delete_project(&self, id: ProjectId) -> Result<DeleteProjectOutcome> {
+        let transaction = self.conn.begin().await.map_err(store_err)?;
+        if !ops::acquire_project_write_lock(&transaction, id).await? {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(DeleteProjectOutcome::NotFound);
+        }
+
+        let has_chats = entities::chat::Entity::find()
+            .filter(entities::chat::Column::ProjectId.eq(id.0))
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .is_some();
+        let has_documents = entities::document::Entity::find()
+            .filter(entities::document::Column::ProjectId.eq(id.0))
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .is_some();
+        let has_roots = entities::project_root_attachment::Entity::find()
+            .filter(entities::project_root_attachment::Column::ProjectId.eq(id.0))
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .is_some();
+        if has_chats || has_documents || has_roots {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(DeleteProjectOutcome::NotEmpty);
+        }
+
+        let deleted = entities::project::Entity::delete_by_id(id.0)
+            .exec(&transaction)
+            .await
+            .map_err(store_err)?;
+        if deleted.rows_affected != 1 {
+            transaction.rollback().await.map_err(store_err)?;
+            return Err(AgentError::Store(format!(
+                "project {id} disappeared while locked"
+            )));
+        }
+        transaction.commit().await.map_err(store_err)?;
+        Ok(DeleteProjectOutcome::Deleted)
+    }
+
     async fn create_document(&self, document: &DocumentRecord) -> Result<()> {
         validate_document_source_regions(&document.canonical_text, &document.source_regions)?;
         let source_byte_len = document
@@ -192,6 +237,7 @@ impl Store for DbStore {
             .transpose()?;
         let transaction = self.conn.begin().await.map_err(store_err)?;
         acquire_document_write_lock(&transaction, document.id).await?;
+        ops::require_project_write_lock(&transaction, document.project_id).await?;
         let revision_token = uuid::Uuid::new_v4();
         entities::document_generation::ActiveModel {
             document_id: Set(document.id.0),
@@ -590,6 +636,7 @@ impl Store for DbStore {
         loop {
             let transaction = self.conn.begin().await.map_err(store_err)?;
             acquire_document_write_lock(&transaction, document.id).await?;
+            ops::require_project_write_lock(&transaction, document.project_id).await?;
             match try_upsert_document_on(&transaction, document).await? {
                 Some(record) => {
                     transaction.commit().await.map_err(store_err)?;
@@ -625,6 +672,7 @@ impl Store for DbStore {
         loop {
             let transaction = self.conn.begin().await.map_err(store_err)?;
             acquire_document_write_lock(&transaction, document.id).await?;
+            ops::require_project_write_lock(&transaction, document.project_id).await?;
             if let Some(current) = entities::document::Entity::find_by_id(document.id.0)
                 .one(&transaction)
                 .await

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -22,7 +22,8 @@ use crate::storage::{
 use super::super::{entities, project_from_models, store_err, DbStore};
 use super::turn::canonical_db_timestamp;
 use super::{
-    acquire_chat_write_lock, acquire_turn_write_lock, agent_run::insert_foreground_agent_run_on,
+    acquire_chat_write_lock, acquire_project_write_lock, acquire_turn_write_lock,
+    agent_run::insert_foreground_agent_run_on,
 };
 
 pub(in crate::db) const MESSAGE_IDENTITY_OWNER_MESSAGE: &str = "message";
@@ -147,6 +148,9 @@ where
     let Some(project_id) = project_id else {
         return Ok(Vec::new());
     };
+    if !acquire_project_write_lock(conn, project_id).await? {
+        return Err(AgentError::ProjectNotFound(project_id));
+    }
     let mut rows = entities::project::Entity::find_by_id(project_id.0)
         .find_with_related(entities::project_root_attachment::Entity)
         .order_by_asc(entities::project_root_attachment::Column::Position)

--- a/crates/openwave-core/src/db/ops/document.rs
+++ b/crates/openwave-core/src/db/ops/document.rs
@@ -17,6 +17,7 @@ use super::super::{
     validate_document_source_blob, validate_document_source_regions, DbStore,
 };
 use super::blob as blob_ops;
+use super::require_project_write_lock;
 
 pub(in crate::db) async fn accept_source_and_enqueue_parse(
     store: &DbStore,
@@ -29,6 +30,7 @@ pub(in crate::db) async fn accept_source_and_enqueue_parse(
     loop {
         let transaction = store.conn.begin().await.map_err(store_err)?;
         acquire_document_write_lock(&transaction, source.id).await?;
+        require_project_write_lock(&transaction, source.project_id).await?;
         let existing = entities::document::Entity::find_by_id(source.id.0)
             .one(&transaction)
             .await

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -1,7 +1,7 @@
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder};
 
 use crate::error::{AgentError, Result};
-use crate::id::{CallId, ChatId, TurnId};
+use crate::id::{CallId, ChatId, ProjectId, TurnId};
 
 use super::{entities, store_err};
 
@@ -34,6 +34,47 @@ where
         .await
         .map_err(store_err)?;
     Ok(locked.rows_affected == 1)
+}
+
+/// Acquire the shared cross-backend write lock for one project row.
+///
+/// Project-scoped child insertion and deletion take this same lock so an empty
+/// project cannot gain a conversation or document between its emptiness check
+/// and deletion.
+pub(in crate::db) async fn acquire_project_write_lock<C>(
+    conn: &C,
+    project_id: ProjectId,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let locked = entities::project::Entity::update_many()
+        .col_expr(
+            entities::project::Column::Title,
+            sea_orm::sea_query::Expr::col(entities::project::Column::Title).into(),
+        )
+        .filter(entities::project::Column::Id.eq(project_id.0))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(locked.rows_affected == 1)
+}
+
+/// Fence a project-scoped child write and report a concurrent deletion with a
+/// typed error that product adapters can map without parsing database text.
+pub(in crate::db) async fn require_project_write_lock<C>(
+    conn: &C,
+    project_id: Option<ProjectId>,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    if let Some(project_id) = project_id {
+        if !acquire_project_write_lock(conn, project_id).await? {
+            return Err(AgentError::ProjectNotFound(project_id));
+        }
+    }
+    Ok(())
 }
 
 /// Allocate the next stable tool-history position while the caller owns the

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -478,6 +478,180 @@ async fn project_title_update_sets_clears_and_reports_missing_identity() {
 }
 
 #[tokio::test]
+async fn project_deletion_requires_an_empty_project_and_reports_missing_identity() {
+    let (_dir, store) = temp_store().await;
+
+    let empty = sample_project();
+    store.create_project(&empty).await.unwrap();
+    assert_eq!(
+        store.delete_project(empty.id).await.unwrap(),
+        DeleteProjectOutcome::Deleted
+    );
+    assert_eq!(
+        store.delete_project(empty.id).await.unwrap(),
+        DeleteProjectOutcome::NotFound
+    );
+
+    let with_chat = sample_project();
+    store.create_project(&with_chat).await.unwrap();
+    let mut chat = sample_chat();
+    chat.project_id = Some(with_chat.id);
+    store.create_chat(&chat).await.unwrap();
+    assert_eq!(
+        store.delete_project(with_chat.id).await.unwrap(),
+        DeleteProjectOutcome::NotEmpty
+    );
+    assert!(store.get_project(with_chat.id).await.unwrap().is_some());
+    assert_eq!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted
+    );
+    assert_eq!(
+        store.delete_project(with_chat.id).await.unwrap(),
+        DeleteProjectOutcome::Deleted
+    );
+
+    let with_document = sample_project();
+    store.create_project(&with_document).await.unwrap();
+    let document = sample_document(Some(with_document.id));
+    store.create_document(&document).await.unwrap();
+    assert_eq!(
+        store.delete_project(with_document.id).await.unwrap(),
+        DeleteProjectOutcome::NotEmpty
+    );
+    store.delete_document(document.id).await.unwrap();
+    assert_eq!(
+        store.delete_project(with_document.id).await.unwrap(),
+        DeleteProjectOutcome::Deleted
+    );
+
+    let root = HostRootId::from_uuid(uuid::Uuid::new_v4()).unwrap();
+    let mut with_root = sample_project();
+    with_root.attachment_revision = 1;
+    with_root.root_attachments = vec![root];
+    store.create_project(&with_root).await.unwrap();
+    assert_eq!(
+        store.delete_project(with_root.id).await.unwrap(),
+        DeleteProjectOutcome::NotEmpty
+    );
+    entities::project_root_attachment::Entity::delete_many()
+        .filter(entities::project_root_attachment::Column::ProjectId.eq(with_root.id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+    assert_eq!(
+        store.delete_project(with_root.id).await.unwrap(),
+        DeleteProjectOutcome::Deleted
+    );
+}
+
+#[tokio::test]
+async fn project_deletion_serializes_with_staged_source_ingestion() {
+    let (_dir, store) = temp_store().await;
+
+    for attempt in 0..16_u8 {
+        let project = sample_project();
+        store.create_project(&project).await.unwrap();
+        let mut source = sample_raw_source(
+            DocumentId::new(),
+            &format!("file:///project-race-{attempt}.bin"),
+            DocumentSourceBlob::from_digest([attempt.saturating_add(1); 32], 1),
+        );
+        source.project_id = Some(project.id);
+
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(3));
+        let delete_store = store.clone();
+        let delete_barrier = barrier.clone();
+        let delete = tokio::spawn(async move {
+            delete_barrier.wait().await;
+            delete_store.delete_project(project.id).await
+        });
+        let ingest_store = store.clone();
+        let ingest_barrier = barrier.clone();
+        let ingest_source = source.clone();
+        let ingest = tokio::spawn(async move {
+            ingest_barrier.wait().await;
+            ingest_store
+                .accept_document_source_and_enqueue_parse(&ingest_source, "parser-v1", 3)
+                .await
+        });
+        barrier.wait().await;
+
+        let deleted = delete.await.unwrap().unwrap();
+        let ingested = ingest.await.unwrap();
+        match (deleted, ingested) {
+            (DeleteProjectOutcome::Deleted, Err(AgentError::ProjectNotFound(missing_project))) => {
+                assert_eq!(missing_project, project.id)
+            }
+            (DeleteProjectOutcome::NotEmpty, Ok((record, _))) => {
+                assert_eq!(record.project_id, Some(project.id));
+                store.delete_document(record.id).await.unwrap();
+                assert_eq!(
+                    store.delete_project(project.id).await.unwrap(),
+                    DeleteProjectOutcome::Deleted
+                );
+            }
+            (outcome, result) => {
+                panic!("unexpected deletion/ingestion race result: {outcome:?}, {result:?}")
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn every_project_scoped_first_write_reports_a_typed_missing_project() {
+    let (_dir, store) = temp_store().await;
+    let missing = ProjectId::new();
+
+    let legacy = sample_document(Some(missing));
+    assert!(matches!(
+        store.create_document(&legacy).await,
+        Err(AgentError::ProjectNotFound(id)) if id == missing
+    ));
+
+    let canonical = DocumentUpsert {
+        id: DocumentId::new(),
+        project_id: Some(missing),
+        source_uri: Some("file:///missing-project.txt".into()),
+        media_type: "text/plain".into(),
+        title: None,
+        canonical_text: "missing project".into(),
+        source_regions: Vec::new(),
+        updated_at: Utc::now(),
+    };
+    assert!(matches!(
+        store.upsert_document(&canonical).await,
+        Err(AgentError::ProjectNotFound(id)) if id == missing
+    ));
+    assert!(matches!(
+        store
+            .upsert_document_and_enqueue_index(&canonical, "pipeline-v1", 3)
+            .await,
+        Err(AgentError::ProjectNotFound(id)) if id == missing
+    ));
+
+    let mut staged = sample_raw_source(
+        DocumentId::new(),
+        "file:///missing-project.bin",
+        DocumentSourceBlob::from_digest([0x41; 32], 1),
+    );
+    staged.project_id = Some(missing);
+    assert!(matches!(
+        store
+            .accept_document_source_and_enqueue_parse(&staged, "parser-v1", 3)
+            .await,
+        Err(AgentError::ProjectNotFound(id)) if id == missing
+    ));
+
+    let mut chat = sample_chat();
+    chat.project_id = Some(missing);
+    assert!(matches!(
+        store.create_chat_with_project_defaults(&chat).await,
+        Err(AgentError::ProjectNotFound(id)) if id == missing
+    ));
+}
+
+#[tokio::test]
 async fn documents_roundtrip_and_list_by_corpus_scope() {
     let (_dir, store) = temp_store().await;
     let project_a = sample_project();

--- a/crates/openwave-core/src/error.rs
+++ b/crates/openwave-core/src/error.rs
@@ -8,6 +8,8 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::ProjectId;
+
 /// Shorthand for results across the core crate.
 pub type Result<T, E = AgentError> = std::result::Result<T, E>;
 
@@ -22,6 +24,10 @@ pub enum AgentError {
     /// A persistence failure from the `Store` / `BlobStore`.
     #[error("store error: {0}")]
     Store(String),
+
+    /// A project-scoped atomic write lost a concurrent project deletion race.
+    #[error("project {0} not found")]
+    ProjectNotFound(ProjectId),
 
     /// A failure reaching the secret store (keychain / KMS).
     #[error("secret error: {0}")]
@@ -64,6 +70,7 @@ impl AgentError {
         match self {
             Self::Config(_) => "config",
             Self::Store(_) => "store",
+            Self::ProjectNotFound(_) => "not_found",
             Self::Secret(_) => "secret",
             Self::Provider(_) => "provider",
             Self::PromptTooLong(_) => "prompt_too_long",

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -119,7 +119,7 @@ pub use storage::{
     ClaimClientToolCallOutcome, ClaimDelegatedFileReadOutcome, ClaimSandboxToolCallOutcome,
     ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim, CompleteTurnRunOutcome,
     ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
-    DecideToolApprovalOutcome, DeleteChatOutcome, DocumentIndexJobReason,
+    DecideToolApprovalOutcome, DeleteChatOutcome, DeleteProjectOutcome, DocumentIndexJobReason,
     EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FailAgentRunOutcome,
     FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -77,6 +77,21 @@ pub enum DeleteChatOutcome {
     RootAttachmentStateUnresolved,
 }
 
+/// Result of a fail-closed project deletion request.
+///
+/// Project deletion never cascades conversations, documents, or host-root
+/// projections. Callers must explicitly remove each owned resource through its
+/// lifecycle-aware API before the empty project record can be removed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteProjectOutcome {
+    /// The empty project was removed.
+    Deleted,
+    /// No project owns this id.
+    NotFound,
+    /// Conversations, documents, or host-root defaults still belong to it.
+    NotEmpty,
+}
+
 /// Fixed lifecycle vocabulary exposed for a historical tool card.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -822,6 +837,13 @@ pub trait Store: Send + Sync {
     async fn update_project_title(&self, _id: ProjectId, _title: Option<String>) -> Result<bool> {
         Err(AgentError::Store(
             "project metadata storage is not implemented by this Store".into(),
+        ))
+    }
+
+    /// Remove one empty project without cascading owned product state.
+    async fn delete_project(&self, _id: ProjectId) -> Result<DeleteProjectOutcome> {
+        Err(AgentError::Store(
+            "project deletion is not implemented by this Store".into(),
         ))
     }
 

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -4,15 +4,16 @@ use std::{sync::Arc, time::Duration as StdDuration};
 
 use chrono::{Duration, Utc};
 use openwave_core::{
-    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentEvent,
+    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentError, AgentEvent,
     AgentRunCancellationReason, AgentRunExecution, AgentRunId, AgentRunInboxStatus,
     AgentRunResultPayload, AgentRunStatus, AgentRunWaitCondition, AgentRunWaitSetCheckpointRequest,
     ApplyTurnSteerOutcome, AssistantCitationReference, BeginRootAttachmentChange,
     BeginRootAttachmentChangeOutcome, ByteSpan, CallId, Chat, ChatId, ChatRootAttachment,
     CheckpointSandboxSpawnOutcome, ChunkId, ClaimClientToolCallOutcome, ClientToolCallRequest,
-    CompleteTurnRunOutcome, DbStore, DeleteChatOutcome, DocumentGeneration, DocumentId,
-    FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
-    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, HostRootId, Message, MessageId,
+    CompleteTurnRunOutcome, DbStore, DeleteChatOutcome, DeleteProjectOutcome, DocumentGeneration,
+    DocumentId, DocumentSourceBlob, DocumentSourceUpsert, FinishAgentRunCancellationOutcome,
+    FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
+    HeartbeatClientToolCallOutcome, HostRootId, Message, MessageId,
     ParkTurnForAgentRunWaitSetOutcome, ParkTurnForClientCallOutcome, Project, ProjectId,
     RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome,
     ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, RetrievalEvidenceInput,
@@ -1942,6 +1943,73 @@ async fn postgres_ordered_root_projection_roundtrips_and_snapshots_atomically() 
         ]
     );
     assert_eq!(store.get_chat(chat.id).await.unwrap(), Some(chat));
+}
+
+#[tokio::test]
+async fn postgres_project_deletion_serializes_with_staged_source_ingestion() {
+    let _guard = POSTGRES_TEST_LOCK.lock().await;
+    let url = match std::env::var("OPENWAVE_POSTGRES_TEST_URL") {
+        Ok(url) => url,
+        Err(_) if std::env::var_os("OPENWAVE_REQUIRE_POSTGRES_TEST").is_some() => {
+            panic!("OPENWAVE_POSTGRES_TEST_URL must name an isolated test database")
+        }
+        Err(_) => return,
+    };
+    let store = DbStore::connect(&url).await.unwrap();
+    let project = Project {
+        id: ProjectId::new(),
+        title: Some("postgres deletion race".into()),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
+        created_at: utc_now_at_postgres_precision(),
+    };
+    store.create_project(&project).await.unwrap();
+    let source = DocumentSourceUpsert {
+        id: DocumentId::new(),
+        project_id: Some(project.id),
+        source_uri: Some("file:///postgres-project-race.bin".into()),
+        media_type: "application/octet-stream".into(),
+        title: None,
+        source_blob: DocumentSourceBlob::from_digest([0x7a; 32], 1),
+        updated_at: utc_now_at_postgres_precision(),
+    };
+
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+    let delete_store = store.clone();
+    let delete_barrier = barrier.clone();
+    let delete = tokio::spawn(async move {
+        delete_barrier.wait().await;
+        delete_store.delete_project(project.id).await
+    });
+    let ingest_store = store.clone();
+    let ingest_barrier = barrier.clone();
+    let ingest_source = source.clone();
+    let ingest = tokio::spawn(async move {
+        ingest_barrier.wait().await;
+        ingest_store
+            .accept_document_source_and_enqueue_parse(&ingest_source, "parser-v1", 3)
+            .await
+    });
+    barrier.wait().await;
+
+    let deleted = delete.await.unwrap().unwrap();
+    let ingested = ingest.await.unwrap();
+    match (deleted, ingested) {
+        (DeleteProjectOutcome::Deleted, Err(AgentError::ProjectNotFound(missing_project))) => {
+            assert_eq!(missing_project, project.id);
+        }
+        (DeleteProjectOutcome::NotEmpty, Ok((record, _))) => {
+            assert_eq!(record.project_id, Some(project.id));
+            store.delete_document(record.id).await.unwrap();
+            assert_eq!(
+                store.delete_project(project.id).await.unwrap(),
+                DeleteProjectOutcome::Deleted
+            );
+        }
+        (outcome, result) => {
+            panic!("unexpected deletion/ingestion race result: {outcome:?}, {result:?}")
+        }
+    }
 }
 
 #[tokio::test]

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -58,6 +58,7 @@ import {
   sandboxAgentStopKey,
 } from "./SandboxAgentStop";
 import { ProjectNavigation } from "./ProjectNavigation";
+import { existingChatAfterDeletion, prependReplacementChat } from "./ChatDeletion";
 
 type Msg = ChatMessage;
 
@@ -117,6 +118,7 @@ export default function App() {
   const [creatingChat, setCreatingChat] = useState(false);
   const [creatingProject, setCreatingProject] = useState(false);
   const [deletingChatId, setDeletingChatId] = useState<string | null>(null);
+  const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState("");
   const [savingTitle, setSavingTitle] = useState(false);
@@ -1026,6 +1028,33 @@ export default function App() {
     }
   }
 
+  async function onDeleteProject(target: Project): Promise<boolean> {
+    if (!client || deletionInFlightRef.current || creationInFlightRef.current) return false;
+    const label = target.title?.trim() || "Untitled project";
+    if (
+      !window.confirm(
+        `Delete ${label}? Remove its conversations, documents, and connected folders first. This cannot be undone.`,
+      )
+    ) {
+      return false;
+    }
+
+    deletionInFlightRef.current = true;
+    setDeletingProjectId(target.id);
+    setProjectsError(null);
+    try {
+      await client.deleteProject(target.id);
+      setProjects((current) => current.filter((project) => project.id !== target.id));
+      return true;
+    } catch (err) {
+      setProjectsError(`Could not delete project: ${String(err)}`);
+      return false;
+    } finally {
+      deletionInFlightRef.current = false;
+      setDeletingProjectId(null);
+    }
+  }
+
   async function onDeleteChat(target: Chat) {
     if (!client || deletionInFlightRef.current || creationInFlightRef.current) return;
     const label = target.title?.trim() || "this conversation";
@@ -1052,10 +1081,10 @@ export default function App() {
         return;
       }
 
-      let next = refreshed.find((item) => item.project_id === target.project_id);
+      let next = existingChatAfterDeletion(refreshed, target.project_id);
       if (!next) {
-        next = await client.createChat(models[0]?.id, target.project_id);
-        refreshed = await client.listChats();
+        next = await client.createChat(models[0]?.id, null);
+        refreshed = prependReplacementChat(refreshed, next);
       }
       setChats(refreshed);
       selectChat(next, true);
@@ -1268,22 +1297,36 @@ export default function App() {
           type="button"
           className="new-chat"
           onClick={() => void onNewChat()}
-          disabled={creatingChat || creatingProject || deletingChatId !== null}
+          disabled={
+            creatingChat ||
+            creatingProject ||
+            deletingChatId !== null ||
+            deletingProjectId !== null
+          }
         >
           <span aria-hidden="true">+</span>
-          {creatingChat ? "Starting…" : deletingChatId ? "Deleting…" : "New chat"}
+          {creatingChat
+            ? "Starting…"
+            : deletingChatId || deletingProjectId
+              ? "Deleting…"
+              : "New chat"}
         </button>
 
         <ProjectNavigation
           projects={projects}
           selectedProjectId={selectedProjectId}
           disabled={
-            projectsLoading || creatingChat || creatingProject || deletingChatId !== null
+            projectsLoading ||
+            creatingChat ||
+            creatingProject ||
+            deletingChatId !== null ||
+            deletingProjectId !== null
           }
           error={projectsError}
           onSelect={(projectId) => void onSelectProject(projectId)}
           onCreate={onCreateProject}
           onRename={onRenameProject}
+          onDelete={onDeleteProject}
         />
 
         {hasNativeHost() && (
@@ -1312,7 +1355,12 @@ export default function App() {
                   type="button"
                   className="conversation-item"
                   aria-current={primaryView === "chat" && item.id === chat.id ? "page" : undefined}
-                  disabled={deletingChatId !== null || creatingChat || creatingProject}
+                  disabled={
+                    deletingChatId !== null ||
+                    deletingProjectId !== null ||
+                    creatingChat ||
+                    creatingProject
+                  }
                   onClick={() => selectChat(item)}
                 >
                   <span className="conversation-dot" aria-hidden="true" />
@@ -1323,7 +1371,12 @@ export default function App() {
                   className="conversation-delete"
                   aria-label={`Delete ${item.title?.trim() || "conversation"}`}
                   title="Delete conversation"
-                  disabled={deletingChatId !== null || creatingChat || creatingProject}
+                  disabled={
+                    deletingChatId !== null ||
+                    deletingProjectId !== null ||
+                    creatingChat ||
+                    creatingProject
+                  }
                   onClick={() => void onDeleteChat(item)}
                 >
                   ×
@@ -1410,7 +1463,9 @@ export default function App() {
                   <button
                     type="submit"
                     className="btn"
-                    disabled={savingTitle || deletingChatId !== null}
+                    disabled={
+                      savingTitle || deletingChatId !== null || deletingProjectId !== null
+                    }
                   >
                     {savingTitle ? "Saving…" : "Save"}
                   </button>
@@ -1421,7 +1476,7 @@ export default function App() {
                   <button
                     type="button"
                     className="title-action"
-                    disabled={deletingChatId !== null}
+                    disabled={deletingChatId !== null || deletingProjectId !== null}
                     onClick={() => {
                       setTitleDraft(chat.title ?? "");
                       setEditingTitle(true);
@@ -1493,7 +1548,7 @@ export default function App() {
               Model{" "}
               <select
                 value={chat.model ?? ""}
-                disabled={deletingChatId !== null}
+                disabled={deletingChatId !== null || deletingProjectId !== null}
                 onChange={(e) => void onModelChange(e.target.value)}
               >
                 <option value="">default</option>
@@ -1584,7 +1639,7 @@ export default function App() {
             cancelPending={
               activeTurnId !== null && cancelPendingTurnId === activeTurnId
             }
-            disabled={deletingChatId !== null}
+            disabled={deletingChatId !== null || deletingProjectId !== null}
             draft={draft}
             onDraftChange={onComposerDraftChange}
             onSend={onSend}

--- a/crates/openwave-desktop/ui/src/ChatDeletion.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatDeletion.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { Chat } from "./api";
+import { existingChatAfterDeletion, prependReplacementChat } from "./ChatDeletion";
+
+function chat(id: string, projectId: string | null): Chat {
+  return {
+    id,
+    project_id: projectId,
+    title: null,
+    model: null,
+    attachment_revision: 0,
+    root_attachments: [],
+    created_at: "2026-07-21T12:00:00Z",
+  };
+}
+
+describe("chat deletion replacement", () => {
+  it("preserves loose scope without hiding project conversations", () => {
+    const projectChat = chat("project-chat", "project-1");
+    const refreshed = [projectChat];
+
+    expect(existingChatAfterDeletion(refreshed, null)).toBeUndefined();
+
+    const replacement = chat("loose-replacement", null);
+    expect(prependReplacementChat(refreshed, replacement)).toEqual([
+      replacement,
+      projectChat,
+    ]);
+  });
+
+  it("leaves an emptied project by selecting another existing chat", () => {
+    const loose = chat("loose-chat", null);
+    expect(existingChatAfterDeletion([loose], "project-1")).toBe(loose);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatDeletion.ts
+++ b/crates/openwave-desktop/ui/src/ChatDeletion.ts
@@ -1,0 +1,16 @@
+import type { Chat } from "./api";
+
+/** Choose an existing post-delete selection without collapsing loose scope. */
+export function existingChatAfterDeletion(
+  chats: Chat[],
+  deletedProjectId: string | null,
+): Chat | undefined {
+  const sameScope = chats.find((chat) => chat.project_id === deletedProjectId);
+  if (sameScope) return sameScope;
+  return deletedProjectId === null ? undefined : chats[0];
+}
+
+/** Retain every refreshed chat when a new loose replacement is required. */
+export function prependReplacementChat(chats: Chat[], replacement: Chat): Chat[] {
+  return [replacement, ...chats];
+}

--- a/crates/openwave-desktop/ui/src/ProjectNavigation.test.tsx
+++ b/crates/openwave-desktop/ui/src/ProjectNavigation.test.tsx
@@ -24,6 +24,7 @@ describe("ProjectNavigation", () => {
         onSelect={vi.fn()}
         onCreate={vi.fn()}
         onRename={vi.fn()}
+        onDelete={vi.fn().mockResolvedValue(true)}
       />,
     );
 
@@ -34,6 +35,8 @@ describe("ProjectNavigation", () => {
     expect(markup).toContain('aria-current="page"');
     expect(markup.match(/aria-current="page"/g)).toHaveLength(1);
     expect(markup).toContain('aria-label="Rename Research"');
+    expect(markup).toContain('aria-label="Delete Research"');
+    expect(markup).toContain('aria-label="Delete Untitled project"');
   });
 
   it("keeps project failures bounded to the sidebar", () => {
@@ -46,6 +49,7 @@ describe("ProjectNavigation", () => {
         onSelect={vi.fn()}
         onCreate={vi.fn()}
         onRename={vi.fn()}
+        onDelete={vi.fn().mockResolvedValue(false)}
       />,
     );
 

--- a/crates/openwave-desktop/ui/src/ProjectNavigation.tsx
+++ b/crates/openwave-desktop/ui/src/ProjectNavigation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent, type Ref } from "react";
 import type { Project } from "./api";
 
 type Props = {
@@ -9,6 +9,7 @@ type Props = {
   onSelect: (projectId: string | null) => void;
   onCreate: (title: string) => Promise<boolean>;
   onRename: (projectId: string, title: string | null) => Promise<boolean>;
+  onDelete: (project: Project) => Promise<boolean>;
 };
 
 export function ProjectNavigation({
@@ -19,6 +20,7 @@ export function ProjectNavigation({
   onSelect,
   onCreate,
   onRename,
+  onDelete,
 }: Props) {
   const [adding, setAdding] = useState(false);
   const [title, setTitle] = useState("");
@@ -27,6 +29,7 @@ export function ProjectNavigation({
   const [savingRename, setSavingRename] = useState(false);
   const renameInFlightRef = useRef(false);
   const renameActionRefs = useRef(new Map<string, HTMLButtonElement>());
+  const looseChatsRef = useRef<HTMLButtonElement>(null);
   const renaming = editingProjectId !== null;
 
   useEffect(() => {
@@ -67,6 +70,12 @@ export function ProjectNavigation({
     setEditingProjectId(null);
     setRenameTitle("");
     requestAnimationFrame(() => renameActionRefs.current.get(projectId)?.focus());
+  }
+
+  async function deleteProject(project: Project) {
+    if (await onDelete(project)) {
+      requestAnimationFrame(() => looseChatsRef.current?.focus());
+    }
   }
 
   return (
@@ -122,6 +131,7 @@ export function ProjectNavigation({
 
       <div className="project-list">
         <ProjectButton
+          buttonRef={looseChatsRef}
           title="Loose chats"
           selected={selectedProjectId === null}
           disabled={disabled || renaming}
@@ -196,6 +206,16 @@ export function ProjectNavigation({
                   ···
                 </button>
               )}
+              <button
+                type="button"
+                className="project-delete-action"
+                aria-label={`Delete ${projectTitle}`}
+                title="Delete project"
+                disabled={disabled || savingRename || renaming || adding}
+                onClick={() => void deleteProject(project)}
+              >
+                ×
+              </button>
             </div>
           );
         })}
@@ -206,11 +226,13 @@ export function ProjectNavigation({
 }
 
 function ProjectButton({
+  buttonRef,
   title,
   selected,
   disabled,
   onClick,
 }: {
+  buttonRef?: Ref<HTMLButtonElement>;
   title: string;
   selected: boolean;
   disabled: boolean;
@@ -218,6 +240,7 @@ function ProjectButton({
 }) {
   return (
     <button
+      ref={buttonRef}
       type="button"
       className={`project-item${selected ? " is-active" : ""}`}
       aria-current={selected ? "page" : undefined}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -315,6 +315,21 @@ describe("project-scoped conversation API", () => {
       }),
     );
   });
+
+  it("deletes the exact project without a request body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await client.deleteProject("project/1");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1/projects/project%2F1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.body).toBeUndefined();
+  });
 });
 
 describe("sandbox agent cancellation", () => {

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -356,6 +356,13 @@ export class ApiClient {
     });
   }
 
+  deleteProject(projectId: string): Promise<void> {
+    return this.json(`/projects/${encodeURIComponent(projectId)}`, {
+      method: "DELETE",
+      headers: this.headers(),
+    });
+  }
+
   createChat(model?: string, projectId?: string | null): Promise<Chat> {
     return this.json("/chats", {
       method: "POST",

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -181,7 +181,8 @@ button {
   background: var(--sidebar-active);
 }
 
-.project-rename-action {
+.project-rename-action,
+.project-delete-action {
   width: 1.8rem;
   height: 1.65rem;
   flex: 0 0 auto;
@@ -196,6 +197,23 @@ button {
 .project-rename-action:hover:not(:disabled) {
   color: var(--ink);
   background: var(--bg-elevated);
+}
+
+.project-delete-action {
+  margin-right: 0.2rem;
+  font-size: 1.1rem;
+  opacity: 0;
+}
+
+.project-row:hover .project-delete-action,
+.project-row.is-active .project-delete-action,
+.project-delete-action:focus-visible {
+  opacity: 1;
+}
+
+.project-delete-action:hover:not(:disabled) {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
 }
 
 .project-rename {

--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -92,12 +92,19 @@ impl ServerError {
     }
 }
 
-/// Core errors surfacing from a handler are internal failures (a store write
-/// failed, a provider errored); map them to `500` with their info preserved.
+/// Core errors surfacing from a handler are normally internal failures. The
+/// typed missing-project result is the deliberate exception: a project-scoped
+/// write may lose a concurrent deletion race after an adapter's preflight, and
+/// that remains a product-facing `404` rather than a database failure.
 impl From<AgentError> for ServerError {
     fn from(err: AgentError) -> Self {
+        let status = if matches!(err, AgentError::ProjectNotFound(_)) {
+            StatusCode::NOT_FOUND
+        } else {
+            StatusCode::INTERNAL_SERVER_ERROR
+        };
         Self {
-            status: StatusCode::INTERNAL_SERVER_ERROR,
+            status,
             info: (&err).into(),
         }
     }
@@ -106,5 +113,19 @@ impl From<AgentError> for ServerError {
 impl IntoResponse for ServerError {
     fn into_response(self) -> Response {
         (self.status, Json(self.info)).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_project_write_that_loses_deletion_maps_to_not_found() {
+        let project_id = openwave_core::ProjectId::new();
+        let error = ServerError::from(AgentError::ProjectNotFound(project_id));
+        assert_eq!(error.status, StatusCode::NOT_FOUND);
+        assert_eq!(error.info.kind, "not_found");
+        assert!(error.info.message.contains(&project_id.to_string()));
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -188,6 +188,7 @@ pub fn app(state: AppState) -> Router {
             "/projects/{id}",
             get(routes::get_project)
                 .patch(routes::patch_project)
+                .delete(routes::delete_project)
                 .layer(DefaultBodyLimit::max(
                     routes::MAX_PROJECT_METADATA_BODY_BYTES,
                 )),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -14,10 +14,11 @@ use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{
     AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunExecution, AgentRunStatus,
-    ApprovalDecision, CallId, Chat, ChatId, DeleteChatOutcome, Message as StoredMessage, MessageId,
-    Project, ProjectId, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, Role,
-    SandboxToolCall, SandboxToolCallStatus, SecretProvider, SequencedEvent, Store,
-    ToolCallExecution, ToolCallRecord, ToolCallStatus, TurnId, TurnSteer, TurnSteerId,
+    ApprovalDecision, CallId, Chat, ChatId, DeleteChatOutcome, DeleteProjectOutcome,
+    Message as StoredMessage, MessageId, Project, ProjectId, RequestAgentRunCancellationOutcome,
+    RequestTurnCancellationOutcome, Role, SandboxToolCall, SandboxToolCallStatus, SecretProvider,
+    SequencedEvent, Store, ToolCallExecution, ToolCallRecord, ToolCallStatus, TurnId, TurnSteer,
+    TurnSteerId,
 };
 
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
@@ -448,6 +449,25 @@ pub async fn get_project(
         .ok_or_else(|| ServerError::not_found(format!("project {id} not found")))
 }
 
+/// `DELETE /projects/{id}` — remove an empty project. Owned conversations,
+/// documents, and root defaults must be removed through their explicit
+/// lifecycle APIs first; this boundary never cascades them.
+pub async fn delete_project(
+    State(state): State<AppState>,
+    Path(id): Path<ProjectId>,
+) -> Result<StatusCode, ServerError> {
+    match state.store.delete_project(id).await? {
+        DeleteProjectOutcome::Deleted => Ok(StatusCode::NO_CONTENT),
+        DeleteProjectOutcome::NotFound => {
+            Err(ServerError::not_found(format!("project {id} not found")))
+        }
+        DeleteProjectOutcome::NotEmpty => Err(ServerError::conflict_kind(
+            "project_not_empty",
+            "remove the project's conversations, documents, and connected folders before deleting it",
+        )),
+    }
+}
+
 /// Body of `POST /chats`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -475,7 +495,7 @@ pub async fn create_chat(
             .store
             .get_project(project_id)
             .await?
-            .ok_or_else(|| ServerError::bad_request(format!("project {project_id} not found")))?;
+            .ok_or_else(|| ServerError::not_found(format!("project {project_id} not found")))?;
     }
     if body.model.as_deref().is_some_and(str::is_empty) {
         return Err(ServerError::bad_request("model must not be empty"));

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -11,13 +11,13 @@ use futures::stream::{self, BoxStream, StreamExt};
 use openwave_core::{
     Agent, AgentConfig, AgentErrorInfo, AgentEvent, AgentRunInboxStatus, AgentRunStatus,
     ApprovalClass, BeginRootAttachmentChange, BlobStore, CallId, Chat, ChatId, ChatRequest,
-    ChatRootAttachment, ClaimedAgentEvent, ClientToolCallRequest, ContentBlock, HostRootId,
-    Message, MessageId, ModelProvider, ParkSandboxToolCallOutcome, ParkTurnForClientCallOutcome,
-    Project, ProjectId, ProviderEvent, ProviderId, Role, RootAttachmentChangeAction,
-    RootAttachmentChangeId, RootAttachmentOrigin, SandboxToolCallRequest, SecretProvider,
-    SequencedEvent, StopReason, Tool, ToolCallExecution, ToolCallRecord, ToolCallResolution,
-    ToolCallStatus, ToolCtx, ToolOutput, ToolRegistry, ToolSpec, TurnCheckpointProgress, TurnId,
-    TurnRunStatus, TurnSteerId, Usage,
+    ChatRootAttachment, ClaimedAgentEvent, ClientToolCallRequest, ContentBlock,
+    DeleteProjectOutcome, HostRootId, Message, MessageId, ModelProvider,
+    ParkSandboxToolCallOutcome, ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent,
+    ProviderId, Role, RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentOrigin,
+    SandboxToolCallRequest, SecretProvider, SequencedEvent, StopReason, Tool, ToolCallExecution,
+    ToolCallRecord, ToolCallResolution, ToolCallStatus, ToolCtx, ToolOutput, ToolRegistry,
+    ToolSpec, TurnCheckpointProgress, TurnId, TurnRunStatus, TurnSteerId, Usage,
 };
 use openwave_retrieval::{
     Embedding, InMemoryVectorStore, RetrievalError, ScoredChunk, VectorRecord,
@@ -812,6 +812,7 @@ struct PauseTerminalStore {
     pause_nonterminal_event: std::sync::atomic::AtomicBool,
     pause_accept: std::sync::atomic::AtomicBool,
     fail_document_delete: std::sync::atomic::AtomicBool,
+    delete_project_after_get: std::sync::atomic::AtomicBool,
 }
 
 impl PauseTerminalStore {
@@ -841,6 +842,7 @@ impl PauseTerminalStore {
             pause_nonterminal_event: std::sync::atomic::AtomicBool::new(false),
             pause_accept: std::sync::atomic::AtomicBool::new(false),
             fail_document_delete: std::sync::atomic::AtomicBool::new(false),
+            delete_project_after_get: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -928,6 +930,10 @@ impl PauseTerminalStore {
         self.fail_document_delete.store(true, Ordering::SeqCst);
     }
 
+    fn delete_project_after_next_get(&self) {
+        self.delete_project_after_get.store(true, Ordering::SeqCst);
+    }
+
     async fn terminalize_expired_turn(&self, id: TurnId) -> Result<()> {
         let turn = self
             .inner
@@ -961,7 +967,14 @@ impl Store for PauseTerminalStore {
         self.inner.create_project(project).await
     }
     async fn get_project(&self, id: ProjectId) -> Result<Option<Project>> {
-        self.inner.get_project(id).await
+        let project = self.inner.get_project(id).await?;
+        if project.is_some() && self.delete_project_after_get.swap(false, Ordering::SeqCst) {
+            assert_eq!(
+                self.inner.delete_project(id).await?,
+                DeleteProjectOutcome::Deleted
+            );
+        }
+        Ok(project)
     }
     async fn list_projects(&self) -> Result<Vec<Project>> {
         self.inner.list_projects().await
@@ -7437,6 +7450,76 @@ async fn project_title_patch_is_trimmed_bounded_and_clearable() {
 }
 
 #[tokio::test]
+async fn delete_project_removes_only_an_empty_project() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    let empty = make_project(&router, &bearer).await;
+    let deleted = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/projects/{}", empty.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
+    assert!(store.get_project(empty.id).await.unwrap().is_none());
+
+    let missing = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/projects/{}", empty.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+    let nonempty = make_project(&router, &bearer).await;
+    let chat_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chats")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"project_id": nonempty.id}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(chat_response.status(), StatusCode::CREATED);
+
+    let blocked = router
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/projects/{}", nonempty.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(blocked.status(), StatusCode::CONFLICT);
+    let info: AgentErrorInfo = json_body(blocked).await;
+    assert_eq!(info.kind, "project_not_empty");
+    assert!(store.get_project(nonempty.id).await.unwrap().is_some());
+}
+
+#[tokio::test]
 async fn chat_can_be_filed_under_a_project() {
     let (router, token, _store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
@@ -7525,9 +7608,63 @@ async fn chat_referencing_an_unknown_project_is_rejected() {
         )
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let info: AgentErrorInfo = json_body(response).await;
-    assert_eq!(info.kind, "bad_request");
+    assert_eq!(info.kind, "not_found");
+}
+
+#[tokio::test]
+async fn chat_creation_reports_not_found_when_project_deletion_wins_after_preflight() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("project-chat-race.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let project = Project {
+        id: ProjectId::new(),
+        title: Some("delete during chat creation".into()),
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
+        created_at: chrono::Utc::now(),
+    };
+    database.create_project(&project).await.unwrap();
+    let injected = Arc::new(PauseTerminalStore::new(
+        database.clone(),
+        Arc::new(Notify::new()),
+        Arc::new(Notify::new()),
+    ));
+    injected.do_not_pause_terminal();
+    injected.delete_project_after_next_get();
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let (router, token, _store, _dir) =
+        test_app_from_parts(Arc::new(FakeProvider), retrieval, injected, dir);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chats")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"project_id": project.id}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "not_found");
+    assert!(database.get_project(project.id).await.unwrap().is_none());
+    assert!(database.list_chats().await.unwrap().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add an atomic, fail-closed project deletion primitive and `DELETE /projects/{id}`
- reject deletion while conversations, documents, or folder defaults still belong to the project
- serialize project-scoped child creation with deletion across SQLite and PostgreSQL
- return a typed `404` when a project-scoped write loses a concurrent deletion race
- expose project deletion in the desktop and let deleting a last conversation leave its project empty
- preserve project conversations when deleting the final loose conversation creates a replacement

## Validation

- `cargo test --workspace`
- `bw dev lint --rust`
- `cargo fmt --all --check`
- `npm test -- --run` in `crates/openwave-desktop/ui` (142 tests)
- `npm run build` in `crates/openwave-desktop/ui`
- staged-source deletion race coverage for SQLite and the PostgreSQL feature lane
