### PR TITLE
build(desktop): keep tauri dev from restarting on UI edits

### DIFF
--- a/crates/openwave-desktop/.taurignore
+++ b/crates/openwave-desktop/.taurignore
@@ -1,0 +1,9 @@
+# Dev-watcher ignores (gitignore syntax). The frontend under ui/ is served by
+# Vite (build.devUrl) with its own hot reload; without this, any UI edit makes
+# `cargo tauri dev` rebuild the Rust host and relaunch the window.
+/ui
+
+# Staged or generated during builds; watching them retriggers the watcher.
+# (node_modules, target, and gen are already in tauri-cli's builtin ignores.)
+/binaries
+/resources/pdfium


### PR DESCRIPTION
Closes #365.

`crates/openwave-desktop` is both the Tauri app dir and the parent of the React frontend (`ui/`), an unconventional layout — tauri-cli's dev watcher watches the whole app dir and its builtin ignore list (`node_modules/`, `target/`, `gen/`, `Cargo.lock`, `.DS_Store`) doesn't cover a nested frontend. Every `ui/src` edit therefore triggered a full Rust rebuild and window relaunch, clobbering the Vite HMR that `build.devUrl` already provides.

This adds a `.taurignore` (honored by the dev watcher only — verified against tauri-cli 2.11.4's `IgnoreMatcher`) excluding `ui/` plus the build-staged `binaries/` and `resources/pdfium/`. Bundling is unaffected: `frontendDist` still reads `ui/dist`.

Verified locally: with the file in place, UI edits hot-reload in the open window; Rust and `tauri.conf.json` changes still rebuild and relaunch as intended. (Requires restarting `cargo tauri dev` once to take effect — the watcher reads it at startup.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)