### PR TITLE
Configure external MCP servers at product boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6727,6 +6727,7 @@ dependencies = [
  "chrono",
  "futures",
  "openwave-core",
+ "openwave-mcp",
  "openwave-retrieval",
  "openwave-router",
  "openwave-web-search",

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ agent loop **on your machine**, keeps your data local, and lets you bring your
 own model — hosted or fully offline. Its MCP server foundation can expose the
 same tool registry to external agents; `openwave mcp <workspace>` serves the
 built-in read-only file tools today. The inverse client foundation can initialize
-external stdio MCP servers and mount their tools into that registry; app-level
-server configuration and indexed search wiring remain in development.
+external stdio MCP servers configured at boot and mount their tools into that
+registry; configuration UI and indexed search wiring remain in development.
 
 ## Principles
 
@@ -77,9 +77,9 @@ local file tools, multi-provider model routing, a turn engine with live journale
 WebSocket events, a workspace-style desktop conversation shell, a bounded
 foreground/sandbox agent-run foundation, and durable asynchronous document
 ingestion/retrieval with grounded citations — all behind `openwave serve`.
-Connectors, richer document parsers, indexed-search MCP wiring, and app-level
-MCP client configuration remain in development. Expect rapid change and rough
-edges — and see [CONTRIBUTING](CONTRIBUTING.md) if you'd like to help.
+Connectors, richer document parsers, indexed-search MCP wiring, and MCP
+configuration UI remain in development. Expect rapid change and rough edges —
+and see [CONTRIBUTING](CONTRIBUTING.md) if you'd like to help.
 
 ## Building
 
@@ -107,6 +107,39 @@ ANTHROPIC_API_KEY=sk-... cargo run -p openwave-cli -- serve
 # MCP stdio server confined to an explicit workspace (read_file + list_dir):
 cargo run -p openwave-cli -- mcp /absolute/path/to/workspace
 ```
+
+### External MCP servers
+
+Both `openwave serve` and the desktop app can mount external stdio MCP servers
+at startup. Set `OPENWAVE_MCP_CONFIG` to a JSON file:
+
+```json
+{
+  "servers": [
+    {
+      "name": "private_docs",
+      "command": "/absolute/path/to/docs-mcp",
+      "args": ["--stdio"],
+      "env": { "DOCS_TOKEN": "secret" },
+      "cwd": "/srv/docs",
+      "request_timeout_ms": 60000
+    }
+  ]
+}
+```
+
+```sh
+OPENWAVE_MCP_CONFIG=/absolute/path/to/mcp.json \
+  cargo run -p openwave-cli -- serve
+```
+
+Commands are executed directly, without a shell. Each server receives only its
+configured `env` by default, so use an absolute command path; set
+`"inherit_env": true` only when the server must inherit OpenWave's process
+environment. Treat the JSON file as sensitive when it contains credentials and
+restrict its filesystem permissions. Startup fails if a configured server
+cannot initialize. Its discovered tools are named
+`mcp__{server}__{tool}` and always cross the sensitive-tool approval boundary.
 
 ## Layout
 

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -4,7 +4,8 @@
 //! port and prints the address and per-launch bearer token it minted, so a local
 //! client (the desktop shell, or a script) can connect. Configuration comes from
 //! the environment via [`Config::from_env`] (`OPENWAVE_PROFILE`,
-//! `OPENWAVE_DATA_DIR`); the model API key comes from `ANTHROPIC_API_KEY`.
+//! `OPENWAVE_DATA_DIR`); the model API key comes from `ANTHROPIC_API_KEY`, and
+//! `OPENWAVE_MCP_CONFIG` may name an external stdio-server configuration file.
 //!
 //! `openwave mcp <workspace>` serves the built-in read-only filesystem tools over
 //! MCP stdio, confined to the explicit workspace directory.
@@ -61,7 +62,7 @@ fn usage_error(message: &str) -> ! {
 /// Bind the server and run its accept loop, announcing where to reach it.
 async fn serve() -> Result<()> {
     let config = Config::from_env()?;
-    let server = openwave_server::bind(config).await?;
+    let server = openwave_server::bind_configured(config).await?;
     // The address and token are the client's entry point: the parent process that
     // launched the daemon reads them from stdout to connect. The token is a secret,
     // so an integrator should capture this process's stdout directly (a piped

--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -54,6 +54,7 @@ fn serve_announces_its_address_and_answers_health() {
         .arg("serve")
         .env("OPENWAVE_DATA_DIR", dir.path())
         .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env_remove("OPENWAVE_MCP_CONFIG")
         .env_remove("ANTHROPIC_API_KEY")
         .stdout(Stdio::piped())
         .spawn()
@@ -87,6 +88,76 @@ fn serve_announces_its_address_and_answers_health() {
 
     assert!(response.contains("200 OK"), "response: {response}");
     assert!(response.trim_end().ends_with("ok"), "response: {response}");
+}
+
+#[test]
+fn serve_mounts_external_mcp_servers_from_boot_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let workspace = dir.path().join("mcp-workspace");
+    std::fs::create_dir(&workspace).unwrap();
+    let config_path = dir.path().join("mcp.json");
+    let config = serde_json::json!({
+        "servers": [{
+            "name": "fixture",
+            "command": env!("CARGO_BIN_EXE_openwave"),
+            "args": ["mcp", workspace],
+            "request_timeout_ms": 5_000
+        }]
+    });
+    std::fs::write(&config_path, config.to_string()).unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .arg("serve")
+        .env("OPENWAVE_DATA_DIR", dir.path().join("data"))
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env("OPENWAVE_MCP_CONFIG", &config_path)
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn configured openwave serve");
+
+    let stdout = child.stdout.take().unwrap();
+    let _reaper = Reaper(child);
+    let mut lines = BufReader::new(stdout).lines();
+    let addr_line = lines.next().unwrap().unwrap();
+    let token_line = lines.next().unwrap().unwrap();
+    assert!(addr_line.contains("listening on http://127.0.0.1:"));
+    assert!(token_line.starts_with("openwave: token "));
+}
+
+#[test]
+fn serve_fails_closed_when_a_configured_mcp_server_cannot_start() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing_command = dir.path().join("missing-mcp-server");
+    let config_path = dir.path().join("mcp.json");
+    let config = serde_json::json!({
+        "servers": [{
+            "name": "broken",
+            "command": missing_command
+        }]
+    });
+    std::fs::write(&config_path, config.to_string()).unwrap();
+
+    let child = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .arg("serve")
+        .env("OPENWAVE_DATA_DIR", dir.path().join("data"))
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env("OPENWAVE_MCP_CONFIG", &config_path)
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave serve with broken MCP config");
+    let mut child = Reaper(child);
+    let output = child.wait_with_output(PROCESS_EXIT_TIMEOUT);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("external MCP server broken failed to start"),
+        "stderr: {stderr}"
+    );
 }
 
 #[test]

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -182,10 +182,12 @@ async fn boot_server(
     data_dir: PathBuf,
 ) -> Result<(), String> {
     let client_executor_id = app.state::<host_access::HostAccess>().client_executor_id();
-    let server =
-        openwave_server::bind_with_desktop_executor(Config::desktop(data_dir), client_executor_id)
-            .await
-            .map_err(|e| e.to_string())?;
+    let server = openwave_server::bind_configured_with_desktop_executor(
+        Config::desktop(data_dir),
+        client_executor_id,
+    )
+    .await
+    .map_err(|e| e.to_string())?;
     app.state::<host_access::HostAccess>()
         .initialize_store(server.store())?;
     let base_url = format!("http://{}", server.local_addr());

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -25,11 +25,12 @@ parse-office = ["openwave-retrieval/parse-office"]
 
 [dependencies]
 openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools", "keychain", "blob-fs"] }
+openwave-mcp = { path = "../openwave-mcp" }
 openwave-router = { path = "../openwave-router" }
 openwave-retrieval = { path = "../openwave-retrieval", features = ["vec-lance"] }
 openwave-web-search = { path = "../openwave-web-search", features = ["http"] }
 axum = { workspace = true }
-tokio = { workspace = true, features = ["net", "rt", "sync", "macros", "time"] }
+tokio = { workspace = true, features = ["net", "process", "rt", "sync", "macros", "time"] }
 tower-http = { version = "=0.7.0", features = ["cors"] }
 futures = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -24,6 +24,7 @@ mod document_worker;
 mod error;
 mod event_projection;
 mod extract;
+mod mcp_config;
 mod provider;
 mod providers;
 mod resolver;
@@ -381,7 +382,16 @@ const DEFAULT_MODEL: &str = "claude-opus-4-8";
 /// This generic embedding does not expose durable root-attachment mutations,
 /// because it has no restart-stable native executor identity.
 pub async fn bind(config: Config) -> Result<Server> {
-    bind_inner(config, None).await
+    bind_inner(config, None, mcp_config::ConfiguredMcpServers::default()).await
+}
+
+/// Bind the API and mount external MCP servers from `OPENWAVE_MCP_CONFIG`.
+///
+/// This is the product boot path used by the CLI. Custom embedders can continue
+/// to use [`bind`] when process-environment configuration is undesirable.
+pub async fn bind_configured(config: Config) -> Result<Server> {
+    let mcp_servers = mcp_config::ConfiguredMcpServers::from_env()?;
+    bind_inner(config, None, mcp_servers).await
 }
 
 /// Bind the API with a stable app-private native executor identity.
@@ -395,10 +405,32 @@ pub async fn bind_with_desktop_executor(
     if client_executor_id.is_nil() {
         return Err(AgentError::config("client executor id must not be nil"));
     }
-    bind_inner(config, Some(client_executor_id)).await
+    bind_inner(
+        config,
+        Some(client_executor_id),
+        mcp_config::ConfiguredMcpServers::default(),
+    )
+    .await
 }
 
-async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<Server> {
+/// Desktop counterpart to [`bind_configured`], retaining the stable native
+/// executor identity used by host-owned continuations.
+pub async fn bind_configured_with_desktop_executor(
+    config: Config,
+    client_executor_id: Uuid,
+) -> Result<Server> {
+    if client_executor_id.is_nil() {
+        return Err(AgentError::config("client executor id must not be nil"));
+    }
+    let mcp_servers = mcp_config::ConfiguredMcpServers::from_env()?;
+    bind_inner(config, Some(client_executor_id), mcp_servers).await
+}
+
+async fn bind_inner(
+    config: Config,
+    client_executor_id: Option<Uuid>,
+    mcp_servers: mcp_config::ConfiguredMcpServers,
+) -> Result<Server> {
     // Desktop live delivery remains process-local. Turns, steering, and tool
     // approvals are durable, while one process still owns the complete data
     // directory and its worker set.
@@ -411,7 +443,9 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
     let resolver = Arc::new(KeyedResolver::new(store.clone(), secrets.clone()));
     let embedder = resolve_embedder(&*store, &*secrets).await;
     let vector_store = connect_vector_store(&config, embedder.dimensions()).await?;
-    let (retrieval, tools, agent_config) = agent_deps(embedder, vector_store);
+    let (retrieval, mut tools, agent_config) = agent_deps(embedder, vector_store);
+    mcp_servers.mount(&mut tools).await?;
+    let tools = Arc::new(tools);
     let state = match client_executor_id {
         Some(client_executor_id) => AppState::new_with_client_executor_id(
             config,
@@ -543,7 +577,7 @@ async fn bind_inner(config: Config, client_executor_id: Option<Uuid>) -> Result<
 fn agent_deps(
     embedder: Arc<dyn Embedder>,
     store: Arc<dyn VectorStore>,
-) -> (Arc<Retriever>, Arc<ToolRegistry>, AgentConfig) {
+) -> (Arc<Retriever>, ToolRegistry, AgentConfig) {
     let (retrieval, search) = build_retrieval(embedder, store);
     let mut tools = ToolRegistry::new()
         .with(Box::new(ReadFile))
@@ -567,7 +601,6 @@ fn agent_deps(
     // an explicit ordered wait parks only when results are needed. The bounded
     // sandbox worker below never receives either orchestration definition.
     tools.register_foreground_agent_orchestration();
-    let tools = Arc::new(tools);
     let model = std::env::var("OPENWAVE_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string());
     let agent_config = AgentConfig {
         model,

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -1,0 +1,290 @@
+//! Boot-time configuration for external MCP stdio servers.
+
+use std::collections::{BTreeMap, HashSet};
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use openwave_core::{AgentError, Result, ToolRegistry};
+use openwave_mcp::McpClient;
+use serde::Deserialize;
+use tokio::process::Command;
+
+const CONFIG_ENV: &str = "OPENWAVE_MCP_CONFIG";
+const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
+const MAX_SERVERS: usize = 32;
+const MAX_ARGS: usize = 128;
+const MAX_ENVIRONMENT_VARIABLES: usize = 128;
+const MAX_REQUEST_TIMEOUT_MS: u64 = 60 * 60 * 1000;
+const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 60 * 1000;
+
+/// Validated external servers selected for one process boot.
+#[derive(Default)]
+pub(crate) struct ConfiguredMcpServers(Vec<StdioServerConfig>);
+
+impl ConfiguredMcpServers {
+    pub(crate) fn from_env() -> Result<Self> {
+        let Some(path) = std::env::var_os(CONFIG_ENV).filter(|path| !path.is_empty()) else {
+            return Ok(Self::default());
+        };
+        Self::from_path(Path::new(&path))
+    }
+
+    fn from_path(path: &Path) -> Result<Self> {
+        let file = File::open(path).map_err(|error| {
+            AgentError::config(format!(
+                "could not open MCP config {}: {error}",
+                path.display()
+            ))
+        })?;
+        let mut bytes = Vec::new();
+        file.take(MAX_CONFIG_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|error| {
+                AgentError::config(format!(
+                    "could not read MCP config {}: {error}",
+                    path.display()
+                ))
+            })?;
+        if bytes.len() as u64 > MAX_CONFIG_BYTES {
+            return Err(AgentError::config(format!(
+                "MCP config {} exceeds {MAX_CONFIG_BYTES} bytes",
+                path.display()
+            )));
+        }
+        Self::parse(path, &bytes)
+    }
+
+    fn parse(path: &Path, bytes: &[u8]) -> Result<Self> {
+        let config: ConfigFile = serde_json::from_slice(bytes).map_err(|error| {
+            AgentError::config(format!("invalid MCP config {}: {error}", path.display()))
+        })?;
+        validate_servers(config.servers).map(Self)
+    }
+
+    pub(crate) async fn mount(self, registry: &mut ToolRegistry) -> Result<()> {
+        for server in self.0 {
+            let name = server.name.clone();
+            let client = server.connect().await.map_err(|error| {
+                AgentError::config(format!(
+                    "external MCP server {name} failed to start: {error}"
+                ))
+            })?;
+            client.mount(registry);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConfigFile {
+    servers: Vec<StdioServerConfig>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StdioServerConfig {
+    name: String,
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    #[serde(default)]
+    inherit_env: bool,
+    #[serde(default)]
+    cwd: Option<PathBuf>,
+    #[serde(default = "default_request_timeout_ms")]
+    request_timeout_ms: u64,
+}
+
+impl StdioServerConfig {
+    async fn connect(self) -> Result<McpClient> {
+        let mut command = Command::new(&self.command);
+        command.args(&self.args);
+        if !self.inherit_env {
+            command.env_clear();
+        }
+        command.envs(&self.env);
+        if let Some(cwd) = self.cwd {
+            command.current_dir(cwd);
+        }
+        McpClient::spawn_with_timeout(
+            self.name,
+            command,
+            Duration::from_millis(self.request_timeout_ms),
+        )
+        .await
+    }
+}
+
+const fn default_request_timeout_ms() -> u64 {
+    DEFAULT_REQUEST_TIMEOUT_MS
+}
+
+fn validate_servers(servers: Vec<StdioServerConfig>) -> Result<Vec<StdioServerConfig>> {
+    if servers.len() > MAX_SERVERS {
+        return Err(AgentError::config(format!(
+            "MCP config contains more than {MAX_SERVERS} servers"
+        )));
+    }
+    let mut names = HashSet::new();
+    for server in &servers {
+        validate_name(&server.name)?;
+        validate_process_string(&server.name, "command", &server.command)?;
+        if server.command.is_empty() {
+            return Err(server_error(&server.name, "command must not be empty"));
+        }
+        if server.args.len() > MAX_ARGS {
+            return Err(server_error(
+                &server.name,
+                format!("must not contain more than {MAX_ARGS} arguments"),
+            ));
+        }
+        for argument in &server.args {
+            validate_process_string(&server.name, "argument", argument)?;
+        }
+        if server.env.len() > MAX_ENVIRONMENT_VARIABLES {
+            return Err(server_error(
+                &server.name,
+                format!(
+                    "must not contain more than {MAX_ENVIRONMENT_VARIABLES} environment variables"
+                ),
+            ));
+        }
+        for (key, value) in &server.env {
+            if key.is_empty() || key.contains('=') || key.contains('\0') {
+                return Err(server_error(
+                    &server.name,
+                    format!("invalid environment variable name {key:?}"),
+                ));
+            }
+            validate_process_string(&server.name, "environment value", value)?;
+        }
+        if server
+            .cwd
+            .as_ref()
+            .and_then(|path| path.to_str())
+            .is_some_and(|path| path.contains('\0'))
+        {
+            return Err(server_error(
+                &server.name,
+                "working directory must not contain NUL",
+            ));
+        }
+        if !(1..=MAX_REQUEST_TIMEOUT_MS).contains(&server.request_timeout_ms) {
+            return Err(server_error(
+                &server.name,
+                format!("request_timeout_ms must be between 1 and {MAX_REQUEST_TIMEOUT_MS}"),
+            ));
+        }
+        if !names.insert(server.name.clone()) {
+            return Err(server_error(&server.name, "server name is duplicated"));
+        }
+    }
+    Ok(servers)
+}
+
+fn validate_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        return Err(server_error(
+            name,
+            "name must contain only ASCII letters, digits, '_' or '-'",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_process_string(name: &str, field: &str, value: &str) -> Result<()> {
+    if value.contains('\0') {
+        return Err(server_error(name, format!("{field} must not contain NUL")));
+    }
+    Ok(())
+}
+
+fn server_error(name: &str, message: impl std::fmt::Display) -> AgentError {
+    AgentError::config(format!("invalid external MCP server {name:?}: {message}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(json: &str) -> Result<ConfiguredMcpServers> {
+        ConfiguredMcpServers::parse(Path::new("test-mcp.json"), json.as_bytes())
+    }
+
+    #[test]
+    fn parses_a_bounded_stdio_server_configuration() {
+        let config = parse(
+            r#"{
+                "servers": [{
+                    "name": "private_docs",
+                    "command": "/usr/local/bin/docs-mcp",
+                    "args": ["--stdio"],
+                    "env": {"DOCS_TOKEN": "secret"},
+                    "cwd": "/srv/docs",
+                    "request_timeout_ms": 2500
+                }]
+            }"#,
+        )
+        .unwrap();
+        let server = &config.0[0];
+        assert_eq!(server.name, "private_docs");
+        assert_eq!(server.command, "/usr/local/bin/docs-mcp");
+        assert_eq!(server.args, ["--stdio"]);
+        assert_eq!(server.env.get("DOCS_TOKEN").unwrap(), "secret");
+        assert!(!server.inherit_env);
+        assert_eq!(server.cwd.as_deref(), Some(Path::new("/srv/docs")));
+        assert_eq!(server.request_timeout_ms, 2500);
+    }
+
+    #[test]
+    fn defaults_to_an_isolated_environment_and_sixty_second_timeout() {
+        let config = parse(r#"{"servers":[{"name":"docs","command":"/bin/docs"}]}"#).unwrap();
+        let server = &config.0[0];
+        assert!(!server.inherit_env);
+        assert!(server.args.is_empty());
+        assert!(server.env.is_empty());
+        assert_eq!(server.request_timeout_ms, 60_000);
+    }
+
+    #[test]
+    fn rejects_duplicate_names_and_unsafe_process_strings() {
+        let duplicate = parse(
+            r#"{"servers":[
+                {"name":"docs","command":"/bin/one"},
+                {"name":"docs","command":"/bin/two"}
+            ]}"#,
+        )
+        .err()
+        .unwrap();
+        assert!(duplicate.to_string().contains("duplicated"));
+
+        let nul = parse("{\"servers\":[{\"name\":\"docs\",\"command\":\"bad\\u0000command\"}]}")
+            .err()
+            .unwrap();
+        assert!(nul.to_string().contains("must not contain NUL"));
+    }
+
+    #[test]
+    fn rejects_unknown_fields_and_out_of_range_timeouts() {
+        let unknown =
+            parse(r#"{"servers":[{"name":"docs","command":"/bin/docs","transport":"http"}]}"#)
+                .err()
+                .unwrap();
+        assert!(unknown.to_string().contains("unknown field"));
+
+        let timeout =
+            parse(r#"{"servers":[{"name":"docs","command":"/bin/docs","request_timeout_ms":0}]}"#)
+                .err()
+                .unwrap();
+        assert!(timeout.to_string().contains("request_timeout_ms"));
+    }
+}

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -146,8 +146,9 @@ and its execution boundary exposes only tools classified read-only. Its client
 half initializes external stdio servers, follows paginated tool discovery, and
 mounts each proxy as `mcp__{server}__{tool}` in the same registry. Mounted tools
 are classified sensitive so they cross OpenWave's approval boundary before the
-client forwards a call. Product configuration and dynamic tool-list refresh are
-still follow-up work.
+client forwards a call. The CLI and desktop boot paths load external stdio
+servers from `OPENWAVE_MCP_CONFIG`. Configuration UI, reconnect supervision,
+and dynamic tool-list refresh are still follow-up work.
 
 **Depends on:** `openwave-core`.
 

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -79,7 +79,10 @@ and lazily starts its bundled host-broker sidecar. Server startup acquires
 exclusive ownership of the data directory, opens the operational database and
 Lance index, loads provider configuration, registers tools, starts the turn and
 document workers, and finally binds an ephemeral loopback port with a fresh
-bearer token.
+bearer token. When `OPENWAVE_MCP_CONFIG` names a JSON file, startup also
+initializes every configured external stdio MCP server and registers its
+namespaced tools before accepting requests. A malformed configuration or failed
+server initialization fails startup instead of silently omitting tools.
 
 The main local data is easy to recognize:
 
@@ -710,11 +713,13 @@ effective API specification.
 
 `openwave mcp /absolute/workspace` starts an MCP stdio server confined to that
 workspace. It currently exposes only `read_file` and `list_dir`, and only after a
-proper MCP initialize lifecycle. Indexed search, approval-aware writable tools,
-and app-level external-server configuration are not wired yet. The `openwave-mcp`
-library also implements the inverse lifecycle for external stdio servers: it
-discovers their tools, mounts namespaced sensitive proxies into `ToolRegistry`,
-and forwards approved calls over the shared MCP session.
+proper MCP initialize lifecycle. Indexed search and approval-aware writable
+tools are not wired yet. The inverse client lifecycle loads external stdio
+servers from the `OPENWAVE_MCP_CONFIG` file used by the desktop and headless boot
+paths, discovers their tools, mounts namespaced sensitive proxies into
+`ToolRegistry`, and forwards approved calls over the shared MCP session. Server
+commands execute directly rather than through a shell, and receive only their
+explicitly configured environment by default.
 
 ### Self-host
 
@@ -793,7 +798,8 @@ The main next steps are:
   sandbox-safe capabilities without widening exact delegated-file or spawn
   authority;
 - add richer parsers and wire indexed search into MCP;
-- wire MCP client configuration and lifecycle into product surfaces;
+- add MCP configuration UI, health/reconnect supervision, and dynamic tool-list
+  refresh;
 - finish the self-host profile rather than only testing Postgres state logic;
 - add health-aware provider failover;
 - bound the agent-to-worker event channel and batch or page journal traffic so

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -63,6 +63,16 @@ serialized per external server and their text, structured content, and error
 flag are translated back into `ToolOutput`. Because MCP tools can cross both the
 workspace and process boundary, every mounted proxy is classified `Sensitive`.
 
+The desktop and `openwave serve` boot paths read external stdio servers from the
+JSON file named by `OPENWAVE_MCP_CONFIG`. Each entry declares a unique namespace,
+an executable plus argument array, an optional working directory and explicit
+environment, and an optional bounded request timeout. No shell interprets these
+values. Child environments are cleared by default to avoid leaking provider or
+host credentials; `inherit_env` is an explicit opt-in. Initialization is
+fail-closed so the advertised tool surface never silently differs from the boot
+configuration. Configuration UI, reconnect supervision, and MCP
+`tools/list_changed` refresh remain future work.
+
 ## Foreground and sandbox surfaces
 
 Foreground and background agents need different tools. OpenWave should not


### PR DESCRIPTION
Closes #325

## Summary

- load a bounded, validated external stdio-server JSON file from `OPENWAVE_MCP_CONFIG`
- mount initialized, namespaced MCP tools in both headless and desktop product boot paths
- execute command/argument arrays without a shell and isolate child environments by default
- fail startup when configuration or server initialization is invalid
- document configuration, approval behavior, security defaults, and remaining lifecycle work

## Validation

- `cargo test -p openwave-cli --test serve --locked` (4 passed)
- `cargo test -p openwave-server mcp_config::tests --locked` (4 passed)
- `bw dev lint --rust --check`
- `cargo check --workspace --all-targets --locked`
- `git diff --check`