### PR TITLE
feat(desktop): enable automatic updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -2801,6 +2804,17 @@ name = "derive-where"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5991,6 +6005,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6463,6 +6483,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6646,6 +6678,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -6808,6 +6841,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -9898,6 +9945,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.19",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12019,6 +12099,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { workspace = true }
 tauri = { version = "=2.11.5", features = [] }
 tauri-plugin-dialog = "=2.7.2"
 tauri-plugin-shell = "=2.3.5"
+tauri-plugin-updater = "=2.10.1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -18,6 +18,7 @@ mod broker;
 mod client_execution;
 mod documents;
 mod host_access;
+mod updater;
 
 /// Connection details the webview needs to reach the in-process API.
 #[derive(Clone, Serialize)]
@@ -140,7 +141,9 @@ pub fn run() {
     let app = builder
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(state)
+        .manage(updater::UpdateManager::default())
         .invoke_handler(tauri::generate_handler![
             server_info,
             documents::import_library_document,
@@ -149,11 +152,15 @@ pub fn run() {
             client_execution::resolve_folder_access_request,
             host_access::connect_folder,
             host_access::list_connected_folders,
-            host_access::disconnect_folder
+            host_access::disconnect_folder,
+            updater::desktop_update_state,
+            updater::check_for_update,
+            updater::restart_for_update
         ])
         .setup(move |app| {
             let handle = app.handle().clone();
             point_pdfium_at_bundle(&handle);
+            updater::spawn_update_loop(handle.clone());
             let data = data_dir(&handle)?;
             let home = home_dir(&handle)?;
             let host_access = host_access::HostAccess::new(handle.clone(), data.clone(), home)?;

--- a/crates/openwave-desktop/src/updater.rs
+++ b/crates/openwave-desktop/src/updater.rs
@@ -1,0 +1,257 @@
+//! Background update checks and renderer-facing update state.
+//!
+//! Release builds check the signed feed after a short startup delay and then
+//! periodically. Updates are downloaded and installed in place, but relaunching
+//! is always left to an explicit user action so native work is never
+//! interrupted automatically.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_updater::UpdaterExt;
+
+const UPDATE_STATE_EVENT: &str = "desktop-update-state";
+const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs(15);
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
+const UPDATE_CHECK_ERROR: &str = "Could not check for updates. Try again later.";
+const UPDATE_INSTALL_ERROR: &str = "Could not prepare the update. Try again later.";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum DesktopUpdateStatus {
+    Idle,
+    Checking,
+    Downloading,
+    Ready,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DesktopUpdateState {
+    status: DesktopUpdateStatus,
+    version: Option<String>,
+    error: Option<String>,
+    enabled: bool,
+}
+
+impl DesktopUpdateState {
+    fn idle() -> Self {
+        Self {
+            status: DesktopUpdateStatus::Idle,
+            version: None,
+            error: None,
+            enabled: updates_enabled(),
+        }
+    }
+
+    fn failed(message: &'static str) -> Self {
+        Self {
+            error: Some(message.to_owned()),
+            ..Self::idle()
+        }
+    }
+}
+
+impl Default for DesktopUpdateState {
+    fn default() -> Self {
+        Self::idle()
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct UpdateManager {
+    state: Mutex<DesktopUpdateState>,
+    busy: AtomicBool,
+}
+
+pub(crate) const fn updates_enabled() -> bool {
+    cfg!(all(not(debug_assertions), target_os = "macos"))
+}
+
+fn current_update_state(app: &AppHandle) -> DesktopUpdateState {
+    app.state::<UpdateManager>()
+        .state
+        .lock()
+        .expect("update state mutex poisoned")
+        .clone()
+}
+
+fn set_update_state(app: &AppHandle, next: DesktopUpdateState) {
+    *app.state::<UpdateManager>()
+        .state
+        .lock()
+        .expect("update state mutex poisoned") = next.clone();
+    if let Err(error) = app.emit(UPDATE_STATE_EVENT, next) {
+        eprintln!("openwave-desktop: could not emit update state: {error}");
+    }
+}
+
+async fn perform_update_check(app: &AppHandle) {
+    set_update_state(
+        app,
+        DesktopUpdateState {
+            status: DesktopUpdateStatus::Checking,
+            ..DesktopUpdateState::idle()
+        },
+    );
+
+    let updater = match app.updater() {
+        Ok(updater) => updater,
+        Err(error) => {
+            eprintln!("openwave-desktop: could not initialize updater: {error}");
+            return set_update_state(app, DesktopUpdateState::failed(UPDATE_CHECK_ERROR));
+        }
+    };
+
+    let update = match updater.check().await {
+        Ok(Some(update)) => update,
+        Ok(None) => return set_update_state(app, DesktopUpdateState::idle()),
+        Err(error) => {
+            eprintln!("openwave-desktop: update check failed: {error}");
+            return set_update_state(app, DesktopUpdateState::failed(UPDATE_CHECK_ERROR));
+        }
+    };
+
+    let version = Some(update.version.clone());
+    set_update_state(
+        app,
+        DesktopUpdateState {
+            status: DesktopUpdateStatus::Downloading,
+            version: version.clone(),
+            ..DesktopUpdateState::idle()
+        },
+    );
+
+    match update
+        .download_and_install(|_chunk, _total| {}, || {})
+        .await
+    {
+        Ok(()) => set_update_state(
+            app,
+            DesktopUpdateState {
+                status: DesktopUpdateStatus::Ready,
+                version,
+                ..DesktopUpdateState::idle()
+            },
+        ),
+        Err(error) => {
+            eprintln!("openwave-desktop: update installation failed: {error}");
+            set_update_state(app, DesktopUpdateState::failed(UPDATE_INSTALL_ERROR));
+        }
+    }
+}
+
+async fn run_update_check(app: AppHandle) -> DesktopUpdateState {
+    if !updates_enabled() {
+        return current_update_state(&app);
+    }
+
+    {
+        let manager = app.state::<UpdateManager>();
+        if manager.busy.swap(true, Ordering::AcqRel) {
+            return current_update_state(&app);
+        }
+
+        let update_is_staged = matches!(
+            manager
+                .state
+                .lock()
+                .expect("update state mutex poisoned")
+                .status,
+            DesktopUpdateStatus::Downloading | DesktopUpdateStatus::Ready
+        );
+        if update_is_staged {
+            manager.busy.store(false, Ordering::Release);
+            return current_update_state(&app);
+        }
+    }
+
+    perform_update_check(&app).await;
+    app.state::<UpdateManager>()
+        .busy
+        .store(false, Ordering::Release);
+    current_update_state(&app)
+}
+
+pub(crate) fn spawn_update_loop(app: AppHandle) {
+    if !updates_enabled() {
+        return;
+    }
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(UPDATE_CHECK_STARTUP_DELAY).await;
+        loop {
+            run_update_check(app.clone()).await;
+            tokio::time::sleep(UPDATE_CHECK_INTERVAL).await;
+        }
+    });
+}
+
+#[tauri::command]
+pub(crate) fn desktop_update_state(app: AppHandle) -> DesktopUpdateState {
+    current_update_state(&app)
+}
+
+#[tauri::command]
+pub(crate) async fn check_for_update(app: AppHandle) -> DesktopUpdateState {
+    run_update_check(app).await
+}
+
+fn can_restart(state: &DesktopUpdateState) -> bool {
+    state.enabled && state.status == DesktopUpdateStatus::Ready
+}
+
+#[tauri::command]
+pub(crate) fn restart_for_update(app: AppHandle) -> Result<(), String> {
+    if !can_restart(&current_update_state(&app)) {
+        return Err("no update is ready to install".to_owned());
+    }
+    app.restart();
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn renderer_state_uses_stable_public_field_names() {
+        let state = DesktopUpdateState {
+            status: DesktopUpdateStatus::Ready,
+            version: Some("1.2.3".to_owned()),
+            error: None,
+            enabled: true,
+        };
+
+        assert_eq!(
+            serde_json::to_value(state).unwrap(),
+            json!({
+                "status": "ready",
+                "version": "1.2.3",
+                "error": null,
+                "enabled": true,
+            })
+        );
+    }
+
+    #[test]
+    fn relaunch_requires_an_enabled_staged_update() {
+        let mut state = DesktopUpdateState {
+            status: DesktopUpdateStatus::Ready,
+            version: Some("1.2.3".to_owned()),
+            error: None,
+            enabled: true,
+        };
+        assert!(can_restart(&state));
+
+        state.status = DesktopUpdateStatus::Downloading;
+        assert!(!can_restart(&state));
+
+        state.status = DesktopUpdateStatus::Ready;
+        state.enabled = false;
+        assert!(!can_restart(&state));
+    }
+}

--- a/crates/openwave-desktop/src/updater.rs
+++ b/crates/openwave-desktop/src/updater.rs
@@ -1,9 +1,9 @@
 //! Background update checks and renderer-facing update state.
 //!
 //! Release builds check the signed feed after a short startup delay and then
-//! periodically. Updates are downloaded and installed in place, but relaunching
-//! is always left to an explicit user action so native work is never
-//! interrupted automatically.
+//! periodically. Updates are downloaded and signature-verified in the
+//! background, but the app bundle is not replaced until an explicit user
+//! restart so the running host and its sidecar always stay on the same version.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -11,13 +11,15 @@ use std::time::Duration;
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager};
-use tauri_plugin_updater::UpdaterExt;
+use tauri_plugin_updater::{Update, UpdaterExt};
+
+use crate::host_access::HostAccess;
 
 const UPDATE_STATE_EVENT: &str = "desktop-update-state";
 const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs(15);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const UPDATE_CHECK_ERROR: &str = "Could not check for updates. Try again later.";
-const UPDATE_INSTALL_ERROR: &str = "Could not prepare the update. Try again later.";
+const UPDATE_PREPARE_ERROR: &str = "Could not prepare the update. Try again later.";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -61,9 +63,15 @@ impl Default for DesktopUpdateState {
     }
 }
 
+struct StagedUpdate {
+    update: Update,
+    bytes: Vec<u8>,
+}
+
 #[derive(Default)]
 pub(crate) struct UpdateManager {
     state: Mutex<DesktopUpdateState>,
+    staged: Mutex<Option<StagedUpdate>>,
     busy: AtomicBool,
 }
 
@@ -125,21 +133,24 @@ async fn perform_update_check(app: &AppHandle) {
         },
     );
 
-    match update
-        .download_and_install(|_chunk, _total| {}, || {})
-        .await
-    {
-        Ok(()) => set_update_state(
-            app,
-            DesktopUpdateState {
-                status: DesktopUpdateStatus::Ready,
-                version,
-                ..DesktopUpdateState::idle()
-            },
-        ),
+    match update.download(|_chunk, _total| {}, || {}).await {
+        Ok(bytes) => {
+            *app.state::<UpdateManager>()
+                .staged
+                .lock()
+                .expect("staged update mutex poisoned") = Some(StagedUpdate { update, bytes });
+            set_update_state(
+                app,
+                DesktopUpdateState {
+                    status: DesktopUpdateStatus::Ready,
+                    version,
+                    ..DesktopUpdateState::idle()
+                },
+            );
+        }
         Err(error) => {
-            eprintln!("openwave-desktop: update installation failed: {error}");
-            set_update_state(app, DesktopUpdateState::failed(UPDATE_INSTALL_ERROR));
+            eprintln!("openwave-desktop: update download failed: {error}");
+            set_update_state(app, DesktopUpdateState::failed(UPDATE_PREPARE_ERROR));
         }
     }
 }
@@ -199,15 +210,36 @@ pub(crate) async fn check_for_update(app: AppHandle) -> DesktopUpdateState {
     run_update_check(app).await
 }
 
-fn can_restart(state: &DesktopUpdateState) -> bool {
-    state.enabled && state.status == DesktopUpdateStatus::Ready
+fn can_restart(state: &DesktopUpdateState, has_staged_update: bool) -> bool {
+    state.enabled && state.status == DesktopUpdateStatus::Ready && has_staged_update
 }
 
 #[tauri::command]
-pub(crate) fn restart_for_update(app: AppHandle) -> Result<(), String> {
-    if !can_restart(&current_update_state(&app)) {
-        return Err("no update is ready to install".to_owned());
+pub(crate) async fn restart_for_update(app: AppHandle) -> Result<(), String> {
+    let staged = {
+        let manager = app.state::<UpdateManager>();
+        let state = manager
+            .state
+            .lock()
+            .expect("update state mutex poisoned")
+            .clone();
+        let mut staged = manager.staged.lock().expect("staged update mutex poisoned");
+        if !can_restart(&state, staged.is_some()) {
+            return Err("no update is ready to install".to_owned());
+        }
+        staged.take().expect("ready update must have staged bytes")
+    };
+
+    // Once the bundle is replaced, every new sidecar process would come from
+    // the new app. Close the old host's broker permanently before installation
+    // so it cannot respawn a mismatched sidecar in the install/restart window.
+    app.state::<HostAccess>().shutdown().await;
+    if let Err(error) = staged.update.install(&staged.bytes) {
+        eprintln!("openwave-desktop: update installation failed: {error}");
     }
+
+    // Relaunch even if installation failed so the current app gets a fresh,
+    // usable broker instead of remaining alive after its broker was closed.
     app.restart();
 }
 
@@ -245,13 +277,15 @@ mod tests {
             error: None,
             enabled: true,
         };
-        assert!(can_restart(&state));
+        assert!(can_restart(&state, true));
+
+        assert!(!can_restart(&state, false));
 
         state.status = DesktopUpdateStatus::Downloading;
-        assert!(!can_restart(&state));
+        assert!(!can_restart(&state, true));
 
         state.status = DesktopUpdateStatus::Ready;
         state.enabled = false;
-        assert!(!can_restart(&state));
+        assert!(!can_restart(&state, true));
     }
 }

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -31,6 +31,7 @@ import {
   Monitor,
   Moon,
   Pencil,
+  RotateCw,
   Settings,
   SquarePen,
   Sun,
@@ -81,6 +82,7 @@ import {
 import { prependReplacementChat } from "./ChatDeletion";
 import { useConfirm } from "./components/ConfirmDialog";
 import { Button } from "@/components/ui/button";
+import { useDesktopUpdates } from "./updates";
 
 type Msg = ChatMessage;
 
@@ -179,6 +181,7 @@ export default function App() {
   const deletionInFlightRef = useRef(false);
   const { confirm, dialog: confirmDialog } = useConfirm();
   const { mode: themeMode, cycle: cycleTheme, setMode: setThemeMode } = useTheme();
+  const desktopUpdates = useDesktopUpdates();
 
   useEffect(() => {
     let cancelled = false;
@@ -1236,6 +1239,16 @@ export default function App() {
     }
   }
 
+  async function onRestartForUpdate() {
+    const version = desktopUpdates.state.version;
+    const confirmed = await confirm({
+      title: "Restart OpenWave to update?",
+      description: `${version ? `Version ${version}` : "The update"} is ready. OpenWave will close and reopen. Wait for active work to finish before restarting.`,
+      confirmLabel: "Restart and update",
+    });
+    if (confirmed) await desktopUpdates.restart();
+  }
+
   if (bootError) {
     return (
       <div className="boot">
@@ -1408,6 +1421,21 @@ export default function App() {
         </div>
 
         <div className="sidebar-footer">
+          {desktopUpdates.state.status === "ready" && (
+            <button
+              type="button"
+              className="sidebar-action sidebar-update"
+              onClick={() => void onRestartForUpdate()}
+            >
+              <RotateCw size={16} />
+              <span>Restart to update</span>
+              {desktopUpdates.state.version && (
+                <span className="sidebar-update-version">
+                  v{desktopUpdates.state.version}
+                </span>
+              )}
+            </button>
+          )}
           {hasNativeHost() && (
             <button
               type="button"
@@ -1451,6 +1479,9 @@ export default function App() {
             onBack={() => setPrimaryView("chat")}
             themeMode={themeMode}
             onThemeChange={setThemeMode}
+            updateState={desktopUpdates.state}
+            onCheckForUpdate={desktopUpdates.check}
+            onRestartForUpdate={onRestartForUpdate}
           />
         ) : (
           <>

--- a/crates/openwave-desktop/ui/src/SettingsView.tsx
+++ b/crates/openwave-desktop/ui/src/SettingsView.tsx
@@ -1,13 +1,27 @@
 import { useState, type ComponentType } from "react";
-import { ArrowLeft, Cpu, Globe, KeyRound, Palette } from "lucide-react";
+import {
+  ArrowLeft,
+  Cpu,
+  Globe,
+  KeyRound,
+  Palette,
+  RefreshCw,
+} from "lucide-react";
 import type { ApiClient, ModelInfo, ProviderInfo } from "./api";
 import type { ThemeMode } from "./theme";
+import type { DesktopUpdateState } from "./updates";
 import { ProvidersPanel } from "./settings/ProvidersPanel";
 import { WebSearchPanel } from "./settings/WebSearchPanel";
 import { ModelsPanel } from "./settings/ModelsPanel";
 import { AppearancePanel } from "./settings/AppearancePanel";
+import { UpdatesPanel } from "./settings/UpdatesPanel";
 
-type SettingsSectionKey = "providers" | "models" | "web-search" | "appearance";
+type SettingsSectionKey =
+  | "providers"
+  | "models"
+  | "web-search"
+  | "appearance"
+  | "updates";
 
 const SECTIONS: {
   key: SettingsSectionKey;
@@ -18,6 +32,7 @@ const SECTIONS: {
   { key: "models", label: "Models", icon: Cpu },
   { key: "web-search", label: "Web search", icon: Globe },
   { key: "appearance", label: "Appearance", icon: Palette },
+  { key: "updates", label: "Updates", icon: RefreshCw },
 ];
 
 export function SettingsView({
@@ -28,6 +43,9 @@ export function SettingsView({
   onBack,
   themeMode,
   onThemeChange,
+  updateState,
+  onCheckForUpdate,
+  onRestartForUpdate,
 }: {
   client: ApiClient;
   models: ModelInfo[];
@@ -36,6 +54,9 @@ export function SettingsView({
   onBack: () => void;
   themeMode: ThemeMode;
   onThemeChange: (mode: ThemeMode) => void;
+  updateState: DesktopUpdateState;
+  onCheckForUpdate: () => Promise<DesktopUpdateState>;
+  onRestartForUpdate: () => Promise<void>;
 }) {
   const [section, setSection] = useState<SettingsSectionKey>("providers");
 
@@ -83,6 +104,13 @@ export function SettingsView({
         {section === "web-search" && <WebSearchPanel client={client} />}
         {section === "appearance" && (
           <AppearancePanel mode={themeMode} onChange={onThemeChange} />
+        )}
+        {section === "updates" && (
+          <UpdatesPanel
+            state={updateState}
+            onCheck={onCheckForUpdate}
+            onRestart={onRestartForUpdate}
+          />
         )}
       </div>
     </section>

--- a/crates/openwave-desktop/ui/src/settings/UpdatesPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/UpdatesPanel.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopUpdateState } from "../updates";
+import { UpdatesPanel, updateStateSummary } from "./UpdatesPanel";
+
+const idle: DesktopUpdateState = {
+  status: "idle",
+  version: null,
+  error: null,
+  enabled: true,
+};
+
+describe("UpdatesPanel", () => {
+  it("keeps update checks disabled outside supported packaged builds", () => {
+    const markup = renderToStaticMarkup(
+      <UpdatesPanel
+        state={{ ...idle, enabled: false }}
+        onCheck={vi.fn()}
+        onRestart={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("available in packaged macOS builds");
+    expect(markup).toContain("disabled");
+  });
+
+  it("offers an explicit relaunch only after an update is staged", () => {
+    const state: DesktopUpdateState = {
+      ...idle,
+      status: "ready",
+      version: "1.2.3",
+    };
+    const markup = renderToStaticMarkup(
+      <UpdatesPanel
+        state={state}
+        onCheck={vi.fn()}
+        onRestart={vi.fn()}
+      />,
+    );
+
+    expect(updateStateSummary(state)).toContain("Version 1.2.3");
+    expect(markup).toContain("Restart to update");
+    expect(markup).not.toContain("Check for updates");
+  });
+
+  it("shows generic host errors without exposing updater diagnostics", () => {
+    const markup = renderToStaticMarkup(
+      <UpdatesPanel
+        state={{ ...idle, error: "Could not check for updates. Try again later." }}
+        onCheck={vi.fn()}
+        onRestart={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Could not check for updates");
+    expect(markup).toContain('role="alert"');
+  });
+});

--- a/crates/openwave-desktop/ui/src/settings/UpdatesPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/UpdatesPanel.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import { RefreshCw, RotateCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { DesktopUpdateState } from "../updates";
+import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
+
+export function updateStateSummary(state: DesktopUpdateState): string {
+  if (!state.enabled) {
+    return "Automatic updates are available in packaged macOS builds.";
+  }
+  switch (state.status) {
+    case "checking":
+      return "Checking for updates…";
+    case "downloading":
+      return state.version
+        ? `Downloading and verifying version ${state.version}…`
+        : "Downloading and verifying the update…";
+    case "ready":
+      return state.version
+        ? `Version ${state.version} is ready to install.`
+        : "An update is ready to install.";
+    case "idle":
+      return "OpenWave checks for signed updates automatically.";
+  }
+}
+
+export function UpdatesPanel({
+  state,
+  onCheck,
+  onRestart,
+}: {
+  state: DesktopUpdateState;
+  onCheck: () => Promise<DesktopUpdateState>;
+  onRestart: () => Promise<void>;
+}) {
+  const [manualResult, setManualResult] = useState<string | null>(null);
+  const busy = state.status === "checking" || state.status === "downloading";
+
+  useEffect(() => {
+    if (busy || state.status === "ready" || state.error) {
+      setManualResult(null);
+    }
+  }, [busy, state.error, state.status]);
+
+  async function check() {
+    setManualResult(null);
+    const next = await onCheck();
+    if (next.enabled && next.status === "idle" && !next.error) {
+      setManualResult("OpenWave is up to date.");
+    }
+  }
+
+  return (
+    <SettingsPanel
+      title="Updates"
+      description="OpenWave checks shortly after launch and every five minutes. Updates are downloaded in the background, but OpenWave only restarts when you choose."
+      busy={busy}
+    >
+      <SettingsSection title="Automatic updates">
+        <p className="text-sm text-muted-foreground" aria-live="polite">
+          {updateStateSummary(state)}
+        </p>
+        {manualResult && (
+          <p className="text-sm text-muted-foreground" role="status">
+            {manualResult}
+          </p>
+        )}
+        {state.error && <SettingsError>{state.error}</SettingsError>}
+        <div>
+          {state.status === "ready" ? (
+            <Button type="button" onClick={() => void onRestart()}>
+              <RotateCw />
+              Restart to update
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              disabled={!state.enabled || busy}
+              onClick={() => void check()}
+            >
+              <RefreshCw className={busy ? "animate-spin" : undefined} />
+              {state.status === "checking"
+                ? "Checking…"
+                : state.status === "downloading"
+                  ? "Downloading…"
+                  : "Check for updates"}
+            </Button>
+          )}
+        </div>
+      </SettingsSection>
+    </SettingsPanel>
+  );
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -506,6 +506,28 @@ body {
   margin-top: auto;
 }
 
+.sidebar-update {
+  color: var(--success-foreground);
+  background: var(--success-background);
+}
+
+.sidebar-update:hover {
+  color: var(--success-foreground);
+  background: color-mix(in srgb, var(--success-background) 78%, var(--success));
+}
+
+.sidebar-update svg,
+.sidebar-update:hover svg {
+  color: var(--success-foreground);
+}
+
+.sidebar-update-version {
+  margin-left: auto;
+  color: inherit;
+  font-size: 0.7rem;
+  opacity: 0.75;
+}
+
 /* ---------- Buttons ---------- */
 
 .btn {

--- a/crates/openwave-desktop/ui/src/updates.ts
+++ b/crates/openwave-desktop/ui/src/updates.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke, isTauri } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+const UPDATE_STATE_EVENT = "desktop-update-state";
+const UPDATE_CONTROL_ERROR = "Update controls are temporarily unavailable.";
+const UPDATE_RESTART_ERROR = "Could not restart OpenWave. Try again.";
+
+export type DesktopUpdateState = {
+  status: "idle" | "checking" | "downloading" | "ready";
+  version: string | null;
+  error: string | null;
+  enabled: boolean;
+};
+
+export type DesktopUpdatesController = {
+  state: DesktopUpdateState;
+  check: () => Promise<DesktopUpdateState>;
+  restart: () => Promise<void>;
+};
+
+export const INITIAL_UPDATE_STATE: DesktopUpdateState = {
+  status: "idle",
+  version: null,
+  error: null,
+  enabled: false,
+};
+
+function unavailableUpdateState(): DesktopUpdateState {
+  return {
+    ...INITIAL_UPDATE_STATE,
+    enabled: isTauri(),
+    error: UPDATE_CONTROL_ERROR,
+  };
+}
+
+async function getDesktopUpdateState(): Promise<DesktopUpdateState> {
+  if (!isTauri()) return INITIAL_UPDATE_STATE;
+  try {
+    return await invoke<DesktopUpdateState>("desktop_update_state");
+  } catch {
+    return unavailableUpdateState();
+  }
+}
+
+async function checkForDesktopUpdate(): Promise<DesktopUpdateState> {
+  if (!isTauri()) return INITIAL_UPDATE_STATE;
+  try {
+    return await invoke<DesktopUpdateState>("check_for_update");
+  } catch {
+    return unavailableUpdateState();
+  }
+}
+
+async function restartForDesktopUpdate(): Promise<void> {
+  if (!isTauri()) return;
+  await invoke("restart_for_update");
+}
+
+export function useDesktopUpdates(): DesktopUpdatesController {
+  const [state, setState] = useState<DesktopUpdateState>(INITIAL_UPDATE_STATE);
+
+  useEffect(() => {
+    if (!isTauri()) return;
+    let cancelled = false;
+    let unlisten: UnlistenFn | undefined;
+
+    void (async () => {
+      try {
+        unlisten = await listen<DesktopUpdateState>(
+          UPDATE_STATE_EVENT,
+          (event) => {
+            if (!cancelled) setState(event.payload);
+          },
+        );
+        const current = await getDesktopUpdateState();
+        if (!cancelled) setState(current);
+      } catch {
+        if (!cancelled) {
+          setState(unavailableUpdateState());
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
+  const check = useCallback(async () => {
+    setState((current) =>
+      current.enabled
+        ? { ...current, status: "checking", error: null }
+        : current,
+    );
+    const next = await checkForDesktopUpdate();
+    setState(next);
+    return next;
+  }, []);
+
+  const restart = useCallback(async () => {
+    try {
+      await restartForDesktopUpdate();
+    } catch {
+      setState((current) => ({
+        ...current,
+        error: UPDATE_RESTART_ERROR,
+      }));
+    }
+  }, []);
+
+  return { state, check, restart };
+}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -162,8 +162,17 @@ The root `manifest.json` and Tauri-compatible `latest.json` are the only mutable
 objects. The workflow refuses to overwrite a versioned object with different
 bytes or move `latest.json` to an older version.
 
-The current app does not yet install updates automatically; `latest.json` is the
-stable server-side updater contract for that client integration.
+Packaged macOS apps check `latest.json` 15 seconds after launch and every five
+minutes. When a newer signed version is available, the Tauri updater downloads
+and installs it in place, then emits a ready state to the UI. The user must
+choose **Restart to update** before OpenWave relaunches; the app never
+interrupts active work automatically. Development and unsupported-platform
+builds do not contact the production update feed.
+
+The first release containing this client integration is a bootstrap release:
+older installed binaries have no updater and therefore cannot discover it.
+Users must install that first updater-enabled release manually; subsequent
+releases can advance automatically.
 
 **Warm macOS release cache** runs independently after relevant changes land on
 `main`. A short prerequisite job saves Cargo dependency downloads before the

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -318,7 +318,12 @@ test("the packaged desktop activates the signed updater feed", () => {
   assert.match(desktopHost, /updater::check_for_update/);
   assert.match(desktopHost, /updater::restart_for_update/);
   assert.match(desktopUpdater, /updater\.check\(\)\.await/);
-  assert.match(desktopUpdater, /update\s*\.download_and_install/);
+  assert.match(desktopUpdater, /update\.download\(/);
+  assert.doesNotMatch(desktopUpdater, /download_and_install/);
+  assert.match(
+    desktopUpdater,
+    /state::<HostAccess>\(\)\.shutdown\(\)\.await[\s\S]*staged\.update\.install\(&staged\.bytes\)/,
+  );
   assert.match(desktopUpdater, /app\.restart\(\)/);
   assert.match(
     desktopUpdater,

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -14,6 +14,18 @@ const tauriConfig = JSON.parse(
     "utf8",
   ),
 );
+const desktopCargo = readFileSync(
+  new URL("../crates/openwave-desktop/Cargo.toml", import.meta.url),
+  "utf8",
+);
+const desktopHost = readFileSync(
+  new URL("../crates/openwave-desktop/src/lib.rs", import.meta.url),
+  "utf8",
+);
+const desktopUpdater = readFileSync(
+  new URL("../crates/openwave-desktop/src/updater.rs", import.meta.url),
+  "utf8",
+);
 const macosResourceSigner = readFileSync(
   new URL("./sign-macos-release-resources.sh", import.meta.url),
   "utf8",
@@ -292,4 +304,32 @@ test("the packaged updater trusts the production signing key and endpoint", () =
   assert.deepEqual(updater.endpoints, [
     "https://downloads.brightwave.io/openwave/latest.json",
   ]);
+});
+
+test("the packaged desktop activates the signed updater feed", () => {
+  assert.match(desktopCargo, /tauri-plugin-updater = "=[^"]+"/);
+  assert.match(
+    desktopHost,
+    /\.plugin\(tauri_plugin_updater::Builder::new\(\)\.build\(\)\)/,
+  );
+  assert.match(desktopHost, /\.manage\(updater::UpdateManager::default\(\)\)/);
+  assert.match(desktopHost, /updater::spawn_update_loop\(handle\.clone\(\)\)/);
+  assert.match(desktopHost, /updater::desktop_update_state/);
+  assert.match(desktopHost, /updater::check_for_update/);
+  assert.match(desktopHost, /updater::restart_for_update/);
+  assert.match(desktopUpdater, /updater\.check\(\)\.await/);
+  assert.match(desktopUpdater, /update\s*\.download_and_install/);
+  assert.match(desktopUpdater, /app\.restart\(\)/);
+  assert.match(
+    desktopUpdater,
+    /cfg!\(all\(not\(debug_assertions\), target_os = "macos"\)\)/,
+  );
+  assert.match(
+    desktopUpdater,
+    /const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs\(15\)/,
+  );
+  assert.match(
+    desktopUpdater,
+    /const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs\(5 \* 60\)/,
+  );
 });


### PR DESCRIPTION
## Summary
Adds a macOS-only Tauri update manager that checks the signed production feed, downloads updates in the background, and only relaunches after explicit confirmation.
Exposes update state through the React UI with a sidebar restart action and an Updates settings page for status and manual checks.
Adds host, UI, and release regression coverage and documents the bootstrap-release requirement.

## Testing
Validated with the repository Rust lint, desktop Clippy and formatting checks, UI tests and production build, and all release-policy tests.