### PR TITLE
ci(release): publish signed macOS builds

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       # pull_request_target is safe here because only trusted base-branch code is
       # checked out; no code or workflow from the PR head is executed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build macOS release
+name: Publish macOS release
 
 on:
   release:
@@ -8,7 +8,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: macos-release-${{ github.event.release.tag_name }}
+  # Serialize public releases so two tags cannot race the mutable latest.json.
+  group: openwave-macos-production-release
   cancel-in-progress: false
 
 jobs:
@@ -25,8 +26,14 @@ jobs:
       - name: Derive the product version from the release tag
         id: version
         env:
+          RELEASE_IS_PRERELEASE: ${{ github.event.release.prerelease }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: node scripts/check-release-tag.mjs "$RELEASE_TAG"
+        run: |
+          [[ "$RELEASE_IS_PRERELEASE" = false ]] || {
+            echo "Production desktop builds cannot be published from a GitHub prerelease." >&2
+            exit 1
+          }
+          node scripts/check-release-tag.mjs "$RELEASE_TAG"
       - name: Require a commit from main
         run: |
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA" || {
@@ -43,6 +50,9 @@ jobs:
     name: macOS · ${{ matrix.arch }}
     needs: validate
     runs-on: macos-latest
+    environment:
+      name: desktop-production
+      url: https://downloads.brightwave.io/openwave/manifest.json
     strategy:
       fail-fast: false
       matrix:
@@ -55,11 +65,49 @@ jobs:
       # Rust code that reports or gates on the product version reads this value.
       # Cargo package versions remain development metadata and are not released.
       OPENWAVE_VERSION: ${{ needs.validate.outputs.version }}
+      APPLE_API_ISSUER: ${{ vars.APPLE_API_ISSUER }}
+      APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
+      APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_SIGNING_IDENTITY }}
     steps:
       - uses: actions/checkout@v7
         with:
           # Build the immutable commit carried by the validated release event.
           ref: ${{ github.sha }}
+
+      - name: Validate production signing configuration
+        env:
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          missing=()
+          for name in \
+            APPLE_API_ISSUER \
+            APPLE_API_KEY_ID \
+            APPLE_API_PRIVATE_KEY \
+            APPLE_CERTIFICATE \
+            APPLE_CERTIFICATE_PASSWORD \
+            APPLE_SIGNING_IDENTITY \
+            TAURI_SIGNING_PRIVATE_KEY \
+            TAURI_SIGNING_PRIVATE_KEY_PASSWORD; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing desktop-production signing configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Prepare App Store Connect key
+        env:
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        run: |
+          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$key_path"
+          chmod 600 "$key_path"
+          echo "APPLE_API_KEY=$APPLE_API_KEY_ID" >> "$GITHUB_ENV"
+          echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
       - name: Install Rust target
         run: |
@@ -89,20 +137,285 @@ jobs:
             const fs = require("node:fs");
             fs.writeFileSync(process.env.RELEASE_CONFIG, JSON.stringify({
               version: process.env.OPENWAVE_VERSION,
-              bundle: { targets: ["app"], macOS: { signingIdentity: "-" } }
+              bundle: {
+                targets: ["app", "dmg"],
+                createUpdaterArtifacts: true,
+                macOS: { signingIdentity: process.env.APPLE_SIGNING_IDENTITY }
+              }
             }));
           '
 
-      # These are deliberately internal, ad-hoc-signed verification artifacts.
-      # A follow-up will notarize/package them and publish the stable manifest
-      # contract under downloads.brightwave.io.
-      - name: Build versioned Tauri app
+      - name: Build, sign, and notarize the Tauri app
+        id: tauri
         uses: tauri-apps/tauri-action@v1
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: crates/openwave-desktop
           args: >-
             --target ${{ matrix.target }}
             --config ${{ runner.temp }}/openwave-release.json
