### PR TITLE
ci(release): backfill title-derived release labels

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -5,6 +5,13 @@ on:
     types: [opened, reopened, synchronize, edited, labeled, unlabeled, ready_for_review]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: Apply the title-derived labels instead of only reporting the plan
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -60,3 +67,64 @@ jobs:
       pull-requests: read
     steps:
       - uses: release-drafter/release-drafter@v7
+
+  backfill:
+    name: backfill release labels
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Plan title-derived labels for merged pull requests
+        run: |
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state merged \
+            --base main \
+            --limit 1000 \
+            --json number,title,labels \
+            > "$RUNNER_TEMP/merged-prs.json"
+          node scripts/create-release-label-plan.mjs \
+            < "$RUNNER_TEMP/merged-prs.json" \
+            > "$RUNNER_TEMP/release-label-plan.json"
+
+          total="$(jq -r .summary.total "$RUNNER_TEMP/release-label-plan.json")"
+          (( total < 1000 )) || {
+            echo "The merged-PR query reached its 1000-item safety limit." >&2
+            exit 1
+          }
+          jq .summary "$RUNNER_TEMP/release-label-plan.json"
+          {
+            echo '## Release-label backfill'
+            echo
+            echo '| Result | Count |'
+            echo '| --- | ---: |'
+            jq -r '.summary | to_entries[] | "| \(.key) | \(.value) |"' \
+              "$RUNNER_TEMP/release-label-plan.json"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Apply managed label changes
+        if: ${{ inputs.apply }}
+        run: |
+          while IFS= read -r update; do
+            number="$(jq -r .number <<<"$update")"
+            additions="$(jq -c .add_labels <<<"$update")"
+            if (( $(jq length <<<"$additions") > 0 )); then
+              jq -n --argjson labels "$additions" '{labels: $labels}' | gh api \
+                --method POST \
+                "repos/$GITHUB_REPOSITORY/issues/$number/labels" \
+                --input - >/dev/null
+            fi
+            while IFS= read -r label; do
+              encoded="$(jq -rn --arg value "$label" '$value | @uri')"
+              gh api --method DELETE \
+                "repos/$GITHUB_REPOSITORY/issues/$number/labels/$encoded" \
+                >/dev/null
+            done < <(jq -r '.remove_labels[]' <<<"$update")
+            echo "Updated #$number"
+          done < <(jq -c '.updates[]' "$RUNNER_TEMP/release-label-plan.json")

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -70,6 +70,14 @@ Documentation and other maintenance-only types remain excluded. In the rendered
 notes, the section heading supplies the type, so Release Drafter removes the
 redundant Conventional Commit prefix from each PR title.
 
+For historical or imported pull requests, the **Release draft** workflow has a
+manual `workflow_dispatch` backfill. Its default dry run reports the exact
+changes; rerun it with `apply` enabled to synchronize only the managed
+`semver:*` and `release-note:*` labels from titles that pass the current policy.
+It deliberately leaves free-form historical titles in **Other Changes** rather
+than guessing their impact. The job uses the repository `GITHUB_TOKEN`, so its
+label writes do not fan out into hundreds of labeled-event workflow runs.
+
 ## How the native release draft works
 
 The release-draft workflow keeps exactly one draft GitHub Release up to date:

--- a/scripts/create-release-label-plan.mjs
+++ b/scripts/create-release-label-plan.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+import {
+  MANAGED_RELEASE_LABELS,
+  releaseLabels,
+} from "./release-label.mjs";
+
+const managedLabels = new Set(MANAGED_RELEASE_LABELS);
+
+function currentManagedLabels(labels) {
+  return labels
+    .map((label) => (typeof label === "string" ? label : label?.name))
+    .filter((label) => managedLabels.has(label))
+    .sort();
+}
+
+export function createReleaseLabelPlan(pullRequests) {
+  if (!Array.isArray(pullRequests)) {
+    throw new Error("merged pull requests must be a JSON array");
+  }
+
+  const updates = [];
+  const skipped = [];
+  let unchanged = 0;
+
+  for (const pullRequest of pullRequests) {
+    const { number, title, labels } = pullRequest;
+    if (!Number.isInteger(number) || number <= 0) {
+      throw new Error(`invalid pull request number: ${number}`);
+    }
+    if (typeof title !== "string" || !Array.isArray(labels)) {
+      throw new Error(`invalid pull request payload for #${number}`);
+    }
+
+    let desiredLabels;
+    try {
+      desiredLabels = releaseLabels(title).sort();
+    } catch (error) {
+      skipped.push({ number, title, reason: error.message });
+      continue;
+    }
+
+    const existingLabels = currentManagedLabels(labels);
+    const addLabels = desiredLabels.filter(
+      (label) => !existingLabels.includes(label),
+    );
+    const removeLabels = existingLabels.filter(
+      (label) => !desiredLabels.includes(label),
+    );
+    if (addLabels.length === 0 && removeLabels.length === 0) {
+      unchanged += 1;
+      continue;
+    }
+    updates.push({
+      number,
+      title,
+      desired_labels: desiredLabels,
+      add_labels: addLabels,
+      remove_labels: removeLabels,
+    });
+  }
+
+  return {
+    summary: {
+      total: pullRequests.length,
+      classified: pullRequests.length - skipped.length,
+      updates: updates.length,
+      unchanged,
+      skipped: skipped.length,
+    },
+    updates,
+    skipped,
+  };
+}
+
+async function main() {
+  let input = "";
+  for await (const chunk of process.stdin) input += chunk;
+  const plan = createReleaseLabelPlan(JSON.parse(input));
+  console.log(JSON.stringify(plan, null, 2));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/scripts/create-release-label-plan.test.mjs
+++ b/scripts/create-release-label-plan.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createReleaseLabelPlan } from "./create-release-label-plan.mjs";
+
+test("plans exact title-derived labels without touching unrelated labels", () => {
+  const plan = createReleaseLabelPlan([
+    {
+      number: 12,
+      title: "feat(core): add search",
+      labels: [{ name: "area:core" }, { name: "semver:patch" }],
+    },
+  ]);
+
+  assert.deepEqual(plan.summary, {
+    total: 1,
+    classified: 1,
+    updates: 1,
+    unchanged: 0,
+    skipped: 0,
+  });
+  assert.deepEqual(plan.updates[0], {
+    number: 12,
+    title: "feat(core): add search",
+    desired_labels: ["release-note:feature", "semver:minor"],
+    add_labels: ["release-note:feature", "semver:minor"],
+    remove_labels: ["semver:patch"],
+  });
+});
+
+test("leaves already-correct labels unchanged", () => {
+  const plan = createReleaseLabelPlan([
+    {
+      number: 13,
+      title: "fix: prevent a race",
+      labels: ["release-note:fix", "semver:patch", "area:core"],
+    },
+  ]);
+
+  assert.equal(plan.summary.unchanged, 1);
+  assert.deepEqual(plan.updates, []);
+});
+
+test("skips ambiguous historical titles instead of guessing", () => {
+  const plan = createReleaseLabelPlan([
+    { number: 14, title: "Add search", labels: [] },
+  ]);
+
+  assert.equal(plan.summary.skipped, 1);
+  assert.deepEqual(plan.updates, []);
+  assert.match(plan.skipped[0].reason, /invalid pull request title/);
+});
+
+test("rejects malformed pull request input", () => {
+  assert.throws(
+    () => createReleaseLabelPlan([{ number: 0, title: "feat: add search", labels: [] }]),
+    /invalid pull request number/,
+  );
+});


### PR DESCRIPTION
## Summary

- add a trusted manual Release draft workflow mode that classifies merged PRs from their titles
- provide dry-run and explicit apply modes, changing only managed semver:* and release-note:* labels
- skip ambiguous free-form historical titles instead of guessing their release impact
- add a tested, reusable label-plan generator and document the backfill operation

## Live dry run

- 317 merged PRs scanned
- 178 valid Conventional Commit titles classified
- 174 label updates planned
- 4 already correct
- 139 free-form historical titles left for Other Changes

The planned classifications include 114 features, 17 fixes, and 47 maintenance PRs that will be excluded from generated notes.

## Validation

- node --test scripts/*.test.mjs (52 tests)
- actionlint v1.7.7 .github/workflows/release-draft.yml
- live read-only backfill plan
- git diff --check

After merge, I will first dispatch the dry run from main, then dispatch apply and verify GitHub native generated notes. Label writes use GITHUB_TOKEN so they do not fan out into labeled-event workflow runs.