### PR TITLE
Layer app CSS so Tailwind utilities reliably override it

### DIFF
--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -245,6 +245,17 @@ body {
   }
 }
 
+/* The app's component and legacy styles live in `@layer components`, which
+   Tailwind v4 orders before `@layer utilities`. Unlayered rules beat any layered
+   rule regardless of specificity, so leaving these unlayered let app CSS silently
+   override Tailwind utilities applied to shadcn components. Grouping the whole
+   block in a single layer lets utilities win when applied, while preserving the
+   existing app-vs-app cascade — source order and specificity are unchanged within
+   one layer, and `components` still outranks the `base` resets above. Token
+   definitions (`:root`, `.dark`, `@theme inline`) and element resets stay
+   unlayered/in `base` on purpose. */
+@layer components {
+
 /* ---------- App shell ---------- */
 
 .app-shell {
@@ -2685,6 +2696,8 @@ body {
     margin-top: -0.5rem;
   }
 }
+
+} /* @layer components */
 
 /* Scrollbar styling */
 * {


### PR DESCRIPTION
## What changed

The desktop UI's hand-written stylesheet `crates/openwave-desktop/ui/src/styles.css` kept most of its component/legacy CSS **unlayered**. In the CSS cascade, an unlayered rule beats any rule inside an `@layer` regardless of specificity, so Tailwind v4's utilities (which live in `@layer utilities`) lost to app CSS. A utility class applied to a shadcn component could be silently overridden.

That is the root cause behind the Tailwind v4 bugs that were being fixed one at a time this cycle (#312 dark-on-dark button, #314 heavy borders): each was a symptom of app CSS structurally outranking utilities.

This wraps the app's component styles in `@layer components`, which `@import "tailwindcss"` orders **before** `@layer utilities`. Now a utility class wins when it is applied to a component, ending the whack-a-mole.

## Why it is safe for app-internal precedence

- The entire component block goes into **one** layer, so the existing app-vs-app cascade is unchanged — source order and specificity still resolve exactly as before within a single layer.
- `components` still outranks the two existing `@layer base` reset blocks (base < components in Tailwind's order), matching the prior unlayered-beats-base behaviour.
- Token definitions (`:root`, `.dark`, `@theme inline`) and element resets (`*` box-sizing, `html/body/#root`, the scrollbar rule) are **left unlayered / in `base` on purpose** — they were not wrapped.

The diff is intentionally tiny: an opening `@layer components {` before the first component rule and a matching `}` after the last one (13 inserted lines, no deletions, no reindentation), so the change is easy to audit line-by-line.

I verified in the compiled output that app component rules (e.g. `.app-shell`) now physically precede Tailwind utilities (e.g. `.items-center`), so utilities win on equal specificity.

## Verification

Run under `crates/openwave-desktop/ui`:
- `pnpm exec tsc --noEmit` — passes
- `pnpm test` (vitest) — 160 tests pass
- `pnpm build` (tsc + vite) — builds clean

## Visual review required before merge — automated checks cannot catch this

Re-layering can silently shift many styles, and none of tsc/vitest/build detect visual regressions. **I cannot and do not claim the UI is visually unchanged.** A human must visually verify the following in **both light and dark mode** before merging (look specifically for any spot where a Tailwind utility now wins that previously lost to app CSS — that is the intended behaviour change and where any regression would surface):

- [ ] Buttons — all variants (`.btn`, `.btn-primary`, `.btn-danger`, `.btn-stop`, shadcn Button variants), including hover/disabled states
- [ ] Dropdown menus (conversation menu, model menu) — borders, background, item hover
- [ ] Cards (agent activity, tool-call cards, approval, folder consent, document cards)
- [ ] Inputs (project rename/create, conversation rename, document search) — borders and focus rings
- [ ] Composer — border, focus-within shadow, textarea, send/stop icon buttons, model menu trigger pill
- [ ] Message list / markdown — headings, code blocks, blockquotes, tables, links, source pills
- [ ] Model selector — trigger, group labels, item meta
- [ ] Settings panels — full-page settings nav + content, appearance theme options, web-search state
- [ ] Sidebar — brand, new chat, project/conversation rows, active/hover states
- [ ] Responsive layout at <=720px

This PR should be human-reviewed, not auto-merged.

Closes #338