### PR TITLE
Fence intermediate turn effects on the lease

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -54,7 +54,7 @@ use crate::provider::{
 use crate::steer::SteerInbox;
 use crate::storage::{
     AcceptToolCallOutcome, ApplyTurnSteerOutcome, JournaledTurnSteerOutcome,
-    ResolveToolCallOutcome, Store,
+    ResolveToolCallOutcome, Store, TurnLeaseFence,
 };
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
 
@@ -1323,6 +1323,16 @@ impl Agent {
                 continue;
             }
 
+            // This step is about to persist tool-call rows, execute server tool
+            // side effects, and record the assistant message. Fence those on the
+            // lease first: the provider stream just consumed may have outlasted
+            // it, and a stale segment must neither commit nor replay an effect a
+            // later attempt now owns. Terminal completion is left to the worker's
+            // own lease compare-and-swap, so only fence the tool-bearing path.
+            if !calls.is_empty() {
+                self.ensure_durable_lease_current(turn_id).await?;
+            }
+
             // Record the assistant message (text + any tool-use blocks).
             let mut blocks: Vec<ContentBlock> = Vec::new();
             if !text.is_empty() {
@@ -1673,6 +1683,37 @@ impl Agent {
             events.send_committed(event_ordinal, event)?;
         }
         Ok(true)
+    }
+
+    /// Confirm the durable lease still owns this turn before the current model
+    /// step commits or replays any intermediate tool or message effect.
+    ///
+    /// The per-step generation fence proves the lease before the provider call,
+    /// but a long provider stream can outlast the lease; once it expires another
+    /// worker may terminalize or reclaim the turn. Re-checking here keeps a
+    /// segment whose lease was stolen mid-stream from writing tool-call rows,
+    /// executing filesystem or external side effects, or persisting messages a
+    /// later attempt now owns. Legacy (unclaimed) turns carry no lease and are
+    /// never fenced.
+    async fn ensure_durable_lease_current(&self, turn_id: TurnId) -> Result<()> {
+        let Some(lease_token) = self.durable_steer_lease else {
+            return Ok(());
+        };
+        loop {
+            match self
+                .store
+                .fence_turn_lease(turn_id, lease_token, Utc::now())
+                .await
+            {
+                Ok(TurnLeaseFence::Current) => return Ok(()),
+                Ok(TurnLeaseFence::Stale) => {
+                    return Err(AgentError::Store(format!(
+                        "turn {turn_id} no longer owns lease {lease_token}; refusing to commit intermediate effects"
+                    )));
+                }
+                Err(_) => self.wait_for_durable_store_retry(turn_id).await?,
+            }
+        }
     }
 
     async fn durable_generation_revision(&self, turn_id: TurnId) -> Result<Option<i64>> {
@@ -4256,6 +4297,152 @@ mod tests {
             "an uncovered call must still park on the gate"
         );
         assert_eq!(ran.load(Ordering::SeqCst), 0, "RefuseGate blocks the tool");
+    }
+
+    /// Counts every execution so a test can prove a fenced tool never ran.
+    struct SpyTool {
+        ran: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for SpyTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: "spy".into(),
+                description: "records whether it executed".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::ReadOnly
+        }
+        async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+            self.ran.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolOutput::text("spied"))
+        }
+    }
+
+    /// Asks for the `spy` tool once, but first lets the turn's lease be stolen
+    /// while this provider call is in flight: a fresh claim scan past the lease
+    /// expiry terminalizes the single-attempt turn out from under this worker.
+    struct LeaseStealingProvider {
+        store: Arc<dyn Store>,
+        steal_at: DateTime<Utc>,
+        stole: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ModelProvider for LeaseStealingProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("lease-steal")
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            if self.stole.fetch_add(1, Ordering::SeqCst) == 0 {
+                let outcome = self
+                    .store
+                    .claim_turn_run(
+                        uuid::Uuid::new_v4(),
+                        self.steal_at,
+                        self.steal_at + chrono::Duration::minutes(1),
+                    )
+                    .await?;
+                assert!(
+                    outcome.terminal_event.is_some(),
+                    "expired single-attempt turn should be terminalized by the steal"
+                );
+            }
+            Ok(stream::iter(vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "call_spy".into(),
+                    name: "spy".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{}".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    #[tokio::test]
+    async fn a_stolen_lease_fences_intermediate_tool_effects() {
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "fake", "go")
+            .await
+            .unwrap();
+        let now = Utc::now();
+        let lease_token = uuid::Uuid::new_v4();
+        store
+            .claim_turn_run(lease_token, now, now + chrono::Duration::minutes(1))
+            .await
+            .unwrap();
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let tools = Arc::new(ToolRegistry::new().with(Box::new(SpyTool { ran: ran.clone() })));
+        let agent = Agent::new(
+            Arc::new(LeaseStealingProvider {
+                store: store.clone(),
+                // The steal reads a claim time past the lease expiry, so the
+                // scan reclaims and terminalizes the turn deterministically.
+                steal_at: now + chrono::Duration::minutes(2),
+                stole: AtomicUsize::new(0),
+            }),
+            tools,
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        )
+        .with_durable_steer(lease_token);
+
+        let (tx, rx) = unbounded();
+        let outcome = agent
+            .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
+            .await
+            .unwrap();
+        drop(tx);
+        let _ = rx.collect::<Vec<_>>().await;
+
+        // The stale segment refuses to persist tool-call rows or run the tool.
+        assert!(
+            matches!(outcome, AgentTurnOutcome::Failed { .. }),
+            "a stolen lease must not complete the turn: {outcome:?}"
+        );
+        assert_eq!(
+            ran.load(Ordering::SeqCst),
+            0,
+            "a stolen lease must not execute tool side effects"
+        );
+        // The thief's terminal state stands; the stale worker committed nothing.
+        let turn = store.get_turn_run(turn_id).await.unwrap().unwrap();
+        assert_eq!(turn.status, TurnRunStatus::Failed);
+        assert_eq!(turn.lease_token, None);
     }
 
     /// Streams one text delta, then stalls forever — lets a test cancel mid-stream

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -55,7 +55,7 @@ use crate::storage::{
     ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
     RequestToolApprovalOutcome, RequestTurnCancellationOutcome, ResolveSandboxToolCallOutcome,
     ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, Store,
-    SubmitAgentRunResultOutcome,
+    SubmitAgentRunResultOutcome, TurnLeaseFence,
 };
 
 mod ops;
@@ -2212,6 +2212,15 @@ impl Store for DbStore {
         lease_expires_at: chrono::DateTime<Utc>,
     ) -> Result<bool> {
         ops::turn::heartbeat_turn_run(self, id, lease_token, now, lease_expires_at).await
+    }
+
+    async fn fence_turn_lease(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<TurnLeaseFence> {
+        ops::turn::fence_turn_lease(self, id, lease_token, now).await
     }
 
     async fn accept_turn_steer(

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -746,6 +746,56 @@ pub(in crate::db) async fn heartbeat_turn_run(
     Ok(heartbeat.rows_affected == 1)
 }
 
+pub(in crate::db) async fn fence_turn_lease(
+    store: &DbStore,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+) -> Result<crate::storage::TurnLeaseFence> {
+    use crate::storage::TurnLeaseFence;
+
+    if id.0.is_nil() {
+        return Err(AgentError::Store("fenced turn id must not be nil".into()));
+    }
+    if lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "fence lease token must not be nil".into(),
+        ));
+    }
+    let now = canonical_db_timestamp(now)?;
+    // The claim receipt binds this token to the exact attempt and claim segment
+    // it was issued for. Matching it against the turn's live counters rejects a
+    // token that once owned an earlier segment of the same turn.
+    let Some(claim) = entities::turn_claim::Entity::find_by_id(lease_token)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .filter(|claim| claim.turn_id == id.0)
+    else {
+        return Ok(TurnLeaseFence::Stale);
+    };
+    let Some(turn) = entities::turn_run::Entity::find_by_id(id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+    else {
+        return Ok(TurnLeaseFence::Stale);
+    };
+    let owns_live_segment = (turn.status == TurnRunStatus::Running.as_str()
+        || turn.status == TurnRunStatus::Cancelling.as_str())
+        && turn.attempt_count == claim.attempt_count
+        && turn.claim_count == claim.claim_count
+        && turn.lease_token == Some(lease_token)
+        && turn
+            .lease_expires_at
+            .is_some_and(|lease_expires_at| lease_expires_at > now);
+    Ok(if owns_live_segment {
+        TurnLeaseFence::Current
+    } else {
+        TurnLeaseFence::Stale
+    })
+}
+
 pub(in crate::db) fn canonical_db_timestamp(
     timestamp: chrono::DateTime<Utc>,
 ) -> Result<chrono::DateTime<Utc>> {

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5793,6 +5793,119 @@ async fn concurrent_cross_chat_reuse_of_a_turn_id_commits_once() {
 }
 
 #[tokio::test]
+async fn fence_turn_lease_reports_only_the_exact_live_segment() {
+    use crate::TurnLeaseFence;
+
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let expiry = claimed_at + chrono::Duration::minutes(1);
+    let token = uuid::Uuid::new_v4();
+    let claimed = store
+        .claim_turn_run(token, claimed_at, expiry)
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(claimed.lease_token, Some(token));
+
+    // Nil identities are rejected outright rather than reported as a state.
+    assert!(store
+        .fence_turn_lease(TurnId(uuid::Uuid::nil()), token, claimed_at)
+        .await
+        .is_err());
+    assert!(store
+        .fence_turn_lease(turn_id, uuid::Uuid::nil(), claimed_at)
+        .await
+        .is_err());
+
+    // The exact live token owns the segment until its lease expires.
+    assert_eq!(
+        store
+            .fence_turn_lease(turn_id, token, claimed_at + chrono::Duration::seconds(1))
+            .await
+            .unwrap(),
+        TurnLeaseFence::Current
+    );
+    assert_eq!(
+        store
+            .fence_turn_lease(turn_id, token, expiry)
+            .await
+            .unwrap(),
+        TurnLeaseFence::Stale
+    );
+
+    // A token that never claimed this turn — or claimed a different one — never
+    // owns its segment.
+    assert_eq!(
+        store
+            .fence_turn_lease(turn_id, uuid::Uuid::new_v4(), claimed_at)
+            .await
+            .unwrap(),
+        TurnLeaseFence::Stale
+    );
+    let other_turn = TurnId::new();
+    match store
+        .accept_turn(other_turn, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::ChatBusy(_) => {}
+        outcome => panic!("second turn should observe a busy chat: {outcome:?}"),
+    }
+
+    // A cancellation request keeps the same worker's lease live: the segment
+    // still owns the turn and winds down under its own cancel signal.
+    store
+        .request_turn_cancellation(turn_id, claimed_at + chrono::Duration::seconds(2))
+        .await
+        .unwrap();
+    assert_eq!(
+        store.get_turn_run(turn_id).await.unwrap().unwrap().status,
+        TurnRunStatus::Cancelling
+    );
+    assert_eq!(
+        store
+            .fence_turn_lease(turn_id, token, claimed_at + chrono::Duration::seconds(3))
+            .await
+            .unwrap(),
+        TurnLeaseFence::Current
+    );
+
+    // Once the expired lease is reclaimed at the attempt limit, the turn is
+    // terminalized and the original token no longer owns anything.
+    let past_expiry = expiry + chrono::Duration::seconds(1);
+    let steal_token = uuid::Uuid::new_v4();
+    let outcome = store
+        .claim_turn_run(
+            steal_token,
+            past_expiry,
+            past_expiry + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap();
+    assert!(outcome.turn.is_none());
+    assert!(outcome.terminal_event.is_some());
+    assert_eq!(
+        store
+            .fence_turn_lease(turn_id, token, past_expiry + chrono::Duration::seconds(1))
+            .await
+            .unwrap(),
+        TurnLeaseFence::Stale
+    );
+}
+
+#[tokio::test]
 async fn turn_claim_and_heartbeat_require_the_exact_live_lease() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -128,7 +128,7 @@ pub use storage::{
     ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
     RequestToolApprovalOutcome, RequestTurnCancellationOutcome, ResolveSandboxToolCallOutcome,
     ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, SecretProvider, Store,
-    SubmitAgentRunResultOutcome, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+    SubmitAgentRunResultOutcome, TurnLeaseFence, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -791,6 +791,21 @@ pub struct ClaimTurnRunOutcome {
     pub terminal_event: Option<ClaimScanTerminalEvent>,
 }
 
+/// Whether a lease token still owns the exact live worker segment of a turn.
+///
+/// This is the read side of the lease compare-and-swap that guards durable turn
+/// writes. A worker fences an intermediate tool or message side effect on the
+/// current lease so that a segment whose lease was stolen after expiry can
+/// neither commit a fresh effect nor replay one a later attempt already owns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnLeaseFence {
+    /// The turn is running (or cancelling) under exactly this unexpired lease.
+    Current,
+    /// The token no longer owns a live segment: it expired, was superseded by a
+    /// later claim, or the turn already reached a terminal state.
+    Stale,
+}
+
 fn document_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "document storage is not implemented by this Store".into(),
@@ -1828,6 +1843,24 @@ pub trait Store: Send + Sync {
         _now: chrono::DateTime<chrono::Utc>,
         _lease_expires_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool> {
+        turn_storage_unavailable()
+    }
+
+    /// Report whether `lease_token` still owns the exact live segment of a turn.
+    ///
+    /// Returns [`TurnLeaseFence::Current`] only while the turn is running or
+    /// cancelling under this exact token, its claim receipt still matches the
+    /// turn's attempt and claim counters, and the lease has not expired at
+    /// `now`. Any other state — a superseding claim, an expired lease, or a
+    /// terminal turn — is [`TurnLeaseFence::Stale`]. This is a read-only fence a
+    /// worker consults before committing an intermediate tool or message effect;
+    /// it never mutates durable state.
+    async fn fence_turn_lease(
+        &self,
+        _id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<TurnLeaseFence> {
         turn_storage_unavailable()
     }
 

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1348,6 +1348,14 @@ impl Store for PauseTerminalStore {
         }
         Ok(heartbeat)
     }
+    async fn fence_turn_lease(
+        &self,
+        id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::TurnLeaseFence> {
+        self.inner.fence_turn_lease(id, lease_token, now).await
+    }
     async fn complete_turn_run_and_append_event(
         &self,
         id: TurnId,


### PR DESCRIPTION
Turn execution is pinned to a single attempt because a claimed segment's intermediate tool and message effects are not gated on the worker lease. `append_turn_event`, completion, and the park/checkpoint ops all commit under a lease compare-and-swap, but the agent persists tool-call rows, executes server tool side effects, and records assistant messages with no such check. A long provider stream can outlast the lease, and once it expires another worker may terminalize or reclaim the turn while the original segment keeps mutating durable and external state.

## What this does

- Adds `Store::fence_turn_lease(turn_id, lease_token, now) -> TurnLeaseFence { Current, Stale }` — the read side of the lease CAS that already guards the durable turn writes. It reports `Current` only while the turn is running or cancelling under exactly this unexpired token whose claim receipt still matches the live attempt and claim counters; an expired lease, a superseding claim, or a terminal turn is `Stale`. It never mutates state.
- Wires the fence into the claimed agent loop: before a model step persists tool-call rows, runs a server tool, or records its assistant message, the segment reconfirms it still owns the lease and otherwise stops without writing. Terminal completion is still resolved by the worker's own lease CAS, so only the intermediate, tool-bearing path is fenced.

This tightens the single-attempt path so a segment whose lease was stolen mid-stream can neither commit nor replay an intermediate effect a later attempt now owns. `max_attempts` stays pinned at 1; lifting it to a real retry policy needs the tool-result commits co-committed under the CAS and is tracked as follow-up checkboxes on the issue.

## Tests

- Store-level coverage of every fence state: current, expired, unknown and cross-turn tokens, cancelling stays current, a terminalized turn goes stale, and nil identities are rejected.
- Agent-level test proving a claimed turn whose lease is stolen mid-stream neither executes the tool nor persists its rows, and returns a non-completing outcome.

Ran locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, `cargo check --workspace --locked` — all green, no lockfile change.

Closes #311