### PR TITLE
Pin all direct dependencies to exact versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,22 +16,22 @@ all = { level = "warn", priority = -1 }
 # Shared dependency versions. Crates opt in with `dep.workspace = true` so the
 # whole workspace resolves one version of each.
 [workspace.dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-async-trait = "0.1"
-cap-std = "4.0.2"
-cap-fs-ext = "4.0.2"
-futures = "0.3"
-futures-timer = "3"
-thiserror = "2"
-uuid = { version = "1", features = ["v4", "serde"] }
-unicode-general-category = "1.1.0"
-chrono = { version = "0.4", features = ["serde"] }
-windows-sys = "0.61"
-sea-orm = { version = "2", default-features = false, features = ["macros", "runtime-tokio-rustls", "with-uuid", "with-chrono", "with-json"] }
-sea-orm-migration = { version = "2", default-features = false, features = ["runtime-tokio-rustls"] }
-tokio = { version = "1", features = ["rt", "macros", "fs"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
-sha2 = "0.11"
-async-stream = "0.3"
-axum = { version = "0.8", features = ["ws"] }
+serde = { version = "=1.0.228", features = ["derive"] }
+serde_json = "=1.0.151"
+async-trait = "=0.1.91"
+cap-std = "=4.0.2"
+cap-fs-ext = "=4.0.2"
+futures = "=0.3.32"
+futures-timer = "=3.0.4"
+thiserror = "=2.0.19"
+uuid = { version = "=1.24.0", features = ["v4", "serde"] }
+unicode-general-category = "=1.1.0"
+chrono = { version = "=0.4.45", features = ["serde"] }
+windows-sys = "=0.61.2"
+sea-orm = { version = "=2.0.0", default-features = false, features = ["macros", "runtime-tokio-rustls", "with-uuid", "with-chrono", "with-json"] }
+sea-orm-migration = { version = "=2.0.0", default-features = false, features = ["runtime-tokio-rustls"] }
+tokio = { version = "=1.53.1", features = ["rt", "macros", "fs"] }
+reqwest = { version = "=0.12.28", default-features = false, features = ["json", "stream", "rustls-tls"] }
+sha2 = "=0.11.0"
+async-stream = "=0.3.6"
+axum = { version = "=0.8.9", features = ["ws"] }

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -26,4 +26,4 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 serde_json = { workspace = true }
-tempfile = "3"
+tempfile = "=3.27.0"

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -55,13 +55,13 @@ tokio = { workspace = true, optional = true }
 # async-secret-service (pure-Rust zbus + rustcrypto) — no system libdbus/pkg-config
 # at build time; the blocking `keyring` calls already run under `spawn_blocking`.
 [target.'cfg(target_os = "macos")'.dependencies]
-keyring = { version = "3", features = ["apple-native"], optional = true }
+keyring = { version = "=3.6.3", features = ["apple-native"], optional = true }
 [target.'cfg(target_os = "windows")'.dependencies]
-keyring = { version = "3", features = ["windows-native"], optional = true }
-windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"], optional = true }
+keyring = { version = "=3.6.3", features = ["windows-native"], optional = true }
+windows-sys = { version = "=0.61.2", features = ["Win32_Storage_FileSystem"], optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
-keyring = { version = "3", features = ["async-secret-service", "crypto-rust", "tokio"], optional = true }
+keyring = { version = "=3.6.3", features = ["async-secret-service", "crypto-rust", "tokio"], optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
-tempfile = "3"
+tempfile = "=3.27.0"

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -19,7 +19,7 @@ name = "openwave-desktop"
 path = "src/main.rs"
 
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "=2.6.3", features = [] }
 serde_json = { workspace = true }
 
 [dependencies]
@@ -30,9 +30,9 @@ openwave-core = { path = "../openwave-core", default-features = false }
 openwave-host-broker = { path = "../openwave-host-broker" }
 openwave-server = { path = "../openwave-server" }
 reqwest = { workspace = true }
-tauri = { version = "2", features = [] }
-tauri-plugin-dialog = "2"
-tauri-plugin-shell = "2"
+tauri = { version = "=2.11.5", features = [] }
+tauri-plugin-dialog = "=2.7.2"
+tauri-plugin-shell = "=2.3.5"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -42,10 +42,10 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 chrono = { workspace = true }
-tempfile = "3"
+tempfile = "=3.27.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux", windows))'.dependencies]
-tauri-plugin-single-instance = "2"
+tauri-plugin-single-instance = "=2.4.3"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }

--- a/crates/openwave-desktop/ui/.npmrc
+++ b/crates/openwave-desktop/ui/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -13,29 +13,29 @@
     "tauri": "cargo tauri"
   },
   "dependencies": {
-    "@radix-ui/react-alert-dialog": "^1.1.20",
-    "@radix-ui/react-dropdown-menu": "^2.1.21",
-    "@radix-ui/react-slot": "^1.3.0",
-    "@radix-ui/react-tooltip": "^1.2.13",
-    "@tauri-apps/api": "^2",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "lucide-react": "^1.25.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1",
-    "tailwind-merge": "^3.6.0",
-    "tailwindcss-animate": "^1.0.7"
+    "@radix-ui/react-alert-dialog": "1.1.20",
+    "@radix-ui/react-dropdown-menu": "2.1.21",
+    "@radix-ui/react-slot": "1.3.0",
+    "@radix-ui/react-tooltip": "1.2.13",
+    "@tauri-apps/api": "2.11.1",
+    "class-variance-authority": "0.7.1",
+    "clsx": "2.1.1",
+    "lucide-react": "1.25.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "react-markdown": "10.1.0",
+    "remark-gfm": "4.0.1",
+    "tailwind-merge": "3.6.0",
+    "tailwindcss-animate": "1.0.7"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.3.3",
-    "@types/react": "^19.1.8",
-    "@types/react-dom": "^19.1.6",
-    "@vitejs/plugin-react": "^4.6.0",
-    "tailwindcss": "^4.3.3",
-    "typescript": "~5.8.3",
-    "vite": "^7.0.4",
-    "vitest": "^3.2.7"
+    "@tailwindcss/vite": "4.3.3",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "4.7.0",
+    "tailwindcss": "4.3.3",
+    "typescript": "5.8.3",
+    "vite": "7.3.6",
+    "vitest": "3.2.7"
   }
 }

