### PR TITLE
Accept PDF uploads via the liteparse parser

### DIFF
--- a/crates/openwave-desktop/src/documents.rs
+++ b/crates/openwave-desktop/src/documents.rs
@@ -330,8 +330,8 @@ async fn pick_document(app: &AppHandle) -> Result<Option<PathBuf>, String> {
     let mut picker = app
         .dialog()
         .file()
-        .set_title("Import a text or Markdown document")
-        .add_filter("Text and Markdown", &["txt", "md", "markdown"]);
+        .set_title("Import a document")
+        .add_filter("Documents", &["txt", "md", "markdown", "pdf"]);
     if let Some(window) = app.get_webview_window("main") {
         picker = picker.set_parent(&window);
     }
@@ -356,7 +356,8 @@ fn import_metadata(path: &Path) -> Result<(&'static str, String), String> {
     let media_type = match extension.as_deref() {
         Some("md" | "markdown") => "text/markdown",
         Some("txt") => "text/plain",
-        _ => return Err("Choose a .txt, .md, or .markdown file".to_owned()),
+        Some("pdf") => "application/pdf",
+        _ => return Err("Choose a .txt, .md, .markdown, or .pdf file".to_owned()),
     };
     let display_name = path
         .file_name()
@@ -519,7 +520,12 @@ mod tests {
         assert_eq!(media_type, "text/markdown");
         assert_eq!(name, "plan.md");
         assert!(!name.contains("private"));
-        assert!(import_metadata(Path::new("/Users/private/plan.pdf")).is_err());
+        // PDFs are accepted and map to their canonical media type.
+        let (pdf_media_type, pdf_name) =
+            import_metadata(Path::new("/Users/private/plan.pdf")).unwrap();
+        assert_eq!(pdf_media_type, "application/pdf");
+        assert_eq!(pdf_name, "plan.pdf");
+        assert!(import_metadata(Path::new("/Users/private/sheet.csv")).is_err());
         assert!(import_metadata(Path::new("relative.md")).is_err());
         assert!(import_metadata(Path::new("/Users/private/bad\u{202e}txt.md")).is_err());
         for unsafe_character in ['\u{200d}', '\u{206a}', '\u{206f}', '\u{2028}', '\u{2029}'] {

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -280,7 +280,9 @@ function documentTitle(document: LibraryDocument): string {
 }
 
 function mediaTypeLabel(mediaType: string): string {
-  return mediaType.startsWith("text/markdown") ? "Markdown" : "Text";
+  if (mediaType.startsWith("application/pdf")) return "PDF";
+  if (mediaType.startsWith("text/markdown")) return "Markdown";
+  return "Text";
 }
 
 function formatDate(value: string): string {

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -10,6 +10,14 @@ authors.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Rich PDF ingestion via the local, PDFium-backed liteparse parser. On by
+# default so the desktop and `openwave serve` accept `application/pdf` uploads.
+# The liteparse build downloads a prebuilt PDFium binary; build with
+# `--no-default-features` for a lean, text-only pipeline with no such fetch.
+default = ["parse-liteparse"]
+parse-liteparse = ["openwave-retrieval/parse-liteparse"]
+
 [dependencies]
 openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools", "keychain", "blob-fs"] }
 openwave-router = { path = "../openwave-router" }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -625,13 +625,23 @@ fn build_retrieval(
     store: Arc<dyn VectorStore>,
 ) -> (Arc<Retriever>, Box<SearchTool>) {
     let retrieval = Arc::new(Retriever::new(
-        Box::new(ParserRegistry::new().with_parser(PlainTextParser::new())),
+        Box::new(document_parser_registry()),
         Box::new(TextChunker::default()),
         embedder.clone(),
         store.clone(),
     ));
     let search = Box::new(SearchTool::new(embedder, store));
     (retrieval, search)
+}
+
+/// Assemble the document parsers. `PlainTextParser` is the always-on fallback
+/// for `text/*`; with the `parse-liteparse` feature, the narrow PDF parser is
+/// registered ahead of it so `application/pdf` ingests as extracted Markdown.
+fn document_parser_registry() -> ParserRegistry {
+    let registry = ParserRegistry::new();
+    #[cfg(feature = "parse-liteparse")]
+    let registry = registry.with_parser(openwave_retrieval::LiteParsePdfParser::new());
+    registry.with_parser(PlainTextParser::new())
 }
 
 /// Open the persistent vector store for this launch: a LanceDB dataset under

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -5865,7 +5865,9 @@ async fn ingest_rejects_unsupported_media_type() {
         &router,
         &bearer,
         "/documents",
-        serde_json::json!({ "content": "%PDF-1.7", "media_type": "application/pdf" }),
+        // `image/png` is handled by no registered parser in any feature config
+        // (unlike `application/pdf`, which the liteparse parser claims).
+        serde_json::json!({ "content": "\u{89}PNG", "media_type": "image/png" }),
     )
     .await;
     // A parser that can't handle the media type is the caller's problem: 400.


### PR DESCRIPTION
Wires the feature-gated liteparse PDF parser (added in #295) into the ingest pipeline so **`application/pdf` documents parse and index end-to-end**.

### Changes
- **openwave-server**: new **on-by-default `parse-liteparse` feature** that enables `openwave-retrieval/parse-liteparse`, and registers `LiteParsePdfParser` ahead of the `text/*` fallback in the document parser registry. `--no-default-features` gives a text-only pipeline that skips liteparse's PDFium download.
- **desktop**: the import picker now accepts `.pdf` (→ `application/pdf`); the library labels PDF documents as "PDF".
- **test**: the "unsupported media type" server test now uses `image/png` (claimed by no parser in any config) since `application/pdf` is now accepted.

Ingested PDFs become liteparse's Markdown output as canonical text → chunked → embedded → searchable, same as any other document.

### Verification (local)
- Server builds with liteparse (default) **and** with `--no-default-features` (lean path).
- `cargo clippy -p openwave-server --all-targets -- -D warnings` clean; server tests **263/263**; desktop `import_metadata` test updated + passing; UI **146/146**; fmt clean.

### CI note
This is the first build that compiles liteparse in CI: its `pdfium-sys` **downloads a prebuilt PDFium** from GitHub releases at build time (needs network on the runner). Watching the Linux `fmt · clippy · build · test` job to confirm the download works there.

### Follow-up
A packaged desktop app needs the **PDFium runtime library bundled** (Tauri resources) for PDF parsing to work in distribution; dev builds resolve it via the cache. Office/image formats (liteparse's LibreOffice/ImageMagick conversion path) remain out of scope.