### PR TITLE
build: sign macOS dev binaries so keychain approvals persist

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# On macOS, launch dev binaries through a wrapper that gives them a stable
+# code signature first — otherwise every rebuild re-triggers the keychain
+# access prompt. See scripts/macos-dev-sign-runner.sh for details.
+[target.'cfg(target_os = "macos")']
+runner = "scripts/macos-dev-sign-runner.sh"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,19 @@ cargo test --workspace
 The Rust toolchain is pinned in [`rust-toolchain.toml`](rust-toolchain.toml);
 `rustup` will pick it up automatically.
 
+### macOS keychain prompts
+
+OpenWave keeps secrets in the login keychain, and macOS ties keychain
+approvals to the binary's code signature — so unsigned dev builds would
+re-trigger the access prompt on every rebuild. To prevent that, `cargo run`
+and `cargo test` launch through
+[`scripts/macos-dev-sign-runner.sh`](scripts/macos-dev-sign-runner.sh), which
+signs the binary with your `openwave-dev` or `Apple Development` certificate
+(whichever exists) before running it. Click **Always Allow** once per binary
+and the prompt won't return. With no certificate in the keychain the wrapper
+is a no-op; you can also set `OPENWAVE_DEV_SIGNING_IDENTITY` to pick an
+identity explicitly, or set it empty to opt out.
+
 ### Desktop UI
 
 See [`crates/openwave-desktop/README.md`](crates/openwave-desktop/README.md).

--- a/scripts/macos-dev-sign-runner.sh
+++ b/scripts/macos-dev-sign-runner.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Cargo runner for macOS (wired up in `.cargo/config.toml`): re-sign the
+# freshly built binary with a stable code-signing identity, then launch it.
+#
+# Why: OpenWave stores secrets in the macOS login keychain, and keychain
+# access approvals are tied to the binary's code signature. Dev builds are
+# only ad-hoc signed by the linker, so every rebuild produces a new
+# signature and the "OpenWave wants to use your confidential information"
+# prompt returns — "Always Allow" can never stick. Signing with a real,
+# stable identity gives the binary a stable designated requirement, so one
+# approval per binary persists across rebuilds.
+#
+# Identity, in order of preference:
+#   1. $OPENWAVE_DEV_SIGNING_IDENTITY (set to opt out with an empty value)
+#   2. an "openwave-dev" self-signed certificate, if one exists
+#   3. the first "Apple Development" identity in the keychain
+# With no identity available the binary runs unsigned, exactly as before.
+
+set -euo pipefail
+
+bin="$1"
+shift
+
+find_identity() {
+  local identities
+  identities="$(security find-identity -v -p codesigning 2>/dev/null)" || return 0
+  local pattern
+  for pattern in '"\(openwave-dev\)"' '"\(Apple Development: [^"]*\)"'; do
+    local match
+    match="$(sed -n "s/.*${pattern}.*/\\1/p" <<<"$identities" | head -n 1)"
+    if [[ -n "$match" ]]; then
+      printf '%s' "$match"
+      return 0
+    fi
+  done
+}
+
+identity="${OPENWAVE_DEV_SIGNING_IDENTITY-$(find_identity)}"
+
+if [[ -n "$identity" ]]; then
+  # Unchanged binaries keep their signature from the previous run; re-signing
+  # only when the identity differs leaves them untouched.
+  current="$(codesign --display --verbose=2 "$bin" 2>&1 || true)"
+  if [[ "$current" != *"Authority=$identity"* ]]; then
+    codesign --force --sign "$identity" "$bin" 2>/dev/null ||
+      echo "warning: codesign with '$identity' failed; running unsigned" >&2
+  fi
+fi
+
+exec "$bin" "$@"


### PR DESCRIPTION
Closes #366

## Problem

Every rebuild of the workspace (`cargo run -p openwave-cli`, `cargo tauri dev`) re-triggers the macOS keychain access prompt ("OpenWave wants to use your confidential information stored in your keychain"). Keychain approvals are tied to the binary's code signature, and dev builds are only ad-hoc signed by the linker — the signature changes on every rebuild, so **Always Allow** can never persist.

## Fix

Route `cargo run` / `cargo test` on macOS through a runner wrapper (`.cargo/config.toml` → `scripts/macos-dev-sign-runner.sh`) that gives the freshly built binary a stable code signature before launching it. A stably signed binary has a stable designated requirement, so one **Always Allow** per binary persists across rebuilds.

Identity selection, in order:
1. `OPENWAVE_DEV_SIGNING_IDENTITY` (set empty to opt out)
2. an `openwave-dev` self-signed certificate, if present
3. the first `Apple Development` identity in the keychain

With no identity available the wrapper just `exec`s the binary unchanged, so contributors without a certificate (and CI runners) see no behavior change. Unchanged binaries that already carry the target signature are not re-signed. Non-macOS platforms are untouched (`cfg(target_os = "macos")`).

## Verification

- Runner script signs an unsigned binary, skips an already-signed one, honors the empty-identity opt-out, and forwards args/exit status.
- `cargo run -p openwave-cli --locked -- bogus-command` builds and launches through the runner; the resulting `target/debug/openwave` carries the Apple Development signature.
- `cargo test -p openwave-core --locked --lib keychain` passes through the runner.
- No Rust code, dependencies, or lockfiles touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)