### PR TITLE
fix(ui): restore list markers in chat messages

### DIFF
--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1513,6 +1513,14 @@ body {
   padding-left: 1.35rem;
 }
 
+.message-markdown ul {
+  list-style: disc;
+}
+
+.message-markdown ol {
+  list-style: decimal;
+}
+
 .message-markdown li + li {
   margin-top: 0.2rem;
 }


### PR DESCRIPTION
## Summary

- restore bullet markers for unordered Markdown lists
- restore numeric markers for ordered Markdown lists
- keep the styles scoped to chat message Markdown

## Validation

- `bw dev lint --react --check`