### PR TITLE
feat(web-search): expose search to foreground agents

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -2114,9 +2114,20 @@ impl Agent {
             || ToolCtx::without_private_scratch(chat.id, chat.project_id),
             |scratch| ToolCtx::with_private_scratch(chat.id, chat.project_id, scratch.clone()),
         );
-        let mut output = match tool.execute(&ctx, parse_args(&call.args)).await {
-            Ok(output) => output,
-            Err(err) => ToolOutput::error(err.to_string()),
+        // `future::select` polls cancellation first. If it wins, dropping the
+        // unselected execution future propagates cancellation into async tools
+        // such as reqwest instead of leaving egress alive after the turn ends.
+        // Recheck after the execution arm wins to close a same-tick race.
+        let executing = tool.execute(&ctx, parse_args(&call.args));
+        let mut output = match future::select(self.cancel.cancelled(), executing).await {
+            Either::Left(((), _)) => ToolOutput::error("turn cancelled during tool execution"),
+            Either::Right((_, _)) if self.cancel.is_cancelled() => {
+                ToolOutput::error("turn cancelled during tool execution")
+            }
+            Either::Right((result, _)) => match result {
+                Ok(output) => output,
+                Err(err) => ToolOutput::error(err.to_string()),
+            },
         };
         if let Some(truncated) =
             truncate_to_bytes(&output.content, self.config.max_tool_result_bytes)
@@ -2623,7 +2634,7 @@ fn parse_client_args(raw: &str) -> Option<Value> {
 // The end-to-end test needs the SQLite store and the built-in tools.
 #[cfg(all(test, feature = "sqlite", feature = "tools"))]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     use async_trait::async_trait;
@@ -5059,6 +5070,67 @@ mod tests {
         (store, chat, workspace)
     }
 
+    struct ToolFutureDropMarker(Arc<AtomicBool>);
+
+    impl Drop for ToolFutureDropMarker {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    struct BlockingTool {
+        entered: Arc<tokio::sync::Notify>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Tool for BlockingTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: "blocking".into(),
+                description: "wait until the turn is cancelled".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::ReadOnly
+        }
+
+        async fn execute(&self, _ctx: &ToolCtx, _args: Value) -> Result<ToolOutput> {
+            let _drop = ToolFutureDropMarker(self.dropped.clone());
+            self.entered.notify_one();
+            future::pending().await
+        }
+    }
+
+    struct BlockingToolProvider;
+
+    #[async_trait]
+    impl ModelProvider for BlockingToolProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("blocking-tool")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            Ok(stream::iter(vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "blocking_1".into(),
+                    name: "blocking".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{}".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ])
+            .boxed())
+        }
+    }
+
     #[tokio::test]
     async fn cancel_before_the_turn_stops_before_any_model_call() {
         let (store, chat, _workspace) = cancel_test_chat().await;
@@ -5212,6 +5284,54 @@ mod tests {
             .map(|m| m.role)
             .collect();
         assert_eq!(roles, vec![Role::User]);
+    }
+
+    #[tokio::test]
+    async fn cancel_drops_an_in_flight_server_tool_future() {
+        let (store, chat, _workspace) = cancel_test_chat().await;
+        let cancel = CancelToken::new();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let dropped = Arc::new(AtomicBool::new(false));
+        let agent = Agent::new(
+            Arc::new(BlockingToolProvider),
+            Arc::new(ToolRegistry::new().with(Box::new(BlockingTool {
+                entered: entered.clone(),
+                dropped: dropped.clone(),
+            }))),
+            store,
+            AgentConfig {
+                model: "blocking-tool".into(),
+                ..Default::default()
+            },
+        )
+        .with_cancel(cancel.clone());
+
+        let (tx, rx) = unbounded();
+        let handle = tokio::spawn(async move {
+            agent.run_turn(&chat, "go", &tx).await.unwrap();
+        });
+
+        entered.notified().await;
+        cancel.cancel();
+        tokio::time::timeout(std::time::Duration::from_secs(1), handle)
+            .await
+            .expect("cancellation should stop an in-flight tool promptly")
+            .unwrap();
+        let events = rx.collect::<Vec<_>>().await;
+
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "cancellation must drop the tool future so its HTTP request can abort"
+        );
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::ToolCallCompleted { output, .. }
+                if output.is_error && output.content == "turn cancelled during tool execution"
+        )));
+        assert!(matches!(
+            events.last(),
+            Some(AgentEvent::TurnCancelled { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -20,8 +20,10 @@ use crate::tool::ToolSpec;
 pub const SPAWN_SANDBOX_AGENT_TOOL: &str = "spawn_sandbox_agent";
 /// Stable name for the prepared foreground-only multi-child wait tool.
 pub const WAIT_FOR_AGENTS_TOOL: &str = "wait_for_agents";
-/// Public-web tool a depth-one sandbox may receive.
-pub const SANDBOX_WEB_SEARCH_TOOL: &str = "web_search";
+/// Stable name for the provider-backed public-web search tool.
+pub const WEB_SEARCH_TOOL: &str = "web_search";
+/// Compatibility name for the same contract when checkpointed by a sandbox.
+pub const SANDBOX_WEB_SEARCH_TOOL: &str = WEB_SEARCH_TOOL;
 /// Stable name for the native-executed exact delegated file read.
 pub const SANDBOX_READ_DELEGATED_FILE_TOOL: &str = "read_delegated_file";
 
@@ -323,20 +325,20 @@ pub fn wait_for_agents_tool_spec() -> ToolSpec {
     }
 }
 
-/// Narrow, host-executed web-search contract for an isolated sandbox run.
+/// Narrow, host-executed web-search contract shared by trusted runtimes.
 ///
-/// This is deliberately not registered in the foreground tool registry. The
-/// sandbox worker checkpoints it under its own durable lease, and the host
-/// decides whether any configured provider may execute it.
+/// The provider-backed implementation belongs to `openwave-web-search`; core
+/// owns this schema because the sandbox checkpoint protocol must advertise the
+/// same closed arguments without depending on a network integration crate.
 #[must_use]
-pub fn sandbox_web_search_tool_spec() -> ToolSpec {
+pub fn web_search_tool_spec() -> ToolSpec {
     ToolSpec {
-        name: SANDBOX_WEB_SEARCH_TOOL.into(),
-        description: "Search the public web for current information. Use at most once, with a focused query. Results may be unavailable when the host has not configured web search.".into(),
+        name: WEB_SEARCH_TOOL.into(),
+        description: "Search the public web for current information. Use focused queries and cite sources with the exact result URLs. Results may be unavailable when the host has not configured web search.".into(),
         input_schema: serde_json::json!({
             "type": "object",
             "properties": {
-                "query": { "type": "string", "minLength": 1, "maxLength": 1024 },
+                "query": { "type": "string", "minLength": 1, "maxLength": 400 },
                 "max_results": { "type": "integer", "minimum": 1, "maximum": 10 },
                 "domains": { "type": "array", "items": { "type": "string" }, "maxItems": 20 },
                 "start_published_at": { "type": "string", "format": "date-time" },
@@ -346,6 +348,18 @@ pub fn sandbox_web_search_tool_spec() -> ToolSpec {
             "additionalProperties": false
         }),
     }
+}
+
+/// Sandbox-specific presentation of the shared web-search contract.
+///
+/// The checkpoint worker, not the ordinary tool registry, executes this
+/// definition under its own durable lease. The one-call instruction matches
+/// the sandbox state machine's admission bound.
+#[must_use]
+pub fn sandbox_web_search_tool_spec() -> ToolSpec {
+    let mut spec = web_search_tool_spec();
+    spec.description = "Search the public web for current information. Use at most once, with a focused query, and cite sources with the exact result URLs. Results may be unavailable when the host has not configured web search.".into();
+    spec
 }
 
 /// Native-executed contract for reading the exact file delegated at spawn.
@@ -578,6 +592,30 @@ mod tests {
         assert!(!validate_sandbox_read_delegated_file_arguments(
             &serde_json::Value::Null
         ));
+    }
+
+    #[test]
+    fn foreground_and_sandbox_web_search_share_one_bounded_schema() {
+        let foreground = web_search_tool_spec();
+        let sandbox = sandbox_web_search_tool_spec();
+
+        assert_eq!(foreground.name, WEB_SEARCH_TOOL);
+        assert_eq!(sandbox.input_schema, foreground.input_schema);
+        assert_eq!(
+            foreground.input_schema["properties"]["query"]["maxLength"],
+            400
+        );
+        assert_eq!(
+            foreground.input_schema["properties"]["max_results"]["maximum"],
+            10
+        );
+        assert_eq!(
+            foreground.input_schema["properties"]["domains"]["maxItems"],
+            20
+        );
+        assert_eq!(foreground.input_schema["additionalProperties"], false);
+        assert!(foreground.description.contains("exact result URLs"));
+        assert!(sandbox.description.contains("at most once"));
     }
 
     #[test]

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -73,6 +73,9 @@ pub enum ToolApprovalKind {
     /// A library search may share the query and matched excerpts with the
     /// provider.
     SearchMayShareQueryAndExcerpts,
+    /// A public-web search may share the query and explicit filters with the
+    /// host's configured provider.
+    WebSearchMayShareQuery,
     /// A command execution escapes the chat workspace and may reach the network.
     ExecMayRunNetworkedCommand,
     /// A Sensitive action with no presentable consent semantics: rejectable but
@@ -85,6 +88,7 @@ impl ToolApprovalKind {
     pub fn for_tool_name(name: &str) -> Self {
         match name {
             "search" => Self::SearchMayShareQueryAndExcerpts,
+            "web_search" => Self::WebSearchMayShareQuery,
             "exec" => Self::ExecMayRunNetworkedCommand,
             _ => Self::Unsupported,
         }
@@ -94,6 +98,11 @@ impl ToolApprovalKind {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::SearchMayShareQueryAndExcerpts => "search_may_share_query_and_excerpts",
+            // Existing databases constrain this column to the original closed
+            // search vocabulary. The exact tool name stored beside it
+            // disambiguates document search from web search on recovery, while
+            // serde still exposes the narrower renderer kind.
+            Self::WebSearchMayShareQuery => "search_may_share_query_and_excerpts",
             Self::ExecMayRunNetworkedCommand => "exec_may_run_networked_command",
             Self::Unsupported => "unsupported",
         }
@@ -103,7 +112,9 @@ impl ToolApprovalKind {
     pub const fn is_approvable(self) -> bool {
         matches!(
             self,
-            Self::SearchMayShareQueryAndExcerpts | Self::ExecMayRunNetworkedCommand
+            Self::SearchMayShareQueryAndExcerpts
+                | Self::WebSearchMayShareQuery
+                | Self::ExecMayRunNetworkedCommand
         )
     }
 }
@@ -459,6 +470,21 @@ mod standing_grant_tests {
         // `Unsupported`, so an approved escaping action stays approvable on
         // recovery.
         assert_eq!(kind.as_str(), "exec_may_run_networked_command");
+    }
+
+    #[test]
+    fn web_search_has_narrow_presentable_consent_semantics() {
+        let kind = ToolApprovalKind::for_tool_name("web_search");
+        assert_eq!(kind, ToolApprovalKind::WebSearchMayShareQuery);
+        assert!(kind.is_approvable());
+        assert_eq!(
+            serde_json::to_string(&kind).unwrap(),
+            "\"web_search_may_share_query\""
+        );
+        assert_eq!(
+            kind.as_str(),
+            ToolApprovalKind::SearchMayShareQueryAndExcerpts.as_str()
+        );
     }
 
     #[test]

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -456,8 +456,14 @@ fn approval_from_model(model: &entities::tool_call::Model) -> Result<ToolApprova
         }
     };
     let kind = match model.approval_kind.as_deref() {
+        Some("search_may_share_query_and_excerpts") if model.name == "web_search" => {
+            ToolApprovalKind::WebSearchMayShareQuery
+        }
         Some("search_may_share_query_and_excerpts") => {
             ToolApprovalKind::SearchMayShareQueryAndExcerpts
+        }
+        Some("web_search_may_share_query") if model.name == "web_search" => {
+            ToolApprovalKind::WebSearchMayShareQuery
         }
         Some("exec_may_run_networked_command") => ToolApprovalKind::ExecMayRunNetworkedCommand,
         Some("unsupported") => ToolApprovalKind::Unsupported,

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -56,10 +56,11 @@ pub use agent_tools::{
     sandbox_read_delegated_file_tool_spec, sandbox_web_search_tool_spec,
     spawn_sandbox_agent_tool_spec, validate_sandbox_read_delegated_file_arguments,
     validate_spawn_sandbox_agent_arguments, validate_wait_for_agents_arguments,
-    wait_for_agents_tool_spec, SandboxAgentFileResource, SpawnSandboxAgentArgs,
-    SpawnSandboxAgentResult, WaitForAgentResult, WaitForAgentsArgs, WaitForAgentsResult,
-    MAX_SANDBOX_AGENT_TASK_CHARS, MAX_WAIT_FOR_AGENTS_CHILDREN, SANDBOX_READ_DELEGATED_FILE_TOOL,
-    SANDBOX_WEB_SEARCH_TOOL, SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL,
+    wait_for_agents_tool_spec, web_search_tool_spec, SandboxAgentFileResource,
+    SpawnSandboxAgentArgs, SpawnSandboxAgentResult, WaitForAgentResult, WaitForAgentsArgs,
+    WaitForAgentsResult, MAX_SANDBOX_AGENT_TASK_CHARS, MAX_WAIT_FOR_AGENTS_CHILDREN,
+    SANDBOX_READ_DELEGATED_FILE_TOOL, SANDBOX_WEB_SEARCH_TOOL, SPAWN_SANDBOX_AGENT_TOOL,
+    WAIT_FOR_AGENTS_TOOL, WEB_SEARCH_TOOL,
 };
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -107,6 +107,11 @@ describe("ToolCallCard", () => {
         "Allow search to send your query and potentially matching document excerpts to configured AI services outside OpenWave?",
       canApprove: true,
     });
+    expect(toolApprovalPresentation("web_search_may_share_query")).toEqual({
+      summary:
+        "Allow web search to send this query and its explicit filters to the configured search provider outside OpenWave?",
+      canApprove: true,
+    });
     expect(
       toolApprovalPresentation("exec_may_run_networked_command"),
     ).toEqual({

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -183,6 +183,13 @@ export function toolApprovalPresentation(
       canApprove: true,
     };
   }
+  if (kind === "web_search_may_share_query") {
+    return {
+      summary:
+        "Allow web search to send this query and its explicit filters to the configured search provider outside OpenWave?",
+      canApprove: true,
+    };
+  }
   if (kind === "exec_may_run_networked_command") {
     return {
       summary:

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -147,6 +147,28 @@ describe("pending approval recovery", () => {
     ).toBeNull();
   });
 
+  it("recovers the narrow foreground web-search approval", () => {
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "web_search",
+        approval: "web_search_may_share_query",
+      }),
+    ).toMatchObject({
+      action: "web_search",
+      approval: "web_search_may_share_query",
+      canApprove: true,
+    });
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "web_search",
+        approval: "web_search_may_share_query",
+        can_approve: false,
+      }),
+    ).toBeNull();
+  });
+
   it("recognizes the fixed background wait name without accepting extensions", () => {
     expect(
       parsePendingToolApproval({

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -222,6 +222,7 @@ export type RendererToolName =
 
 export type RendererApprovalKind =
   | "search_may_share_query_and_excerpts"
+  | "web_search_may_share_query"
   | "exec_may_run_networked_command"
   | "unsupported";
 
@@ -229,6 +230,7 @@ export type RendererApprovalKind =
 export function isApprovableKind(kind: RendererApprovalKind): boolean {
   return (
     kind === "search_may_share_query_and_excerpts" ||
+    kind === "web_search_may_share_query" ||
     kind === "exec_may_run_networked_command"
   );
 }
@@ -721,6 +723,7 @@ function isRendererToolName(value: unknown): value is RendererToolName {
 function isRendererApprovalKind(value: unknown): value is RendererApprovalKind {
   return (
     value === "search_may_share_query_and_excerpts" ||
+    value === "web_search_may_share_query" ||
     value === "exec_may_run_networked_command" ||
     value === "unsupported"
   );

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -136,7 +136,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
   return (
     <SettingsPanel
       title="Web search"
-      description="Choose a local provider and a bounded request timeout. Existing keys are never shown here."
+      description="Choose the provider agents may use and bound every request. Existing keys are never shown here."
       busy={loading}
     >
       {loading ? (
@@ -249,8 +249,9 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
           )}
 
           <p className="text-sm leading-relaxed text-muted-foreground">
-            This configures host-owned search access only. Search is not yet a
-            chat tool in this build.
+            Foreground and background agents can request configured search.
+            Foreground requests ask for approval before the query leaves
+            OpenWave.
           </p>
         </>
       )}

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -332,6 +332,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn web_search_consent_kind_survives_durable_recovery() {
+        let (store, request) = setup("web_search").await;
+        assert_eq!(
+            request.kind,
+            openwave_core::ToolApprovalKind::WebSearchMayShareQuery
+        );
+        let first = ApprovalBroker::new(store.clone());
+        let pending = first.register(request.clone(), None).await;
+        drop(pending.decision);
+        let persisted = store
+            .get_tool_call_approval(request.call_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            persisted.kind,
+            openwave_core::ToolApprovalKind::WebSearchMayShareQuery
+        );
+
+        assert_eq!(
+            first
+                .resolve(request.chat_id, request.call_id, ApprovalDecision::Approve)
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+        assert_eq!(
+            ApprovalBroker::new(store)
+                .register(request, None)
+                .await
+                .decision
+                .await,
+            ApprovalDecision::Approve
+        );
+    }
+
+    #[tokio::test]
     async fn decisions_are_exact_and_idempotent() {
         let (store, request) = setup("search").await;
         let broker = ApprovalBroker::new(store);

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -323,6 +323,25 @@ mod tests {
     }
 
     #[test]
+    fn web_search_approval_projects_narrow_query_egress_kind() {
+        let projected = RendererSequencedEvent::from(&SequencedEvent {
+            seq: 8,
+            event: AgentEvent::ApprovalRequired {
+                call_id: CallId::new(),
+                tool_name: "web_search".into(),
+                class: ApprovalClass::Sensitive,
+                kind: ToolApprovalKind::WebSearchMayShareQuery,
+                summary: "private query and domain filters".into(),
+            },
+        });
+        let json = serde_json::to_string(&projected).unwrap();
+        assert!(json.contains(r#""action":"web_search""#));
+        assert!(json.contains(r#""approval":"web_search_may_share_query""#));
+        assert!(!json.contains("private query"));
+        assert!(!json.contains("domain filters"));
+    }
+
+    #[test]
     fn background_agent_tools_use_fixed_renderer_names() {
         for (name, expected) in [
             ("spawn_sandbox_agent", r#""name":"spawn_sandbox_agent""#),

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -56,7 +56,7 @@ use openwave_core::{
     request_folder_access_tool_spec, validate_list_connected_folders_arguments,
     validate_list_folder_arguments, validate_read_connected_file_arguments,
     validate_request_folder_access_arguments, AgentConfig, AgentError, Config,
-    KeychainSecretProvider, ListDir, Profile, ReadFile, Result, SecretProvider, Store,
+    KeychainSecretProvider, ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool,
     ToolRegistry, WriteFile,
 };
 use openwave_retrieval::{
@@ -465,7 +465,10 @@ async fn bind_inner(
     let resolver = Arc::new(KeyedResolver::new(store.clone(), secrets.clone()));
     let embedder = resolve_embedder(&*store, &*secrets).await;
     let vector_store = connect_vector_store(&config, embedder.dimensions()).await?;
-    let (retrieval, mut tools, agent_config) = agent_deps(embedder, vector_store);
+    let foreground_web_search =
+        Box::new(web_search::foreground_tool(store.clone(), secrets.clone()));
+    let (retrieval, mut tools, agent_config) =
+        agent_deps(embedder, vector_store, foreground_web_search);
     mcp_servers.mount(&mut tools).await?;
     let tools = Arc::new(tools);
     let state = match client_executor_id {
@@ -599,13 +602,15 @@ async fn bind_inner(
 fn agent_deps(
     embedder: Arc<dyn Embedder>,
     store: Arc<dyn VectorStore>,
+    web_search: Box<dyn Tool>,
 ) -> (Arc<Retriever>, ToolRegistry, AgentConfig) {
     let (retrieval, search) = build_retrieval(embedder, store);
     let mut tools = ToolRegistry::new()
         .with(Box::new(ReadFile))
         .with(Box::new(ListDir))
         .with(Box::new(WriteFile))
-        .with(search);
+        .with(search)
+        .with(web_search);
     tools.register_validated_client(
         request_folder_access_tool_spec(),
         validate_request_folder_access_arguments,

--- a/crates/openwave-server/src/sandbox_web_search_worker.rs
+++ b/crates/openwave-server/src/sandbox_web_search_worker.rs
@@ -1,28 +1,28 @@
 //! Durable execution of the one sandbox-safe web-search checkpoint.
 //!
-//! A model loop still has no advertised web-search tool. Only a durably
-//! accepted checkpoint can arrive here, where its exact executor lease is the
-//! authority for the bounded outbound operation.
+//! Only a durably accepted sandbox checkpoint can arrive here; foreground
+//! agents use the ordinary tool registry and approval path. The checkpoint's
+//! exact executor lease is the authority for this bounded outbound operation.
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+#[cfg(test)]
+use chrono::Utc;
 use openwave_core::{
     AgentError, ClaimSandboxToolCallOutcome, Result, SandboxToolCall, Store, ToolCallResolution,
 };
 use openwave_web_search::{
-    SearchDomain, WebSearchProvider, WebSearchRequest, WebSearchResponse, MAX_OUTPUT_BYTES,
+    request_from_tool_arguments, WebSearchProvider, WebSearchRequest, WebSearchResponse,
+    MAX_OUTPUT_BYTES,
 };
-use serde::Deserialize;
 use tokio::sync::Notify;
 
 use crate::state::SandboxAttemptGuard;
 use crate::web_search;
 
 const WEB_SEARCH_TOOL: &str = "web_search";
-const DEFAULT_MAX_RESULTS: usize = 5;
 const CANDIDATE_BATCH_SIZE: u64 = 16;
 const EGRESS_SAFETY_MARGIN: Duration = Duration::from_millis(250);
 
@@ -321,24 +321,6 @@ impl SandboxWebSearchWorker {
     }
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct WebSearchArguments {
-    query: String,
-    #[serde(default = "default_max_results")]
-    max_results: usize,
-    #[serde(default)]
-    domains: Vec<String>,
-    #[serde(default)]
-    start_published_at: Option<DateTime<Utc>>,
-    #[serde(default)]
-    end_published_at: Option<DateTime<Utc>>,
-}
-
-const fn default_max_results() -> usize {
-    DEFAULT_MAX_RESULTS
-}
-
 fn parse_web_search_request(
     call: &SandboxToolCall,
 ) -> std::result::Result<WebSearchRequest, ToolCallResolution> {
@@ -348,35 +330,12 @@ fn parse_web_search_request(
             "This sandbox tool is not available.",
         ));
     }
-    let arguments: WebSearchArguments =
-        serde_json::from_value(call.arguments.clone()).map_err(|_| {
-            failed_resolution(
-                "invalid_web_search_arguments",
-                "Web search arguments are invalid.",
-            )
-        })?;
-    let domains = arguments
-        .domains
-        .into_iter()
-        .map(SearchDomain::parse)
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|_| {
-            failed_resolution(
-                "invalid_web_search_arguments",
-                "Web search arguments are invalid.",
-            )
-        })?;
-    WebSearchRequest::new(arguments.query, arguments.max_results)
-        .and_then(|request| request.with_domains(domains))
-        .and_then(|request| {
-            request.with_published_between(arguments.start_published_at, arguments.end_published_at)
-        })
-        .map_err(|_| {
-            failed_resolution(
-                "invalid_web_search_arguments",
-                "Web search arguments are invalid.",
-            )
-        })
+    request_from_tool_arguments(call.arguments.clone()).map_err(|_| {
+        failed_resolution(
+            "invalid_web_search_arguments",
+            "Web search arguments are invalid.",
+        )
+    })
 }
 
 fn remaining_execution_time(remaining: chrono::Duration) -> Option<Duration> {
@@ -633,7 +592,7 @@ mod tests {
         );
         assert_eq!(
             provider.requests.lock().unwrap()[0].max_results,
-            DEFAULT_MAX_RESULTS
+            openwave_web_search::DEFAULT_MAX_RESULTS
         );
         let receipt = store
             .get_sandbox_tool_call_receipt(call.id)

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -6269,11 +6269,24 @@ async fn root_search_never_returns_project_owned_vectors() {
     assert!(results["citations"].as_array().unwrap().is_empty());
 }
 
-#[test]
-fn agent_deps_registers_server_tools_and_closed_foreground_orchestration() {
+#[tokio::test]
+async fn agent_deps_registers_server_tools_and_closed_foreground_orchestration() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("agent-deps.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
     let (_retrieval, tools, _config) = agent_deps(
         Arc::new(HashEmbedder::default()),
         Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+        Box::new(web_search::foreground_tool(
+            store,
+            Arc::new(MemSecrets::default()),
+        )),
     );
     let names: Vec<String> = tools.specs().into_iter().map(|s| s.name).collect();
     assert!(
@@ -6283,6 +6296,14 @@ fn agent_deps_registers_server_tools_and_closed_foreground_orchestration() {
     assert!(
         names.iter().any(|n| n == "read_file"),
         "file tools still present"
+    );
+    assert!(
+        names.iter().any(|n| n == "web_search"),
+        "foreground web search registered"
+    );
+    assert_eq!(
+        tools.get("web_search").unwrap().approval_class(),
+        ApprovalClass::Sensitive
     );
     assert!([
         openwave_core::SPAWN_SANDBOX_AGENT_TOOL,

--- a/crates/openwave-server/src/web_search.rs
+++ b/crates/openwave-server/src/web_search.rs
@@ -1,18 +1,18 @@
 //! Host-owned configuration and provider selection for web search.
 //!
-//! This module deliberately stops before model-tool registration or worker
-//! execution. A selected provider only becomes usable when a future host
-//! component explicitly asks [`resolve_provider`] for it. Provider endpoints
-//! are fixed in `openwave-web-search`; this config never accepts an endpoint,
-//! a secret reference, or a model-controlled network target.
+//! A selected provider becomes usable only when the sandbox worker or approved
+//! foreground tool explicitly asks [`resolve_provider`] for it. Provider
+//! endpoints are fixed in `openwave-web-search`; this config never accepts an
+//! endpoint, a secret reference, or a model-controlled network target.
 
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use openwave_core::{Result, SecretProvider, Store};
 use openwave_web_search::{
     ExaProvider, ReqwestHttpClient, TavilyProvider, WebSearchCredentials, WebSearchProvider,
-    WebSearchProviderKind,
+    WebSearchProviderKind, WebSearchResolver, WebSearchResolverError, WebSearchTool,
 };
 use serde::{Deserialize, Serialize};
 
@@ -225,8 +225,8 @@ pub async fn update_config(
     config_info(store, secrets).await.map_err(Into::into)
 }
 
-/// Resolve the explicitly selected, credentialed provider for a future host
-/// worker. The returned provider is inert until its `search` method is called.
+/// Resolve the explicitly selected, credentialed provider for host execution.
+/// The returned provider is inert until its `search` method is called.
 ///
 /// Secret resolution failures are intentionally projected to one generic
 /// message so keychain implementation details cannot escape through logs or
@@ -259,6 +259,33 @@ pub async fn resolve_provider(
         ),
     };
     Ok(Some(provider))
+}
+
+struct HostWebSearchResolver {
+    store: Arc<dyn Store>,
+    secrets: Arc<dyn SecretProvider>,
+}
+
+#[async_trait]
+impl WebSearchResolver for HostWebSearchResolver {
+    async fn resolve(
+        &self,
+    ) -> std::result::Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError> {
+        resolve_provider(&*self.store, &*self.secrets)
+            .await
+            .map_err(|_| WebSearchResolverError)
+    }
+}
+
+/// Build the inert foreground tool over a live host configuration resolver.
+///
+/// The registry may keep this object for the server lifetime: each approved
+/// call rereads current settings and credentials before any outbound request.
+pub(crate) fn foreground_tool(
+    store: Arc<dyn Store>,
+    secrets: Arc<dyn SecretProvider>,
+) -> WebSearchTool {
+    WebSearchTool::new(Arc::new(HostWebSearchResolver { store, secrets }))
 }
 
 #[cfg(test)]

--- a/crates/openwave-web-search/src/lib.rs
+++ b/crates/openwave-web-search/src/lib.rs
@@ -4,8 +4,8 @@
 //! make network calls at construction time. A host explicitly resolves a
 //! provider's key from [`openwave_core::SecretProvider`], constructs an adapter,
 //! and calls [`WebSearchProvider::search`]. The concrete HTTP client binds each
-//! adapter to its provider's exact HTTPS domain before a sandbox worker can use
-//! it.
+//! adapter to its provider's exact HTTPS domain before any tool or worker can
+//! use it.
 //!
 //! The Exa and Tavily adapters use their public HTTP APIs through the small
 //! [`HttpClient`] seam; no vendor SDK is required. `ReqwestHttpClient` is opt-in
@@ -16,6 +16,7 @@ mod credentials;
 pub mod exa;
 mod http;
 pub mod tavily;
+mod tool;
 mod types;
 
 pub use credentials::{WebSearchCredential, WebSearchCredentials};
@@ -24,6 +25,10 @@ pub use exa::ExaProvider;
 pub use http::ReqwestHttpClient;
 pub use http::{HttpClient, HttpRequest, HttpResponse, MAX_HTTP_RESPONSE_BYTES};
 pub use tavily::TavilyProvider;
+pub use tool::{
+    request_from_tool_arguments, WebSearchResolver, WebSearchResolverError, WebSearchTool,
+    DEFAULT_MAX_RESULTS,
+};
 pub use types::{
     SearchDomain, WebSearchError, WebSearchProvider, WebSearchProviderKind, WebSearchRequest,
     WebSearchResponse, WebSearchResult, MAX_DOMAINS, MAX_OUTPUT_BYTES, MAX_OUTPUT_CHARS,

--- a/crates/openwave-web-search/src/tool.rs
+++ b/crates/openwave-web-search/src/tool.rs
@@ -1,0 +1,279 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use openwave_core::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
+use serde::Deserialize;
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::{SearchDomain, WebSearchError, WebSearchProvider, WebSearchRequest, MAX_OUTPUT_BYTES};
+
+/// Default result count when a model omits `max_results`.
+pub const DEFAULT_MAX_RESULTS: usize = 5;
+
+/// Opaque failure to resolve current host policy or credentials.
+///
+/// Configuration and secret-provider diagnostics must not enter model context.
+#[derive(Debug, Clone, Copy, Error)]
+#[error("web search resolver is unavailable")]
+pub struct WebSearchResolverError;
+
+/// Resolve the provider selected by current host policy without performing
+/// egress. Implementations may load settings and credentials on every call so
+/// configuration changes take effect without rebuilding the tool registry.
+#[async_trait]
+pub trait WebSearchResolver: Send + Sync {
+    async fn resolve(&self) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError>;
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WebSearchArguments {
+    query: String,
+    #[serde(default = "default_max_results")]
+    max_results: usize,
+    #[serde(default)]
+    domains: Vec<String>,
+    #[serde(default)]
+    start_published_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    end_published_at: Option<DateTime<Utc>>,
+}
+
+const fn default_max_results() -> usize {
+    DEFAULT_MAX_RESULTS
+}
+
+/// Decode and validate the one canonical model-facing argument shape.
+///
+/// This is shared by the ordinary foreground tool and the durable sandbox
+/// checkpoint worker so both execution paths enforce identical bounds.
+pub fn request_from_tool_arguments(arguments: Value) -> Result<WebSearchRequest, WebSearchError> {
+    let arguments: WebSearchArguments = serde_json::from_value(arguments)
+        .map_err(|_| WebSearchError::InvalidRequest("invalid tool arguments".into()))?;
+    let domains = arguments
+        .domains
+        .into_iter()
+        .map(SearchDomain::parse)
+        .collect::<Result<Vec<_>, _>>()?;
+    WebSearchRequest::new(arguments.query, arguments.max_results)?
+        .with_domains(domains)?
+        .with_published_between(arguments.start_published_at, arguments.end_published_at)
+}
+
+/// Provider-backed foreground web-search tool.
+///
+/// It is inert until an approved call reaches [`Tool::execute`], then resolves
+/// current host configuration and performs one bounded provider request.
+pub struct WebSearchTool {
+    resolver: Arc<dyn WebSearchResolver>,
+}
+
+impl WebSearchTool {
+    #[must_use]
+    pub fn new(resolver: Arc<dyn WebSearchResolver>) -> Self {
+        Self { resolver }
+    }
+}
+
+#[async_trait]
+impl Tool for WebSearchTool {
+    fn spec(&self) -> ToolSpec {
+        openwave_core::web_search_tool_spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> openwave_core::Result<ToolOutput> {
+        let request = match request_from_tool_arguments(args) {
+            Ok(request) => request,
+            Err(_) => return Ok(ToolOutput::error("Web search arguments are invalid.")),
+        };
+        let provider = match self.resolver.resolve().await {
+            Ok(Some(provider)) => provider,
+            Ok(None) => {
+                return Ok(ToolOutput::error(
+                    "Web search is not configured for this host.",
+                ))
+            }
+            Err(_) => return Ok(ToolOutput::error("Web search could not complete.")),
+        };
+        let response = match provider.search(request).await {
+            Ok(response) => response,
+            Err(_) => return Ok(ToolOutput::error("Web search could not complete.")),
+        };
+        let result = match serde_json::to_string(&response) {
+            Ok(result) if result.len() <= MAX_OUTPUT_BYTES => result,
+            Ok(_) | Err(_) => {
+                return Ok(ToolOutput::error(
+                    "Web search returned an invalid response.",
+                ))
+            }
+        };
+        Ok(ToolOutput::text(result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use openwave_core::{ChatId, Tool};
+
+    use super::*;
+    use crate::{WebSearchProviderKind, WebSearchResponse};
+
+    struct FakeResolver {
+        provider: Option<Arc<dyn WebSearchProvider>>,
+        fail: bool,
+    }
+
+    #[async_trait]
+    impl WebSearchResolver for FakeResolver {
+        async fn resolve(
+            &self,
+        ) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError> {
+            if self.fail {
+                Err(WebSearchResolverError)
+            } else {
+                Ok(self.provider.clone())
+            }
+        }
+    }
+
+    struct FakeProvider {
+        requests: Mutex<Vec<WebSearchRequest>>,
+        response: Result<WebSearchResponse, WebSearchError>,
+    }
+
+    #[async_trait]
+    impl WebSearchProvider for FakeProvider {
+        fn kind(&self) -> WebSearchProviderKind {
+            WebSearchProviderKind::Exa
+        }
+
+        async fn search(
+            &self,
+            request: WebSearchRequest,
+        ) -> Result<WebSearchResponse, WebSearchError> {
+            self.requests.lock().unwrap().push(request);
+            match &self.response {
+                Ok(response) => Ok(response.clone()),
+                Err(_) => Err(WebSearchError::Transport(
+                    "private provider diagnostic".into(),
+                )),
+            }
+        }
+    }
+
+    fn context() -> ToolCtx {
+        ToolCtx::without_private_scratch(ChatId::new(), None)
+    }
+
+    #[test]
+    fn shared_schema_matches_request_contract_bounds() {
+        let spec = openwave_core::web_search_tool_spec();
+        assert_eq!(spec.name, "web_search");
+        assert_eq!(
+            spec.input_schema["properties"]["query"]["maxLength"],
+            crate::MAX_QUERY_CHARS
+        );
+        assert_eq!(
+            spec.input_schema["properties"]["max_results"]["maximum"],
+            crate::MAX_RESULTS
+        );
+        assert_eq!(
+            spec.input_schema["properties"]["domains"]["maxItems"],
+            crate::MAX_DOMAINS
+        );
+        assert_eq!(spec.input_schema["additionalProperties"], false);
+    }
+
+    #[test]
+    fn arguments_are_strict_and_share_provider_validation() {
+        let request = request_from_tool_arguments(serde_json::json!({
+            "query": " current release ",
+            "domains": ["Example.com"],
+        }))
+        .unwrap();
+        assert_eq!(request.query, "current release");
+        assert_eq!(request.max_results, DEFAULT_MAX_RESULTS);
+        assert_eq!(request.domains[0].as_str(), "example.com");
+
+        for invalid in [
+            serde_json::json!({"query": "ok", "endpoint": "https://private.invalid"}),
+            serde_json::json!({"query": "ok", "max_results": 0}),
+            serde_json::json!({"query": "ok", "domains": ["*.example.com"]}),
+            serde_json::json!({"query": ""}),
+        ] {
+            assert!(request_from_tool_arguments(invalid).is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_is_sensitive_and_resolves_configuration_at_execution() {
+        let tool = WebSearchTool::new(Arc::new(FakeResolver {
+            provider: None,
+            fail: false,
+        }));
+        assert_eq!(tool.approval_class(), ApprovalClass::Sensitive);
+
+        let output = tool
+            .execute(&context(), serde_json::json!({"query": "OpenWave"}))
+            .await
+            .unwrap();
+        assert!(output.is_error);
+        assert_eq!(
+            output.content,
+            "Web search is not configured for this host."
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_returns_bounded_normalized_json_without_provider_diagnostics() {
+        let provider = Arc::new(FakeProvider {
+            requests: Mutex::new(Vec::new()),
+            response: Ok(WebSearchResponse::new(
+                WebSearchProviderKind::Exa,
+                Vec::new(),
+            )),
+        });
+        let tool = WebSearchTool::new(Arc::new(FakeResolver {
+            provider: Some(provider.clone()),
+            fail: false,
+        }));
+
+        let output = tool
+            .execute(
+                &context(),
+                serde_json::json!({"query": "OpenWave", "max_results": 3}),
+            )
+            .await
+            .unwrap();
+        assert!(!output.is_error);
+        assert!(output.content.len() <= MAX_OUTPUT_BYTES);
+        assert_eq!(
+            serde_json::from_str::<Value>(&output.content).unwrap(),
+            serde_json::json!({"provider": "exa", "results": []})
+        );
+        assert_eq!(provider.requests.lock().unwrap()[0].max_results, 3);
+
+        let failing = WebSearchTool::new(Arc::new(FakeResolver {
+            provider: Some(Arc::new(FakeProvider {
+                requests: Mutex::new(Vec::new()),
+                response: Err(WebSearchError::Transport("secret value".into())),
+            })),
+            fail: false,
+        }));
+        let output = failing
+            .execute(&context(), serde_json::json!({"query": "OpenWave"}))
+            .await
+            .unwrap();
+        assert_eq!(output.content, "Web search could not complete.");
+        assert!(!output.content.contains("secret"));
+        assert!(!output.content.contains("private provider"));
+    }
+}

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -119,21 +119,23 @@ revisions and Parse→Index jobs are coordinated by `openwave-core` and
 
 ## `openwave-web-search` — provider-neutral web search 🟢
 
-The bounded request/result contract and direct HTTP adapters for Exa and
-Tavily. It is intentionally separate from both the model loop and the tool
-registry: loading a credential or constructing an adapter performs no egress,
-and calling search requires an explicit host-owned HTTP client. API keys are
-resolved only through `SecretProvider` under fixed provider keys, never from a
-model argument or persisted tool-call payload. The optional `http` feature
-provides a timeout- and response-size-bounded `reqwest` client; hosts may supply
-their own proxy, allow-list, audit, or test client through the same seam.
+The bounded request/result contract, direct HTTP adapters for Exa and Tavily,
+strict model-argument decoder, and foreground `WebSearchTool`. It remains
+separate from the model loop: loading a credential, building the tool, or
+constructing an adapter performs no egress, and calling search requires an
+explicit host-owned resolver and HTTP client. API keys are resolved only
+through `SecretProvider` under fixed provider keys, never from a model argument
+or persisted tool-call payload. The optional `http` feature provides a timeout-
+and response-size-bounded `reqwest` client; hosts may supply their own proxy,
+allow-list, audit, or test client through the same seam.
 
 `openwave-server` owns an explicit disabled-by-default Exa/Tavily selection
 and bounded request timeout. Its depth-one sandbox loop may durably checkpoint
 the one fixed `web_search` contract, and the server worker resolves that exact
-checkpoint under a fenced lease. The foreground registry and recursive
-sandboxes never receive this contract. The concrete host client is bound to the
-selected provider's exact HTTPS API domain before credentials are attached;
+checkpoint under a fenced lease. The foreground registry mounts the crate's
+Sensitive tool over the same live resolver and durable approval boundary;
+recursive sandboxes remain unavailable. The concrete host client is bound to
+the selected provider's exact HTTPS API domain before credentials are attached;
 scheme, authority, explicit-port, or userinfo deviations fail before dispatch.
 
 **Depends on:** `openwave-core`.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,7 +7,7 @@ identity.
 
 ## What exists today
 
-The current foreground agent surface contains ten tools:
+The current foreground agent surface contains eleven tools:
 
 | Tool | Purpose | Execution boundary |
 | --- | --- | --- |
@@ -15,6 +15,7 @@ The current foreground agent surface contains ten tools:
 | `list_dir` | List a private-scratch directory | Server, read-only |
 | `write_file` | Atomically write private-scratch text | Server, workspace |
 | `search` | Search sources indexed for this exact conversation | Server, read-only |
+| `web_search` | Search the public web through the configured Exa or Tavily provider | Server, sensitive approval |
 | `request_folder_access` | Ask the trusted desktop host to connect another folder | Client continuation |
 | `list_connected_folders` | List roots already attached to this chat | Native client continuation |
 | `list_folder` | List one directory below an attached root | Native client continuation |
@@ -179,23 +180,24 @@ WebSearchTool
 └── optional durable web-document ingestion
 ```
 
-The first slice supplies the normalized bounded contract, fixed secret keys,
-and direct Exa/Tavily adapters through an injected HTTP seam. The server now
-also owns a disabled-by-default provider selection and a 1–60 second request
-timeout at `GET`/`PUT /web-search`. That setting has no endpoint or credential
-reference, returns only whether the selected fixed key is present, and does not
-construct or call a provider. It does **not** register `WebSearchTool` or grant
-any worker network access. Constructing an adapter is inert; only an explicit
-`search` call can send a request. A separate sandbox checkpoint executor now
-attaches the host policy only after claiming and revalidating an exact durable
-`web_search` checkpoint. Its strict argument contract rejects unknown fields,
-and unavailable/error cases resolve a bounded immutable failure receipt. The
-sandbox model loop may now emit the one fixed checkpoint, with a bounded
-argument collector and deterministic rejection of unknown, partial, or
-multiple calls. The foreground loop remains separate and does not receive this
-tool. The concrete host transport is bound to the selected provider's exact
-HTTPS API domain and rejects scheme, authority, explicit-port, or userinfo
-deviations before credentials can leave the process.
+The crate supplies the normalized bounded contract, fixed secret keys, direct
+Exa/Tavily adapters through an injected HTTP seam, strict tool-argument
+decoding, and the foreground `WebSearchTool`. The server owns a
+disabled-by-default provider selection and a 1–60 second request timeout at
+`GET`/`PUT /web-search`. That setting has no endpoint or credential reference,
+returns only whether the selected fixed key is present, and does not construct
+or call a provider.
+
+The foreground registry advertises `web_search` as Sensitive. A call is
+persisted, durably approved for sharing the query and explicit filters, and
+only then resolves current host policy and credentials. Turn cancellation drops
+an in-flight tool future, aborting its HTTP request. The sandbox path remains a
+separate checkpoint executor: it attaches host policy only after claiming and
+revalidating an exact durable `web_search` checkpoint. Both paths share the
+same strict decoder, so unknown fields and out-of-range requests fail before
+egress. The concrete transport is bound to the selected provider's exact HTTPS
+API domain and rejects scheme, authority, explicit-port, or userinfo deviations
+before credentials can leave the process.
 
 The normalized contract should cover query text, optional date/domain filters,
 bounded result count, canonical URL, title, snippet or extracted text, rank or

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -1,9 +1,10 @@
 # Web search configuration
 
 OpenWave has a bounded `openwave-web-search` library for direct Exa and Tavily
-search. It is intentionally separate from the model tool registry and agent
-workers. At this stage, configuring web search does not give an agent network
-access and does not cause any outbound request.
+search. The crate owns the provider-neutral request/result contract, HTTP
+adapters, and foreground `WebSearchTool`; the server supplies current host
+policy and credentials through a resolver. Configuration alone performs no
+outbound request.
 
 ## Local API
 
@@ -55,13 +56,21 @@ selection are deliberately separate actions, matching the API boundary above.
 ## Current boundary
 
 `openwave-server::web_search::resolve_provider` is the host-only construction
-seam. It is inert until a caller invokes `search`; no route invokes it. The
-server's sandbox checkpoint executor may invoke it only after it has claimed a
-persisted `web_search` checkpoint. It resolves host settings and credentials,
-then revalidates the exact lease, cancellation state, and run deadline with the
-database clock immediately before calling the provider. It keeps its local
-execution timeout below that database-derived lease budget and resolves one
-immutable receipt.
+seam. It is inert until a caller invokes `search`; no route invokes it.
+Foreground agents receive a Sensitive `web_search` tool. Each exact call is
+persisted and parked on the durable approval gate before execution; renderer
+copy describes only that the query and explicit filters will leave OpenWave,
+without exposing model-authored arguments. Approval resolves the provider from
+current settings, so enabling, disabling, or changing providers takes effect
+without rebuilding the registry. Cancelling the turn races and drops an
+in-flight tool future, which aborts the underlying HTTP request.
+
+The server's sandbox checkpoint executor invokes the same resolver and strict
+argument decoder only after it has claimed a persisted `web_search`
+checkpoint. It then revalidates the exact lease, cancellation state, and run
+deadline with the database clock immediately before calling the provider. It
+keeps its local execution timeout below that database-derived lease budget and
+resolves one immutable receipt.
 
 Malformed arguments, disabled selection, missing credentials, provider failure,
 timeout, and invalid output resolve a bounded redacted
@@ -69,8 +78,9 @@ failure receipt rather than leaving a sandbox waiting. The depth-one sandbox
 model loop may advertise only this fixed `web_search` schema, at most once and
 only when two model steps remain. It parks the immutable call before any
 egress; when the receipt resolves, its next claim rebuilds the same
-`ToolUse`/`ToolResult` pair and may finalize. No foreground or recursive agent
-receives the schema. The concrete transport enforces an exact HTTPS
+`ToolUse`/`ToolResult` pair and may finalize. Sandbox checkpoint authority does
+not cross into the foreground registry: that path uses the ordinary durable
+tool-call and approval state machine, while recursive agents remain impossible.
+The concrete transport enforces an exact HTTPS
 outbound-domain policy (`api.exa.ai` for Exa and `api.tavily.com` for Tavily)
-outside model-controlled arguments. Broader search surfaces still require
-their own approval and outbound policy.
+outside model-controlled arguments.


### PR DESCRIPTION
## Summary
- add the provider-backed `WebSearchTool` to `openwave-web-search` and mount it in the foreground registry over live host configuration
- park every foreground query behind durable, renderer-safe consent and abort in-flight tool work when a turn is cancelled
- share strict argument decoding with sandbox checkpoints and update desktop approval/settings UI plus architecture docs

## Validation
- `cargo test -p openwave-web-search --all-features --locked`
- `cargo test -p openwave-core --locked`
- `cargo test -p openwave-server --locked --no-default-features`
- `pnpm test -- ToolCallCard.test.tsx api.test.ts` (168 tests)
- `pnpm build`
- `bw dev lint --rust --check --repo-root /Users/thet/conductor/workspaces/openwave/porto-novo`
- strict no-deps Clippy for `openwave-core`, `openwave-web-search`, and reduced-feature `openwave-server`

Closes #375