### PR TITLE
ci(release): add native semantic release flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,9 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     commit-message:
-      prefix: build
+      # Runtime dependency changes are patch-release candidates. GitHub Actions
+      # updates below remain `ci(deps)` and do not release the product.
+      prefix: deps
       include: scope
     # LanceDB 0.31 exposes Arrow 58 types. Moving any one of these direct
     # dependencies to Arrow 59 creates an incompatible duplicate type graph;

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,32 @@
+name-template: "OpenWave v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+tag-prefix: "v"
+categories:
+  - type: pre-exclude
+    title: "Maintenance"
+    when:
+      label: "semver:none"
+  - title: "Breaking Changes"
+    semver-increment: minor
+    exclusive: true
+    when:
+      label: "semver:breaking"
+  - title: "Features"
+    semver-increment: minor
+    when:
+      label: "semver:minor"
+  - title: "Fixes and Improvements"
+    semver-increment: patch
+    when:
+      label: "semver:patch"
+  # Historical PRs merged before semantic labels existed receive a patch
+  # fallback in the first draft. The first release version is chosen manually.
+  - type: version-resolver
+    title: "Fallback"
+    semver-increment: patch
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&'
+template: |
+  ## What's Changed
+
+  $CHANGES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,13 +74,6 @@ jobs:
             }
           fi
 
-          squash_title="$(gh api "repos/$GITHUB_REPOSITORY" --jq .squash_merge_commit_title)"
-          test "$squash_title" = PR_TITLE || {
-            echo "Set the repository's default squash commit title to 'Pull request title'." >&2
-            echo "The semantic PR title must become the commit title on main." >&2
-            exit 1
-          }
-
   release-policy:
     name: release policy
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   # secret scan, relevant lightweight checks, and aggregate gate. The expensive
   # Rust lanes run on the merged main tip (and on explicit manual dispatch).
   pull_request:
+    types:
+      [opened, reopened, synchronize, edited, labeled, unlabeled, ready_for_review]
   workflow_dispatch:
 
 # Least privilege by default; fork PRs get read-only.
