### PR TITLE
Calibrate tool approval prompts

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -11,7 +11,7 @@
 //! v1 scope (deliberately small; each is a tracked follow-up):
 //! - tool calls run **sequentially** (concurrency for independent calls later);
 //! - approval is **auto** for `ReadOnly`/`Workspace`; `Sensitive` parks via an
-//!   [`ApprovalGate`] until approve/reject (standing grants / auto-judge later);
+//!   [`ApprovalGate`] until approve/reject unless a standing grant covers it;
 //! - context reduction is deterministic floor+restore (no LLM summarization);
 //!   retries with progressive reduction on provider prompt-too-long errors.
 
@@ -1851,7 +1851,8 @@ impl Agent {
         let Some(tool) = self.tools.get(&call.name) else {
             return ToolOutput::error(format!("unknown tool: {}", call.name));
         };
-        // v1 policy: ReadOnly/Workspace auto; Sensitive parks on the approval gate.
+        // Policy: ReadOnly/Workspace auto; uncovered Sensitive calls park on the
+        // approval gate.
         // Commit the approval request *before* emitting ApprovalRequired so a
         // client that sees the event can never race a 404 against a request
         // that exists only in this process.

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -54,8 +54,8 @@ impl ToolScratch {
 /// The approval policy class a tool declares for itself.
 ///
 /// Policy maps class → auto-approve / ask / deny. In v1: `ReadOnly` and
-/// `Workspace` auto-approve; `Sensitive` always parks on the approval gate.
-/// (Workspace-outside prompting and standing grants are deferred.)
+/// `Workspace` auto-approve; `Sensitive` parks on the approval gate unless a
+/// matching standing grant covers the call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ApprovalClass {

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -1109,9 +1109,13 @@ export default function App() {
     );
   }
 
-  async function onApproval(callId: string, decision: "approve" | "reject") {
+  async function onApproval(
+    callId: string,
+    decision: "approve" | "reject",
+    remember = false,
+  ) {
     if (!client || !chat) return;
-    await client.decideApproval(chat.id, callId, decision);
+    await client.decideApproval(chat.id, callId, decision, remember);
     setMessages((prev) =>
       prev.map((m) =>
         m.role === "approval" && m.callId === callId

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -66,6 +66,8 @@ describe("MessageBubble", () => {
       markup.indexOf("Approval needed"),
     );
     expect(markup).toContain("message-approval");
+    expect(markup).toContain(">Approve once<");
+    expect(markup).toContain(">Allow for this chat<");
     expect(markup).not.toContain("Working");
     expect(markup).toContain('aria-live="polite"');
   });

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -47,7 +47,11 @@ type MessageListProps = {
   busy: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
   onScroll: (event: UIEvent<HTMLDivElement>) => void;
-  onApproval: (callId: string, decision: "approve" | "reject") => void;
+  onApproval: (
+    callId: string,
+    decision: "approve" | "reject",
+    remember?: boolean,
+  ) => void;
   onFolderAccessDecision: (
     callId: string,
     decision: FolderAccessDecision,
@@ -137,7 +141,11 @@ function isGroupableTerminalTool(
 export function groupMessageItems(
   messages: ChatMessage[],
   busy: boolean,
-  onApproval: (callId: string, decision: "approve" | "reject") => void,
+  onApproval: (
+    callId: string,
+    decision: "approve" | "reject",
+    remember?: boolean,
+  ) => void,
 ) {
   const items: ReactNode[] = [];
   let index = 0;
@@ -220,7 +228,11 @@ export function MessageBubble({
 }: {
   message: ChatMessage;
   busy: boolean;
-  onApproval: (callId: string, decision: "approve" | "reject") => void;
+  onApproval: (
+    callId: string,
+    decision: "approve" | "reject",
+    remember?: boolean,
+  ) => void;
 }) {
   if (message.role === "tool") {
     return <ToolCallCard name={message.name} status={message.status} />;
@@ -233,13 +245,22 @@ export function MessageBubble({
         {!message.resolved && (
           <div className="approval">
             {message.canApprove && (
-              <button
-                type="button"
-                className="btn btn-primary"
-                onClick={() => onApproval(message.callId, "approve")}
-              >
-                Approve
-              </button>
+              <>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={() => onApproval(message.callId, "approve")}
+                >
+                  Approve once
+                </button>
+                <button
+                  type="button"
+                  className="btn"
+                  onClick={() => onApproval(message.callId, "approve", true)}
+                >
+                  Allow for this chat
+                </button>
+              </>
             )}
             <button
               type="button"

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -490,11 +490,12 @@ export class ApiClient {
     chatId: string,
     callId: string,
     decision: "approve" | "reject",
+    remember = false,
   ): Promise<void> {
     return this.json(`/chats/${chatId}/approvals/${callId}`, {
       method: "POST",
       headers: this.headers(true),
-      body: JSON.stringify({ decision }),
+      body: JSON.stringify({ decision, remember }),
     });
   }
 

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -7,9 +7,9 @@
 //! the *same* `Arc<dyn VectorStore>` the ingest side writes to and the agent
 //! searches a live index.
 //!
-//! It is always `Sensitive`: even local retrieval returns matching document
-//! excerpts to the selected chat model, which may be a remote provider.
-//! Recoverable problems (empty query, an
+//! Its approval class follows the work the tool itself performs: fully local
+//! retrieval is read-only, while a remote embedder, vector store, or reranker
+//! makes the call sensitive. Recoverable problems (empty query, an
 //! embedder/store hiccup) come back as [`ToolOutput::error`] for the model to see
 //! and adapt to, per the tool convention; only genuinely unexpected faults would
 //! be an `Err`.
@@ -160,11 +160,12 @@ impl Tool for SearchTool {
     }
 
     fn approval_class(&self) -> ApprovalClass {
-        // Foreground search results include matching document excerpts. They
-        // are fed back into the selected chat provider even when retrieval,
-        // embedding, and reranking are local. Until the entire consumer path
-        // can prove it remains local, consent is required unconditionally.
-        ApprovalClass::Sensitive
+        let reranker_is_local = self.reranker.as_deref().is_none_or(Reranker::is_local);
+        if self.embedder.is_local() && self.store.is_local() && reranker_is_local {
+            ApprovalClass::ReadOnly
+        } else {
+            ApprovalClass::Sensitive
+        }
     }
 
     async fn execute(&self, ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
@@ -339,6 +340,8 @@ mod tests {
 
     struct FixedReranker(Vec<f32>);
 
+    struct LocalReranker;
+
     struct RemoteEmbedder(HashEmbedder);
 
     #[async_trait]
@@ -371,6 +374,21 @@ mod tests {
             _candidates: &[ScoredChunk],
         ) -> crate::Result<Vec<f32>> {
             Ok(self.0.clone())
+        }
+    }
+
+    #[async_trait]
+    impl Reranker for LocalReranker {
+        fn is_local(&self) -> bool {
+            true
+        }
+
+        async fn rerank(
+            &self,
+            _query: &str,
+            candidates: &[ScoredChunk],
+        ) -> crate::Result<Vec<f32>> {
+            Ok(candidates.iter().map(|candidate| candidate.score).collect())
         }
     }
 
@@ -423,16 +441,20 @@ mod tests {
     }
 
     #[test]
-    fn search_requires_consent_even_when_retrieval_is_local() {
+    fn search_only_requires_consent_when_retrieval_can_escape() {
         let store = Arc::new(InMemoryVectorStore::new(DIMS));
         let local = SearchTool::new(Arc::new(HashEmbedder::new(DIMS)), store.clone());
         assert_eq!(local.spec().name, "search");
-        assert_eq!(local.approval_class(), ApprovalClass::Sensitive);
+        assert_eq!(local.approval_class(), ApprovalClass::ReadOnly);
         assert!(local.spec().input_schema["required"]
             .as_array()
             .unwrap()
             .iter()
             .any(|v| v == "query"));
+
+        let locally_reranked = SearchTool::new(Arc::new(HashEmbedder::new(DIMS)), store.clone())
+            .with_reranker(Arc::new(LocalReranker));
+        assert_eq!(locally_reranked.approval_class(), ApprovalClass::ReadOnly);
 
         let remote = SearchTool::new(
             Arc::new(RemoteEmbedder(HashEmbedder::new(DIMS))),

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -14,13 +14,15 @@ use tokio::sync::Notify;
 use openwave_core::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
     ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, CallId, ChatId,
-    DecideToolApprovalOutcome, RequestToolApprovalOutcome, Result, Store,
+    DecideToolApprovalOutcome, RequestToolApprovalOutcome, Result, StandingGrant, StandingGrants,
+    Store,
 };
 
 /// Coordinates durable approval state with local low-latency waiters.
 pub struct ApprovalBroker {
     store: Arc<dyn Store>,
     wake: Arc<Notify>,
+    standing_grants: Arc<StandingGrants>,
 }
 
 impl ApprovalBroker {
@@ -29,7 +31,13 @@ impl ApprovalBroker {
         Self {
             store,
             wake: Arc::new(Notify::new()),
+            standing_grants: Arc::new(StandingGrants::new()),
         }
+    }
+
+    /// Live remembered approvals shared with foreground agent loops.
+    pub fn standing_grants(&self) -> Arc<StandingGrants> {
+        self.standing_grants.clone()
     }
 
     /// Decide one exact request. The same decision is an idempotent success;
@@ -39,6 +47,19 @@ impl ApprovalBroker {
         chat_id: ChatId,
         call_id: CallId,
         decision: ApprovalDecision,
+    ) -> Result<ResolveApprovalOutcome> {
+        self.resolve_with_remember(chat_id, call_id, decision, false)
+            .await
+    }
+
+    /// Decide one exact request and optionally remember an approval for later
+    /// matching calls in the same chat.
+    pub async fn resolve_with_remember(
+        &self,
+        chat_id: ChatId,
+        call_id: CallId,
+        decision: ApprovalDecision,
+        remember: bool,
     ) -> Result<ResolveApprovalOutcome> {
         let Some(current) = self.store.get_tool_call_approval(call_id).await? else {
             return Ok(ResolveApprovalOutcome::NotPending);
@@ -55,6 +76,16 @@ impl ApprovalBroker {
             .await?;
         match outcome {
             DecideToolApprovalOutcome::Decided(_) | DecideToolApprovalOutcome::Existing(_) => {
+                if remember && matches!(&decision, ApprovalDecision::Approve) {
+                    if let Some(grant) = StandingGrant::new(
+                        current.chat_id,
+                        current.tool_name,
+                        current.kind,
+                        Utc::now(),
+                    ) {
+                        self.standing_grants.record(grant);
+                    }
+                }
                 self.wake.notify_waiters();
                 Ok(ResolveApprovalOutcome::Resolved)
             }
@@ -331,6 +362,29 @@ mod tests {
                 .unwrap(),
             ResolveApprovalOutcome::DecisionConflict
         );
+    }
+
+    #[tokio::test]
+    async fn remembered_approval_grants_matching_calls_in_the_chat() {
+        let (store, request) = setup("search").await;
+        let broker = ApprovalBroker::new(store);
+        let _pending = broker.register(request.clone(), None).await;
+
+        assert_eq!(
+            broker
+                .resolve_with_remember(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    true,
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+        assert!(broker
+            .standing_grants()
+            .covers(request.chat_id, &request.tool_name, request.kind,));
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1324,9 +1324,12 @@ pub async fn post_cancel(
 pub struct ApprovalBody {
     /// `approve` or `reject`.
     pub decision: ApprovalChoice,
-    /// Optional reject reason (ignored on approve).
+    /// Optional reject reason (invalid on approve).
     #[serde(default)]
     pub reason: Option<String>,
+    /// Remember an approval for matching calls in this chat.
+    #[serde(default)]
+    pub remember: bool,
 }
 
 /// Wire form of an approval decision.
@@ -1428,6 +1431,11 @@ pub async fn post_approval(
                 .unwrap_or_else(|| "user denied approval".into()),
         },
     };
+    if body.remember && !matches!(&decision, ApprovalDecision::Approve) {
+        return Err(ServerError::bad_request(
+            "only an approval can be remembered",
+        ));
+    }
     if decision
         .reason()
         .is_some_and(|reason| !openwave_core::ToolApproval::valid_reason(reason))
@@ -1436,7 +1444,11 @@ pub async fn post_approval(
             "approval reject reason is invalid",
         ));
     }
-    match state.approvals.resolve(chat_id, call_id, decision).await? {
+    match state
+        .approvals
+        .resolve_with_remember(chat_id, call_id, decision, body.remember)
+        .await?
+    {
         crate::approvals::ResolveApprovalOutcome::Resolved => Ok(StatusCode::NO_CONTENT),
         crate::approvals::ResolveApprovalOutcome::NotPending => Err(ServerError::not_found(
             format!("no pending approval for call {call_id}"),

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -10519,7 +10519,11 @@ impl ModelProvider for ProbeProvider {
         &self,
         _req: ChatRequest,
     ) -> openwave_core::Result<BoxStream<'static, ProviderEvent>> {
-        let events = if self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+        let events = if self
+            .calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            .is_multiple_of(2)
+        {
             vec![
                 ProviderEvent::ToolCallStarted {
                     index: 0,
@@ -10616,6 +10620,7 @@ async fn approval_endpoint_unparks_a_sensitive_tool() {
     // decision, leaving the exact approval actionable.
     for body in [
         serde_json::json!({"decision": "reject", "reason": "bad\0reason"}),
+        serde_json::json!({"decision": "reject", "remember": true}),
         serde_json::json!({"decision": "approve", "unexpected": true}),
     ] {
         let invalid = router
@@ -10652,7 +10657,7 @@ async fn approval_endpoint_unparks_a_sensitive_tool() {
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({"decision": "approve"}).to_string(),
+                    serde_json::json!({"decision": "approve", "remember": true}).to_string(),
                 ))
                 .unwrap(),
         )
@@ -10672,6 +10677,7 @@ async fn approval_endpoint_unparks_a_sensitive_tool() {
 
     // An exact decision retry remains an idempotent success after execution.
     let again = router
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -10686,6 +10692,37 @@ async fn approval_endpoint_unparks_a_sensitive_tool() {
         .await
         .unwrap();
     assert_eq!(again.status(), StatusCode::NO_CONTENT);
+
+    // A later matching call in this chat runs under the standing grant and
+    // never emits a second approval prompt.
+    let second_turn = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, second_turn, "probe it again").await,
+        StatusCode::ACCEPTED
+    );
+    let mut completed_events = None;
+    for _ in 0..500 {
+        let events = store.list_events(chat.id, 0).await.unwrap();
+        if events
+            .iter()
+            .filter(|event| matches!(event.event, AgentEvent::TurnCompleted { .. }))
+            .count()
+            == 2
+        {
+            completed_events = Some(events);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let events = completed_events.expect("second turn should complete under the standing grant");
+    assert_eq!(ran.load(std::sync::atomic::Ordering::SeqCst), 2);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event.event, AgentEvent::ApprovalRequired { .. }))
+            .count(),
+        1,
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -497,6 +497,7 @@ impl TurnWorker {
             let steer = active.steer_inbox();
             let agent = Agent::new(provider, self.tools.clone(), self.store.clone(), config)
                 .with_approvals(self.approvals.clone())
+                .with_standing_grants(self.approvals.standing_grants())
                 .with_cancel(cancel.clone())
                 .with_steer(steer.clone())
                 .with_durable_steer(lease_token)


### PR DESCRIPTION
## Summary

- classify fully local document search as `ReadOnly` while keeping remote embedding, storage, and reranking `Sensitive`
- add a per-chat “remember this” approval path backed by `StandingGrants`
- expose “Approve once” and “Allow for this chat” actions in the desktop UI
- cover approval classification and repeated-call behavior in unit and end-to-end tests

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo check --workspace --locked`
- `cargo test -p openwave-server --lib -- --test-threads=1`
- `pnpm --dir crates/openwave-desktop/ui test`
- `pnpm --dir crates/openwave-desktop/ui build`

Closes #317
