### PR TITLE
feat(approval): prompt-once consent for escaping exec actions

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -4534,6 +4534,154 @@ mod tests {
         assert_eq!(ran.load(Ordering::SeqCst), 0, "RefuseGate blocks the tool");
     }
 
+    /// A Sensitive tool that escapes the chat workspace (`exec`) and records
+    /// whether it ran.
+    struct ExecTool {
+        ran: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for ExecTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: "exec".into(),
+                description: "an escaping command execution tool".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::Sensitive
+        }
+        async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+            self.ran.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolOutput::text("executed"))
+        }
+    }
+
+    /// Provider that asks for the `exec` tool once, then finishes.
+    struct ExecProvider {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ModelProvider for ExecProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("exec")
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let events = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "call_exec".into(),
+                        name: "exec".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: "{}".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta { text: "ok".into() },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    fn exec_agent(
+        store: Arc<dyn Store>,
+        ran: Arc<AtomicUsize>,
+        grants: Arc<StandingGrants>,
+    ) -> Agent {
+        let tools = Arc::new(ToolRegistry::new().with(Box::new(ExecTool { ran })));
+        // Default gate is `RefuseGate`: it rejects any call that reaches it, so
+        // the tool running proves the standing grant bypassed the gate entirely.
+        Agent::new(
+            Arc::new(ExecProvider {
+                calls: AtomicUsize::new(0),
+            }),
+            tools,
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        )
+        .with_standing_grants(grants)
+    }
+
+    #[tokio::test]
+    async fn standing_grant_runs_escaping_exec_without_parking() {
+        use crate::approval::{StandingGrant, StandingGrants};
+
+        let store = search_grant_store().await;
+        let chat = search_grant_chat(&store).await;
+        let grants = Arc::new(StandingGrants::from_grants(vec![StandingGrant::new(
+            chat.id,
+            "exec",
+            ToolApprovalKind::for_tool_name("exec"),
+            Utc::now(),
+        )
+        .expect("exec is grantable")]));
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let agent = exec_agent(store, ran.clone(), grants);
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ApprovalRequired { .. })),
+            "a covered escaping call must not re-prompt"
+        );
+        assert_eq!(ran.load(Ordering::SeqCst), 1);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            AgentEvent::ToolCallCompleted { output, .. }
+                if output.content == "executed" && !output.is_error
+        )));
+    }
+
+    #[tokio::test]
+    async fn ungranted_escaping_exec_still_parks_deny_by_default() {
+        use crate::approval::StandingGrants;
+
+        let store = search_grant_store().await;
+        let chat = search_grant_chat(&store).await;
+        // No grant covers this chat: an escaping action must still park.
+        let grants = Arc::new(StandingGrants::new());
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let agent = exec_agent(store, ran.clone(), grants);
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                AgentEvent::ApprovalRequired { kind, .. }
+                    if *kind == ToolApprovalKind::ExecMayRunNetworkedCommand
+            )),
+            "an uncovered escaping call must park on the gate with a presentable kind"
+        );
+        assert_eq!(ran.load(Ordering::SeqCst), 0, "RefuseGate blocks the tool");
+    }
+
     /// Counts every execution so a test can prove a fenced tool never ran.
     struct SpyTool {
         ran: Arc<AtomicUsize>,

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -62,10 +62,21 @@ pub enum ToolApprovalStatus {
 }
 
 /// Closed immutable consent semantics stored with each approval request.
+///
+/// Each presentable variant names the egress a human is consenting to, so the
+/// renderer can describe the action without ever seeing the model-authored
+/// summary or arguments. `Unsupported` is the fail-closed default: a Sensitive
+/// action the server can only reject, never approve.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolApprovalKind {
+    /// A library search may share the query and matched excerpts with the
+    /// provider.
     SearchMayShareQueryAndExcerpts,
+    /// A command execution escapes the chat workspace and may reach the network.
+    ExecMayRunNetworkedCommand,
+    /// A Sensitive action with no presentable consent semantics: rejectable but
+    /// not approvable from the renderer.
     Unsupported,
 }
 
@@ -74,6 +85,7 @@ impl ToolApprovalKind {
     pub fn for_tool_name(name: &str) -> Self {
         match name {
             "search" => Self::SearchMayShareQueryAndExcerpts,
+            "exec" => Self::ExecMayRunNetworkedCommand,
             _ => Self::Unsupported,
         }
     }
@@ -82,13 +94,17 @@ impl ToolApprovalKind {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::SearchMayShareQueryAndExcerpts => "search_may_share_query_and_excerpts",
+            Self::ExecMayRunNetworkedCommand => "exec_may_run_networked_command",
             Self::Unsupported => "unsupported",
         }
     }
 
     #[must_use]
     pub const fn is_approvable(self) -> bool {
-        matches!(self, Self::SearchMayShareQueryAndExcerpts)
+        matches!(
+            self,
+            Self::SearchMayShareQueryAndExcerpts | Self::ExecMayRunNetworkedCommand
+        )
     }
 }
 
@@ -432,6 +448,27 @@ mod standing_grant_tests {
             Utc::now(),
         )
         .expect("approvable tool is grantable")
