### PR TITLE
Desktop: move settings into a full-page view

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ApiClient,
   type AgentRun,
@@ -6,12 +6,8 @@ import {
   type ModelInfo,
   type PendingFolderAccessRequest,
   type ProviderInfo,
-  type ProviderKind,
   type SequencedEvent,
   type ServerInfo,
-  type WebSearchConfigInfo,
-  type WebSearchCredentialReadiness,
-  type WebSearchProviderKind,
 } from "./api";
 import { resolveServerInfo } from "./boot";
 import {
@@ -28,10 +24,8 @@ import { Composer } from "./Composer";
 import { MessageList, type ChatMessage } from "./MessageList";
 import {
   ArrowDown,
-  Bot,
   Ellipsis,
   FolderOpen,
-  Globe,
   LibraryBig,
   Monitor,
   Moon,
@@ -42,6 +36,9 @@ import {
   Trash2,
 } from "lucide-react";
 import { useTheme } from "./theme";
+import { SettingsView } from "./SettingsView";
+import { ModelMenu } from "./ModelMenu";
+import { SettingsError, SettingsPanel } from "./settings/primitives";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -83,7 +80,6 @@ import {
 import { prependReplacementChat } from "./ChatDeletion";
 import { useConfirm } from "./components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 
 type Msg = ChatMessage;
 
@@ -142,10 +138,10 @@ export default function App() {
   const [renamingChatId, setRenamingChatId] = useState<string | null>(null);
   const [renameChatDraft, setRenameChatDraft] = useState("");
   const skipRenameCommitRef = useRef(false);
-  const [settingsPanel, setSettingsPanel] = useState<
-    "providers" | "web-search" | "folders" | "model" | null
-  >(null);
-  const [primaryView, setPrimaryView] = useState<"chat" | "documents">("chat");
+  const [settingsPanel, setSettingsPanel] = useState<"folders" | null>(null);
+  const [primaryView, setPrimaryView] = useState<
+    "chat" | "documents" | "settings"
+  >("chat");
   const [status, setStatus] = useState("starting…");
   const [hasUnreadActivity, setHasUnreadActivity] = useState(false);
   const socketRef = useRef<WebSocket | null>(null);
@@ -174,7 +170,7 @@ export default function App() {
   const creationInFlightRef = useRef(false);
   const deletionInFlightRef = useRef(false);
   const { confirm, dialog: confirmDialog } = useConfirm();
-  const { mode: themeMode, cycle: cycleTheme } = useTheme();
+  const { mode: themeMode, cycle: cycleTheme, setMode: setThemeMode } = useTheme();
 
   useEffect(() => {
     let cancelled = false;
@@ -1096,7 +1092,7 @@ export default function App() {
     }
   }
 
-  async function onModelChange(modelId: string) {
+  async function onModelChange(modelId: string | null) {
     if (!client || !chat || deletionInFlightRef.current) return;
     const chatId = chat.id;
     const selection = chatSelectionRef.current;
@@ -1358,7 +1354,7 @@ export default function App() {
           {hasNativeHost() && (
             <button
               type="button"
-              className={`sidebar-action${settingsPanel === "folders" ? " is-active" : ""}`}
+              className={`sidebar-action${primaryView === "chat" && settingsPanel === "folders" ? " is-active" : ""}`}
               onClick={() => {
                 setPrimaryView("chat");
                 setSettingsPanel((panel) =>
@@ -1372,42 +1368,14 @@ export default function App() {
           )}
           <button
             type="button"
-            className={`sidebar-action${settingsPanel === "model" ? " is-active" : ""}`}
+            className={`sidebar-action${primaryView === "settings" ? " is-active" : ""}`}
             onClick={() => {
-              setPrimaryView("chat");
-              setSettingsPanel((panel) =>
-                panel === "model" ? null : "model",
-              );
-            }}
-          >
-            <Bot size={16} />
-            Model
-          </button>
-          <button
-            type="button"
-            className={`sidebar-action${settingsPanel === "providers" ? " is-active" : ""}`}
-            onClick={() => {
-              setPrimaryView("chat");
-              setSettingsPanel((panel) =>
-                panel === "providers" ? null : "providers",
-              );
+              setSettingsPanel(null);
+              setPrimaryView("settings");
             }}
           >
             <Settings size={16} />
-            Providers
-          </button>
-          <button
-            type="button"
-            className={`sidebar-action${settingsPanel === "web-search" ? " is-active" : ""}`}
-            onClick={() => {
-              setPrimaryView("chat");
-              setSettingsPanel((panel) =>
-                panel === "web-search" ? null : "web-search",
-              );
-            }}
-          >
-            <Globe size={16} />
-            Web search
+            Settings
           </button>
         </div>
       </aside>
@@ -1417,6 +1385,16 @@ export default function App() {
       >
         {primaryView === "documents" ? (
           <DocumentsView chatId={chat.id} onBack={() => setPrimaryView("chat")} />
+        ) : primaryView === "settings" ? (
+          <SettingsView
+            client={client}
+            models={models}
+            providers={providers}
+            onProvidersChanged={() => void refreshCatalog()}
+            onBack={() => setPrimaryView("chat")}
+            themeMode={themeMode}
+            onThemeChange={setThemeMode}
+          />
         ) : (
           <>
         <section className="chat-pane">
@@ -1442,6 +1420,7 @@ export default function App() {
                   <button
                     type="button"
                     className={`btn${settingsPanel === "folders" ? " is-active" : ""}`}
+                    aria-label="Folders"
                     onClick={() =>
                       setSettingsPanel((panel) =>
                         panel === "folders" ? null : "folders",
@@ -1453,36 +1432,14 @@ export default function App() {
                 )}
                 <button
                   type="button"
-                  className={`btn${settingsPanel === "model" ? " is-active" : ""}`}
-                  onClick={() =>
-                    setSettingsPanel((panel) =>
-                      panel === "model" ? null : "model",
-                    )
-                  }
-                >
-                  <Bot size={14} />
-                </button>
-                <button
-                  type="button"
-                  className={`btn${settingsPanel === "providers" ? " is-active" : ""}`}
-                  onClick={() =>
-                    setSettingsPanel((panel) =>
-                      panel === "providers" ? null : "providers",
-                    )
-                  }
+                  className="btn"
+                  aria-label="Settings"
+                  onClick={() => {
+                    setSettingsPanel(null);
+                    setPrimaryView("settings");
+                  }}
                 >
                   <Settings size={14} />
-                </button>
-                <button
-                  type="button"
-                  className={`btn${settingsPanel === "web-search" ? " is-active" : ""}`}
-                  onClick={() =>
-                    setSettingsPanel((panel) =>
-                      panel === "web-search" ? null : "web-search",
-                    )
-                  }
-                >
-                  <Globe size={14} />
                 </button>
               </div>
               <span className="status" title={status}>
@@ -1552,6 +1509,14 @@ export default function App() {
             }
             disabled={deletingChatId !== null}
             draft={draft}
+            modelMenu={
+              <ModelMenu
+                models={models}
+                value={chat.model}
+                disabled={deletingChatId !== null}
+                onChange={onModelChange}
+              />
+            }
             onDraftChange={onComposerDraftChange}
             onSend={onSend}
             onSteer={onSteerActiveTurn}
@@ -1565,23 +1530,11 @@ export default function App() {
           />
         </section>
 
-        {settingsPanel === "model" && (
-          <ModelPanel
-            chat={chat}
-            models={models}
-            disabled={deletingChatId !== null}
-            onModelChange={onModelChange}
-          />
+        {settingsPanel === "folders" && (
+          <aside className="settings">
+            <FoldersPanel chat={chat} />
+          </aside>
         )}
-        {settingsPanel === "providers" && (
-          <ProvidersPanel
-            providers={providers}
-            client={client}
-            onChanged={() => void refreshCatalog()}
-          />
-        )}
-        {settingsPanel === "web-search" && <WebSearchPanel client={client} />}
-        {settingsPanel === "folders" && <FoldersPanel chat={chat} />}
           </>
         )}
       </div>
@@ -1667,76 +1620,6 @@ function discardToolCalls(messages: Msg[], callIds: Set<string>): Msg[] {
 
 function withoutConnectionState(status: string): string {
   return status.replace(/ · (?:live|reconnecting)$/, "");
-}
-
-const SETTINGS_SELECT_CLASS =
-  "flex h-10 w-full rounded-md border border-border bg-background px-3 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
-
-function SettingsPanel({
-  title,
-  description,
-  busy,
-  children,
-}: {
-  title: string;
-  description?: string;
-  busy?: boolean;
-  children: ReactNode;
-}) {
-  return (
-    <aside className="settings" aria-busy={busy}>
-      <div className="flex flex-col gap-1">
-        <h2 className="text-base font-semibold tracking-tight">{title}</h2>
-        {description && (
-          <p className="text-sm text-muted-foreground">{description}</p>
-        )}
-      </div>
-      {children}
-    </aside>
-  );
-}
-
-function SettingsField({
-  label,
-  hint,
-  children,
-}: {
-  label: string;
-  hint?: ReactNode;
-  children: ReactNode;
-}) {
-  return (
-    <label className="flex flex-col gap-1.5">
-      <span className="text-sm font-medium">{label}</span>
-      {children}
-      {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
-    </label>
-  );
-}
-
-function SettingsSection({
-  title,
-  children,
-}: {
-  title?: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="flex flex-col gap-3 rounded-lg border border-border p-4">
-      {title && (
-        <h3 className="text-sm font-semibold capitalize">{title}</h3>
-      )}
-      {children}
-    </section>
-  );
-}
-
-function SettingsError({ children }: { children: ReactNode }) {
-  return (
-    <p className="text-sm text-destructive" role="alert">
-      {children}
-    </p>
-  );
 }
 
 function FoldersPanel({ chat }: { chat: Chat }) {
@@ -1829,469 +1712,5 @@ function FoldersPanel({ chat }: { chat: Chat }) {
       </div>
       {error && <SettingsError>{error}</SettingsError>}
     </SettingsPanel>
-  );
-}
-
-const MIN_WEB_SEARCH_TIMEOUT_MS = 1_000;
-const MAX_WEB_SEARCH_TIMEOUT_MS = 60_000;
-
-function WebSearchPanel({ client }: { client: ApiClient }) {
-  const [config, setConfig] = useState<WebSearchConfigInfo | null>(null);
-  const [credentials, setCredentials] = useState<WebSearchCredentialReadiness[]>([]);
-  const [provider, setProvider] = useState<WebSearchProviderKind | "">("");
-  const [timeoutMs, setTimeoutMs] = useState("");
-  const [apiKey, setApiKey] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [savingConfig, setSavingConfig] = useState(false);
-  const [savingCredential, setSavingCredential] = useState(false);
-  const [removingCredential, setRemovingCredential] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  async function refresh() {
-    const [nextConfig, nextCredentials] = await Promise.all([
-      client.getWebSearchConfig(),
-      client.listWebSearchCredentials(),
-    ]);
-    setConfig(nextConfig);
-    setCredentials(nextCredentials.credentials);
-    setProvider(nextConfig.provider ?? "");
-    setTimeoutMs(String(nextConfig.timeout_ms));
-  }
-
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    void (async () => {
-      try {
-        const [nextConfig, nextCredentials] = await Promise.all([
-          client.getWebSearchConfig(),
-          client.listWebSearchCredentials(),
-        ]);
-        if (cancelled) return;
-        setConfig(nextConfig);
-        setCredentials(nextCredentials.credentials);
-        setProvider(nextConfig.provider ?? "");
-        setTimeoutMs(String(nextConfig.timeout_ms));
-      } catch (err) {
-        if (!cancelled) setError(String(err));
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [client]);
-
-  const activeProvider = config?.provider;
-  const selectedCredential = activeProvider
-    ? credentials.find((credential) => credential.provider === activeProvider)
-    : undefined;
-  const selectedHasCredential = selectedCredential?.has_credential ?? false;
-  const working = savingConfig || savingCredential || removingCredential;
-  const state = webSearchState(config);
-
-  async function saveConfig() {
-    const parsedTimeout = Number(timeoutMs);
-    if (
-      !Number.isInteger(parsedTimeout) ||
-      parsedTimeout < MIN_WEB_SEARCH_TIMEOUT_MS ||
-      parsedTimeout > MAX_WEB_SEARCH_TIMEOUT_MS
-    ) {
-      setError(
-        `Timeout must be a whole number between ${MIN_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} and ${MAX_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} ms.`,
-      );
-      return;
-    }
-
-    setSavingConfig(true);
-    setError(null);
-    try {
-      const nextConfig = await client.putWebSearchConfig({
-        provider: provider || null,
-        timeout_ms: parsedTimeout,
-      });
-      setConfig(nextConfig);
-      setTimeoutMs(String(nextConfig.timeout_ms));
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setSavingConfig(false);
-    }
-  }
-
-  async function saveCredential() {
-    if (!activeProvider || !apiKey.trim()) return;
-    setSavingCredential(true);
-    setError(null);
-    try {
-      await client.putWebSearchCredential(activeProvider, apiKey.trim());
-      setApiKey("");
-      await refresh();
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setSavingCredential(false);
-    }
-  }
-
-  async function removeCredential() {
-    if (!activeProvider) return;
-    setRemovingCredential(true);
-    setError(null);
-    try {
-      await client.deleteWebSearchCredential(activeProvider);
-      await refresh();
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setRemovingCredential(false);
-    }
-  }
-
-  return (
-    <SettingsPanel
-      title="Web search"
-      description="Choose a local provider and a bounded request timeout. Existing keys are never shown here."
-      busy={loading}
-    >
-      {loading ? (
-        <p className="text-sm text-muted-foreground">
-          Loading web-search settings…
-        </p>
-      ) : !config ? (
-        <p className="text-sm text-muted-foreground">
-          Web-search settings are unavailable.
-        </p>
-      ) : (
-        <>
-          <div
-            className={`web-search-state is-${state.kind}`}
-            role="status"
-          >
-            <strong>{state.label}</strong>
-            <span>{state.description}</span>
-          </div>
-
-          <SettingsSection>
-            <SettingsField label="Provider">
-              <select
-                className={SETTINGS_SELECT_CLASS}
-                value={provider}
-                disabled={working}
-                onChange={(event) =>
-                  setProvider(event.target.value as WebSearchProviderKind | "")
-                }
-              >
-                <option value="">Disabled</option>
-                <option value="exa">Exa</option>
-                <option value="tavily">Tavily</option>
-              </select>
-            </SettingsField>
-
-            <SettingsField
-              label="Request timeout (ms)"
-              hint={`Between ${MIN_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} and ${MAX_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} ms.`}
-            >
-              <Input
-                type="number"
-                inputMode="numeric"
-                min={MIN_WEB_SEARCH_TIMEOUT_MS}
-                max={MAX_WEB_SEARCH_TIMEOUT_MS}
-                step="1000"
-                value={timeoutMs}
-                disabled={working}
-                onChange={(event) => setTimeoutMs(event.target.value)}
-              />
-            </SettingsField>
-            <Button
-              type="button"
-              className="self-start"
-              disabled={working}
-              onClick={() => void saveConfig()}
-            >
-              {savingConfig ? "Saving…" : "Save configuration"}
-            </Button>
-          </SettingsSection>
-
-          {activeProvider && (
-            <SettingsSection title={`${activeProvider} credential`}>
-              <span className="text-xs text-muted-foreground">
-                {selectedHasCredential
-                  ? "credential saved"
-                  : "no credential saved"}
-              </span>
-              <SettingsField
-                label={selectedHasCredential ? "Replace API key" : "API key"}
-              >
-                <Input
-                  type="password"
-                  placeholder="Paste a new API key"
-                  value={apiKey}
-                  maxLength={8_192}
-                  autoComplete="new-password"
-                  disabled={working}
-                  onChange={(event) => setApiKey(event.target.value)}
-                />
-              </SettingsField>
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  type="button"
-                  disabled={working || !apiKey.trim()}
-                  onClick={() => void saveCredential()}
-                >
-                  {savingCredential
-                    ? "Saving…"
-                    : selectedHasCredential
-                      ? "Update key"
-                      : "Save key"}
-                </Button>
-                {selectedHasCredential && (
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    disabled={working}
-                    onClick={() => void removeCredential()}
-                  >
-                    {removingCredential ? "Removing…" : "Remove saved key"}
-                  </Button>
-                )}
-              </div>
-            </SettingsSection>
-          )}
-
-          {provider !== (activeProvider ?? "") && (
-            <p className="text-xs text-muted-foreground">
-              Save the provider configuration before managing that provider’s
-              key.
-            </p>
-          )}
-
-          <p className="text-sm leading-relaxed text-muted-foreground">
-            This configures host-owned search access only. Search is not yet a
-            chat tool in this build.
-          </p>
-        </>
-      )}
-      {error && <SettingsError>{error}</SettingsError>}
-    </SettingsPanel>
-  );
-}
-
-function webSearchState(config: WebSearchConfigInfo | null): {
-  kind: "disabled" | "ready" | "not-configured";
-  label: string;
-  description: string;
-} {
-  if (!config?.provider) {
-    return {
-      kind: "disabled",
-      label: "Disabled",
-      description: "No web-search provider is selected.",
-    };
-  }
-  if (config.has_credential) {
-    return {
-      kind: "ready",
-      label: "Ready",
-      description: `${config.provider} is selected and has a saved credential.`,
-    };
-  }
-  return {
-    kind: "not-configured",
-    label: "Not configured",
-    description: `${config.provider} is selected but needs an API key.`,
-  };
-}
-
-function ModelPanel({
-  chat,
-  models,
-  disabled,
-  onModelChange,
-}: {
-  chat: Chat;
-  models: ModelInfo[];
-  disabled: boolean;
-  onModelChange: (modelId: string) => Promise<void>;
-}) {
-  return (
-    <SettingsPanel
-      title="Model"
-      description="Choose the model for this chat."
-    >
-      <SettingsField label="Active model">
-        <select
-          className={SETTINGS_SELECT_CLASS}
-          value={chat.model ?? ""}
-          disabled={disabled}
-          onChange={(e) => void onModelChange(e.target.value)}
-        >
-          <option value="">default</option>
-          {models.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.id} ({m.provider})
-            </option>
-          ))}
-          {chat.model && !models.some((m) => m.id === chat.model) && (
-            <option value={chat.model}>{chat.model} (custom)</option>
-          )}
-        </select>
-      </SettingsField>
-      <SettingsField
-        label="Custom model ID"
-        hint="Select from known models above, or type any model ID your provider supports."
-      >
-        <Input
-          type="text"
-          placeholder="e.g. claude-sonnet-4-20250514"
-          defaultValue={
-            chat.model && !models.some((m) => m.id === chat.model)
-              ? chat.model
-              : ""
-          }
-          key={chat.id}
-          onBlur={(e) => {
-            const next = e.target.value.trim();
-            if (next && next !== (chat.model ?? "")) {
-              void onModelChange(next);
-            }
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") e.currentTarget.blur();
-          }}
-        />
-      </SettingsField>
-    </SettingsPanel>
-  );
-}
-
-function ProvidersPanel({
-  providers,
-  client,
-  onChanged,
-}: {
-  providers: ProviderInfo[];
-  client: ApiClient;
-  onChanged: () => void;
-}) {
-  return (
-    <SettingsPanel
-      title="Providers"
-      description="Keys stay on this machine. Enable a provider, then save a credential."
-    >
-      {providers.map((p) => (
-        <ProviderRow key={p.kind} info={p} client={client} onChanged={onChanged} />
-      ))}
-    </SettingsPanel>
-  );
-}
-
-function ProviderRow({
-  info,
-  client,
-  onChanged,
-}: {
-  info: ProviderInfo;
-  client: ApiClient;
-  onChanged: () => void;
-}) {
-  const [key, setKey] = useState("");
-  const [baseUrl, setBaseUrl] = useState(info.base_url ?? "");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  async function save(enabled: boolean) {
-    setSaving(true);
-    setError(null);
-    try {
-      const body: {
-        enabled: boolean;
-        base_url?: string | null;
-        credential?: { type: "api_key"; key: string };
-      } = { enabled };
-      if (info.kind === "openai_compatible") {
-        body.base_url = baseUrl.trim() || null;
-      }
-      if (key.trim()) {
-        body.credential = { type: "api_key", key: key.trim() };
-      }
-      await client.putProvider(info.kind as ProviderKind, body);
-      setKey("");
-      onChanged();
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  async function clearCredential() {
-    setSaving(true);
-    setError(null);
-    try {
-      await client.deleteCredential(info.kind as ProviderKind);
-      onChanged();
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  return (
-    <SettingsSection title={info.kind.replaceAll("_", " ")}>
-      <div className="flex items-center justify-between gap-3">
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            className="size-4 accent-[var(--primary)]"
-            checked={info.enabled}
-            disabled={saving}
-            onChange={(e) => void save(e.target.checked)}
-          />
-          Enabled
-        </label>
-        <span className="text-xs text-muted-foreground">
-          {info.has_credential ? "credential set" : "no credential"}
-        </span>
-      </div>
-      {info.kind === "openai_compatible" && (
-        <Input
-          type="text"
-          placeholder="base URL (e.g. http://127.0.0.1:1234/v1)"
-          value={baseUrl}
-          onChange={(e) => setBaseUrl(e.target.value)}
-        />
-      )}
-      <Input
-        type="password"
-        placeholder="API key"
-        value={key}
-        onChange={(e) => setKey(e.target.value)}
-        autoComplete="off"
-      />
-      <div className="flex flex-wrap gap-2">
-        <Button
-          type="button"
-          disabled={saving || !key.trim()}
-          onClick={() => void save(true)}
-        >
-          Save
-        </Button>
-        {info.has_credential && (
-          <Button
-            type="button"
-            variant="outline"
-            disabled={saving}
-            onClick={() => void clearCredential()}
-          >
-            Clear
-          </Button>
-        )}
-      </div>
-      {error && <SettingsError>{error}</SettingsError>}
-    </SettingsSection>
   );
 }

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -1,6 +1,7 @@
 import {
   type ChangeEvent,
   type KeyboardEvent,
+  type ReactNode,
   useLayoutEffect,
   useRef,
 } from "react";
@@ -78,6 +79,7 @@ export type ComposerProps = {
   cancelPending: boolean;
   disabled: boolean;
   draft: string;
+  modelMenu?: ReactNode;
   onDraftChange: (draft: string) => void;
   onSend: () => Promise<void>;
   onSteer: () => Promise<void>;
@@ -95,6 +97,7 @@ export function Composer({
   cancelPending,
   disabled,
   draft,
+  modelMenu,
   onDraftChange,
   onSend,
   onSteer,
@@ -178,44 +181,47 @@ export function Composer({
           }}
         />
         <div className="composer-actions">
-          {active ? (
-            <>
-              {(hasDraft || steerPending) && (
+          <div className="composer-actions-left">{modelMenu}</div>
+          <div className="composer-actions-right">
+            {active ? (
+              <>
+                {(hasDraft || steerPending) && (
+                  <button
+                    type="submit"
+                    className="btn btn-primary composer-redirect"
+                    aria-label="Redirect active response"
+                    disabled={!canSubmit}
+                  >
+                    {steerPending ? "Sending…" : "Redirect"}
+                  </button>
+                )}
+                <WithTooltip label={cancelPending ? "Stopping…" : "Stop"}>
+                  <button
+                    type="button"
+                    className="composer-icon-btn composer-stop"
+                    aria-label={
+                      cancelPending ? "Stopping response" : "Stop response"
+                    }
+                    disabled={disabled || cancelPending}
+                    onClick={() => void onStop()}
+                  >
+                    <Square size={15} fill="currentColor" strokeWidth={0} />
+                  </button>
+                </WithTooltip>
+              </>
+            ) : (
+              <WithTooltip label="Send · Enter">
                 <button
                   type="submit"
-                  className="btn btn-primary composer-redirect"
-                  aria-label="Redirect active response"
+                  className="composer-icon-btn composer-send"
+                  aria-label="Send message"
                   disabled={!canSubmit}
                 >
-                  {steerPending ? "Sending…" : "Redirect"}
-                </button>
-              )}
-              <WithTooltip label={cancelPending ? "Stopping…" : "Stop"}>
-                <button
-                  type="button"
-                  className="composer-icon-btn composer-stop"
-                  aria-label={
-                    cancelPending ? "Stopping response" : "Stop response"
-                  }
-                  disabled={disabled || cancelPending}
-                  onClick={() => void onStop()}
-                >
-                  <Square size={15} fill="currentColor" strokeWidth={0} />
+                  <ArrowUp size={18} />
                 </button>
               </WithTooltip>
-            </>
-          ) : (
-            <WithTooltip label="Send · Enter">
-              <button
-                type="submit"
-                className="composer-icon-btn composer-send"
-                aria-label="Send message"
-                disabled={!canSubmit}
-              >
-                <ArrowUp size={18} />
-              </button>
-            </WithTooltip>
-          )}
+            )}
+          </div>
         </div>
         <span className="sr-only" role="status">
           {busy ? "Agent is responding" : "Ready to send"}

--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -1,0 +1,42 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ModelMenu } from "./ModelMenu";
+import type { ModelInfo } from "./api";
+
+const MODELS: ModelInfo[] = [
+  { id: "claude-sonnet-4", provider: "anthropic" },
+  { id: "gpt-4o", provider: "openai" },
+];
+
+function triggerMarkup(value: string | null): string {
+  return renderToStaticMarkup(
+    <ModelMenu models={MODELS} value={value} onChange={() => {}} />,
+  );
+}
+
+describe("ModelMenu", () => {
+  it("labels the trigger 'Default' when no override is set", () => {
+    const markup = triggerMarkup(null);
+    expect(markup).toContain('aria-label="Model: Default"');
+    expect(markup).toContain(">Default<");
+  });
+
+  it("labels the trigger with a selected known model id", () => {
+    const markup = triggerMarkup("gpt-4o");
+    expect(markup).toContain('aria-label="Model: gpt-4o"');
+    expect(markup).toContain(">gpt-4o<");
+  });
+
+  it("labels the trigger with an unknown (custom) override verbatim", () => {
+    const markup = triggerMarkup("local-model:latest");
+    expect(markup).toContain('aria-label="Model: local-model:latest"');
+    expect(markup).toContain(">local-model:latest<");
+  });
+
+  it("disables the trigger when asked", () => {
+    const markup = renderToStaticMarkup(
+      <ModelMenu models={MODELS} value={null} disabled onChange={() => {}} />,
+    );
+    expect(markup).toContain("disabled");
+  });
+});

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -1,0 +1,105 @@
+import { Bot, Check, ChevronDown } from "lucide-react";
+import type { ModelInfo } from "./api";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+/**
+ * Per-chat model selector for the message bar. `null` means "use the default"
+ * (the global default model, or the server default when none is set). Mirrors
+ * the Brightwave composer picker: a compact pill that opens a grouped list.
+ */
+export function ModelMenu({
+  models,
+  value,
+  disabled,
+  onChange,
+}: {
+  models: ModelInfo[];
+  value: string | null;
+  disabled?: boolean;
+  onChange: (id: string | null) => void | Promise<void>;
+}) {
+  const known = models.find((m) => m.id === value);
+  const label = value ? (known?.id ?? value) : "Default";
+
+  // Group by provider, preserving first-seen order.
+  const groups: { provider: string; models: ModelInfo[] }[] = [];
+  const byProvider = new Map<string, ModelInfo[]>();
+  for (const model of models) {
+    const existing = byProvider.get(model.provider);
+    if (existing) {
+      existing.push(model);
+    } else {
+      const list = [model];
+      byProvider.set(model.provider, list);
+      groups.push({ provider: model.provider, models: list });
+    }
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="model-menu-trigger"
+          disabled={disabled}
+          aria-label={`Model: ${label}`}
+          title={`Model: ${label}`}
+        >
+          <Bot size={14} />
+          <span className="model-menu-label">{label}</span>
+          <ChevronDown size={13} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        side="top"
+        className="model-menu-content"
+      >
+        <DropdownMenuItem
+          onSelect={() => {
+            if (value !== null) void onChange(null);
+          }}
+        >
+          <span className="model-menu-item-label">Default</span>
+          {value === null && <Check className="ml-auto" />}
+        </DropdownMenuItem>
+        {groups.map((group) => (
+          <div key={group.provider}>
+            <DropdownMenuSeparator />
+            <div className="model-menu-group-label">{group.provider}</div>
+            {group.models.map((model) => {
+              const selected = value === model.id;
+              return (
+                <DropdownMenuItem
+                  key={model.id}
+                  onSelect={() => {
+                    if (!selected) void onChange(model.id);
+                  }}
+                >
+                  <span className="model-menu-item-label">{model.id}</span>
+                  {selected && <Check className="ml-auto" />}
+                </DropdownMenuItem>
+              );
+            })}
+          </div>
+        ))}
+        {value !== null && !known && (
+          <>
+            <DropdownMenuSeparator />
+            <div className="model-menu-group-label">custom</div>
+            <DropdownMenuItem disabled>
+              <span className="model-menu-item-label">{value}</span>
+              <Check className="ml-auto" />
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/crates/openwave-desktop/ui/src/SettingsView.tsx
+++ b/crates/openwave-desktop/ui/src/SettingsView.tsx
@@ -1,0 +1,90 @@
+import { useState, type ComponentType } from "react";
+import { ArrowLeft, Cpu, Globe, KeyRound, Palette } from "lucide-react";
+import type { ApiClient, ModelInfo, ProviderInfo } from "./api";
+import type { ThemeMode } from "./theme";
+import { ProvidersPanel } from "./settings/ProvidersPanel";
+import { WebSearchPanel } from "./settings/WebSearchPanel";
+import { ModelsPanel } from "./settings/ModelsPanel";
+import { AppearancePanel } from "./settings/AppearancePanel";
+
+type SettingsSectionKey = "providers" | "models" | "web-search" | "appearance";
+
+const SECTIONS: {
+  key: SettingsSectionKey;
+  label: string;
+  icon: ComponentType<{ size?: number }>;
+}[] = [
+  { key: "providers", label: "Providers", icon: KeyRound },
+  { key: "models", label: "Models", icon: Cpu },
+  { key: "web-search", label: "Web search", icon: Globe },
+  { key: "appearance", label: "Appearance", icon: Palette },
+];
+
+export function SettingsView({
+  client,
+  models,
+  providers,
+  onProvidersChanged,
+  onBack,
+  themeMode,
+  onThemeChange,
+}: {
+  client: ApiClient;
+  models: ModelInfo[];
+  providers: ProviderInfo[];
+  onProvidersChanged: () => void;
+  onBack: () => void;
+  themeMode: ThemeMode;
+  onThemeChange: (mode: ThemeMode) => void;
+}) {
+  const [section, setSection] = useState<SettingsSectionKey>("providers");
+
+  return (
+    <section className="settings-page">
+      <nav className="settings-nav" aria-label="Settings sections">
+        <button
+          type="button"
+          className="sidebar-action settings-back"
+          onClick={onBack}
+        >
+          <ArrowLeft size={16} />
+          Back to app
+        </button>
+        <div className="settings-nav-list">
+          {SECTIONS.map((item) => {
+            const Icon = item.icon;
+            const active = section === item.key;
+            return (
+              <button
+                key={item.key}
+                type="button"
+                className={`sidebar-action${active ? " is-active" : ""}`}
+                aria-current={active ? "page" : undefined}
+                onClick={() => setSection(item.key)}
+              >
+                <Icon size={16} />
+                {item.label}
+              </button>
+            );
+          })}
+        </div>
+      </nav>
+      <div className="settings-page-content">
+        {section === "providers" && (
+          <ProvidersPanel
+            providers={providers}
+            client={client}
+            onChanged={onProvidersChanged}
+          />
+        )}
+        {section === "models" && (
+          <ModelsPanel client={client} models={models} />
+        )}
+        {section === "web-search" && <WebSearchPanel client={client} />}
+        {section === "appearance" && (
+          <AppearancePanel mode={themeMode} onChange={onThemeChange} />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -18,6 +18,13 @@ export type ModelInfo = {
   provider: string;
 };
 
+/** Global runtime settings (`GET/PUT /settings`). */
+export type RuntimeSettings = {
+  /** The default model, or `null` when the server default is in effect. */
+  model: string | null;
+  has_api_key: boolean;
+};
+
 export type Project = {
   id: string;
   title: string | null;
@@ -293,6 +300,23 @@ export class ApiClient {
 
   listModels(): Promise<{ models: ModelInfo[] }> {
     return this.json("/models", { headers: this.headers() });
+  }
+
+  getSettings(): Promise<RuntimeSettings> {
+    return this.json("/settings", { headers: this.headers() });
+  }
+
+  /**
+   * Update runtime settings. `model` absent leaves it unchanged, `null` resets
+   * it to the server default, and a value sets it (matching the double-option
+   * body the server expects).
+   */
+  putSettings(body: { model?: string | null }): Promise<RuntimeSettings> {
+    return this.json("/settings", {
+      method: "PUT",
+      headers: this.headers(true),
+      body: JSON.stringify(body),
+    });
   }
 
   getWebSearchConfig(): Promise<WebSearchConfigInfo> {

--- a/crates/openwave-desktop/ui/src/settings/AppearancePanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/AppearancePanel.tsx
@@ -1,0 +1,51 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+import type { ComponentType } from "react";
+import type { ThemeMode } from "../theme";
+import { SettingsField, SettingsPanel } from "./primitives";
+
+const OPTIONS: {
+  mode: ThemeMode;
+  label: string;
+  icon: ComponentType<{ size?: number }>;
+}[] = [
+  { mode: "light", label: "Light", icon: Sun },
+  { mode: "dark", label: "Dark", icon: Moon },
+  { mode: "system", label: "System", icon: Monitor },
+];
+
+export function AppearancePanel({
+  mode,
+  onChange,
+}: {
+  mode: ThemeMode;
+  onChange: (mode: ThemeMode) => void;
+}) {
+  return (
+    <SettingsPanel
+      title="Appearance"
+      description="Choose how OpenWave looks. System follows your operating system setting."
+    >
+      <SettingsField label="Theme">
+        <div className="theme-options" role="radiogroup" aria-label="Theme">
+          {OPTIONS.map((option) => {
+            const Icon = option.icon;
+            const active = mode === option.mode;
+            return (
+              <button
+                key={option.mode}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                className={`theme-option${active ? " is-active" : ""}`}
+                onClick={() => onChange(option.mode)}
+              >
+                <Icon size={16} />
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </SettingsField>
+    </SettingsPanel>
+  );
+}

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import type { ApiClient, ModelInfo } from "../api";
+import { Input } from "@/components/ui/input";
+import {
+  SETTINGS_SELECT_CLASS,
+  SettingsError,
+  SettingsField,
+  SettingsPanel,
+  SettingsSection,
+} from "./primitives";
+
+export function ModelsPanel({
+  client,
+  models,
+}: {
+  client: ApiClient;
+  models: ModelInfo[];
+}) {
+  const [defaultModel, setDefaultModel] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const settings = await client.getSettings();
+        if (cancelled) return;
+        setDefaultModel(settings.model);
+      } catch (err) {
+        if (!cancelled) setError(String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  async function save(model: string | null) {
+    setSaving(true);
+    setError(null);
+    try {
+      const next = await client.putSettings({ model });
+      setDefaultModel(next.model);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const isCustom = Boolean(
+    defaultModel && !models.some((m) => m.id === defaultModel),
+  );
+
+  return (
+    <SettingsPanel
+      title="Models"
+      description="Pick the default model for new chats. Any chat left on “Default” uses this. Individual chats can override it from the model menu in the message bar."
+      busy={loading}
+    >
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading model settings…</p>
+      ) : (
+        <>
+          <SettingsSection title="Default model">
+            <SettingsField label="Model">
+              <select
+                className={SETTINGS_SELECT_CLASS}
+                value={defaultModel ?? ""}
+                disabled={saving}
+                onChange={(e) => void save(e.target.value || null)}
+              >
+                <option value="">Server default</option>
+                {models.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.id} ({m.provider})
+                  </option>
+                ))}
+                {isCustom && defaultModel && (
+                  <option value={defaultModel}>{defaultModel} (custom)</option>
+                )}
+              </select>
+            </SettingsField>
+            <SettingsField
+              label="Custom model ID"
+              hint="Select a listed model above, or type any model ID your enabled providers support."
+            >
+              <Input
+                type="text"
+                placeholder="e.g. claude-sonnet-4-20250514"
+                defaultValue={isCustom && defaultModel ? defaultModel : ""}
+                key={defaultModel ?? "none"}
+                disabled={saving}
+                onBlur={(e) => {
+                  const next = e.target.value.trim();
+                  if (next && next !== (defaultModel ?? "")) void save(next);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") e.currentTarget.blur();
+                }}
+              />
+            </SettingsField>
+          </SettingsSection>
+          {models.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              No models are available yet. Add a provider credential on the
+              Providers page to populate the catalog.
+            </p>
+          )}
+        </>
+      )}
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsPanel>
+  );
+}

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import type { ApiClient, ProviderInfo, ProviderKind } from "../api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
+
+export function ProvidersPanel({
+  providers,
+  client,
+  onChanged,
+}: {
+  providers: ProviderInfo[];
+  client: ApiClient;
+  onChanged: () => void;
+}) {
+  return (
+    <SettingsPanel
+      title="Providers"
+      description="Keys stay on this machine. Enable a provider, then save a credential."
+    >
+      {providers.map((p) => (
+        <ProviderRow key={p.kind} info={p} client={client} onChanged={onChanged} />
+      ))}
+    </SettingsPanel>
+  );
+}
+
+function ProviderRow({
+  info,
+  client,
+  onChanged,
+}: {
+  info: ProviderInfo;
+  client: ApiClient;
+  onChanged: () => void;
+}) {
+  const [key, setKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState(info.base_url ?? "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save(enabled: boolean) {
+    setSaving(true);
+    setError(null);
+    try {
+      const body: {
+        enabled: boolean;
+        base_url?: string | null;
+        credential?: { type: "api_key"; key: string };
+      } = { enabled };
+      if (info.kind === "openai_compatible") {
+        body.base_url = baseUrl.trim() || null;
+      }
+      if (key.trim()) {
+        body.credential = { type: "api_key", key: key.trim() };
+      }
+      await client.putProvider(info.kind as ProviderKind, body);
+      setKey("");
+      onChanged();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function clearCredential() {
+    setSaving(true);
+    setError(null);
+    try {
+      await client.deleteCredential(info.kind as ProviderKind);
+      onChanged();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <SettingsSection title={info.kind.replaceAll("_", " ")}>
+      <div className="flex items-center justify-between gap-3">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            className="size-4 accent-[var(--primary)]"
+            checked={info.enabled}
+            disabled={saving}
+            onChange={(e) => void save(e.target.checked)}
+          />
+          Enabled
+        </label>
+        <span className="text-xs text-muted-foreground">
+          {info.has_credential ? "credential set" : "no credential"}
+        </span>
+      </div>
+      {info.kind === "openai_compatible" && (
+        <Input
+          type="text"
+          placeholder="base URL (e.g. http://127.0.0.1:1234/v1)"
+          value={baseUrl}
+          onChange={(e) => setBaseUrl(e.target.value)}
+        />
+      )}
+      <Input
+        type="password"
+        placeholder="API key"
+        value={key}
+        onChange={(e) => setKey(e.target.value)}
+        autoComplete="off"
+      />
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          disabled={saving || !key.trim()}
+          onClick={() => void save(true)}
+        >
+          Save
+        </Button>
+        {info.has_credential && (
+          <Button
+            type="button"
+            variant="outline"
+            disabled={saving}
+            onClick={() => void clearCredential()}
+          >
+            Clear
+          </Button>
+        )}
+      </div>
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsSection>
+  );
+}

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useState } from "react";
+import type {
+  ApiClient,
+  WebSearchConfigInfo,
+  WebSearchCredentialReadiness,
+  WebSearchProviderKind,
+} from "../api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  SETTINGS_SELECT_CLASS,
+  SettingsError,
+  SettingsField,
+  SettingsPanel,
+  SettingsSection,
+} from "./primitives";
+
+const MIN_WEB_SEARCH_TIMEOUT_MS = 1_000;
+const MAX_WEB_SEARCH_TIMEOUT_MS = 60_000;
+
+export function WebSearchPanel({ client }: { client: ApiClient }) {
+  const [config, setConfig] = useState<WebSearchConfigInfo | null>(null);
+  const [credentials, setCredentials] = useState<WebSearchCredentialReadiness[]>([]);
+  const [provider, setProvider] = useState<WebSearchProviderKind | "">("");
+  const [timeoutMs, setTimeoutMs] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [savingConfig, setSavingConfig] = useState(false);
+  const [savingCredential, setSavingCredential] = useState(false);
+  const [removingCredential, setRemovingCredential] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    const [nextConfig, nextCredentials] = await Promise.all([
+      client.getWebSearchConfig(),
+      client.listWebSearchCredentials(),
+    ]);
+    setConfig(nextConfig);
+    setCredentials(nextCredentials.credentials);
+    setProvider(nextConfig.provider ?? "");
+    setTimeoutMs(String(nextConfig.timeout_ms));
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const [nextConfig, nextCredentials] = await Promise.all([
+          client.getWebSearchConfig(),
+          client.listWebSearchCredentials(),
+        ]);
+        if (cancelled) return;
+        setConfig(nextConfig);
+        setCredentials(nextCredentials.credentials);
+        setProvider(nextConfig.provider ?? "");
+        setTimeoutMs(String(nextConfig.timeout_ms));
+      } catch (err) {
+        if (!cancelled) setError(String(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  const activeProvider = config?.provider;
+  const selectedCredential = activeProvider
+    ? credentials.find((credential) => credential.provider === activeProvider)
+    : undefined;
+  const selectedHasCredential = selectedCredential?.has_credential ?? false;
+  const working = savingConfig || savingCredential || removingCredential;
+  const state = webSearchState(config);
+
+  async function saveConfig() {
+    const parsedTimeout = Number(timeoutMs);
+    if (
+      !Number.isInteger(parsedTimeout) ||
+      parsedTimeout < MIN_WEB_SEARCH_TIMEOUT_MS ||
+      parsedTimeout > MAX_WEB_SEARCH_TIMEOUT_MS
+    ) {
+      setError(
+        `Timeout must be a whole number between ${MIN_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} and ${MAX_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} ms.`,
+      );
+      return;
+    }
+
+    setSavingConfig(true);
+    setError(null);
+    try {
+      const nextConfig = await client.putWebSearchConfig({
+        provider: provider || null,
+        timeout_ms: parsedTimeout,
+      });
+      setConfig(nextConfig);
+      setTimeoutMs(String(nextConfig.timeout_ms));
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSavingConfig(false);
+    }
+  }
+
+  async function saveCredential() {
+    if (!activeProvider || !apiKey.trim()) return;
+    setSavingCredential(true);
+    setError(null);
+    try {
+      await client.putWebSearchCredential(activeProvider, apiKey.trim());
+      setApiKey("");
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSavingCredential(false);
+    }
+  }
+
+  async function removeCredential() {
+    if (!activeProvider) return;
+    setRemovingCredential(true);
+    setError(null);
+    try {
+      await client.deleteWebSearchCredential(activeProvider);
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setRemovingCredential(false);
+    }
+  }
+
+  return (
+    <SettingsPanel
+      title="Web search"
+      description="Choose a local provider and a bounded request timeout. Existing keys are never shown here."
+      busy={loading}
+    >
+      {loading ? (
+        <p className="text-sm text-muted-foreground">
+          Loading web-search settings…
+        </p>
+      ) : !config ? (
+        <p className="text-sm text-muted-foreground">
+          Web-search settings are unavailable.
+        </p>
+      ) : (
+        <>
+          <div className={`web-search-state is-${state.kind}`} role="status">
+            <strong>{state.label}</strong>
+            <span>{state.description}</span>
+          </div>
+
+          <SettingsSection>
+            <SettingsField label="Provider">
+              <select
+                className={SETTINGS_SELECT_CLASS}
+                value={provider}
+                disabled={working}
+                onChange={(event) =>
+                  setProvider(event.target.value as WebSearchProviderKind | "")
+                }
+              >
+                <option value="">Disabled</option>
+                <option value="exa">Exa</option>
+                <option value="tavily">Tavily</option>
+              </select>
+            </SettingsField>
+
+            <SettingsField
+              label="Request timeout (ms)"
+              hint={`Between ${MIN_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} and ${MAX_WEB_SEARCH_TIMEOUT_MS.toLocaleString()} ms.`}
+            >
+              <Input
+                type="number"
+                inputMode="numeric"
+                min={MIN_WEB_SEARCH_TIMEOUT_MS}
+                max={MAX_WEB_SEARCH_TIMEOUT_MS}
+                step="1000"
+                value={timeoutMs}
+                disabled={working}
+                onChange={(event) => setTimeoutMs(event.target.value)}
+              />
+            </SettingsField>
+            <Button
+              type="button"
+              className="self-start"
+              disabled={working}
+              onClick={() => void saveConfig()}
+            >
+              {savingConfig ? "Saving…" : "Save configuration"}
+            </Button>
+          </SettingsSection>
+
+          {activeProvider && (
+            <SettingsSection title={`${activeProvider} credential`}>
+              <span className="text-xs text-muted-foreground">
+                {selectedHasCredential
+                  ? "credential saved"
+                  : "no credential saved"}
+              </span>
+              <SettingsField
+                label={selectedHasCredential ? "Replace API key" : "API key"}
+              >
+                <Input
+                  type="password"
+                  placeholder="Paste a new API key"
+                  value={apiKey}
+                  maxLength={8_192}
+                  autoComplete="new-password"
+                  disabled={working}
+                  onChange={(event) => setApiKey(event.target.value)}
+                />
+              </SettingsField>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  disabled={working || !apiKey.trim()}
+                  onClick={() => void saveCredential()}
+                >
+                  {savingCredential
+                    ? "Saving…"
+                    : selectedHasCredential
+                      ? "Update key"
+                      : "Save key"}
+                </Button>
+                {selectedHasCredential && (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    disabled={working}
+                    onClick={() => void removeCredential()}
+                  >
+                    {removingCredential ? "Removing…" : "Remove saved key"}
+                  </Button>
+                )}
+              </div>
+            </SettingsSection>
+          )}
+
+          {provider !== (activeProvider ?? "") && (
+            <p className="text-xs text-muted-foreground">
+              Save the provider configuration before managing that provider’s
+              key.
+            </p>
+          )}
+
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            This configures host-owned search access only. Search is not yet a
+            chat tool in this build.
+          </p>
+        </>
+      )}
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsPanel>
+  );
+}
+
+function webSearchState(config: WebSearchConfigInfo | null): {
+  kind: "disabled" | "ready" | "not-configured";
+  label: string;
+  description: string;
+} {
+  if (!config?.provider) {
+    return {
+      kind: "disabled",
+      label: "Disabled",
+      description: "No web-search provider is selected.",
+    };
+  }
+  if (config.has_credential) {
+    return {
+      kind: "ready",
+      label: "Ready",
+      description: `${config.provider} is selected and has a saved credential.`,
+    };
+  }
+  return {
+    kind: "not-configured",
+    label: "Not configured",
+    description: `${config.provider} is selected but needs an API key.`,
+  };
+}

--- a/crates/openwave-desktop/ui/src/settings/primitives.tsx
+++ b/crates/openwave-desktop/ui/src/settings/primitives.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from "react";
+
+/** Shared styling for the native <select> elements used across settings. */
+export const SETTINGS_SELECT_CLASS =
+  "flex h-10 w-full rounded-md border border-border bg-background px-3 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+
+/**
+ * A single settings surface: a titled, optionally described column of fields.
+ * The surrounding container owns scrolling and chrome, so this stays layout-only
+ * and works both as a full-page section and as a docked side panel.
+ */
+export function SettingsPanel({
+  title,
+  description,
+  busy,
+  children,
+}: {
+  title: string;
+  description?: string;
+  busy?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="settings-panel" aria-busy={busy}>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-base font-semibold tracking-tight">{title}</h2>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function SettingsField({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+      {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
+    </label>
+  );
+}
+
+export function SettingsSection({
+  title,
+  children,
+}: {
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3 rounded-lg border border-border p-4">
+      {title && <h3 className="text-sm font-semibold capitalize">{title}</h3>}
+      {children}
+    </section>
+  );
+}
+
+export function SettingsError({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-sm text-destructive" role="alert">
+      {children}
+    </p>
+  );
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1934,8 +1934,80 @@ button {
 .composer-actions {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 0.45rem;
+}
+
+.composer-actions-left {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.composer-actions-right {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+/* ---------- Model menu (composer) ---------- */
+
+.model-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  max-width: 14rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: color 120ms ease, background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.model-menu-trigger:hover:not(:disabled) {
+  color: var(--ink);
+  background: var(--accent);
+}
+
+.model-menu-trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.model-menu-trigger svg {
+  flex: 0 0 auto;
+}
+
+.model-menu-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-menu-content {
+  min-width: 15rem;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.model-menu-group-label {
+  padding: 0.3rem 0.5rem 0.15rem;
+  color: var(--muted-foreground);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.model-menu-item-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .composer-icon-btn {
@@ -2029,6 +2101,92 @@ button {
   background: var(--bg-elevated);
   overflow-y: auto;
   padding: 1.25rem 1rem;
+}
+
+/* A single settings surface (used full-page and in the folders side panel). */
+.settings-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 44rem;
+}
+
+/* ---------- Full-page settings ---------- */
+
+.settings-page {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.settings-nav {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 2px;
+  width: 220px;
+  padding: 0.85rem 0.6rem;
+  border-right: 1px solid var(--line);
+  overflow-y: auto;
+}
+
+.settings-nav-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 0.35rem;
+}
+
+.settings-back {
+  color: var(--muted-foreground);
+}
+
+.settings-page-content {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 1.5rem clamp(1rem, 4vw, 2.5rem);
+}
+
+/* ---------- Appearance ---------- */
+
+.theme-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.theme-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.5rem 0.85rem;
+  background: var(--bg-elevated);
+  color: var(--ink);
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+.theme-option:hover {
+  background: var(--accent);
+}
+
+.theme-option svg {
+  color: var(--muted-foreground);
+}
+
+.theme-option.is-active {
+  border-color: var(--primary);
+  background: var(--accent);
+}
+
+.theme-option.is-active svg {
+  color: var(--ink);
 }
 
 .web-search-state {
@@ -2416,6 +2574,15 @@ button {
     grid-row: 2;
     border-top: 1px solid var(--line);
     border-left: 0;
+  }
+
+  .settings-nav {
+    width: 160px;
+    padding: 0.6rem 0.4rem;
+  }
+
+  .settings-page-content {
+    padding: 1.25rem 1rem;
   }
 
   .messages {


### PR DESCRIPTION
Promotes the desktop settings surfaces from cramped side panels into a dedicated full-page view with a left-nav rail, and moves per-chat model selection into the message bar.

## Settings page
A full-page `SettingsView` with a left-nav rail and a **Back to app** action, replacing the docked side panels. Four sections:

- **Providers** — API keys per provider (unchanged behavior, moved out of `App.tsx`)
- **Models** — the **global default model**, newly wired to the existing `GET/PUT /settings`; the desktop client never surfaced this before
- **Web search** — provider / key / timeout (moved out of `App.tsx`)
- **Appearance** — theme (light / dark / system), lifted out of the sidebar-brand toggle

The sidebar footer's four panel buttons collapse to a single **Settings** entry (same for the mobile header).

## Per-chat model → message bar
A compact `ModelMenu` pill in the composer opens a dropdown: **Default** (clears the override) + models grouped by provider with a check on the active one. The old per-chat Model side panel is removed. Folders stays a contextual side panel, since it is scoped to a single chat.

## Structure
- Extracted the shared `Settings*` primitives + Providers/Web-search panels into `src/settings/`; added `ModelsPanel` and `AppearancePanel`.
- `api.ts`: `RuntimeSettings` type + `getSettings`/`putSettings`.
- `Composer.tsx`: optional `modelMenu` slot rendered left of the send/stop actions.
- `styles.css`: settings-page shell, model-menu pill, theme-option styles + responsive tweaks.

## Notes
- The model menu shows raw model IDs (the current minimal `{id, provider}` catalog); display names come with the fuller `ModelSpec` slice.
- `openai_compatible`/local models aren't in the catalog, so per-chat they use "Default"; a custom local model is set as the global default via the Models page's free-form field.

## Verification
- `tsc --noEmit` clean, `vite build` succeeds.
- Full suite green: 150 tests (28 files), including a new `ModelMenu.test.tsx`.