### PR TITLE
Accept any document media type via a fallback parser

### DIFF
--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -101,7 +101,7 @@ pub use liteparse_parser::LiteParsePdfParser;
 #[cfg(feature = "embed-openai")]
 pub use openai_embed::OpenAiEmbedder;
 pub use openwave_core::{DocumentGeneration, ProjectId};
-pub use parse::{DocumentParser, ParsedDocument, ParserRegistry, PlainTextParser};
+pub use parse::{DocumentParser, FallbackParser, ParsedDocument, ParserRegistry, PlainTextParser};
 pub use rerank::Reranker;
 pub use retriever::{GenerationIndexOutcome, IngestOutcome, Retriever};
 #[cfg(feature = "tool")]

--- a/crates/openwave-retrieval/src/parse.rs
+++ b/crates/openwave-retrieval/src/parse.rs
@@ -167,6 +167,49 @@ impl DocumentParser for PlainTextParser {
     }
 }
 
+/// A last-resort parser that accepts **any** media type so no upload is rejected
+/// for its format alone.
+///
+/// Register it after the specific parsers ([`PlainTextParser`], a PDF parser,
+/// …): a document only reaches this fallback when nothing narrower claimed it.
+/// Bytes that decode as valid UTF-8 become canonical text and are indexed —
+/// text-like uploads with an unknown media type (`.log`, `.yaml`, `.ndjson`, a
+/// bare `application/octet-stream`) stay searchable. Bytes that are not valid
+/// UTF-8 are treated as binary: the document is still stored and listed, but its
+/// canonical text is empty, so it produces no chunks and never pollutes search
+/// with decoded noise. This mirrors "import anything, index what we can" — the
+/// document remains available to work with even when it is not searchable.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FallbackParser;
+
+impl FallbackParser {
+    /// Construct the parser.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl DocumentParser for FallbackParser {
+    fn fingerprint_for(&self, _media_type: &str) -> Option<String> {
+        Some("fallback:utf8-else-empty:v1".to_string())
+    }
+
+    fn supports(&self, _media_type: &str) -> bool {
+        true
+    }
+
+    async fn parse(&self, raw: &[u8], _media_type: &str) -> Result<ParsedDocument> {
+        // Index only genuinely textual bytes; binary content is retained but not
+        // decoded into the search index.
+        let text = std::str::from_utf8(raw)
+            .map(str::to_owned)
+            .unwrap_or_default();
+        Ok(ParsedDocument::from_text(text))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -355,5 +398,61 @@ mod tests {
     async fn rejects_unsupported_media_type() {
         let p = PlainTextParser::new();
         assert!(p.parse(b"%PDF-1.7", "application/pdf").await.is_err());
+    }
+
+    #[test]
+    fn fallback_supports_and_fingerprints_every_media_type() {
+        let p = FallbackParser::new();
+        for media in [
+            "application/octet-stream",
+            "image/png",
+            "",
+            "application/x-thing",
+        ] {
+            assert!(p.supports(media));
+            assert_eq!(
+                p.fingerprint_for(media).as_deref(),
+                Some("fallback:utf8-else-empty:v1")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn fallback_indexes_utf8_but_stores_binary_as_empty() {
+        let p = FallbackParser::new();
+        // A text-like file with an unknown media type stays searchable.
+        let text = p
+            .parse(b"level=info msg=\"started\"", "application/octet-stream")
+            .await
+            .unwrap();
+        assert_eq!(text.text, "level=info msg=\"started\"");
+        // Binary bytes are retained but not decoded into canonical text.
+        let binary = p
+            .parse(&[0x00, 0xFF, 0x89, 0x50], "application/octet-stream")
+            .await
+            .unwrap();
+        assert!(binary.text.is_empty());
+    }
+
+    #[tokio::test]
+    async fn registry_with_fallback_accepts_any_media_type() {
+        let registry = ParserRegistry::new()
+            .with_parser(PlainTextParser::new())
+            .with_parser(FallbackParser::new());
+        // Specific parser still wins for text/*.
+        assert_eq!(
+            registry.fingerprint_for("text/plain").as_deref(),
+            Some("plain-text-lossy-v1")
+        );
+        // Nothing is unsupported once the fallback is present.
+        assert!(registry.supports("application/vnd.custom"));
+        assert_eq!(
+            registry
+                .parse(b"hello", "application/x-unknown")
+                .await
+                .unwrap()
+                .text,
+            "hello"
+        );
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -58,8 +58,8 @@ use openwave_core::{
     ToolRegistry, WriteFile,
 };
 use openwave_retrieval::{
-    Embedder, HashEmbedder, LanceVectorStore, OpenAiEmbedder, ParserRegistry, PlainTextParser,
-    Retriever, SearchTool, TextChunker, VectorStore,
+    Embedder, FallbackParser, HashEmbedder, LanceVectorStore, OpenAiEmbedder, ParserRegistry,
+    PlainTextParser, Retriever, SearchTool, TextChunker, VectorStore,
 };
 
 use resolver::KeyedResolver;
@@ -634,14 +634,18 @@ fn build_retrieval(
     (retrieval, search)
 }
 
-/// Assemble the document parsers. `PlainTextParser` is the always-on fallback
-/// for `text/*`; with the `parse-liteparse` feature, the narrow PDF parser is
-/// registered ahead of it so `application/pdf` ingests as extracted Markdown.
+/// Assemble the document parsers, narrowest first. With the `parse-liteparse`
+/// feature, the PDF parser claims `application/pdf`; `PlainTextParser` claims
+/// `text/*`; the `FallbackParser` claims everything else so **any** upload is
+/// accepted — text-like unknown types stay searchable and binary ones are
+/// stored without polluting the index.
 fn document_parser_registry() -> ParserRegistry {
     let registry = ParserRegistry::new();
     #[cfg(feature = "parse-liteparse")]
     let registry = registry.with_parser(openwave_retrieval::LiteParsePdfParser::new());
-    registry.with_parser(PlainTextParser::new())
+    registry
+        .with_parser(PlainTextParser::new())
+        .with_parser(FallbackParser::new())
 }
 
 /// Open the persistent vector store for this launch: a LanceDB dataset under

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -4418,16 +4418,6 @@ async fn raw_ingest_enforces_media_type_body_and_project_scope() {
     .await;
     assert_eq!(empty.status(), StatusCode::BAD_REQUEST);
 
-    let unsupported = post_raw(
-        &router,
-        &bearer,
-        "/documents/raw",
-        Some("application/octet-stream"),
-        b"binary".to_vec(),
-    )
-    .await;
-    assert_eq!(unsupported.status(), StatusCode::BAD_REQUEST);
-
     let project = make_project(&router, &bearer).await;
     let response = post_raw(
         &router,
@@ -5895,22 +5885,63 @@ async fn ingest_rejects_empty_content_and_search_rejects_empty_query() {
 }
 
 #[tokio::test]
-async fn ingest_rejects_unsupported_media_type() {
-    let (router, token, _store, _dir) = test_app().await;
+async fn ingest_accepts_any_media_type_via_the_fallback_parser() {
+    let (router, token, store, _dir, worker) = test_app_with_worker().await;
     let bearer = format!("Bearer {token}");
-    let response = post_json(
+
+    // A text-like body with an unrecognized media type is accepted and stays
+    // searchable: the fallback parser decodes valid UTF-8 into canonical text.
+    let textual = post_raw(
         &router,
         &bearer,
-        "/documents",
-        // `image/png` is handled by no registered parser in any feature config
-        // (unlike `application/pdf`, which the liteparse parser claims).
-        serde_json::json!({ "content": "\u{89}PNG", "media_type": "image/png" }),
+        "/documents/raw?uri=file%3A%2F%2F%2Fnotes.log",
+        Some("application/octet-stream"),
+        b"level=info service started ok".to_vec(),
     )
     .await;
-    // A parser that can't handle the media type is the caller's problem: 400.
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    let info: AgentErrorInfo = json_body(response).await;
-    assert_eq!(info.kind, "bad_request");
+    assert_eq!(textual.status(), StatusCode::ACCEPTED);
+    let textual_id: openwave_core::DocumentId = json_body::<serde_json::Value>(textual).await
+        ["document_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+
+    // Binary bytes are accepted too, but retained without decoded canonical text
+    // so they never pollute the search index.
+    let binary = post_raw(
+        &router,
+        &bearer,
+        "/documents/raw?uri=file%3A%2F%2F%2Fimage.png",
+        Some("image/png"),
+        vec![0x89, 0x50, 0x4E, 0x47, 0x00, 0xFF],
+    )
+    .await;
+    assert_eq!(binary.status(), StatusCode::ACCEPTED);
+    let binary_id: openwave_core::DocumentId = json_body::<serde_json::Value>(binary).await
+        ["document_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+
+    // Two documents ⇒ two parse jobs and two index jobs.
+    run_parse_and_index(&worker).await;
+    run_parse_and_index(&worker).await;
+
+    let textual_doc = store.get_document(textual_id).await.unwrap().unwrap();
+    assert_eq!(
+        textual_doc.processing_status,
+        openwave_core::DocumentProcessingStatus::Ready
+    );
+    assert_eq!(textual_doc.canonical_text, "level=info service started ok");
+
+    let binary_doc = store.get_document(binary_id).await.unwrap().unwrap();
+    assert_eq!(
+        binary_doc.processing_status,
+        openwave_core::DocumentProcessingStatus::Ready
+    );
+    assert!(binary_doc.canonical_text.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Aligns document ingest with Brightwave's **"import anything, index what we can"** model — no upload is rejected for its format alone (part 1 of 2; the desktop picker widening follows).

### Before
The server hard-rejected any media type no registered parser claimed (`canonical_fingerprint_for` → 400), so only `text/*` and (with the feature) `application/pdf` could be imported at all.

### Now
`FallbackParser` (in openwave-retrieval) claims **any** media type as a last resort, registered after the PDF and `text/*` parsers so specific parsers still win:
- **valid UTF-8** bytes → canonical text → **indexed/searchable** (text-like unknowns like `.log`, `.yaml`, `.ndjson`, or a bare `application/octet-stream` stay useful).
- **non-UTF-8** bytes → treated as binary → document is **stored and listed** but its canonical text is empty, so it produces no chunks and never pollutes search with decoded noise ("worked with in other ways").

### Tests
Replaced the obsolete "unsupported type is rejected" tests with unit coverage of the fallback + an end-to-end server test: a text-like and a binary upload are both accepted, reach `Ready`, and index their content vs. nothing respectively. Workspace `clippy -D warnings`, fmt, and full server suite (**264/264**) all pass locally.

### Follow-up
PR 2 widens the desktop file picker to accept any file (fixes the picker graying out non-txt/md/pdf types) and maps unknown extensions to a media type instead of erroring.