### PR TITLE
feat(desktop): bundle the PDFium runtime for packaged apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ dist/
 crates/openwave-desktop/gen/
 crates/openwave-desktop/binaries/openwave-host-broker-*
 
+# Staged at release build time by the desktop build script; keep the tracked
+# .gitkeep so the Tauri resources glob still matches on a clean checkout.
+crates/openwave-desktop/resources/pdfium/*
+!crates/openwave-desktop/resources/pdfium/.gitkeep
+
 # OS / editor cruft
 .DS_Store
 Thumbs.db

--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -57,6 +57,24 @@ broker and the default Tauri configuration includes it automatically:
 cargo tauri build
 ```
 
+## PDFium runtime for packaged apps
+
+The in-process server uses the liteparse PDF parser, which loads the PDFium
+shared library at runtime. In a dev build the loader resolves it via the cache
+path `pdfium-sys` bakes into the binary, but an installed app has no such path.
+
+For release builds the desktop build script stages the target's PDFium library
+into `resources/pdfium/`, `tauri.conf.json` ships it via `bundle.resources`, and
+the host exports `PDFIUM_LIB_PATH` to that bundled directory at startup (the
+loader's highest-priority search location). The staged binary is copied from the
+same `target/<profile>/deps/` file `pdfium-sys` resolves, so it always matches
+the pinned version the app was compiled against. If the library is missing at
+build time the bundle still builds (with a loud `cargo:warning`) and PDF parsing
+fails closed with a clear message rather than crashing.
+
+Building an installer per platform and confirming PDF import in the packaged app
+is release-engineering work that must be run on macOS, Windows, and Linux.
+
 ## Run locally (browser UI against `openwave serve`)
 
 Useful when iterating on the React UI without rebuilding the native shell.
@@ -85,6 +103,7 @@ pnpm --dir ui dev
 | `ui/` | React + Vite frontend |
 | `scripts/` | Cross-platform sidecar staging for Tauri dev/build |
 | `binaries/` | Generated target-specific sidecar (gitignored) |
-| `tauri.conf.json` | Window, CSP, sidecar bundle, and build commands |
+| `resources/pdfium/` | Staged PDFium runtime for packaged apps (gitignored) |
+| `tauri.conf.json` | Window, CSP, sidecar bundle, resources, and build commands |
 | `icons/` | App icons (generated from the brand mark) |
 | `capabilities/` | Tauri ACL (loopback remote URLs for the local API) |

--- a/crates/openwave-desktop/build.rs
+++ b/crates/openwave-desktop/build.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 fn main() {
     let target = std::env::var("TARGET").expect("Cargo did not provide TARGET");
     let extension = if target.contains("windows") {
@@ -7,6 +9,14 @@ fn main() {
     };
     let sidecar = format!("binaries/openwave-host-broker-{target}{extension}");
     println!("cargo:rerun-if-changed={sidecar}");
+
+    // A packaged desktop app has no build-time PDFium cache to fall back on, so
+    // stage the shared library the liteparse parser loads into `resources/` for
+    // the bundler to ship. Only release builds are packaged; dev keeps resolving
+    // PDFium via the compile-time cache path pdfium-sys bakes in.
+    if std::env::var("PROFILE").as_deref() == Ok("release") {
+        stage_pdfium_runtime();
+    }
 
     // Plain `cargo check` and `cargo test` do not run Tauri's before-build
     // hook. Keep those workflows usable from a clean checkout; Tauri dev/build
@@ -28,4 +38,68 @@ fn main() {
         println!("cargo:rustc-env=TAURI_CONFIG={overlay}");
     }
     tauri_build::build()
+}
+
+/// Platform file name of the PDFium shared library, keyed off the build target.
+fn pdfium_dylib_name() -> &'static str {
+    match std::env::var("CARGO_CFG_TARGET_OS").as_deref() {
+        Ok("windows") => "pdfium.dll",
+        Ok("macos") => "libpdfium.dylib",
+        _ => "libpdfium.so",
+    }
+}
+
+/// Copy the PDFium shared library into `resources/pdfium/` so `tauri.conf.json`'s
+/// `bundle.resources` glob ships it next to the packaged app.
+///
+/// `liteparse-pdfium-sys`'s own build script copies the resolved library into
+/// this build's `target/<profile>/deps/`; because the desktop crate depends on
+/// it transitively, that copy has already happened by the time this runs. We
+/// read it back from there so the staged binary is exactly the pinned version
+/// the app was compiled against — never a stray system copy. A missing library
+/// is a loud warning rather than a hard error: the bundle still builds, and the
+/// packaged app fails closed on PDF parsing with a clear message until a human
+/// confirms the runtime is present.
+fn stage_pdfium_runtime() {
+    let name = pdfium_dylib_name();
+
+    let Some(source) = pdfium_deps_path(name) else {
+        println!(
+            "cargo:warning=PDFium runtime not found in target/deps; the packaged app will not \
+             parse PDFs. Build the desktop through `cargo tauri build` so pdfium-sys stages the \
+             library first."
+        );
+        return;
+    };
+
+    let dest_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("resources")
+        .join("pdfium");
+    if let Err(error) = std::fs::create_dir_all(&dest_dir) {
+        println!(
+            "cargo:warning=could not create {}: {error}",
+            dest_dir.display()
+        );
+        return;
+    }
+    let dest = dest_dir.join(name);
+    if let Err(error) = std::fs::copy(&source, &dest) {
+        println!(
+            "cargo:warning=could not stage PDFium runtime from {} to {}: {error}",
+            source.display(),
+            dest.display()
+        );
+    }
+    println!("cargo:rerun-if-changed={}", source.display());
+}
+
+/// Locate the PDFium library `pdfium-sys` copied into this build's `deps/` dir.
+///
+/// `OUT_DIR` is `target/[<triple>/]<profile>/build/<pkg>-<hash>/out`; the shared
+/// `deps/` sibling lives three levels up.
+fn pdfium_deps_path(name: &str) -> Option<PathBuf> {
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").ok()?);
+    let deps = out_dir.parent()?.parent()?.parent()?.join("deps");
+    let candidate = deps.join(name);
+    candidate.is_file().then_some(candidate)
 }

--- a/crates/openwave-desktop/resources/pdfium/.gitkeep
+++ b/crates/openwave-desktop/resources/pdfium/.gitkeep
@@ -1,0 +1,3 @@
+# Keep this directory so the Tauri resources glob always matches. The
+# target-specific PDFium shared library is staged here at release build time
+# by build.rs and is gitignored.

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -68,6 +68,41 @@ async fn wait_server_info(state: &Arc<AppState>) -> Result<NativeServerInfo, Str
     }
 }
 
+/// Platform file name of the PDFium shared library the liteparse parser loads.
+fn pdfium_dylib_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "pdfium.dll"
+    } else if cfg!(target_os = "macos") {
+        "libpdfium.dylib"
+    } else {
+        "libpdfium.so"
+    }
+}
+
+/// Point the PDFium loader at the library bundled next to the packaged app.
+///
+/// The build script stages `pdfium/<lib>` into the Tauri resource directory for
+/// release bundles. `liteparse-pdfium-sys` searches `PDFIUM_LIB_PATH` first, so
+/// exporting the bundled directory makes PDF parsing work in an installed app,
+/// where the compile-time cache path baked into the binary does not exist.
+///
+/// Best-effort and idempotent: an explicit `PDFIUM_LIB_PATH` is respected, and a
+/// missing resource (dev runs, or a bundle built before the runtime was staged)
+/// is left alone so the loader falls through to its other search paths. The
+/// parser still fails closed with a clear message if PDFium cannot be loaded.
+fn point_pdfium_at_bundle(app: &tauri::AppHandle) {
+    if std::env::var_os("PDFIUM_LIB_PATH").is_some() {
+        return;
+    }
+    let Ok(resource_dir) = app.path().resource_dir() else {
+        return;
+    };
+    let pdfium_dir = resource_dir.join("pdfium");
+    if pdfium_dir.join(pdfium_dylib_name()).is_file() {
+        std::env::set_var("PDFIUM_LIB_PATH", &pdfium_dir);
+    }
+}
+
 /// Absolute data directory for the desktop profile (platform app-data).
 fn data_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
     let dir = app
@@ -118,6 +153,7 @@ pub fn run() {
         ])
         .setup(move |app| {
             let handle = app.handle().clone();
+            point_pdfium_at_bundle(&handle);
             let data = data_dir(&handle)?;
             let home = home_dir(&handle)?;
             let host_access = host_access::HostAccess::new(handle.clone(), data.clone(), home)?;

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -36,6 +36,9 @@
     "externalBin": [
       "binaries/openwave-host-broker"
     ],
+    "resources": {
+      "resources/pdfium/*": "pdfium/"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## What

Make PDF parsing work in a packaged desktop build by shipping the PDFium shared library alongside the app and pointing the loader at it.

The in-process `openwave-server` uses `openwave-retrieval`'s liteparse PDF parser, which loads PDFium at runtime. A dev build resolves it via the cache path `liteparse-pdfium-sys` bakes into the binary (`PDFIUM_LIB_DIR`), but an installed app has no such path — so PDF import fails closed in a shipped bundle even though it works in `cargo run` / `cargo tauri dev`.

## How

- **`build.rs`** — for release builds only, stages the target's PDFium library into `crates/openwave-desktop/resources/pdfium/<lib>`. The source is the `target/<profile>/deps/<lib>` file that `liteparse-pdfium-sys`'s own build script copies out; since the desktop crate depends on it transitively, that copy has already happened when the desktop build script runs. Reading it back from `deps/` guarantees the staged binary is exactly the pinned version the app was compiled against, never a stray system copy. A missing library is a loud `cargo:warning` rather than a hard error, so the bundle still builds.
- **`tauri.conf.json`** — adds `bundle.resources` (`resources/pdfium/*` → `pdfium/`) so the staged library ships in the packaged app's resource directory.
- **`src/lib.rs`** — at startup the host exports `PDFIUM_LIB_PATH` to the bundled `pdfium/` directory (the loader's highest-priority search location). Best-effort and idempotent: an explicit `PDFIUM_LIB_PATH` is respected, and a missing resource (dev runs) is left alone so the loader falls through to its other search paths.
- **`.gitignore`** — ignores the staged binary; a tracked `.gitkeep` keeps the resources glob matching on a clean checkout. No PDFium blob is committed.
- **README** — documents the packaging layer and flags the per-platform verification still required.

Dev and non-release builds are untouched: staging runs only for release profiles, so `cargo check`/`test` in debug leave the tree clean.

## Verified locally (macOS, aarch64-apple-darwin)

- `cargo fmt --all --check`
- `cargo clippy -p openwave-desktop --all-targets --locked -- -D warnings`
- `cargo test -p openwave-desktop --locked` (42 passed)
- No `Cargo.lock` drift (no new dependencies)
- **Exercised the real release staging path**: `cargo build -p openwave-desktop --release` ran `build.rs`, which copied `libpdfium.dylib` (6.4 MB) into `resources/pdfium/` as intended.

## Still needs a human (release engineering)

I could not build or run a packaged installer per platform in this environment. Before closing out the PDFium-in-packaged-app story, a human should, on **macOS, Windows, and Linux**:

1. Run `cargo tauri build` and confirm `build.rs` stages the correct library (`libpdfium.dylib` / `pdfium.dll` / `libpdfium.so`) into the bundle's resource directory.
2. Install/launch the packaged app and import a PDF, confirming it parses (i.e. `PDFIUM_LIB_PATH` resolves the bundled library and `load_default()` succeeds).
3. Windows in particular: verify `resource_dir()/pdfium/pdfium.dll` is the path the loader picks up.

## Follow-ups

- Wire this into the release/CI packaging workflow once one exists, so bundles are produced and smoke-tested per platform.

Closes #306