-            --bundles app
-          uploadWorkflowArtifacts: true
-          workflowArtifactNamePattern: openwave-macos-${{ matrix.arch }}-[version]
+            --bundles app,dmg
+
+      - name: Verify and collect signed artifacts
+        env:
+          RELEASE_ARCH: ${{ matrix.arch }}
+          RELEASE_TARGET: ${{ matrix.target }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          target_dir="$(cargo metadata --format-version 1 --no-deps | jq -r .target_directory)"
+          bundle_dir="$target_dir/$RELEASE_TARGET/release/bundle"
+          app_paths=("$bundle_dir"/macos/*.app)
+          dmg_paths=("$bundle_dir"/dmg/*.dmg)
+          (( ${#app_paths[@]} == 1 )) && [[ -d "${app_paths[0]}" ]] || {
+            echo "Expected exactly one macOS app bundle in $bundle_dir/macos" >&2
+            exit 1
+          }
+          (( ${#dmg_paths[@]} == 1 )) && [[ -f "${dmg_paths[0]}" ]] || {
+            echo "Expected exactly one DMG in $bundle_dir/dmg" >&2
+            exit 1
+          }
+          app_path="${app_paths[0]}"
+          dmg_path="${dmg_paths[0]}"
+
+          for file in "$app_path" "$dmg_path"; do
+            [[ -e "$file" ]] || {
+              echo "Required macOS release artifact is missing: ${file:-<empty path>}" >&2
+              exit 1
+            }
+          done
+
+          codesign --verify --deep --strict --verbose=2 "$app_path"
+          xcrun stapler validate "$app_path"
+          spctl --assess --type execute --verbose=4 "$app_path"
+          codesign --verify --verbose=2 "$dmg_path"
+          xcrun stapler validate "$dmg_path"
+          spctl --assess --type open --context context:primary-signature --verbose=4 "$dmg_path"
+
+          executable="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$app_path/Contents/Info.plist")"
+          binary_arches="$(lipo -archs "$app_path/Contents/MacOS/$executable")"
+          case "$RELEASE_ARCH" in
+            aarch64) [[ "$binary_arches" = *arm64* && "$binary_arches" != *x86_64* ]] ;;
+            x86_64) [[ "$binary_arches" = *x86_64* && "$binary_arches" != *arm64* ]] ;;
+            *) echo "Unsupported release architecture: $RELEASE_ARCH" >&2; exit 1 ;;
+          esac || {
+            echo "Expected $RELEASE_ARCH app, found Mach-O architectures: $binary_arches" >&2
+            exit 1
+          }
+
+          # Recreate the updater after notarization so the archive contains the
+          # stapled app, then sign those exact bytes for latest.json.
+          updater_path="${app_path}.tar.gz"
+          signature_path="${updater_path}.sig"
+          rm -f "$updater_path" "$signature_path"
+          tar -czf "$updater_path" -C "$(dirname "$app_path")" "$(basename "$app_path")"
+          cargo tauri signer sign "$updater_path"
+          [[ -s "$signature_path" ]] || {
+            echo "Tauri updater signature is empty: $signature_path" >&2
+            exit 1
+          }
+
+          output_dir="$GITHUB_WORKSPACE/dist/macos/$RELEASE_ARCH"
+          base_name="OpenWave_${OPENWAVE_VERSION}_${RELEASE_ARCH}"
+          mkdir -p "$output_dir"
+          cp "$dmg_path" "$output_dir/${base_name}.dmg"
+          cp "$updater_path" "$output_dir/${base_name}.app.tar.gz"
+          cp "$signature_path" "$output_dir/${base_name}.app.tar.gz.sig"
+          ditto -c -k --keepParent "$app_path" "$output_dir/${base_name}.app.zip"
+          find "$output_dir" -type f -print
+
+      - name: Upload verified macOS artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: openwave-macos-${{ matrix.arch }}-${{ needs.validate.outputs.version }}
+          path: dist/macos/${{ matrix.arch }}/
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Remove App Store Connect key
+        if: ${{ always() }}
+        run: |
+          [[ -z "${APPLE_API_KEY_PATH:-}" ]] || rm -f "$APPLE_API_KEY_PATH"
+
+  publish:
+    name: publish downloads.brightwave.io
+    needs: [validate, build-macos]
+    runs-on: ubuntu-latest
+    environment:
+      name: desktop-production
+      url: https://downloads.brightwave.io/openwave/manifest.json
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      OPENWAVE_VERSION: ${{ needs.validate.outputs.version }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_SHA: ${{ github.sha }}
+      RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
+      RELEASE_BASE_URL: https://downloads.brightwave.io/openwave
+      AWS_REGION: ${{ vars.DOWNLOADS_AWS_REGION || 'us-east-1' }}
+      AWS_RELEASE_ROLE_ARN: ${{ vars.AWS_RELEASE_ROLE_ARN }}
+      DOWNLOADS_CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.DOWNLOADS_CLOUDFRONT_DISTRIBUTION_ID }}
+      DOWNLOADS_S3_BUCKET: ${{ vars.DOWNLOADS_S3_BUCKET }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Validate hosting configuration
+        run: |
+          missing=()
+          for name in \
+            AWS_REGION \
+            AWS_RELEASE_ROLE_ARN \
+            DOWNLOADS_CLOUDFRONT_DISTRIBUTION_ID \
+            DOWNLOADS_S3_BUCKET; do
+            [[ -n "${!name:-}" ]] || missing+=("$name")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing desktop-production hosting configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Download Apple Silicon artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: openwave-macos-aarch64-${{ needs.validate.outputs.version }}
+          path: dist/macos/aarch64
+
+      - name: Download Intel artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: openwave-macos-x86_64-${{ needs.validate.outputs.version }}
+          path: dist/macos/x86_64
+
+      - name: Create release manifests and checksums
+        run: >-
+          node scripts/create-release-manifests.mjs
+          --dist dist
+          --version "$OPENWAVE_VERSION"
+          --tag "$RELEASE_TAG"
+          --sha "$RELEASE_SHA"
+          --published-at "$RELEASE_PUBLISHED_AT"
+          --base-url "$RELEASE_BASE_URL"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ env.AWS_RELEASE_ROLE_ARN }}
+          role-session-name: openwave-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Prevent latest-version regression
+        run: |
+          error_file="$RUNNER_TEMP/latest-head-error"
+          if aws s3api head-object \
+            --bucket "$DOWNLOADS_S3_BUCKET" \
+            --key openwave/latest.json >/dev/null 2>"$error_file"; then
+            aws s3 cp \
+              "s3://$DOWNLOADS_S3_BUCKET/openwave/latest.json" \
+              "$RUNNER_TEMP/current-latest.json" >/dev/null
+            current_version="$(jq -er .version "$RUNNER_TEMP/current-latest.json")"
+            node scripts/check-release-order.mjs "$current_version" "$OPENWAVE_VERSION"
+          else
+            error="$(<"$error_file")"
+            case "$error" in
+              *404*|*Not\ Found*) echo "No current OpenWave release is hosted yet." ;;
+              *) printf '%s\n' "$error" >&2; exit 1 ;;
+            esac
+          fi
+
+      - name: Upload immutable release files
+        run: |
+          release_prefix="openwave/releases/v$OPENWAVE_VERSION"
+          head_error="$RUNNER_TEMP/release-head-error"
+
+          content_type() {
+            case "$1" in
+              *.json) echo application/json ;;
+              *.dmg) echo application/x-apple-diskimage ;;
+              *.zip) echo application/zip ;;
+              *.tar.gz) echo application/gzip ;;
+              *.sig|*.sha256) echo text/plain ;;
+              *) echo application/octet-stream ;;
+            esac
+          }
+
+          upload_immutable() {
+            local file="$1"
+            local key="$2"
+            local digest remote_digest error
+            digest="$(sha256sum "$file" | cut -d ' ' -f 1)"
+            if remote_digest="$(aws s3api head-object \
+              --bucket "$DOWNLOADS_S3_BUCKET" \
+              --key "$key" \
+              --query Metadata.sha256 \
+              --output text 2>"$head_error")"; then
+              [[ "$remote_digest" = "$digest" ]] || {
+                echo "Refusing to overwrite immutable s3://$DOWNLOADS_S3_BUCKET/$key" >&2
+                exit 1
+              }
+              echo "Already uploaded with matching digest: $key"
+              return
+            fi
+            error="$(<"$head_error")"
+            case "$error" in
+              *404*|*Not\ Found*) ;;
+              *) printf '%s\n' "$error" >&2; exit 1 ;;
+            esac
+            aws s3 cp "$file" "s3://$DOWNLOADS_S3_BUCKET/$key" \
+              --content-type "$(content_type "$file")" \
+              --cache-control 'public,max-age=31536000,immutable' \
+              --metadata "sha256=$digest"
+          }
+
+          while IFS= read -r -d '' file; do
+            relative="${file#dist/}"
+            upload_immutable "$file" "$release_prefix/$relative"
+          done < <(find dist -type f ! -name manifest.json ! -name latest.json -print0)
+          upload_immutable dist/manifest.json "$release_prefix/manifest.json"
+
+      - name: Publish latest release metadata
+        run: |
+          aws s3 cp dist/manifest.json \
+            "s3://$DOWNLOADS_S3_BUCKET/openwave/manifest.json" \
+            --content-type application/json \
+            --cache-control 'no-cache, max-age=0'
+          aws s3 cp dist/latest.json \
+            "s3://$DOWNLOADS_S3_BUCKET/openwave/latest.json" \
+            --content-type application/json \
+            --cache-control 'no-cache, max-age=0'
+
+      - name: Invalidate release metadata
+        id: invalidate
+        run: |
+          invalidation_id="$(aws cloudfront create-invalidation \
+            --distribution-id "$DOWNLOADS_CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths '/openwave/manifest.json' '/openwave/latest.json' \
+            --query Invalidation.Id \
+            --output text)"
+          echo "id=$invalidation_id" >> "$GITHUB_OUTPUT"
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "$DOWNLOADS_CLOUDFRONT_DISTRIBUTION_ID" \
+            --id "$invalidation_id"
+
+      - name: Smoke test hosted release
+        run: |
+          cache_bust="release=$OPENWAVE_VERSION-$GITHUB_RUN_ID"
+          curl --fail --silent --show-error \
+            "$RELEASE_BASE_URL/latest.json?$cache_bust" \
+            --output "$RUNNER_TEMP/hosted-latest.json"
+          curl --fail --silent --show-error \
+            "$RELEASE_BASE_URL/manifest.json?$cache_bust" \
+            --output "$RUNNER_TEMP/hosted-manifest.json"
+          cmp dist/latest.json "$RUNNER_TEMP/hosted-latest.json"
+          cmp dist/manifest.json "$RUNNER_TEMP/hosted-manifest.json"
+          jq -r '.artifacts[] | .url, .checksum_url, (.signature_url // empty), (.signature_checksum_url // empty)' \
+            dist/manifest.json | while IFS= read -r url; do
+            [[ -n "$url" ]] || continue
+            curl --fail --silent --show-error --head "$url" >/dev/null
+          done

--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -75,8 +75,8 @@ fails closed with a clear message rather than crashing.
 Building an installer per platform and confirming PDF import in the packaged app
 is release-engineering work that must be run on macOS, Windows, and Linux. The
 [release guide](../../docs/releases.md) defines the current tag-derived macOS
-verification build, the signed delivery follow-up, and the additional upgrade
-gate before `1.0.0`.
+signed/notarized delivery pipeline, its hosted artifact contract, and the
+additional upgrade gate before `1.0.0`.
 
 ## Run locally (browser UI against `openwave serve`)
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -73,37 +73,89 @@ published tag and the managed PR labels make the draft version automatic.
 
 1. Open **Releases** in GitHub and select the existing draft.
 2. Confirm the target is the intended commit on `main`, the proposed
-   `vMAJOR.MINOR.PATCH` tag is correct, and the notes contain the intended PRs.
+   `vMAJOR.MINOR.PATCH` tag is correct, the release is not marked as a
+   prerelease, and the notes contain the intended PRs.
 3. Complete the release-readiness review, then click **Publish release**.
 4. GitHub creates the tag and emits the `release.published` event. The macOS
    release workflow checks out that exact tag, rejects malformed tags or commits
    outside `main`, and derives the product version from the tag.
-5. The workflow currently builds ad-hoc-signed Apple Silicon and Intel `.app`
-   bundles as internal Actions artifacts. They are build-pipeline
-   verification only and must not be offered as public downloads.
+5. The workflow builds Apple Silicon and Intel apps, signs them with the
+   production Developer ID identity, notarizes and staples the app and DMG,
+   verifies them with Apple tooling, and creates signed Tauri updater archives.
+6. Only after both architectures pass does the publisher upload immutable
+   versioned files, advance the public manifests, invalidate their CDN paths,
+   and smoke-test the hosted release.
 
 Publishing the native draft is the only release boundary. Merging ordinary PRs
-updates the draft but never builds or ships a desktop version.
+updates the draft but never builds or ships a desktop version. A published
+GitHub Release is considered shipped only when its **Publish macOS release**
+workflow completes successfully.
 
-## Public macOS delivery follow-up
+## Public macOS delivery
 
-The next release-engineering stage will extend the tag-triggered macOS job; it
-will not introduce another version source or release branch. Before a desktop
-build is public, the pipeline must:
+The public download contract is rooted at:
 
-1. Sign both architecture builds with the production Developer ID identity.
-2. Submit them for Apple notarization, wait for acceptance, staple the result,
-   and verify it with `codesign`, `stapler`, and Gatekeeper.
-3. Produce stable DMG and updater artifact names, checksums, and signatures.
-4. Upload immutable versioned artifacts beneath `https://downloads.brightwave.io/`.
-5. Publish `manifest.json` and updater-compatible `latest.json` only after every
-   required artifact is present, then invalidate the CDN metadata paths.
-6. Exercise download, install, launch, and upgrade smoke tests before considering
-   the release shipped.
+```text
+https://downloads.brightwave.io/openwave/
+```
 
-The current internal build is intentionally shaped as two architecture-specific
-outputs so signing, packaging, manifest generation, and hosted delivery can be
-added without changing the release trigger or product-version contract.
+Each release has an immutable prefix:
+
+```text
+openwave/releases/vMAJOR.MINOR.PATCH/
+├── manifest.json
+└── macos/
+    ├── aarch64/
+    └── x86_64/
+```
+
+Each architecture directory contains a notarized DMG, a zip of the notarized
+app, a signed `.app.tar.gz` updater archive, its signature, and SHA-256 files.
+The root `manifest.json` and Tauri-compatible `latest.json` are the only mutable
+objects. The workflow refuses to overwrite a versioned object with different
+bytes or move `latest.json` to an older version.
+
+The current app does not yet install updates automatically; `latest.json` is the
+stable server-side updater contract for that client integration.
+
+### Production environment configuration
+
+Create a GitHub environment named `desktop-production`. Store these secrets in
+that environment:
+
+| Secret                               | Value                                                       |
+| ------------------------------------ | ----------------------------------------------------------- |
+| `APPLE_CERTIFICATE`                  | Base64-encoded Developer ID Application `.p12`              |
+| `APPLE_CERTIFICATE_PASSWORD`         | Password used when exporting that `.p12`                    |
+| `APPLE_API_PRIVATE_KEY`              | Complete App Store Connect `.p8` private key                |
+| `TAURI_SIGNING_PRIVATE_KEY`          | Private key used to sign Tauri updater archives             |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for the Tauri updater-signing key                  |
+
+Generate a dedicated Tauri updater keypair and retain its public key for the
+future updater client configuration. Only the private key and its password
+belong in GitHub secrets.
+
+Configure these environment variables:
+
+| Variable                                   | Value                                                            |
+| ------------------------------------------ | ---------------------------------------------------------------- |
+| `APPLE_SIGNING_IDENTITY`                   | Developer ID Application signing identity                        |
+| `APPLE_API_KEY_ID`                         | App Store Connect API key ID                                      |
+| `APPLE_API_ISSUER`                         | App Store Connect API issuer UUID                                 |
+| `AWS_RELEASE_ROLE_ARN`                     | GitHub OIDC role allowed to publish OpenWave release files        |
+| `DOWNLOADS_S3_BUCKET`                      | S3 bucket behind `downloads.brightwave.io`                        |
+| `DOWNLOADS_CLOUDFRONT_DISTRIBUTION_ID`     | CloudFront distribution serving the bucket                        |
+| `DOWNLOADS_AWS_REGION`                     | AWS region; defaults to `us-east-1` when omitted                   |
+
+The IAM role must trust GitHub's OIDC provider with the environment subject
+`repo:brightwave-inc/openwave:environment:desktop-production`. Grant only the
+S3 permissions needed beneath `openwave/` and CloudFront invalidation access for
+the configured distribution. No long-lived AWS access key belongs in GitHub.
+
+Before the first public release, protect the environment as appropriate, verify
+all configuration values, and exercise the workflow with the intended first
+tag. The workflow references Apple signing secrets only in the macOS jobs;
+publishing uses short-lived AWS credentials obtained through OIDC.
 
 ## Before 1.0
 
@@ -128,8 +180,9 @@ its local profile until this checklist is complete:
    `crates/openwave-server/src/desktop_schema.rs` with the durable v1 lifecycle.
    It must preserve supported data, migrate transactionally, fail safely, and
    test upgrades from the latest 0.x state.
-3. Complete the signed, notarized, hosted macOS pipeline and its install/upgrade
-   smoke tests. Add other supported platforms before claiming support for them.
+3. Verify the provisioned signed, notarized, hosted macOS pipeline with clean
+   install and 0.x upgrade smoke tests. Add other supported platforms before
+   claiming support for them.
 4. Update `SECURITY.md` with supported release lines, security-fix policy, and
    end-of-support expectations. Document backup, migration, and rollback.
 5. In the same readiness work, change the `Breaking Changes` category's

--- a/scripts/check-release-order.mjs
+++ b/scripts/check-release-order.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+import { parseReleaseTag } from "./check-release-tag.mjs";
+
+function parseVersion(version) {
+  const parsed = parseReleaseTag(`v${version}`);
+  if (!parsed) throw new Error(`invalid release version: ${version}`);
+  return [parsed.major, parsed.minor, parsed.patch].map(BigInt);
+}
+
+export function compareReleaseVersions(left, right) {
+  const leftParts = parseVersion(left);
+  const rightParts = parseVersion(right);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] < rightParts[index]) return -1;
+    if (leftParts[index] > rightParts[index]) return 1;
+  }
+  return 0;
+}
+
+export function assertReleaseDoesNotRegress(current, candidate) {
+  if (compareReleaseVersions(candidate, current) < 0) {
+    throw new Error(
+      `refusing to replace current release ${current} with older release ${candidate}`,
+    );
+  }
+}
+
+function main() {
+  const [current, candidate] = process.argv.slice(2);
+  if (!current || !candidate) {
+    throw new Error("usage: check-release-order.mjs <current> <candidate>");
+  }
+  assertReleaseDoesNotRegress(current, candidate);
+  console.log(`release ${candidate} may follow ${current}`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/check-release-order.test.mjs
+++ b/scripts/check-release-order.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertReleaseDoesNotRegress,
+  compareReleaseVersions,
+} from "./check-release-order.mjs";
+
+test("compares semantic release versions numerically", () => {
+  assert.equal(compareReleaseVersions("0.9.9", "0.10.0"), -1);
+  assert.equal(compareReleaseVersions("2.0.0", "1.99.99"), 1);
+  assert.equal(compareReleaseVersions("1.2.3", "1.2.3"), 0);
+});
+
+test("permits a new or idempotently repeated release", () => {
+  assert.doesNotThrow(() => assertReleaseDoesNotRegress("0.4.1", "0.4.2"));
+  assert.doesNotThrow(() => assertReleaseDoesNotRegress("0.4.2", "0.4.2"));
+});
+
+test("rejects moving the public latest pointer backwards", () => {
+  assert.throws(
+    () => assertReleaseDoesNotRegress("1.2.0", "1.1.9"),
+    /older release/,
+  );
+});

--- a/scripts/create-release-manifests.mjs
+++ b/scripts/create-release-manifests.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { parseReleaseTag } from "./check-release-tag.mjs";
+
+export const MACOS_ARCHITECTURES = ["aarch64", "x86_64"];
+
+const ARTIFACT_FORMATS = [
+  { extension: ".dmg", format: "dmg" },
+  { extension: ".app.zip", format: "app.zip" },
+  { extension: ".app.tar.gz", format: "app.tar.gz", updater: true },
+];
+
+function requiredOption(options, name) {
+  const value = options.get(name);
+  if (!value) throw new Error(`missing required option --${name}`);
+  return value;
+}
+
+function parseOptions(args) {
+  const options = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag?.startsWith("--") || value === undefined) {
+      throw new Error(
+        "usage: create-release-manifests.mjs --dist <path> --version <semver> --tag <tag> --sha <commit> --published-at <date> --base-url <url>",
+      );
+    }
+    options.set(flag.slice(2), value);
+  }
+  return options;
+}
+
+function sha256(file) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex");
+}
+
+function publicUrl(baseUrl, version, filename) {
+  const encodedPath = filename.split("/").map(encodeURIComponent).join("/");
+  return `${baseUrl}/releases/v${version}/${encodedPath}`;
+}
+
+function requireFile(file) {
+  if (!existsSync(file) || !statSync(file).isFile()) {
+    throw new Error(`required release artifact is missing: ${file}`);
+  }
+}
+
+export function createReleaseManifests({
+  dist,
+  version,
+  tag,
+  sha,
+  publishedAt,
+  baseUrl,
+}) {
+  const parsedTag = parseReleaseTag(tag);
+  if (!parsedTag || parsedTag.version !== version) {
+    throw new Error(`release tag ${tag} does not select version ${version}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error("release commit must be a full lowercase SHA-1");
+  }
+  if (Number.isNaN(Date.parse(publishedAt))) {
+    throw new Error(`invalid release publication date: ${publishedAt}`);
+  }
+
+  const parsedBaseUrl = new URL(baseUrl);
+  if (
+    parsedBaseUrl.protocol !== "https:" ||
+    parsedBaseUrl.hostname !== "downloads.brightwave.io"
+  ) {
+    throw new Error("release base URL must use https://downloads.brightwave.io");
+  }
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+  const distPath = path.resolve(dist);
+  const artifacts = [];
+  const updaterArtifacts = new Map();
+
+  for (const arch of MACOS_ARCHITECTURES) {
+    const directory = path.join(distPath, "macos", arch);
+    const baseName = `OpenWave_${version}_${arch}`;
+
+    for (const descriptor of ARTIFACT_FORMATS) {
+      const filename = `${baseName}${descriptor.extension}`;
+      const file = path.join(directory, filename);
+      requireFile(file);
+
+      const digest = sha256(file);
+      writeFileSync(`${file}.sha256`, `${digest}  ${filename}\n`);
+      const relativeFilename = path.posix.join("macos", arch, filename);
+      const checksumFilename = `${relativeFilename}.sha256`;
+      const artifact = {
+        platform: "macos",
+        arch,
+        format: descriptor.format,
+        filename: relativeFilename,
+        url: publicUrl(normalizedBaseUrl, version, relativeFilename),
+        size: statSync(file).size,
+        sha256: digest,
+        checksum_filename: checksumFilename,
+        checksum_url: publicUrl(normalizedBaseUrl, version, checksumFilename),
+      };
+
+      if (descriptor.updater) {
+        const signatureFile = `${file}.sig`;
+        requireFile(signatureFile);
+        const signature = readFileSync(signatureFile, "utf8").trim();
+        if (!signature) {
+          throw new Error(`empty updater signature: ${signatureFile}`);
+        }
+        const signatureDigest = sha256(signatureFile);
+        writeFileSync(
+          `${signatureFile}.sha256`,
+          `${signatureDigest}  ${path.basename(signatureFile)}\n`,
+        );
+        artifact.signature = signature;
+        artifact.signature_filename = `${relativeFilename}.sig`;
+        artifact.signature_url = publicUrl(
+          normalizedBaseUrl,
+          version,
+          artifact.signature_filename,
+        );
+        artifact.signature_sha256 = signatureDigest;
+        artifact.signature_checksum_url = publicUrl(
+          normalizedBaseUrl,
+          version,
+          `${artifact.signature_filename}.sha256`,
+        );
+        updaterArtifacts.set(arch, artifact);
+      }
+
+      artifacts.push(artifact);
+    }
+  }
+
+  const manifest = {
+    schema_version: 1,
+    version,
+    tag,
+    sha,
+    published_at: publishedAt,
+    artifacts,
+  };
+  const latest = {
+    version,
+    pub_date: publishedAt,
+    platforms: Object.fromEntries(
+      MACOS_ARCHITECTURES.map((arch) => {
+        const artifact = updaterArtifacts.get(arch);
+        return [
+          `darwin-${arch}`,
+          { signature: artifact.signature, url: artifact.url },
+        ];
+      }),
+    ),
+  };
+
+  writeFileSync(
+    path.join(distPath, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  writeFileSync(
+    path.join(distPath, "latest.json"),
+    `${JSON.stringify(latest, null, 2)}\n`,
+  );
+  return { manifest, latest };
+}
+
+function main() {
+  const options = parseOptions(process.argv.slice(2));
+  const result = createReleaseManifests({
+    dist: requiredOption(options, "dist"),
+    version: requiredOption(options, "version"),
+    tag: requiredOption(options, "tag"),
+    sha: requiredOption(options, "sha"),
+    publishedAt: requiredOption(options, "published-at"),
+    baseUrl: requiredOption(options, "base-url"),
+  });
+  console.log(JSON.stringify(result.manifest, null, 2));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/create-release-manifests.test.mjs
+++ b/scripts/create-release-manifests.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createReleaseManifests,
+  MACOS_ARCHITECTURES,
+} from "./create-release-manifests.mjs";
+
+function releaseFixture() {
+  const dist = mkdtempSync(path.join(tmpdir(), "openwave-release-"));
+  for (const arch of MACOS_ARCHITECTURES) {
+    const directory = path.join(dist, "macos", arch);
+    mkdirSync(directory, { recursive: true });
+    const baseName = `OpenWave_0.4.2_${arch}`;
+    writeFileSync(path.join(directory, `${baseName}.dmg`), `dmg-${arch}`);
+    writeFileSync(path.join(directory, `${baseName}.app.zip`), `zip-${arch}`);
+    writeFileSync(
+      path.join(directory, `${baseName}.app.tar.gz`),
+      `updater-${arch}`,
+    );
+    writeFileSync(
+      path.join(directory, `${baseName}.app.tar.gz.sig`),
+      `signature-${arch}\n`,
+    );
+  }
+  return dist;
+}
+
+const RELEASE = {
+  version: "0.4.2",
+  tag: "v0.4.2",
+  sha: "0123456789abcdef0123456789abcdef01234567",
+  publishedAt: "2026-07-22T16:00:00Z",
+  baseUrl: "https://downloads.brightwave.io/openwave",
+};
+
+test("creates a complete manifest and Tauri updater document", () => {
+  const dist = releaseFixture();
+  const { manifest, latest } = createReleaseManifests({ dist, ...RELEASE });
+
+  assert.equal(manifest.artifacts.length, 6);
+  assert.deepEqual(Object.keys(latest.platforms), [
+    "darwin-aarch64",
+    "darwin-x86_64",
+  ]);
+  assert.match(
+    latest.platforms["darwin-aarch64"].url,
+    /releases\/v0\.4\.2\/macos\/aarch64\/OpenWave_0\.4\.2_aarch64\.app\.tar\.gz$/,
+  );
+  assert.equal(
+    latest.platforms["darwin-x86_64"].signature,
+    "signature-x86_64",
+  );
+
+  const diskManifest = JSON.parse(
+    readFileSync(path.join(dist, "manifest.json"), "utf8"),
+  );
+  assert.deepEqual(diskManifest, manifest);
+  for (const artifact of manifest.artifacts) {
+    assert.equal(artifact.sha256.length, 64);
+    assert.match(artifact.url, /^https:\/\/downloads\.brightwave\.io\/openwave\//);
+    assert.match(
+      readFileSync(path.join(dist, artifact.filename) + ".sha256", "utf8"),
+      new RegExp(`^${artifact.sha256}  `),
+    );
+  }
+});
+
+test("fails closed when an architecture is incomplete", () => {
+  const dist = releaseFixture();
+  const missing = path.join(
+    dist,
+    "macos",
+    "x86_64",
+    "OpenWave_0.4.2_x86_64.app.tar.gz.sig",
+  );
+  writeFileSync(missing, "");
+
+  assert.throws(
+    () => createReleaseManifests({ dist, ...RELEASE }),
+    /empty updater signature/,
+  );
+});
+
+test("rejects mismatched tags and non-production hosts", () => {
+  const dist = releaseFixture();
+  assert.throws(
+    () => createReleaseManifests({ dist, ...RELEASE, tag: "v0.4.3" }),
+    /does not select version/,
+  );
+  assert.throws(
+    () =>
+      createReleaseManifests({
+        dist,
+        ...RELEASE,
+        baseUrl: "https://example.com/openwave",
+      }),
+    /downloads\.brightwave\.io/,
+  );
+});


### PR DESCRIPTION
## Summary

- sign, notarize, staple, and verify Apple Silicon and Intel macOS builds when a native GitHub Release is published
- publish immutable versioned artifacts plus guarded manifest.json and Tauri-compatible latest.json metadata to downloads.brightwave.io through AWS OIDC
- document the desktop-production environment, first-release provisioning, hosted artifact contract, and 1.0 readiness flow

## Validation

- node --test scripts/*.test.mjs (39 tests)
- actionlint v1.7.7 .github/workflows/release.yml
- cargo fmt --all --check
- cargo metadata --locked --no-deps
- git diff --check

## Provisioning prerequisite

The repository currently has no desktop-production environment values. Before publishing the first GitHub Release, provision the documented Apple signing/notarization secrets, Tauri updater key, AWS variables, and GitHub OIDC trust. The workflow fails closed when any required value is absent.

Merging this PR does not trigger a desktop release; only publishing a native GitHub Release does.