### PR TITLE
feat(core): standing grants for approved Sensitive tool calls

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -33,7 +33,7 @@ use crate::agent_tools::{
 };
 use crate::approval::{
     ApprovalDecision, ApprovalGate, ApprovalJournalIdentity, ApprovalRequest,
-    ApprovalRequiredPublication, RefuseGate, ToolApprovalKind,
+    ApprovalRequiredPublication, RefuseGate, StandingGrants, ToolApprovalKind,
 };
 use crate::cancel::CancelToken;
 use crate::citation::{
@@ -719,6 +719,7 @@ pub struct Agent {
     store: Arc<dyn Store>,
     config: AgentConfig,
     approvals: Arc<dyn ApprovalGate>,
+    standing_grants: Arc<StandingGrants>,
     cancel: CancelToken,
     steer: SteerInbox,
     durable_steer_lease: Option<uuid::Uuid>,
@@ -756,6 +757,7 @@ impl Agent {
             store,
             config,
             approvals: Arc::new(RefuseGate),
+            standing_grants: Arc::new(StandingGrants::new()),
             cancel: CancelToken::new(),
             steer: SteerInbox::new(),
             durable_steer_lease: None,
@@ -768,6 +770,17 @@ impl Agent {
     #[must_use]
     pub fn with_approvals(mut self, gate: Arc<dyn ApprovalGate>) -> Self {
         self.approvals = gate;
+        self
+    }
+
+    /// Consult `grants` before parking a Sensitive tool call, so a repeated
+    /// in-scope action the user already approved runs without re-prompting.
+    ///
+    /// Deny-by-default: an empty set (the default) makes every Sensitive call
+    /// park on the gate exactly as before.
+    #[must_use]
+    pub fn with_standing_grants(mut self, grants: Arc<StandingGrants>) -> Self {
+        self.standing_grants = grants;
         self
     }
 
@@ -1804,7 +1817,20 @@ impl Agent {
         let approval_class = durable_approval
             .map(|approval| approval.class)
             .unwrap_or_else(|| tool.approval_class());
-        if matches!(approval_class, ApprovalClass::Sensitive) {
+        // Standing grant: a brand-new Sensitive call the user already approved
+        // for this chat runs without re-parking on the gate. A recovered call
+        // (`durable_approval` present) keeps its durable park-and-resume
+        // reconciliation. When `durable_approval` is `None` the request kind is
+        // exactly `for_tool_name`, matching what the park block computes below.
+        // Deny-by-default: only approvable kinds are ever covered.
+        let bypass_by_standing_grant = matches!(approval_class, ApprovalClass::Sensitive)
+            && durable_approval.is_none()
+            && self.standing_grants.covers(
+                chat.id,
+                &call.name,
+                ToolApprovalKind::for_tool_name(&call.name),
+            );
+        if matches!(approval_class, ApprovalClass::Sensitive) && !bypass_by_standing_grant {
             let summary = format!("{} requires approval", call.name);
             let kind = durable_approval
                 .map(|approval| approval.kind)
@@ -4049,6 +4075,187 @@ mod tests {
             AgentEvent::ToolCallCompleted { output, .. }
                 if output.content == "boomed" && !output.is_error
         )));
+    }
+
+    /// A Sensitive, standing-grantable tool (`search`) that records whether it
+    /// ran.
+    struct SearchTool {
+        ran: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for SearchTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: "search".into(),
+                description: "a sensitive search tool".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::Sensitive
+        }
+        async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+            self.ran.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolOutput::text("searched"))
+        }
+    }
+
+    /// Provider that asks for the `search` tool once, then finishes.
+    struct SearchProvider {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ModelProvider for SearchProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("search")
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let events = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "call_search".into(),
+                        name: "search".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: "{}".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta { text: "ok".into() },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    async fn search_grant_chat(store: &Arc<dyn Store>) -> Chat {
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        chat
+    }
+
+    async fn search_grant_store() -> Arc<dyn Store> {
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        // Keep the temp dir alive for the process; SQLite owns its connection.
+        std::mem::forget(db);
+        store
+    }
+
+    fn search_agent(
+        store: Arc<dyn Store>,
+        ran: Arc<AtomicUsize>,
+        grants: Arc<crate::approval::StandingGrants>,
+    ) -> Agent {
+        let tools = Arc::new(ToolRegistry::new().with(Box::new(SearchTool { ran })));
+        // Default gate is `RefuseGate`: it rejects any call that reaches it, so
+        // the tool running proves the standing grant bypassed the gate entirely.
+        Agent::new(
+            Arc::new(SearchProvider {
+                calls: AtomicUsize::new(0),
+            }),
+            tools,
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        )
+        .with_standing_grants(grants)
+    }
+
+    #[tokio::test]
+    async fn standing_grant_runs_sensitive_tool_without_parking() {
+        use crate::approval::{StandingGrant, StandingGrants};
+
+        let store = search_grant_store().await;
+        let chat = search_grant_chat(&store).await;
+        let grants = Arc::new(StandingGrants::from_grants(vec![StandingGrant::new(
+            chat.id,
+            "search",
+            ToolApprovalKind::for_tool_name("search"),
+            Utc::now(),
+        )
+        .expect("search is grantable")]));
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let agent = search_agent(store, ran.clone(), grants);
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ApprovalRequired { .. })),
+            "a covered call must not re-prompt"
+        );
+        assert_eq!(ran.load(Ordering::SeqCst), 1);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolCallCompleted { output, .. }
+                if output.content == "searched" && !output.is_error
+        )));
+    }
+
+    #[tokio::test]
+    async fn standing_grant_for_another_chat_does_not_bypass_the_gate() {
+        use crate::approval::{StandingGrant, StandingGrants};
+
+        let store = search_grant_store().await;
+        let chat = search_grant_chat(&store).await;
+        // A grant scoped to a different chat must not cover this chat's call.
+        let grants = Arc::new(StandingGrants::from_grants(vec![StandingGrant::new(
+            ChatId::new(),
+            "search",
+            ToolApprovalKind::for_tool_name("search"),
+            Utc::now(),
+        )
+        .expect("search is grantable")]));
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let agent = search_agent(store, ran.clone(), grants);
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ApprovalRequired { .. })),
+            "an uncovered call must still park on the gate"
+        );
+        assert_eq!(ran.load(Ordering::SeqCst), 0, "RefuseGate blocks the tool");
     }
 
     /// Streams one text delta, then stalls forever — lets a test cancel mid-stream

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -11,6 +11,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::RwLock;
 
 use crate::event::SequencedEvent;
 use crate::id::{CallId, ChatId, TurnId};
