### PR TITLE
Fail closed when PDFium is unavailable instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6691,6 +6691,7 @@ dependencies = [
  "futures",
  "lancedb",
  "liteparse",
+ "liteparse-pdfium-sys",
  "openwave-core",
  "reqwest 0.12.28",
  "serde",

--- a/crates/openwave-retrieval/Cargo.toml
+++ b/crates/openwave-retrieval/Cargo.toml
@@ -31,7 +31,7 @@ vec-lance = ["dep:lancedb", "dep:arrow-array", "dep:arrow-schema", "dep:arrow-se
 # (`default-features = false`), so text-layer PDFs parse fully offline with no
 # system OCR dependency; image-only pages simply yield little text. The server
 # enables this feature explicitly to accept `application/pdf` uploads.
-parse-liteparse = ["dep:liteparse"]
+parse-liteparse = ["dep:liteparse", "dep:liteparse-pdfium-sys"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -58,6 +58,11 @@ futures = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync"], optional = true }
 # Rich PDF parser (parse-liteparse feature only). Local + PDFium-backed; OCR off.
 liteparse = { version = "2.8", default-features = false, optional = true }
+# The PDFium loader liteparse builds on. Depended on directly (pinned to the same
+# version liteparse resolves, so cargo unifies the one runtime binding) only to
+# probe `load_default()` and fail closed with a clear error instead of the panic
+# liteparse raises when the PDFium library is absent.
+liteparse-pdfium-sys = { version = "1.3", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/openwave-retrieval/src/liteparse_parser.rs
+++ b/crates/openwave-retrieval/src/liteparse_parser.rs
@@ -81,6 +81,17 @@ impl DocumentParser for LiteParsePdfParser {
                 "LiteParsePdfParser does not support media type `{media_type}`"
             )));
         }
+        // Fail closed if the PDFium runtime library is unavailable. liteparse
+        // otherwise panics (`load_default().expect(..)`) the first time it
+        // touches PDFium, which would abort the parse task instead of marking
+        // the document failed. This probe shares liteparse's runtime binding
+        // (same pinned `liteparse-pdfium-sys`), so a success here also primes
+        // liteparse's own lazy load; it is memoized and cheap to repeat.
+        liteparse_pdfium_sys::dynamic::load_default().map_err(|error| {
+            RetrievalError::parse(format!(
+                "PDF parsing is unavailable: the PDFium runtime library could not be loaded ({error})"
+            ))
+        })?;
         let result = LiteParse::new(Self::config())
             .parse_input(PdfInput::Bytes(raw.to_vec()))
             .await


### PR DESCRIPTION
A production-safety fix for the PDF path (follow-up to #295/#296).

### The bug
liteparse loads its PDFium runtime library lazily via `liteparse-pdfium`'s `Library::init()`, which does `pdfium_sys::dynamic::load_default().expect("failed to load pdfium shared library")`. So the **first PDF parse in any environment where PDFium can't be found panics** — e.g. a packaged desktop app that hasn't bundled the library yet, or a misconfigured deploy. A panic in the parse task is far worse than a clean failure: it aborts the task instead of letting the durable document worker mark the document failed with a reason.

### The fix
`LiteParsePdfParser::parse` now probes `liteparse_pdfium_sys::dynamic::load_default()` first and maps any error to a clear `RetrievalError` ("PDF parsing is unavailable: the PDFium runtime library could not be loaded …"). Because the sys crate is pinned to the same version liteparse resolves, cargo unifies the **single** runtime binding — so a successful probe also primes liteparse's own lazy load (memoized, cheap to repeat), and a failing probe intercepts before liteparse's panicking `.expect()`.

### Verification
- Cargo resolves a single `liteparse-pdfium-sys` (shared static binding).
- Real-PDF integration test still passes (the guard's success path runs before liteparse); unit tests, clippy, fmt clean.
- The missing-library path can't be reliably forced in-process here (the loader's self-dir/exe-dir/bare-name fallbacks find the cached PDFium), so it's covered by the logic + the clear error, not a negative test.

This makes PDF ingestion safe **before** the desktop PDFium bundling lands — a missing library degrades to a clean per-document failure rather than a worker panic.