### PR TITLE
ci(release): group generated release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,29 +3,60 @@ tag-template: "v$RESOLVED_VERSION"
 tag-prefix: "v"
 categories:
   - type: pre-exclude
-    title: "Maintenance"
     when:
       label: "semver:none"
   - title: "Breaking Changes"
-    semver-increment: minor
     exclusive: true
     when:
       label: "semver:breaking"
-  - title: "Features"
+  - title: "New Features"
+    exclusive: true
+    when:
+      label: "release-note:feature"
+  - title: "Bug Fixes"
+    exclusive: true
+    when:
+      label: "release-note:fix"
+  - title: "Performance Improvements"
+    exclusive: true
+    when:
+      label: "release-note:performance"
+  - title: "Dependency Updates"
+    exclusive: true
+    when:
+      label: "release-note:dependencies"
+  - title: "Reverted Changes"
+    exclusive: true
+    when:
+      label: "release-note:revert"
+  # Historical PRs merged before managed labels existed remain visible here in
+  # the first draft. Current maintenance PRs are removed by the pre-exclude.
+  - title: "Other Changes"
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      label: "semver:breaking"
+  - type: version-resolver
     semver-increment: minor
     when:
       label: "semver:minor"
-  - title: "Fixes and Improvements"
+  - type: version-resolver
     semver-increment: patch
     when:
       label: "semver:patch"
   # Historical PRs merged before semantic labels existed receive a patch
   # fallback in the first draft. The first release version is chosen manually.
   - type: version-resolver
-    title: "Fallback"
     semver-increment: patch
-change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+category-template: "### $TITLE"
+change-template: "- $TITLE ([#$NUMBER]($URL)) by @$AUTHOR"
 change-title-escapes: '\<*_&'
+no-changes-template: "- No user-facing changes."
+replacers:
+  # Category headings already communicate the change type, so remove the
+  # Conventional Commit prefix from each rendered PR title.
+  - search: '/- (?:feat|fix|perf|deps|revert)(?:\([^)]+\))?!?: /g'
+    replace: "- "
 template: |
   ## What's Changed
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+# GitHub's native "Generate release notes" button uses this configuration.
+# Keep these categories aligned with release-drafter.yml.
+changelog:
+  exclude:
+    labels:
+      - "semver:none"
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - "semver:breaking"
+    - title: "New Features"
+      labels:
+        - "release-note:feature"
+    - title: "Bug Fixes"
+      labels:
+        - "release-note:fix"
+    - title: "Performance Improvements"
+      labels:
+        - "release-note:performance"
+    - title: "Dependency Updates"
+      labels:
+        - "release-note:dependencies"
+    - title: "Reverted Changes"
+      labels:
+        - "release-note:revert"
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,14 @@ jobs:
           fi
 
           node "$policy_dir/scripts/check-pr-title.mjs" "$PR_TITLE"
-          expected_labels="$(node "$policy_dir/scripts/release-label.mjs" --labels "$PR_TITLE" | jq -r 'sort | join(",")')"
+          # The transition PR runs this workflow from its head while loading the
+          # older trusted classifier from main. Fall back once to its single
+          # label interface; after merge, the trusted copy supports --labels.
+          if expected_labels_json="$(node "$policy_dir/scripts/release-label.mjs" --labels "$PR_TITLE" 2>/dev/null)"; then
+            expected_labels="$(jq -r 'sort | join(",")' <<<"$expected_labels_json")"
+          else
+            expected_labels="$(node "$policy_dir/scripts/release-label.mjs" --title "$PR_TITLE")"
+          fi
           if [[ "$bootstrap" = false ]]; then
             actual_labels=""
             for _ in {1..10}; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,17 +58,17 @@ jobs:
           fi
 
           node "$policy_dir/scripts/check-pr-title.mjs" "$PR_TITLE"
-          expected_label="$(node "$policy_dir/scripts/release-label.mjs" --title "$PR_TITLE")"
+          expected_labels="$(node "$policy_dir/scripts/release-label.mjs" --labels "$PR_TITLE" | jq -r 'sort | join(",")')"
           if [[ "$bootstrap" = false ]]; then
             actual_labels=""
             for _ in {1..10}; do
               actual_labels="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
-                --jq '[.labels[].name | select(startswith("semver:"))] | sort | join(",")')"
-              [[ "$actual_labels" = "$expected_label" ]] && break
+                --jq '[.labels[].name | select(startswith("semver:") or startswith("release-note:"))] | sort | join(",")')"
+              [[ "$actual_labels" = "$expected_labels" ]] && break
               sleep 2
             done
