### PR TITLE
feat(web-search): enforce provider outbound domains

### DIFF
--- a/crates/openwave-server/src/web_search.rs
+++ b/crates/openwave-server/src/web_search.rs
@@ -246,7 +246,7 @@ pub async fn resolve_provider(
     let Some(credential) = credential else {
         return Ok(None);
     };
-    let client = ReqwestHttpClient::with_timeout(Duration::from_millis(config.timeout_ms))
+    let client = ReqwestHttpClient::with_timeout(kind, Duration::from_millis(config.timeout_ms))
         .map_err(|_| ServerError::internal("web search configuration is unavailable"))?;
     let provider: Arc<dyn WebSearchProvider> = match kind {
         WebSearchProviderKind::Exa => Arc::new(

--- a/crates/openwave-web-search/src/exa.rs
+++ b/crates/openwave-web-search/src/exa.rs
@@ -12,8 +12,6 @@ use crate::{
     WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult,
 };
 
-const EXA_SEARCH_URL: &str = "https://api.exa.ai/search";
-
 /// Exa adapter backed by an injected HTTP client.
 ///
 /// It has no default constructor because the host must explicitly decide which
@@ -44,7 +42,7 @@ impl<C: HttpClient> WebSearchProvider for ExaProvider<C> {
         let response = self
             .client
             .post_json(HttpRequest {
-                url: EXA_SEARCH_URL.into(),
+                url: self.kind().search_url().into(),
                 headers: vec![
                     ("x-api-key".into(), self.credential.api_key().into()),
                     ("content-type".into(), "application/json".into()),
@@ -211,7 +209,7 @@ mod tests {
         assert_eq!(response.results[0].snippet, "short summary");
         let sent = seen.lock().unwrap();
         assert_eq!(sent.len(), 1);
-        assert_eq!(sent[0].url, EXA_SEARCH_URL);
+        assert_eq!(sent[0].url, WebSearchProviderKind::Exa.search_url());
         assert_eq!(sent[0].body["numResults"], 2);
         assert_eq!(sent[0].body["includeDomains"][0], "docs.example.com");
         assert_eq!(sent[0].headers[0], ("x-api-key".into(), "exa-key".into()));

--- a/crates/openwave-web-search/src/http.rs
+++ b/crates/openwave-web-search/src/http.rs
@@ -136,15 +136,20 @@ fn redacted_json(value: &Value) -> Value {
 #[derive(Clone, Debug)]
 pub struct ReqwestHttpClient {
     client: reqwest::Client,
+    allowed_domain: &'static str,
 }
 
 #[cfg(feature = "http")]
 impl ReqwestHttpClient {
-    /// Build a client with one bounded end-to-end request timeout.
+    /// Build a client for one provider with a bounded end-to-end timeout.
     ///
-    /// The caller owns the policy for the value. Redirects stay disabled for
-    /// every timeout so credentials are never replayed to another origin.
-    pub fn with_timeout(timeout: std::time::Duration) -> Result<Self, WebSearchError> {
+    /// The selected provider fixes the only HTTPS domain this client may
+    /// contact. Redirects stay disabled so credentials are never replayed to
+    /// another origin.
+    pub fn with_timeout(
+        provider: crate::WebSearchProviderKind,
+        timeout: std::time::Duration,
+    ) -> Result<Self, WebSearchError> {
         if timeout.is_zero() {
             return Err(WebSearchError::Transport(
                 "web search timeout must be greater than zero".into(),
@@ -159,11 +164,14 @@ impl ReqwestHttpClient {
             .timeout(timeout)
             .build()
             .map_err(|error| WebSearchError::Transport(error.to_string()))?;
-        Ok(Self { client })
+        Ok(Self {
+            client,
+            allowed_domain: provider.outbound_domain(),
+        })
     }
 
-    pub fn new() -> Result<Self, WebSearchError> {
-        Self::with_timeout(std::time::Duration::from_secs(20))
+    pub fn new(provider: crate::WebSearchProviderKind) -> Result<Self, WebSearchError> {
+        Self::with_timeout(provider, std::time::Duration::from_secs(20))
     }
 }
 
@@ -173,6 +181,7 @@ impl HttpClient for ReqwestHttpClient {
     async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
         use futures::StreamExt;
 
+        validate_outbound_url(&request.url, self.allowed_domain)?;
         let mut builder = self.client.post(request.url).json(&request.body);
         for (name, value) in request.headers {
             builder = builder.header(name, value);
@@ -195,6 +204,24 @@ impl HttpClient for ReqwestHttpClient {
         }
         Ok(HttpResponse { status, body })
     }
+}
+
+#[cfg(feature = "http")]
+fn validate_outbound_url(value: &str, allowed_domain: &str) -> Result<(), WebSearchError> {
+    let parsed = Url::parse(value).map_err(|_| WebSearchError::OutboundNotAllowed)?;
+    let authority = value
+        .strip_prefix("https://")
+        .and_then(|remainder| remainder.split(['/', '?', '#']).next());
+    if authority != Some(allowed_domain)
+        || parsed.scheme() != "https"
+        || parsed.host_str() != Some(allowed_domain)
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.port().is_some()
+    {
+        return Err(WebSearchError::OutboundNotAllowed);
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -242,6 +269,46 @@ mod tests {
 
     #[cfg(feature = "http")]
     #[tokio::test]
+    async fn reqwest_client_rejects_requests_outside_its_provider_domain() {
+        let client = ReqwestHttpClient::new(crate::WebSearchProviderKind::Exa).unwrap();
+        for url in [
+            "http://api.exa.ai/search",
+            "https://api.tavily.com/search",
+            "https://api.exa.ai:443/search",
+            "https://api.exa.ai.evil.example/search",
+            "https://api.exa.ai./search",
+            "https://user:password@api.exa.ai/search",
+        ] {
+            let error = client
+                .post_json(HttpRequest {
+                    url: url.into(),
+                    headers: vec![("x-api-key".into(), "must-not-egress".into())],
+                    body: serde_json::json!({ "query": "openwave" }),
+                })
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(error, WebSearchError::OutboundNotAllowed),
+                "unexpected result for {url}: {error}"
+            );
+        }
+    }
+
+    #[cfg(feature = "http")]
+    #[test]
+    fn provider_endpoints_satisfy_their_fixed_domain_policy() {
+        for provider in [
+            crate::WebSearchProviderKind::Exa,
+            crate::WebSearchProviderKind::Tavily,
+        ] {
+            assert!(
+                validate_outbound_url(provider.search_url(), provider.outbound_domain()).is_ok()
+            );
+        }
+    }
+
+    #[cfg(feature = "http")]
+    #[tokio::test]
     async fn reqwest_client_does_not_follow_cross_host_redirects_with_credentials() {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
@@ -266,17 +333,17 @@ mod tests {
                 .unwrap();
         });
 
-        let client = ReqwestHttpClient::new().unwrap();
+        let client = ReqwestHttpClient::new(crate::WebSearchProviderKind::Exa).unwrap();
         let response = client
-            .post_json(HttpRequest {
-                url: format!("http://{source_address}/search"),
-                headers: vec![("x-api-key".into(), "not-for-the-redirect-target".into())],
-                body: serde_json::json!({ "query": "openwave" }),
-            })
+            .client
+            .post(format!("http://{source_address}/search"))
+            .header("x-api-key", "not-for-the-redirect-target")
+            .json(&serde_json::json!({ "query": "openwave" }))
+            .send()
             .await
             .unwrap();
 
-        assert_eq!(response.status, 307);
+        assert_eq!(response.status().as_u16(), 307);
         source_task.await.unwrap();
         assert!(
             tokio::time::timeout(std::time::Duration::from_millis(150), target.accept())

--- a/crates/openwave-web-search/src/lib.rs
+++ b/crates/openwave-web-search/src/lib.rs
@@ -3,8 +3,9 @@
 //! This crate deliberately does not register a model tool, load credentials, or
 //! make network calls at construction time. A host explicitly resolves a
 //! provider's key from [`openwave_core::SecretProvider`], constructs an adapter,
-//! and calls [`WebSearchProvider::search`]. The same contract is therefore safe
-//! to use from a sandbox worker once that worker has an outbound-network policy.
+//! and calls [`WebSearchProvider::search`]. The concrete HTTP client binds each
+//! adapter to its provider's exact HTTPS domain before a sandbox worker can use
+//! it.
 //!
 //! The Exa and Tavily adapters use their public HTTP APIs through the small
 //! [`HttpClient`] seam; no vendor SDK is required. `ReqwestHttpClient` is opt-in

--- a/crates/openwave-web-search/src/tavily.rs
+++ b/crates/openwave-web-search/src/tavily.rs
@@ -12,8 +12,6 @@ use crate::{
     WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult,
 };
 
-const TAVILY_SEARCH_URL: &str = "https://api.tavily.com/search";
-
 /// Tavily adapter backed by an injected HTTP client.
 #[derive(Clone, Debug)]
 pub struct TavilyProvider<C> {
@@ -41,7 +39,7 @@ impl<C: HttpClient> WebSearchProvider for TavilyProvider<C> {
         let response = self
             .client
             .post_json(HttpRequest {
-                url: TAVILY_SEARCH_URL.into(),
+                url: self.kind().search_url().into(),
                 headers: vec![("content-type".into(), "application/json".into())],
                 body: request_body(&request, self.credential.api_key()),
             })
@@ -209,7 +207,7 @@ mod tests {
         );
         let sent = request.lock().unwrap();
         let sent = sent.as_ref().unwrap();
-        assert_eq!(sent.url, TAVILY_SEARCH_URL);
+        assert_eq!(sent.url, WebSearchProviderKind::Tavily.search_url());
         assert_eq!(sent.body["api_key"], "tavily-key");
         assert!(sent.headers.iter().all(|(_, value)| value != "tavily-key"));
     }

--- a/crates/openwave-web-search/src/types.rs
+++ b/crates/openwave-web-search/src/types.rs
@@ -55,6 +55,26 @@ impl WebSearchProviderKind {
             Self::Tavily => "web_search.tavily.api_key",
         }
     }
+
+    pub(crate) const fn search_url(self) -> &'static str {
+        match self {
+            Self::Exa => "https://api.exa.ai/search",
+            Self::Tavily => "https://api.tavily.com/search",
+        }
+    }
+
+    /// Exact HTTPS domain the host transport may contact for this provider.
+    ///
+    /// Keeping this mapping beside the fixed credential key and endpoint
+    /// prevents host configuration or model arguments from selecting an
+    /// outbound target.
+    #[must_use]
+    pub const fn outbound_domain(self) -> &'static str {
+        match self {
+            Self::Exa => "api.exa.ai",
+            Self::Tavily => "api.tavily.com",
+        }
+    }
 }
 
 impl std::fmt::Display for WebSearchProviderKind {
@@ -373,6 +393,8 @@ pub enum WebSearchError {
     NotConfigured(WebSearchProviderKind),
     #[error("web search transport failed: {0}")]
     Transport(String),
+    #[error("web search outbound request is not allowed")]
+    OutboundNotAllowed,
     #[error("web search provider {provider} returned HTTP {status}")]
     HttpStatus {
         provider: WebSearchProviderKind,

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -132,8 +132,9 @@ their own proxy, allow-list, audit, or test client through the same seam.
 and bounded request timeout. Its depth-one sandbox loop may durably checkpoint
 the one fixed `web_search` contract, and the server worker resolves that exact
 checkpoint under a fenced lease. The foreground registry and recursive
-sandboxes never receive this contract. The follow-on slice defines the
-outbound-domain policy before expanding the search surface.
+sandboxes never receive this contract. The concrete host client is bound to the
+selected provider's exact HTTPS API domain before credentials are attached;
+scheme, authority, explicit-port, or userinfo deviations fail before dispatch.
 
 **Depends on:** `openwave-core`.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -193,8 +193,9 @@ and unavailable/error cases resolve a bounded immutable failure receipt. The
 sandbox model loop may now emit the one fixed checkpoint, with a bounded
 argument collector and deterministic rejection of unknown, partial, or
 multiple calls. The foreground loop remains separate and does not receive this
-tool. Outbound-domain policy is the next hardening slice before broadening the
-search surface.
+tool. The concrete host transport is bound to the selected provider's exact
+HTTPS API domain and rejects scheme, authority, explicit-port, or userinfo
+deviations before credentials can leave the process.
 
 The normalized contract should cover query text, optional date/domain filters,
 bounded result count, canonical URL, title, snippet or extracted text, rank or

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -29,7 +29,10 @@ Example:
 Timeouts must be between 1,000 and 60,000 milliseconds. There is no endpoint,
 proxy URL, arbitrary secret reference, or API-key field in this API. The Exa
 and Tavily adapters own their fixed HTTPS endpoints, disable redirects, and
-bound request input and retained response output.
+bound request input and retained response output. The host constructs the
+concrete HTTP client for the selected provider only; that client rejects any
+request whose scheme or exact authority differs from the provider's fixed API
+domain before dispatch.
 
 No response contains a credential. `/web-search` reports only
 `has_credential` for the currently selected provider, while
@@ -67,5 +70,7 @@ model loop may advertise only this fixed `web_search` schema, at most once and
 only when two model steps remain. It parks the immutable call before any
 egress; when the receipt resolves, its next claim rebuilds the same
 `ToolUse`/`ToolResult` pair and may finalize. No foreground or recursive agent
-receives the schema. An explicit outbound-domain policy remains the next
-hardening slice before broadening this search surface.
+receives the schema. The concrete transport enforces an exact HTTPS
+outbound-domain policy (`api.exa.ai` for Exa and `api.tavily.com` for Tavily)
+outside model-controlled arguments. Broader search surfaces still require
+their own approval and outbound policy.


### PR DESCRIPTION
## Summary

- bind the concrete web-search HTTP client to the selected provider fixed HTTPS domain
- reject scheme, authority, explicit-port, trailing-dot, subdomain, and userinfo deviations before dispatch
- centralize provider endpoints and allowed domains so policy cannot drift from adapters
- document the enforced outbound boundary

## Validation

- `cargo test -p openwave-web-search --all-features --locked`
- `cargo test -p openwave-server web_search --locked --no-default-features`
- `cargo clippy -p openwave-web-search --all-targets --all-features --locked --no-deps -- -D warnings`
- `cargo clippy -p openwave-server --lib --no-default-features --locked --no-deps -- -D warnings`
- `bw dev lint --rust --check --repo-root /Users/thet/conductor/workspaces/openwave/porto-novo`
- `cargo fmt --all --check`

Closes #369