### PR TITLE
test: make committed-steer cancellation race deterministic

### DIFF
--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1291,14 +1291,24 @@ impl Store for PauseTerminalStore {
                 .cancel_after_apply_steer_commit
                 .swap(false, Ordering::SeqCst)
         {
-            self.inner
-                .request_turn_cancellation_and_append_event(turn_id, chrono::Utc::now())
-                .await?
-                .ok_or_else(|| {
-                    AgentError::Store(
-                        "injected cancellation could not follow steer application".into(),
-                    )
-                })?;
+            // Commit the cancellation that beats the steer's ambiguous response.
+            // `request_turn_cancellation` returns `Ok(None)` when it loses the
+            // optimistic-concurrency race against a concurrent heartbeat that has
+            // just bumped `updated_at`; production callers retry with a fresh
+            // timestamp. Retry here too so the modeled cancellation always lands
+            // instead of being silently abandoned (which left the turn Running
+            // with the steer applied and the notify never fired — the flake).
+            loop {
+                if self
+                    .inner
+                    .request_turn_cancellation_and_append_event(turn_id, chrono::Utc::now())
+                    .await?
+                    .is_some()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
             self.apply_steer_cancellation_committed.notify_one();
             return Err(AgentError::Store(
                 "injected cancelled ambiguous steer application response".into(),
@@ -3042,10 +3052,7 @@ async fn durable_steer_retries_heartbeat_races_and_ambiguous_application() {
     );
 }
 
-// Quarantined: flaky under parallel test load (cancellation/steer timing race).
-// Passes in isolation. Tracked in #350; remove `#[ignore]` once made deterministic.
 #[tokio::test]
-#[ignore = "flaky under parallel load — see #350"]
 async fn committed_steer_event_recovers_when_cancellation_wins_ambiguous_response() {
     struct NeverFinish {
         entered: Arc<Notify>,


### PR DESCRIPTION
`committed_steer_event_recovers_when_cancellation_wins_ambiguous_response` failed intermittently under parallel test load, timing out after 5s at the wait for the injected cancellation to commit (`tests.rs:3140`, `Elapsed`). It passed in isolation.

## Root cause

The failure was in the test's fault-injection harness, not production code. The `PauseTerminalStore` wrapper models "a cancellation wins the steer's ambiguous response" like this:

1. apply the steer (commits `steer_revision`),
2. consume the one-shot `cancel_after_apply_steer_commit` flag with `swap(false)`,
3. call `request_turn_cancellation_and_append_event` once, `.ok_or_else()?` on the result,
4. notify `apply_steer_cancellation_committed` and return an error to model the ambiguous response.

`request_turn_cancellation` returns `Ok(None)` when it loses the optimistic-concurrency race against a concurrent heartbeat that just bumped `updated_at` (the `turn.updated_at > requested_at` guard in `request_turn_cancellation_inner`). Under load, the 20ms heartbeat frequently interleaved between the steer commit and the cancellation read, so the cancellation returned `None`. The harness turned that into an error — but the flag was already consumed, so the agent's retry never re-attempted the cancellation. The steer stayed applied, the turn stayed `Running`, and the notify never fired, so the test hit its 5s timeout.

Instrumented runs confirmed this exactly: at timeout, `steer_revision: 1` / `last_steer_applied_at` set (steer applied), turn still `Running`, `apply_turn_steer` entered twice with the cancellation never committing.

## Fix

Real cancellation callers retry through this transient `None` with a fresh timestamp. Do the same in the harness: retry the injected cancellation until it lands before notifying and returning the ambiguous-response error. The modeled race now resolves deterministically regardless of heartbeat timing. Assertions and the intended recovery scenario are unchanged.

## Verification

- 50x + 40x loops of the test single-threaded while the full server suite hammered the CPU across 6–8 threads (previously ~5-7% failure rate): 0 failures.
- `cargo test --workspace` twice: all green.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo check --workspace --locked`: pass.

Closes #350