--- a/crates/openwave-desktop/ui/pnpm-lock.yaml
+++ b/crates/openwave-desktop/ui/pnpm-lock.yaml
@@ -9,71 +9,71 @@ importers:
   .:
     dependencies:
       '@radix-ui/react-alert-dialog':
-        specifier: ^1.1.20
+        specifier: 1.1.20
         version: 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dropdown-menu':
-        specifier: ^2.1.21
+        specifier: 2.1.21
         version: 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot':
-        specifier: ^1.3.0
+        specifier: 1.3.0
         version: 1.3.0(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-tooltip':
-        specifier: ^1.2.13
+        specifier: 1.2.13
         version: 1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tauri-apps/api':
-        specifier: ^2
+        specifier: 2.11.1
         version: 2.11.1
       class-variance-authority:
-        specifier: ^0.7.1
+        specifier: 0.7.1
         version: 0.7.1
       clsx:
-        specifier: ^2.1.1
+        specifier: 2.1.1
         version: 2.1.1
       lucide-react:
-        specifier: ^1.25.0
+        specifier: 1.25.0
         version: 1.25.0(react@19.2.7)
       react:
-        specifier: ^19.1.0
+        specifier: 19.2.7
         version: 19.2.7
       react-dom:
-        specifier: ^19.1.0
+        specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
       react-markdown:
-        specifier: ^10.1.0
+        specifier: 10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       remark-gfm:
-        specifier: ^4.0.1
+        specifier: 4.0.1
         version: 4.0.1
       tailwind-merge:
-        specifier: ^3.6.0
+        specifier: 3.6.0
         version: 3.6.0
       tailwindcss-animate:
-        specifier: ^1.0.7
+        specifier: 1.0.7
         version: 1.0.7(tailwindcss@4.3.3)
     devDependencies:
       '@tailwindcss/vite':
-        specifier: ^4.3.3
+        specifier: 4.3.3
         version: 4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
       '@types/react':
-        specifier: ^19.1.8
+        specifier: 19.2.17
         version: 19.2.17
       '@types/react-dom':
-        specifier: ^19.1.6
+        specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
-        specifier: ^4.6.0
+        specifier: 4.7.0
         version: 4.7.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
       tailwindcss:
-        specifier: ^4.3.3
+        specifier: 4.3.3
         version: 4.3.3
       typescript:
-        specifier: ~5.8.3
+        specifier: 5.8.3
         version: 5.8.3
       vite:
-        specifier: ^7.0.4
+        specifier: 7.3.6
         version: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
       vitest:
-        specifier: ^3.2.7
+        specifier: 3.2.7
         version: 3.2.7(@types/debug@4.1.13)(jiti@2.7.0)(lightningcss@1.32.0)
 
 packages:

--- a/crates/openwave-host-broker/Cargo.toml
+++ b/crates/openwave-host-broker/Cargo.toml
@@ -25,7 +25,7 @@ uuid.workspace = true
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = "=3.27.0"
 
 [lints]
 workspace = true

--- a/crates/openwave-retrieval/Cargo.toml
+++ b/crates/openwave-retrieval/Cargo.toml
@@ -50,20 +50,20 @@ reqwest = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 # The LanceDB vector backend (vec-lance feature only). arrow-array/-schema are
 # pinned to the exact major LanceDB uses (58) so RecordBatch types are compatible.
-lancedb = { version = "0.31", optional = true }
-arrow-array = { version = "58", optional = true }
-arrow-schema = { version = "58", optional = true }
-arrow-select = { version = "58", optional = true }
+lancedb = { version = "=0.31.0", optional = true }
+arrow-array = { version = "=58.3.0", optional = true }
+arrow-schema = { version = "=58.3.0", optional = true }
+arrow-select = { version = "=58.3.0", optional = true }
 futures = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync"], optional = true }
 # Rich PDF parser (parse-liteparse feature only). Local + PDFium-backed; OCR off.
-liteparse = { version = "2.8", default-features = false, optional = true }
+liteparse = { version = "=2.8.0", default-features = false, optional = true }
 # The PDFium loader liteparse builds on. Depended on directly (pinned to the same
 # version liteparse resolves, so cargo unifies the one runtime binding) only to
 # probe `load_default()` and fail closed with a clear error instead of the panic
 # liteparse raises when the PDFium library is absent.
-liteparse-pdfium-sys = { version = "1.3", optional = true }
+liteparse-pdfium-sys = { version = "=1.3.0", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-tempfile = "3"
+tempfile = "=3.27.0"

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -25,7 +25,7 @@ openwave-retrieval = { path = "../openwave-retrieval", features = ["vec-lance"] 
 openwave-web-search = { path = "../openwave-web-search", features = ["http"] }
 axum = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "sync", "macros", "time"] }
-tower-http = { version = "0.7", features = ["cors"] }
+tower-http = { version = "=0.7.0", features = ["cors"] }
 futures = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
@@ -41,7 +41,7 @@ windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
-tower = { version = "0.5", features = ["util"] }
+tower = { version = "=0.5.3", features = ["util"] }
 reqwest = { workspace = true }
-tokio-tungstenite = "0.30"
-tempfile = "3"
+tokio-tungstenite = "=0.30.0"
+tempfile = "=3.27.0"

--- a/crates/openwave-web-search/Cargo.toml
+++ b/crates/openwave-web-search/Cargo.toml
@@ -23,7 +23,7 @@ openwave-core = { path = "../openwave-core", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-url = "2"
+url = "=2.5.8"
 reqwest = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 


### PR DESCRIPTION
Replaces the caret/range version requirements on every direct dependency with exact pins matching what the lockfiles already resolve, so `cargo update` / `pnpm update` can't drift a dependency without an explicit change. Dependabot still proposes bumps (it edits the pin).

### Cargo
- Every `[workspace.dependencies]` entry and per-crate dependency version is pinned to `=x.y.z` (the exact resolved version). For crates present at multiple versions in the lock (e.g. `windows-sys`, `thiserror`, `reqwest`, `arrow-*`, `tower-http`, `tokio-tungstenite`) the pin is the one our requirement actually selected.
- **Cargo.lock is unchanged** and `cargo check --workspace --locked` passes — proof the pins equal the resolved graph, so nothing moved.

### npm (desktop UI)
- `package.json` deps pinned to exact versions; `.npmrc` adds `save-exact=true` so future `pnpm add` stays pinned.
- The `pnpm-lock.yaml` diff is **specifier-only** (0 `version:` changes, 44 `specifier:` lines) — no dependency version changed. `tsc`, vitest (146/146), and the production build all pass.

No behavior change: the exact same versions are used; the requirements are just stricter.