### PR TITLE
fix(desktop): correct chat Markdown line-break rendering

### DIFF
--- a/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
@@ -1,6 +1,19 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { MessageMarkdown, safeMarkdownUrl } from "./MessageMarkdown";
+import {
+  MessageMarkdown,
+  preserveLineBreaks,
+  safeMarkdownUrl,
+} from "./MessageMarkdown";
+
+describe("preserveLineBreaks", () => {
+  it("turns single newlines into hard breaks but leaves paragraph breaks", () => {
+    expect(preserveLineBreaks("one\ntwo")).toBe("one  \ntwo");
+    expect(preserveLineBreaks("para one\n\npara two")).toBe(
+      "para one\n\npara two",
+    );
+  });
+});
 
 describe("safeMarkdownUrl", () => {
   it("permits only secure external links", () => {
@@ -43,5 +56,23 @@ describe("MessageMarkdown", () => {
     expect(markup).toContain('aria-label="Copy table contents"');
     expect(markup).toContain("Alpha");
     expect(markup).toContain("<strong>1</strong>");
+  });
+
+  it("renders single newlines as line breaks without splitting paragraphs", () => {
+    const markup = renderToStaticMarkup(
+      <MessageMarkdown>{"first line\nsecond line"}</MessageMarkdown>,
+    );
+
+    expect(markup).toContain("<br/>");
+    // One paragraph with a break, not two separate paragraphs.
+    expect(markup.match(/<p>/g)).toHaveLength(1);
+  });
+
+  it("keeps blank-line separated text as distinct paragraphs", () => {
+    const markup = renderToStaticMarkup(
+      <MessageMarkdown>{"first para\n\nsecond para"}</MessageMarkdown>,
+    );
+
+    expect(markup.match(/<p>/g)).toHaveLength(2);
   });
 });

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
@@ -9,6 +9,17 @@ import { MarkdownTable } from "./MarkdownTable";
  * this allowlist keeps rendered links from opening local files or executable
  * schemes.
  */
+/**
+ * Convert single newlines to Markdown hard breaks (two trailing spaces + newline)
+ * so a model's intended line breaks render, while double+ newlines stay paragraph
+ * breaks. This is what lets us drop `white-space: pre-wrap` on the container: the
+ * line breaks flow through the parser instead of being forced by CSS, so source
+ * indentation no longer leaks and the parsed block structure renders cleanly.
+ */
+export function preserveLineBreaks(input: string): string {
+  return input.replace(/([^\n])\n(?!\n)/g, "$1  \n");
+}
+
 export function safeMarkdownUrl(url: string | undefined): string | undefined {
   if (!url) return undefined;
 
@@ -66,7 +77,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
         skipHtml
         urlTransform={(url) => safeMarkdownUrl(url) ?? ""}
       >
-        {children}
+        {preserveLineBreaks(children)}
       </ReactMarkdown>
     </div>
   );

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1409,7 +1409,6 @@ button {
 .message-markdown {
   font-size: 1rem;
   line-height: 1.625;
-  white-space: pre-wrap;
 }
 
 .message-markdown > :first-child {


### PR DESCRIPTION
Chat messages render through `react-markdown`, but the `.message-markdown` container also carried `white-space: pre-wrap`. That fought the parser: every source newline was preserved literally, so single newlines inside a paragraph became hard breaks and source indentation leaked into the output — lists and paragraphs looked over-spaced and off.

## Fix
Handle line breaks in the parser instead of via CSS, so the rendered structure is clean:

- `MessageMarkdown` now runs a small `preserveLineBreaks` pass that converts single newlines to Markdown hard breaks (`  \n`) while leaving blank-line paragraph breaks intact. A model's intended line breaks are respected the way chat users expect, without preserving raw indentation.
- Dropped `white-space: pre-wrap` from `.message-markdown` (the hard-break pass replaces it). The other `pre-wrap` uses — citation source snippets, folder-consent reason, document-search results — are plain-text previews and are intentionally left as-is.

## Tests
Added coverage: single newline → one paragraph with a `<br/>`; blank line → two paragraphs; and the `preserveLineBreaks` transform itself. Verified under `crates/openwave-desktop/ui`: `tsc` clean, production build succeeds, 153/153 vitest.