### PR TITLE
Make turn retries replay-safe

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -43,7 +43,7 @@ use crate::citation::{
 use crate::context;
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
-use crate::id::{AgentRunId, CallId, MessageId, TurnId};
+use crate::id::{AgentRunId, CallId, ChatId, MessageId, TurnId};
 use crate::model::{
     Chat, Message, Role, ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus,
     TurnRunStatus,
@@ -53,8 +53,9 @@ use crate::provider::{
 };
 use crate::steer::SteerInbox;
 use crate::storage::{
-    AcceptToolCallOutcome, ApplyTurnSteerOutcome, JournaledTurnSteerOutcome,
-    ResolveToolCallOutcome, Store, TurnLeaseFence,
+    AcceptClaimedToolCallOutcome, AcceptToolCallOutcome, AppendClaimedMessageOutcome,
+    ApplyTurnSteerOutcome, JournaledTurnSteerOutcome, ResolveToolCallOutcome, Store,
+    TurnLeaseFence,
 };
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
 
@@ -740,6 +741,13 @@ struct AssistantCandidate {
     citations: Vec<AssistantCitationReference>,
 }
 
+enum AcceptedServerCall {
+    Accepted,
+    Existing(Box<ToolCallRecord>),
+    IdentityConflict,
+    LeaseLost,
+}
+
 impl Agent {
     /// Assemble an agent from its dependencies and config.
     ///
@@ -1351,29 +1359,27 @@ impl Agent {
                 });
                 // Persist the call as soon as args are known so a crash mid-tool
                 // still leaves a reconstructable ToolUse on the next turn.
-                let outcome = self
-                    .store
-                    .accept_tool_call(&ToolCallRecord {
-                        id: call.call_id,
-                        chat_id: chat.id,
-                        turn_id,
-                        provider_id: call.provider_id.clone(),
-                        name: call.name.clone(),
-                        arguments: args,
-                        execution: ToolCallExecution::Server,
-                        status: ToolCallStatus::Pending,
-                        result: None,
-                        error_code: None,
-                        error_detail: None,
-                        client_executor_id: None,
-                        client_lease_expires_at: None,
-                        created_at: Utc::now(),
-                        resolved_at: None,
-                    })
-                    .await?;
+                let record = ToolCallRecord {
+                    id: call.call_id,
+                    chat_id: chat.id,
+                    turn_id,
+                    provider_id: call.provider_id.clone(),
+                    name: call.name.clone(),
+                    arguments: args,
+                    execution: ToolCallExecution::Server,
+                    status: ToolCallStatus::Pending,
+                    result: None,
+                    error_code: None,
+                    error_detail: None,
+                    client_executor_id: None,
+                    client_lease_expires_at: None,
+                    created_at: Utc::now(),
+                    resolved_at: None,
+                };
+                let outcome = self.accept_server_call_retry(&record).await?;
                 match outcome {
-                    AcceptToolCallOutcome::Accepted(_) => {}
-                    AcceptToolCallOutcome::Existing(existing) if existing.status.is_terminal() => {
+                    AcceptedServerCall::Accepted => {}
+                    AcceptedServerCall::Existing(existing) if existing.status.is_terminal() => {
                         let content = existing.result.ok_or_else(|| {
                             AgentError::Store(format!(
                                 "terminal tool call {} is missing its result",
@@ -1390,10 +1396,16 @@ impl Agent {
                             },
                         );
                     }
-                    AcceptToolCallOutcome::Existing(_) => {}
-                    AcceptToolCallOutcome::IdentityConflict => {
+                    AcceptedServerCall::Existing(_) => {}
+                    AcceptedServerCall::IdentityConflict => {
                         return Err(AgentError::Store(format!(
                             "tool call {} identity conflicts with its canonical request",
+                            call.call_id
+                        )));
+                    }
+                    AcceptedServerCall::LeaseLost => {
+                        return Err(AgentError::Store(format!(
+                            "turn {turn_id} lost its lease while accepting tool call {}",
                             call.call_id
                         )));
                     }
@@ -1504,7 +1516,10 @@ impl Agent {
                         ToolOutput::error("turn cancelled before tool execution"),
                         true,
                     ),
-                    None => (self.run_tool(chat, turn_id, call, events, None).await, true),
+                    None => {
+                        self.ensure_durable_lease_current(turn_id).await?;
+                        (self.run_tool(chat, turn_id, call, events, None).await, true)
+                    }
                 };
                 events.send(AgentEvent::ToolCallCompleted {
                     call_id: call.call_id,
@@ -1523,11 +1538,11 @@ impl Agent {
                         }
                     };
                     let outcome = self
-                        .store
-                        .resolve_server_tool_call_with_evidence(
+                        .resolve_server_call_retry(
+                            chat.id,
+                            turn_id,
                             call.call_id,
                             &resolution,
-                            Utc::now(),
                             &output.private_evidence,
                         )
                         .await?;
@@ -1712,6 +1727,115 @@ impl Agent {
                     )));
                 }
                 Err(_) => self.wait_for_durable_store_retry(turn_id).await?,
+            }
+        }
+    }
+
+    async fn accept_server_call_retry(&self, call: &ToolCallRecord) -> Result<AcceptedServerCall> {
+        let Some(lease_token) = self.durable_steer_lease else {
+            return Ok(match self.store.accept_tool_call(call).await? {
+                AcceptToolCallOutcome::Accepted(_) => AcceptedServerCall::Accepted,
+                AcceptToolCallOutcome::Existing(existing) => {
+                    AcceptedServerCall::Existing(Box::new(existing))
+                }
+                AcceptToolCallOutcome::IdentityConflict => AcceptedServerCall::IdentityConflict,
+            });
+        };
+        loop {
+            match self
+                .store
+                .accept_claimed_tool_call(call, lease_token, Utc::now())
+                .await
+            {
+                Ok(AcceptClaimedToolCallOutcome::Accepted(_)) => {
+                    return Ok(AcceptedServerCall::Accepted);
+                }
+                Ok(AcceptClaimedToolCallOutcome::Existing(existing)) => {
+                    return Ok(AcceptedServerCall::Existing(Box::new(existing)));
+                }
+                Ok(AcceptClaimedToolCallOutcome::IdentityConflict) => {
+                    return Ok(AcceptedServerCall::IdentityConflict);
+                }
+                Ok(AcceptClaimedToolCallOutcome::LeaseLost) => {
+                    return Ok(AcceptedServerCall::LeaseLost);
+                }
+                Err(_) => {
+                    self.ensure_durable_lease_current(call.turn_id).await?;
+                    self.wait_for_durable_store_retry(call.turn_id).await?;
+                }
+            }
+        }
+    }
+
+    async fn resolve_server_call_retry(
+        &self,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        call_id: CallId,
+        resolution: &ToolCallResolution,
+        evidence: &[crate::RetrievalEvidenceInput],
+    ) -> Result<ResolveToolCallOutcome> {
+        let resolved_at = Utc::now();
+        let Some(lease_token) = self.durable_steer_lease else {
+            return self
+                .store
+                .resolve_server_tool_call_with_evidence(call_id, resolution, resolved_at, evidence)
+                .await;
+        };
+        loop {
+            match self
+                .store
+                .resolve_claimed_server_tool_call_with_evidence(
+                    call_id,
+                    chat_id,
+                    turn_id,
+                    lease_token,
+                    Utc::now(),
+                    resolution,
+                    resolved_at,
+                    evidence,
+                )
+                .await
+            {
+                Ok(outcome) => return Ok(outcome),
+                Err(_) => {
+                    self.ensure_durable_lease_current(turn_id).await?;
+                    self.wait_for_durable_store_retry(turn_id).await?;
+                }
+            }
+        }
+    }
+
+    async fn abandon_inherited_server_call_retry(
+        &self,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        call_id: CallId,
+        resolution: &ToolCallResolution,
+    ) -> Result<ResolveToolCallOutcome> {
+        let lease_token = self.durable_steer_lease.ok_or_else(|| {
+            AgentError::Store("inherited tool abandonment requires a durable lease".into())
+        })?;
+        let resolved_at = Utc::now();
+        loop {
+            match self
+                .store
+                .abandon_inherited_server_tool_call(
+                    call_id,
+                    chat_id,
+                    turn_id,
+                    lease_token,
+                    Utc::now(),
+                    resolution,
+                    resolved_at,
+                )
+                .await
+            {
+                Ok(outcome) => return Ok(outcome),
+                Err(_) => {
+                    self.ensure_durable_lease_current(turn_id).await?;
+                    self.wait_for_durable_store_retry(turn_id).await?;
+                }
             }
         }
     }
@@ -2045,6 +2169,65 @@ impl Agent {
                 args: serde_json::to_string(&stored.arguments)?,
             };
             let durable_approval = self.store.get_tool_call_approval(call.call_id).await?;
+            if self.durable_steer_lease.is_some() {
+                // A pending call recovered at startup is ambiguous: the prior
+                // process may have performed its side effect and died
+                // before committing the result. Never execute it again. Commit
+                // a deterministic failed result under this attempt's lease so
+                // the model can recover without double-applying the effect.
+                let output = ToolOutput::error(
+                    "tool execution was interrupted before its result was committed; the call was not replayed",
+                );
+                let resolution = ToolCallResolution::Failed {
+                    result: output.content.clone(),
+                    error_code: "tool_execution_interrupted".into(),
+                    error_detail: Some(
+                        "a prior turn attempt may have executed this call; replay was suppressed"
+                            .into(),
+                    ),
+                };
+                let outcome = self
+                    .abandon_inherited_server_call_retry(
+                        chat.id,
+                        turn_id,
+                        call.call_id,
+                        &resolution,
+                    )
+                    .await?;
+                if !matches!(
+                    outcome,
+                    ResolveToolCallOutcome::Resolved | ResolveToolCallOutcome::Existing
+                ) {
+                    return Err(AgentError::Store(format!(
+                        "inherited tool call {} could not be abandoned: {outcome:?}",
+                        call.call_id
+                    )));
+                }
+                if durable_approval.is_some() {
+                    if let Some(approval) = self.store.get_tool_call_approval(call.call_id).await? {
+                        events.send(AgentEvent::ApprovalDecided {
+                            call_id: call.call_id,
+                            approved: matches!(
+                                approval.status,
+                                crate::approval::ToolApprovalStatus::Approved
+                            ),
+                        });
+                    }
+                }
+                events.send(AgentEvent::ToolCallCompleted {
+                    call_id: call.call_id,
+                    output: output.clone(),
+                });
+                transcript.push(ChatMessage {
+                    role: Role::User,
+                    content: vec![ContentBlock::ToolResult {
+                        tool_use_id: call.provider_id,
+                        content: output.content,
+                        is_error: true,
+                    }],
+                });
+                continue;
+            }
             let tool_available = self.tools.get(&call.name).is_some();
             let cancelled_before_run = self.cancel.is_cancelled();
             let output = if cancelled_before_run {
@@ -2159,6 +2342,39 @@ impl Agent {
         message: &Message,
         citations: &[AssistantCitationReference],
     ) -> Result<()> {
+        if let Some(lease_token) = self.durable_steer_lease {
+            loop {
+                match self
+                    .store
+                    .append_claimed_assistant_message_with_citations(
+                        message,
+                        citations,
+                        lease_token,
+                        Utc::now(),
+                    )
+                    .await
+                {
+                    Ok(AppendClaimedMessageOutcome::Appended)
+                    | Ok(AppendClaimedMessageOutcome::Existing) => return Ok(()),
+                    Ok(AppendClaimedMessageOutcome::IdentityConflict) => {
+                        return Err(AgentError::Store(format!(
+                            "message identity {} conflicts with its claimed assistant payload",
+                            message.id
+                        )));
+                    }
+                    Ok(AppendClaimedMessageOutcome::LeaseLost) => {
+                        return Err(AgentError::Store(format!(
+                            "turn {} lost its lease while appending assistant message {}",
+                            message.turn_id, message.id
+                        )));
+                    }
+                    Err(_) => {
+                        self.ensure_durable_lease_current(message.turn_id).await?;
+                        self.wait_for_durable_store_retry(message.turn_id).await?;
+                    }
+                }
+            }
+        }
         if self
             .store
             .append_assistant_message_with_citations(message, citations)
@@ -4325,7 +4541,7 @@ mod tests {
 
     /// Asks for the `spy` tool once, but first lets the turn's lease be stolen
     /// while this provider call is in flight: a fresh claim scan past the lease
-    /// expiry terminalizes the single-attempt turn out from under this worker.
+    /// expiry starts the retry attempt under a new token.
     struct LeaseStealingProvider {
         store: Arc<dyn Store>,
         steal_at: DateTime<Utc>,
@@ -4348,8 +4564,8 @@ mod tests {
                     )
                     .await?;
                 assert!(
-                    outcome.terminal_event.is_some(),
-                    "expired single-attempt turn should be terminalized by the steal"
+                    outcome.turn.is_some(),
+                    "expired turn should be reclaimed for a retry by the steal"
                 );
             }
             Ok(stream::iter(vec![
@@ -4364,6 +4580,27 @@ mod tests {
                 },
                 ProviderEvent::Stop {
                     reason: StopReason::ToolUse,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    struct AnswerOnlyProvider;
+
+    #[async_trait]
+    impl ModelProvider for AnswerOnlyProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("answer-only")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "recovered".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
                 },
             ])
             .boxed())
@@ -4440,10 +4677,128 @@ mod tests {
             0,
             "a stolen lease must not execute tool side effects"
         );
-        // The thief's terminal state stands; the stale worker committed nothing.
+        // The retry claim stands; the stale worker committed nothing.
         let turn = store.get_turn_run(turn_id).await.unwrap().unwrap();
-        assert_eq!(turn.status, TurnRunStatus::Failed);
-        assert_eq!(turn.lease_token, None);
+        assert_eq!(turn.status, TurnRunStatus::Running);
+        assert_ne!(turn.lease_token, Some(lease_token));
+    }
+
+    #[tokio::test]
+    async fn retry_abandons_an_inherited_pending_tool_without_replaying_it() {
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        let accepted = match store
+            .accept_turn(turn_id, chat.id, "fake", "go")
+            .await
+            .unwrap()
+        {
+            crate::storage::AcceptTurnOutcome::Accepted(turn) => turn,
+            outcome => panic!("unexpected acceptance: {outcome:?}"),
+        };
+        let first_claim_at = accepted.available_at;
+        let first_lease = uuid::Uuid::new_v4();
+        store
+            .claim_turn_run(
+                first_lease,
+                first_claim_at,
+                first_claim_at + chrono::Duration::seconds(1),
+            )
+            .await
+            .unwrap();
+        let call_id = CallId::new();
+        let call = ToolCallRecord {
+            id: call_id,
+            chat_id: chat.id,
+            turn_id,
+            provider_id: "call_spy".into(),
+            name: "spy".into(),
+            arguments: serde_json::json!({}),
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: first_claim_at,
+            resolved_at: None,
+        };
+        assert!(matches!(
+            store
+                .accept_claimed_tool_call(&call, first_lease, first_claim_at)
+                .await
+                .unwrap(),
+            AcceptClaimedToolCallOutcome::Accepted(_)
+        ));
+
+        // Simulate a crash after acceptance and possible execution but before
+        // result commit. Reclaiming creates the next failure attempt.
+        let retry_at = first_claim_at + chrono::Duration::seconds(2);
+        let retry_lease = uuid::Uuid::new_v4();
+        let retried = store
+            .claim_turn_run(
+                retry_lease,
+                retry_at,
+                retry_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap()
+            .turn
+            .unwrap();
+        assert_eq!(retried.attempt_count, 2);
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let tools = Arc::new(ToolRegistry::new().with(Box::new(SpyTool { ran: ran.clone() })));
+        let agent = Agent::new(
+            Arc::new(AnswerOnlyProvider),
+            tools,
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        )
+        .with_durable_steer(retry_lease);
+        let (tx, rx) = unbounded();
+        let outcome = agent
+            .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
+            .await
+            .unwrap();
+        drop(tx);
+        let _ = rx.collect::<Vec<_>>().await;
+
+        assert!(matches!(outcome, AgentTurnOutcome::Completed { .. }));
+        assert_eq!(ran.load(Ordering::SeqCst), 0, "pending work was replayed");
+        let stored = store
+            .list_tool_calls(chat.id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|item| item.id == call_id)
+            .unwrap();
+        assert_eq!(stored.status, ToolCallStatus::Failed);
+        assert_eq!(
+            stored.error_code.as_deref(),
+            Some("tool_execution_interrupted")
+        );
     }
 
     /// Streams one text delta, then stalls forever — lets a test cancel mid-stream
@@ -4939,7 +5294,13 @@ mod tests {
             created_at: claimed_at,
             resolved_at: None,
         };
-        store.accept_tool_call(&call).await.unwrap();
+        assert!(matches!(
+            store
+                .accept_claimed_tool_call(&call, lease_token, claimed_at)
+                .await
+                .unwrap(),
+            AcceptClaimedToolCallOutcome::Accepted(_)
+        ));
         store
             .request_tool_call_approval(
                 &ApprovalRequest {
@@ -4972,7 +5333,7 @@ mod tests {
         let agent = Agent::new(
             Arc::new(RestartProvider {
                 provider_id: call.provider_id.clone(),
-                expect_error: !tool_present,
+                expect_error: true,
             }),
             Arc::new(registry),
             store.clone(),
@@ -5009,7 +5370,7 @@ mod tests {
         ));
         drop(tx);
         let events = events.await.unwrap();
-        assert_eq!(ran.load(Ordering::SeqCst), usize::from(tool_present));
+        assert_eq!(ran.load(Ordering::SeqCst), 0);
         assert_eq!(
             store
                 .list_tool_calls(chat.id)
@@ -5019,40 +5380,31 @@ mod tests {
                 .find(|stored| stored.id == call.id)
                 .unwrap()
                 .status,
-            if tool_present {
-                ToolCallStatus::Completed
-            } else {
-                ToolCallStatus::Failed
-            }
+            ToolCallStatus::Failed
         );
-        if !tool_present {
-            let approval_decided = events
-                .iter()
-                .position(|event| {
-                    matches!(
-                        event,
-                        AgentEvent::ApprovalDecided {
-                            call_id,
-                            approved: false,
-                        } if *call_id == call.id
-                    )
-                })
-                .expect("missing tool must close its durable approval card");
-            let tool_completed = events
-                .iter()
-                .position(|event| {
-                    matches!(
-                        event,
-                        AgentEvent::ToolCallCompleted { call_id, .. } if *call_id == call.id
-                    )
-                })
-                .expect("missing tool must publish its failed completion");
-            assert!(approval_decided < tool_completed);
-        }
+        let approval_decided = events
+            .iter()
+            .position(|event| {
+                matches!(
+                    event,
+                    AgentEvent::ApprovalDecided { call_id, .. } if *call_id == call.id
+                )
+            })
+            .expect("recovery must close its durable approval card");
+        let tool_completed = events
+            .iter()
+            .position(|event| {
+                matches!(
+                    event,
+                    AgentEvent::ToolCallCompleted { call_id, .. } if *call_id == call.id
+                )
+            })
+            .expect("recovery must publish its failed completion");
+        assert!(approval_decided < tool_completed);
     }
 
     #[tokio::test]
-    async fn reclaimed_turn_resumes_pending_and_preapproved_sensitive_calls() {
+    async fn reclaimed_turn_suppresses_pending_and_preapproved_sensitive_calls() {
         assert_sensitive_restart_recovery(false, ApprovalClass::ReadOnly, true).await;
         assert_sensitive_restart_recovery(true, ApprovalClass::Sensitive, true).await;
         assert_sensitive_restart_recovery(false, ApprovalClass::ReadOnly, false).await;
@@ -5126,7 +5478,13 @@ mod tests {
             created_at: claimed_at,
             resolved_at: None,
         };
-        store.accept_tool_call(&call).await.unwrap();
+        assert!(matches!(
+            store
+                .accept_claimed_tool_call(&call, lease_token, claimed_at)
+                .await
+                .unwrap(),
+            AcceptClaimedToolCallOutcome::Accepted(_)
+        ));
         (db, store, chat, turn_id, lease_token, call)
     }
 
@@ -5244,7 +5602,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn recovery_rechecks_cancellation_immediately_before_tool_execution() {
+    async fn recovery_never_reexecutes_a_pending_workspace_call() {
         let (_db, store, chat, turn_id, lease_token, call) =
             pending_workspace_restart("recovery_write", serde_json::json!({})).await;
         let cancel = CancelToken::new();
@@ -5273,7 +5631,7 @@ mod tests {
                 .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
                 .await
                 .unwrap(),
-            AgentTurnOutcome::Cancelled { .. }
+            AgentTurnOutcome::Completed { .. }
         ));
         assert_eq!(ran.load(Ordering::SeqCst), 0);
         assert_eq!(

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -317,6 +317,7 @@ pub mod message {
         pub seq: i64,
         pub role: String,
         pub content: String,
+        pub turn_lease_token: Option<Uuid>,
         pub created_at: DateTimeUtc,
     }
 
@@ -909,6 +910,8 @@ pub mod tool_call {
         pub client_executor_id: Option<Uuid>,
         pub client_lease_token: Option<Uuid>,
         pub client_lease_expires_at: Option<DateTimeUtc>,
+        pub turn_lease_token: Option<Uuid>,
+        pub resolution_turn_lease_token: Option<Uuid>,
         pub created_at: DateTimeUtc,
         pub resolved_at: Option<DateTimeUtc>,
     }

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -22,6 +22,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddDocuments),
             Box::new(AddSandboxToolCalls),
             Box::new(AddAgentRunResultPayload),
+            Box::new(AddClaimedTurnEffectLeases),
         ]
     }
 }
@@ -4773,6 +4774,81 @@ impl MigrationName for AddAgentRunResultPayload {
     }
 }
 
+struct AddClaimedTurnEffectLeases;
+
+impl MigrationName for AddClaimedTurnEffectLeases {
+    fn name(&self) -> &str {
+        "m20260722_000009_add_claimed_turn_effect_leases"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddClaimedTurnEffectLeases {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Message::Table)
+                    .add_column(ColumnDef::new(Message::TurnLeaseToken).uuid())
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ToolCall::Table)
+                    .add_column(ColumnDef::new(ToolCall::TurnLeaseToken).uuid())
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ToolCall::Table)
+                    .add_column(ColumnDef::new(ToolCall::ResolutionTurnLeaseToken).uuid())
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "UPDATE turn_run SET max_attempts = 3 \
+                 WHERE max_attempts = 1 AND status IN \
+                 ('queued', 'running', 'retry_wait', 'resuming', 'waiting_for_client', \
+                  'waiting_for_agent_run', 'cancelling', 'cancelling_client')",
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ToolCall::Table)
+                    .drop_column(ToolCall::ResolutionTurnLeaseToken)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ToolCall::Table)
+                    .drop_column(ToolCall::TurnLeaseToken)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Message::Table)
+                    .drop_column(Message::TurnLeaseToken)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
 #[async_trait::async_trait]
 impl MigrationTrait for AddAgentRunResultPayload {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
@@ -5269,6 +5345,7 @@ enum Message {
     Seq,
     Role,
     Content,
+    TurnLeaseToken,
     CreatedAt,
 }
 
@@ -5389,6 +5466,8 @@ enum ToolCall {
     ClientExecutorId,
     ClientLeaseToken,
     ClientLeaseExpiresAt,
+    TurnLeaseToken,
+    ResolutionTurnLeaseToken,
     CreatedAt,
     ResolvedAt,
 }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -40,18 +40,18 @@ use crate::model::{
 };
 use crate::provider::{StopReason, Usage};
 use crate::storage::{
-    AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, AcceptToolCallOutcome,
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, AdmitSandboxAgentRunOutcome,
-    BeginRootAttachmentChangeOutcome, CheckpointSandboxSpawnOutcome, ClaimAgentRunInboxOutcome,
-    ClaimClientToolCallOutcome, ClaimDelegatedFileReadOutcome, ClaimSandboxToolCallOutcome,
-    ClaimTurnRunOutcome, CompleteTurnRunOutcome, ConsumeAgentRunInboxAndResumeTurnOutcome,
-    ConsumeAgentRunInboxOutcome, DecideToolApprovalOutcome, DeleteChatOutcome,
-    DeleteProjectOutcome, DocumentIndexJobReason, EnsureDocumentIndexJobOutcome,
-    EnsureDocumentParseJobOutcome, FailAgentRunOutcome, FinishAgentRunCancellationOutcome,
-    FinishRootAttachmentChangeOutcome, FinishTurnCancellationOutcome,
-    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, JournaledToolApprovalOutcome,
-    JournaledTurnOutcome, JournaledTurnSteerOutcome, ParkSandboxToolCallOutcome,
-    ParkTurnForAgentRunInboxOutcome, ParkTurnForAgentRunWaitSetOutcome,
+    AcceptAgentRunOutcome, AcceptClaimedToolCallOutcome, AcceptSandboxAgentRunAndParkTurnOutcome,
+    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AdmitSandboxAgentRunOutcome,
+    AppendClaimedMessageOutcome, BeginRootAttachmentChangeOutcome, CheckpointSandboxSpawnOutcome,
+    ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome, ClaimDelegatedFileReadOutcome,
+    ClaimSandboxToolCallOutcome, ClaimTurnRunOutcome, CompleteTurnRunOutcome,
+    ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
+    DecideToolApprovalOutcome, DeleteChatOutcome, DeleteProjectOutcome, DocumentIndexJobReason,
+    EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FailAgentRunOutcome,
+    FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
+    FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
+    JournaledToolApprovalOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
+    ParkSandboxToolCallOutcome, ParkTurnForAgentRunInboxOutcome, ParkTurnForAgentRunWaitSetOutcome,
     ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
     RequestToolApprovalOutcome, RequestTurnCancellationOutcome, ResolveSandboxToolCallOutcome,
     ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, Store,
@@ -2482,12 +2482,32 @@ impl Store for DbStore {
         ops::citation::append_assistant_message(self, message, references).await
     }
 
+    async fn append_claimed_assistant_message_with_citations(
+        &self,
+        message: &Message,
+        references: &[crate::AssistantCitationReference],
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<AppendClaimedMessageOutcome> {
+        ops::citation::append_claimed_assistant_message(self, message, references, lease_token, now)
+            .await
+    }
+
     async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>> {
         ops::conversation::list_messages(self, chat_id).await
     }
 
     async fn accept_tool_call(&self, call: &ToolCallRecord) -> Result<AcceptToolCallOutcome> {
         ops::client_execution::accept_tool_call(self, call).await
+    }
+
+    async fn accept_claimed_tool_call(
+        &self,
+        call: &ToolCallRecord,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<AcceptClaimedToolCallOutcome> {
+        ops::client_execution::accept_claimed_tool_call(self, call, lease_token, now).await
     }
 
     async fn request_tool_call_approval(
@@ -2599,6 +2619,56 @@ impl Store for DbStore {
             resolution,
             resolved_at,
             evidence,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn resolve_claimed_server_tool_call_with_evidence(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<Utc>,
+        evidence: &[crate::RetrievalEvidenceInput],
+    ) -> Result<ResolveToolCallOutcome> {
+        ops::client_execution::resolve_claimed_server_tool_call_with_evidence(
+            self,
+            id,
+            chat_id,
+            turn_id,
+            lease_token,
+            now,
+            resolution,
+            resolved_at,
+            evidence,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn abandon_inherited_server_tool_call(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<Utc>,
+    ) -> Result<ResolveToolCallOutcome> {
+        ops::client_execution::abandon_inherited_server_tool_call(
+            self,
+            id,
+            chat_id,
+            turn_id,
+            lease_token,
+            now,
+            resolution,
+            resolved_at,
         )
         .await
     }

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -2874,6 +2874,7 @@ where
         seq: Set(next_message_seq_on(conn, entry.chat_id).await?),
         role: Set("system".to_owned()),
         content: Set(content),
+        turn_lease_token: Set(None),
         created_at: Set(now),
     }
     .insert(conn)

--- a/crates/openwave-core/src/db/ops/citation.rs
+++ b/crates/openwave-core/src/db/ops/citation.rs
@@ -13,12 +13,13 @@ use crate::citation::{
 use crate::error::{AgentError, Result};
 use crate::id::{AssistantCitationId, ChatId, MessageId, TurnId};
 use crate::model::{Message, Role, SourceLocation};
+use crate::storage::{AppendClaimedMessageOutcome, TurnLeaseFence};
 
 use super::super::{entities, store_err, DbStore};
-use super::acquire_chat_write_lock;
 use super::conversation::{
     next_message_seq_on, reserve_message_identity_on, MESSAGE_IDENTITY_OWNER_MESSAGE,
 };
+use super::{acquire_chat_write_lock, acquire_turn_write_lock};
 
 pub(in crate::db) async fn append_assistant_message(
     store: &DbStore,
@@ -62,6 +63,7 @@ pub(in crate::db) async fn append_assistant_message(
         seq: Set(next_message_seq_on(&transaction, message.chat_id).await?),
         role: Set("assistant".into()),
         content: Set(message.content.clone()),
+        turn_lease_token: Set(None),
         created_at: Set(created_at),
     }
     .insert(&transaction)
@@ -71,12 +73,94 @@ pub(in crate::db) async fn append_assistant_message(
     transaction.commit().await.map_err(store_err)
 }
 
+pub(in crate::db) async fn append_claimed_assistant_message(
+    store: &DbStore,
+    message: &Message,
+    references: &[AssistantCitationReference],
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<AppendClaimedMessageOutcome> {
+    validate_assistant_message(message, references)?;
+    if lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "claimed message lease token must not be nil".into(),
+        ));
+    }
+    let created_at = super::turn::canonical_db_timestamp(message.created_at)?;
+    let now = super::turn::canonical_db_timestamp(now)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, message.chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(AppendClaimedMessageOutcome::LeaseLost);
+    }
+    if !acquire_turn_write_lock(&transaction, message.turn_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(AppendClaimedMessageOutcome::LeaseLost);
+    }
+    if let Some(existing) = entities::message::Entity::find_by_id(message.id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let exact = exact_appended_message_model_on(
+            &transaction,
+            &existing,
+            message,
+            references,
+            Some(lease_token),
+        )
+        .await?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(if exact {
+            AppendClaimedMessageOutcome::Existing
+        } else {
+            AppendClaimedMessageOutcome::IdentityConflict
+        });
+    }
+    if super::turn::turn_lease_is_current_on(&transaction, message.turn_id, lease_token, now)
+        .await?
+        != TurnLeaseFence::Current
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(AppendClaimedMessageOutcome::LeaseLost);
+    }
+    if !reserve_message_identity_on(
+        &transaction,
+        message.id,
+        message.chat_id,
+        message.turn_id,
+        MESSAGE_IDENTITY_OWNER_MESSAGE,
+    )
+    .await?
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(AppendClaimedMessageOutcome::IdentityConflict);
+    }
+    let evidence =
+        resolve_references_on(&transaction, message.chat_id, message.turn_id, references).await?;
+    entities::message::ActiveModel {
+        id: Set(message.id.0),
+        chat_id: Set(message.chat_id.0),
+        turn_id: Set(message.turn_id.0),
+        seq: Set(next_message_seq_on(&transaction, message.chat_id).await?),
+        role: Set("assistant".into()),
+        content: Set(message.content.clone()),
+        turn_lease_token: Set(Some(lease_token)),
+        created_at: Set(created_at),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    insert_for_message_on(&transaction, message, &evidence).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(AppendClaimedMessageOutcome::Appended)
+}
+
 async fn exact_appended_message_on(
     store: &DbStore,
     message: &Message,
     references: &[AssistantCitationReference],
 ) -> Result<bool> {
-    let created_at = super::turn::canonical_db_timestamp(message.created_at)?;
     let Some(stored) = entities::message::Entity::find_by_id(message.id.0)
         .one(&store.conn)
         .await
@@ -84,22 +168,37 @@ async fn exact_appended_message_on(
     else {
         return Ok(false);
     };
+    exact_appended_message_model_on(&store.conn, &stored, message, references, None).await
+}
+
+async fn exact_appended_message_model_on<C>(
+    conn: &C,
+    stored: &entities::message::Model,
+    message: &Message,
+    references: &[AssistantCitationReference],
+    turn_lease_token: Option<uuid::Uuid>,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let created_at = super::turn::canonical_db_timestamp(message.created_at)?;
     if stored.chat_id != message.chat_id.0
         || stored.turn_id != message.turn_id.0
         || stored.role != "assistant"
         || stored.content != message.content
+        || stored.turn_lease_token != turn_lease_token
         || stored.created_at != created_at
     {
         return Ok(false);
     }
-    let expected = resolve_references_on(&store.conn, message.chat_id, message.turn_id, references)
+    let expected = resolve_references_on(conn, message.chat_id, message.turn_id, references)
         .await?
         .into_iter()
         .map(|evidence| AssistantCitationReference {
             source_token: evidence.source_token,
         })
         .collect::<Vec<_>>();
-    Ok(exact_references_for_message_on(&store.conn, message.id).await? == expected)
+    Ok(exact_references_for_message_on(conn, message.id).await? == expected)
 }
 
 pub(in crate::db) fn validate_assistant_message(

--- a/crates/openwave-core/src/db/ops/client_execution.rs
+++ b/crates/openwave-core/src/db/ops/client_execution.rs
@@ -11,13 +11,17 @@ use crate::model::{
     ToolCallRecord, ToolCallResolution, ToolCallStatus,
 };
 use crate::storage::{
-    AcceptToolCallOutcome, ClaimClientToolCallOutcome, ClientToolCallClaim,
-    HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome, ResolveToolCallOutcome,
+    AcceptClaimedToolCallOutcome, AcceptToolCallOutcome, ClaimClientToolCallOutcome,
+    ClientToolCallClaim, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
+    ResolveToolCallOutcome, TurnLeaseFence,
 };
 
 use super::super::{entities, store_err, DbStore};
 use super::turn::canonical_db_timestamp;
-use super::{acquire_chat_write_lock, acquire_tool_call_write_lock, next_tool_history_order_on};
+use super::{
+    acquire_chat_write_lock, acquire_tool_call_write_lock, acquire_turn_write_lock,
+    next_tool_history_order_on,
+};
 
 pub(in crate::db) async fn accept_tool_call(
     store: &DbStore,
@@ -70,6 +74,8 @@ pub(in crate::db) async fn accept_tool_call(
         client_executor_id: Set(None),
         client_lease_token: Set(None),
         client_lease_expires_at: Set(None),
+        turn_lease_token: Set(None),
+        resolution_turn_lease_token: Set(None),
         created_at: Set(created_at),
         resolved_at: Set(None),
     }
@@ -79,6 +85,86 @@ pub(in crate::db) async fn accept_tool_call(
     let inserted = tool_call_from_model(inserted)?;
     transaction.commit().await.map_err(store_err)?;
     Ok(AcceptToolCallOutcome::Accepted(inserted))
+}
+
+pub(in crate::db) async fn accept_claimed_tool_call(
+    store: &DbStore,
+    call: &ToolCallRecord,
+    lease_token: uuid::Uuid,
+    now: DateTime<Utc>,
+) -> Result<AcceptClaimedToolCallOutcome> {
+    validate_accept(call)?;
+    if call.execution != ToolCallExecution::Server || lease_token.is_nil() {
+        return Err(AgentError::Store(
+            "claimed tool acceptance requires a server call and non-nil lease".into(),
+        ));
+    }
+    let created_at = canonical_db_timestamp(call.created_at)?;
+    let now = canonical_db_timestamp(now)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, call.chat_id).await?
+        || !acquire_turn_write_lock(&transaction, call.turn_id).await?
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(AcceptClaimedToolCallOutcome::LeaseLost);
+    }
+    if let Some(existing) = entities::tool_call::Entity::find_by_id(call.id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let outcome = if immutable_request_matches(&existing, call, created_at)
+            && existing.turn_lease_token == Some(lease_token)
+        {
+            AcceptClaimedToolCallOutcome::Existing(tool_call_from_model(existing)?)
+        } else {
+            AcceptClaimedToolCallOutcome::IdentityConflict
+        };
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(outcome);
+    }
+    if super::turn::turn_lease_is_current_on(&transaction, call.turn_id, lease_token, now).await?
+        != TurnLeaseFence::Current
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(AcceptClaimedToolCallOutcome::LeaseLost);
+    }
+
+    let history_order = next_tool_history_order_on(&transaction, call.chat_id).await?;
+    let inserted = entities::tool_call::ActiveModel {
+        id: Set(call.id.0),
+        chat_id: Set(call.chat_id.0),
+        turn_id: Set(call.turn_id.0),
+        provider_id: Set(call.provider_id.clone()),
+        history_order: Set(history_order),
+        name: Set(call.name.clone()),
+        arguments: Set(call.arguments.clone()),
+        execution: Set(call.execution.as_str().into()),
+        status: Set(ToolCallStatus::Pending.as_str().into()),
+        result: Set(None),
+        error_code: Set(None),
+        error_detail: Set(None),
+        approval_status: Set(None),
+        approval_class: Set(None),
+        approval_kind: Set(None),
+        approval_reason: Set(None),
+        approval_requested_at: Set(None),
+        approval_decided_at: Set(None),
+        approval_event_seq: Set(None),
+        client_executor_id: Set(None),
+        client_lease_token: Set(None),
+        client_lease_expires_at: Set(None),
+        turn_lease_token: Set(Some(lease_token)),
+        resolution_turn_lease_token: Set(None),
+        created_at: Set(created_at),
+        resolved_at: Set(None),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    let inserted = tool_call_from_model(inserted)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(AcceptClaimedToolCallOutcome::Accepted(inserted))
 }
 
 pub(in crate::db) async fn claim_client_tool_call(
@@ -229,6 +315,65 @@ pub(in crate::db) async fn resolve_server_tool_call_with_evidence(
     .outcome)
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(in crate::db) async fn resolve_claimed_server_tool_call_with_evidence(
+    store: &DbStore,
+    id: CallId,
+    chat_id: ChatId,
+    turn_id: crate::TurnId,
+    lease_token: uuid::Uuid,
+    now: DateTime<Utc>,
+    resolution: &ToolCallResolution,
+    resolved_at: DateTime<Utc>,
+    evidence: &[RetrievalEvidenceInput],
+) -> Result<ResolveToolCallOutcome> {
+    Ok(resolve_tool_call(
+        store,
+        id,
+        ResolutionAuthority::ClaimedServer {
+            chat_id,
+            turn_id,
+            lease_token,
+            now,
+            inherited: false,
+        },
+        resolved_at,
+        resolution,
+        Some(evidence),
+    )
+    .await?
+    .outcome)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(in crate::db) async fn abandon_inherited_server_tool_call(
+    store: &DbStore,
+    id: CallId,
+    chat_id: ChatId,
+    turn_id: crate::TurnId,
+    lease_token: uuid::Uuid,
+    now: DateTime<Utc>,
+    resolution: &ToolCallResolution,
+    resolved_at: DateTime<Utc>,
+) -> Result<ResolveToolCallOutcome> {
+    Ok(resolve_tool_call(
+        store,
+        id,
+        ResolutionAuthority::ClaimedServer {
+            chat_id,
+            turn_id,
+            lease_token,
+            now,
+            inherited: true,
+        },
+        resolved_at,
+        resolution,
+        None,
+    )
+    .await?
+    .outcome)
+}
+
 pub(in crate::db) async fn list_retrieval_evidence(
     store: &DbStore,
     id: CallId,
@@ -331,6 +476,12 @@ async fn resolve_tool_call(
             return Ok(journaled_call_outcome(ResolveToolCallOutcome::LeaseLost));
         }
     }
+    if let Some(turn_id) = authority.turn_id() {
+        if !acquire_turn_write_lock(&transaction, turn_id).await? {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(journaled_call_outcome(ResolveToolCallOutcome::LeaseLost));
+        }
+    }
     if !acquire_tool_call_write_lock(&transaction, id).await? {
         transaction.commit().await.map_err(store_err)?;
         return Ok(journaled_call_outcome(ResolveToolCallOutcome::NotFound));
@@ -365,9 +516,7 @@ async fn resolve_tool_call(
                 }
             }
         }
-        let transition = if outcome == ResolveToolCallOutcome::Existing
-            && authority.chat_id().is_some()
-        {
+        let transition = if outcome == ResolveToolCallOutcome::Existing && authority.is_client() {
             super::turn::recover_turn_after_client_resolution_on(&transaction, &existing).await?
         } else {
             None
@@ -380,8 +529,32 @@ async fn resolve_tool_call(
         });
     }
 
+    if let Some((turn_id, lease_token, now)) = authority.turn_lease() {
+        if super::turn::turn_lease_is_current_on(&transaction, turn_id, lease_token, now).await?
+            != TurnLeaseFence::Current
+        {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(journaled_call_outcome(ResolveToolCallOutcome::LeaseLost));
+        }
+    }
+
     let owns = match authority {
-        ResolutionAuthority::Server => existing.execution == ToolCallExecution::Server.as_str(),
+        ResolutionAuthority::Server => {
+            existing.execution == ToolCallExecution::Server.as_str()
+                && existing.turn_lease_token.is_none()
+        }
+        ResolutionAuthority::ClaimedServer {
+            chat_id,
+            turn_id,
+            lease_token,
+            inherited,
+            ..
+        } => {
+            existing.chat_id == chat_id.0
+                && existing.turn_id == turn_id.0
+                && existing.execution == ToolCallExecution::Server.as_str()
+                && (inherited || existing.turn_lease_token == Some(lease_token))
+        }
         ResolutionAuthority::LiveClient {
             chat_id,
             lease_token,
@@ -425,6 +598,7 @@ async fn resolve_tool_call(
     active.error_code = Set(error_code);
     active.error_detail = Set(error_detail);
     active.client_lease_expires_at = Set(None);
+    active.resolution_turn_lease_token = Set(authority.turn_lease_token());
     active.resolved_at = Set(Some(resolved_at));
     if approval_status.as_deref() == Some(crate::ToolApprovalStatus::Pending.as_str()) {
         let requested_at = approval_requested_at
@@ -434,7 +608,7 @@ async fn resolve_tool_call(
         active.approval_decided_at = Set(Some(resolved_at.max(requested_at)));
     }
     let resolved = active.update(&transaction).await.map_err(store_err)?;
-    let transition = if authority.chat_id().is_some() {
+    let transition = if authority.is_client() {
         super::turn::advance_turn_after_client_resolution_on(&transaction, &resolved, resolved_at)
             .await?
     } else {
@@ -669,6 +843,13 @@ fn evidence_models_match(
 #[derive(Clone, Copy)]
 enum ResolutionAuthority {
     Server,
+    ClaimedServer {
+        chat_id: ChatId,
+        turn_id: crate::TurnId,
+        lease_token: uuid::Uuid,
+        now: DateTime<Utc>,
+        inherited: bool,
+    },
     LiveClient {
         chat_id: ChatId,
         lease_token: uuid::Uuid,
@@ -685,6 +866,19 @@ impl ResolutionAuthority {
     fn canonicalized(self) -> Result<Self> {
         Ok(match self {
             Self::Server => Self::Server,
+            Self::ClaimedServer {
+                chat_id,
+                turn_id,
+                lease_token,
+                now,
+                inherited,
+            } => Self::ClaimedServer {
+                chat_id,
+                turn_id,
+                lease_token,
+                now: canonical_db_timestamp(now)?,
+                inherited,
+            },
             Self::LiveClient {
                 chat_id,
                 lease_token,
@@ -708,7 +902,7 @@ impl ResolutionAuthority {
 
     const fn lease_token(self) -> Option<uuid::Uuid> {
         match self {
-            Self::Server => None,
+            Self::Server | Self::ClaimedServer { .. } => None,
             Self::LiveClient { lease_token, .. } | Self::ExpiredClient { lease_token, .. } => {
                 Some(lease_token)
             }
@@ -718,8 +912,40 @@ impl ResolutionAuthority {
     const fn chat_id(self) -> Option<ChatId> {
         match self {
             Self::Server => None,
-            Self::LiveClient { chat_id, .. } | Self::ExpiredClient { chat_id, .. } => Some(chat_id),
+            Self::ClaimedServer { chat_id, .. }
+            | Self::LiveClient { chat_id, .. }
+            | Self::ExpiredClient { chat_id, .. } => Some(chat_id),
         }
+    }
+
+    const fn turn_id(self) -> Option<crate::TurnId> {
+        match self {
+            Self::ClaimedServer { turn_id, .. } => Some(turn_id),
+            _ => None,
+        }
+    }
+
+    const fn turn_lease(self) -> Option<(crate::TurnId, uuid::Uuid, DateTime<Utc>)> {
+        match self {
+            Self::ClaimedServer {
+                turn_id,
+                lease_token,
+                now,
+                ..
+            } => Some((turn_id, lease_token, now)),
+            _ => None,
+        }
+    }
+
+    const fn turn_lease_token(self) -> Option<uuid::Uuid> {
+        match self {
+            Self::ClaimedServer { lease_token, .. } => Some(lease_token),
+            _ => None,
+        }
+    }
+
+    const fn is_client(self) -> bool {
+        matches!(self, Self::LiveClient { .. } | Self::ExpiredClient { .. })
     }
 }
 
@@ -818,6 +1044,19 @@ fn terminal_authority_matches(
         ResolutionAuthority::Server => {
             model.execution == ToolCallExecution::Server.as_str()
                 && model.client_lease_token.is_none()
+                && model.turn_lease_token.is_none()
+                && model.resolution_turn_lease_token.is_none()
+        }
+        ResolutionAuthority::ClaimedServer {
+            chat_id,
+            turn_id,
+            lease_token,
+            ..
+        } => {
+            model.execution == ToolCallExecution::Server.as_str()
+                && model.chat_id == chat_id.0
+                && model.turn_id == turn_id.0
+                && model.resolution_turn_lease_token == Some(lease_token)
         }
         ResolutionAuthority::LiveClient { .. } | ResolutionAuthority::ExpiredClient { .. } => {
             model.execution == ToolCallExecution::Client.as_str()

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -678,6 +678,7 @@ pub(in crate::db) async fn append_message(store: &DbStore, message: &Message) ->
         seq: Set(seq),
         role: Set(role_to_db(message.role).to_string()),
         content: Set(message.content.clone()),
+        turn_lease_token: Set(None),
         created_at: Set(message.created_at),
     };
     if let Err(error) = active.insert(&transaction).await {

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -176,6 +176,7 @@ pub(in crate::db) async fn accept_turn(
         seq: Set(next_message_seq_on(&transaction, chat_id).await?),
         role: Set("user".into()),
         content: Set(content.into()),
+        turn_lease_token: Set(None),
         created_at: Set(now),
     };
     if let Err(error) = message.insert(&transaction).await {
@@ -752,8 +753,6 @@ pub(in crate::db) async fn fence_turn_lease(
     lease_token: uuid::Uuid,
     now: chrono::DateTime<Utc>,
 ) -> Result<crate::storage::TurnLeaseFence> {
-    use crate::storage::TurnLeaseFence;
-
     if id.0.is_nil() {
         return Err(AgentError::Store("fenced turn id must not be nil".into()));
     }
@@ -763,11 +762,28 @@ pub(in crate::db) async fn fence_turn_lease(
         ));
     }
     let now = canonical_db_timestamp(now)?;
+    turn_lease_is_current_on(&store.conn, id, lease_token, now).await
+}
+
+/// Check the exact turn-claim identity on an existing transaction. Callers
+/// that co-commit an effect first acquire the chat and turn write locks, then
+/// use this helper before inserting or resolving that effect.
+pub(in crate::db) async fn turn_lease_is_current_on<C>(
+    conn: &C,
+    id: TurnId,
+    lease_token: uuid::Uuid,
+    now: chrono::DateTime<Utc>,
+) -> Result<crate::storage::TurnLeaseFence>
+where
+    C: ConnectionTrait,
+{
+    use crate::storage::TurnLeaseFence;
+
     // The claim receipt binds this token to the exact attempt and claim segment
     // it was issued for. Matching it against the turn's live counters rejects a
     // token that once owned an earlier segment of the same turn.
     let Some(claim) = entities::turn_claim::Entity::find_by_id(lease_token)
-        .one(&store.conn)
+        .one(conn)
         .await
         .map_err(store_err)?
         .filter(|claim| claim.turn_id == id.0)
@@ -775,7 +791,7 @@ pub(in crate::db) async fn fence_turn_lease(
         return Ok(TurnLeaseFence::Stale);
     };
     let Some(turn) = entities::turn_run::Entity::find_by_id(id.0)
-        .one(&store.conn)
+        .one(conn)
         .await
         .map_err(store_err)?
     else {

--- a/crates/openwave-core/src/db/ops/turn/client_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/client_wait.rs
@@ -155,6 +155,8 @@ pub(in crate::db) async fn park_turn_for_client_tool_call(
         client_executor_id: Set(None),
         client_lease_token: Set(None),
         client_lease_expires_at: Set(None),
+        turn_lease_token: Set(Some(lease_token)),
+        resolution_turn_lease_token: Set(None),
         created_at: Set(now),
         resolved_at: Set(None),
     })

--- a/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait.rs
@@ -407,6 +407,8 @@ pub(in crate::db) async fn park_turn_for_agent_run_wait_set(
         client_executor_id: Set(None),
         client_lease_token: Set(None),
         client_lease_expires_at: Set(None),
+        turn_lease_token: Set(Some(lease_token)),
+        resolution_turn_lease_token: Set(None),
         created_at: Set(now),
         resolved_at: Set(None),
     }

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -294,6 +294,7 @@ async fn complete_turn_run_inner(
         seq: Set(next_message_seq_on(&transaction, output.chat_id).await?),
         role: Set("assistant".into()),
         content: Set(output.content.clone()),
+        turn_lease_token: Set(Some(lease_token)),
         created_at: Set(output_created_at),
     };
     if let Err(error) = message.insert(&transaction).await {

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -235,6 +235,8 @@ where
         client_executor_id: Set(None),
         client_lease_token: Set(None),
         client_lease_expires_at: Set(None),
+        turn_lease_token: Set(Some(request.lease_token)),
+        resolution_turn_lease_token: Set(Some(request.lease_token)),
         created_at: Set(created_at),
         resolved_at: Set(Some(created_at)),
     }

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -442,6 +442,7 @@ pub(in crate::db) async fn apply_turn_steer(
             seq: Set(next_message_seq_on(&transaction, preceding.chat_id).await?),
             role: Set("assistant".into()),
             content: Set(preceding.content.clone()),
+            turn_lease_token: Set(Some(lease_token)),
             created_at: Set(preceding_created_at),
         };
         if let Err(error) = message.insert(&transaction).await {
@@ -478,6 +479,7 @@ pub(in crate::db) async fn apply_turn_steer(
         seq: Set(next_message_seq_on(&transaction, ChatId(steer.chat_id)).await?),
         role: Set("user".into()),
         content: Set(steer.content.clone()),
+        turn_lease_token: Set(Some(lease_token)),
         created_at: Set(now),
     };
     if let Err(error) = message.insert(&transaction).await {

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -25,6 +25,18 @@ async fn temp_store() -> (tempfile::TempDir, DbStore) {
     (dir, store)
 }
 
+async fn set_turn_max_attempts(store: &DbStore, turn_id: TurnId, max_attempts: i32) {
+    entities::turn_run::Entity::update_many()
+        .col_expr(
+            entities::turn_run::Column::MaxAttempts,
+            sea_orm::sea_query::Expr::value(max_attempts),
+        )
+        .filter(entities::turn_run::Column::Id.eq(turn_id.0))
+        .exec(&store.conn)
+        .await
+        .unwrap();
+}
+
 fn sample_chat() -> Chat {
     Chat {
         id: ChatId::new(),
@@ -5090,6 +5102,7 @@ async fn make_queued_turn(
         seq: Set(seq),
         role: Set("user".into()),
         content: Set("turn input".into()),
+        turn_lease_token: Set(None),
         created_at: Set(now),
     }
     .insert(&store.conn)
@@ -5169,6 +5182,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         seq: Set(first_output_seq),
         role: Set("assistant".into()),
         content: Set("done".into()),
+        turn_lease_token: Set(None),
         created_at: Set(now),
     }
     .insert(&store.conn)
@@ -5547,7 +5561,7 @@ async fn turn_acceptance_is_atomic_idempotent_and_chat_scoped() {
     assert_eq!(accepted.model, "gpt-5");
     assert_eq!(accepted.status, TurnRunStatus::Queued);
     assert_eq!(accepted.attempt_count, 0);
-    assert_eq!(accepted.max_attempts, 1);
+    assert_eq!(accepted.max_attempts, TurnRun::DEFAULT_MAX_ATTEMPTS);
     assert_eq!(accepted.lease_token, None);
 
     let messages = store.list_messages(chat.id).await.unwrap();
@@ -6156,7 +6170,7 @@ async fn resuming_turn_claims_a_new_lease_without_consuming_failure_budget() {
         .turn
         .unwrap();
     assert_eq!((first.attempt_count, first.claim_count), (1, 1));
-    assert_eq!(first.max_attempts, 1);
+    assert_eq!(first.max_attempts, TurnRun::DEFAULT_MAX_ATTEMPTS);
 
     let resume_at = first_claimed_at + chrono::Duration::seconds(10);
     let parked = entities::turn_run::Entity::update_many()
@@ -6208,7 +6222,7 @@ async fn resuming_turn_claims_a_new_lease_without_consuming_failure_budget() {
     assert_eq!(resumed.id, turn_id);
     assert_eq!(resumed.status, TurnRunStatus::Running);
     assert_eq!((resumed.attempt_count, resumed.claim_count), (1, 2));
-    assert_eq!(resumed.max_attempts, 1);
+    assert_eq!(resumed.max_attempts, TurnRun::DEFAULT_MAX_ATTEMPTS);
 
     let output = Message {
         id: MessageId::new(),
@@ -7502,6 +7516,7 @@ async fn turn_failure_exhaustion_retains_retry_intent_and_rolls_back_atomically(
         AcceptTurnOutcome::Accepted(turn) => turn,
         outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
     };
+    set_turn_max_attempts(&store, turn_id, 1).await;
     let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
     let token = uuid::Uuid::new_v4();
     store
@@ -8260,6 +8275,7 @@ async fn claim_scan_rolls_back_terminal_state_when_event_append_fails() {
         AcceptTurnOutcome::Accepted(turn) => turn,
         outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
     };
+    set_turn_max_attempts(&store, turn.id, 1).await;
     let claimed_at = turn.available_at + chrono::Duration::seconds(1);
     let expires_at = claimed_at + chrono::Duration::minutes(1);
     let token = uuid::Uuid::new_v4();
@@ -8335,6 +8351,8 @@ async fn claim_scan_returns_one_routable_terminal_action_at_a_time() {
         AcceptTurnOutcome::Accepted(turn) => turn,
         outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
     };
+    set_turn_max_attempts(&store, first_turn.id, 1).await;
+    set_turn_max_attempts(&store, second_turn.id, 1).await;
     let claimed_at =
         first_turn.available_at.max(second_turn.available_at) + chrono::Duration::seconds(1);
     let expires_at = claimed_at + chrono::Duration::minutes(1);
@@ -9836,6 +9854,219 @@ async fn server_tool_call_lifecycle_is_atomic_and_idempotent() {
     assert_eq!(listed[0].status, ToolCallStatus::Completed);
     assert_eq!(listed[0].result.as_deref(), Some("hello"));
     assert_eq!(listed[0].arguments, serde_json::json!({"path": "note.txt"}));
+}
+
+#[tokio::test]
+async fn claimed_tool_results_are_co_committed_with_the_turn_lease() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "run a tool")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected turn acceptance: {outcome:?}"),
+    };
+    let first_claim_at = accepted.available_at;
+    let first_lease = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(
+            first_lease,
+            first_claim_at,
+            first_claim_at + chrono::Duration::seconds(1),
+        )
+        .await
+        .unwrap();
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: chat.id,
+        turn_id,
+        provider_id: "tu_claimed".into(),
+        name: "write_file".into(),
+        arguments: serde_json::json!({"path": "note.txt"}),
+        execution: ToolCallExecution::Server,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: first_claim_at,
+        resolved_at: None,
+    };
+    assert!(matches!(
+        store
+            .accept_claimed_tool_call(&call, first_lease, first_claim_at)
+            .await
+            .unwrap(),
+        AcceptClaimedToolCallOutcome::Accepted(_)
+    ));
+    let stored = entities::tool_call::Entity::find_by_id(call.id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.turn_lease_token, Some(first_lease));
+    assert_eq!(stored.resolution_turn_lease_token, None);
+
+    let resolution = ToolCallResolution::Completed {
+        result: "written".into(),
+    };
+    assert_eq!(
+        store
+            .resolve_claimed_server_tool_call_with_evidence(
+                call.id,
+                chat.id,
+                turn_id,
+                uuid::Uuid::new_v4(),
+                first_claim_at,
+                &resolution,
+                first_claim_at,
+                &[],
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::LeaseLost
+    );
+    assert_eq!(
+        store.list_tool_calls(chat.id).await.unwrap()[0].status,
+        ToolCallStatus::Pending
+    );
+
+    let retry_at = first_claim_at + chrono::Duration::seconds(2);
+    let retry_lease = uuid::Uuid::new_v4();
+    let retried = store
+        .claim_turn_run(
+            retry_lease,
+            retry_at,
+            retry_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    assert_eq!(retried.attempt_count, 2);
+    assert_eq!(
+        store
+            .resolve_claimed_server_tool_call_with_evidence(
+                call.id,
+                chat.id,
+                turn_id,
+                first_lease,
+                retry_at,
+                &resolution,
+                retry_at,
+                &[],
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::LeaseLost,
+        "the result and stale lease check must commit together"
+    );
+
+    let interrupted = ToolCallResolution::Failed {
+        result: "not replayed".into(),
+        error_code: "tool_execution_interrupted".into(),
+        error_detail: None,
+    };
+    assert_eq!(
+        store
+            .abandon_inherited_server_tool_call(
+                call.id,
+                chat.id,
+                turn_id,
+                retry_lease,
+                retry_at,
+                &interrupted,
+                retry_at,
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Resolved
+    );
+    let stored = entities::tool_call::Entity::find_by_id(call.id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.resolution_turn_lease_token, Some(retry_lease));
+    assert_eq!(stored.status, ToolCallStatus::Failed.as_str());
+}
+
+#[tokio::test]
+async fn claimed_intermediate_message_is_co_committed_with_the_turn_lease() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "draft")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected turn acceptance: {outcome:?}"),
+    };
+    let claimed_at = accepted.available_at;
+    let lease = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(lease, claimed_at, claimed_at + chrono::Duration::seconds(1))
+        .await
+        .unwrap();
+    let message = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "intermediate".into(),
+        created_at: claimed_at,
+    };
+    assert_eq!(
+        store
+            .append_claimed_assistant_message_with_citations(&message, &[], lease, claimed_at,)
+            .await
+            .unwrap(),
+        AppendClaimedMessageOutcome::Appended
+    );
+    assert_eq!(
+        store
+            .append_claimed_assistant_message_with_citations(&message, &[], lease, claimed_at,)
+            .await
+            .unwrap(),
+        AppendClaimedMessageOutcome::Existing
+    );
+
+    let retry_at = claimed_at + chrono::Duration::seconds(2);
+    let retry_lease = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(
+            retry_lease,
+            retry_at,
+            retry_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap();
+    let stale_message = Message {
+        id: MessageId::new(),
+        content: "stale".into(),
+        created_at: retry_at,
+        ..message
+    };
+    assert_eq!(
+        store
+            .append_claimed_assistant_message_with_citations(&stale_message, &[], lease, retry_at,)
+            .await
+            .unwrap(),
+        AppendClaimedMessageOutcome::LeaseLost
+    );
+    assert!(entities::message::Entity::find_by_id(stale_message.id.0)
+        .one(&store.conn)
+        .await
+        .unwrap()
+        .is_none());
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/db/tests/turn_steer.rs
+++ b/crates/openwave-core/src/db/tests/turn_steer.rs
@@ -75,6 +75,7 @@ async fn turn_steer_schema_enforces_durable_delivery_identity() {
         seq: Set(2),
         role: Set("user".into()),
         content: Set("change course".into()),
+        turn_lease_token: Set(None),
         created_at: Set(now),
     }
     .insert(&store.conn)
@@ -119,6 +120,7 @@ async fn turn_steer_schema_enforces_durable_delivery_identity() {
         seq: Set(3),
         role: Set("user".into()),
         content: Set("mismatched identity".into()),
+        turn_lease_token: Set(None),
         created_at: Set(now),
     }
     .insert(&store.conn)
@@ -1224,6 +1226,7 @@ async fn terminal_turn_paths_reject_pending_steers_but_retry_wait_preserves_them
         AcceptTurnOutcome::Accepted(turn) => turn,
         other => panic!("unexpected turn acceptance: {other:?}"),
     };
+    set_turn_max_attempts(&store, expired_turn.id, 1).await;
     let expired_lease = uuid::Uuid::new_v4();
     let expired_claim_at = Utc::now();
     let expires_at = expired_claim_at + chrono::Duration::seconds(1);
@@ -1309,6 +1312,7 @@ async fn failed_steer_message_insert_rolls_back_the_application_receipt() {
         seq: Set(2),
         role: Set("assistant".into()),
         content: Set("occupy identity".into()),
+        turn_lease_token: Set(None),
         created_at: Set(Utc::now()),
     }
     .insert(&store.conn)

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -112,12 +112,13 @@ pub use provider::{
 };
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
-    AcceptAgentRunOutcome, AcceptSandboxAgentRunAndParkTurnOutcome, AcceptToolCallOutcome,
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, AdmitSandboxAgentRunOutcome, ApplyTurnSteerOutcome,
-    BeginRootAttachmentChangeOutcome, BlobStore, ChatToolActivitySnapshot, ChatToolActivityStatus,
-    ChatTranscriptSnapshot, CheckpointSandboxSpawnOutcome, ClaimAgentRunInboxOutcome,
-    ClaimClientToolCallOutcome, ClaimDelegatedFileReadOutcome, ClaimSandboxToolCallOutcome,
-    ClaimScanTerminalEvent, ClaimTurnRunOutcome, ClientToolCallClaim, CompleteTurnRunOutcome,
+    AcceptAgentRunOutcome, AcceptClaimedToolCallOutcome, AcceptSandboxAgentRunAndParkTurnOutcome,
+    AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AdmitSandboxAgentRunOutcome,
+    AppendClaimedMessageOutcome, ApplyTurnSteerOutcome, BeginRootAttachmentChangeOutcome,
+    BlobStore, ChatToolActivitySnapshot, ChatToolActivityStatus, ChatTranscriptSnapshot,
+    CheckpointSandboxSpawnOutcome, ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome,
+    ClaimDelegatedFileReadOutcome, ClaimSandboxToolCallOutcome, ClaimScanTerminalEvent,
+    ClaimTurnRunOutcome, ClientToolCallClaim, CompleteTurnRunOutcome,
     ConsumeAgentRunInboxAndResumeTurnOutcome, ConsumeAgentRunInboxOutcome,
     DecideToolApprovalOutcome, DeleteChatOutcome, DeleteProjectOutcome, DocumentIndexJobReason,
     EnsureDocumentIndexJobOutcome, EnsureDocumentParseJobOutcome, FailAgentRunOutcome,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1674,9 +1674,9 @@ pub struct TurnRun {
 }
 
 impl TurnRun {
-    /// New turns are not automatically replayed after an ambiguous side effect.
-    /// A later resumable-checkpoint slice may opt specific turns into more.
-    pub const DEFAULT_MAX_ATTEMPTS: i32 = 1;
+    /// New turns retry transient failures while per-attempt effect provenance
+    /// prevents ambiguous tool work from being replayed.
+    pub const DEFAULT_MAX_ATTEMPTS: i32 = 3;
     /// Maximum persisted model identifier length.
     pub const MAX_MODEL_LEN: usize = 512;
     /// Maximum persisted machine-readable error code length.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -554,6 +554,32 @@ pub enum AcceptToolCallOutcome {
     IdentityConflict,
 }
 
+/// Result of accepting a tool call under an exact live turn lease.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AcceptClaimedToolCallOutcome {
+    /// The request and its originating turn lease were committed together.
+    Accepted(ToolCallRecord),
+    /// An exact retry recovered the request committed by this same lease.
+    Existing(ToolCallRecord),
+    /// The call identity already names different request bytes or another lease.
+    IdentityConflict,
+    /// The exact turn lease was no longer current at commit time.
+    LeaseLost,
+}
+
+/// Result of appending an intermediate assistant message under a turn lease.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppendClaimedMessageOutcome {
+    /// The message and citations were committed under the lease.
+    Appended,
+    /// An exact retry recovered the same message, citations, and lease owner.
+    Existing,
+    /// The message identity names different bytes or another lease.
+    IdentityConflict,
+    /// The exact turn lease was no longer current at commit time.
+    LeaseLost,
+}
+
 /// Result of registering one exact durable approval request.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RequestToolApprovalOutcome {
@@ -2176,11 +2202,34 @@ pub trait Store: Send + Sync {
         }
     }
 
+    /// Atomically append one intermediate assistant message and its citations
+    /// only while `lease_token` owns the exact live turn segment.
+    async fn append_claimed_assistant_message_with_citations(
+        &self,
+        _message: &Message,
+        _references: &[crate::AssistantCitationReference],
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<AppendClaimedMessageOutcome> {
+        turn_storage_unavailable()
+    }
+
     /// List a chat's messages in creation order.
     async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>>;
 
     /// Accept immutable canonical tool-call identity and arguments exactly once.
     async fn accept_tool_call(&self, call: &ToolCallRecord) -> Result<AcceptToolCallOutcome>;
+
+    /// Atomically accept one server tool call only while its exact originating
+    /// turn lease remains live. The stored lease is private replay state.
+    async fn accept_claimed_tool_call(
+        &self,
+        _call: &ToolCallRecord,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<AcceptClaimedToolCallOutcome> {
+        turn_storage_unavailable()
+    }
 
     /// Register a Sensitive server tool call for durable human review.
     async fn request_tool_call_approval(
@@ -2284,6 +2333,42 @@ pub trait Store: Send + Sync {
         }
         self.resolve_server_tool_call(id, resolution, resolved_at)
             .await
+    }
+
+    /// Resolve a server tool result and retain its evidence only if the same
+    /// live turn lease that accepted the call still owns the turn. The result,
+    /// evidence, and lease comparison commit atomically.
+    #[allow(clippy::too_many_arguments)]
+    async fn resolve_claimed_server_tool_call_with_evidence(
+        &self,
+        _id: CallId,
+        _chat_id: ChatId,
+        _turn_id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+        _resolution: &ToolCallResolution,
+        _resolved_at: chrono::DateTime<chrono::Utc>,
+        _evidence: &[crate::RetrievalEvidenceInput],
+    ) -> Result<ResolveToolCallOutcome> {
+        turn_storage_unavailable()
+    }
+
+    /// Resolve a pending server call recovered at worker startup without
+    /// executing it again. An exact live lease for the same turn may commit
+    /// this conservative interrupted result, including after a process restart
+    /// that retained the lease.
+    #[allow(clippy::too_many_arguments)]
+    async fn abandon_inherited_server_tool_call(
+        &self,
+        _id: CallId,
+        _chat_id: ChatId,
+        _turn_id: TurnId,
+        _lease_token: uuid::Uuid,
+        _now: chrono::DateTime<chrono::Utc>,
+        _resolution: &ToolCallResolution,
+        _resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<ResolveToolCallOutcome> {
+        turn_storage_unavailable()
     }
 
     /// Read private evidence for trusted server-side citation assembly.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -944,20 +944,29 @@ impl PauseTerminalStore {
             .lease_expires_at
             .ok_or_else(|| AgentError::Store("injected scan found no lease".into()))?
             + chrono::Duration::microseconds(1);
-        let outcome = self
-            .inner
-            .claim_turn_run(
-                uuid::Uuid::new_v4(),
-                now,
-                now + chrono::Duration::seconds(1),
-            )
-            .await?;
-        if outcome.terminal_event.is_none() {
-            return Err(AgentError::Store(
-                "injected scan did not terminalize the turn".into(),
-            ));
+        let mut scan_at = now;
+        loop {
+            let outcome = self
+                .inner
+                .claim_turn_run(
+                    uuid::Uuid::new_v4(),
+                    scan_at,
+                    scan_at + chrono::Duration::seconds(1),
+                )
+                .await?;
+            if outcome.terminal_event.is_some() {
+                return Ok(());
+            }
+            let Some(retried) = outcome.turn else {
+                return Err(AgentError::Store(
+                    "injected scan neither retried nor terminalized the turn".into(),
+                ));
+            };
+            scan_at = retried
+                .lease_expires_at
+                .ok_or_else(|| AgentError::Store("injected retry has no lease".into()))?
+                + chrono::Duration::microseconds(1);
         }
-        Ok(())
     }
 }
 
@@ -1567,6 +1576,28 @@ impl Store for PauseTerminalStore {
         }
         Ok(())
     }
+    async fn append_claimed_assistant_message_with_citations(
+        &self,
+        message: &Message,
+        citations: &[openwave_core::AssistantCitationReference],
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::AppendClaimedMessageOutcome> {
+        self.assistant_append_calls.fetch_add(1, Ordering::SeqCst);
+        let outcome = self
+            .inner
+            .append_claimed_assistant_message_with_citations(message, citations, lease_token, now)
+            .await?;
+        if self
+            .fail_after_assistant_commit
+            .swap(false, Ordering::SeqCst)
+        {
+            return Err(AgentError::Store(
+                "injected ambiguous claimed assistant append response".into(),
+            ));
+        }
+        Ok(outcome)
+    }
     async fn list_messages(&self, chat_id: ChatId) -> Result<Vec<Message>> {
         self.inner.list_messages(chat_id).await
     }
@@ -1575,6 +1606,16 @@ impl Store for PauseTerminalStore {
         call: &openwave_core::ToolCallRecord,
     ) -> Result<openwave_core::AcceptToolCallOutcome> {
         self.inner.accept_tool_call(call).await
+    }
+    async fn accept_claimed_tool_call(
+        &self,
+        call: &openwave_core::ToolCallRecord,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::AcceptClaimedToolCallOutcome> {
+        self.inner
+            .accept_claimed_tool_call(call, lease_token, now)
+            .await
     }
     async fn claim_client_tool_call(
         &self,
@@ -1620,6 +1661,54 @@ impl Store for PauseTerminalStore {
     ) -> Result<openwave_core::ResolveToolCallOutcome> {
         self.inner
             .resolve_server_tool_call_with_evidence(id, resolution, resolved_at, evidence)
+            .await
+    }
+    #[allow(clippy::too_many_arguments)]
+    async fn resolve_claimed_server_tool_call_with_evidence(
+        &self,
+        id: openwave_core::CallId,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &openwave_core::ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+        evidence: &[openwave_core::RetrievalEvidenceInput],
+    ) -> Result<openwave_core::ResolveToolCallOutcome> {
+        self.inner
+            .resolve_claimed_server_tool_call_with_evidence(
+                id,
+                chat_id,
+                turn_id,
+                lease_token,
+                now,
+                resolution,
+                resolved_at,
+                evidence,
+            )
+            .await
+    }
+    #[allow(clippy::too_many_arguments)]
+    async fn abandon_inherited_server_tool_call(
+        &self,
+        id: openwave_core::CallId,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &openwave_core::ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<openwave_core::ResolveToolCallOutcome> {
+        self.inner
+            .abandon_inherited_server_tool_call(
+                id,
+                chat_id,
+                turn_id,
+                lease_token,
+                now,
+                resolution,
+                resolved_at,
+            )
             .await
     }
     async fn resolve_client_tool_call_and_append_event(
@@ -9662,6 +9751,60 @@ async fn worker_recovers_ambiguous_claim_and_completion_with_exact_receipts() {
         next_events.last().map(|event| &event.event),
         Some(AgentEvent::TurnCompleted { .. })
     ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn worker_retries_a_transient_provider_failure_without_a_terminal_event() {
+    struct FailOnceProvider {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for FailOnceProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("retry-once")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(AgentError::Provider("injected transient failure".into()));
+            }
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "recovered".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (router, token, store, _dir) = test_app_with(Arc::new(FailOnceProvider {
+        calls: calls.clone(),
+    }))
+    .await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "retry me").await,
+        StatusCode::ACCEPTED
+    );
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert!(!events
+        .iter()
+        .any(|event| matches!(event.event, AgentEvent::TurnFailed { .. })));
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCompleted { .. })
+    ));
+    let turn = store.list_turn_runs(chat.id).await.unwrap().pop().unwrap();
+    assert_eq!(turn.attempt_count, 2);
+    assert_eq!(turn.status, TurnRunStatus::Completed);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -363,21 +363,6 @@ impl TurnWorker {
             )));
         }
         let mut total_model_steps = turn.model_steps;
-        // Intermediate tool/message effects are not yet lease-CAS fenced. Keep
-        // execution explicitly single-attempt so a crash can fail conservatively
-        // but can never replay a filesystem or external tool side effect.
-        if turn.max_attempts != 1 {
-            return self
-                .record_failure(
-                    &turn,
-                    lease_token,
-                    total_model_steps,
-                    turn.usage,
-                    "unsupported_retry_policy",
-                    "turn execution requires max_attempts = 1",
-                )
-                .await;
-        }
         let consumed_steps = usize::try_from(total_model_steps).map_err(|_| {
             AgentError::msg(format!(
                 "turn {} has invalid durable model-step accounting",
@@ -1601,7 +1586,7 @@ impl TurnWorker {
                     };
                     drop(active);
                     return self
-                        .record_failure(
+                        .record_classified_failure(
                             &turn,
                             lease_token,
                             total_model_steps,
@@ -1619,12 +1604,12 @@ impl TurnWorker {
                             .await;
                     }
                     return self
-                        .record_failure(
+                        .record_classified_failure(
                             &turn,
                             lease_token,
                             total_model_steps,
                             total_usage,
-                            "agent_error",
+                            error.kind(),
                             &error.to_string(),
                         )
                         .await;
@@ -1913,6 +1898,47 @@ impl TurnWorker {
         code: &str,
         detail: &str,
     ) -> Result<TurnWorkerOutcome> {
+        self.record_failure_with_retry(
+            turn,
+            lease_token,
+            model_steps,
+            usage,
+            code,
+            detail,
+            TurnFailureRetry::Permanent,
+        )
+        .await
+    }
+
+    async fn record_classified_failure(
+        &self,
+        turn: &TurnRun,
+        lease_token: uuid::Uuid,
+        model_steps: i32,
+        usage: openwave_core::Usage,
+        code: &str,
+        detail: &str,
+    ) -> Result<TurnWorkerOutcome> {
+        let retry = if matches!(code, "provider" | "store" | "secret") {
+            TurnFailureRetry::RetryAt(Utc::now() + chrono_duration(self.config.failure_delay)?)
+        } else {
+            TurnFailureRetry::Permanent
+        };
+        self.record_failure_with_retry(turn, lease_token, model_steps, usage, code, detail, retry)
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn record_failure_with_retry(
+        &self,
+        turn: &TurnRun,
+        lease_token: uuid::Uuid,
+        model_steps: i32,
+        usage: openwave_core::Usage,
+        code: &str,
+        detail: &str,
+        retry: TurnFailureRetry,
+    ) -> Result<TurnWorkerOutcome> {
         let mut detail: String = detail
             .chars()
             .map(|character| {
@@ -1940,7 +1966,7 @@ impl TurnWorker {
                     turn.id,
                     lease_token,
                     Utc::now(),
-                    TurnFailureRetry::Permanent,
+                    retry,
                     model_steps,
                     usage,
                     code,
@@ -1971,6 +1997,12 @@ impl TurnWorker {
                 Err(error) => {
                     self.retry_after("failure resolution", turn.id, &error)
                         .await;
+                    if !matches!(retry, TurnFailureRetry::Permanent) {
+                        // Retry the exact failure identity and timestamp. The
+                        // immutable failure receipt is recoverable even after
+                        // the first commit released this lease into retry_wait.
+                        continue;
+                    }
                     match self
                         .resolution_state_retry(
                             turn,


### PR DESCRIPTION
## Summary
- co-commit intermediate assistant messages and server tool outcomes under the exact live turn lease
- suppress replay of ambiguous pending tool side effects after crash or lease recovery
- classify provider, store, and secret failures as bounded retries and lift turns to three attempts
- migrate existing active turns and persist private per-attempt lease provenance

## Testing
- bw dev lint --rust --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked
- cargo fmt --all --check

Closes #321