### PR TITLE
Align the desktop UI with the Brightwave design language

### DIFF
--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -13,16 +13,27 @@
     "tauri": "cargo tauri"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.20",
+    "@radix-ui/react-dropdown-menu": "^2.1.21",
+    "@radix-ui/react-slot": "^1.3.0",
+    "@radix-ui/react-tooltip": "^1.2.13",
     "@tauri-apps/api": "^2",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.25.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "tailwind-merge": "^3.6.0",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.3.3",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "tailwindcss": "^4.3.3",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
     "vitest": "^3.2.7"

--- a/crates/openwave-desktop/ui/pnpm-lock.yaml
+++ b/crates/openwave-desktop/ui/pnpm-lock.yaml
@@ -8,9 +8,30 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.20
+        version: 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.21
+        version: 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot':
+        specifier: ^1.3.0
+        version: 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.13
+        version: 1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tauri-apps/api':
         specifier: ^2
         version: 2.11.1
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^1.25.0
+        version: 1.25.0(react@19.2.7)
       react:
         specifier: ^19.1.0
         version: 19.2.7
@@ -23,7 +44,16 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@4.3.3)
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.3
+        version: 4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
       '@types/react':
         specifier: ^19.1.8
         version: 19.2.17
@@ -32,16 +62,19 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@7.3.6)
+        version: 4.7.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+      tailwindcss:
+        specifier: ^4.3.3
+        version: 4.3.3
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
       vite:
         specifier: ^7.0.4
-        version: 7.3.6
+        version: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.13)
+        version: 3.2.7(@types/debug@4.1.13)(jiti@2.7.0)(lightningcss@1.32.0)
 
 packages:
 