@@ -151,6 +152,146 @@ impl ToolApproval {
     }
 }
 
+/// A remembered approval that lets a repeated in-scope Sensitive action run
+/// without re-prompting.
+///
+/// Deny-by-default, like the host broker's capability grants: a grant covers
+/// exactly one chat and one approvable tool. Resource-level sub-scoping (a path
+/// subtree, a single connector) is deliberately deferred until
+/// [`ApprovalRequest`] carries a structured resource — see the follow-up on the
+/// capability-model issue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StandingGrant {
+    chat_id: ChatId,
+    tool_name: String,
+    kind: ToolApprovalKind,
+    granted_at: DateTime<Utc>,
+}
+
+impl StandingGrant {
+    /// Record consent to stop re-prompting `tool_name` in `chat_id`.
+    ///
+    /// Returns `None` for a tool whose consent semantics are not standing-
+    /// grantable (mirrors [`ToolApprovalKind::is_approvable`]); an unknown or
+    /// non-approvable action must keep parking on the gate every call.
+    #[must_use]
+    pub fn new(
+        chat_id: ChatId,
+        tool_name: impl Into<String>,
+        kind: ToolApprovalKind,
+        granted_at: DateTime<Utc>,
+    ) -> Option<Self> {
+        if !kind.is_approvable() {
+            return None;
+        }
+        Some(Self {
+            chat_id,
+            tool_name: tool_name.into(),
+            kind,
+            granted_at,
+        })
+    }
+
+    /// Chat the standing consent belongs to.
+    #[must_use]
+    pub const fn chat_id(&self) -> ChatId {
+        self.chat_id
+    }
+
+    /// Tool name the consent covers.
+    #[must_use]
+    pub fn tool_name(&self) -> &str {
+        &self.tool_name
+    }
+
+    /// Frozen consent semantics the grant was created under.
+    #[must_use]
+    pub const fn kind(&self) -> ToolApprovalKind {
+        self.kind
+    }
+
+    /// When the user granted the standing approval.
+    #[must_use]
+    pub const fn granted_at(&self) -> DateTime<Utc> {
+        self.granted_at
+    }
+
+    /// Whether this grant covers an exact Sensitive action.
+    #[must_use]
+    fn covers(&self, chat_id: ChatId, tool_name: &str, kind: ToolApprovalKind) -> bool {
+        self.chat_id == chat_id
+            && self.tool_name == tool_name
+            && self.kind == kind
+            && kind.is_approvable()
+    }
+}
+
+/// A live, deny-by-default set of standing grants consulted before a Sensitive
+/// tool call parks on the approval gate.
+///
+/// Held behind `Arc` and shared with the agent loop. Interior mutability lets a
+/// later decision path record a grant mid-turn without re-threading the agent;
+/// this slice only seeds and consults the set.
+#[derive(Debug, Default)]
+pub struct StandingGrants {
+    grants: RwLock<Vec<StandingGrant>>,
+}
+
+impl StandingGrants {
+    /// An empty set — nothing is pre-approved.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seed a fixed set of grants, e.g. recovered from durable state at turn
+    /// start.
+    #[must_use]
+    pub fn from_grants(grants: Vec<StandingGrant>) -> Self {
+        Self {
+            grants: RwLock::new(grants),
+        }
+    }
+
+    /// Remember `grant`, ignoring a duplicate so the set never grows unbounded
+    /// on repeated approvals of the same action.
+    pub fn record(&self, grant: StandingGrant) {
+        let mut grants = self.write();
+        if !grants.iter().any(|existing| {
+            existing.chat_id == grant.chat_id
+                && existing.tool_name == grant.tool_name
+                && existing.kind == grant.kind
+        }) {
+            grants.push(grant);
+        }
+    }
+
+    /// Whether a live grant covers this exact Sensitive action.
+    #[must_use]
+    pub fn covers(&self, chat_id: ChatId, tool_name: &str, kind: ToolApprovalKind) -> bool {
+        self.read()
+            .iter()
+            .any(|grant| grant.covers(chat_id, tool_name, kind))
+    }
+
+    /// Drop every grant, e.g. on explicit revocation.
+    pub fn clear(&self) {
+        self.write().clear();
+    }
+
+    fn read(&self) -> std::sync::RwLockReadGuard<'_, Vec<StandingGrant>> {
+        self.grants
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn write(&self) -> std::sync::RwLockWriteGuard<'_, Vec<StandingGrant>> {
+        self.grants
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
 /// What the agent asks the gate to decide.
 #[derive(Debug, Clone)]
 pub struct ApprovalRequest {
@@ -276,5 +417,68 @@ impl ApprovalGate for AutoApproveGate {
                 publication: ApprovalRequiredPublication::Ordinary,
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod standing_grant_tests {
+    use super::*;
+
+    fn grant(chat_id: ChatId, tool: &str) -> StandingGrant {
+        StandingGrant::new(
+            chat_id,
+            tool,
+            ToolApprovalKind::for_tool_name(tool),
+            Utc::now(),
+        )
+        .expect("approvable tool is grantable")
+    }
+
+    #[test]
+    fn non_approvable_tools_cannot_be_granted() {
+        assert!(StandingGrant::new(
+            ChatId::new(),
+            "third_party_sensitive",
+            ToolApprovalKind::for_tool_name("third_party_sensitive"),
+            Utc::now(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn empty_set_covers_nothing() {
+        let chat = ChatId::new();
+        let grants = StandingGrants::new();
+        assert!(!grants.covers(chat, "search", ToolApprovalKind::for_tool_name("search")));
+    }
+
+    #[test]
+    fn grant_covers_only_its_exact_chat_and_tool() {
+        let chat = ChatId::new();
+        let other_chat = ChatId::new();
+        let grants = StandingGrants::from_grants(vec![grant(chat, "search")]);
+        let kind = ToolApprovalKind::for_tool_name("search");
+
+        assert!(grants.covers(chat, "search", kind));
+        assert!(!grants.covers(other_chat, "search", kind));
+        assert!(!grants.covers(
+            chat,
+            "third_party_sensitive",
+            ToolApprovalKind::for_tool_name("third_party_sensitive"),
+        ));
+    }
+
+    #[test]
+    fn recording_is_idempotent_and_revocable() {
+        let chat = ChatId::new();
+        let kind = ToolApprovalKind::for_tool_name("search");
+        let grants = StandingGrants::new();
+        grants.record(grant(chat, "search"));
+        grants.record(grant(chat, "search"));
+        assert_eq!(grants.read().len(), 1);
+        assert!(grants.covers(chat, "search", kind));
+
+        grants.clear();
+        assert!(!grants.covers(chat, "search", kind));
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -54,7 +54,7 @@ pub use agent_tools::{
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
     ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, AutoApproveGate,
-    RefuseGate, ToolApproval, ToolApprovalKind, ToolApprovalStatus,
+    RefuseGate, StandingGrant, StandingGrants, ToolApproval, ToolApprovalKind, ToolApprovalStatus,
 };
 #[cfg(feature = "blob-fs")]
 pub use blob::FsBlobStore;


### PR DESCRIPTION
## What

Extends the tool approval model (`ApprovalClass` in `openwave-core`) so a repeated in-scope Sensitive action the user already approved does not re-prompt every turn.

In v1, `ReadOnly`/`Workspace` auto-approve and every `Sensitive` call parks on the approval gate with no memory of a prior decision. This adds a **standing-grant** primitive:

- `StandingGrant` — records consent to run one approvable tool (`ToolApprovalKind::is_approvable`) in one chat. Deny-by-default, mirroring the host broker's capability grants: non-approvable / unknown actions can never be granted.
- `StandingGrants` — a live, deny-by-default set behind `Arc` with interior mutability (`from_grants`, `record`, `covers`, `clear`).
- The agent loop consults the set before parking. A **brand-new** Sensitive call covered by a grant runs without re-prompting (no `ApprovalRequired`). A **recovered** call (durable approval present) keeps its existing durable park-and-resume reconciliation, and any uncovered or non-approvable call still parks exactly as before.
- `Agent::with_standing_grants` seeds the set; the default is empty, so behavior is unchanged unless a grant is wired in.

## Scope

Kept to one reviewable slice: the data model + agent-loop consultation. No changes to `ApprovalDecision`, the durable store, or the HTTP surface, so there is no regression risk to the existing park-and-resume path.

## Tests

- Pure model tests: non-approvable tools cannot be granted, empty set covers nothing, a grant covers only its exact chat + tool, recording is idempotent and revocable.
- Agent-loop tests: a covered Sensitive call runs without emitting `ApprovalRequired` (using `RefuseGate` as the gate, so the tool running proves the bypass); a grant scoped to a different chat still parks.

Verified locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, `cargo check --workspace --locked` all pass with no `Cargo.lock` diff.

## Follow-ups (deferred on this issue)

- Durable persistence of standing grants and recovery at turn start.
- Decision-time "remember this" affordance: thread an approval scope (once vs. standing) from the approval UI through the server resolve path so an approval can create a grant.
- Workspace-outside prompting: give `ApprovalRequest` a structured resource so grants (and prompts) can be scoped to a path subtree / single connector rather than a whole tool, and surface an audit event when a standing grant is used.

Closes #310