+    }
+
+    #[test]
+    fn escaping_exec_is_a_presentable_approvable_kind() {
+        let kind = ToolApprovalKind::for_tool_name("exec");
+        assert_eq!(kind, ToolApprovalKind::ExecMayRunNetworkedCommand);
+        assert!(kind.is_approvable());
+        // The string round-trips through durable storage without collapsing to
+        // `Unsupported`, so an approved escaping action stays approvable on
+        // recovery.
+        assert_eq!(kind.as_str(), "exec_may_run_networked_command");
+    }
+
+    #[test]
+    fn escaping_exec_is_standing_grantable() {
+        let chat = ChatId::new();
+        let grants = StandingGrants::from_grants(vec![grant(chat, "exec")]);
+        let kind = ToolApprovalKind::for_tool_name("exec");
+        assert!(grants.covers(chat, "exec", kind));
+        // Deny-by-default still holds for a different chat.
+        assert!(!grants.covers(ChatId::new(), "exec", kind));
     }
 
     #[test]

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -3604,6 +3604,7 @@ impl MigrationTrait for AddToolCalls {
                                     .eq(crate::ApprovalClass::Sensitive.as_str()))
                                 .and(Expr::col(ToolCall::ApprovalKind).is_in([
                                     crate::ToolApprovalKind::SearchMayShareQueryAndExcerpts.as_str(),
+                                    crate::ToolApprovalKind::ExecMayRunNetworkedCommand.as_str(),
                                     crate::ToolApprovalKind::Unsupported.as_str(),
                                 ]))
                                 .and(Expr::col(ToolCall::ApprovalRequestedAt).is_not_null())

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -459,6 +459,7 @@ fn approval_from_model(model: &entities::tool_call::Model) -> Result<ToolApprova
         Some("search_may_share_query_and_excerpts") => {
             ToolApprovalKind::SearchMayShareQueryAndExcerpts
         }