-            test "$actual_labels" = "$expected_label" || {
-              echo "Expected the release-impact label $expected_label; found: ${actual_labels:-none}." >&2
+            test "$actual_labels" = "$expected_labels" || {
+              echo "Expected managed release labels $expected_labels; found: ${actual_labels:-none}." >&2
               echo "The trusted Release draft workflow may still be synchronizing it." >&2
               exit 1
             }

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -34,9 +34,10 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          desired="$(node scripts/release-label.mjs --title "$PR_TITLE")"
+          desired_labels="$(node scripts/release-label.mjs --labels "$PR_TITLE")"
+          desired="$(jq -r 'sort | join(",")' <<<"$desired_labels")"
           current="$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER" \
-            --jq '[.labels[].name | select(startswith("semver:"))] | sort | join(",")')"
+            --jq '[.labels[].name | select(startswith("semver:") or startswith("release-note:"))] | sort | join(",")')"
           if [[ "$current" = "$desired" ]]; then
             exit 0
           fi
@@ -46,7 +47,7 @@ jobs:
               "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/$encoded" \
               >/dev/null 2>&1 || true
           done < <(node scripts/release-label.mjs --managed | jq -r '.[]')
-          jq -n --arg label "$desired" '{labels: [$label]}' | gh api \
+          jq -n --argjson labels "$desired_labels" '{labels: $labels}' | gh api \
             --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels" \
             --input - >/dev/null
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -53,21 +53,45 @@ GitHub Actions dependency updates remain `ci(deps)` and do not release the
 product. Cargo Dependabot updates use `deps` because those dependencies ship in
 the desktop app.
 
+User-facing PRs also receive a managed release-note label derived from the same
+validated title. These labels make the native release notes easier to scan
+without asking authors to classify a PR twice:
+
+| Title type | Release-notes section       |
+| ---------- | --------------------------- |
+| `feat`     | New Features                |
+| `fix`      | Bug Fixes                   |
+| `perf`     | Performance Improvements    |
+| `deps`     | Dependency Updates          |
+| `revert`   | Reverted Changes            |
+| Any `!`    | Breaking Changes            |
+
+Documentation and other maintenance-only types remain excluded. In the rendered
+notes, the section heading supplies the type, so Release Drafter removes the
+redundant Conventional Commit prefix from each PR title.
+
 ## How the native release draft works
 
 The release-draft workflow keeps exactly one draft GitHub Release up to date:
 
-1. A trusted workflow maps the validated PR title to one managed label:
-   `semver:breaking`, `semver:minor`, `semver:patch`, or `semver:none`.
-   Required CI also verifies that exact label before merge.
+1. A trusted workflow maps the validated PR title to exactly one managed
+   `semver:*` label and, for a non-breaking user-facing change, one managed
+   `release-note:*` category label. Required CI verifies that exact label set
+   before merge.
 2. After the PR is squash-merged to `main`, Release Drafter adds it to the
-   native draft, groups the release notes, and suggests the next tag.
+   native draft, groups the release notes into the sections above, and suggests
+   the next tag. Breaking changes are always shown first.
 3. Maintenance-only PRs are omitted. The largest release effect among included
-   PRs chooses the proposed version.
+   PRs chooses the proposed version; the category labels do not independently
+   change the version.
 
-The first release predates these managed labels, so set its tag deliberately
-(normally `v0.1.0`) immediately before publishing. From then on, the last
-published tag and the managed PR labels make the draft version automatic.
+The first release has no previous published release to use as a comparison
+baseline, so Release Drafter intentionally leaves that draft as a manual
+starting point. For `v0.1.0`, set the tag deliberately and click **Generate
+release notes** in GitHub; `.github/release.yml` applies the same sections to
+GitHub's native output. Curate that one-time full-history result before
+publishing. From then on, the last published tag and the managed PR labels make
+the maintained draft and its proposed version automatic.
 
 ## Publishing a release
 
@@ -75,6 +99,8 @@ published tag and the managed PR labels make the draft version automatic.
 2. Confirm the target is the intended commit on `main`, the proposed
    `vMAJOR.MINOR.PATCH` tag is correct, the release is not marked as a
    prerelease, and the notes contain the intended PRs.
+   For the first release only, set `v0.1.0`, click **Generate release notes**,
+   and curate the full-history result as described above.
 3. Complete the release-readiness review, then click **Publish release**.
 4. GitHub creates the tag and emits the `release.published` event. The macOS
    release workflow checks out that exact tag, rejects malformed tags or commits
@@ -161,8 +187,8 @@ publishing uses short-lived AWS credentials obtained through OIDC.
 
 While the latest published version is below `1.0.0`, fixes increment patch,
 features increment minor, and breaking changes also increment minor. The
-`Breaking Changes` category in `.github/release-drafter.yml` encodes that
-pre-1.0 behavior.
+`semver:breaking` version-resolver entry in `.github/release-drafter.yml`
+encodes that pre-1.0 behavior.
 
 For example, `0.3.2` becomes `0.3.3` for a fix and `0.4.0` for either a feature
 or a breaking pre-1.0 change.
@@ -185,7 +211,7 @@ its local profile until this checklist is complete:
    claiming support for them.
 4. Update `SECURITY.md` with supported release lines, security-fix policy, and
    end-of-support expectations. Document backup, migration, and rollback.
-5. In the same readiness work, change the `Breaking Changes` category's
+5. In the same readiness work, change the `semver:breaking` version resolver's
    `semver-increment` from `minor` to `major`. This activates normal SemVer for
    all releases after 1.0.
 6. Finish the last 0.x release if needed, review the accumulated native draft,

