### PR TITLE
fix(desktop): surface failed approval decisions and honor per-chat allow

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -121,6 +121,12 @@ export default function App() {
   const [folderAccessErrors, setFolderAccessErrors] = useState<
     Record<string, string>
   >({});
+  const [decidingApprovalCalls, setDecidingApprovalCalls] = useState<
+    Set<string>
+  >(new Set());
+  const [approvalErrors, setApprovalErrors] = useState<Record<string, string>>(
+    {},
+  );
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
   const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
@@ -160,6 +166,7 @@ export default function App() {
   const refreshFolderAccessRef = useRef<(() => void) | null>(null);
   const refreshAgentRunsRef = useRef<(() => void) | null>(null);
   const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
+  const decidingApprovalCallsRef = useRef<Set<string>>(new Set());
   const visibleFolderCallIdsRef = useRef<Set<string>>(new Set());
   const cancelRequestTurnRef = useRef<string | null>(null);
   const activeTurnIdRef = useRef<string | null>(null);
@@ -930,6 +937,9 @@ export default function App() {
     setAgentRunsError(null);
     setFolderAccessRequests([]);
     setFolderAccessErrors({});
+    decidingApprovalCallsRef.current = new Set();
+    setDecidingApprovalCalls(new Set());
+    setApprovalErrors({});
     setComposerDraft("");
     setBusy(false);
     setCurrentActiveTurnId(null);
@@ -1027,6 +1037,9 @@ export default function App() {
     setAgentRunsError(null);
     setFolderAccessRequests([]);
     setFolderAccessErrors({});
+    decidingApprovalCallsRef.current = new Set();
+    setDecidingApprovalCalls(new Set());
+    setApprovalErrors({});
     setComposerDraft("");
     setBusy(false);
     setCurrentActiveTurnId(null);
@@ -1133,14 +1146,36 @@ export default function App() {
     remember = false,
   ) {
     if (!client || !chat) return;
-    await client.decideApproval(chat.id, callId, decision, remember);
-    setMessages((prev) =>
-      prev.map((m) =>
-        m.role === "approval" && m.callId === callId
-          ? { ...m, resolved: true }
-          : m,
-      ),
-    );
+    if (decidingApprovalCallsRef.current.has(callId)) return;
+    decidingApprovalCallsRef.current.add(callId);
+    setDecidingApprovalCalls((calls) => new Set(calls).add(callId));
+    setApprovalErrors((errors) => {
+      const next = { ...errors };
+      delete next[callId];
+      return next;
+    });
+    try {
+      await client.decideApproval(chat.id, callId, decision, remember);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.role === "approval" && m.callId === callId
+            ? { ...m, resolved: true }
+            : m,
+        ),
+      );
+    } catch (err) {
+      setApprovalErrors((errors) => ({
+        ...errors,
+        [callId]: `Could not send your decision: ${String(err)}`,
+      }));
+    } finally {
+      decidingApprovalCallsRef.current.delete(callId);
+      setDecidingApprovalCalls((calls) => {
+        const next = new Set(calls);
+        next.delete(callId);
+        return next;
+      });
+    }
   }
 
   async function onFolderAccessDecision(
@@ -1489,6 +1524,8 @@ export default function App() {
               nativeBusy={resolvingFolderCalls.size > 0}
               resolvingFolderCalls={resolvingFolderCalls}
               folderAccessErrors={folderAccessErrors}
+              decidingApprovalCalls={decidingApprovalCalls}
+              approvalErrors={approvalErrors}
               busy={busy}
               scrollRef={scrollRef}
               onScroll={(event) => {
@@ -1496,7 +1533,9 @@ export default function App() {
                 followsLatestRef.current = followsLatest;
                 if (followsLatest) setHasUnreadActivity(false);
               }}
-              onApproval={(callId, decision) => void onApproval(callId, decision)}
+              onApproval={(callId, decision, remember) =>
+                void onApproval(callId, decision, remember)
+              }
               onFolderAccessDecision={(callId, decision) =>
                 void onFolderAccessDecision(callId, decision)
               }

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -53,6 +53,8 @@ describe("MessageBubble", () => {
         nativeBusy={false}
         resolvingFolderCalls={new Set()}
         folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
         busy
         scrollRef={{ current: null }}
         onScroll={noop}
@@ -83,6 +85,8 @@ describe("MessageBubble", () => {
         nativeBusy={false}
         resolvingFolderCalls={new Set()}
         folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
         busy
         scrollRef={{ current: null }}
         onScroll={noop}
@@ -114,6 +118,8 @@ describe("MessageBubble", () => {
         nativeBusy={false}
         resolvingFolderCalls={new Set()}
         folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
         busy
         scrollRef={{ current: null }}
         onScroll={noop}
@@ -168,6 +174,8 @@ describe("MessageBubble", () => {
         nativeBusy={false}
         resolvingFolderCalls={new Set()}
         folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
         busy={false}
         scrollRef={{ current: null }}
         onScroll={noop}
@@ -207,6 +215,8 @@ describe("MessageBubble", () => {
         nativeBusy={false}
         resolvingFolderCalls={new Set()}
         folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
         busy={false}
         scrollRef={{ current: null }}
         onScroll={noop}
@@ -240,6 +250,8 @@ describe("MessageBubble", () => {
         nativeBusy={false}
         resolvingFolderCalls={new Set()}
         folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
         busy={false}
         scrollRef={{ current: null }}
         onScroll={noop}
@@ -287,6 +299,8 @@ describe("MessageBubble", () => {
         nativeBusy={false}
         resolvingFolderCalls={new Set()}
         folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
         busy={false}
         scrollRef={{ current: null }}
         onScroll={noop}
@@ -337,6 +351,8 @@ describe("MessageBubble", () => {
         nativeBusy={false}
         resolvingFolderCalls={new Set()}
         folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
         busy
         scrollRef={{ current: null }}
         onScroll={noop}
@@ -372,6 +388,8 @@ describe("MessageBubble", () => {
         nativeBusy={false}
         resolvingFolderCalls={new Set()}
         folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
         busy={false}
         scrollRef={{ current: null }}
         onScroll={noop}
@@ -409,6 +427,8 @@ describe("MessageBubble", () => {
         nativeBusy={false}
         resolvingFolderCalls={new Set()}
         folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
         busy
         scrollRef={{ current: null }}
         onScroll={noop}
@@ -421,5 +441,87 @@ describe("MessageBubble", () => {
     expect(markup).toContain('aria-label="Copy"');
     expect(markup).toContain('dateTime="2026-07-20T10:00:00Z"');
     expect(markup).toContain('dateTime="2026-07-20T10:01:00Z"');
+  });
+});
+
+describe("approval decision feedback", () => {
+  const approval: ChatMessage = {
+    id: "approval-1",
+    role: "approval",
+    callId: "call-1",
+    summary: "Search a site",
+    canApprove: true,
+  };
+
+  it("disables the decision buttons while a decision is in flight", () => {
+    const markup = renderToStaticMarkup(
+      <MessageBubble
+        message={approval}
+        busy={false}
+        onApproval={noop}
+        approvalState={{
+          decidingApprovalCalls: new Set(["call-1"]),
+          approvalErrors: {},
+        }}
+      />,
+    );
+
+    expect(markup).toContain('aria-busy="true"');
+    expect((markup.match(/disabled=""/g) ?? []).length).toBe(3);
+  });
+
+  it("renders a per-card error and keeps the buttons actionable for retry", () => {
+    const markup = renderToStaticMarkup(
+      <MessageBubble
+        message={approval}
+        busy={false}
+        onApproval={noop}
+        approvalState={{
+          decidingApprovalCalls: new Set(),
+          approvalErrors: {
+            "call-1": "Could not send your decision: Error: 500: boom",
+          },
+        }}
+      />,
+    );
+
+    expect(markup).toContain('class="approval-error"');
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("Could not send your decision");
+    expect(markup).not.toContain("disabled");
+  });
+
+  it("hides the error once the approval is resolved", () => {
+    const markup = renderToStaticMarkup(
+      <MessageBubble
+        message={{ ...approval, resolved: true }}
+        busy={false}
+        onApproval={noop}
+        approvalState={{
+          decidingApprovalCalls: new Set(),
+          approvalErrors: { "call-1": "Could not send your decision: nope" },
+        }}
+      />,
+    );
+
+    expect(markup).not.toContain("approval-error");
+    expect(markup).not.toContain("Could not send your decision");
+  });
+
+  it("shows no error for a card whose call has none", () => {
+    const markup = renderToStaticMarkup(
+      <MessageBubble
+        message={approval}
+        busy={false}
+        onApproval={noop}
+        approvalState={{
+          decidingApprovalCalls: new Set(["other-call"]),
+          approvalErrors: { "other-call": "Could not send your decision: x" },
+        }}
+      />,
+    );
+
+    expect(markup).not.toContain("approval-error");
+    expect(markup).not.toContain("disabled");
   });
 });

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -44,6 +44,8 @@ type MessageListProps = {
   nativeBusy: boolean;
   resolvingFolderCalls: Set<string>;
   folderAccessErrors: Record<string, string>;
+  decidingApprovalCalls: Set<string>;
+  approvalErrors: Record<string, string>;
   busy: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
   onScroll: (event: UIEvent<HTMLDivElement>) => void;
@@ -68,6 +70,8 @@ export function MessageList({
   nativeBusy,
   resolvingFolderCalls,
   folderAccessErrors,
+  decidingApprovalCalls,
+  approvalErrors,
   busy,
   scrollRef,
   onScroll,
@@ -77,7 +81,10 @@ export function MessageList({
   onSelectPrompt,
   hydrated = true,
 }: MessageListProps) {
-  const messageItems = groupMessageItems(messages, busy, onApproval);
+  const messageItems = groupMessageItems(messages, busy, onApproval, {
+    decidingApprovalCalls,
+    approvalErrors,
+  });
   // Only greet a genuinely empty, fully-hydrated conversation. While an
   // existing chat's transcript is still loading it is transiently empty; showing
   // the welcome there would flash "How can I help?" before its history renders.
@@ -146,6 +153,10 @@ export function groupMessageItems(
     decision: "approve" | "reject",
     remember?: boolean,
   ) => void,
+  approvalState?: {
+    decidingApprovalCalls: Set<string>;
+    approvalErrors: Record<string, string>;
+  },
 ) {
   const items: ReactNode[] = [];
   let index = 0;
@@ -178,6 +189,7 @@ export function groupMessageItems(
           message={message}
           busy={message.id === streamingAssistantId}
           onApproval={onApproval}
+          approvalState={approvalState}
         />,
       );
       index += 1;
@@ -203,6 +215,7 @@ export function groupMessageItems(
           message={message}
           busy={message.id === streamingAssistantId}
           onApproval={onApproval}
+          approvalState={approvalState}
         />,
       );
       continue;
@@ -225,6 +238,7 @@ export function MessageBubble({
   message,
   busy,
   onApproval,
+  approvalState,
 }: {
   message: ChatMessage;
   busy: boolean;
@@ -233,14 +247,25 @@ export function MessageBubble({
     decision: "approve" | "reject",
     remember?: boolean,
   ) => void;
+  approvalState?: {
+    decidingApprovalCalls: Set<string>;
+    approvalErrors: Record<string, string>;
+  };
 }) {
   if (message.role === "tool") {
     return <ToolCallCard name={message.name} status={message.status} />;
   }
 
   if (message.role === "approval") {
+    const deciding =
+      approvalState?.decidingApprovalCalls.has(message.callId) ?? false;
+    const error = approvalState?.approvalErrors[message.callId];
     return (
-      <section className="message-approval" aria-label="Approval needed">
+      <section
+        className="message-approval"
+        aria-label="Approval needed"
+        aria-busy={deciding}
+      >
         <p>Approval needed: {message.summary}</p>
         {!message.resolved && (
           <div className="approval">
@@ -249,6 +274,7 @@ export function MessageBubble({
                 <button
                   type="button"
                   className="btn btn-primary"
+                  disabled={deciding}
                   onClick={() => onApproval(message.callId, "approve")}
                 >
                   Approve once
@@ -256,6 +282,7 @@ export function MessageBubble({
                 <button
                   type="button"
                   className="btn"
+                  disabled={deciding}
                   onClick={() => onApproval(message.callId, "approve", true)}
                 >
                   Allow for this chat
@@ -265,11 +292,17 @@ export function MessageBubble({
             <button
               type="button"
               className="btn"
+              disabled={deciding}
               onClick={() => onApproval(message.callId, "reject")}
             >
               Reject
             </button>
           </div>
+        )}
+        {!message.resolved && error && (
+          <p className="approval-error" role="alert">
+            {error}
+          </p>
         )}
       </section>
     );

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1433,6 +1433,13 @@ body {
   font-size: 0.84rem;
 }
 
+.message-approval .approval-error {
+  margin-top: 0.5rem;
+  color: var(--danger);
+  font-size: 0.82rem;
+  overflow-wrap: anywhere;
+}
+
 /* ---------- Markdown ---------- */
 
 .message-markdown {


### PR DESCRIPTION
Closes #363, closes #364.

## What

Two defects in the same six lines of approval-card wiring:

- `onApproval` awaited `client.decideApproval` with no error handling, invoked as `void onApproval(...)`. A failed POST (connection loss, expired turn, server error) was an unhandled rejection: no feedback, buttons still active, turn left parked on a decision the server never received.
- The wrapper App passed to `MessageList` dropped the third argument, so **Allow for this chat** never sent `remember: true` — the standing grant was never recorded and the button silently behaved as **Approve once**. This was the only call path into `decideApproval`, so `remember` could never be true in the shipped app, despite the server fully supporting it (`resolve_with_remember`, `approvals.rs:79`).

## How

Mirrors the sibling folder-access consent pattern: per-call in-flight set + per-call error record, buttons disabled while the decision is pending (`aria-busy` on the card), failures render an inline retryable `Could not send your decision: …` (`role="alert"`), and the card is only marked resolved on success. Both new pieces of state reset on chat switch/create alongside the existing cleanup. The wrapper now passes `remember` through.

## Testing

- `tsc` clean, vitest 168/168 (4 new tests pin the disabled/error/resolved/unaffected-card states), production build passes.
- Smoke-tested both paths: "Allow for this chat" verified to suppress re-prompts for the remembered tool within the chat (native app), and the offline-failure path verified to show the inline error with working retry (browser mode against `openwave serve`, DevTools offline).

Note for reviewers: triggering an approvable card requires a `Sensitive`-class tool — in practice `search` with the OpenAI embedder active (enable the OpenAI provider, restart). `write_file` is `Workspace`-class and does not prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)