### PR TITLE
feat(server): add capability-bearing ModelSpec registry

### DIFF
--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -4,8 +4,22 @@ import { ModelMenu } from "./ModelMenu";
 import type { ModelInfo } from "./api";
 
 const MODELS: ModelInfo[] = [
-  { id: "claude-sonnet-4", provider: "anthropic" },
-  { id: "gpt-4o", provider: "openai" },
+  {
+    id: "claude-sonnet-4",
+    display_name: "Claude Sonnet 4",
+    provider: "anthropic",
+    context_window: 200_000,
+    supports_reasoning_effort: true,
+    multimodal: true,
+  },
+  {
+    id: "gpt-4o",
+    display_name: "GPT-4o",
+    provider: "openai",
+    context_window: 128_000,
+    supports_reasoning_effort: false,
+    multimodal: true,
+  },
 ];
 
 function triggerMarkup(value: string | null): string {
@@ -21,10 +35,10 @@ describe("ModelMenu", () => {
     expect(markup).toContain(">Default<");
   });
 
-  it("labels the trigger with a selected known model id", () => {
+  it("labels the trigger with a selected model's display name", () => {
     const markup = triggerMarkup("gpt-4o");
-    expect(markup).toContain('aria-label="Model: gpt-4o"');
-    expect(markup).toContain(">gpt-4o<");
+    expect(markup).toContain('aria-label="Model: GPT-4o"');
+    expect(markup).toContain(">GPT-4o<");
   });
 
   it("labels the trigger with an unknown (custom) override verbatim", () => {

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -25,7 +25,7 @@ export function ModelMenu({
   onChange: (id: string | null) => void | Promise<void>;
 }) {
   const known = models.find((m) => m.id === value);
-  const label = value ? (known?.id ?? value) : "Default";
+  const label = value ? (known?.display_name ?? value) : "Default";
 
   // Group by provider, preserving first-seen order.
   const groups: { provider: string; models: ModelInfo[] }[] = [];
@@ -82,7 +82,9 @@ export function ModelMenu({
                     if (!selected) void onChange(model.id);
                   }}
                 >
-                  <span className="model-menu-item-label">{model.id}</span>
+                  <span className="model-menu-item-label">
+                    {model.display_name}
+                  </span>
                   {selected && <Check className="ml-auto" />}
                 </DropdownMenuItem>
               );

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -15,7 +15,15 @@ export type ProviderInfo = {
 
 export type ModelInfo = {
   id: string;
+  /** Human-readable label for the selector (e.g. "Claude Opus 4.8"). */
+  display_name: string;
   provider: string;
+  /** Approximate context window in tokens. */
+  context_window: number;
+  /** Whether the model exposes a reasoning-effort control. */
+  supports_reasoning_effort: boolean;
+  /** Whether the model accepts image input alongside text. */
+  multimodal: boolean;
 };
 
 /** Global runtime settings (`GET/PUT /settings`). */

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -79,20 +79,175 @@ impl ProviderKind {
         )
     }
 
-    /// Curated model ids this kind contributes to `GET /models`.
+    /// Curated model specs this kind contributes to `GET /models`.
     ///
     /// `openai_compatible` is free-form (local / custom gateways) — it contributes
     /// nothing to the curated catalog; the chat model field accepts any string.
-    pub fn curated_models(self) -> &'static [&'static str] {
+    pub fn curated_specs(self) -> &'static [ModelSpec] {
         match self {
-            ProviderKind::Anthropic => &[
-                "claude-opus-4-8",
-                "claude-sonnet-5",
-                "claude-haiku-4-5-20251001",
-            ],
-            ProviderKind::Openai => &["gpt-4o", "gpt-4o-mini", "o3", "o4-mini"],
+            ProviderKind::Anthropic => ANTHROPIC_MODELS,
+            ProviderKind::Openai => OPENAI_MODELS,
             ProviderKind::OpenaiCompatible => &[],
         }
+    }
+}
+
+/// Capability metadata for a curated model, surfaced by `GET /models` so the
+/// chat model selector can show a human label and (later) reason about what a
+/// model supports.
+///
+/// Kept deliberately small — the fields we need at the reasoning-effort /
+/// multimodal boundary. Values are conservative where a hard number isn't
+/// obvious; extend as new capability boundaries (pricing, extra modalities)
+/// start to matter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelSpec {
+    /// Identifier passed to the provider and stored as `chat.model`.
+    pub id: &'static str,
+    /// Human-readable label for the selector (e.g. `"Claude Opus 4.8"`).
+    pub display_name: &'static str,
+    /// Provider that serves the model.
+    pub provider: ProviderKind,
+    /// Approximate context window in tokens.
+    pub context_window: u32,
+    /// Whether the model exposes a reasoning-effort control.
+    pub supports_reasoning_effort: bool,
+    /// Whether the model accepts image input alongside text.
+    pub multimodal: bool,
+}
+
+/// Anthropic's curated catalog.
+const ANTHROPIC_MODELS: &[ModelSpec] = &[
+    ModelSpec {
+        id: "claude-opus-4-8",
+        display_name: "Claude Opus 4.8",
+        provider: ProviderKind::Anthropic,
+        context_window: 200_000,
+        supports_reasoning_effort: true,
+        multimodal: true,
+    },
+    ModelSpec {
+        id: "claude-sonnet-5",
+        display_name: "Claude Sonnet 5",
+        provider: ProviderKind::Anthropic,
+        context_window: 200_000,
+        supports_reasoning_effort: true,
+        multimodal: true,
+    },
+    ModelSpec {
+        id: "claude-haiku-4-5-20251001",
+        display_name: "Claude Haiku 4.5",
+        provider: ProviderKind::Anthropic,
+        context_window: 200_000,
+        supports_reasoning_effort: true,
+        multimodal: true,
+    },
+];
+
+/// OpenAI's curated catalog.
+const OPENAI_MODELS: &[ModelSpec] = &[
+    ModelSpec {
+        id: "gpt-4o",
+        display_name: "GPT-4o",
+        provider: ProviderKind::Openai,
+        context_window: 128_000,
+        supports_reasoning_effort: false,
+        multimodal: true,
+    },
+    ModelSpec {
+        id: "gpt-4o-mini",
+        display_name: "GPT-4o mini",
+        provider: ProviderKind::Openai,
+        context_window: 128_000,
+        supports_reasoning_effort: false,
+        multimodal: true,
+    },
+    ModelSpec {
+        id: "o3",
+        display_name: "o3",
+        provider: ProviderKind::Openai,
+        context_window: 200_000,
+        supports_reasoning_effort: true,
+        multimodal: true,
+    },
+    ModelSpec {
+        id: "o4-mini",
+        display_name: "o4-mini",
+        provider: ProviderKind::Openai,
+        context_window: 200_000,
+        supports_reasoning_effort: true,
+        multimodal: true,
+    },
+];
+
+/// Human label for a model id: the curated display name when the id is in the
+/// registry, else a readable fallback derived from the id (a trailing date
+/// suffix is dropped and the remaining `-`-separated tokens are title-cased).
+///
+/// Useful for ids outside the curated catalog — a free-form
+/// `openai_compatible` model, or a `chat.model` a client set directly.
+pub fn display_name_for(id: &str) -> String {
+    for &kind in ProviderKind::ALL {
+        for spec in kind.curated_specs() {
+            if spec.id == id {
+                return spec.display_name.to_string();
+            }
+        }
+    }
+    derive_display_name(id)
+}
+
+/// Fallback label for an id with no curated entry.
+fn derive_display_name(id: &str) -> String {
+    strip_date_suffix(id)
+        .split('-')
+        .map(title_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Drop a trailing `-YYYYMMDD` or `-YYYY-MM-DD` date suffix, if present.
+fn strip_date_suffix(id: &str) -> &str {
+    let tokens: Vec<&str> = id.split('-').collect();
+    if tokens.len() < 2 {
+        return id;
+    }
+    let is_digits = |t: &str, len: usize| t.len() == len && t.bytes().all(|b| b.is_ascii_digit());
+
+    let last = tokens[tokens.len() - 1];
+    if is_digits(last, 8) {
+        return &id[..id.len() - last.len() - 1];
+    }
+    if tokens.len() >= 4 {
+        let (y, m, d) = (
+            tokens[tokens.len() - 3],
+            tokens[tokens.len() - 2],
+            tokens[tokens.len() - 1],
+        );
+        if is_digits(y, 4) && is_digits(m, 2) && is_digits(d, 2) {
+            let cut = y.len() + m.len() + d.len() + 3; // three separating dashes
+            return &id[..id.len() - cut];
+        }
+    }
+    id
+}
+
+/// Title-case a single id token, honoring a few brand spellings.
+fn title_token(token: &str) -> String {
+    match token {
+        "gpt" => return "GPT".to_string(),
+        "claude" => return "Claude".to_string(),
+        "opus" => return "Opus".to_string(),
+        "sonnet" => return "Sonnet".to_string(),
+        "haiku" => return "Haiku".to_string(),
+        "mini" => return "Mini".to_string(),
+        "nano" => return "Nano".to_string(),
+        _ => {}
+    }
+    let mut chars = token.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
     }
 }
 
@@ -418,9 +573,9 @@ pub async fn collect_routes(
             api_key,
             base_url: config.base_url,
             curated_models: kind
-                .curated_models()
+                .curated_specs()
                 .iter()
-                .map(|m| (*m).to_string())
+                .map(|spec| spec.id.to_string())
                 .collect(),
         });
     }
@@ -458,12 +613,12 @@ pub async fn migrate_legacy_anthropic(
     Ok(())
 }
 
-/// Models from providers that are both enabled and credentialed.
+/// Model specs from providers that are both enabled and credentialed.
 pub async fn catalog_models(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
-) -> Result<Vec<(ProviderKind, &'static str)>> {
-    let mut models = Vec::new();
+) -> Result<Vec<&'static ModelSpec>> {
+    let mut models: Vec<&'static ModelSpec> = Vec::new();
     for &kind in ProviderKind::ALL {
         let config = read_config(store, kind).await?;
         if !config.enabled {
@@ -472,17 +627,13 @@ pub async fn catalog_models(
         if !has_credential(secrets, kind).await {
             continue;
         }
-        for id in kind.curated_models() {
-            models.push((kind, *id));
-        }
+        models.extend(kind.curated_specs());
     }
     // If nothing is enabled+credentialed yet, still surface Anthropic's curated
     // list so a fresh install's model selector isn't empty before the user
     // finishes provider setup (turns still fail-closed without a key).
     if models.is_empty() {
-        for id in ProviderKind::Anthropic.curated_models() {
-            models.push((ProviderKind::Anthropic, *id));
-        }
+        models.extend(ProviderKind::Anthropic.curated_specs());
     }
     Ok(models)
 }
@@ -500,6 +651,34 @@ mod tests {
         let back: ProviderCredential = serde_json::from_str(&json).unwrap();
         assert_eq!(back.as_api_key(), Some("sk-secret"));
         assert!(!format!("{cred:?}").contains("sk-secret"));
+    }
+
+    #[test]
+    fn display_name_prefers_curated_entry() {
+        assert_eq!(display_name_for("claude-opus-4-8"), "Claude Opus 4.8");
+        assert_eq!(display_name_for("gpt-4o-mini"), "GPT-4o mini");
+    }
+
+    #[test]
+    fn display_name_falls_back_for_unknown_ids() {
+        // Trailing date suffix is dropped, remaining tokens title-cased.
+        assert_eq!(
+            display_name_for("claude-sonnet-9-20260101"),
+            "Claude Sonnet 9"
+        );
+        assert_eq!(display_name_for("gpt-6-2026-01-01"), "GPT 6");
+        assert_eq!(display_name_for("local-model"), "Local Model");
+    }
+
+    #[test]
+    fn curated_specs_ids_match_across_kinds() {
+        // Every spec reports the provider whose catalog it lives in.
+        for &kind in ProviderKind::ALL {
+            for spec in kind.curated_specs() {
+                assert_eq!(spec.provider, kind);
+            }
+        }
+        assert!(ProviderKind::OpenaiCompatible.curated_specs().is_empty());
     }
 
     #[test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -333,8 +333,16 @@ pub async fn delete_provider_credential(
 pub struct ModelInfo {
     /// The identifier passed to the provider and stored as `chat.model`.
     pub id: String,
+    /// Human-readable label for the selector (e.g. `"Claude Opus 4.8"`).
+    pub display_name: String,
     /// The provider that serves the model.
     pub provider: String,
+    /// Approximate context window in tokens.
+    pub context_window: u32,
+    /// Whether the model exposes a reasoning-effort control.
+    pub supports_reasoning_effort: bool,
+    /// Whether the model accepts image input alongside text.
+    pub multimodal: bool,
 }
 
 /// Response for `GET /models`.
@@ -352,9 +360,13 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCata
     let models = providers::catalog_models(&*state.store, &*state.secrets)
         .await?
         .into_iter()
-        .map(|(kind, id)| ModelInfo {
-            id: id.to_string(),
-            provider: kind.as_str().to_string(),
+        .map(|spec| ModelInfo {
+            id: spec.id.to_string(),
+            display_name: providers::display_name_for(spec.id),
+            provider: spec.provider.as_str().to_string(),
+            context_window: spec.context_window,
+            supports_reasoning_effort: spec.supports_reasoning_effort,
+            multimodal: spec.multimodal,
         })
         .collect();
     Ok(Json(ModelCatalog { models }))

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -7763,6 +7763,15 @@ async fn models_catalog_is_served() {
     let models = catalog["models"].as_array().unwrap();
     assert!(!models.is_empty());
     assert!(models.iter().any(|m| m["provider"] == "anthropic"));
+    // Each entry carries a human label and capability metadata.
+    let opus = models
+        .iter()
+        .find(|m| m["id"] == "claude-opus-4-8")
+        .expect("curated Anthropic model is present");
+    assert_eq!(opus["display_name"], "Claude Opus 4.8");
+    assert!(opus["context_window"].as_u64().unwrap() > 0);
+    assert!(opus["multimodal"].as_bool().unwrap());
+    assert!(opus["supports_reasoning_effort"].as_bool().unwrap());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Grows the curated model catalog from flat id lists into a `ModelSpec` registry carrying per-model capability metadata, and surfaces the richer info through the existing `GET /models` endpoint and the chat model selector.

- **`ModelSpec`** (`providers.rs`) describes each curated model: `id`, `display_name`, `provider`, `context_window`, `supports_reasoning_effort`, `multimodal`. Anthropic and OpenAI catalogs are now `&'static [ModelSpec]`; `openai_compatible` stays free-form (empty).
- **`display_name_for(id)`** resolves a human label — curated name when the id is in the registry, else a readable fallback derived from the id (trailing `-YYYYMMDD` / `-YYYY-MM-DD` date suffix dropped, remaining tokens title-cased). Useful for ids outside the catalog.
- **`GET /models`** `ModelInfo` gains `display_name` plus the capability flags and `context_window`, populated from the specs.
- **`ModelMenu`** renders the human `display_name` (trigger label and list items) instead of the raw id; provider grouping unchanged. `api.ts` type and `ModelMenu.test.tsx` updated to match.

Capability numbers are conservative where a hard value isn't obvious — they can be tuned per-model later.

## Scope

Backend registry + display-name surfacing only. The settings provider/model config pages and full reasoning-effort UI wiring are out of scope (tracked separately). Deferred follow-ups are noted as checkboxes on the issue.

## Verification

- Rust: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, `cargo check --workspace --locked` (no lock diff) all pass.
- Desktop UI (`crates/openwave-desktop/ui`): `tsc --noEmit`, `pnpm test` (153 tests), and `pnpm build` all pass.

Closes #303