@@ -284,6 +317,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/react-dom@2.1.9':
+    resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -299,6 +347,324 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@radix-ui/primitive@1.1.6':
+    resolution: {integrity: sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==}
+
+  '@radix-ui/react-alert-dialog@1.1.20':
+    resolution: {integrity: sha512-Ft1W+jPqSh5BKfSTe4dpq6UYQKKQJ5Tvq3wfux+WVlg7nPwFK/3pIlHTb3Rbe+b/tNurx8YGXD9em91ujmgwuQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.12':
+    resolution: {integrity: sha512-ltXCE0glRomMZ9+u10d9o1Go+edqa1aLxufH59JRNNM3Yz1uvaeNWSaS1HeVh1X64agtdBG5JA1W1I6ySqWiwA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.12':
+    resolution: {integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.2.0':
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.20':
+    resolution: {integrity: sha512-cngVJcvK0yMvR7wICJpv+1uW3Qw4T7QM5sdbb+oE/lxOdTdvF00oaRpWUjVgmjyXe3J+xh7eZyXZlVF3g2g59g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.2':
+    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.16':
+    resolution: {integrity: sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.21':
+    resolution: {integrity: sha512-gavFM1iWLmWdxWNdGJHVeWeSQul5WE/0pxfvWWt1QnD71hyyujyMCDVacqBomaSOjdxwDzYB+Ng4+MxOvrFB1A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.4':
+    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.13':
+    resolution: {integrity: sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.21':
+    resolution: {integrity: sha512-2BHtaJHvvoWTECyrja1mOjN6z2dWdpeHL6b8PxqZYgex8J8xakT2KAchpZIaMwNPauIRHH/VlPJYhSSKe8lz2g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.3.4':
+    resolution: {integrity: sha512-PXnCa3XgTQk0FegMctxgqJXtFLZe4IFJdbUkB7jKSCKEpb6utEO4S9Vog/pkyCfEPdzM331gvE4xpztmBAfMng==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.14':
+    resolution: {integrity: sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.8':
+    resolution: {integrity: sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.7':
+    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.16':
+    resolution: {integrity: sha512-w7lLsTSd3940vFYEshKkHw+NGf7H0QDJPHYsy8NRjDCVbO6ZdKW1X/xoJSYHZtttnrdZiYqbN2O/2uHGB0zasw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.13':
+    resolution: {integrity: sha512-56XPNYGMnGBcPyiBTaEXB7IGPybbsdNkFgSv90SCrHkXnu2Av1HhsyZMegzXlTu/QHA3V6/l22GZCv9iEoiqmQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.4':
+    resolution: {integrity: sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.1':
+    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.2':
+    resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.8':
+    resolution: {integrity: sha512-FjsQEpkNBJJYiPSat6jh2LGKLPX2jAoDVS3AZSBNX3cOUoEGhw/f+z2FCY8Cf1NkoYIbytJ1f4mlWPQpR+MjVg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.2':
+    resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -428,6 +794,96 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@tauri-apps/api@2.11.1':
     resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
 
@@ -519,6 +975,10 @@ packages:
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -566,6 +1026,13 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -595,11 +1062,22 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
+
+  enhanced-resolve@5.24.3:
+    resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
+    engines: {node: '>=10.13.0'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -648,6 +1126,13 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -676,6 +1161,10 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -692,6 +1181,76 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -700,6 +1259,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.25.0:
+    resolution: {integrity: sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -887,6 +1451,36 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
@@ -943,6 +1537,21 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
+  tailwindcss-animate@1.0.7:
+    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -970,6 +1579,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -999,6 +1611,26 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -1282,6 +1914,23 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@floating-ui/utils@0.2.12': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1300,6 +1949,313 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@radix-ui/primitive@1.1.6': {}
+
+  '@radix-ui/react-alert-dialog@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-arrow@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-collection@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-context@1.2.0(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-dialog@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-direction@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-dismissable-layer@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-dropdown-menu@2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-focus-scope@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-menu@2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-popper@1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-portal@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-presence@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-roving-focus@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-tooltip@1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-controllable-state@1.2.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-rect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-visually-hidden@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/rect@1.1.2': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -1378,6 +2334,74 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@tailwindcss/node@4.3.3':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
+
+  '@tailwindcss/vite@4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+
   '@tauri-apps/api@2.11.1': {}
 
   '@types/babel__core@7.20.5':
@@ -1442,7 +2466,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.6)':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -1450,7 +2474,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.6
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1462,13 +2486,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(vite@7.3.6)':
+  '@vitest/mocker@3.2.7(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@3.2.7':
     dependencies:
@@ -1495,6 +2519,10 @@ snapshots:
       '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   assertion-error@2.0.1: {}
 
@@ -1534,6 +2562,12 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
+  clsx@2.1.1: {}
+
   comma-separated-tokens@2.0.3: {}
 
   convert-source-map@2.0.0: {}
@@ -1552,11 +2586,20 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
 
   electron-to-chromium@1.5.389: {}
+
+  enhanced-resolve@5.24.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   es-module-lexer@1.7.0: {}
 
@@ -1612,6 +2655,10 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-nonce@1.0.1: {}
+
+  graceful-fs@4.2.11: {}
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -1653,6 +2700,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  jiti@2.7.0: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -1661,6 +2710,55 @@ snapshots:
 
   json5@2.2.3: {}
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
@@ -1668,6 +2766,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.25.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   magic-string@0.30.21:
     dependencies:
@@ -2076,6 +3178,33 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
+      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   react@19.2.7: {}
 
   remark-gfm@4.0.1:
@@ -2174,6 +3303,16 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  tailwind-merge@3.6.0: {}
+
+  tailwindcss-animate@1.0.7(tailwindcss@4.3.3):
+    dependencies:
+      tailwindcss: 4.3.3
+
+  tailwindcss@4.3.3: {}
+
+  tapable@2.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -2192,6 +3331,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  tslib@2.8.1: {}
 
   typescript@5.8.3: {}
 
@@ -2234,6 +3375,21 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -2244,13 +3400,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4:
+  vite-node@3.2.4(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.6
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2265,7 +3421,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.6:
+  vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
@@ -2275,12 +3431,14 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
 
-  vitest@3.2.7(@types/debug@4.1.13):
+  vitest@3.2.7(@types/debug@4.1.13)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@7.3.6)
+      '@vitest/mocker': 3.2.7(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7
@@ -2298,8 +3456,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.6
-      vite-node: 3.2.4
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-node: 3.2.4(jiti@2.7.0)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13

--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.test.tsx
@@ -151,7 +151,9 @@ describe("AgentActivityPanel", () => {
     expect(markup).not.toContain("future_status");
   });
 
-  it("keeps load and retry states compact and accessible", () => {
+  it("stays silent while loading and keeps the retry state accessible", () => {
+    // Background agents are the exception, so the panel renders nothing while
+    // loading rather than flashing a standing status line under the header.
     expect(
       renderToStaticMarkup(
         <AgentActivityPanel
@@ -162,7 +164,7 @@ describe("AgentActivityPanel", () => {
           {...noStops}
         />,
       ),
-    ).toContain("Loading activity…");
+    ).toBe("");
 
     const failure = renderToStaticMarkup(
       <AgentActivityPanel

--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
@@ -77,8 +77,8 @@ export function AgentActivityPanel({
       </div>
 
       {foreground && (
-        <ul className="agent-activity-list" aria-label="Conversation activity">
-          <AgentActivityItem run={foreground} label="Conversation" />
+        <ul className="agent-activity-list" aria-label="Chat activity">
+          <AgentActivityItem run={foreground} label="Chat" />
         </ul>
       )}
 
@@ -281,7 +281,7 @@ function isActiveAgentRunStatus(status: AgentRun["status"]): boolean {
 function agentRunStatusDescription(status: AgentRun["status"]): string {
   switch (status) {
     case "active":
-      return "Ready for this conversation";
+      return "Ready for this chat";
     case "queued":
       return "Queued to start";
     case "running":

--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
@@ -29,8 +29,11 @@ export function AgentActivityPanel({
   stopErrorRunIds: ReadonlySet<string>;
   onStop: (runId: string) => void;
 }) {
+  // Stay invisible while loading: background agents are the exception, so a
+  // standing "Loading activity…" line under the header would be noise on every
+  // chat. The panel simply appears once background work is present.
   if (loading) {
-    return <div className="agent-activity-state">Loading activity…</div>;
+    return null;
   }
 
   if (error) {
@@ -46,7 +49,11 @@ export function AgentActivityPanel({
 
   const foreground = runs.find((run) => run.execution === "foreground");
   const sandboxes = runs.filter((run) => run.execution === "sandbox");
-  if (!foreground && sandboxes.length === 0) return null;
+  // The foreground conversation turn is already represented by the streaming
+  // reply, tool cards, and the working indicator, so a standing "Activity:
+  // Conversation" card just adds noise. Surface this panel only when there is
+  // real background (sandbox) agent work to report.
+  if (sandboxes.length === 0) return null;
 
   const activeSandboxes = sandboxes.filter((run) =>
     isActiveAgentRunStatus(run.status),

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -5,7 +5,6 @@ import {
   type Chat,
   type ModelInfo,
   type PendingFolderAccessRequest,
-  type Project,
   type ProviderInfo,
   type ProviderKind,
   type SequencedEvent,
@@ -81,8 +80,7 @@ import {
   reconcileSandboxAgentCancellation,
   sandboxAgentStopKey,
 } from "./SandboxAgentStop";
-import { ProjectNavigation } from "./ProjectNavigation";
-import { existingChatAfterDeletion, prependReplacementChat } from "./ChatDeletion";
+import { prependReplacementChat } from "./ChatDeletion";
 import { useConfirm } from "./components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -104,10 +102,6 @@ export default function App() {
   const [hydratedChatId, setHydratedChatId] = useState<string | null>(null);
   const [chats, setChats] = useState<Chat[]>([]);
   const [chatsError, setChatsError] = useState<string | null>(null);
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [projectsLoading, setProjectsLoading] = useState(true);
-  const [projectsError, setProjectsError] = useState<string | null>(null);
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [messages, setMessages] = useState<Msg[]>([]);
@@ -143,9 +137,7 @@ export default function App() {
   const [steerError, setSteerError] = useState<string | null>(null);
   const [steerStatus, setSteerStatus] = useState<string | null>(null);
   const [creatingChat, setCreatingChat] = useState(false);
-  const [creatingProject, setCreatingProject] = useState(false);
   const [deletingChatId, setDeletingChatId] = useState<string | null>(null);
-  const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
   const [savingTitle, setSavingTitle] = useState(false);
   const [renamingChatId, setRenamingChatId] = useState<string | null>(null);
   const [renameChatDraft, setRenameChatDraft] = useState("");
@@ -210,16 +202,6 @@ export default function App() {
     let cancelled = false;
     (async () => {
       try {
-        void (async () => {
-          try {
-            const existingProjects = await client.listProjects();
-            if (!cancelled) setProjects(existingProjects);
-          } catch {
-            if (!cancelled) setProjectsError("Could not load projects.");
-          } finally {
-            if (!cancelled) setProjectsLoading(false);
-          }
-        })();
         const [catalog, providerList, existingChats] = await Promise.all([
           client.listModels(),
           client.listProviders(),
@@ -278,7 +260,7 @@ export default function App() {
             {
               id: nextId(),
               role: "error",
-              text: `Could not load this conversation: ${String(err)}`,
+              text: `Could not load this chat: ${String(err)}`,
             },
           ]);
         }
@@ -915,7 +897,7 @@ export default function App() {
     try {
       const created = await client.createChat(
         chat?.model ?? models[0]?.id,
-        selectedProjectId,
+        null,
       );
       openCreatedChat(created);
     } catch (err) {
@@ -961,140 +943,16 @@ export default function App() {
     activateChat(created);
     setChats((current) => [created, ...current]);
     setChatsError(null);
-    setProjectsError(null);
     setStatus(`chat ${created.id.slice(0, 8)}…`);
-  }
-
-  async function onSelectProject(projectId: string | null) {
-    if (
-      !client ||
-      projectsLoading ||
-      creationInFlightRef.current ||
-      deletionInFlightRef.current
-    ) {
-      return;
-    }
-    const existing = chats.find((item) => item.project_id === projectId);
-    if (existing) {
-      setProjectsError(null);
-      selectChat(existing);
-      return;
-    }
-
-    creationInFlightRef.current = true;
-    setCreatingChat(true);
-    setProjectsError(null);
-    try {
-      const created = await client.createChat(
-        chat?.model ?? models[0]?.id,
-        projectId,
-      );
-      openCreatedChat(created);
-    } catch (err) {
-      setProjectsError(`Could not open project: ${String(err)}`);
-    } finally {
-      creationInFlightRef.current = false;
-      setCreatingChat(false);
-    }
-  }
-
-  async function onCreateProject(title: string): Promise<boolean> {
-    if (
-      !client ||
-      projectsLoading ||
-      creationInFlightRef.current ||
-      deletionInFlightRef.current
-    ) {
-      return false;
-    }
-    creationInFlightRef.current = true;
-    setCreatingProject(true);
-    setProjectsError(null);
-    let project: Project;
-    try {
-      project = await client.createProject(title);
-      setProjects((current) => [project, ...current]);
-    } catch (err) {
-      setProjectsError(`Could not create project: ${String(err)}`);
-      creationInFlightRef.current = false;
-      setCreatingProject(false);
-      return false;
-    }
-
-    try {
-      const created = await client.createChat(
-        chat?.model ?? models[0]?.id,
-        project.id,
-      );
-      openCreatedChat(created);
-      return true;
-    } catch (err) {
-      setProjectsError(`Project created, but its first chat could not start: ${String(err)}`);
-      return true;
-    } finally {
-      creationInFlightRef.current = false;
-      setCreatingProject(false);
-    }
-  }
-
-  async function onRenameProject(
-    projectId: string,
-    title: string | null,
-  ): Promise<boolean> {
-    if (!client) return false;
-    setProjectsError(null);
-    try {
-      const updated = await client.patchProjectTitle(projectId, title);
-      if (updated.id !== projectId) {
-        throw new Error("project rename response has the wrong identity");
-      }
-      setProjects((current) =>
-        current.map((project) => (project.id === updated.id ? updated : project)),
-      );
-      return true;
-    } catch (err) {
-      setProjectsError(`Could not rename project: ${String(err)}`);
-      return false;
-    }
-  }
-
-  async function onDeleteProject(target: Project): Promise<boolean> {
-    if (!client || deletionInFlightRef.current || creationInFlightRef.current) return false;
-    const label = target.title?.trim() || "Untitled project";
-    const confirmed = await confirm({
-      title: `Delete ${label}?`,
-      description:
-        "Remove its conversations, documents, and connected folders first. This cannot be undone.",
-      confirmLabel: "Delete project",
-      destructive: true,
-    });
-    if (!confirmed) {
-      return false;
-    }
-
-    deletionInFlightRef.current = true;
-    setDeletingProjectId(target.id);
-    setProjectsError(null);
-    try {
-      await client.deleteProject(target.id);
-      setProjects((current) => current.filter((project) => project.id !== target.id));
-      return true;
-    } catch (err) {
-      setProjectsError(`Could not delete project: ${String(err)}`);
-      return false;
-    } finally {
-      deletionInFlightRef.current = false;
-      setDeletingProjectId(null);
-    }
   }
 
   async function onDeleteChat(target: Chat) {
     if (!client || deletionInFlightRef.current || creationInFlightRef.current) return;
-    const label = target.title?.trim() || "this conversation";
+    const label = target.title?.trim() || "this chat";
     const confirmed = await confirm({
       title: `Delete ${label}?`,
       description: "This cannot be undone.",
-      confirmLabel: "Delete conversation",
+      confirmLabel: "Delete chat",
       destructive: true,
     });
     if (!confirmed) return;
@@ -1120,7 +978,7 @@ export default function App() {
         return;
       }
 
-      let next = existingChatAfterDeletion(refreshed, target.project_id);
+      let next: Chat | undefined = refreshed[0];
       if (!next) {
         next = await client.createChat(models[0]?.id, null);
         refreshed = prependReplacementChat(refreshed, next);
@@ -1128,7 +986,7 @@ export default function App() {
       setChats(refreshed);
       selectChat(next, true);
     } catch (err) {
-      setChatsError(`Could not delete conversation: ${String(err)}`);
+      setChatsError(`Could not delete chat: ${String(err)}`);
     } finally {
       deletionInFlightRef.current = false;
       setDeletingChatId(null);
@@ -1145,7 +1003,6 @@ export default function App() {
     assistantMarkerScrubberRef.current =
       new AssistantSourceMarkerStreamScrubber();
     setChat(next);
-    setSelectedProjectId(next.project_id);
   }
 
   function selectChat(next: Chat, force = false) {
@@ -1229,7 +1086,7 @@ export default function App() {
       // silently. Otherwise keep the editor open with the typed draft so the
       // rename can be retried instead of being discarded.
       if (chatSelectionRef.current === selection) {
-        setChatsError(`Could not rename conversation: ${String(err)}`);
+        setChatsError(`Could not rename chat: ${String(err)}`);
       } else {
         setRenamingChatId(null);
         setRenameChatDraft("");
@@ -1350,9 +1207,7 @@ export default function App() {
     );
   }
 
-  const visibleChats = chats.filter(
-    (item) => item.project_id === selectedProjectId,
-  );
+  const visibleChats = chats;
 
   return (
     <div className="app-shell">
@@ -1386,37 +1241,15 @@ export default function App() {
           type="button"
           className="new-chat"
           onClick={() => void onNewChat()}
-          disabled={
-            creatingChat ||
-            creatingProject ||
-            deletingChatId !== null ||
-            deletingProjectId !== null
-          }
+          disabled={creatingChat || deletingChatId !== null}
         >
           <SquarePen size={15} />
           {creatingChat
             ? "Starting…"
-            : deletingChatId || deletingProjectId
+            : deletingChatId
               ? "Deleting…"
               : "New chat"}
         </button>
-
-        <ProjectNavigation
-          projects={projects}
-          selectedProjectId={selectedProjectId}
-          disabled={
-            projectsLoading ||
-            creatingChat ||
-            creatingProject ||
-            deletingChatId !== null ||
-            deletingProjectId !== null
-          }
-          error={projectsError}
-          onSelect={(projectId) => void onSelectProject(projectId)}
-          onCreate={onCreateProject}
-          onRename={onRenameProject}
-          onDelete={onDeleteProject}
-        />
 
         {hasNativeHost() && (
           <button
@@ -1433,16 +1266,12 @@ export default function App() {
         )}
 
         <div className="sidebar-section">
-          <span className="sidebar-label">Conversations</span>
-          <div className="conversation-list" aria-label="Conversations">
+          <span className="sidebar-label">Chats</span>
+          <div className="conversation-list" aria-label="Chats">
             {visibleChats.map((item) => {
-              const chatTitle = item.title?.trim() || "New conversation";
+              const chatTitle = item.title?.trim() || "New chat";
               const isActive = primaryView === "chat" && item.id === chat.id;
-              const mutating =
-                deletingChatId !== null ||
-                deletingProjectId !== null ||
-                creatingChat ||
-                creatingProject;
+              const mutating = deletingChatId !== null || creatingChat;
 
               if (renamingChatId === item.id) {
                 return (
@@ -1453,7 +1282,7 @@ export default function App() {
                     <input
                       className="conversation-rename-input"
                       autoFocus
-                      aria-label="Conversation title"
+                      aria-label="Chat title"
                       value={renameChatDraft}
                       disabled={savingTitle}
                       onChange={(event) =>
@@ -1495,7 +1324,7 @@ export default function App() {
                         type="button"
                         className="conversation-menu"
                         aria-label={`Actions for ${chatTitle}`}
-                        title="Conversation actions"
+                        title="Chat actions"
                         disabled={mutating}
                       >
                         <Ellipsis size={15} />
@@ -1593,7 +1422,7 @@ export default function App() {
         <section className="chat-pane">
           <header className="conversation-header">
             <div className="conversation-title-row">
-              <h1>{chat.title?.trim() || "New conversation"}</h1>
+              <h1>{chat.title?.trim() || "New chat"}</h1>
             </div>
             <div className="conversation-header-actions">
               <div className="mobile-settings-actions">
@@ -1721,7 +1550,7 @@ export default function App() {
             cancelPending={
               activeTurnId !== null && cancelPendingTurnId === activeTurnId
             }
-            disabled={deletingChatId !== null || deletingProjectId !== null}
+            disabled={deletingChatId !== null}
             draft={draft}
             onDraftChange={onComposerDraftChange}
             onSend={onSend}
@@ -1740,7 +1569,7 @@ export default function App() {
           <ModelPanel
             chat={chat}
             models={models}
-            disabled={deletingChatId !== null || deletingProjectId !== null}
+            disabled={deletingChatId !== null}
             onModelChange={onModelChange}
           />
         )}
@@ -1914,7 +1743,7 @@ function FoldersPanel({ chat }: { chat: Chat }) {
   const [folders, setFolders] = useState<ConnectedFolder[]>([]);
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const scopeLabel = chat.project_id ? "project" : "chat";
+  const scopeLabel = "chat";
 
   async function refresh() {
     setError(null);
@@ -2290,7 +2119,7 @@ function ModelPanel({
   return (
     <SettingsPanel
       title="Model"
-      description="Choose the model for this conversation."
+      description="Choose the model for this chat."
     >
       <SettingsField label="Active model">
         <select

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   ApiClient,
   type AgentRun,
@@ -27,6 +27,30 @@ import {
 import { Logomark } from "./Logomark";
 import { Composer } from "./Composer";
 import { MessageList, type ChatMessage } from "./MessageList";
+import {
+  ArrowDown,
+  Bot,
+  Ellipsis,
+  FolderOpen,
+  Globe,
+  LibraryBig,
+  Monitor,
+  Moon,
+  Pencil,
+  Settings,
+  SquarePen,
+  Sun,
+  Trash2,
+} from "lucide-react";
+import { useTheme } from "./theme";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { WithTooltip } from "@/components/ui/tooltip";
 import {
   toolApprovalPresentation,
   type ToolCallStatus,
@@ -59,6 +83,9 @@ import {
 } from "./SandboxAgentStop";
 import { ProjectNavigation } from "./ProjectNavigation";
 import { existingChatAfterDeletion, prependReplacementChat } from "./ChatDeletion";
+import { useConfirm } from "./components/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 type Msg = ChatMessage;
 
@@ -119,11 +146,12 @@ export default function App() {
   const [creatingProject, setCreatingProject] = useState(false);
   const [deletingChatId, setDeletingChatId] = useState<string | null>(null);
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
-  const [editingTitle, setEditingTitle] = useState(false);
-  const [titleDraft, setTitleDraft] = useState("");
   const [savingTitle, setSavingTitle] = useState(false);
+  const [renamingChatId, setRenamingChatId] = useState<string | null>(null);
+  const [renameChatDraft, setRenameChatDraft] = useState("");
+  const skipRenameCommitRef = useRef(false);
   const [settingsPanel, setSettingsPanel] = useState<
-    "providers" | "web-search" | "folders" | null
+    "providers" | "web-search" | "folders" | "model" | null
   >(null);
   const [primaryView, setPrimaryView] = useState<"chat" | "documents">("chat");
   const [status, setStatus] = useState("starting…");
@@ -153,6 +181,8 @@ export default function App() {
   const provisionalToolCallIdsRef = useRef<Set<string>>(new Set());
   const creationInFlightRef = useRef(false);
   const deletionInFlightRef = useRef(false);
+  const { confirm, dialog: confirmDialog } = useConfirm();
+  const { mode: themeMode, cycle: cycleTheme } = useTheme();
 
   useEffect(() => {
     let cancelled = false;
@@ -1031,11 +1061,14 @@ export default function App() {
   async function onDeleteProject(target: Project): Promise<boolean> {
     if (!client || deletionInFlightRef.current || creationInFlightRef.current) return false;
     const label = target.title?.trim() || "Untitled project";
-    if (
-      !window.confirm(
-        `Delete ${label}? Remove its conversations, documents, and connected folders first. This cannot be undone.`,
-      )
-    ) {
+    const confirmed = await confirm({
+      title: `Delete ${label}?`,
+      description:
+        "Remove its conversations, documents, and connected folders first. This cannot be undone.",
+      confirmLabel: "Delete project",
+      destructive: true,
+    });
+    if (!confirmed) {
       return false;
     }
 
@@ -1058,7 +1091,13 @@ export default function App() {
   async function onDeleteChat(target: Chat) {
     if (!client || deletionInFlightRef.current || creationInFlightRef.current) return;
     const label = target.title?.trim() || "this conversation";
-    if (!window.confirm(`Delete ${label}? This cannot be undone.`)) return;
+    const confirmed = await confirm({
+      title: `Delete ${label}?`,
+      description: "This cannot be undone.",
+      confirmLabel: "Delete conversation",
+      destructive: true,
+    });
+    if (!confirmed) return;
 
     deletionInFlightRef.current = true;
     setDeletingChatId(target.id);
@@ -1141,27 +1180,60 @@ export default function App() {
     setCancelError(null);
     cancelRequestTurnRef.current = null;
     clearSteerRequestState();
-    setEditingTitle(false);
+    cancelChatRename();
     activateChat(next);
     setStatus(`chat ${next.id.slice(0, 8)}…`);
   }
 
-  async function onRenameChat() {
-    if (!client || !chat || savingTitle || deletionInFlightRef.current) return;
-    const chatId = chat.id;
+  function startChatRename(target: Chat) {
+    skipRenameCommitRef.current = false;
+    setRenameChatDraft(target.title ?? "");
+    setRenamingChatId(target.id);
+  }
+
+  function cancelChatRename() {
+    skipRenameCommitRef.current = true;
+    setRenamingChatId(null);
+    setRenameChatDraft("");
+  }
+
+  async function commitChatRename(target: Chat) {
+    // A single rename resolves through the input's blur; Enter blurs the field
+    // and Escape sets the skip flag before blurring, so the blur that follows
+    // must not also patch.
+    if (skipRenameCommitRef.current) {
+      skipRenameCommitRef.current = false;
+      return;
+    }
+    if (!client || savingTitle || deletionInFlightRef.current) return;
+    const trimmed = renameChatDraft.trim();
+    if (trimmed === (target.title?.trim() ?? "")) {
+      setRenamingChatId(null);
+      setRenameChatDraft("");
+      return;
+    }
     const selection = chatSelectionRef.current;
     setSavingTitle(true);
     try {
-      const updated = await client.patchChatTitle(chatId, titleDraft.trim() || null);
+      const updated = await client.patchChatTitle(target.id, trimmed || null);
       setChats((current) =>
         current.map((item) => (item.id === updated.id ? updated : item)),
       );
-      if (chatSelectionRef.current !== selection) return;
-      setChat(updated);
-      setEditingTitle(false);
+      if (chat?.id === updated.id && chatSelectionRef.current === selection) {
+        setChat(updated);
+      }
+      setRenamingChatId(null);
+      setRenameChatDraft("");
     } catch (err) {
-      if (chatSelectionRef.current !== selection) return;
-      setChatsError(`Could not rename conversation: ${String(err)}`);
+      // If the user has since switched conversations, abandon this stale edit
+      // silently. Otherwise keep the editor open with the typed draft so the
+      // rename can be retried instead of being discarded.
+      if (chatSelectionRef.current === selection) {
+        setChatsError(`Could not rename conversation: ${String(err)}`);
+      } else {
+        setRenamingChatId(null);
+        setRenameChatDraft("");
+      }
     } finally {
       setSavingTitle(false);
     }
@@ -1281,16 +1353,33 @@ export default function App() {
   const visibleChats = chats.filter(
     (item) => item.project_id === selectedProjectId,
   );
-  const activeProject = selectedProjectId
-    ? projects.find((project) => project.id === selectedProjectId) ?? null
-    : null;
 
   return (
     <div className="app-shell">
+      {confirmDialog}
       <aside className="sidebar">
         <div className="sidebar-brand">
           <Logomark />
           <span>OpenWave</span>
+          <WithTooltip
+            label={`Theme: ${themeMode} — click to change`}
+            side="bottom"
+          >
+            <button
+              type="button"
+              className="theme-toggle"
+              aria-label={`Theme: ${themeMode}. Click to change.`}
+              onClick={cycleTheme}
+            >
+              {themeMode === "light" ? (
+                <Sun size={15} />
+              ) : themeMode === "dark" ? (
+                <Moon size={15} />
+              ) : (
+                <Monitor size={15} />
+              )}
+            </button>
+          </WithTooltip>
         </div>
 
         <button
@@ -1304,7 +1393,7 @@ export default function App() {
             deletingProjectId !== null
           }
         >
-          <span aria-hidden="true">+</span>
+          <SquarePen size={15} />
           {creatingChat
             ? "Starting…"
             : deletingChatId || deletingProjectId
@@ -1338,7 +1427,7 @@ export default function App() {
               setPrimaryView("documents");
             }}
           >
-            <span aria-hidden="true">▤</span>
+            <LibraryBig size={16} />
             Documents
           </button>
         )}
@@ -1346,43 +1435,92 @@ export default function App() {
         <div className="sidebar-section">
           <span className="sidebar-label">Conversations</span>
           <div className="conversation-list" aria-label="Conversations">
-            {visibleChats.map((item) => (
-              <div
-                key={item.id}
-                className={`conversation-row${primaryView === "chat" && item.id === chat.id ? " is-active" : ""}`}
-              >
-                <button
-                  type="button"
-                  className="conversation-item"
-                  aria-current={primaryView === "chat" && item.id === chat.id ? "page" : undefined}
-                  disabled={
-                    deletingChatId !== null ||
-                    deletingProjectId !== null ||
-                    creatingChat ||
-                    creatingProject
-                  }
-                  onClick={() => selectChat(item)}
+            {visibleChats.map((item) => {
+              const chatTitle = item.title?.trim() || "New conversation";
+              const isActive = primaryView === "chat" && item.id === chat.id;
+              const mutating =
+                deletingChatId !== null ||
+                deletingProjectId !== null ||
+                creatingChat ||
+                creatingProject;
+
+              if (renamingChatId === item.id) {
+                return (
+                  <div
+                    key={item.id}
+                    className="conversation-row is-renaming"
+                  >
+                    <input
+                      className="conversation-rename-input"
+                      autoFocus
+                      aria-label="Conversation title"
+                      value={renameChatDraft}
+                      disabled={savingTitle}
+                      onChange={(event) =>
+                        setRenameChatDraft(event.target.value)
+                      }
+                      onBlur={() => void commitChatRename(item)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                          event.preventDefault();
+                          event.currentTarget.blur();
+                        }
+                        if (event.key === "Escape") {
+                          event.preventDefault();
+                          cancelChatRename();
+                        }
+                      }}
+                    />
+                  </div>
+                );
+              }
+
+              return (
+                <div
+                  key={item.id}
+                  className={`conversation-row${isActive ? " is-active" : ""}`}
                 >
-                  <span className="conversation-dot" aria-hidden="true" />
-                  <span>{item.title?.trim() || "New conversation"}</span>
-                </button>
-                <button
-                  type="button"
-                  className="conversation-delete"
-                  aria-label={`Delete ${item.title?.trim() || "conversation"}`}
-                  title="Delete conversation"
-                  disabled={
-                    deletingChatId !== null ||
-                    deletingProjectId !== null ||
-                    creatingChat ||
-                    creatingProject
-                  }
-                  onClick={() => void onDeleteChat(item)}
-                >
-                  ×
-                </button>
-              </div>
-            ))}
+                  <button
+                    type="button"
+                    className="conversation-item"
+                    aria-current={isActive ? "page" : undefined}
+                    disabled={mutating}
+                    onClick={() => selectChat(item)}
+                  >
+                    <span className="conversation-title">{chatTitle}</span>
+                  </button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        className="conversation-menu"
+                        aria-label={`Actions for ${chatTitle}`}
+                        title="Conversation actions"
+                        disabled={mutating}
+                      >
+                        <Ellipsis size={15} />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" side="right">
+                      <DropdownMenuItem
+                        onSelect={() => startChatRename(item)}
+                      >
+                        <Pencil />
+                        Rename
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        variant="destructive"
+                        onSelect={() => void onDeleteChat(item)}
+                      >
+                        <Trash2 />
+                        Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              );
+            })}
           </div>
           {chatsError && <p className="sidebar-error">{chatsError}</p>}
         </div>
@@ -1399,9 +1537,23 @@ export default function App() {
                 );
               }}
             >
+              <FolderOpen size={16} />
               Folders
             </button>
           )}
+          <button
+            type="button"
+            className={`sidebar-action${settingsPanel === "model" ? " is-active" : ""}`}
+            onClick={() => {
+              setPrimaryView("chat");
+              setSettingsPanel((panel) =>
+                panel === "model" ? null : "model",
+              );
+            }}
+          >
+            <Bot size={16} />
+            Model
+          </button>
           <button
             type="button"
             className={`sidebar-action${settingsPanel === "providers" ? " is-active" : ""}`}
@@ -1412,6 +1564,7 @@ export default function App() {
               );
             }}
           >
+            <Settings size={16} />
             Providers
           </button>
           <button
@@ -1424,6 +1577,7 @@ export default function App() {
               );
             }}
           >
+            <Globe size={16} />
             Web search
           </button>
         </div>
@@ -1438,54 +1592,8 @@ export default function App() {
           <>
         <section className="chat-pane">
           <header className="conversation-header">
-            <div>
-              <p className="eyebrow">
-                {activeProject?.title?.trim() ||
-                  (selectedProjectId ? "Untitled project" : "Loose conversation")}
-              </p>
-              {editingTitle ? (
-                <form
-                  className="conversation-title-editor"
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    void onRenameChat();
-                  }}
-                >
-                  <input
-                    autoFocus
-                    value={titleDraft}
-                    aria-label="Conversation title"
-                    onChange={(event) => setTitleDraft(event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Escape") setEditingTitle(false);
-                    }}
-                  />
-                  <button
-                    type="submit"
-                    className="btn"
-                    disabled={
-                      savingTitle || deletingChatId !== null || deletingProjectId !== null
-                    }
-                  >
-                    {savingTitle ? "Saving…" : "Save"}
-                  </button>
-                </form>
-              ) : (
-                <div className="conversation-title-row">
-                  <h1>{chat.title?.trim() || "New conversation"}</h1>
-                  <button
-                    type="button"
-                    className="title-action"
-                    disabled={deletingChatId !== null || deletingProjectId !== null}
-                    onClick={() => {
-                      setTitleDraft(chat.title ?? "");
-                      setEditingTitle(true);
-                    }}
-                  >
-                    Rename
-                  </button>
-                </div>
-              )}
+            <div className="conversation-title-row">
+              <h1>{chat.title?.trim() || "New conversation"}</h1>
             </div>
             <div className="conversation-header-actions">
               <div className="mobile-settings-actions">
@@ -1498,7 +1606,7 @@ export default function App() {
                       setPrimaryView("documents");
                     }}
                   >
-                    Documents
+                    <LibraryBig size={14} />
                   </button>
                 )}
                 {hasNativeHost() && (
@@ -1511,9 +1619,20 @@ export default function App() {
                       )
                     }
                   >
-                    Folders
+                    <FolderOpen size={14} />
                   </button>
                 )}
+                <button
+                  type="button"
+                  className={`btn${settingsPanel === "model" ? " is-active" : ""}`}
+                  onClick={() =>
+                    setSettingsPanel((panel) =>
+                      panel === "model" ? null : "model",
+                    )
+                  }
+                >
+                  <Bot size={14} />
+                </button>
                 <button
                   type="button"
                   className={`btn${settingsPanel === "providers" ? " is-active" : ""}`}
@@ -1523,7 +1642,7 @@ export default function App() {
                     )
                   }
                 >
-                  Providers
+                  <Settings size={14} />
                 </button>
                 <button
                   type="button"
@@ -1534,7 +1653,7 @@ export default function App() {
                     )
                   }
                 >
-                  Web search
+                  <Globe size={14} />
                 </button>
               </div>
               <span className="status" title={status}>
@@ -1543,55 +1662,15 @@ export default function App() {
             </div>
           </header>
 
-          <div className="chat-meta">
-            <label>
-              Model{" "}
-              <select
-                value={chat.model ?? ""}
-                disabled={deletingChatId !== null || deletingProjectId !== null}
-                onChange={(e) => void onModelChange(e.target.value)}
-              >
-                <option value="">default</option>
-                {models.map((m) => (
-                  <option key={m.id} value={m.id}>
-                    {m.id} ({m.provider})
-                  </option>
-                ))}
-                {chat.model && !models.some((m) => m.id === chat.model) && (
-                  <option value={chat.model}>{chat.model} (custom)</option>
-                )}
-              </select>
-            </label>
-            <input
-              className="model-custom"
-              type="text"
-              placeholder="or type a model id"
-              defaultValue={
-                chat.model && !models.some((m) => m.id === chat.model)
-                  ? chat.model
-                  : ""
-              }
-              key={chat.id}
-              onBlur={(e) => {
-                const next = e.target.value.trim();
-                if (next && next !== (chat.model ?? "")) {
-                  void onModelChange(next);
-                }
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") e.currentTarget.blur();
-              }}
-            />
-            <AgentActivityPanel
-              runs={visibleAgentRuns}
-              loading={agentRunsChatId === chat.id ? agentRunsLoading : true}
-              error={agentRunsChatId === chat.id ? agentRunsError : null}
-              onRetry={() => refreshAgentRunsRef.current?.()}
-              stoppingRunIds={visibleStoppingSandboxRunIds}
-              stopErrorRunIds={visibleSandboxStopErrorRunIds}
-              onStop={(runId) => void onStopSandboxAgentRun(runId)}
-            />
-          </div>
+          <AgentActivityPanel
+            runs={visibleAgentRuns}
+            loading={agentRunsChatId === chat.id ? agentRunsLoading : true}
+            error={agentRunsChatId === chat.id ? agentRunsError : null}
+            onRetry={() => refreshAgentRunsRef.current?.()}
+            stoppingRunIds={visibleStoppingSandboxRunIds}
+            stopErrorRunIds={visibleSandboxStopErrorRunIds}
+            onStop={(runId) => void onStopSandboxAgentRun(runId)}
+          />
 
           <div className="message-view">
             <MessageList
@@ -1616,6 +1695,8 @@ export default function App() {
               onFolderAccessCancel={(callId, turnId) =>
                 void onFolderAccessCancel(callId, turnId)
               }
+              onSelectPrompt={setComposerDraft}
+              hydrated={hydratedChatId === chat.id}
             />
             {hasUnreadActivity && (
               <button
@@ -1627,7 +1708,8 @@ export default function App() {
                   if (scrollRef.current) scrollToLatest(scrollRef.current);
                 }}
               >
-                New activity ↓
+                New activity
+                <ArrowDown size={13} />
               </button>
             )}
           </div>
@@ -1654,6 +1736,14 @@ export default function App() {
           />
         </section>
 
+        {settingsPanel === "model" && (
+          <ModelPanel
+            chat={chat}
+            models={models}
+            disabled={deletingChatId !== null || deletingProjectId !== null}
+            onModelChange={onModelChange}
+          />
+        )}
         {settingsPanel === "providers" && (
           <ProvidersPanel
             providers={providers}
@@ -1750,6 +1840,76 @@ function withoutConnectionState(status: string): string {
   return status.replace(/ · (?:live|reconnecting)$/, "");
 }
 
+const SETTINGS_SELECT_CLASS =
+  "flex h-10 w-full rounded-md border border-border bg-background px-3 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+
+function SettingsPanel({
+  title,
+  description,
+  busy,
+  children,
+}: {
+  title: string;
+  description?: string;
+  busy?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <aside className="settings" aria-busy={busy}>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-base font-semibold tracking-tight">{title}</h2>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {children}
+    </aside>
+  );
+}
+
+function SettingsField({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+      {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
+    </label>
+  );
+}
+
+function SettingsSection({
+  title,
+  children,
+}: {
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3 rounded-lg border border-border p-4">
+      {title && (
+        <h3 className="text-sm font-semibold capitalize">{title}</h3>
+      )}
+      {children}
+    </section>
+  );
+}
+
+function SettingsError({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-sm text-destructive" role="alert">
+      {children}
+    </p>
+  );
+}
+
 function FoldersPanel({ chat }: { chat: Chat }) {
   const [folders, setFolders] = useState<ConnectedFolder[]>([]);
   const [working, setWorking] = useState(false);
@@ -1796,45 +1956,50 @@ function FoldersPanel({ chat }: { chat: Chat }) {
   }
 
   return (
-    <aside className="settings">
-      <h2>Connected folders</h2>
-      <p>
-        OpenWave can read only folders you choose for this {scopeLabel}. Folder
-        locations stay with the native host.
-      </p>
-      <button
+    <SettingsPanel
+      title="Connected folders"
+      description={`OpenWave can read only folders you choose for this ${scopeLabel}. Folder locations stay with the native host.`}
+    >
+      <Button
         type="button"
-        className="btn btn-primary"
+        variant="outline"
+        className="self-start"
         disabled={working}
         onClick={() => void addFolder()}
       >
         Choose folder…
-      </button>
-      <div className="folder-list">
+      </Button>
+      <div className="flex flex-col gap-2">
         {folders.length === 0 && !error && (
-          <div className="status">
+          <p className="text-sm text-muted-foreground">
             No folders connected to this {scopeLabel}.
-          </div>
+          </p>
         )}
         {folders.map((folder) => (
-          <div className="folder" key={folder.rootId}>
-            <div>
-              <strong>{folder.displayName}</strong>
-              <div className="status">read access</div>
+          <div
+            className="flex items-center justify-between gap-3 rounded-lg border border-border p-3"
+            key={folder.rootId}
+          >
+            <div className="min-w-0">
+              <strong className="block truncate text-sm font-medium">
+                {folder.displayName}
+              </strong>
+              <span className="text-xs text-muted-foreground">read access</span>
             </div>
-            <button
+            <Button
               type="button"
-              className="btn"
+              variant="outline"
+              size="sm"
               disabled={working}
               onClick={() => void removeFolder(folder.rootId)}
             >
-              Disconnect from {scopeLabel}
-            </button>
+              Disconnect
+            </Button>
           </div>
         ))}
       </div>
-      {error && <div className="folder-error">{error}</div>}
-    </aside>
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsPanel>
   );
 }
 
@@ -1957,41 +2122,50 @@ function WebSearchPanel({ client }: { client: ApiClient }) {
   }
 
   return (
-    <aside className="settings web-search-settings" aria-busy={loading}>
-      <h2>Web search</h2>
-      <p>
-        Choose a local provider and a bounded request timeout. Existing keys are
-        never shown here.
-      </p>
-
+    <SettingsPanel
+      title="Web search"
+      description="Choose a local provider and a bounded request timeout. Existing keys are never shown here."
+      busy={loading}
+    >
       {loading ? (
-        <div className="status">Loading web-search settings…</div>
+        <p className="text-sm text-muted-foreground">
+          Loading web-search settings…
+        </p>
       ) : !config ? (
-        <div className="status">Web-search settings are unavailable.</div>
+        <p className="text-sm text-muted-foreground">
+          Web-search settings are unavailable.
+        </p>
       ) : (
         <>
-          <div className={`web-search-state is-${state.kind}`} role="status">
+          <div
+            className={`web-search-state is-${state.kind}`}
+            role="status"
+          >
             <strong>{state.label}</strong>
             <span>{state.description}</span>
           </div>
 
-          <div className="provider">
-            <label className="settings-field">
-              <span>Provider</span>
+          <SettingsSection>
+            <SettingsField label="Provider">
               <select
+                className={SETTINGS_SELECT_CLASS}
                 value={provider}
                 disabled={working}
-                onChange={(event) => setProvider(event.target.value as WebSearchProviderKind | "")}
+                onChange={(event) =>
+                  setProvider(event.target.value as WebSearchProviderKind | "")
+                }
               >
                 <option value="">Disabled</option>
                 <option value="exa">Exa</option>
                 <option value="tavily">Tavily</option>
               </select>
-            </label>
+            </SettingsField>
 
-            <label className="settings-field">
-              <span>Request timeout (ms)</span>
-              <input
+            <SettingsField
+              label="Request timeout (ms)"
+              hint={`Between ${MIN_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} and ${MAX_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} ms.`}
+            >
+              <Input
                 type="number"
                 inputMode="numeric"
                 min={MIN_WEB_SEARCH_TIMEOUT_MS}
@@ -2001,31 +2175,28 @@ function WebSearchPanel({ client }: { client: ApiClient }) {
                 disabled={working}
                 onChange={(event) => setTimeoutMs(event.target.value)}
               />
-            </label>
-            <p className="settings-hint">
-              Between {MIN_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} and {MAX_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} ms.
-            </p>
-            <div className="row">
-              <button
-                type="button"
-                className="btn btn-primary"
-                disabled={working}
-                onClick={() => void saveConfig()}
-              >
-                {savingConfig ? "Saving…" : "Save configuration"}
-              </button>
-            </div>
-          </div>
+            </SettingsField>
+            <Button
+              type="button"
+              className="self-start"
+              disabled={working}
+              onClick={() => void saveConfig()}
+            >
+              {savingConfig ? "Saving…" : "Save configuration"}
+            </Button>
+          </SettingsSection>
 
           {activeProvider && (
-            <div className="provider">
-              <h3>{activeProvider} credential</h3>
-              <span className="status">
-                {selectedHasCredential ? "credential saved" : "no credential saved"}
+            <SettingsSection title={`${activeProvider} credential`}>
+              <span className="text-xs text-muted-foreground">
+                {selectedHasCredential
+                  ? "credential saved"
+                  : "no credential saved"}
               </span>
-              <label className="settings-field">
-                <span>{selectedHasCredential ? "Replace API key" : "API key"}</span>
-                <input
+              <SettingsField
+                label={selectedHasCredential ? "Replace API key" : "API key"}
+              >
+                <Input
                   type="password"
                   placeholder="Paste a new API key"
                   value={apiKey}
@@ -2034,44 +2205,48 @@ function WebSearchPanel({ client }: { client: ApiClient }) {
                   disabled={working}
                   onChange={(event) => setApiKey(event.target.value)}
                 />
-              </label>
-              <div className="row">
-                <button
+              </SettingsField>
+              <div className="flex flex-wrap gap-2">
+                <Button
                   type="button"
-                  className="btn btn-primary"
                   disabled={working || !apiKey.trim()}
                   onClick={() => void saveCredential()}
                 >
-                  {savingCredential ? "Saving…" : selectedHasCredential ? "Update key" : "Save key"}
-                </button>
+                  {savingCredential
+                    ? "Saving…"
+                    : selectedHasCredential
+                      ? "Update key"
+                      : "Save key"}
+                </Button>
                 {selectedHasCredential && (
-                  <button
+                  <Button
                     type="button"
-                    className="btn btn-danger"
+                    variant="destructive"
                     disabled={working}
                     onClick={() => void removeCredential()}
                   >
                     {removingCredential ? "Removing…" : "Remove saved key"}
-                  </button>
+                  </Button>
                 )}
               </div>
-            </div>
+            </SettingsSection>
           )}
 
           {provider !== (activeProvider ?? "") && (
-            <p className="settings-hint">
-              Save the provider configuration before managing that provider’s key.
+            <p className="text-xs text-muted-foreground">
+              Save the provider configuration before managing that provider’s
+              key.
             </p>
           )}
 
-          <p className="settings-note">
+          <p className="text-sm leading-relaxed text-muted-foreground">
             This configures host-owned search access only. Search is not yet a
             chat tool in this build.
           </p>
         </>
       )}
-      {error && <div className="folder-error" role="alert">{error}</div>}
-    </aside>
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsPanel>
   );
 }
 
@@ -2101,6 +2276,68 @@ function webSearchState(config: WebSearchConfigInfo | null): {
   };
 }
 
+function ModelPanel({
+  chat,
+  models,
+  disabled,
+  onModelChange,
+}: {
+  chat: Chat;
+  models: ModelInfo[];
+  disabled: boolean;
+  onModelChange: (modelId: string) => Promise<void>;
+}) {
+  return (
+    <SettingsPanel
+      title="Model"
+      description="Choose the model for this conversation."
+    >
+      <SettingsField label="Active model">
+        <select
+          className={SETTINGS_SELECT_CLASS}
+          value={chat.model ?? ""}
+          disabled={disabled}
+          onChange={(e) => void onModelChange(e.target.value)}
+        >
+          <option value="">default</option>
+          {models.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.id} ({m.provider})
+            </option>
+          ))}
+          {chat.model && !models.some((m) => m.id === chat.model) && (
+            <option value={chat.model}>{chat.model} (custom)</option>
+          )}
+        </select>
+      </SettingsField>
+      <SettingsField
+        label="Custom model ID"
+        hint="Select from known models above, or type any model ID your provider supports."
+      >
+        <Input
+          type="text"
+          placeholder="e.g. claude-sonnet-4-20250514"
+          defaultValue={
+            chat.model && !models.some((m) => m.id === chat.model)
+              ? chat.model
+              : ""
+          }
+          key={chat.id}
+          onBlur={(e) => {
+            const next = e.target.value.trim();
+            if (next && next !== (chat.model ?? "")) {
+              void onModelChange(next);
+            }
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+          }}
+        />
+      </SettingsField>
+    </SettingsPanel>
+  );
+}
+
 function ProvidersPanel({
   providers,
   client,
@@ -2111,13 +2348,14 @@ function ProvidersPanel({
   onChanged: () => void;
 }) {
   return (
-    <aside className="settings">
-      <h2>Providers</h2>
-      <p>Keys stay on this machine. Enable a provider, then save a credential.</p>
+    <SettingsPanel
+      title="Providers"
+      description="Keys stay on this machine. Enable a provider, then save a credential."
+    >
       {providers.map((p) => (
         <ProviderRow key={p.kind} info={p} client={client} onChanged={onChanged} />
       ))}
-    </aside>
+    </SettingsPanel>
   );
 }
 
@@ -2174,60 +2412,57 @@ function ProviderRow({
   }
 
   return (
-    <div className="provider">
-      <h3>{info.kind.replaceAll("_", " ")}</h3>
-      <div className="row">
-        <label>
+    <SettingsSection title={info.kind.replaceAll("_", " ")}>
+      <div className="flex items-center justify-between gap-3">
+        <label className="flex items-center gap-2 text-sm">
           <input
             type="checkbox"
+            className="size-4 accent-[var(--primary)]"
             checked={info.enabled}
             disabled={saving}
             onChange={(e) => void save(e.target.checked)}
-          />{" "}
-          enabled
+          />
+          Enabled
         </label>
-        <span className="status">
+        <span className="text-xs text-muted-foreground">
           {info.has_credential ? "credential set" : "no credential"}
         </span>
       </div>
       {info.kind === "openai_compatible" && (
-        <div className="row">
-          <input
-            type="text"
-            placeholder="base URL (e.g. http://127.0.0.1:1234/v1)"
-            value={baseUrl}
-            onChange={(e) => setBaseUrl(e.target.value)}
-          />
-        </div>
-      )}
-      <div className="row">
-        <input
-          type="password"
-          placeholder="API key"
-          value={key}
-          onChange={(e) => setKey(e.target.value)}
-          autoComplete="off"
+        <Input
+          type="text"
+          placeholder="base URL (e.g. http://127.0.0.1:1234/v1)"
+          value={baseUrl}
+          onChange={(e) => setBaseUrl(e.target.value)}
         />
-        <button
+      )}
+      <Input
+        type="password"
+        placeholder="API key"
+        value={key}
+        onChange={(e) => setKey(e.target.value)}
+        autoComplete="off"
+      />
+      <div className="flex flex-wrap gap-2">
+        <Button
           type="button"
-          className="btn btn-primary"
           disabled={saving || !key.trim()}
           onClick={() => void save(true)}
         >
           Save
-        </button>
+        </Button>
         {info.has_credential && (
-          <button
+          <Button
             type="button"
-            className="btn"
+            variant="outline"
             disabled={saving}
             onClick={() => void clearCredential()}
           >
             Clear
-          </button>
+          </Button>
         )}
       </div>
-      {error && <div className="status">{error}</div>}
-    </div>
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsSection>
   );
 }

--- a/crates/openwave-desktop/ui/src/AssistantSources.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantSources.tsx
@@ -1,3 +1,5 @@
+import { ChevronRight } from "lucide-react";
+
 export type AssistantSource = Readonly<{
   id: string;
   ordinal: number;
@@ -56,7 +58,7 @@ export function AssistantSources({ sources }: AssistantSourcesProps) {
           ))}
         </span>
         <span className="assistant-sources-chevron" aria-hidden="true">
-          ›
+          <ChevronRight size={15} />
         </span>
       </summary>
       <ol className="assistant-source-list">

--- a/crates/openwave-desktop/ui/src/ClipboardCopyButton.tsx
+++ b/crates/openwave-desktop/ui/src/ClipboardCopyButton.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Check, Copy } from "lucide-react";
 
 export type ClipboardWriter = {
   writeText(text: string): Promise<void>;
@@ -60,7 +61,9 @@ export function ClipboardCopyButton({
         title={visibleLabel}
         onClick={() => void onCopy()}
       >
-        <span aria-hidden="true">{copyState === "copied" ? "✓" : "⧉"}</span>
+        <span aria-hidden="true" className="clipboard-copy-icon">
+          {copyState === "copied" ? <Check size={13} /> : <Copy size={13} />}
+        </span>
         <span>{visibleLabel}</span>
       </button>
       <span className="sr-only" role="status" aria-live="polite">

--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -99,7 +99,7 @@ describe("Composer", () => {
 
     expect(markup).toContain('class="composer-actions"');
     expect(markup).toContain("Redirect");
-    expect(markup).toContain(">Stop<");
+    expect(markup).toContain('aria-label="Stop response"');
     expect(markup).toContain('aria-label="Redirect active response"');
     expect(markup).toContain('aria-label="Stop response"');
     expect(markup).toContain('aria-label="Message"');
@@ -127,7 +127,7 @@ describe("Composer", () => {
       />,
     );
 
-    expect(markup).toContain(">Stop<");
+    expect(markup).toContain('aria-label="Stop response"');
     expect(markup).toContain('aria-label="Stop response"');
     expect(markup).toContain("Guide the active response…");
     expect(markup).not.toContain('<textarea disabled=""');
@@ -154,7 +154,7 @@ describe("Composer", () => {
     );
 
     expect(markup).toContain(">Sending…<");
-    expect(markup).toContain(">Stop<");
+    expect(markup).toContain('aria-label="Stop response"');
     expect(markup).toContain('aria-label="Redirect active response"');
     expect(markup).not.toContain('<textarea disabled=""');
     expect(markup).toContain("Sending guidance…");
@@ -181,7 +181,7 @@ describe("Composer", () => {
     );
 
     expect(markup).toContain(">Redirect<");
-    expect(markup).toContain(">Stopping…<");
+    expect(markup).toContain('aria-label="Stopping response"');
     expect(markup.match(/disabled=""/g)).toHaveLength(2);
   });
 
@@ -230,7 +230,7 @@ describe("Composer", () => {
       />,
     );
 
-    expect(markup).toContain(">Send<");
+    expect(markup).toContain('aria-label="Send message"');
     expect(markup).toContain('type="submit"');
     expect(markup).toContain('disabled=""');
   });

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -4,7 +4,9 @@ import {
   useLayoutEffect,
   useRef,
 } from "react";
+import { ArrowUp, Square } from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
+import { WithTooltip } from "@/components/ui/tooltip";
 
 const MIN_COMPOSER_LINES = 1;
 export const MAX_COMPOSER_LINES = 6;
@@ -152,91 +154,98 @@ export function Composer({
   }
 
   return (
-    <form
-      className="composer"
-      onSubmit={(event) => {
-        event.preventDefault();
-        void submit();
-      }}
-    >
-      <textarea
-        ref={textareaRef}
-        value={draft}
-        placeholder={
-          active ? "Guide the active response…" : "Message OpenWave…"
-        }
-        aria-label="Message"
-        disabled={inputDisabled}
-        onChange={onChange}
-        onKeyDown={(event) => {
-          if (!shouldSubmitComposerKey(event.nativeEvent)) return;
+    <div className="composer-wrap">
+      <form
+        className="composer"
+        onSubmit={(event) => {
           event.preventDefault();
           void submit();
         }}
-      />
-      <div className="composer-actions">
-        {active ? (
-          <>
-            {(hasDraft || steerPending) && (
+      >
+        <textarea
+          ref={textareaRef}
+          value={draft}
+          placeholder={
+            active ? "Guide the active response…" : "Message OpenWave…"
+          }
+          aria-label="Message"
+          disabled={inputDisabled}
+          onChange={onChange}
+          onKeyDown={(event) => {
+            if (!shouldSubmitComposerKey(event.nativeEvent)) return;
+            event.preventDefault();
+            void submit();
+          }}
+        />
+        <div className="composer-actions">
+          {active ? (
+            <>
+              {(hasDraft || steerPending) && (
+                <button
+                  type="submit"
+                  className="btn btn-primary composer-redirect"
+                  aria-label="Redirect active response"
+                  disabled={!canSubmit}
+                >
+                  {steerPending ? "Sending…" : "Redirect"}
+                </button>
+              )}
+              <WithTooltip label={cancelPending ? "Stopping…" : "Stop"}>
+                <button
+                  type="button"
+                  className="composer-icon-btn composer-stop"
+                  aria-label={
+                    cancelPending ? "Stopping response" : "Stop response"
+                  }
+                  disabled={disabled || cancelPending}
+                  onClick={() => void onStop()}
+                >
+                  <Square size={15} fill="currentColor" strokeWidth={0} />
+                </button>
+              </WithTooltip>
+            </>
+          ) : (
+            <WithTooltip label="Send · Enter">
               <button
                 type="submit"
-                className="btn btn-primary"
-                aria-label="Redirect active response"
+                className="composer-icon-btn composer-send"
+                aria-label="Send message"
                 disabled={!canSubmit}
               >
-                {steerPending ? "Sending…" : "Redirect"}
+                <ArrowUp size={18} />
               </button>
-            )}
-            <button
-              type="button"
-              className="btn btn-stop"
-              aria-label={
-                cancelPending ? "Stopping response" : "Stop response"
-              }
-              disabled={disabled || cancelPending}
-              onClick={() => void onStop()}
-            >
-              {cancelPending ? "Stopping…" : "Stop"}
-            </button>
-          </>
-        ) : (
-          <button
-            type="submit"
-            className="btn btn-primary"
-            disabled={!canSubmit}
-          >
-            Send
-          </button>
+            </WithTooltip>
+          )}
+        </div>
+        <span className="sr-only" role="status">
+          {busy ? "Agent is responding" : "Ready to send"}
+        </span>
+        {cancelError && (
+          <span className="composer-turn-error" role="status">
+            Couldn’t stop turn: {cancelError}
+          </span>
         )}
-      </div>
-      <span className="sr-only" role="status">
-        {busy ? "Agent is responding" : "Ready to send"}
-      </span>
-      {cancelError && (
-        <span className="composer-turn-error" role="status">
-          Couldn’t stop turn: {cancelError}
-        </span>
-      )}
-      {steerError && (
-        <span className="composer-turn-error" role="alert">
-          Couldn’t redirect: {steerError}
-        </span>
-      )}
-      {steerStatus && !steerError && (
-        <span className="composer-turn-status" role="status">
-          {steerStatus}
-        </span>
-      )}
-      {steerTooLong && (
-        <span className="composer-turn-error" role="alert">
-          Guidance is too long.
-        </span>
-      )}
-      {steerHasUnsupportedCharacter && (
-        <span className="composer-turn-error" role="alert">
-          Guidance contains an unsupported character.
-        </span>
-      )}
-    </form>
+        {steerError && (
+          <span className="composer-turn-error" role="alert">
+            Couldn’t redirect: {steerError}
+          </span>
+        )}
+        {steerStatus && !steerError && (
+          <span className="composer-turn-status" role="status">
+            {steerStatus}
+          </span>
+        )}
+        {steerTooLong && (
+          <span className="composer-turn-error" role="alert">
+            Guidance is too long.
+          </span>
+        )}
+        {steerHasUnsupportedCharacter && (
+          <span className="composer-turn-error" role="alert">
+            Guidance contains an unsupported character.
+          </span>
+        )}
+      </form>
+    </div>
   );
 }

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { FileText } from "lucide-react";
 import {
   importLibraryDocument,
   listLibraryDocuments,
@@ -242,7 +243,9 @@ export function DocumentsView({
             <div className="document-list">
               {documents.map((document) => (
                 <article className="document-row" key={document.documentId}>
-                  <div className="document-icon" aria-hidden="true">⌑</div>
+                  <div className="document-icon" aria-hidden="true">
+                    <FileText size={16} />
+                  </div>
                   <div className="document-copy">
                     <strong>{documentTitle(document)}</strong>
                     <span>

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -8,6 +8,7 @@ import { MessageFooter } from "./MessageFooter";
 import { AssistantSources, type AssistantSource } from "./AssistantSources";
 import { ToolCallCard, type ToolCallStatus } from "./ToolCallCard";
 import { ToolActivityGroup } from "./ToolActivityGroup";
+import { WelcomeState } from "./WelcomeState";
 
 export type ChatMessage =
   | { id: string; role: "user"; text: string; createdAt?: string }
@@ -52,6 +53,8 @@ type MessageListProps = {
     decision: FolderAccessDecision,
   ) => void;
   onFolderAccessCancel: (callId: string, turnId: string) => void;
+  onSelectPrompt?: (prompt: string) => void;
+  hydrated?: boolean;
 };
 
 export function MessageList({
@@ -67,36 +70,51 @@ export function MessageList({
   onApproval,
   onFolderAccessDecision,
   onFolderAccessCancel,
+  onSelectPrompt,
+  hydrated = true,
 }: MessageListProps) {
   const messageItems = groupMessageItems(messages, busy, onApproval);
+  // Only greet a genuinely empty, fully-hydrated conversation. While an
+  // existing chat's transcript is still loading it is transiently empty; showing
+  // the welcome there would flash "How can I help?" before its history renders.
+  const isEmpty =
+    hydrated &&
+    messages.length === 0 &&
+    folderAccessRequests.length === 0 &&
+    !busy;
+
+  if (isEmpty) {
+    return (
+      <div className="messages is-empty" ref={scrollRef} onScroll={onScroll}>
+        <WelcomeState onSelectPrompt={onSelectPrompt} />
+      </div>
+    );
+  }
 
   return (
     <div className="messages" ref={scrollRef} onScroll={onScroll}>
-      {messages.length === 0 && folderAccessRequests.length === 0 && (
-        <div className="message-notice" role="status">
-          Configure a provider, pick a model, then send a message.
-        </div>
-      )}
-      {messageItems}
-      {folderAccessRequests.map((request) => (
-        <FolderAccessCard
-          key={request.callId}
-          request={request}
-          nativeHost={nativeHost}
-          nativeBusy={nativeBusy}
-          working={resolvingFolderCalls.has(request.callId)}
-          error={folderAccessErrors[request.callId]}
-          onDecision={(decision) =>
-            onFolderAccessDecision(request.callId, decision)
-          }
-          onCancel={() => onFolderAccessCancel(request.callId, request.turnId)}
-        />
-      ))}
-      {shouldShowAssistantWorking(
-        messages,
-        busy,
-        folderAccessRequests.length,
-      ) && <AssistantWorkingIndicator />}
+      <div className="messages-column">
+        {messageItems}
+        {folderAccessRequests.map((request) => (
+          <FolderAccessCard
+            key={request.callId}
+            request={request}
+            nativeHost={nativeHost}
+            nativeBusy={nativeBusy}
+            working={resolvingFolderCalls.has(request.callId)}
+            error={folderAccessErrors[request.callId]}
+            onDecision={(decision) =>
+              onFolderAccessDecision(request.callId, decision)
+            }
+            onCancel={() => onFolderAccessCancel(request.callId, request.turnId)}
+          />
+        ))}
+        {shouldShowAssistantWorking(
+          messages,
+          busy,
+          folderAccessRequests.length,
+        ) && <AssistantWorkingIndicator />}
+      </div>
     </div>
   );
 }

--- a/crates/openwave-desktop/ui/src/ProjectNavigation.test.tsx
+++ b/crates/openwave-desktop/ui/src/ProjectNavigation.test.tsx
@@ -29,7 +29,7 @@ describe("ProjectNavigation", () => {
     );
 
     expect(markup).toContain('aria-label="Projects"');
-    expect(markup).toContain("Loose chats");
+    expect(markup).toContain("Direct chats");
     expect(markup).toContain("Research");
     expect(markup).toContain("Untitled project");
     expect(markup).toContain('aria-current="page"');

--- a/crates/openwave-desktop/ui/src/ProjectNavigation.tsx
+++ b/crates/openwave-desktop/ui/src/ProjectNavigation.tsx
@@ -1,4 +1,13 @@
 import { useEffect, useRef, useState, type FormEvent, type Ref } from "react";
+import {
+  Check,
+  FolderOpen,
+  MessagesSquare,
+  Pencil,
+  Plus,
+  X,
+} from "lucide-react";
+import type { ReactNode } from "react";
 import type { Project } from "./api";
 
 type Props = {
@@ -90,7 +99,7 @@ export function ProjectNavigation({
           disabled={disabled || renaming}
           onClick={() => setAdding((current) => !current)}
         >
-          +
+          <Plus size={14} />
         </button>
       </div>
 
@@ -132,7 +141,8 @@ export function ProjectNavigation({
       <div className="project-list">
         <ProjectButton
           buttonRef={looseChatsRef}
-          title="Loose chats"
+          title="Direct chats"
+          icon={<MessagesSquare size={13} />}
           selected={selectedProjectId === null}
           disabled={disabled || renaming}
           onClick={() => onSelect(null)}
@@ -166,7 +176,7 @@ export function ProjectNavigation({
                   aria-label="Save project name"
                   disabled={disabled || savingRename}
                 >
-                  ✓
+                  <Check size={13} />
                 </button>
                 <button
                   type="button"
@@ -174,7 +184,7 @@ export function ProjectNavigation({
                   disabled={disabled || savingRename}
                   onClick={() => finishRename(project.id)}
                 >
-                  ×
+                  <X size={13} />
                 </button>
               </form>
             );
@@ -203,7 +213,7 @@ export function ProjectNavigation({
                     setRenameTitle(project.title ?? "");
                   }}
                 >
-                  ···
+                  <Pencil size={12} />
                 </button>
               )}
               <button
@@ -214,7 +224,7 @@ export function ProjectNavigation({
                 disabled={disabled || savingRename || renaming || adding}
                 onClick={() => void deleteProject(project)}
               >
-                ×
+                <X size={13} />
               </button>
             </div>
           );
@@ -228,12 +238,14 @@ export function ProjectNavigation({
 function ProjectButton({
   buttonRef,
   title,
+  icon,
   selected,
   disabled,
   onClick,
 }: {
   buttonRef?: Ref<HTMLButtonElement>;
   title: string;
+  icon?: ReactNode;
   selected: boolean;
   disabled: boolean;
   onClick: () => void;
@@ -248,7 +260,7 @@ function ProjectButton({
       onClick={onClick}
     >
       <span className="project-icon" aria-hidden="true">
-        {selected ? "◆" : "◇"}
+        {icon ?? <FolderOpen size={12} />}
       </span>
       <span>{title}</span>
     </button>

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
+import { ChevronRight } from "lucide-react";
 import {
   toolCallPresentation,
   type ToolCallStatus,
 } from "./ToolCallCard";
+import { ToolStatusIcon } from "./ToolStatusIcon";
 
 export type ToolActivity = {
   id?: string;
@@ -52,14 +54,14 @@ export function ToolActivityGroup({
           className={`tool-activity-group-status is-${summary.tone}`}
           aria-hidden="true"
         >
-          {summary.icon}
+          <ToolStatusIcon tone={summary.tone} size={13} />
         </span>
         <span className="tool-activity-group-label">{summary.label}</span>
         <span
           className={`tool-activity-group-chevron${expanded ? " is-expanded" : ""}`}
           aria-hidden="true"
         >
-          ›
+          <ChevronRight size={15} />
         </span>
       </button>
       <div
@@ -80,7 +82,7 @@ export function ToolActivityGroup({
               key={index}
             >
               <span className="tool-activity-timeline-marker" aria-hidden="true">
-                {presentation.icon}
+                <ToolStatusIcon tone={presentation.tone} size={12} />
               </span>
               <span className="tool-activity-timeline-copy">
                 <strong>{presentation.label}</strong>

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -5,6 +5,13 @@ import {
   toolApprovalPresentation,
 } from "./ToolCallCard";
 
+// Strip element markup so leak checks assert on the visible copy only. The
+// status glyph is an inline SVG whose element names (e.g. `<path>`) are not
+// user-facing text and must not be mistaken for a leaked resource path.
+function visibleText(markup: string): string {
+  return markup.replace(/<[^>]*>/g, "");
+}
+
 describe("ToolCallCard", () => {
   it("uses an allowlisted presentation and a polite live status", () => {
     const markup = renderToStaticMarkup(
@@ -48,8 +55,8 @@ describe("ToolCallCard", () => {
 
     expect(markup).toContain("Read a delegated file");
     expect(markup).toContain("Reading a delegated file");
-    expect(markup).not.toContain("path");
-    expect(markup).not.toContain("root");
+    expect(visibleText(markup)).not.toContain("path");
+    expect(visibleText(markup)).not.toContain("root");
   });
 
   it("distinguishes delegation from waiting for the child results", () => {

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,3 +1,5 @@
+import { ToolStatusIcon } from "./ToolStatusIcon";
+
 export type ToolCallStatus =
   | "running"
   | "waiting_approval"
@@ -133,7 +135,7 @@ export function ToolCallCard({ name, status }: ToolCallCardProps) {
       aria-atomic="true"
     >
       <span className="tool-call-icon" aria-hidden="true">
-        {presentation.icon}
+        <ToolStatusIcon tone={presentation.tone} />
       </span>
       <div className="tool-call-copy">
         <strong>{presentation.label}</strong>

--- a/crates/openwave-desktop/ui/src/ToolStatusIcon.tsx
+++ b/crates/openwave-desktop/ui/src/ToolStatusIcon.tsx
@@ -1,0 +1,44 @@
+import {
+  ArrowUpRight,
+  Check,
+  CircleHelp,
+  Clock,
+  Minus,
+  TriangleAlert,
+} from "lucide-react";
+
+export type ToolTone =
+  | "running"
+  | "waiting_approval"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "unknown";
+
+/**
+ * Renderer-owned status glyph for tool cards and activity groups. It is derived
+ * only from the allowlisted presentation tone, never from a provider-supplied
+ * tool name or payload.
+ */
+export function ToolStatusIcon({
+  tone,
+  size = 15,
+}: {
+  tone: ToolTone;
+  size?: number;
+}) {
+  switch (tone) {
+    case "completed":
+      return <Check size={size} />;
+    case "failed":
+      return <TriangleAlert size={size} />;
+    case "cancelled":
+      return <Minus size={size} />;
+    case "waiting_approval":
+      return <Clock size={size} />;
+    case "running":
+      return <ArrowUpRight size={size} />;
+    default:
+      return <CircleHelp size={size} />;
+  }
+}

--- a/crates/openwave-desktop/ui/src/WelcomeState.test.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { WelcomeState } from "./WelcomeState";
+
+describe("WelcomeState", () => {
+  it("renders the greeting and starter prompts when a handler is provided", () => {
+    const markup = renderToStaticMarkup(
+      <WelcomeState onSelectPrompt={vi.fn()} />,
+    );
+
+    expect(markup).toContain("How can I help?");
+    expect(markup).toContain("What can you help me with?");
+    expect(markup).toContain("Draft a plan");
+    expect(markup).toContain('aria-label="Start a conversation"');
+  });
+
+  it("omits the starter prompts when no handler is provided", () => {
+    const markup = renderToStaticMarkup(<WelcomeState />);
+
+    expect(markup).toContain("How can I help?");
+    expect(markup).not.toContain("welcome-prompt");
+  });
+});

--- a/crates/openwave-desktop/ui/src/WelcomeState.test.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.test.tsx
@@ -11,7 +11,7 @@ describe("WelcomeState", () => {
     expect(markup).toContain("How can I help?");
     expect(markup).toContain("What can you help me with?");
     expect(markup).toContain("Draft a plan");
-    expect(markup).toContain('aria-label="Start a conversation"');
+    expect(markup).toContain('aria-label="Start a chat"');
   });
 
   it("omits the starter prompts when no handler is provided", () => {

--- a/crates/openwave-desktop/ui/src/WelcomeState.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.tsx
@@ -36,7 +36,7 @@ export function WelcomeState({
   onSelectPrompt?: (prompt: string) => void;
 }) {
   return (
-    <section className="welcome" aria-label="Start a conversation">
+    <section className="welcome" aria-label="Start a chat">
       <span className="welcome-mark" aria-hidden="true">
         <Logomark />
       </span>

--- a/crates/openwave-desktop/ui/src/WelcomeState.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.tsx
@@ -1,0 +1,66 @@
+import { FileSearch, ListChecks, MessageCircle, Sparkles } from "lucide-react";
+import { Logomark } from "./Logomark";
+
+type StarterPrompt = {
+  icon: typeof Sparkles;
+  label: string;
+  prompt: string;
+};
+
+const STARTER_PROMPTS: StarterPrompt[] = [
+  {
+    icon: MessageCircle,
+    label: "What can you help me with?",
+    prompt: "What can you help me with?",
+  },
+  {
+    icon: FileSearch,
+    label: "Search my documents",
+    prompt: "Search my connected documents for ",
+  },
+  {
+    icon: Sparkles,
+    label: "Summarize a document",
+    prompt: "Summarize the key points from ",
+  },
+  {
+    icon: ListChecks,
+    label: "Draft a plan",
+    prompt: "Help me draft a plan for ",
+  },
+];
+
+export function WelcomeState({
+  onSelectPrompt,
+}: {
+  onSelectPrompt?: (prompt: string) => void;
+}) {
+  return (
+    <section className="welcome" aria-label="Start a conversation">
+      <span className="welcome-mark" aria-hidden="true">
+        <Logomark />
+      </span>
+      <div className="welcome-copy">
+        <h2>How can I help?</h2>
+        <p>
+          Ask a question, search your connected documents, or start a task.
+        </p>
+      </div>
+      {onSelectPrompt && (
+        <div className="welcome-prompts">
+          {STARTER_PROMPTS.map(({ icon: Icon, label, prompt }) => (
+            <button
+              key={label}
+              type="button"
+              className="welcome-prompt"
+              onClick={() => onSelectPrompt(prompt)}
+            >
+              <Icon size={16} />
+              <span>{label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/components/ConfirmDialog.tsx
+++ b/crates/openwave-desktop/ui/src/components/ConfirmDialog.tsx
@@ -1,0 +1,85 @@
+import { useCallback, useRef, useState, type ReactElement } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+export type ConfirmOptions = {
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+};
+
+type PendingConfirm = ConfirmOptions & {
+  resolve: (value: boolean) => void;
+};
+
+/**
+ * Promise-based confirmation backed by the shared AlertDialog. Replaces
+ * `window.confirm`, which renders a native OS dialog that breaks visually from
+ * the rest of the app. Returns a `confirm()` that resolves to the user's choice
+ * plus a `dialog` element to render once at the app root.
+ */
+export function useConfirm(): {
+  confirm: (options: ConfirmOptions) => Promise<boolean>;
+  dialog: ReactElement;
+} {
+  const [pending, setPending] = useState<PendingConfirm | null>(null);
+  const pendingRef = useRef<PendingConfirm | null>(null);
+  pendingRef.current = pending;
+
+  const confirm = useCallback((options: ConfirmOptions) => {
+    return new Promise<boolean>((resolve) => {
+      setPending({ ...options, resolve });
+    });
+  }, []);
+
+  const settle = useCallback((result: boolean) => {
+    const current = pendingRef.current;
+    if (current) current.resolve(result);
+    setPending(null);
+  }, []);
+
+  const dialog = (
+    <AlertDialog
+      open={pending !== null}
+      onOpenChange={(open) => {
+        if (!open) settle(false);
+      }}
+    >
+      {pending && (
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{pending.title}</AlertDialogTitle>
+            {pending.description && (
+              <AlertDialogDescription>
+                {pending.description}
+              </AlertDialogDescription>
+            )}
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => settle(false)}>
+              {pending.cancelLabel ?? "Cancel"}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant={pending.destructive ? "destructive" : "default"}
+              onClick={() => settle(true)}
+            >
+              {pending.confirmLabel ?? "Confirm"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      )}
+    </AlertDialog>
+  );
+
+  return { confirm, dialog };
+}

--- a/crates/openwave-desktop/ui/src/components/ui/alert-dialog.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,138 @@
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import * as React from "react";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { VariantProps } from "class-variance-authority";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
+
+const AlertDialogTitle = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-muted-foreground text-sm", className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> &
+    VariantProps<typeof buttonVariants>
+>(({ variant, size, className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants({ variant, size }), className)}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ComponentRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className,
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/crates/openwave-desktop/ui/src/components/ui/badge.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/badge.tsx
@@ -1,0 +1,51 @@
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center gap-1 rounded-full border text-xs transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 whitespace-nowrap",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-muted-foreground",
+        success:
+          "border-transparent bg-success-background text-success-foreground",
+        warning:
+          "border-transparent bg-warning-background text-warning-foreground",
+        critical:
+          "border-transparent bg-critical-background text-critical-foreground",
+        info: "border-transparent bg-info-background text-info-foreground",
+      },
+      size: {
+        default: "px-2.5 py-0.5 font-semibold",
+        sm: "px-2 py-0.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(badgeVariants({ variant, size }), className)}
+      {...props}
+    />
+  ),
+);
+
+export { Badge, badgeVariants };

--- a/crates/openwave-desktop/ui/src/components/ui/button.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/button.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "cursor-pointer select-none inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        "ghost-destructive":
+          "hover:bg-critical-background hover:text-critical",
+        outline:
+          "border border-border bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        primary:
+          "bg-brightwave hover:bg-brightwave/80 active:bg-brightwave dark:text-black",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "size-10",
+        "icon-sm": "size-9",
+        xs: "h-7 px-2 rounded-md text-xs",
+        "2xs": "h-5 px-1.5 rounded text-xs gap-1 [&_svg]:size-3",
+        "icon-xs": "size-6 rounded-md [&_svg]:size-3.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/crates/openwave-desktop/ui/src/components/ui/card.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "bg-card text-card-foreground flex flex-col gap-6 rounded-md p-6",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center gap-2", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-xl leading-tight font-medium tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-muted-foreground text-sm", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col gap-1.5", className)}
+    {...props}
+  />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "text-muted-foreground flex flex-col gap-1.5 text-sm font-medium",
+      className,
+    )}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent,
+};

--- a/crates/openwave-desktop/ui/src/components/ui/dropdown-menu.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      onCloseAutoFocus={(e) => e.preventDefault()}
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[9rem] overflow-hidden rounded-md border p-1 shadow-lg",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const dropdownMenuItemVariants = cva(
+  "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "focus:bg-accent focus:text-accent-foreground",
+        destructive: "text-destructive focus:bg-critical-background",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const DropdownMenuItem = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> &
+    VariantProps<typeof dropdownMenuItemVariants>
+>(({ className, variant, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(dropdownMenuItemVariants({ variant }), className)}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("bg-border -mx-1 my-1 h-px", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+};

--- a/crates/openwave-desktop/ui/src/components/ui/input.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/crates/openwave-desktop/ui/src/components/ui/tooltip.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/tooltip.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+const Tooltip = TooltipPrimitive.Root;
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ComponentRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, children, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      hideWhenDetached
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-w-xs rounded-md bg-neutral-900 px-2.5 py-1.5 text-xs font-medium text-neutral-50 shadow-md select-none dark:bg-neutral-100 dark:text-neutral-900 data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-[state=closed]:zoom-out-95",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <TooltipPrimitive.Arrow className="fill-neutral-900 dark:fill-neutral-100" />
+    </TooltipPrimitive.Content>
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+/**
+ * Convenience wrapper: a trigger element with a text tooltip. Self-contained —
+ * it carries its own provider so it works anywhere, including components
+ * rendered outside the app root (e.g. in unit tests).
+ */
+export function WithTooltip({
+  label,
+  side = "top",
+  align = "center",
+  children,
+}: {
+  label: React.ReactNode;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+  children: React.ReactNode;
+}) {
+  return (
+    <TooltipProvider delayDuration={300} skipDelayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side} align={align}>
+          {label}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/crates/openwave-desktop/ui/src/lib/utils.ts
+++ b/crates/openwave-desktop/ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/crates/openwave-desktop/ui/src/main.tsx
+++ b/crates/openwave-desktop/ui/src/main.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { initTheme } from "./theme";
 import "./styles.css";
+
+initTheme();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1,24 +1,203 @@
+@import "tailwindcss";
+@plugin "tailwindcss-animate";
+
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
-  color-scheme: light;
-  --bg: oklch(0.975 0.003 95);
-  --bg-elevated: oklch(1 0 0);
-  --ink: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.54 0.014 285.938);
-  --line: oklch(0.9 0.004 95);
-  --sidebar: oklch(0.955 0.006 95);
-  --sidebar-active: oklch(0.91 0.015 95);
-  --accent: oklch(0.73 0.16 150);
-  --accent-ink: oklch(0.21 0.006 285.885);
-  --danger: oklch(0.505 0.213 27.518);
-  --user-bg: oklch(0.924 0.001 0);
-  --assistant-bg: oklch(1 0 0);
+  /* --- BW-aligned palette (oklch, light mode) --- */
+  --background: oklch(1 0 0);
+  --foreground: oklch(0 0 0);
+  --page-background: oklch(98.2% 0 0);
+
+  --border: var(--color-zinc-200);
+  --input: oklch(0.929 0.013 255.508);
+  --ring: oklch(0.704 0.04 256.788);
+
+  --primary: var(--color-zinc-900);
+  --primary-foreground: var(--color-zinc-100);
+
+  --secondary: oklch(0.924 0.001 0);
+  --secondary-foreground: var(--color-zinc-600);
+
+  --muted: oklch(0.924 0.001 0);
+  --muted-foreground: var(--color-zinc-500);
+
+  --accent: oklch(0.924 0.001 0);
+  --accent-foreground: var(--color-zinc-900);
+
+  --card: var(--color-neutral-50);
+  --card-foreground: var(--color-neutral-900);
+
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.2912 0.0215 94.24);
+
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.984 0.003 247.858);
+
+  --color-brightwave: oklch(0.87 0.2 102);
+  --color-brightwave-light: oklch(0.966 0.155 102);
+
+  /* Semantic status */
+  --success: oklch(0.627 0.194 149.214);
+  --success-foreground: oklch(0.393 0.095 152.535);
+  --success-background: oklch(0.962 0.044 156.743);
+  --warning: oklch(0.666 0.179 58.318);
+  --warning-foreground: oklch(0.414 0.112 45.904);
+  --warning-background: oklch(0.962 0.059 95.617);
+  --critical: oklch(0.577 0.245 27.325);
+  --critical-foreground: oklch(0.396 0.141 25.723);
+  --critical-background: oklch(0.936 0.032 17.717);
+  --info: oklch(0.588 0.158 241.966);
+  --info-foreground: oklch(0.391 0.09 240.876);
+  --info-background: oklch(0.951 0.026 236.824);
+
+  --radius: 0.5rem;
+
+  --shadow-sm: 0 0px 8px 0px oklch(0 0 0 / 0.06);
+  --shadow: 0 0px 8px 0px oklch(0 0 0 / 0.07);
+  --shadow-lg: 0 0px 12px 0px oklch(0 0 0 / 0.07);
+
+  /* Legacy aliases consumed by existing component CSS */
+  --bg: var(--page-background);
+  --bg-elevated: var(--background);
+  --ink: var(--foreground);
+  --line: var(--border);
+  --sidebar-bg: transparent;
+  --sidebar-active: var(--accent);
+  --danger: var(--destructive);
+  --user-bg: var(--muted);
+  --assistant-bg: var(--background);
   --sans: "Inter", "Segoe UI", system-ui, sans-serif;
   --mono: "SF Mono", ui-monospace, Menlo, monospace;
+  --code-ink: oklch(0.47 0.13 55);
+  --code-block-bg: oklch(0.19 0.01 285);
+  --code-block-ink: oklch(0.94 0.008 95);
+  --code-block-border: oklch(0.19 0.01 285);
+
+  color-scheme: light;
   font-family: var(--sans);
   font-size: 14px;
   line-height: 1.45;
   color: var(--ink);
-  background: var(--bg);
+  background: var(--page-background);
+}
+
+.dark {
+  /* --- BW-aligned palette (oklch, dark mode) --- */
+  color-scheme: dark;
+
+  --background: oklch(0.1993 0.01 85);
+  --foreground: oklch(0.95 0 0);
+  --page-background: oklch(0.09 0 0);
+
+  --border: oklch(0.3 0.007 69);
+  --input: oklch(0.4 0.007 69);
+  --ring: oklch(0.65 0.04 256.788);
+
+  --primary: oklch(0.95 0 0);
+  --primary-foreground: oklch(0.09 0 0);
+
+  --secondary: oklch(0.26 0.02 85);
+  --secondary-foreground: oklch(0.75 0 0);
+
+  --muted: oklch(0.26 0.02 85);
+  --muted-foreground: oklch(0.65 0 0);
+
+  --accent: oklch(0.26 0.02 85);
+  --accent-foreground: var(--color-zinc-100);
+
+  --card: var(--color-neutral-950);
+  --card-foreground: var(--color-neutral-200);
+
+  --popover: oklch(0.12 0.005 0);
+  --popover-foreground: oklch(0.9 0.03 97.54);
+
+  --destructive: oklch(0.68 0.22 27.325);
+  --destructive-foreground: oklch(0.95 0.005 247.858);
+
+  --color-brightwave: oklch(0.87 0.2 102);
+  --color-brightwave-light: oklch(0.68 0.14 102);
+
+  /* Semantic status — dark */
+  --success: oklch(0.792 0.209 151.711);
+  --success-foreground: oklch(0.962 0.044 156.743);
+  --success-background: oklch(0.393 0.095 152.535);
+  --warning: oklch(0.828 0.189 84.429);
+  --warning-foreground: oklch(0.962 0.059 95.617);
+  --warning-background: oklch(0.414 0.112 45.904);
+  --critical: oklch(0.704 0.191 22.216);
+  --critical-foreground: oklch(0.936 0.032 17.717);
+  --critical-background: oklch(0.396 0.141 25.723);
+  --info: oklch(0.746 0.16 232.661);
+  --info-foreground: oklch(0.951 0.026 236.824);
+  --info-background: oklch(0.391 0.09 240.876);
+
+  --shadow-sm: 0 0px 8px 0px oklch(0 0 0 / 0.24);
+  --shadow: 0 0px 8px 0px oklch(0 0 0 / 0.28);
+  --shadow-lg: 0 0px 12px 0px oklch(0 0 0 / 0.32);
+
+  --code-ink: oklch(0.82 0.12 62);
+  --code-block-bg: oklch(0.14 0.005 285);
+  --code-block-ink: oklch(0.92 0.008 95);
+  --code-block-border: oklch(0.28 0.008 285);
+}
+
+@theme inline {
+  --color-brightwave: var(--color-brightwave);
+  --color-brightwave-light: var(--color-brightwave-light);
+
+  --color-page-background: var(--page-background);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-success-background: var(--success-background);
+
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-warning-background: var(--warning-background);
+
+  --color-critical: var(--critical);
+  --color-critical-foreground: var(--critical-foreground);
+  --color-critical-background: var(--critical-background);
+
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
+  --color-info-background: var(--info-background);
+
+  --shadow-2xs: var(--shadow-sm);
+  --shadow-xs: var(--shadow-sm);
+  --shadow-sm: var(--shadow-sm);
+  --shadow: var(--shadow);
+  --shadow-md: var(--shadow);
+  --shadow-lg: var(--shadow-lg);
+  --shadow-xl: var(--shadow-lg);
+  --shadow-2xl: var(--shadow-lg);
 }
 
 * {
@@ -33,7 +212,7 @@ body,
 }
 
 body {
-  background: var(--bg);
+  background: var(--page-background);
 }
 
 button,
@@ -48,78 +227,103 @@ button {
   cursor: pointer;
 }
 
+/* ---------- App shell ---------- */
+
 .app-shell {
   height: 100%;
-  display: grid;
-  grid-template-columns: 244px minmax(0, 1fr);
-  overflow: hidden;
+  display: flex;
+  background: var(--page-background);
 }
 
 .sidebar {
   display: flex;
+  flex: 0 0 224px;
   min-width: 0;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1rem 0.75rem 0.75rem;
-  border-right: 1px solid var(--line);
-  background: var(--sidebar);
+  gap: 0.15rem;
+  padding: 0.5rem;
+  overflow: hidden;
 }
 
 .sidebar-brand {
   display: flex;
   align-items: center;
   gap: 0.55rem;
-  padding: 0.25rem 0.4rem;
+  height: 2.25rem;
+  padding: 0 0.5rem;
+  margin-bottom: 0.85rem;
   font-weight: 600;
   font-size: 0.95rem;
   letter-spacing: -0.01em;
 }
 
-.sidebar-brand svg {
+.sidebar-brand > svg {
   width: 1.15rem;
   height: auto;
   color: var(--ink);
 }
 
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  flex: 0 0 auto;
+  margin-left: auto;
+  border: 0;
+  border-radius: 6px;
+  color: var(--muted-foreground);
+  background: transparent;
+  transition: background-color 100ms ease, color 100ms ease;
+}
+
+.theme-toggle:hover {
+  color: var(--ink);
+  background: var(--accent);
+}
+
 .new-chat {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.4rem;
-  min-height: 2.35rem;
-  padding: 0.45rem 0.7rem;
-  border: 1px solid var(--line);
-  border-radius: 8px;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 0;
+  border-radius: 6px;
   color: var(--ink);
-  background: var(--bg-elevated);
-  font-weight: 550;
+  background: transparent;
+  font-size: 0.875rem;
+  font-weight: 500;
   text-align: left;
+  transition: background-color 100ms ease;
 }
 
 .new-chat:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--ink) 28%, var(--line));
-  background: var(--sidebar-active);
+  background: var(--accent);
 }
 
-.new-chat span {
-  font-size: 1.15rem;
-  font-weight: 400;
-  line-height: 0;
+.new-chat svg {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
 }
 
 .sidebar-section {
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   flex: 1 1 auto;
-  gap: 0.45rem;
+  gap: 0.15rem;
   min-height: 0;
+  margin-top: 0.85rem;
   overflow: hidden;
 }
 
 .project-navigation {
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 auto;
   min-height: 0;
-  gap: 0.4rem;
+  margin-top: 0.5rem;
+  gap: 0.15rem;
 }
 
 .sidebar-section-heading {
@@ -134,20 +338,21 @@ button {
   height: 1.6rem;
   border: 0;
   border-radius: 5px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   background: transparent;
   line-height: 1;
 }
 
 .sidebar-add:hover:not(:disabled) {
   color: var(--ink);
-  background: var(--sidebar-active);
+  background: var(--accent);
 }
 
 .project-list {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   max-height: min(20vh, 12rem);
-  gap: 0.12rem;
+  gap: 1px;
   overflow-y: auto;
 }
 
@@ -156,21 +361,23 @@ button {
   width: 100%;
   min-width: 0;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.5rem;
   border: 0;
-  border-radius: 7px;
-  padding: 0.48rem 0.55rem;
-  color: var(--muted);
+  border-radius: 6px;
+  padding: 0.5rem;
+  color: var(--ink);
   background: transparent;
   font-size: 0.84rem;
+  font-weight: 500;
   text-align: left;
 }
 
 .project-row {
   display: flex;
+  flex: 0 0 auto;
   min-width: 0;
   align-items: center;
-  border-radius: 7px;
+  border-radius: 6px;
 }
 
 .project-row .project-item {
@@ -178,7 +385,7 @@ button {
 }
 
 .project-row.is-active {
-  background: var(--sidebar-active);
+  background: var(--accent);
 }
 
 .project-rename-action,
@@ -186,10 +393,10 @@ button {
   width: 1.8rem;
   height: 1.65rem;
   flex: 0 0 auto;
-  margin-right: 0.2rem;
+  margin-right: 0.15rem;
   border: 0;
   border-radius: 5px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   background: transparent;
   line-height: 1;
 }
@@ -200,7 +407,6 @@ button {
 }
 
 .project-delete-action {
-  margin-right: 0.2rem;
   font-size: 1.1rem;
   opacity: 0;
 }
@@ -213,7 +419,7 @@ button {
 
 .project-delete-action:hover:not(:disabled) {
   color: var(--danger);
-  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  background: var(--critical-background);
 }
 
 .project-rename {
@@ -239,19 +445,19 @@ button {
   height: 1.6rem;
   border: 0;
   border-radius: 5px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   background: transparent;
 }
 
 .project-rename button:hover:not(:disabled) {
   color: var(--ink);
-  background: var(--sidebar-active);
+  background: var(--accent);
 }
 
 .project-item:hover:not(:disabled),
 .project-item.is-active {
   color: var(--ink);
-  background: var(--sidebar-active);
+  background: var(--accent);
 }
 
 .project-item > span:last-child {
@@ -263,7 +469,7 @@ button {
 .project-icon {
   width: 0.75rem;
   flex: 0 0 auto;
-  color: var(--accent);
+  color: var(--color-brightwave);
   text-align: center;
   font-size: 0.58rem;
 }
@@ -299,24 +505,25 @@ button {
 
 .project-create-actions button:first-child:not(:disabled) {
   border-color: var(--ink);
-  color: var(--bg);
+  color: var(--bg-elevated);
   background: var(--ink);
 }
 
 .conversation-list {
-  display: grid;
-  max-height: none;
-  gap: 0.12rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  align-content: flex-start;
+  gap: 1px;
+  min-height: 0;
   overflow-y: auto;
 }
 
 .sidebar-label {
-  padding: 0 0.4rem;
-  color: var(--muted);
-  font-size: 0.68rem;
-  font-weight: 650;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+  font-weight: 500;
 }
 
 .conversation-item,
@@ -325,26 +532,30 @@ button {
   width: 100%;
   min-width: 0;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.5rem;
   border: 0;
-  border-radius: 7px;
-  padding: 0.48rem 0.55rem;
-  color: var(--muted);
+  border-radius: 6px;
+  padding: 0.5rem;
+  color: var(--ink);
   background: transparent;
-  font-size: 0.84rem;
+  font-size: 0.875rem;
+  font-weight: 450;
   text-align: left;
 }
 
 .conversation-row {
   display: flex;
+  flex: 0 0 auto;
+  height: 2.25rem;
   align-items: center;
   min-width: 0;
-  border-radius: 7px;
+  border-radius: 6px;
+  transition: background-color 100ms ease;
 }
 
 .conversation-row:hover,
 .conversation-row.is-active {
-  background: var(--sidebar-active);
+  background: var(--accent);
 }
 
 .conversation-row:hover .conversation-item,
@@ -357,69 +568,93 @@ button {
   background: transparent;
 }
 
+.conversation-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.84rem;
+  font-weight: 500;
+}
+
 .sidebar-action.is-active,
 .sidebar-action:hover {
   color: var(--ink);
-  background: var(--sidebar-active);
+  background: var(--accent);
 }
 
 .sidebar-library {
-  margin-top: -0.75rem;
+  margin-top: 0.15rem;
   color: var(--ink);
 }
 
-.sidebar-library span {
-  width: 1rem;
-  color: var(--muted);
-  text-align: center;
+.sidebar-action svg,
+.sidebar-library svg {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+}
+
+.sidebar-action.is-active svg,
+.sidebar-action:hover svg {
+  color: var(--ink);
 }
 
 .conversation-item {
   flex: 1 1 auto;
 }
 
-.conversation-delete {
+.conversation-menu {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 1.65rem;
   height: 1.65rem;
   flex: 0 0 auto;
-  margin-right: 0.2rem;
+  margin-right: 0.15rem;
   border: 0;
   border-radius: 5px;
-  color: var(--muted);
+  color: var(--muted-foreground);
   background: transparent;
-  font-size: 1.1rem;
   line-height: 1;
   opacity: 0;
+  transition: opacity 100ms ease, background-color 100ms ease;
 }
 
-.conversation-row:hover .conversation-delete,
-.conversation-row.is-active .conversation-delete,
-.conversation-delete:focus-visible {
+.conversation-row:hover .conversation-menu,
+.conversation-row.is-active .conversation-menu,
+.conversation-menu:focus-visible,
+.conversation-menu[data-state="open"] {
   opacity: 1;
 }
 
-.conversation-delete:hover:not(:disabled) {
-  color: var(--danger);
-  background: color-mix(in srgb, var(--danger) 10%, transparent);
+.conversation-menu:hover:not(:disabled),
+.conversation-menu[data-state="open"] {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--accent) 70%, transparent);
 }
 
-.conversation-delete:disabled {
-  cursor: progress;
+.conversation-menu:disabled {
+  cursor: not-allowed;
 }
 
-.conversation-item span:last-child {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.conversation-dot {
-  width: 0.42rem;
-  height: 0.42rem;
-  flex: 0 0 auto;
-  border-radius: 999px;
+.conversation-row.is-renaming {
+  padding: 0 0.15rem;
   background: var(--accent);
 }
+
+.conversation-rename-input {
+  width: 100%;
+  min-width: 0;
+  height: 1.85rem;
+  border: 0;
+  border-radius: 5px;
+  padding: 0 0.35rem;
+  background: transparent;
+  color: var(--ink);
+  font-size: 0.84rem;
+  font-weight: 500;
+  outline: none;
+}
+
 
 .sidebar-error {
   margin: 0;
@@ -430,29 +665,33 @@ button {
 
 .sidebar-footer {
   display: grid;
-  gap: 0.15rem;
+  gap: 2px;
   margin-top: auto;
 }
 
+/* ---------- Buttons ---------- */
+
 .btn {
   border: 1px solid var(--line);
-  border-radius: 7px;
+  border-radius: 6px;
   padding: 0.35rem 0.7rem;
   background: var(--bg-elevated);
+  font-size: 0.84rem;
+  font-weight: 500;
 }
 
 .btn:hover {
-  background: var(--user-bg);
+  background: var(--accent);
 }
 
 .btn-primary {
   border-color: var(--ink);
   background: var(--ink);
-  color: var(--bg);
+  color: var(--bg-elevated);
 }
 
 .btn-primary:hover {
-  filter: brightness(1.15);
+  opacity: 0.9;
 }
 
 .btn-danger {
@@ -462,7 +701,7 @@ button {
 
 .btn-danger:hover:not(:disabled) {
   border-color: var(--danger);
-  background: oklch(0.97 0.01 25);
+  background: var(--critical-background);
 }
 
 .btn:disabled,
@@ -471,11 +710,19 @@ button {
   cursor: not-allowed;
 }
 
+/* ---------- Main content (floating card) ---------- */
+
 .main {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
+  flex: 1 1 auto;
   min-height: 0;
-  background: var(--bg);
+  margin: 0.5rem;
+  margin-left: 0;
+  border: 1px solid var(--line);
+  border-radius: 0.5rem;
+  background: var(--bg-elevated);
+  overflow: hidden;
 }
 
 .main.with-settings {
@@ -483,21 +730,21 @@ button {
 }
 
 .chat-pane {
-  display: grid;
-  grid-template-rows: auto auto 1fr auto;
+  display: flex;
+  flex-direction: column;
   min-height: 0;
   min-width: 0;
+  overflow: clip;
 }
 
 .conversation-header {
   display: flex;
-  min-height: 4.45rem;
+  min-height: 3.5rem;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.8rem clamp(1rem, 3vw, 2rem);
+  padding: 0.65rem clamp(1rem, 3vw, 2rem);
   border-bottom: 1px solid var(--line);
-  background: color-mix(in srgb, var(--bg-elevated) 86%, var(--bg));
 }
 
 .conversation-header h1,
@@ -506,39 +753,22 @@ button {
 }
 
 .conversation-header h1 {
-  font-size: 1rem;
-  font-weight: 620;
-  letter-spacing: -0.015em;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
-.conversation-title-row,
-.conversation-title-editor {
+.conversation-title-row {
   display: flex;
   align-items: center;
   gap: 0.55rem;
+  min-width: 0;
 }
 
-.conversation-title-editor input {
-  width: min(22rem, 48vw);
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  padding: 0.36rem 0.5rem;
-  background: var(--bg-elevated);
-  font-size: 1rem;
-  font-weight: 620;
-}
-
-.title-action {
-  border: 0;
-  padding: 0.15rem 0.25rem;
-  color: var(--muted);
-  background: transparent;
-  font-size: 0.76rem;
-}
-
-.title-action:hover {
-  color: var(--ink);
-  text-decoration: underline;
+.conversation-title-row h1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .conversation-header-actions,
@@ -554,52 +784,29 @@ button {
 
 .mobile-settings-actions .btn.is-active {
   border-color: var(--ink);
-  background: var(--sidebar-active);
+  background: var(--accent);
 }
 
 .eyebrow {
-  margin-bottom: 0.1rem !important;
-  color: var(--muted);
+  margin-bottom: 0.05rem !important;
+  color: var(--muted-foreground);
   font-size: 0.68rem;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
-.chat-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  align-items: center;
-  padding: 0.55rem clamp(1rem, 3vw, 2rem);
-  border-bottom: 1px solid var(--line);
-  color: var(--muted);
-  font-size: 0.85rem;
-}
 
-.chat-meta select,
-.chat-meta .model-custom {
-  border: 1px solid var(--line);
-  background: var(--bg-elevated);
-  border-radius: 6px;
-  padding: 0.25rem 0.45rem;
-  max-width: 18rem;
-}
-
-.chat-meta .model-custom {
-  min-width: 12rem;
-  font-family: var(--mono);
-  font-size: 0.8rem;
-}
+/* ---------- Agent activity ---------- */
 
 .agent-activity {
   display: grid;
   width: min(100%, 42rem);
   gap: 0.5rem;
-  padding: 0.65rem 0.75rem;
+  padding: 0.6rem 0.7rem;
   border: 1px solid var(--line);
-  border-radius: 9px;
-  background: color-mix(in srgb, var(--bg-elevated) 78%, var(--sidebar));
+  border-radius: 8px;
+  background: var(--card);
 }
 
 .agent-activity-heading {
@@ -609,13 +816,13 @@ button {
   gap: 0.75rem;
   color: var(--ink);
   font-size: 0.78rem;
-  font-weight: 650;
+  font-weight: 600;
 }
 
 .agent-activity-summary,
 .agent-activity-detail,
 .agent-activity-history {
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.72rem;
   font-weight: 450;
 }
@@ -639,21 +846,21 @@ button {
   align-items: center;
   gap: 0.4rem;
   padding-top: 0.35rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.7rem;
-  font-weight: 620;
+  font-weight: 600;
 }
 
 .agent-activity-group-indicator {
   width: 0.42rem;
   height: 0.42rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--muted) 45%, var(--line));
+  background: color-mix(in srgb, var(--muted-foreground) 45%, var(--line));
 }
 
 .agent-activity-group-indicator.is-active {
-  background: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+  background: var(--color-brightwave);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-brightwave) 14%, transparent);
 }
 
 .agent-activity-group-count {
@@ -696,9 +903,9 @@ button {
 }
 
 .agent-activity-item strong {
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.71rem;
-  font-weight: 620;
+  font-weight: 600;
   text-transform: capitalize;
 }
 
@@ -713,11 +920,11 @@ button {
   border: 1px solid color-mix(in srgb, var(--line) 84%, transparent);
   border-radius: 5px;
   padding: 0.14rem 0.38rem;
-  color: var(--muted);
-  background: color-mix(in srgb, var(--bg-elevated) 88%, var(--sidebar));
+  color: var(--muted-foreground);
+  background: var(--card);
   font: inherit;
   font-size: 0.68rem;
-  font-weight: 620;
+  font-weight: 600;
 }
 
 .agent-activity-stop:hover:not(:disabled) {
@@ -738,7 +945,7 @@ button {
 .agent-activity-indicator {
   width: 0.5rem;
   height: 0.5rem;
-  border: 1px solid color-mix(in srgb, var(--muted) 45%, var(--line));
+  border: 1px solid color-mix(in srgb, var(--muted-foreground) 45%, var(--line));
   border-radius: 999px;
   background: var(--bg-elevated);
 }
@@ -746,17 +953,17 @@ button {
 .agent-activity-item.is-active .agent-activity-indicator,
 .agent-activity-item.is-running .agent-activity-indicator,
 .agent-activity-item.is-activity-running .agent-activity-indicator {
-  border-color: var(--accent);
-  background: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+  border-color: var(--color-brightwave);
+  background: var(--color-brightwave);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-brightwave) 18%, transparent);
 }
 
 .agent-activity-item.is-queued .agent-activity-indicator,
 .agent-activity-item.is-waiting .agent-activity-indicator,
 .agent-activity-item.is-retry_wait .agent-activity-indicator,
 .agent-activity-item.is-cancelling .agent-activity-indicator {
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
-  background: color-mix(in srgb, var(--accent) 38%, var(--bg-elevated));
+  border-color: color-mix(in srgb, var(--color-brightwave) 55%, var(--line));
+  background: color-mix(in srgb, var(--color-brightwave) 38%, var(--bg-elevated));
 }
 
 .agent-activity-item.is-failed .agent-activity-indicator {
@@ -765,12 +972,12 @@ button {
 }
 
 .agent-activity-item.is-completed .agent-activity-indicator {
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
-  background: color-mix(in srgb, var(--accent) 26%, var(--bg-elevated));
+  border-color: color-mix(in srgb, var(--color-brightwave) 55%, var(--line));
+  background: color-mix(in srgb, var(--color-brightwave) 26%, var(--bg-elevated));
 }
 
 .agent-activity-state {
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.76rem;
 }
 
@@ -785,22 +992,120 @@ button {
   color: inherit;
   background: transparent;
   font: inherit;
-  font-weight: 650;
+  font-weight: 600;
   text-decoration: underline;
 }
+
+/* ---------- Message view ---------- */
 
 .message-view {
   position: relative;
   min-height: 0;
+  flex: 1 1 0;
 }
 
 .messages {
   height: 100%;
-  overflow: auto;
-  padding: 2rem clamp(1rem, 9vw, 10rem) 2.5rem;
+  overflow-x: hidden;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 1.15rem;
+  align-items: center;
+  padding: 2.5rem clamp(0.5rem, 4%, 5rem) 1.5rem;
+  scrollbar-gutter: stable;
+}
+
+.messages-column {
+  width: 100%;
+  max-width: 48rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.messages.is-empty {
+  align-items: center;
+  justify-content: center;
+  padding-bottom: 4rem;
+}
+
+.welcome {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 34rem;
+  text-align: center;
+}
+
+.welcome-mark svg {
+  width: 2.25rem;
+  height: auto;
+  color: var(--ink);
+  opacity: 0.9;
+}
+
+.welcome-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.welcome-copy h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.welcome-copy p {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.95rem;
+}
+
+.welcome-prompts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+  width: 100%;
+  margin-top: 0.25rem;
+}
+
+.welcome-prompt {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg-elevated);
+  color: var(--ink);
+  font-size: 0.85rem;
+  font-weight: 500;
+  text-align: left;
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.welcome-prompt svg {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+}
+
+.welcome-prompt:hover {
+  border-color: color-mix(in srgb, var(--ink) 22%, var(--line));
+  background: var(--accent);
+}
+
+.welcome-prompt:hover svg {
+  color: var(--color-brightwave);
+}
+
+@media (max-width: 720px) {
+  .welcome-prompts {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .new-activity {
@@ -808,22 +1113,25 @@ button {
   z-index: 1;
   right: clamp(1rem, 7vw, 7rem);
   bottom: 1rem;
-  border: 1px solid color-mix(in srgb, var(--ink) 26%, var(--line));
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border: 1px solid var(--line);
   border-radius: 999px;
-  padding: 0.38rem 0.7rem;
+  padding: 0.38rem 0.7rem 0.38rem 0.85rem;
   color: var(--ink);
   background: var(--bg-elevated);
-  box-shadow: 0 4px 16px color-mix(in srgb, var(--ink) 14%, transparent);
+  box-shadow: var(--shadow);
   font-size: 0.78rem;
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .new-activity:hover {
-  background: var(--sidebar-active);
+  background: var(--accent);
 }
 
 .message {
-  width: min(100%, 48rem);
+  width: 100%;
   overflow-wrap: anywhere;
 }
 
@@ -835,9 +1143,9 @@ button {
 
 .message-user {
   width: 100%;
-  border-radius: 15px 15px 4px 15px;
-  padding: 0.52rem 0.78rem;
-  background: color-mix(in srgb, var(--sidebar-active) 84%, var(--bg-elevated));
+  border-radius: 12px;
+  padding: 0.6rem 0.85rem;
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
   color: var(--ink);
 }
 
@@ -853,7 +1161,7 @@ button {
   align-items: center;
   gap: 0.35rem;
   padding-top: 0.25rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.72rem;
   opacity: 0;
   transition: opacity 120ms ease;
@@ -886,7 +1194,7 @@ button {
   border: 0;
   border-radius: 5px;
   padding: 0.18rem 0.32rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
   background: transparent;
   font-size: 0.72rem;
 }
@@ -894,7 +1202,12 @@ button {
 .message-copy:hover,
 .message-copy:focus-visible {
   color: var(--ink);
-  background: color-mix(in srgb, var(--sidebar-active) 60%, transparent);
+  background: color-mix(in srgb, var(--accent) 60%, transparent);
+}
+
+.clipboard-copy-icon {
+  display: inline-flex;
+  align-items: center;
 }
 
 @media (hover: none) {
@@ -903,10 +1216,12 @@ button {
   }
 }
 
+/* ---------- Sources ---------- */
+
 .assistant-sources {
   width: min(100%, 38rem);
   margin-top: 0.7rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.78rem;
 }
 
@@ -916,7 +1231,7 @@ button {
   max-width: 100%;
   align-items: center;
   gap: 0.4rem;
-  border-radius: 7px;
+  border-radius: 6px;
   padding: 0.22rem 0.32rem;
   cursor: pointer;
   list-style: none;
@@ -929,7 +1244,7 @@ button {
 .assistant-sources-toggle:hover,
 .assistant-sources-toggle:focus-visible {
   color: var(--ink);
-  background: color-mix(in srgb, var(--sidebar-active) 58%, transparent);
+  background: color-mix(in srgb, var(--accent) 58%, transparent);
 }
 
 .assistant-sources-label {
@@ -953,15 +1268,16 @@ button {
   border: 1px solid var(--line);
   border-radius: 999px;
   color: var(--ink);
-  background: color-mix(in srgb, var(--bg-elevated) 82%, var(--sidebar));
+  background: var(--card);
   font-size: 0.69rem;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1;
 }
 
 .assistant-sources-chevron {
-  font-size: 1rem;
-  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted-foreground);
   transition: transform 120ms ease;
 }
 
@@ -1005,35 +1321,39 @@ button {
 .assistant-source-copy p {
   margin: 0;
   overflow-wrap: anywhere;
-  color: var(--muted);
+  color: var(--muted-foreground);
   line-height: 1.45;
   white-space: pre-wrap;
 }
 
 .assistant-source-pages {
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.7rem;
   font-weight: 550;
 }
+
+/* ---------- Notices ---------- */
 
 .message-notice {
   align-self: center;
   max-width: min(100%, 42rem);
   padding: 0.35rem 0.6rem;
-  border-radius: 7px;
-  color: var(--muted);
+  border-radius: 6px;
+  color: var(--muted-foreground);
   font-size: 0.8rem;
   text-align: center;
-  background: color-mix(in srgb, var(--sidebar) 68%, transparent);
+  background: color-mix(in srgb, var(--muted) 68%, transparent);
 }
 
 .message-notice.is-error {
   align-self: stretch;
   border: 1px solid color-mix(in srgb, var(--danger) 35%, var(--line));
   color: var(--danger);
-  background: oklch(0.97 0.01 25);
+  background: var(--critical-background);
   text-align: left;
 }
+
+/* ---------- Working indicator ---------- */
 
 .assistant-working {
   display: flex;
@@ -1043,9 +1363,9 @@ button {
   align-items: center;
   gap: 0.45rem;
   padding: 0.2rem 0;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.8rem;
-  font-weight: 550;
+  font-weight: 500;
 }
 
 .assistant-working-mark {
@@ -1061,20 +1381,21 @@ button {
     opacity: 0.38;
     transform: scale(0.92);
   }
-
   50% {
     opacity: 1;
     transform: scale(1);
   }
 }
 
+/* ---------- Approval ---------- */
+
 .message-approval {
   width: min(100%, 38rem);
   align-self: flex-start;
-  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--line));
-  border-radius: 9px;
+  border: 1px solid color-mix(in srgb, var(--color-brightwave) 45%, var(--line));
+  border-radius: 8px;
   padding: 0.7rem 0.8rem;
-  background: color-mix(in srgb, var(--bg-elevated) 88%, var(--sidebar));
+  background: var(--card);
 }
 
 .message-approval p {
@@ -1083,10 +1404,11 @@ button {
   font-size: 0.84rem;
 }
 
+/* ---------- Markdown ---------- */
+
 .message-markdown {
-  line-height: 1.55;
-  /* A streamed plain-text response keeps its line breaks before it forms
-     complete Markdown blocks. */
+  font-size: 1rem;
+  line-height: 1.625;
   white-space: pre-wrap;
 }
 
@@ -1113,24 +1435,49 @@ button {
 .message-markdown h4,
 .message-markdown h5,
 .message-markdown h6 {
-  margin: 1rem 0 0.45rem;
-  line-height: 1.25;
-  letter-spacing: -0.015em;
+  font-weight: 600;
 }
 
 .message-markdown h1 {
-  font-size: 1.2rem;
+  margin: 2rem 0 1rem;
+  font-size: 2rem;
+  line-height: 2.5rem;
+  letter-spacing: -0.02em;
 }
 
 .message-markdown h2 {
-  font-size: 1.08rem;
+  margin: 1.75rem 0 0.75rem;
+  font-size: 1.5rem;
+  line-height: 2rem;
+  letter-spacing: -0.01em;
 }
 
-.message-markdown h3,
-.message-markdown h4,
-.message-markdown h5,
+.message-markdown h3 {
+  margin: 1.5rem 0 0.625rem;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  letter-spacing: -0.01em;
+}
+
+.message-markdown h4 {
+  margin: 1.25rem 0 0.5rem;
+  font-size: 1.125rem;
+  line-height: 1.625rem;
+  letter-spacing: -0.005em;
+}
+
+.message-markdown h5 {
+  margin: 1rem 0 0.375rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
 .message-markdown h6 {
-  font-size: 0.96rem;
+  margin: 0.75rem 0 0.25rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .message-markdown ul,
@@ -1144,7 +1491,7 @@ button {
 
 .message-markdown a {
   color: inherit;
-  font-weight: 550;
+  font-weight: 500;
   text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
   text-underline-offset: 0.16em;
 }
@@ -1154,21 +1501,23 @@ button {
 }
 
 .message-markdown :not(pre) > code {
-  border: 1px solid var(--line);
+  border: 0.5px solid var(--line);
   border-radius: 4px;
   padding: 0.08em 0.3em;
-  background: color-mix(in srgb, var(--sidebar) 70%, var(--bg-elevated));
+  background: color-mix(in srgb, var(--muted) 75%, transparent);
+  color: var(--code-ink);
   font-family: var(--mono);
-  font-size: 0.9em;
+  font-size: 0.8em;
+  font-weight: 450;
 }
 
 .message-markdown pre {
   overflow-x: auto;
-  border: 1px solid var(--line);
-  border-radius: 7px;
+  border: 1px solid var(--code-block-border);
+  border-radius: 8px;
   padding: 0.7rem 0.8rem;
-  background: oklch(0.19 0.01 285);
-  color: oklch(0.94 0.008 95);
+  background: var(--code-block-bg);
+  color: var(--code-block-ink);
   font-family: var(--mono);
   font-size: 0.82rem;
   line-height: 1.55;
@@ -1179,9 +1528,9 @@ button {
 }
 
 .message-markdown blockquote {
-  border-left: 2px solid var(--accent);
+  border-left: 2px solid var(--color-brightwave);
   padding-left: 0.75rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
 }
 
 .message-markdown hr {
@@ -1190,10 +1539,12 @@ button {
   border-top: 1px solid var(--line);
 }
 
+/* ---------- Tables ---------- */
+
 .markdown-table-frame {
   overflow: hidden;
   border: 1px solid var(--line);
-  border-radius: 7px;
+  border-radius: 8px;
 }
 
 .markdown-table-wrap {
@@ -1215,7 +1566,7 @@ button {
 }
 
 .message-markdown th {
-  font-weight: 650;
+  font-weight: 600;
 }
 
 .markdown-table-actions {
@@ -1223,7 +1574,7 @@ button {
   justify-content: flex-end;
   border-top: 1px solid var(--line);
   padding: 0.25rem;
-  background: color-mix(in srgb, var(--sidebar) 45%, transparent);
+  background: var(--muted);
 }
 
 .markdown-table-copy {
@@ -1233,7 +1584,7 @@ button {
   border: 0;
   border-radius: 5px;
   padding: 0.2rem 0.38rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
   background: transparent;
   font-size: 0.72rem;
 }
@@ -1241,7 +1592,7 @@ button {
 .markdown-table-copy:hover,
 .markdown-table-copy:focus-visible {
   color: var(--ink);
-  background: color-mix(in srgb, var(--sidebar-active) 60%, transparent);
+  background: color-mix(in srgb, var(--accent) 60%, transparent);
 }
 
 .markdown-image-omitted {
@@ -1249,9 +1600,11 @@ button {
   border: 1px solid var(--line);
   border-radius: 4px;
   padding: 0.12rem 0.35rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.82em;
 }
+
+/* ---------- Tool call cards ---------- */
 
 .tool-call-card {
   display: flex;
@@ -1260,10 +1613,10 @@ button {
   align-items: center;
   gap: 0.65rem;
   border: 1px solid var(--line);
-  border-radius: 9px;
+  border-radius: 8px;
   padding: 0.6rem 0.7rem;
-  color: var(--muted);
-  background: color-mix(in srgb, var(--bg-elevated) 88%, var(--sidebar));
+  color: var(--muted-foreground);
+  background: var(--card);
 }
 
 .tool-call-icon {
@@ -1274,9 +1627,9 @@ button {
   place-items: center;
   border-radius: 5px;
   color: var(--ink);
-  background: var(--user-bg);
+  background: var(--muted);
   font-size: 0.82rem;
-  font-weight: 650;
+  font-weight: 600;
 }
 
 .tool-call-copy {
@@ -1300,25 +1653,27 @@ button {
   height: 0.8rem;
   flex: 0 0 auto;
   margin-left: auto;
-  border: 2px solid color-mix(in srgb, var(--muted) 25%, transparent);
-  border-top-color: var(--muted);
+  border: 2px solid color-mix(in srgb, var(--muted-foreground) 25%, transparent);
+  border-top-color: var(--muted-foreground);
   border-radius: 999px;
   animation: tool-call-spin 800ms linear infinite;
 }
 
 .tool-call-card.is-completed .tool-call-icon {
-  color: oklch(0.42 0.13 150);
-  background: oklch(0.95 0.035 150);
+  color: var(--success-foreground);
+  background: var(--success-background);
 }
 
 .tool-call-card.is-failed .tool-call-icon {
   color: var(--danger);
-  background: oklch(0.97 0.01 25);
+  background: var(--critical-background);
 }
 
 .tool-call-card.is-cancelled {
   opacity: 0.7;
 }
+
+/* ---------- Tool activity groups ---------- */
 
 .tool-activity-group {
   width: min(100%, 31rem);
@@ -1334,7 +1689,7 @@ button {
   border: 0;
   border-radius: 6px;
   padding: 0.24rem 0.32rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
   background: transparent;
   text-align: left;
 }
@@ -1342,7 +1697,7 @@ button {
 .tool-activity-group-toggle:hover,
 .tool-activity-group-toggle:focus-visible {
   color: var(--ink);
-  background: color-mix(in srgb, var(--sidebar-active) 58%, transparent);
+  background: color-mix(in srgb, var(--accent) 58%, transparent);
 }
 
 .tool-activity-group-status {
@@ -1353,21 +1708,21 @@ button {
   place-items: center;
   border-radius: 999px;
   color: var(--ink);
-  background: var(--user-bg);
+  background: var(--muted);
   font-size: 0.7rem;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1;
 }
 
 .tool-activity-group-status.is-completed {
-  color: oklch(0.42 0.13 150);
-  background: oklch(0.95 0.035 150);
+  color: var(--success-foreground);
+  background: var(--success-background);
 }
 
 .tool-activity-group-status.is-failed,
 .tool-activity-group-status.is-unknown {
   color: var(--danger);
-  background: oklch(0.97 0.01 25);
+  background: var(--critical-background);
 }
 
 .tool-activity-group-label {
@@ -1376,13 +1731,14 @@ button {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 0.82rem;
-  font-weight: 550;
+  font-weight: 500;
 }
 
 .tool-activity-group-chevron {
+  display: inline-flex;
+  align-items: center;
   flex: 0 0 auto;
-  font-size: 1rem;
-  line-height: 1;
+  color: var(--muted-foreground);
   transition: transform 120ms ease;
 }
 
@@ -1404,7 +1760,7 @@ button {
   min-width: 0;
   align-items: flex-start;
   gap: 0.55rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
 }
 
 .tool-activity-timeline-marker {
@@ -1416,15 +1772,15 @@ button {
   place-items: center;
   border-radius: 999px;
   color: var(--ink);
-  background: var(--bg);
+  background: var(--bg-elevated);
   font-size: 0.67rem;
-  font-weight: 650;
+  font-weight: 600;
   line-height: 1;
   transform: translateX(-50%);
 }
 
 .tool-activity-timeline-item.is-completed .tool-activity-timeline-marker {
-  color: oklch(0.42 0.13 150);
+  color: var(--success-foreground);
 }
 
 .tool-activity-timeline-item.is-failed .tool-activity-timeline-marker,
@@ -1441,7 +1797,7 @@ button {
 .tool-activity-timeline-copy strong {
   color: var(--ink);
   font-size: 0.8rem;
-  font-weight: 550;
+  font-weight: 500;
 }
 
 .tool-activity-timeline-copy span {
@@ -1452,7 +1808,7 @@ button {
   width: fit-content;
   max-width: 100%;
   margin: 0;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.8rem;
 }
 
@@ -1471,21 +1827,22 @@ button {
     animation: none;
     transition: none;
   }
-
   .assistant-working-mark {
     opacity: 0.72;
     transform: none;
   }
 }
 
+/* ---------- Folder consent ---------- */
+
 .folder-consent {
   align-self: flex-start;
   width: min(100%, 34rem);
-  border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--line));
-  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--color-brightwave) 55%, var(--line));
+  border-radius: 8px;
   padding: 0.85rem;
   background: var(--bg-elevated);
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--ink) 6%, transparent);
+  box-shadow: var(--shadow);
 }
 
 .folder-consent-heading {
@@ -1515,7 +1872,7 @@ button {
 
 .folder-consent-hint,
 .folder-consent-note {
-  color: var(--muted);
+  color: var(--muted-foreground);
 }
 
 .folder-consent-error {
@@ -1530,35 +1887,100 @@ button {
   margin-top: 0.75rem;
 }
 
+/* ---------- Composer ---------- */
+
+.composer-wrap {
+  padding: 0 clamp(0.5rem, 4%, 5rem) 0.5rem;
+}
+
 .composer {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.55rem;
-  padding: 0.85rem clamp(1rem, 3vw, 2rem) 1rem;
-  border-top: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-width: 48rem;
+  margin: 0 auto;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 1rem;
   background: var(--bg-elevated);
+  box-shadow: var(--shadow-sm);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.composer:focus-within {
+  border-color: var(--color-zinc-300, var(--line));
+  box-shadow: var(--shadow-lg);
 }
 
 .composer textarea {
   resize: none;
-  min-height: calc(1.45rem + 1.2rem + 2px);
-  max-height: calc(8.7rem + 1.2rem + 2px);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 0.6rem 0.7rem;
-  background: var(--bg);
-  line-height: 1.45rem;
+  width: 100%;
+  min-height: 2.5rem;
+  max-height: calc(7.25rem + 2px);
+  border: 0;
+  border-radius: 0;
+  padding: 0.125rem 0.125rem;
+  background: transparent;
+  font-size: 1rem;
+  line-height: 1.625rem;
   overflow-y: hidden;
+  outline: none;
+}
+
+.composer textarea::placeholder {
+  color: var(--muted-foreground);
 }
 
 .composer-actions {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 0.45rem;
 }
 
-.composer-actions .btn {
-  min-width: 5.5rem;
+.composer-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 999px;
+  padding: 0;
+  transition: background-color 120ms ease, opacity 120ms ease;
+}
+
+.composer-send {
+  color: var(--primary-foreground);
+  background: var(--primary);
+}
+
+.composer-send:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--primary) 90%, transparent);
+}
+
+.composer-send:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.composer-stop {
+  color: var(--primary-foreground);
+  background: var(--primary);
+}
+
+.composer-stop:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger) 88%, var(--primary));
+}
+
+.composer-stop:disabled {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.composer-redirect {
+  min-width: 5rem;
 }
 
 .btn-stop {
@@ -1568,7 +1990,7 @@ button {
 
 .btn-stop:hover:not(:disabled) {
   border-color: var(--danger);
-  background: oklch(0.97 0.01 25);
+  background: var(--critical-background);
 }
 
 .composer-turn-error {
@@ -1581,7 +2003,7 @@ button {
 
 .composer-turn-status {
   grid-column: 1 / -1;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.78rem;
 }
 
@@ -1597,35 +2019,16 @@ button {
   border: 0;
 }
 
+/* ---------- Settings panel ---------- */
+
 .settings {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   border-left: 1px solid var(--line);
   background: var(--bg-elevated);
-  overflow: auto;
-  padding: 1rem;
-}
-
-.settings h2 {
-  font-size: 0.95rem;
-  margin: 0 0 0.35rem;
-}
-
-.settings > p {
-  margin: 0 0 1rem;
-  color: var(--muted);
-  font-size: 0.85rem;
-}
-
-.provider {
-  border-top: 1px solid var(--line);
-  padding: 0.85rem 0;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.provider h3 {
-  margin: 0;
-  font-size: 0.9rem;
-  text-transform: capitalize;
+  overflow-y: auto;
+  padding: 1.25rem 1rem;
 }
 
 .web-search-state {
@@ -1634,8 +2037,8 @@ button {
   padding: 0.65rem 0.7rem;
   border: 1px solid var(--line);
   border-radius: 8px;
-  color: var(--muted);
-  background: var(--bg);
+  color: var(--muted-foreground);
+  background: var(--page-background);
   font-size: 0.82rem;
 }
 
@@ -1645,90 +2048,20 @@ button {
 }
 
 .web-search-state.is-ready {
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  border-color: color-mix(in srgb, var(--success) 55%, var(--line));
 }
 
 .web-search-state.is-not-configured {
   border-color: color-mix(in srgb, var(--danger) 30%, var(--line));
 }
 
-.settings-field {
-  display: grid;
-  gap: 0.3rem;
-  color: var(--muted);
-  font-size: 0.8rem;
-}
-
-.settings-field select,
-.settings-field input {
-  width: 100%;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 0.35rem 0.45rem;
-  color: var(--ink);
-  background: var(--bg);
-}
-
-.settings-hint,
-.settings-note {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.78rem;
-}
-
-.settings-note {
-  margin-top: 1rem;
-  line-height: 1.5;
-}
-
-.folder-list {
-  display: grid;
-  gap: 0.55rem;
-  margin-top: 1rem;
-}
-
-.folder {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  border-top: 1px solid var(--line);
-  padding-top: 0.7rem;
-}
-
-.folder strong {
-  display: block;
-  overflow-wrap: anywhere;
-}
-
-.folder-error {
-  margin-top: 0.75rem;
-  color: var(--danger);
-  font-size: 0.8rem;
-}
-
-.row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.row input[type="text"],
-.row input[type="password"] {
-  flex: 1;
-  min-width: 8rem;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 0.3rem 0.45rem;
-  background: var(--bg);
-}
-
 .status {
   font-family: var(--mono);
   font-size: 0.7rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
 }
+
+/* ---------- Boot screen ---------- */
 
 .boot {
   height: 100%;
@@ -1737,6 +2070,7 @@ button {
   text-align: center;
   padding: 2rem;
   gap: 0.75rem;
+  background: var(--bg-elevated);
 }
 
 .boot-brand {
@@ -1758,7 +2092,7 @@ button {
 }
 
 .boot p {
-  color: var(--muted);
+  color: var(--muted-foreground);
   margin: 0;
 }
 
@@ -1770,11 +2104,13 @@ button {
   margin-top: 0.5rem;
 }
 
+/* ---------- Documents view ---------- */
+
 .documents-view {
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
-  background: var(--bg);
+  background: var(--bg-elevated);
 }
 
 .documents-header {
@@ -1784,7 +2120,6 @@ button {
   gap: 2rem;
   padding: 2.2rem clamp(1.25rem, 5vw, 4rem) 1.7rem;
   border-bottom: 1px solid var(--line);
-  background: color-mix(in srgb, var(--bg-elevated) 86%, var(--bg));
 }
 
 .documents-header h1,
@@ -1799,14 +2134,14 @@ button {
 .documents-header h1 {
   margin-top: 0.15rem;
   font-size: 1.65rem;
-  font-weight: 630;
+  font-weight: 600;
   letter-spacing: -0.035em;
 }
 
 .documents-header > div > p:last-child {
   max-width: 41rem;
   margin-top: 0.45rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
 }
 
 .documents-header-actions {
@@ -1834,9 +2169,9 @@ button {
   justify-content: space-between;
   gap: 1rem;
   padding: 0.75rem 0.9rem;
-  border: 1px solid color-mix(in srgb, var(--accent) 48%, var(--line));
-  border-radius: 9px;
-  background: color-mix(in srgb, var(--accent) 7%, var(--bg-elevated));
+  border: 1px solid color-mix(in srgb, var(--color-brightwave) 48%, var(--line));
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-brightwave) 7%, var(--bg-elevated));
   font-size: 0.84rem;
 }
 
@@ -1854,21 +2189,21 @@ button {
 .document-catalog {
   padding: 1.1rem;
   border: 1px solid var(--line);
-  border-radius: 12px;
+  border-radius: 8px;
   background: var(--bg-elevated);
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--ink) 4%, transparent);
+  box-shadow: var(--shadow-sm);
 }
 
 .document-search h2,
 .document-catalog h2 {
   font-size: 0.98rem;
-  font-weight: 620;
+  font-weight: 600;
 }
 
 .document-search > div:first-child > p,
 .document-section-heading p {
   margin-top: 0.2rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.8rem;
 }
 
@@ -1884,11 +2219,11 @@ button {
   border: 1px solid var(--line);
   border-radius: 8px;
   padding: 0.55rem 0.7rem;
-  background: var(--bg);
+  background: var(--page-background);
 }
 
 .document-search input:focus {
-  outline: 2px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--color-brightwave) 40%, transparent);
   outline-offset: 1px;
 }
 
@@ -1911,7 +2246,7 @@ button {
   gap: 0.4rem;
   padding: 0.75rem;
   border-radius: 8px;
-  background: var(--bg);
+  background: var(--page-background);
 }
 
 .document-result-source {
@@ -1923,13 +2258,13 @@ button {
 }
 
 .document-result-source span {
-  color: var(--muted);
+  color: var(--muted-foreground);
 }
 
 .document-result p {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
-  color: color-mix(in srgb, var(--ink) 88%, var(--muted));
+  color: color-mix(in srgb, var(--ink) 88%, var(--muted-foreground));
   font-size: 0.85rem;
   line-height: 1.55;
 }
@@ -1945,7 +2280,7 @@ button {
 .document-refresh {
   border: 0;
   padding: 0.25rem;
-  color: var(--muted);
+  color: var(--muted-foreground);
   background: transparent;
   font-size: 0.78rem;
 }
@@ -1983,9 +2318,9 @@ button {
   height: 2rem;
   place-items: center;
   border: 1px solid var(--line);
-  border-radius: 7px;
-  color: var(--muted);
-  background: var(--bg);
+  border-radius: 6px;
+  color: var(--muted-foreground);
+  background: var(--page-background);
 }
 
 .document-copy {
@@ -2003,33 +2338,33 @@ button {
 }
 
 .document-copy span {
-  color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.74rem;
 }
 
 .document-status {
   padding: 0.2rem 0.5rem;
   border-radius: 999px;
-  color: var(--muted);
-  background: var(--sidebar);
+  color: var(--muted-foreground);
+  background: var(--muted);
   font-size: 0.72rem;
   font-weight: 570;
 }
 
 .document-status.is-ready {
-  color: oklch(0.39 0.12 150);
-  background: color-mix(in srgb, var(--accent) 13%, var(--bg));
+  color: var(--success-foreground);
+  background: var(--success-background);
 }
 
 .document-status.is-processing,
 .document-status.is-queued {
-  color: oklch(0.47 0.11 75);
-  background: oklch(0.96 0.035 80);
+  color: var(--warning-foreground);
+  background: var(--warning-background);
 }
 
 .document-status.is-failed {
   color: var(--danger);
-  background: color-mix(in srgb, var(--danger) 9%, var(--bg));
+  background: color-mix(in srgb, var(--danger) 9%, var(--page-background));
 }
 
 .document-empty,
@@ -2039,7 +2374,7 @@ button {
   gap: 0.25rem;
   min-height: 8rem;
   border-top: 1px solid var(--line);
-  color: var(--muted);
+  color: var(--muted-foreground);
   text-align: center;
 }
 
@@ -2052,9 +2387,11 @@ button {
   border-top: 0;
 }
 
+/* ---------- Responsive ---------- */
+
 @media (max-width: 720px) {
   .app-shell {
-    grid-template-columns: 1fr;
+    flex-direction: column;
   }
 
   .sidebar {
@@ -2063,6 +2400,12 @@ button {
 
   .mobile-settings-actions {
     display: flex;
+  }
+
+  .main {
+    margin: 0;
+    border: 0;
+    border-radius: 0;
   }
 
   .main.with-settings {
@@ -2131,4 +2474,10 @@ button {
     justify-self: start;
     margin-top: -0.5rem;
   }
+}
+
+/* Scrollbar styling */
+* {
+  scrollbar-color: var(--muted-foreground) transparent;
+  scrollbar-width: thin;
 }

--- a/crates/openwave-desktop/ui/src/theme.test.ts
+++ b/crates/openwave-desktop/ui/src/theme.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isThemeMode, resolveTheme } from "./theme";
+
+describe("theme", () => {
+  it("accepts only the three known modes", () => {
+    expect(isThemeMode("light")).toBe(true);
+    expect(isThemeMode("dark")).toBe(true);
+    expect(isThemeMode("system")).toBe(true);
+    expect(isThemeMode("")).toBe(false);
+    expect(isThemeMode("Dark")).toBe(false);
+    expect(isThemeMode(null)).toBe(false);
+    expect(isThemeMode(undefined)).toBe(false);
+  });
+
+  it("resolves explicit modes without consulting the system", () => {
+    expect(resolveTheme("light")).toBe("light");
+    expect(resolveTheme("dark")).toBe("dark");
+  });
+});

--- a/crates/openwave-desktop/ui/src/theme.ts
+++ b/crates/openwave-desktop/ui/src/theme.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type ThemeMode = "light" | "dark" | "system";
+
+const STORAGE_KEY = "openwave-theme";
+
+export function isThemeMode(value: unknown): value is ThemeMode {
+  return value === "light" || value === "dark" || value === "system";
+}
+
+export function readStoredTheme(): ThemeMode {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY);
+    if (isThemeMode(value)) return value;
+  } catch {
+    // Ignore storage access failures (private mode, disabled storage).
+  }
+  return "system";
+}
+
+function storeTheme(mode: ThemeMode): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, mode);
+  } catch {
+    // Ignore storage access failures.
+  }
+}
+
+export function systemPrefersDark(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+}
+
+export function resolveTheme(mode: ThemeMode): "light" | "dark" {
+  if (mode === "system") return systemPrefersDark() ? "dark" : "light";
+  return mode;
+}
+
+export function applyTheme(mode: ThemeMode): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.classList.toggle("dark", resolveTheme(mode) === "dark");
+}
+
+/** Applies the stored theme synchronously to avoid a flash before React mounts. */
+export function initTheme(): void {
+  applyTheme(readStoredTheme());
+}
+
+export function useTheme(): {
+  mode: ThemeMode;
+  resolved: "light" | "dark";
+  setMode: (mode: ThemeMode) => void;
+  cycle: () => void;
+} {
+  const [mode, setModeState] = useState<ThemeMode>(() => readStoredTheme());
+
+  useEffect(() => {
+    applyTheme(mode);
+    storeTheme(mode);
+  }, [mode]);
+
+  // Follow the OS preference live while in system mode.
+  useEffect(() => {
+    if (mode !== "system") return;
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const query = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    query.addEventListener("change", handler);
+    return () => query.removeEventListener("change", handler);
+  }, [mode]);
+
+  const setMode = useCallback((next: ThemeMode) => setModeState(next), []);
+  const cycle = useCallback(() => {
+    setModeState((current) =>
+      current === "light" ? "dark" : current === "dark" ? "system" : "light",
+    );
+  }, []);
+
+  return { mode, resolved: resolveTheme(mode), setMode, cycle };
+}

--- a/crates/openwave-desktop/ui/tsconfig.json
+++ b/crates/openwave-desktop/ui/tsconfig.json
@@ -15,7 +15,11 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/crates/openwave-desktop/ui/vite.config.ts
+++ b/crates/openwave-desktop/ui/vite.config.ts
@@ -1,11 +1,18 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "path";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 
 export default defineConfig(async () => ({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   clearScreen: false,
   server: {
     port: 1420,


### PR DESCRIPTION
Reworks the desktop UI to match Brightwave's visual language, adopting Tailwind v4 and a small set of shadcn/ui primitives while preserving the existing local-host trust boundaries and durable-state model. Renderer-safe transcript/tool projections are unchanged.

## Foundation
- Tailwind v4 via `@tailwindcss/vite`, the `@/` path alias, and a `cn()` helper.
- Ported shadcn/ui primitives: `Button`, `Card`, `Input`, `Badge`, `AlertDialog`, `DropdownMenu`, `Tooltip`.
- Ported Brightwave's oklch token palette with **full light + dark mode**; the existing component CSS now resolves off the shared tokens (so it themes automatically).

## Layout & components
- Floating rounded content panel over a page background; centered `max-w-3xl` message column; card-style composer with a **circular icon send/stop** control.
- Sidebar reworked to flat nav rows with lucide icons; conversation list restyled; the no-project bucket relabelled **"Direct chats"** with a distinct icon.
- **Model selection moved out of the transcript** into a Model settings panel; the settings panels (Model / Providers / Web search / Folders) rebuilt on `Button`/`Input`/bordered sections.
- **Conversation rename is now inline** in the list via a per-row `⋯` dropdown (Rename / Delete), matching Brightwave. Delete confirmation uses the in-app `AlertDialog` instead of the native `window.confirm`.
- All placeholder Unicode glyphs (`◆ ◇ ▤ ✓ ↗ ×` …) replaced with lucide icons.
- Added a **welcome/empty state** with starter prompts, and a system-aware **light / dark / system** theme toggle (persisted, follows the OS while in system mode).
- `AgentActivityPanel` now surfaces only real background-agent work instead of a standing "Conversation" card.

## Tests
New pure logic (`theme`, `WelcomeState`, tool-status icons, confirm dialog) has unit coverage. `tsc` clean, `vitest` 146/146 pass, production build succeeds.

Follow-ups intentionally deferred: collapsible/compact sidebar, and citation chips (need a provenance data contract).