--- a/scripts/release-label.mjs
+++ b/scripts/release-label.mjs
@@ -9,9 +9,21 @@ export const MANAGED_RELEASE_LABELS = [
   "semver:minor",
   "semver:patch",
   "semver:none",
+  "release-note:feature",
+  "release-note:fix",
+  "release-note:performance",
+  "release-note:dependencies",
+  "release-note:revert",
 ];
 
 const PATCH_TYPES = new Set(["fix", "perf", "deps", "revert"]);
+const RELEASE_NOTE_LABELS = new Map([
+  ["feat", "release-note:feature"],
+  ["fix", "release-note:fix"],
+  ["perf", "release-note:performance"],
+  ["deps", "release-note:dependencies"],
+  ["revert", "release-note:revert"],
+]);
 
 export function releaseLabel(title) {
   const error = validatePrTitle(title);
@@ -23,16 +35,35 @@ export function releaseLabel(title) {
   return "semver:none";
 }
 
+export function releaseNoteLabel(title) {
+  const error = validatePrTitle(title);
+  if (error) throw new Error(error);
+  const parsed = parsePrTitle(title);
+  if (parsed.breaking) return null;
+  return RELEASE_NOTE_LABELS.get(parsed.type) ?? null;
+}
+
+export function releaseLabels(title) {
+  return [releaseLabel(title), releaseNoteLabel(title)].filter(Boolean);
+}
+
 function main() {
   const [mode, ...rest] = process.argv.slice(2);
   if (mode === "--managed") {
     console.log(JSON.stringify(MANAGED_RELEASE_LABELS));
     return;
   }
-  if (mode !== "--title" || rest.length === 0) {
-    throw new Error("usage: release-label.mjs --title <PR title> | --managed");
+  if (!["--title", "--labels"].includes(mode) || rest.length === 0) {
+    throw new Error(
+      "usage: release-label.mjs --title <PR title> | --labels <PR title> | --managed",
+    );
   }
-  console.log(releaseLabel(rest.join(" ")));
+  const title = rest.join(" ");
+  console.log(
+    mode === "--labels"
+      ? JSON.stringify(releaseLabels(title))
+      : releaseLabel(title),
+  );
 }
 
 if (

--- a/scripts/release-label.test.mjs
+++ b/scripts/release-label.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { releaseLabel } from "./release-label.mjs";
+import {
+  MANAGED_RELEASE_LABELS,
+  releaseLabel,
+  releaseLabels,
+  releaseNoteLabel,
+} from "./release-label.mjs";
 
 for (const [title, label] of [
   ["feat: add search", "semver:minor"],
@@ -20,4 +25,36 @@ for (const [title, label] of [
 
 test("rejects an invalid title instead of guessing its impact", () => {
   assert.throws(() => releaseLabel("Add search"), /invalid pull request title/);
+});
+
+for (const [title, label] of [
+  ["feat: add search", "release-note:feature"],
+  ["fix(core): prevent a race", "release-note:fix"],
+  ["perf: reduce startup time", "release-note:performance"],
+  ["deps(cargo): update sqlite", "release-note:dependencies"],
+  ["revert: restore startup behavior", "release-note:revert"],
+  ["feat(core)!: replace the API", null],
+  ["docs: explain search", null],
+]) {
+  test(`maps ${title} to release-note label ${label}`, () => {
+    assert.equal(releaseNoteLabel(title), label);
+  });
+}
+
+test("returns the exact managed labels expected on a pull request", () => {
+  assert.deepEqual(releaseLabels("feat: add search"), [
+    "semver:minor",
+    "release-note:feature",
+  ]);
+  assert.deepEqual(releaseLabels("fix(core)!: replace the API"), [
+    "semver:breaking",
+  ]);
+  assert.deepEqual(releaseLabels("ci: update checkout"), ["semver:none"]);
+});
+
+test("managed release labels are unique", () => {
+  assert.equal(
+    new Set(MANAGED_RELEASE_LABELS).size,
+    MANAGED_RELEASE_LABELS.length,
+  );
 });


### PR DESCRIPTION
## Summary

- derive trusted release-note category labels from validated Conventional Commit PR titles
- separate generated notes into Breaking Changes, New Features, Bug Fixes, Performance Improvements, Dependency Updates, Reverted Changes, and Other Changes
- keep semantic version resolution independent and continue excluding maintenance-only PRs
- configure GitHub native Generate release notes with the same categories for the first release, which has no published comparison baseline
- document the one-time v0.1.0 curation step and the automatic post-baseline flow

## Validation

- node --test scripts/*.test.mjs (48 tests)
- actionlint v1.7.7 on changed workflows, excluding five pre-existing rust-cache input warnings from main
- Release Drafter configuration validated against the official JSON schema
- native release-note YAML parse check
- git diff --check

The five release-note:* repository labels have also been provisioned. This PR is maintenance-only and does not trigger a desktop release.