### PR TITLE
fix(desktop): restore subtle borders on menus, dialogs, and badges

### DIFF
--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -232,6 +232,19 @@ body {
   }
 }
 
+/* Tailwind v4 leaves border-color at its `currentColor` initial value, so shadcn
+   components that use a bare `border` utility (dropdown menus, dialogs, badges)
+   would draw a heavy near-black outline in the text color. Default it to the
+   themed border here, in `@layer base` so explicit border-color utilities and
+   our own component CSS still win. */
+@layer base {
+  *,
+  ::before,
+  ::after {
+    border-color: var(--color-border);
+  }
+}
+
 /* ---------- App shell ---------- */
 
 .app-shell {


### PR DESCRIPTION
Popover menus (the chat "…" Rename/Delete menu), dialogs, and badges rendered with a heavy near-black outline instead of the intended subtle border.

## Cause
Those shadcn components style their frame with a bare `border` utility and rely on the border color coming from the theme. Tailwind v4 changed the default: it no longer sets a border color, so `border-color` stays at its CSS initial value of `currentColor` — i.e. the component's text color. On a dark-text popover that paints a dark, chunky outline.

## Fix
Add the standard Tailwind-v4 compatibility rule — default `border-color` to the themed `--color-border` for all elements, in `@layer base` so explicit `border-*` utilities and our own component CSS still override it. This is a one-time systemic fix: it repairs the dropdown menu, alert dialog, and badge together and keeps future shadcn components correct.

No markup changes. Verified under `crates/openwave-desktop/ui`: `tsc` clean, production build succeeds, 150/150 vitest.