### PR TITLE
fix(desktop): restore legible primary button text

### DIFF
--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -215,16 +215,21 @@ body {
   background: var(--page-background);
 }
 
-button,
-input,
-select,
-textarea {
-  font: inherit;
-  color: inherit;
-}
+/* Kept in `@layer base` (like Tailwind's Preflight) so utility text colors —
+   e.g. `text-primary-foreground` on the shadcn Button — override these resets
+   instead of losing to an unlayered rule and rendering dark-on-dark. */
+@layer base {
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+    color: inherit;
+  }
 
-button {
-  cursor: pointer;
+  button {
+    cursor: pointer;
+  }
 }
 
 /* ---------- App shell ---------- */


### PR DESCRIPTION
Primary shadcn buttons (the `default` variant — dark `bg-primary` background) rendered their label in near-black, dark-on-dark and nearly invisible — e.g. the **Save configuration** button on the web-search settings panel.

## Cause
The global element reset

```css
button, input, select, textarea { font: inherit; color: inherit; }
```

was **unlayered**. Tailwind v4 puts its utilities in `@layer utilities`, and in the cascade an unlayered rule beats any layered rule regardless of specificity — so `color: inherit` on `<button>` overrode `text-primary-foreground`. The button kept its dark background but its text inherited the surrounding dark foreground.

## Fix
Move the reset into `@layer base`, where Tailwind's own Preflight resets live, so utility text colors (`text-primary-foreground`, etc.) win. This repairs every shadcn `<Button>` with a text-color utility, not just the one in the screenshot. No markup changes.

Verified under `crates/openwave-desktop/ui`: `tsc` clean, production build succeeds, 150/150 vitest.