+        Some("exec_may_run_networked_command") => ToolApprovalKind::ExecMayRunNetworkedCommand,
         Some("unsupported") => ToolApprovalKind::Unsupported,
         _ => {
             return Err(AgentError::Store(

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -107,6 +107,13 @@ describe("ToolCallCard", () => {
         "Allow search to send your query and potentially matching document excerpts to configured AI services outside OpenWave?",
       canApprove: true,
     });
+    expect(
+      toolApprovalPresentation("exec_may_run_networked_command"),
+    ).toEqual({
+      summary:
+        "Allow OpenWave to run a command that leaves the chat workspace and may reach the network?",
+      canApprove: true,
+    });
     expect(toolApprovalPresentation("unsupported")).toEqual({
       summary: "The exact action cannot be safely described.",
       canApprove: false,

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -114,6 +114,12 @@ const TOOL_PRESENTATIONS: Record<string, ToolPresentation> = {
     complete: "Background agents finished",
     settled: "Background agents finished",
   },
+  exec: {
+    label: "Run a command",
+    active: "Running a command",
+    complete: "Command complete",
+    settled: "Ran a command",
+  },
 };
 
 const FALLBACK_TOOL: ToolPresentation = {
@@ -174,6 +180,13 @@ export function toolApprovalPresentation(
     return {
       summary:
         "Allow search to send your query and potentially matching document excerpts to configured AI services outside OpenWave?",
+      canApprove: true,
+    };
+  }
+  if (kind === "exec_may_run_networked_command") {
+    return {
+      summary:
+        "Allow OpenWave to run a command that leaves the chat workspace and may reach the network?",
       canApprove: true,
     };
   }

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -122,6 +122,31 @@ describe("pending approval recovery", () => {
     expect(parsePendingToolApproval({ ...safe, action: "private_plugin" })).toBeNull();
   });
 
+  it("recovers an approvable escaping exec action", () => {
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "exec",
+        approval: "exec_may_run_networked_command",
+        can_approve: true,
+      }),
+    ).toMatchObject({
+      action: "exec",
+      approval: "exec_may_run_networked_command",
+      canApprove: true,
+    });
+    // The approvable invariant still binds: a presentable escaping kind that
+    // claims it cannot be approved is rejected.
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "exec",
+        approval: "exec_may_run_networked_command",
+        can_approve: false,
+      }),
+    ).toBeNull();
+  });
+
   it("recognizes the fixed background wait name without accepting extensions", () => {
     expect(
       parsePendingToolApproval({

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -211,11 +211,21 @@ export type RendererToolName =
   | "read_connected_file"
   | "spawn_sandbox_agent"
   | "wait_for_agents"
+  | "exec"
   | "other";
 
 export type RendererApprovalKind =
   | "search_may_share_query_and_excerpts"
+  | "exec_may_run_networked_command"
   | "unsupported";
+
+/** Approval kinds a human may approve from the renderer. */
+export function isApprovableKind(kind: RendererApprovalKind): boolean {
+  return (
+    kind === "search_may_share_query_and_excerpts" ||
+    kind === "exec_may_run_networked_command"
+  );
+}
 
 /** A strict renderer-safe snapshot used to recover a parked approval. */
 export type PendingToolApproval = {
@@ -668,7 +678,7 @@ export function parsePendingToolApproval(
       value.class !== "workspace" &&
       value.class !== "sensitive") ||
     typeof value.can_approve !== "boolean" ||
-    value.can_approve !== (value.approval === "search_may_share_query_and_excerpts")
+    value.can_approve !== isApprovableKind(value.approval)
   ) {
     return null;
   }
@@ -697,13 +707,16 @@ function isRendererToolName(value: unknown): value is RendererToolName {
     value === "read_connected_file" ||
     value === "spawn_sandbox_agent" ||
     value === "wait_for_agents" ||
+    value === "exec" ||
     value === "other"
   );
 }
 
 function isRendererApprovalKind(value: unknown): value is RendererApprovalKind {
   return (
-    value === "search_may_share_query_and_excerpts" || value === "unsupported"
+    value === "search_may_share_query_and_excerpts" ||
+    value === "exec_may_run_networked_command" ||
+    value === "unsupported"
   );
 }
 

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -389,6 +389,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn escaping_exec_can_be_approved_and_remembered() {
+        // Deny-by-default previously blocked every non-`search` Sensitive action
+        // from being approved (409 `NotApprovable`). An escaping `exec` is now a
+        // presentable, grantable action.
+        let (store, request) = setup("exec").await;
+        let broker = ApprovalBroker::new(store);
+        let _pending = broker.register(request.clone(), None).await;
+
+        assert_eq!(
+            broker
+                .resolve_with_remember(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    true,
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+        assert!(broker
+            .standing_grants()
+            .covers(request.chat_id, &request.tool_name, request.kind));
+    }
+
+    #[tokio::test]
     async fn unknown_action_cannot_be_approved_but_can_be_rejected() {
         let (store, request) = setup("third_party_sensitive").await;
         let broker = ApprovalBroker::new(store);

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever a pre-v1 baseline migration changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 1;
+const DESKTOP_SCHEMA_EPOCH: u32 = 2;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -83,6 +83,7 @@ pub(crate) enum RendererToolName {
     ReadConnectedFile,
     SpawnSandboxAgent,
     WaitForAgents,
+    Exec,
     Other,
 }
 
@@ -109,6 +110,7 @@ impl From<&str> for RendererToolName {
             "read_connected_file" => Self::ReadConnectedFile,
             "spawn_sandbox_agent" => Self::SpawnSandboxAgent,
             "wait_for_agents" => Self::WaitForAgents,
+            "exec" => Self::Exec,
             _ => Self::Other,
         }
     }


### PR DESCRIPTION
## Summary

The other half of the capability model. Standing grants (#310) and approval calibration (#323) shipped, and #343 routes mutating MCP `tools/call` through the same gate. But a Sensitive action that **escapes the chat workspace** could only hard-park: `ToolApprovalKind::for_tool_name` mapped every name except `search` to `Unsupported`, which the approval endpoint can only reject (409), never approve. Escaping actions were therefore stuck on the gate forever.

This adds **prompt-once, scoped consent** for one clear escaping category — networked command execution (`exec`) — leaning on the existing `StandingGrants` machinery, consistent with OpenWave's "favor usability over strictness" principle.

## What changed

- New presentable, approvable `ToolApprovalKind::ExecMayRunNetworkedCommand`, mapped from the `exec` tool name. `is_approvable()` now covers it, so approving with `remember: true` records a `StandingGrant` and a later matching call in the same chat runs **without re-prompting**.
- The kind round-trips through durable storage: the DB parse path and the tool-call `approval_kind` CHECK constraint both accept it. Bumped the pre-v1 desktop schema epoch since a baseline migration constraint changed.
- Renderer projection and the desktop approval card present the escaping action (fixed `exec` tool name + a plain-language consent summary); the UI `can_approve` invariant now recognizes the new approvable kind.

**Deny-by-default still holds:** an un-granted escaping action parks on the gate, and any Sensitive tool without a presentable kind stays rejectable-only.

## Tests

- `escaping_exec_is_a_presentable_approvable_kind`, `escaping_exec_is_standing_grantable` (core kind/grant semantics).
- `standing_grant_runs_escaping_exec_without_parking` and `ungranted_escaping_exec_still_parks_deny_by_default` (agent loop: covered call re-runs without prompting; un-granted call still parks).
- `escaping_exec_can_be_approved_and_remembered` (server broker: approve-with-remember records the grant — no longer `NotApprovable`).
- Desktop: exec approval presentation + strict pending-approval recovery for the new kind.

Verified locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, `cargo check --workspace --locked`, plus UI vitest + `tsc`/vite build. (The one intermittent failure, `committed_steer_event_recovers_when_cancellation_wins_ambiguous_response`, is a pre-existing timing flake and passes on rerun.)

## Follow-ups (tracked on #337)

- Extend presentable kinds to the remaining escaping categories: workspace-outside file writes and connector writes.
- Resource-level sub-scoping of grants (a path subtree, a single connector, a specific command) once `ApprovalRequest` carries a structured resource, rather than one grant per (chat, tool).
- Durable persistence of standing grants so prompt-once consent survives a restart within a chat.

Closes #337