### PR TITLE
Test PDF ingest→parse→index end to end

### DIFF
--- a/crates/openwave-server/src/fixtures/minimal.pdf
+++ b/crates/openwave-server/src/fixtures/minimal.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 64 >>
+stream
+BT /F1 24 Tf 72 700 Td (Quarterly liteparse ingest report) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000355 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+425
+%%EOF

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -4361,6 +4361,43 @@ async fn raw_ingest_retains_exact_bytes_and_runs_the_async_pipeline() {
     );
 }
 
+/// End-to-end proof that a PDF ingested through the raw route parses (via the
+/// liteparse parser registered in the real pipeline) and indexes to `Ready`,
+/// with the extracted text as canonical text. Only runs with the parser feature.
+#[cfg(feature = "parse-liteparse")]
+#[tokio::test]
+async fn raw_ingest_parses_and_indexes_a_pdf_end_to_end() {
+    let (router, token, store, _dir, worker) = test_app_with_worker().await;
+    let bearer = format!("Bearer {token}");
+    let pdf = include_bytes!("fixtures/minimal.pdf").to_vec();
+
+    let response = post_raw(
+        &router,
+        &bearer,
+        "/documents/raw?uri=file%3A%2F%2F%2Freport.pdf",
+        Some("application/pdf"),
+        pdf,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let accepted: serde_json::Value = json_body(response).await;
+    let document_id: openwave_core::DocumentId =
+        accepted["document_id"].as_str().unwrap().parse().unwrap();
+
+    run_parse_and_index(&worker).await;
+
+    let ready = store.get_document(document_id).await.unwrap().unwrap();
+    assert_eq!(
+        ready.processing_status,
+        openwave_core::DocumentProcessingStatus::Ready
+    );
+    assert!(
+        ready.canonical_text.contains("liteparse ingest report"),
+        "expected the PDF's extracted text as canonical text, got: {:?}",
+        ready.canonical_text
+    );
+}
+
 #[tokio::test]
 async fn raw_ingest_enforces_media_type_body_and_project_scope() {
     let (router, token, store, _dir) = test_app().await;


### PR DESCRIPTION
Adds an end-to-end server test proving PDF documents flow through the real pipeline (follow-up to #295/#296/#297).

Posts a real PDF to the raw ingest route, drives the document worker, and asserts the document reaches `Ready` with the liteparse-extracted text as its canonical text. This exercises the **actual** pipeline — the parser registry (with the liteparse PDF parser), the durable parse + index jobs, chunking, embedding, and storage — proving PDFs ingest and become searchable, not just that the parser works in isolation.

Gated on `parse-liteparse` so a lean text-only build still compiles and passes. Full server suite: **264/264**.