### PR TITLE
Forward selected environment variables to MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ at startup. Set `OPENWAVE_MCP_CONFIG` to a JSON file:
       "name": "private_docs",
       "command": "/absolute/path/to/docs-mcp",
       "args": ["--stdio"],
-      "env": { "DOCS_TOKEN": "secret" },
+      "env": { "LOG_LEVEL": "info" },
+      "env_from": ["DOCS_TOKEN"],
       "cwd": "/srv/docs",
       "request_timeout_ms": 60000
     }
@@ -134,11 +135,13 @@ OPENWAVE_MCP_CONFIG=/absolute/path/to/mcp.json \
 ```
 
 Commands are executed directly, without a shell. Each server receives only its
-configured `env` by default, so use an absolute command path; set
-`"inherit_env": true` only when the server must inherit OpenWave's process
-environment. Treat the JSON file as sensitive when it contains credentials and
-restrict its filesystem permissions. Startup fails if a configured server
-cannot initialize. Its discovered tools are named
+configured literal `env` and the parent variables explicitly named by
+`env_from`, so use an absolute command path. A missing `env_from` variable fails
+startup; set `"inherit_env": true` only when the server must inherit OpenWave's
+entire process environment. Prefer `env_from` for credentials so they need not
+be stored in JSON. Treat the file as sensitive and restrict its filesystem
+permissions if it does contain credentials. Startup fails if a configured
+server cannot initialize. Its discovered tools are named
 `mcp__{server}__{tool}` and always cross the sensitive-tool approval boundary.
 
 ## Layout

--- a/crates/openwave-cli/tests/serve.rs
+++ b/crates/openwave-cli/tests/serve.rs
@@ -161,6 +161,45 @@ fn serve_fails_closed_when_a_configured_mcp_server_cannot_start() {
 }
 
 #[test]
+fn serve_fails_closed_when_a_selected_mcp_environment_variable_is_missing() {
+    const MISSING: &str = "OPENWAVE_TEST_MCP_ENV_FROM_MUST_NOT_EXIST_46F54489";
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("mcp.json");
+    let config = serde_json::json!({
+        "servers": [{
+            "name": "protected",
+            "command": env!("CARGO_BIN_EXE_openwave"),
+            "args": ["mcp", dir.path()],
+            "env_from": [MISSING]
+        }]
+    });
+    std::fs::write(&config_path, config.to_string()).unwrap();
+
+    let child = Command::new(env!("CARGO_BIN_EXE_openwave"))
+        .arg("serve")
+        .env("OPENWAVE_DATA_DIR", dir.path().join("data"))
+        .env("OPENWAVE_KEYCHAIN_MOCK", "1")
+        .env("OPENWAVE_MCP_CONFIG", &config_path)
+        .env_remove(MISSING)
+        .env_remove("ANTHROPIC_API_KEY")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn openwave serve with missing MCP environment");
+    let mut child = Reaper(child);
+    let output = child.wait_with_output(PROCESS_EXIT_TIMEOUT);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("external MCP server protected failed to start"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains(MISSING), "stderr: {stderr}");
+    assert!(stderr.contains("is not set"), "stderr: {stderr}");
+}
+
+#[test]
 fn mcp_serves_read_only_tools_with_protocol_pure_stdout() {
     let workspace = tempfile::tempdir().unwrap();
     std::fs::write(workspace.path().join("note.txt"), "workspace note").unwrap();

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -93,6 +93,8 @@ struct StdioServerConfig {
     #[serde(default)]
     env: BTreeMap<String, String>,
     #[serde(default)]
+    env_from: Vec<String>,
+    #[serde(default)]
     inherit_env: bool,
     #[serde(default)]
     cwd: Option<PathBuf>,
@@ -101,16 +103,29 @@ struct StdioServerConfig {
 }
 
 impl StdioServerConfig {
-    async fn connect(self) -> Result<McpClient> {
+    fn build_command(&self) -> Result<Command> {
         let mut command = Command::new(&self.command);
         command.args(&self.args);
         if !self.inherit_env {
             command.env_clear();
         }
+        for name in &self.env_from {
+            let value = std::env::var_os(name).ok_or_else(|| {
+                AgentError::config(format!(
+                    "required parent environment variable {name:?} is not set"
+                ))
+            })?;
+            command.env(name, value);
+        }
         command.envs(&self.env);
-        if let Some(cwd) = self.cwd {
+        if let Some(cwd) = &self.cwd {
             command.current_dir(cwd);
         }
+        Ok(command)
+    }
+
+    async fn connect(self) -> Result<McpClient> {
+        let command = self.build_command()?;
         McpClient::spawn_with_timeout(
             self.name,
             command,
@@ -146,7 +161,7 @@ fn validate_servers(servers: Vec<StdioServerConfig>) -> Result<Vec<StdioServerCo
         for argument in &server.args {
             validate_process_string(&server.name, "argument", argument)?;
         }
-        if server.env.len() > MAX_ENVIRONMENT_VARIABLES {
+        if server.env.len().saturating_add(server.env_from.len()) > MAX_ENVIRONMENT_VARIABLES {
             return Err(server_error(
                 &server.name,
                 format!(
@@ -154,14 +169,20 @@ fn validate_servers(servers: Vec<StdioServerConfig>) -> Result<Vec<StdioServerCo
                 ),
             ));
         }
+        let mut environment_names = HashSet::new();
         for (key, value) in &server.env {
-            if key.is_empty() || key.contains('=') || key.contains('\0') {
+            validate_environment_name(&server.name, key)?;
+            environment_names.insert(key.as_str());
+            validate_process_string(&server.name, "environment value", value)?;
+        }
+        for key in &server.env_from {
+            validate_environment_name(&server.name, key)?;
+            if !environment_names.insert(key) {
                 return Err(server_error(
                     &server.name,
-                    format!("invalid environment variable name {key:?}"),
+                    format!("environment variable {key:?} is configured more than once"),
                 ));
             }
-            validate_process_string(&server.name, "environment value", value)?;
         }
         if server
             .cwd
@@ -208,6 +229,16 @@ fn validate_process_string(name: &str, field: &str, value: &str) -> Result<()> {
     Ok(())
 }
 
+fn validate_environment_name(server_name: &str, name: &str) -> Result<()> {
+    if name.is_empty() || name.contains('=') || name.contains('\0') {
+        return Err(server_error(
+            server_name,
+            format!("invalid environment variable name {name:?}"),
+        ));
+    }
+    Ok(())
+}
+
 fn server_error(name: &str, message: impl std::fmt::Display) -> AgentError {
     AgentError::config(format!("invalid external MCP server {name:?}: {message}"))
 }
@@ -228,7 +259,8 @@ mod tests {
                     "name": "private_docs",
                     "command": "/usr/local/bin/docs-mcp",
                     "args": ["--stdio"],
-                    "env": {"DOCS_TOKEN": "secret"},
+                    "env": {"LOG_LEVEL": "info"},
+                    "env_from": ["DOCS_TOKEN"],
                     "cwd": "/srv/docs",
                     "request_timeout_ms": 2500
                 }]
@@ -239,7 +271,8 @@ mod tests {
         assert_eq!(server.name, "private_docs");
         assert_eq!(server.command, "/usr/local/bin/docs-mcp");
         assert_eq!(server.args, ["--stdio"]);
-        assert_eq!(server.env.get("DOCS_TOKEN").unwrap(), "secret");
+        assert_eq!(server.env.get("LOG_LEVEL").unwrap(), "info");
+        assert_eq!(server.env_from, ["DOCS_TOKEN"]);
         assert!(!server.inherit_env);
         assert_eq!(server.cwd.as_deref(), Some(Path::new("/srv/docs")));
         assert_eq!(server.request_timeout_ms, 2500);
@@ -252,6 +285,7 @@ mod tests {
         assert!(!server.inherit_env);
         assert!(server.args.is_empty());
         assert!(server.env.is_empty());
+        assert!(server.env_from.is_empty());
         assert_eq!(server.request_timeout_ms, 60_000);
     }
 
@@ -286,5 +320,79 @@ mod tests {
                 .err()
                 .unwrap();
         assert!(timeout.to_string().contains("request_timeout_ms"));
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_invalid_environment_sources() {
+        let duplicate = parse(
+            r#"{"servers":[{
+                "name":"docs",
+                "command":"/bin/docs",
+                "env":{"DOCS_TOKEN":"literal"},
+                "env_from":["DOCS_TOKEN"]
+            }]}"#,
+        )
+        .err()
+        .unwrap();
+        assert!(duplicate.to_string().contains("configured more than once"));
+
+        let invalid = parse(
+            r#"{"servers":[{
+                "name":"docs",
+                "command":"/bin/docs",
+                "env_from":["BAD=NAME"]
+            }]}"#,
+        )
+        .err()
+        .unwrap();
+        assert!(invalid
+            .to_string()
+            .contains("invalid environment variable name"));
+    }
+
+    #[test]
+    fn forwards_only_explicitly_selected_parent_environment_values() {
+        let config = parse(
+            r#"{"servers":[{
+                "name":"docs",
+                "command":"/bin/docs",
+                "env_from":["PATH"]
+            }]}"#,
+        )
+        .unwrap();
+        let command = config.0[0].build_command().unwrap();
+        let forwarded_path = command
+            .as_std()
+            .get_envs()
+            .find(|(name, _)| *name == "PATH")
+            .and_then(|(_, value)| value)
+            .expect("PATH is selected for forwarding");
+        assert_eq!(Some(forwarded_path), std::env::var_os("PATH").as_deref());
+        assert!(command.as_std().get_envs().all(|(name, _)| name == "PATH"));
+    }
+
+    #[tokio::test]
+    async fn missing_selected_parent_environment_fails_before_spawn() {
+        const MISSING: &str = "OPENWAVE_TEST_MCP_ENV_FROM_MUST_NOT_EXIST_46F54489";
+        assert!(std::env::var_os(MISSING).is_none());
+        let config = parse(&format!(
+            r#"{{"servers":[{{
+                "name":"docs",
+                "command":"/definitely/not/a/real/command",
+                "env_from":["{MISSING}"]
+            }}]}}"#
+        ))
+        .unwrap();
+        let error = config
+            .0
+            .into_iter()
+            .next()
+            .unwrap()
+            .connect()
+            .await
+            .err()
+            .unwrap();
+        assert!(error.to_string().contains(MISSING));
+        assert!(error.to_string().contains("is not set"));
     }
 }

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -719,7 +719,7 @@ servers from the `OPENWAVE_MCP_CONFIG` file used by the desktop and headless boo
 paths, discovers their tools, mounts namespaced sensitive proxies into
 `ToolRegistry`, and forwards approved calls over the shared MCP session. Server
 commands execute directly rather than through a shell, and receive only their
-explicitly configured environment by default.
+literal environment plus specifically selected parent variables by default.
 
 ### Self-host
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -68,8 +68,10 @@ JSON file named by `OPENWAVE_MCP_CONFIG`. Each entry declares a unique namespace
 an executable plus argument array, an optional working directory and explicit
 environment, and an optional bounded request timeout. No shell interprets these
 values. Child environments are cleared by default to avoid leaking provider or
-host credentials; `inherit_env` is an explicit opt-in. Initialization is
-fail-closed so the advertised tool surface never silently differs from the boot
+host credentials; `env_from` selectively forwards named parent variables without
+putting their values in JSON, while `inherit_env` remains an explicit broad
+opt-in. A missing selected variable fails startup. Initialization is fail-closed
+so the advertised tool surface never silently differs from the boot
 configuration. Configuration UI, reconnect supervision, and MCP
 `tools/list_changed` refresh remain future work.
 


### PR DESCRIPTION
Closes #331

## Summary

- add bounded `env_from` entries to external MCP stdio server configuration
- copy only explicitly selected parent values while preserving isolated child environments by default
- reject invalid, duplicate, or ambiguous environment names during validation
- fail startup before process spawn when a selected variable is missing
- document the credential-forwarding flow without putting secret values in JSON

## Validation

- `cargo test -p openwave-server mcp_config::tests --locked` (7 passed)
- `cargo test -p openwave-cli --test serve --locked` (5 passed)
- `bw dev lint --rust --check`
- `cargo check --workspace --all-targets --locked`
- `git diff --check`