### PR TITLE
fix(desktop): use outline-hidden for focus states (Tailwind v4)

### DIFF
--- a/crates/openwave-desktop/ui/src/components/ui/button.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "cursor-pointer select-none inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "cursor-pointer select-none inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/crates/openwave-desktop/ui/src/components/ui/input.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,
         )}
         ref={ref}

--- a/crates/openwave-desktop/ui/src/settings/primitives.tsx
+++ b/crates/openwave-desktop/ui/src/settings/primitives.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 /** Shared styling for the native <select> elements used across settings. */
 export const SETTINGS_SELECT_CLASS =
-  "flex h-10 w-full rounded-md border border-border bg-background px-3 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+  "flex h-10 w-full rounded-md border border-border bg-background px-3 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
 
 /**
  * A single settings surface: a titled, optionally described column of fields.


### PR DESCRIPTION
Follow-up sweep for Tailwind v4 utility-migration issues, after the button-text and border-color fixes.

Button, Input, and the settings field primitive suppressed the native focus outline with `outline-none`. In Tailwind v4 that utility changed meaning — the v3 "hide the outline but keep it available to forced-colors mode" behavior is now `outline-hidden`. Switched the three to `focus-visible:outline-hidden`, matching what Badge already uses, so the visible focus ring is unchanged and high-contrast/forced-colors accessibility is preserved.

No visual change in normal rendering; this is a correctness + consistency fix. Verified under `crates/openwave-desktop/ui`: `tsc` clean, build succeeds, 153/153 vitest.