### PR TITLE
fix(release): configure and cache signed macOS builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,11 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Once this policy has landed, always execute its trusted base-branch
           # copy. The root checkout is retained only to bootstrap this PR.
@@ -85,7 +85,7 @@ jobs:
     name: release policy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Test semantic title and tag policy
         run: node --test scripts/*.test.mjs
 
@@ -96,7 +96,7 @@ jobs:
       rust: ${{ steps.scope.outputs.rust }}
       ui: ${{ steps.scope.outputs.ui }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       - name: Detect validation scope
@@ -160,14 +160,15 @@ jobs:
     name: secret scan (gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
       # Run gitleaks via its Docker image to avoid the org-license requirement
-      # of gitleaks-action. TODO: pin to a specific digest once the repo settles.
+      # of gitleaks-action. Keep the multi-architecture image pinned by digest.
       - name: gitleaks
         run: |
-          docker run --rm -v "$PWD:/repo" ghcr.io/gitleaks/gitleaks:latest \
+          docker run --rm -v "$PWD:/repo" \
+            ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f \
             detect --source=/repo --redact --verbose
 
   fmt:
@@ -176,7 +177,7 @@ jobs:
     if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install toolchain (honors rust-toolchain.toml)
         run: rustup show
       - name: rustfmt
@@ -197,11 +198,11 @@ jobs:
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: -C link-arg=-fuse-ld=mold
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install toolchain (honors rust-toolchain.toml)
         run: rustup show
       - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         with:
           version: v0.16.0
       - name: Install system deps (Tauri; protobuf for the LanceDB vector store)
@@ -215,7 +216,7 @@ jobs:
             mold \
             patchelf \
             protobuf-compiler
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: cargo-registry-v2
           add-job-id-key: "false"
@@ -245,11 +246,11 @@ jobs:
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: -C link-arg=-fuse-ld=mold
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install toolchain (honors rust-toolchain.toml)
         run: rustup show
       - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         with:
           version: v0.16.0
       - name: Install system deps (Tauri; protobuf for the LanceDB vector store)
@@ -263,7 +264,7 @@ jobs:
             mold \
             patchelf \
             protobuf-compiler
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: cargo-registry-v2
           add-job-id-key: "false"
@@ -291,11 +292,11 @@ jobs:
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: -C link-arg=-fuse-ld=mold
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install toolchain (honors rust-toolchain.toml)
         run: rustup show
       - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         with:
           version: v0.16.0
       - name: Install system deps (Tauri; protobuf for the LanceDB vector store)
@@ -309,7 +310,7 @@ jobs:
             mold \
             patchelf \
             protobuf-compiler
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: cargo-registry-v2
           add-job-id-key: "false"
@@ -334,11 +335,11 @@ jobs:
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: -C link-arg=-fuse-ld=mold
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install toolchain (honors rust-toolchain.toml)
         run: rustup show
       - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         with:
           version: v0.16.0
       - name: Install headless system deps (protobuf for the LanceDB vector store)
@@ -348,7 +349,7 @@ jobs:
             libprotobuf-dev \
             mold \
             protobuf-compiler
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: cargo-registry-v2
           add-job-id-key: "false"
@@ -366,7 +367,7 @@ jobs:
     timeout-minutes: 10
     services:
       postgres:
-        image: postgres:17-alpine
+        image: postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
         env:
           POSTGRES_DB: openwave_test
           POSTGRES_PASSWORD: postgres
@@ -388,14 +389,14 @@ jobs:
       SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install toolchain (honors rust-toolchain.toml)
         run: rustup show
       - name: Set up compiler cache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         with:
           version: v0.16.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: cargo-registry-v2
           add-job-id-key: "false"
@@ -417,11 +418,11 @@ jobs:
       run:
         working-directory: crates/openwave-desktop/ui
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 10
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # pull_request_target is safe here because only trusted base-branch code is
       # checked out; no code or workflow from the PR head is executed.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
       - name: Synchronize the release-impact label
@@ -66,7 +66,7 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7
 
   backfill:
     name: backfill release labels
@@ -79,7 +79,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Plan title-derived labels for merged pull requests
         run: |
           gh pr list \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           ref: refs/tags/${{ github.event.release.tag_name }}
@@ -62,6 +62,12 @@ jobs:
           - arch: x86_64
             target: x86_64-apple-darwin
     env:
+      # Reuse compiler outputs across trusted release runs without caching the
+      # signed bundles or any signing material.
+      CARGO_INCREMENTAL: 0
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_WRITE
       # Rust code that reports or gates on the product version reads this value.
       # Cargo package versions remain development metadata and are not released.
       OPENWAVE_VERSION: ${{ needs.validate.outputs.version }}
@@ -69,7 +75,7 @@ jobs:
       APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
       APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_SIGNING_IDENTITY }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Build the immutable commit carried by the validated release event.
           ref: ${{ github.sha }}
@@ -114,10 +120,28 @@ jobs:
           rustup show
           rustup target add "${{ matrix.target }}"
 
-      - uses: pnpm/action-setup@v6
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: v0.16.0
+
+      - name: Cache Cargo downloads
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: macos-release-cargo-registry-v1
+          add-job-id-key: "false"
+          cache-bin: false
+          # Signed apps, DMGs, updater archives, and signatures remain outside
+          # the cache. sccache handles individual compiler outputs instead.
+          cache-targets: false
+          # The matrix shares these architecture-independent downloads. Use a
+          # single writer so simultaneous cold builds cannot race the save.
+          save-if: ${{ matrix.arch == 'aarch64' }}
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 10
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
           cache: pnpm
@@ -139,7 +163,6 @@ jobs:
               version: process.env.OPENWAVE_VERSION,
               bundle: {
                 targets: ["app", "dmg"],
-                createUpdaterArtifacts: true,
                 macOS: { signingIdentity: process.env.APPLE_SIGNING_IDENTITY }
               }
             }));
@@ -147,12 +170,10 @@ jobs:
 
       - name: Build, sign, and notarize the Tauri app
         id: tauri
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: crates/openwave-desktop
           args: >-
@@ -229,7 +250,7 @@ jobs:
           find "$output_dir" -type f -print
 
       - name: Upload verified macOS artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: openwave-macos-${{ matrix.arch }}-${{ needs.validate.outputs.version }}
           path: dist/macos/${{ matrix.arch }}/
@@ -262,7 +283,7 @@ jobs:
       DOWNLOADS_CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.DOWNLOADS_CLOUDFRONT_DISTRIBUTION_ID }}
       DOWNLOADS_S3_BUCKET: ${{ vars.DOWNLOADS_S3_BUCKET }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.sha }}
 
@@ -282,13 +303,13 @@ jobs:
           fi
 
       - name: Download Apple Silicon artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: openwave-macos-aarch64-${{ needs.validate.outputs.version }}
           path: dist/macos/aarch64
 
       - name: Download Intel artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: openwave-macos-x86_64-${{ needs.validate.outputs.version }}
           path: dist/macos/x86_64
@@ -304,7 +325,7 @@ jobs:
           --base-url "$RELEASE_BASE_URL"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6
         with:
           role-to-assume: ${{ env.AWS_RELEASE_ROLE_ARN }}
           role-session-name: openwave-${{ github.run_id }}

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -30,6 +30,14 @@
       "csp": "default-src 'self' customprotocol: asset:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; img-src 'self' asset: data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
     }
   },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEUyRjM1NjZGOTQxRUFBNwpSV1NuNmtINVpqVXZEaXY4cVFWZ0RrbThUbHlEZFB1RnVtT01MSGcwRElhcjdtUUpJckJzM2ZjTAo=",
+      "endpoints": [
+        "https://downloads.brightwave.io/openwave/latest.json"
+      ]
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -165,9 +165,9 @@ that environment:
 | `TAURI_SIGNING_PRIVATE_KEY`          | Private key used to sign Tauri updater archives             |
 | `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Password for the Tauri updater-signing key                  |
 
-Generate a dedicated Tauri updater keypair and retain its public key for the
-future updater client configuration. Only the private key and its password
-belong in GitHub secrets.
+Retain the Tauri updater keypair. Its public key is intentionally committed in
+`crates/openwave-desktop/tauri.conf.json` so packaged apps can verify update
+signatures. Only the private key and its password belong in GitHub secrets.
 
 Configure these environment variables:
 
@@ -190,6 +190,34 @@ Before the first public release, protect the environment as appropriate, verify
 all configuration values, and exercise the workflow with the intended first
 tag. The workflow references Apple signing secrets only in the macOS jobs;
 publishing uses short-lived AWS credentials obtained through OIDC.
+
+### Release CI and cache security
+
+Treat the release workflow as public even while the repository is private:
+
+- Release actions are pinned to immutable commit SHAs. Dependabot is responsible
+  for proposing reviewed action updates.
+- The workflow runs only for a published native GitHub Release, then verifies
+  that the tag resolves to the release event commit and that the commit is on
+  `main`. It never runs with production secrets for a pull request.
+- Apple and Tauri credentials remain environment secrets. The Tauri private key
+  is exposed only to the post-notarization updater-signing step, not the build
+  action. AWS authentication uses GitHub OIDC, so no long-lived AWS key is
+  stored in GitHub or the source tree. Infrastructure identifiers remain
+  environment variables rather than committed configuration.
+- `sccache` stores individual Rust compiler outputs. The Cargo cache stores
+  dependency downloads with `cache-targets: false`; it does not archive
+  `target/`, signed apps, DMGs, updater archives, signatures, or temporary Apple
+  key files.
+- Production artifacts are collected only after code-signing, notarization,
+  stapling, and local verification succeed. The temporary App Store Connect key
+  is removed even when the build fails.
+
+Public source does not eliminate the need for operational controls. Restrict
+who can publish releases and change Actions configuration, protect `main`, and
+consider required reviewers on `desktop-production` before making the
+repository public. Never add a pull-request trigger to the production workflow
+or expose its environment secrets to code from forks.
 
 ## Before 1.0
 

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflowDirectory = new URL("../.github/workflows/", import.meta.url);
+const workflows = Object.fromEntries(
+  readdirSync(workflowDirectory)
+    .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+    .map((name) => [name, readFileSync(new URL(name, workflowDirectory), "utf8")]),
+);
+const tauriConfig = JSON.parse(
+  readFileSync(
+    new URL("../crates/openwave-desktop/tauri.conf.json", import.meta.url),
+    "utf8",
+  ),
+);
+
+test("third-party workflow actions use immutable commit SHAs", () => {
+  for (const [name, source] of Object.entries(workflows)) {
+    for (const match of source.matchAll(/^\s*(?:-\s*)?uses:\s*([^\s#]+)/gm)) {
+      const reference = match[1];
+      if (reference.startsWith("./")) {
+        continue;
+      }
+      assert.match(
+        reference,
+        /^[^@\s]+@[0-9a-f]{40}$/,
+        `${name} has a mutable action reference: ${reference}`,
+      );
+    }
+  }
+});
+
+test("workflow container images are pinned by digest", () => {
+  for (const [name, source] of Object.entries(workflows)) {
+    for (const match of source.matchAll(/^\s*image:\s*([^\s#]+)/gm)) {
+      assert.match(
+        match[1],
+        /^[^@\s]+@sha256:[0-9a-f]{64}$/,
+        `${name} has a mutable container image: ${match[1]}`,
+      );
+    }
+  }
+
+  assert.match(
+    workflows["ci.yml"],
+    /ghcr\.io\/gitleaks\/gitleaks@sha256:[0-9a-f]{64}/,
+  );
+  assert.doesNotMatch(workflows["ci.yml"], /gitleaks\/gitleaks:latest/);
+});
+
+test("production secrets remain isolated to the release workflow", () => {
+  const secretConsumers = Object.entries(workflows)
+    .filter(([, source]) => source.includes("secrets."))
+    .map(([name]) => name);
+  assert.deepEqual(secretConsumers, ["release.yml"]);
+
+  const release = workflows["release.yml"];
+  assert.match(release, /^on:\n  release:\n    types: \[published\]/m);
+  assert.doesNotMatch(release, /^\s*pull_request(?:_target)?:/m);
+  assert.match(release, /^permissions:\n  contents: read$/m);
+});
+
+test("release caches exclude signed artifacts and target directories", () => {
+  const release = workflows["release.yml"];
+  assert.match(release, /SCCACHE_GHA_ENABLED: "true"/);
+  assert.match(release, /cache-targets: false/);
+  assert.doesNotMatch(release, /actions\/cache/);
+});
+
+test("the updater private key is isolated from compilation", () => {
+  const release = workflows["release.yml"];
+  const buildStep = release.match(
+    /- name: Build, sign, and notarize the Tauri app[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  assert.ok(buildStep);
+  assert.doesNotMatch(buildStep, /TAURI_SIGNING_PRIVATE_KEY/);
+  assert.doesNotMatch(release, /createUpdaterArtifacts/);
+});
+
+test("the packaged updater trusts the production signing key and endpoint", () => {
+  const updater = tauriConfig.plugins?.updater;
+  assert.ok(updater, "plugins.updater must exist when updater artifacts are built");
+  assert.match(
+    Buffer.from(updater.pubkey, "base64").toString("utf8"),
+    /minisign public key/,
+  );
+  assert.deepEqual(updater.endpoints, [
+    "https://downloads.brightwave.io/openwave/latest.json",
+  ]);
+});


### PR DESCRIPTION
## Summary

- configure the packaged Tauri updater trust key and production endpoint, while signing updater bytes only after notarization
- add release-only sccache compiler reuse and a registry-only Cargo cache that excludes target directories and signed artifacts
- harden the public-repository CI surface with immutable action/image pins, documentation, and regression tests

## v0.1.0 diagnosis

Both macOS targets completed their cold Rust builds, then failed before bundling because updater artifacts were enabled without updater configuration. Nothing reached the publish job or S3. This patch removes the redundant pre-notarization updater generation and supplies the updater trust configuration for future clients.

## Validation

- node --test scripts/*.test.mjs (58 passing)
- actionlint
- jq validation of tauri.conf.json
- gitleaks full-history and changed-file scans (zero findings)
- Tauri config inspection