@@ -20,6 +22,73 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  pr-title:
+    name: semantic PR title
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      - uses: actions/checkout@v7
+        with:
+          # Once this policy has landed, always execute its trusted base-branch
+          # copy. The root checkout is retained only to bootstrap this PR.
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-release-policy
+          fetch-depth: 1
+      - name: Validate Conventional Commit title
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          policy_dir="$GITHUB_WORKSPACE/.trusted-release-policy"
+          bootstrap=false
+          if [[ ! -f "$policy_dir/scripts/check-pr-title.mjs" ]] ||
+            [[ ! -f "$policy_dir/scripts/release-label.mjs" ]]; then
+            policy_dir="$GITHUB_WORKSPACE"
+            bootstrap=true
+            echo "Bootstrapping the release policy from this PR; future PRs use the trusted base copy."
+          fi
+
+          node "$policy_dir/scripts/check-pr-title.mjs" "$PR_TITLE"
+          expected_label="$(node "$policy_dir/scripts/release-label.mjs" --title "$PR_TITLE")"
+          if [[ "$bootstrap" = false ]]; then
+            actual_labels=""
+            for _ in {1..10}; do
+              actual_labels="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+                --jq '[.labels[].name | select(startswith("semver:"))] | sort | join(",")')"
+              [[ "$actual_labels" = "$expected_label" ]] && break
+              sleep 2
+            done
+            test "$actual_labels" = "$expected_label" || {
+              echo "Expected the release-impact label $expected_label; found: ${actual_labels:-none}." >&2
+              echo "The trusted Release draft workflow may still be synchronizing it." >&2
+              exit 1
+            }
+          fi
+
+          squash_title="$(gh api "repos/$GITHUB_REPOSITORY" --jq .squash_merge_commit_title)"
+          test "$squash_title" = PR_TITLE || {
+            echo "Set the repository's default squash commit title to 'Pull request title'." >&2
+            echo "The semantic PR title must become the commit title on main." >&2
+            exit 1
+          }
+
+  release-policy:
+    name: release policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test semantic title and tag policy
+        run: node --test scripts/*.test.mjs
+
   changes:
     name: change scope
     runs-on: ubuntu-latest
@@ -367,7 +436,19 @@ jobs:
   rust:
     name: fmt · clippy · build · test
     if: ${{ always() }}
-    needs: [changes, fmt, lint, build, desktop, test, postgres, ui]
+    needs:
+      [
+        pr-title,
+        release-policy,
+        changes,
+        fmt,
+        lint,
+        build,
+        desktop,
+        test,
+        postgres,
+        ui,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: Require every Rust lane
@@ -379,12 +460,20 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
           POSTGRES_RESULT: ${{ needs.postgres.result }}
           UI_RESULT: ${{ needs.ui.result }}
+          PR_TITLE_RESULT: ${{ needs.pr-title.result }}
+          RELEASE_POLICY_RESULT: ${{ needs.release-policy.result }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           RUST_CHANGED: ${{ needs.changes.outputs.rust }}
           UI_CHANGED: ${{ needs.changes.outputs.ui }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           test "$CHANGES_RESULT" = success
+          test "$RELEASE_POLICY_RESULT" = success
+          case "$EVENT_NAME" in
+            pull_request) test "$PR_TITLE_RESULT" = success ;;
+            *) test "$PR_TITLE_RESULT" = skipped ;;
+          esac
+
           case "$UI_CHANGED" in
             true) test "$UI_RESULT" = success ;;
             false) test "$UI_RESULT" = skipped ;;

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,61 @@
+name: Release draft
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-draft-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
+jobs:
+  label:
+    name: semantic version label
+    if: ${{ github.event_name == 'pull_request_target' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      # pull_request_target is safe here because only trusted base-branch code is
+      # checked out; no code or workflow from the PR head is executed.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+      - name: Synchronize the release-impact label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          desired="$(node scripts/release-label.mjs --title "$PR_TITLE")"
+          current="$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER" \
+            --jq '[.labels[].name | select(startswith("semver:"))] | sort | join(",")')"
+          if [[ "$current" = "$desired" ]]; then
+            exit 0
+          fi
+          while IFS= read -r label; do
+            encoded="$(jq -rn --arg value "$label" '$value | @uri')"
+            gh api --method DELETE \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/$encoded" \
+              >/dev/null 2>&1 || true
+          done < <(node scripts/release-label.mjs --managed | jq -r '.[]')
+          jq -n --arg label "$desired" '{labels: [$label]}' | gh api \
+            --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
+            --input - >/dev/null
+
+  draft:
+    name: update native GitHub release draft
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Build macOS release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ github.event.release.tag_name }}
+      - name: Derive the product version from the release tag
+        id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: node scripts/check-release-tag.mjs "$RELEASE_TAG"
+      - name: Require a commit from main
+        run: |
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA" || {
+            echo "The release event and tag resolve to different commits." >&2
+            exit 1
+          }
+          git fetch origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main || {
+            echo "Release tag ${{ github.event.release.tag_name }} does not point to a commit on main." >&2
+            exit 1
+          }
+
+  build-macos:
+    name: macOS · ${{ matrix.arch }}
+    needs: validate
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            target: aarch64-apple-darwin
+          - arch: x86_64
+            target: x86_64-apple-darwin
+    env:
+      # Rust code that reports or gates on the product version reads this value.
+      # Cargo package versions remain development metadata and are not released.
+      OPENWAVE_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Build the immutable commit carried by the validated release event.
+          ref: ${{ github.sha }}
+
+      - name: Install Rust target
+        run: |
+          rustup show
+          rustup target add "${{ matrix.target }}"
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/openwave-desktop/ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        working-directory: crates/openwave-desktop/ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Install protobuf compiler
+        run: brew install protobuf
+
+      - name: Write tag-derived Tauri configuration
+        env:
+          RELEASE_CONFIG: ${{ runner.temp }}/openwave-release.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
+              version: process.env.OPENWAVE_VERSION,
+              bundle: { targets: ["app"], macOS: { signingIdentity: "-" } }
+            }));
+          '
+
+      # These are deliberately internal, ad-hoc-signed verification artifacts.
+      # A follow-up will notarize/package them and publish the stable manifest
+      # contract under downloads.brightwave.io.
+      - name: Build versioned Tauri app
+        uses: tauri-apps/tauri-action@v1
+        with:
+          projectPath: crates/openwave-desktop
+          args: >-
+            --target ${{ matrix.target }}
+            --config ${{ runner.temp }}/openwave-release.json
+            --bundles app
+          uploadWorkflowArtifacts: true
+          workflowArtifactNamePattern: openwave-macos-${{ matrix.arch }}-[version]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,10 +64,15 @@ For the desktop UI, run `tsc`, the vitest suite, and a production build under
 
 ## Commits and PRs
 
-- Follow the Conventional Commits prefixes documented in
-  [`CONTRIBUTING.md`](CONTRIBUTING.md) (`feat:`, `fix:`, `docs:`, …).
+- Follow the semantic PR-title policy in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+  The title becomes the squash commit and controls the next version; use `!`
+  only for an intentional breaking change. Published `vX.Y.Z` tags, not
+  committed Cargo/Tauri placeholders, are the desktop product's version source.
 - Commit and PR text should read as ordinary engineering writing: describe what
   changed and why, not the tooling that produced it.
 - This is a public repository. Do not reference internal or private design
   documents in code, comments, commits, or PRs.
 - Never commit secrets — see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+Release maintainers should follow [`docs/releases.md`](docs/releases.md),
+especially the compatibility and desktop-schema checklist before `1.0.0`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,21 @@ dev`, or run the React UI in a browser against `openwave serve` via
 
 ## Commit and PR conventions
 
-- Use [Conventional Commits](https://www.conventionalcommits.org/) prefixes:
-  `feat:`, `fix:`, `docs:`, `refactor:`, `chore:`, `build:`, `ci:`, `test:`.
+- Pull request titles must use a
+  [Conventional Commits](https://www.conventionalcommits.org/) header. CI checks
+  the title because squash merge makes it the release commit on `main`:
+  `type(optional-scope)[!]: description`.
+- Allowed types are `feat`, `fix`, `perf`, `deps`, `revert`, `docs`, `refactor`,
+  `chore`, `build`, `ci`, and `test`. Use `!` only with a release-driving type
+  (`feat`, `fix`, `perf`, `deps`, or `revert`) and only for an intentionally
+  breaking product, API, data, or configuration change.
+- `feat` drives a minor release; `fix`, `perf`, shipped `deps`, and `revert`
+  changes drive a patch; maintenance-only types do not release. Before 1.0,
+  breaking changes drive a minor release. See the
+  [release guide](docs/releases.md) for the full policy and the deliberate
+  `1.0.0` procedure.
+- Individual commits on a PR may use the same convention, but only the PR title
+  becomes the squash commit used for release calculation.
 - Write a clear PR description: what changed and why.
 
 ## Contributor License Agreement

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,4 +15,7 @@ coordinate disclosure once a fix is available.
 ## Scope
 
 OpenWave is pre-alpha and under active development. Security fixes land on the
-default branch; there are no supported release branches yet.
+default branch; there are no supported release branches yet. Before `1.0.0`,
+maintainers must replace this statement with explicit supported release lines
+and an end-of-support policy as required by the
+[release readiness checklist](docs/releases.md#preparing-and-shipping-100).

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -13,6 +13,16 @@
 //! model), [`tool`] (the tool contract), and [`provider`] (the model-provider
 //! contract).
 
+/// Version of the OpenWave product containing this crate.
+///
+/// Published desktop builds inject the version selected by their `vX.Y.Z` Git
+/// tag. Ordinary development and independently published crates fall back to
+/// Cargo package metadata.
+pub const VERSION: &str = match option_env!("OPENWAVE_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
 pub mod agent;
 pub mod agent_tools;
 pub mod approval;

--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -73,7 +73,10 @@ build time the bundle still builds (with a loud `cargo:warning`) and PDF parsing
 fails closed with a clear message rather than crashing.
 
 Building an installer per platform and confirming PDF import in the packaged app
-is release-engineering work that must be run on macOS, Windows, and Linux.
+is release-engineering work that must be run on macOS, Windows, and Linux. The
+[release guide](../../docs/releases.md) defines the current tag-derived macOS
+verification build, the signed delivery follow-up, and the additional upgrade
+gate before `1.0.0`.
 
 ## Run locally (browser UI against `openwave serve`)
 

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -16,7 +16,7 @@ use std::sync::{
     Arc,
 };
 
-use openwave_core::{ApprovalClass, ChatId, ToolCtx, ToolRegistry};
+use openwave_core::{ApprovalClass, ChatId, ToolCtx, ToolRegistry, VERSION};
 use serde_json::Value;
 
 use crate::protocol::{
@@ -51,7 +51,7 @@ impl McpServer {
             tools,
             ctx,
             server_name: "openwave".to_string(),
-            server_version: env!("CARGO_PKG_VERSION").to_string(),
+            server_version: VERSION.to_string(),
             session_state: AtomicU8::new(SESSION_UNINITIALIZED),
         }
     }
@@ -372,6 +372,7 @@ mod tests {
         let result = resp.result.unwrap();
         assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
         assert_eq!(result["serverInfo"]["name"], "openwave");
+        assert_eq!(result["serverInfo"]["version"], VERSION);
         assert!(result["capabilities"]["tools"].is_object());
     }
 

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -66,13 +66,16 @@ where
 /// Prepare the SQLite files and return whether a current marker must be
 /// recorded after migrations succeed.
 fn prepare(data_dir: &Path) -> Result<bool> {
-    prepare_for_package_major(data_dir, env!("CARGO_PKG_VERSION_MAJOR"))
+    let product_major = openwave_core::VERSION
+        .split_once('.')
+        .map_or(openwave_core::VERSION, |(major, _)| major);
+    prepare_for_product_major(data_dir, product_major)
 }
 
-fn prepare_for_package_major(data_dir: &Path, package_major: &str) -> Result<bool> {
-    if package_major != "0" {
+fn prepare_for_product_major(data_dir: &Path, product_major: &str) -> Result<bool> {
+    if product_major != "0" {
         return Err(AgentError::config(format!(
-            "pre-v1 local SQLite schema lifecycle is disabled for package major {package_major}"
+            "pre-v1 local SQLite schema lifecycle is disabled for product major {product_major}"
         )));
     }
     let database = data_dir.join(DATABASE_FILE);
@@ -574,9 +577,9 @@ mod tests {
         std::fs::create_dir_all(vector.parent().unwrap()).unwrap();
         std::fs::write(&vector, b"vector").unwrap();
 
-        let error = prepare_for_package_major(dir.path(), "1").unwrap_err();
+        let error = prepare_for_product_major(dir.path(), "1").unwrap_err();
 
-        assert!(error.to_string().contains("disabled for package major 1"));
+        assert!(error.to_string().contains("disabled for product major 1"));
         assert_eq!(std::fs::read(database).unwrap(), b"database");
         assert_eq!(std::fs::read(vector).unwrap(), b"vector");
         for sidecar in sqlite_files(&dir.path().join(DATABASE_FILE))

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ Project documentation, versioned alongside the code.
   foreground/sandbox split, provider boundaries, and web-search plan.
 - [Web search configuration](web-search.md) — the local host-owned Exa/Tavily
   selection boundary and its current no-tool state.
+- [Releases and versioning](releases.md) — semantic PR titles, native release
+  drafts, tag-derived macOS builds, and the deliberate path to `1.0.0`.
 
 More to come as the product surfaces land (running locally, API reference, and
 writing tools).

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,152 @@
+# Releases and versioning
+
+OpenWave uses one Semantic Version for the desktop product. A published native
+GitHub Release and its `vMAJOR.MINOR.PATCH` tag are the source of truth. There is
+no release branch, release pull request, or committed version-bump commit.
+
+The `0.0.0` values in Cargo, Tauri, and the private UI package are development
+metadata. On a release build, the workflow validates the tag, passes its version
+to Tauri through a configuration overlay, and exports `OPENWAVE_VERSION` so Rust
+code reports and gates on the same product version.
+
+## Classify every pull request
+
+Pull request titles use a Conventional Commits header:
+
+```text
+type(optional-scope)[!]: description
+```
+
+CI validates the title, and squash merge makes it the commit title on `main`.
+Scopes are optional and descriptive; common examples are `core`, `server`,
+`desktop`, `retrieval`, `mcp`, `cli`, `deps`, and `release`.
+
+| Title type                                          | Use for                                              | Release effect |
+| --------------------------------------------------- | ---------------------------------------------------- | -------------- |
+| `feat`                                              | New user-visible capability                          | Minor          |
+| `fix`                                               | User-visible defect correction                       | Patch          |
+| `perf`                                              | User-visible performance improvement                 | Patch          |
+| `deps`                                              | Shipped runtime dependency update                    | Patch          |
+| `revert`                                            | Reversal of a previously shipped change              | Patch          |
+| `docs`, `refactor`, `test`, `build`, `ci`, `chore`  | Non-user-facing maintenance                          | None           |
+| `feat`, `fix`, `perf`, `deps`, or `revert` with `!` | Breaking product, API, data, or configuration change | Breaking       |
+
+Examples:
+
+```text
+feat(desktop): add document search
+fix(core): prevent duplicate turn completion
+deps(cargo): update the database stack
+revert: restore the previous storage behavior
+feat(core)!: replace the persisted conversation format
+docs: explain local model configuration
+```
+
+Choose the type based on user impact, not the files changed. A refactor that
+fixes observable behavior is `fix`; a build change that adds a shipped
+capability is `feat`. A breaking refactor is normally `feat!` or `fix!`, based
+on its user impact. CI rejects `!` on maintenance-only types. If the PR body has
+a `BREAKING CHANGE:` footer, its title must also carry `!` so the impact is
+visible during review.
+
+GitHub Actions dependency updates remain `ci(deps)` and do not release the
+product. Cargo Dependabot updates use `deps` because those dependencies ship in
+the desktop app.
+
+## How the native release draft works
+
+The release-draft workflow keeps exactly one draft GitHub Release up to date:
+
+1. A trusted workflow maps the validated PR title to one managed label:
+   `semver:breaking`, `semver:minor`, `semver:patch`, or `semver:none`.
+   Required CI also verifies that exact label before merge.
+2. After the PR is squash-merged to `main`, Release Drafter adds it to the
+   native draft, groups the release notes, and suggests the next tag.
+3. Maintenance-only PRs are omitted. The largest release effect among included
+   PRs chooses the proposed version.
+
+The first release predates these managed labels, so set its tag deliberately
+(normally `v0.1.0`) immediately before publishing. From then on, the last
+published tag and the managed PR labels make the draft version automatic.
+
+## Publishing a release
+
+1. Open **Releases** in GitHub and select the existing draft.
+2. Confirm the target is the intended commit on `main`, the proposed
+   `vMAJOR.MINOR.PATCH` tag is correct, and the notes contain the intended PRs.
+3. Complete the release-readiness review, then click **Publish release**.
+4. GitHub creates the tag and emits the `release.published` event. The macOS
+   release workflow checks out that exact tag, rejects malformed tags or commits
+   outside `main`, and derives the product version from the tag.
+5. The workflow currently builds ad-hoc-signed Apple Silicon and Intel `.app`
+   bundles as internal Actions artifacts. They are build-pipeline
+   verification only and must not be offered as public downloads.
+
+Publishing the native draft is the only release boundary. Merging ordinary PRs
+updates the draft but never builds or ships a desktop version.
+
+## Public macOS delivery follow-up
+
+The next release-engineering stage will extend the tag-triggered macOS job; it
+will not introduce another version source or release branch. Before a desktop
+build is public, the pipeline must:
+
+1. Sign both architecture builds with the production Developer ID identity.
+2. Submit them for Apple notarization, wait for acceptance, staple the result,
+   and verify it with `codesign`, `stapler`, and Gatekeeper.
+3. Produce stable DMG and updater artifact names, checksums, and signatures.
+4. Upload immutable versioned artifacts beneath `https://downloads.brightwave.io/`.
+5. Publish `manifest.json` and updater-compatible `latest.json` only after every
+   required artifact is present, then invalidate the CDN metadata paths.
+6. Exercise download, install, launch, and upgrade smoke tests before considering
+   the release shipped.
+
+The current internal build is intentionally shaped as two architecture-specific
+outputs so signing, packaging, manifest generation, and hosted delivery can be
+added without changing the release trigger or product-version contract.
+
+## Before 1.0
+
+While the latest published version is below `1.0.0`, fixes increment patch,
+features increment minor, and breaking changes also increment minor. The
+`Breaking Changes` category in `.github/release-drafter.yml` encodes that
+pre-1.0 behavior.
+
+For example, `0.3.2` becomes `0.3.3` for a fix and `0.4.0` for either a feature
+or a breaking pre-1.0 change.
+
+## Preparing and shipping 1.0.0
+
+`1.0.0` is a deliberate compatibility commitment. The current desktop schema
+guard rejects every non-zero product major, so a `v1.0.0` app cannot initialize
+its local profile until this checklist is complete:
+
+1. Define the stable compatibility surface: persisted local data,
+   configuration, CLI/API behavior, extension protocols, and supported upgrade
+   window.
+2. Replace the pre-v1-only guard in
+   `crates/openwave-server/src/desktop_schema.rs` with the durable v1 lifecycle.
+   It must preserve supported data, migrate transactionally, fail safely, and
+   test upgrades from the latest 0.x state.
+3. Complete the signed, notarized, hosted macOS pipeline and its install/upgrade
+   smoke tests. Add other supported platforms before claiming support for them.
+4. Update `SECURITY.md` with supported release lines, security-fix policy, and
+   end-of-support expectations. Document backup, migration, and rollback.
+5. In the same readiness work, change the `Breaking Changes` category's
+   `semver-increment` from `minor` to `major`. This activates normal SemVer for
+   all releases after 1.0.
+6. Finish the last 0.x release if needed, review the accumulated native draft,
+   set its tag to exactly `v1.0.0`, and publish it.
+7. Verify the tag, signed artifacts, hosted manifests, clean installation, 0.x
+   upgrade behavior, and every reported application/protocol version.
+
+After `1.0.0`, breaking changes increment major, features increment minor, and
+fixes increment patch. Add supported release branches only if the project later
+commits to maintaining multiple release lines.
+
+## Required repository settings
+
+Keep squash merge as the only merge method and set its defaults to **Pull
+request title** and **Pull request body**. Keep the protected aggregate CI and
+secret-scan checks required on `main`. The release-draft workflow uses the
+built-in `GITHUB_TOKEN`; it does not require a personal access token.

--- a/scripts/check-pr-title.mjs
+++ b/scripts/check-pr-title.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+export const ALLOWED_TYPES = [
+  "feat",
+  "fix",
+  "perf",
+  "deps",
+  "revert",
+  "docs",
+  "refactor",
+  "chore",
+  "build",
+  "ci",
+  "test",
+];
+
+const RELEASING_TYPES = new Set(["feat", "fix", "perf", "deps", "revert"]);
+
+const TITLE_PATTERN = new RegExp(
+  `^(${ALLOWED_TYPES.join("|")})(?:\\(([a-z0-9][a-z0-9._/-]*)\\))?(!)?: (\\S.*)$`,
+);
+
+export function parsePrTitle(title) {
+  if (typeof title !== "string") return null;
+  const match = TITLE_PATTERN.exec(title);
+  if (!match) return null;
+  return {
+    type: match[1],
+    scope: match[2] ?? null,
+    breaking: Boolean(match[3]),
+    description: match[4],
+  };
+}
+
+export function validatePrTitle(title, body = "") {
+  if (typeof title !== "string" || title.length === 0) {
+    return "the pull request title is empty";
+  }
+
+  const parsed = parsePrTitle(title);
+  if (!parsed) {
+    return [
+      `invalid pull request title: ${JSON.stringify(title)}`,
+      "expected: type(optional-scope)[!]: description",
+      `allowed types: ${ALLOWED_TYPES.join(", ")}`,
+      "examples: feat(desktop): add search, fix(core): prevent a race, feat(core)!: replace the storage format",
+    ].join("\n");
+  }
+
+  const { type, breaking } = parsed;
+  if (breaking && !RELEASING_TYPES.has(type)) {
+    return [
+      `invalid breaking pull request title: ${JSON.stringify(title)}`,
+      "the ! marker must use a release-driving type: feat, fix, perf, deps, or revert",
+      "classify a breaking refactor or build change by its user impact, usually feat! or fix!",
+    ].join("\n");
+  }
+
+  const hasBreakingFooter = /^(?:BREAKING CHANGE|BREAKING-CHANGE):\s*\S/im.test(
+    body,
+  );
+  if (hasBreakingFooter && !breaking) {
+    return [
+      "the pull request body contains a breaking-change footer but the title has no ! marker",
+      "put ! before the colon in the semantic title so the release impact is visible during review",
+    ].join("\n");
+  }
+
+  return null;
+}
+
+function main() {
+  const title = process.argv.slice(2).join(" ");
+  const error = validatePrTitle(title, process.env.PR_BODY ?? "");
+  if (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } else {
+    console.log(`valid semantic pull request title: ${title}`);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/check-pr-title.test.mjs
+++ b/scripts/check-pr-title.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parsePrTitle, validatePrTitle } from "./check-pr-title.mjs";
+
+for (const title of [
+  "feat: add document search",
+  "fix(core): prevent duplicate turns",
+  "feat(core)!: replace the storage format",
+  "deps(cargo): update database dependencies",
+  "revert: restore the previous storage behavior",
+  "ci(deps): update the checkout action",
+  "chore(main): release 0.1.0",
+]) {
+  test(`accepts ${title}`, () => {
+    assert.equal(validatePrTitle(title), null);
+  });
+}
+
+test("accepts a matching breaking-change footer", () => {
+  assert.equal(
+    validatePrTitle(
+      "feat(core)!: replace the public API",
+      "Migration details.\n\nBREAKING CHANGE: callers must use the new API.",
+    ),
+    null,
+  );
+});
+
+test("rejects a hidden breaking-change footer", () => {
+  assert.notEqual(
+    validatePrTitle(
+      "feat(core): replace the public API",
+      "BREAKING CHANGE: callers must use the new API.",
+    ),
+    null,
+  );
+});
+
+test("parses the release-relevant parts of a title", () => {
+  assert.deepEqual(parsePrTitle("feat(core)!: replace the API"), {
+    type: "feat",
+    scope: "core",
+    breaking: true,
+    description: "replace the API",
+  });
+});
+
+for (const title of [
+  "Add document search",
+  "feature: add document search",
+  "feat(Core): add document search",
+  "feat: ",
+  "feat(core) add document search",
+  "refactor(core)!: replace the public API",
+  "chore!: reset the persisted format",
+]) {
+  test(`rejects ${title}`, () => {
+    assert.notEqual(validatePrTitle(title), null);
+  });
+}

--- a/scripts/check-release-tag.mjs
+++ b/scripts/check-release-tag.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const RELEASE_TAG = /^v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))$/;
+
+export function parseReleaseTag(tag) {
+  if (typeof tag !== "string") return null;
+  const match = RELEASE_TAG.exec(tag);
+  if (!match || match[1] === "0.0.0") return null;
+  return {
+    version: match[1],
+    major: match[2],
+    minor: match[3],
+    patch: match[4],
+  };
+}
+
+function main() {
+  const tag = process.argv[2];
+  const parsed = parseReleaseTag(tag);
+  if (!parsed) {
+    throw new Error(
+      `invalid release tag ${JSON.stringify(tag)}; expected vMAJOR.MINOR.PATCH (and not v0.0.0)`,
+    );
+  }
+  const output = process.env.GITHUB_OUTPUT;
+  if (output) {
+    appendFileSync(
+      output,
+      `version=${parsed.version}\nmajor=${parsed.major}\nminor=${parsed.minor}\npatch=${parsed.patch}\n`,
+    );
+  }
+  console.log(`release tag ${tag} selects OpenWave ${parsed.version}`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/check-release-tag.test.mjs
+++ b/scripts/check-release-tag.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseReleaseTag } from "./check-release-tag.mjs";
+
+test("parses a strict semantic release tag", () => {
+  assert.deepEqual(parseReleaseTag("v1.24.3"), {
+    version: "1.24.3",
+    major: "1",
+    minor: "24",
+    patch: "3",
+  });
+});
+
+for (const tag of [
+  "1.2.3",
+  "v01.2.3",
+  "v1.2",
+  "v1.2.3-rc.1",
+  "v0.0.0",
+  "release-v1.2.3",
+]) {
+  test(`rejects ${tag}`, () => {
+    assert.equal(parseReleaseTag(tag), null);
+  });
+}

--- a/scripts/release-label.mjs
+++ b/scripts/release-label.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+import { parsePrTitle, validatePrTitle } from "./check-pr-title.mjs";
+
+export const MANAGED_RELEASE_LABELS = [
+  "semver:breaking",
+  "semver:minor",
+  "semver:patch",
+  "semver:none",
+];
+
+const PATCH_TYPES = new Set(["fix", "perf", "deps", "revert"]);
+
+export function releaseLabel(title) {
+  const error = validatePrTitle(title);
+  if (error) throw new Error(error);
+  const parsed = parsePrTitle(title);
+  if (parsed.breaking) return "semver:breaking";
+  if (parsed.type === "feat") return "semver:minor";
+  if (PATCH_TYPES.has(parsed.type)) return "semver:patch";
+  return "semver:none";
+}
+
+function main() {
+  const [mode, ...rest] = process.argv.slice(2);
+  if (mode === "--managed") {
+    console.log(JSON.stringify(MANAGED_RELEASE_LABELS));
+    return;
+  }
+  if (mode !== "--title" || rest.length === 0) {
+    throw new Error("usage: release-label.mjs --title <PR title> | --managed");
+  }
+  console.log(releaseLabel(rest.join(" ")));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/release-label.test.mjs
+++ b/scripts/release-label.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { releaseLabel } from "./release-label.mjs";
+
+for (const [title, label] of [
+  ["feat: add search", "semver:minor"],
+  ["fix(core): prevent a race", "semver:patch"],
+  ["perf: reduce startup time", "semver:patch"],
+  ["deps(cargo): update sqlite", "semver:patch"],
+  ["revert: restore startup behavior", "semver:patch"],
+  ["feat(core)!: replace the API", "semver:breaking"],
+  ["docs: explain search", "semver:none"],
+  ["ci: update checkout", "semver:none"],
+]) {
+  test(`maps ${title} to ${label}`, () => {
+    assert.equal(releaseLabel(title), label);
+  });
+}
+
+test("rejects an invalid title instead of guessing its impact", () => {
+  assert.throws(() => releaseLabel("Add search"), /invalid pull request title/);
+});


### PR DESCRIPTION
## Summary

- enforce semantic PR titles and synchronize trusted semver impact labels
- maintain a native GitHub release draft without release PRs or committed version bumps
- build tag-versioned Intel and Apple Silicon Tauri apps when a GitHub Release is published
- document the macOS signing and downloads.brightwave.io delivery follow-up and the path to 1.0.0

## Validation

- actionlint
- node --test scripts/*.test.mjs
- cargo fmt --all --check
- cargo metadata --locked --no-deps
- cargo test -p openwave-mcp --locked
- cargo test -p openwave-server desktop_schema --locked

Production signing, notarization, packaging, and hosted delivery remain intentionally scoped to a separate PR.