### PR TITLE
refactor(desktop): extract the chat event reducer into a pure module

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -48,19 +48,19 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
-import {
-  toolApprovalPresentation,
-  type ToolCallStatus,
-} from "./ToolCallCard";
 import { useChatEventStream } from "./ChatEventStream";
 import { isNearBottom, scrollToLatest } from "./ChatScroll";
 import { DocumentsView } from "./DocumentsView";
-import {
-  reconcilePendingApprovalCards,
-  upsertPendingApprovalCard,
-} from "./ApprovalHistory";
+import { reconcilePendingApprovalCards } from "./ApprovalHistory";
 import { loadChatApprovalHydration } from "./ChatApprovalHydration";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
+import {
+  applyTerminalHydration,
+  initialChatSessionState,
+  reduceChatSessionEvent,
+  type ChatSessionEffect,
+  type ChatSessionState,
+} from "./ChatSessionReducer";
 import {
   ActiveTurnSteerFence,
   canBeginActiveTurnSteer,
@@ -71,7 +71,6 @@ import {
   presentChatTranscript,
 } from "./ChatTranscriptPresentation";
 import { AgentActivityPanel, agentRunsForChat } from "./AgentActivityPanel";
-import { shouldRefreshAgentRunsAfterToolEvent } from "./AgentRunRefresh";
 import {
   SandboxAgentStopFence,
   canStopSandboxAgentRun,
@@ -90,6 +89,11 @@ function nextId(): string {
   msgSeq += 1;
   return `m${msgSeq}`;
 }
+
+const sessionDeps = {
+  nextId,
+  now: () => new Date().toISOString(),
+};
 
 export default function App() {
   const [bootError, setBootError] = useState<string | null>(null);
@@ -154,12 +158,11 @@ export default function App() {
   const socketRef = useRef<WebSocket | null>(null);
   const socketGenerationRef = useRef(0);
   const chatSelectionRef = useRef(0);
-  const hydratedMessageIdsRef = useRef<Set<string>>(new Set());
+  // The chat session's live state machine. `sessionRef` is the source of
+  // truth; React state (`messages`, `busy`, `activeTurnId`) and the two
+  // mirrors below are projections refreshed by `commitSession`.
+  const sessionRef = useRef<ChatSessionState>(initialChatSessionState());
   const lastSeqRef = useRef(0);
-  const assistantBufRef = useRef("");
-  const assistantMarkerScrubberRef = useRef(
-    new AssistantSourceMarkerStreamScrubber(),
-  );
   const terminalHydrationGenerationRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const followsLatestRef = useRef(true);
@@ -174,7 +177,6 @@ export default function App() {
   const selectedChatIdRef = useRef<string | null>(null);
   const steerFenceRef = useRef(new ActiveTurnSteerFence());
   const sandboxStopFenceRef = useRef(new SandboxAgentStopFence());
-  const provisionalToolCallIdsRef = useRef<Set<string>>(new Set());
   const creationInFlightRef = useRef(false);
   const deletionInFlightRef = useRef(false);
   const { confirm, dialog: confirmDialog } = useConfirm();
@@ -236,8 +238,11 @@ export default function App() {
     let cancelled = false;
     const selection = chatSelectionRef.current;
     setHydratedChatId(null);
-    setMessages([]);
-    hydratedMessageIdsRef.current = new Set();
+    updateSession((session) => ({
+      ...session,
+      messages: [],
+      hydratedMessageIds: new Set(),
+    }));
     (async () => {
       try {
         const hydration = await loadChatApprovalHydration(
@@ -247,26 +252,33 @@ export default function App() {
         );
         if (!hydration) return;
         const { transcript, pendingApprovals } = hydration;
-        lastSeqRef.current = transcript.last_event_seq;
         const presented = presentChatTranscript(transcript);
-        hydratedMessageIdsRef.current = presented.messageIds;
-        setMessages(
-          reconcilePendingApprovalCards(presented.messages, pendingApprovals),
-        );
         const pendingTurnId = pendingApprovals[0]?.turnId ?? null;
-        setCurrentActiveTurnId(pendingTurnId);
-        setBusy(pendingTurnId !== null);
+        updateSession((session) => ({
+          ...session,
+          lastSeq: transcript.last_event_seq,
+          hydratedMessageIds: presented.messageIds,
+          messages: reconcilePendingApprovalCards(
+            presented.messages,
+            pendingApprovals,
+          ),
+          activeTurnId: pendingTurnId,
+          busy: pendingTurnId !== null,
+        }));
         setHydratedChatId(chat.id);
       } catch (err) {
         if (!cancelled && selection === chatSelectionRef.current) {
-          setBusy(true);
-          setMessages([
-            {
-              id: nextId(),
-              role: "error",
-              text: `Could not load this chat: ${String(err)}`,
-            },
-          ]);
+          updateSession((session) => ({
+            ...session,
+            busy: true,
+            messages: [
+              {
+                id: nextId(),
+                role: "error",
+                text: `Could not load this chat: ${String(err)}`,
+              },
+            ],
+          }));
         }
       }
     })();
@@ -461,228 +473,61 @@ export default function App() {
     }
   }, [folderAccessRequests]);
 
-  function handleEvent(framed: SequencedEvent) {
-    if (framed.seq <= lastSeqRef.current) return;
-    lastSeqRef.current = framed.seq;
-    const event = framed.event;
-
-    if (shouldRefreshAgentRunsAfterToolEvent(event)) {
-      refreshAgentRunsRef.current?.();
-    }
-
-    if (event.type === "turn_started") {
-      const startsDifferentTurn = activeTurnIdRef.current !== event.turn_id;
-      refreshAgentRunsRef.current?.();
-      terminalHydrationGenerationRef.current += 1;
-      assistantBufRef.current = "";
-      assistantMarkerScrubberRef.current =
-        new AssistantSourceMarkerStreamScrubber();
-      provisionalToolCallIdsRef.current = new Set();
-      setBusy(true);
-      setCurrentActiveTurnId(event.turn_id);
-      setCancelPendingTurnId(null);
-      setCancelError(null);
-      cancelRequestTurnRef.current = null;
-      if (startsDifferentTurn) clearSteerRequestState();
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: nextId(),
-          role: "assistant",
-          text: "",
-          sources: [],
-          createdAt: new Date().toISOString(),
-        },
-      ]);
-      return;
-    }
-
-    if (event.type === "text_delta") {
-      assistantBufRef.current += assistantMarkerScrubberRef.current.push(
-        event.text,
-      );
-      const text = assistantBufRef.current;
-      setMessages((prev) => {
-        const copy = [...prev];
-        const last = copy[copy.length - 1];
-        if (last?.role === "assistant") {
-          copy[copy.length - 1] = { ...last, text };
-        } else {
-          copy.push({
-            id: nextId(),
-            role: "assistant",
-            text,
-            sources: [],
-            createdAt: new Date().toISOString(),
-          });
-        }
-        return copy;
-      });
-      return;
-    }
-
-    if (event.type === "stream_interrupted") {
-      // The whole optimistic candidate is invalidated at this boundary. Finish
-      // clears any withheld marker-like tail before the replacement starts.
-      assistantMarkerScrubberRef.current.finish();
-      assistantBufRef.current = "";
-      const provisionalCallIds = provisionalToolCallIdsRef.current;
-      provisionalToolCallIdsRef.current = new Set();
-      setMessages((prev) => {
-        const copy = discardToolCalls(prev, provisionalCallIds);
-        if (copy[copy.length - 1]?.role === "assistant") {
-          copy.pop();
-        }
-        return copy;
-      });
-      return;
-    }
-
-    if (event.type === "tool_call_started") {
-      flushAssistantMarkerTail();
-      if (provisionalToolCallIdsRef.current.size === 0) {
-        assistantBufRef.current = "";
-        assistantMarkerScrubberRef.current =
-          new AssistantSourceMarkerStreamScrubber();
-      }
-      if (event.name === "request_folder_access") {
-        refreshFolderAccessRef.current?.();
-      }
-      provisionalToolCallIdsRef.current.add(event.call_id);
-      setMessages((prev) =>
-        upsertToolCall(prev, event.call_id, event.name, "running"),
-      );
-      return;
-    }
-
-    if (event.type === "tool_call_args_delta") {
-      // Arguments are intentionally not retained in renderer state. They can
-      // contain paths, file content, credentials, or provider-specific data.
-      setMessages((prev) =>
-        updateToolCall(prev, event.call_id, (tool) => ({
-          ...tool,
-          status: tool.status === "waiting_approval" ? tool.status : "running",
-        })),
-      );
-      return;
-    }
-
-    if (event.type === "approval_required") {
-      const approval = toolApprovalPresentation(event.approval);
-      provisionalToolCallIdsRef.current.delete(event.call_id);
-      setMessages((prev) =>
-        upsertPendingApprovalCard(prev, {
-          callId: event.call_id,
-          action: event.action,
-          approval: event.approval,
-          canApprove: approval.canApprove,
-        }),
-      );
-      return;
-    }
-
-    if (event.type === "approval_decided") {
-      setMessages((prev) =>
-        updateApprovalAndToolCall(prev, event.call_id, event.approved),
-      );
-      return;
-    }
-
-    if (event.type === "tool_call_completed") {
-      provisionalToolCallIdsRef.current.delete(event.call_id);
-      setMessages((prev) =>
-        updateToolCall(prev, event.call_id, (tool) => ({
-          ...tool,
-          status:
-            tool.status === "cancelled"
-              ? "cancelled"
-              : event.status === "failed"
-                ? "failed"
-                : "completed",
-        })),
-      );
-      return;
-    }
-
-    if (event.type === "user_steered") {
-      if (hydratedMessageIdsRef.current.has(event.message_id)) return;
-      hydratedMessageIdsRef.current.add(event.message_id);
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: event.message_id,
-          role: "user",
-          text: event.text,
-          createdAt: new Date().toISOString(),
-        },
-      ]);
-      return;
-    }
-
-    if (event.type === "turn_completed") {
-      flushAssistantMarkerTail();
-      provisionalToolCallIdsRef.current = new Set();
-      resolveActiveTurn();
-      refreshAgentRunsRef.current?.();
-      const selection = chatSelectionRef.current;
-      const generation = ++terminalHydrationGenerationRef.current;
-      if (chat) {
-        void refreshTerminalTranscript(chat.id, selection, generation);
-      }
-      return;
-    }
-
-    if (event.type === "turn_cancelled") {
-      flushAssistantMarkerTail();
-      terminalHydrationGenerationRef.current += 1;
-      provisionalToolCallIdsRef.current = new Set();
-      resolveActiveTurn();
-      refreshAgentRunsRef.current?.();
-      setMessages((prev) => [
-        ...settleActiveToolCalls(prev, "cancelled"),
-        { id: nextId(), role: "system", text: "turn cancelled" },
-      ]);
-      return;
-    }
-
-    if (event.type === "turn_failed") {
-      flushAssistantMarkerTail();
-      terminalHydrationGenerationRef.current += 1;
-      provisionalToolCallIdsRef.current = new Set();
-      resolveActiveTurn();
-      refreshAgentRunsRef.current?.();
-      setMessages((prev) => [
-        ...settleActiveToolCalls(prev, "failed"),
-        {
-          id: nextId(),
-          role: "error",
-          text: "The turn could not be completed.",
-        },
-      ]);
-    }
+  function commitSession(next: ChatSessionState) {
+    sessionRef.current = next;
+    lastSeqRef.current = next.lastSeq;
+    activeTurnIdRef.current = next.activeTurnId;
+    setMessages(next.messages);
+    setBusy(next.busy);
+    setActiveTurnId(next.activeTurnId);
   }
 
-  function flushAssistantMarkerTail() {
-    const tail = assistantMarkerScrubberRef.current.finish();
-    if (!tail) return;
-    assistantBufRef.current += tail;
-    const text = assistantBufRef.current;
-    setMessages((previous) => {
-      const copy = [...previous];
-      const last = copy[copy.length - 1];
-      if (last?.role === "assistant") {
-        copy[copy.length - 1] = { ...last, text };
-      } else {
-        copy.push({
-          id: nextId(),
-          role: "assistant",
-          text,
-          sources: [],
-          createdAt: new Date().toISOString(),
-        });
+  function updateSession(update: (state: ChatSessionState) => ChatSessionState) {
+    commitSession(update(sessionRef.current));
+  }
+
+  function handleEvent(framed: SequencedEvent) {
+    const { state, effects } = reduceChatSessionEvent(
+      sessionRef.current,
+      framed,
+      sessionDeps,
+    );
+    commitSession(state);
+    for (const effect of effects) applySessionEffect(effect);
+  }
+
+  function applySessionEffect(effect: ChatSessionEffect) {
+    switch (effect.type) {
+      case "refresh_agent_runs":
+        refreshAgentRunsRef.current?.();
+        return;
+      case "refresh_folder_access":
+        refreshFolderAccessRef.current?.();
+        return;
+      case "turn_began":
+        setCancelPendingTurnId(null);
+        setCancelError(null);
+        cancelRequestTurnRef.current = null;
+        if (effect.startsDifferentTurn) clearSteerRequestState();
+        return;
+      case "turn_resolved":
+        setCancelPendingTurnId(null);
+        setCancelError(null);
+        cancelRequestTurnRef.current = null;
+        clearSteerRequestState();
+        return;
+      case "invalidate_terminal_hydration":
+        terminalHydrationGenerationRef.current += 1;
+        return;
+      case "hydrate_terminal_transcript": {
+        const selection = chatSelectionRef.current;
+        const generation = ++terminalHydrationGenerationRef.current;
+        if (chat) {
+          void refreshTerminalTranscript(chat.id, selection, generation);
+        }
+        return;
       }
-      return copy;
-    });
+    }
   }
 
   async function refreshTerminalTranscript(
@@ -700,12 +545,7 @@ export default function App() {
           terminalHydrationGenerationRef.current === generation,
       );
       if (!presented) return;
-      lastSeqRef.current = Math.max(
-        lastSeqRef.current,
-        presented.lastEventSeq,
-      );
-      hydratedMessageIdsRef.current = presented.messageIds;
-      setMessages(presented.messages);
+      updateSession((session) => applyTerminalHydration(session, presented));
     } catch {
       // The scrubbed optimistic response remains safe and visible. Reopening
       // the conversation will load a fresh authoritative snapshot.
@@ -713,17 +553,15 @@ export default function App() {
   }
 
   function resolveActiveTurn() {
-    setBusy(false);
-    setCurrentActiveTurnId(null);
+    updateSession((session) => ({
+      ...session,
+      busy: false,
+      activeTurnId: null,
+    }));
     setCancelPendingTurnId(null);
     setCancelError(null);
     cancelRequestTurnRef.current = null;
     clearSteerRequestState();
-  }
-
-  function setCurrentActiveTurnId(turnId: string | null) {
-    activeTurnIdRef.current = turnId;
-    setActiveTurnId(turnId);
   }
 
   function setComposerDraft(nextDraft: string) {
@@ -762,17 +600,20 @@ export default function App() {
     const turnId = crypto.randomUUID();
     terminalHydrationGenerationRef.current += 1;
     setComposerDraft("");
-    setMessages((prev) => [
-      ...prev,
-      {
-        id: nextId(),
-        role: "user",
-        text: content,
-        createdAt: new Date().toISOString(),
-      },
-    ]);
-    setBusy(true);
-    setCurrentActiveTurnId(turnId);
+    updateSession((session) => ({
+      ...session,
+      busy: true,
+      activeTurnId: turnId,
+      messages: [
+        ...session.messages,
+        {
+          id: nextId(),
+          role: "user",
+          text: content,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    }));
     setCancelPendingTurnId(null);
     setCancelError(null);
     try {
@@ -782,10 +623,13 @@ export default function App() {
     } catch (err) {
       if (chatSelectionRef.current !== selection) return;
       resolveActiveTurn();
-      setMessages((prev) => [
-        ...prev,
-        { id: nextId(), role: "error", text: String(err) },
-      ]);
+      updateSession((session) => ({
+        ...session,
+        messages: [
+          ...session.messages,
+          { id: nextId(), role: "error", text: String(err) },
+        ],
+      }));
     }
   }
 
@@ -905,14 +749,17 @@ export default function App() {
       );
       openCreatedChat(created);
     } catch (err) {
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: nextId(),
-          role: "error",
-          text: `Could not create a chat: ${String(err)}`,
-        },
-      ]);
+      updateSession((session) => ({
+        ...session,
+        messages: [
+          ...session.messages,
+          {
+            id: nextId(),
+            role: "error",
+            text: `Could not create a chat: ${String(err)}`,
+          },
+        ],
+      }));
     } finally {
       creationInFlightRef.current = false;
       setCreatingChat(false);
@@ -924,15 +771,9 @@ export default function App() {
     socketGenerationRef.current += 1;
     socketRef.current?.close();
     socketRef.current = null;
-    assistantBufRef.current = "";
-    assistantMarkerScrubberRef.current =
-      new AssistantSourceMarkerStreamScrubber();
-    provisionalToolCallIdsRef.current = new Set();
-    lastSeqRef.current = 0;
+    commitSession(initialChatSessionState());
     followsLatestRef.current = true;
     setHasUnreadActivity(false);
-    setMessages([]);
-    hydratedMessageIdsRef.current = new Set();
     setAgentRuns([]);
     setAgentRunsError(null);
     setFolderAccessRequests([]);
@@ -941,8 +782,6 @@ export default function App() {
     setDecidingApprovalCalls(new Set());
     setApprovalErrors({});
     setComposerDraft("");
-    setBusy(false);
-    setCurrentActiveTurnId(null);
     setCancelPendingTurnId(null);
     setCancelError(null);
     cancelRequestTurnRef.current = null;
@@ -1007,8 +846,10 @@ export default function App() {
     sandboxStopFenceRef.current.invalidate();
     setStoppingSandboxRunKeys(new Set());
     setSandboxStopErrorKeys(new Set());
-    assistantMarkerScrubberRef.current =
-      new AssistantSourceMarkerStreamScrubber();
+    updateSession((session) => ({
+      ...session,
+      markerScrubber: new AssistantSourceMarkerStreamScrubber(),
+    }));
     setChat(next);
   }
 
@@ -1025,14 +866,9 @@ export default function App() {
     socketGenerationRef.current += 1;
     socketRef.current?.close();
     socketRef.current = null;
-    assistantBufRef.current = "";
-    assistantMarkerScrubberRef.current =
-      new AssistantSourceMarkerStreamScrubber();
-    lastSeqRef.current = 0;
+    commitSession(initialChatSessionState());
     followsLatestRef.current = true;
     setHasUnreadActivity(false);
-    setMessages([]);
-    hydratedMessageIdsRef.current = new Set();
     setAgentRuns([]);
     setAgentRunsError(null);
     setFolderAccessRequests([]);
@@ -1041,8 +877,6 @@ export default function App() {
     setDecidingApprovalCalls(new Set());
     setApprovalErrors({});
     setComposerDraft("");
-    setBusy(false);
-    setCurrentActiveTurnId(null);
     setCancelPendingTurnId(null);
     setCancelError(null);
     cancelRequestTurnRef.current = null;
@@ -1156,13 +990,14 @@ export default function App() {
     });
     try {
       await client.decideApproval(chat.id, callId, decision, remember);
-      setMessages((prev) =>
-        prev.map((m) =>
+      updateSession((session) => ({
+        ...session,
+        messages: session.messages.map((m) =>
           m.role === "approval" && m.callId === callId
             ? { ...m, resolved: true }
             : m,
         ),
-      );
+      }));
     } catch (err) {
       setApprovalErrors((errors) => ({
         ...errors,
@@ -1610,82 +1445,6 @@ export default function App() {
         )}
       </div>
     </div>
-  );
-}
-
-function upsertToolCall(
-  messages: Msg[],
-  callId: string,
-  name: string,
-  status: ToolCallStatus,
-): Msg[] {
-  const existing = messages.findIndex(
-    (message) => message.role === "tool" && message.callId === callId,
-  );
-  if (existing >= 0) {
-    return messages.map((message, index) =>
-      index === existing && message.role === "tool" ? { ...message, status } : message,
-    );
-  }
-  return [...messages, { id: nextId(), role: "tool", callId, name, status }];
-}
-
-function updateToolCall(
-  messages: Msg[],
-  callId: string,
-  update: (tool: Extract<Msg, { role: "tool" }>) => Extract<Msg, { role: "tool" }>,
-): Msg[] {
-  return messages.map((message) =>
-    message.role === "tool" && message.callId === callId ? update(message) : message,
-  );
-}
-
-function updateApprovalAndToolCall(
-  messages: Msg[],
-  callId: string,
-  approved: boolean,
-): Msg[] {
-  return messages.map((message) => {
-    if (message.role === "approval" && message.callId === callId) {
-      return { ...message, resolved: true };
-    }
-    if (message.role === "tool" && message.callId === callId) {
-      return {
-        ...message,
-        status: approved ? "running" : "cancelled",
-      };
-    }
-    return message;
-  });
-}
-
-function settleActiveToolCalls(
-  messages: Msg[],
-  status: Extract<ToolCallStatus, "failed" | "cancelled">,
-): Msg[] {
-  const activeCallIds = new Set(
-    messages.flatMap((message) =>
-      message.role === "tool" &&
-      (message.status === "running" || message.status === "waiting_approval")
-        ? [message.callId]
-        : [],
-    ),
-  );
-  return messages.map((message) =>
-    message.role === "tool" &&
-    (message.status === "running" || message.status === "waiting_approval")
-      ? { ...message, status }
-      : message.role === "approval" &&
-          !message.resolved &&
-          activeCallIds.has(message.callId)
-        ? { ...message, resolved: true }
-      : message,
-  );
-}
-
-function discardToolCalls(messages: Msg[], callIds: Set<string>): Msg[] {
-  return messages.filter(
-    (message) => message.role !== "tool" || !callIds.has(message.callId),
   );
 }
 

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -1,0 +1,426 @@
+import { describe, expect, it } from "vitest";
+import type { AgentEvent, SequencedEvent } from "./api";
+import {
+  applyTerminalHydration,
+  initialChatSessionState,
+  reduceChatSessionEvent,
+  type ChatSessionDeps,
+  type ChatSessionState,
+  type ChatSessionTransition,
+} from "./ChatSessionReducer";
+import type { ChatMessage } from "./MessageList";
+
+const NOW = "2026-07-23T12:00:00.000Z";
+
+function makeDeps(): ChatSessionDeps {
+  let seq = 0;
+  return {
+    nextId: () => `t${++seq}`,
+    now: () => NOW,
+  };
+}
+
+/** Feed events in order, auto-assigning increasing seqs. */
+function play(
+  events: AgentEvent[],
+  state: ChatSessionState = initialChatSessionState(),
+  deps: ChatSessionDeps = makeDeps(),
+): ChatSessionTransition {
+  let transition: ChatSessionTransition = { state, effects: [] };
+  events.forEach((event, index) => {
+    transition = reduceChatSessionEvent(
+      transition.state,
+      { seq: state.lastSeq + index + 1, event },
+      deps,
+    );
+  });
+  return transition;
+}
+
+function framed(seq: number, event: AgentEvent): SequencedEvent {
+  return { seq, event };
+}
+
+const TURN: AgentEvent = { type: "turn_started", turn_id: "turn-1" };
+
+describe("seq cursor", () => {
+  it("ignores duplicate and stale events entirely", () => {
+    const deps = makeDeps();
+    const { state } = play([TURN, { type: "text_delta", text: "Hello" }]);
+    const replay = reduceChatSessionEvent(
+      state,
+      framed(state.lastSeq, { type: "text_delta", text: "AGAIN" }),
+      deps,
+    );
+    expect(replay.state).toBe(state);
+    expect(replay.effects).toEqual([]);
+  });
+
+  it("advances the cursor for decoded-but-unrendered events", () => {
+    for (const type of [
+      "reasoning_delta",
+      "context_truncated",
+      "event_omitted",
+    ] as const) {
+      const { state, effects } = reduceChatSessionEvent(
+        initialChatSessionState(),
+        framed(7, { type }),
+        makeDeps(),
+      );
+      expect(state.lastSeq).toBe(7);
+      expect(state.messages).toEqual([]);
+      expect(effects).toEqual([]);
+    }
+  });
+});
+
+describe("turn_started", () => {
+  it("begins a busy turn with a fresh assistant bubble and reset stream state", () => {
+    const { state, effects } = play([TURN]);
+    expect(state.busy).toBe(true);
+    expect(state.activeTurnId).toBe("turn-1");
+    expect(state.messages).toEqual([
+      { id: "t1", role: "assistant", text: "", sources: [], createdAt: NOW },
+    ]);
+    expect(effects).toEqual([
+      { type: "refresh_agent_runs" },
+      { type: "invalidate_terminal_hydration" },
+      { type: "turn_began", turnId: "turn-1", startsDifferentTurn: true },
+    ]);
+  });
+
+  it("does not report a different turn when the id matches the active one", () => {
+    const first = play([TURN]);
+    const again = reduceChatSessionEvent(
+      first.state,
+      framed(first.state.lastSeq + 1, TURN),
+      makeDeps(),
+    );
+    expect(again.effects).toContainEqual({
+      type: "turn_began",
+      turnId: "turn-1",
+      startsDifferentTurn: false,
+    });
+  });
+});
+
+describe("text_delta", () => {
+  it("accumulates scrubbed text into the trailing assistant bubble", () => {
+    const { state } = play([
+      TURN,
+      { type: "text_delta", text: "Hel" },
+      { type: "text_delta", text: "lo" },
+    ]);
+    const last = state.messages[state.messages.length - 1];
+    expect(last).toMatchObject({ role: "assistant", text: "Hello" });
+    expect(state.messages).toHaveLength(1);
+  });
+
+  it("starts a new assistant bubble when the transcript ends elsewhere", () => {
+    const { state } = play([{ type: "text_delta", text: "orphan" }]);
+    expect(state.messages).toEqual([
+      {
+        id: "t1",
+        role: "assistant",
+        text: "orphan",
+        sources: [],
+        createdAt: NOW,
+      },
+    ]);
+  });
+
+  it("withholds a partial source marker until the stream settles", () => {
+    const marker = "[[ow-source:0123456789abcdef0123456789abcdef]]";
+    const split = 10;
+    const mid = play([
+      TURN,
+      { type: "text_delta", text: `Answer ${marker.slice(0, split)}` },
+    ]);
+    const lastMid = mid.state.messages[mid.state.messages.length - 1];
+    expect(lastMid).toMatchObject({ role: "assistant", text: "Answer " });
+
+    const done = reduceChatSessionEvent(
+      mid.state,
+      framed(mid.state.lastSeq + 1, {
+        type: "text_delta",
+        text: marker.slice(split),
+      }),
+      makeDeps(),
+    );
+    const lastDone = done.state.messages[done.state.messages.length - 1];
+    expect(lastDone).toMatchObject({ role: "assistant", text: "Answer " });
+  });
+
+  it("flushes a withheld non-marker tail at a terminal boundary", () => {
+    const mid = play([TURN, { type: "text_delta", text: "Answer [[ow-sour" }]);
+    const done = reduceChatSessionEvent(
+      mid.state,
+      framed(mid.state.lastSeq + 1, { type: "turn_completed" }),
+      makeDeps(),
+    );
+    const last = done.state.messages[done.state.messages.length - 1];
+    expect(last).toMatchObject({ role: "assistant", text: "Answer [[ow-sour" });
+  });
+});
+
+describe("tool call lifecycle", () => {
+  const START_SEARCH: AgentEvent = {
+    type: "tool_call_started",
+    call_id: "call-1",
+    name: "search",
+  };
+
+  it("upserts a running tool card and marks it provisional", () => {
+    const { state } = play([TURN, START_SEARCH]);
+    expect(state.messages).toContainEqual({
+      id: "t2",
+      role: "tool",
+      callId: "call-1",
+      name: "search",
+      status: "running",
+    });
+    expect(state.provisionalToolCallIds.has("call-1")).toBe(true);
+  });
+
+  it("requests a folder-access refresh for that specific tool", () => {
+    const { effects } = play([
+      TURN,
+      { type: "tool_call_started", call_id: "c", name: "request_folder_access" },
+    ]);
+    expect(effects).toContainEqual({ type: "refresh_folder_access" });
+  });
+
+  it("keeps args streaming from downgrading an approval wait", () => {
+    const { state } = play([
+      TURN,
+      START_SEARCH,
+      {
+        type: "approval_required",
+        call_id: "call-1",
+        action: "search",
+        approval: "search_may_share_query_and_excerpts",
+        class: "sensitive",
+      },
+      { type: "tool_call_args_delta", call_id: "call-1" },
+    ]);
+    const tool = state.messages.find((m) => m.role === "tool");
+    expect(tool).toMatchObject({ status: "waiting_approval" });
+  });
+
+  it("completes, fails, and keeps cancellation sticky", () => {
+    const completed = play([
+      TURN,
+      START_SEARCH,
+      { type: "tool_call_completed", call_id: "call-1", status: "completed" },
+    ]);
+    expect(completed.state.messages.find((m) => m.role === "tool")).toMatchObject(
+      { status: "completed" },
+    );
+    expect(completed.state.provisionalToolCallIds.size).toBe(0);
+    expect(completed.effects).toContainEqual({ type: "refresh_agent_runs" });
+
+    const rejectedThenCompleted = play([
+      TURN,
+      START_SEARCH,
+      {
+        type: "approval_required",
+        call_id: "call-1",
+        action: "search",
+        approval: "search_may_share_query_and_excerpts",
+        class: "sensitive",
+      },
+      { type: "approval_decided", call_id: "call-1", approved: false },
+      { type: "tool_call_completed", call_id: "call-1", status: "completed" },
+    ]);
+    expect(
+      rejectedThenCompleted.state.messages.find((m) => m.role === "tool"),
+    ).toMatchObject({ status: "cancelled" });
+  });
+});
+
+describe("approvals", () => {
+  const APPROVAL: AgentEvent = {
+    type: "approval_required",
+    call_id: "call-1",
+    action: "search",
+    approval: "search_may_share_query_and_excerpts",
+    class: "sensitive",
+  };
+
+  it("adds an approvable card and releases the call from provisional", () => {
+    const { state } = play([
+      TURN,
+      { type: "tool_call_started", call_id: "call-1", name: "search" },
+      APPROVAL,
+    ]);
+    const card = state.messages.find((m) => m.role === "approval");
+    expect(card).toMatchObject({ callId: "call-1", canApprove: true });
+    expect(state.provisionalToolCallIds.has("call-1")).toBe(false);
+  });
+
+  it("resolves the card and resumes or cancels the tool on decision", () => {
+    const approved = play([
+      TURN,
+      { type: "tool_call_started", call_id: "call-1", name: "search" },
+      APPROVAL,
+      { type: "approval_decided", call_id: "call-1", approved: true },
+    ]);
+    expect(approved.state.messages.find((m) => m.role === "approval")).toMatchObject(
+      { resolved: true },
+    );
+    expect(approved.state.messages.find((m) => m.role === "tool")).toMatchObject(
+      { status: "running" },
+    );
+
+    const rejected = play([
+      TURN,
+      { type: "tool_call_started", call_id: "call-1", name: "search" },
+      APPROVAL,
+      { type: "approval_decided", call_id: "call-1", approved: false },
+    ]);
+    expect(rejected.state.messages.find((m) => m.role === "tool")).toMatchObject(
+      { status: "cancelled" },
+    );
+  });
+});
+
+describe("stream_interrupted", () => {
+  it("discards the optimistic candidate but keeps settled work", () => {
+    const { state } = play([
+      TURN,
+      { type: "tool_call_started", call_id: "done", name: "search" },
+      { type: "tool_call_completed", call_id: "done", status: "completed" },
+      { type: "text_delta", text: "partial answer" },
+      { type: "tool_call_started", call_id: "pending", name: "search" },
+      { type: "stream_interrupted" },
+    ]);
+    // The empty bubble minted at turn start survives (it renders as nothing);
+    // the streamed partial answer and the pending tool card are discarded.
+    const roles = state.messages.map((m) => m.role);
+    expect(roles).toEqual(["assistant", "tool"]);
+    expect(state.messages[0]).toMatchObject({ role: "assistant", text: "" });
+    expect(state.messages[1]).toMatchObject({ callId: "done" });
+    expect(state.assistantBuffer).toBe("");
+    expect(state.provisionalToolCallIds.size).toBe(0);
+  });
+});
+
+describe("user_steered", () => {
+  it("appends the steered message once, deduping hydrated echoes", () => {
+    const steer: AgentEvent = {
+      type: "user_steered",
+      message_id: "srv-1",
+      text: "take a left",
+    };
+    const first = play([TURN, steer]);
+    expect(first.state.messages).toContainEqual({
+      id: "srv-1",
+      role: "user",
+      text: "take a left",
+      createdAt: NOW,
+    });
+    const replayed = reduceChatSessionEvent(
+      first.state,
+      framed(first.state.lastSeq + 1, steer),
+      makeDeps(),
+    );
+    expect(
+      replayed.state.messages.filter((m) => m.id === "srv-1"),
+    ).toHaveLength(1);
+  });
+});
+
+describe("terminal events", () => {
+  it("turn_completed resolves the turn and requests hydration", () => {
+    const { state, effects } = play([TURN, { type: "turn_completed" }]);
+    expect(state.busy).toBe(false);
+    expect(state.activeTurnId).toBeNull();
+    expect(effects).toEqual([
+      { type: "turn_resolved" },
+      { type: "refresh_agent_runs" },
+      { type: "hydrate_terminal_transcript" },
+    ]);
+  });
+
+  it("turn_cancelled settles active tools, resolves their cards, and notes it", () => {
+    const { state, effects } = play([
+      TURN,
+      { type: "tool_call_started", call_id: "call-1", name: "search" },
+      {
+        type: "approval_required",
+        call_id: "call-1",
+        action: "search",
+        approval: "search_may_share_query_and_excerpts",
+        class: "sensitive",
+      },
+      { type: "turn_cancelled" },
+    ]);
+    expect(state.busy).toBe(false);
+    expect(state.messages.find((m) => m.role === "tool")).toMatchObject({
+      status: "cancelled",
+    });
+    expect(state.messages.find((m) => m.role === "approval")).toMatchObject({
+      resolved: true,
+    });
+    expect(state.messages[state.messages.length - 1]).toMatchObject({
+      role: "system",
+      text: "turn cancelled",
+    });
+    expect(effects).toEqual([
+      { type: "invalidate_terminal_hydration" },
+      { type: "turn_resolved" },
+      { type: "refresh_agent_runs" },
+    ]);
+  });
+
+  it("turn_failed settles active tools as failed and appends the error bubble", () => {
+    const { state } = play([
+      TURN,
+      { type: "tool_call_started", call_id: "call-1", name: "search" },
+      { type: "turn_failed" },
+    ]);
+    expect(state.messages.find((m) => m.role === "tool")).toMatchObject({
+      status: "failed",
+    });
+    expect(state.messages[state.messages.length - 1]).toMatchObject({
+      role: "error",
+      text: "The turn could not be completed.",
+    });
+  });
+
+  it("terminal settling leaves already-finished tools untouched", () => {
+    const { state } = play([
+      TURN,
+      { type: "tool_call_started", call_id: "done", name: "search" },
+      { type: "tool_call_completed", call_id: "done", status: "completed" },
+      { type: "turn_failed" },
+    ]);
+    expect(state.messages.find((m) => m.role === "tool")).toMatchObject({
+      status: "completed",
+    });
+  });
+});
+
+describe("applyTerminalHydration", () => {
+  it("replaces the transcript and only moves the seq cursor forward", () => {
+    const authoritative: ChatMessage[] = [
+      { id: "srv-1", role: "user", text: "hi", createdAt: NOW },
+    ];
+    const base = play([TURN]).state;
+    const behind = applyTerminalHydration(base, {
+      messages: authoritative,
+      messageIds: new Set(["srv-1"]),
+      lastEventSeq: 0,
+    });
+    expect(behind.lastSeq).toBe(base.lastSeq);
+    expect(behind.messages).toEqual(authoritative);
+    expect(behind.hydratedMessageIds.has("srv-1")).toBe(true);
+
+    const ahead = applyTerminalHydration(base, {
+      messages: authoritative,
+      messageIds: new Set(["srv-1"]),
+      lastEventSeq: 99,
+    });
+    expect(ahead.lastSeq).toBe(99);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -1,0 +1,504 @@
+import type { SequencedEvent } from "./api";
+import { shouldRefreshAgentRunsAfterToolEvent } from "./AgentRunRefresh";
+import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
+import type { ChatMessage } from "./MessageList";
+import type { ToolCallStatus } from "./ToolCallCard";
+import { toolApprovalPresentation } from "./ToolCallCard";
+import { upsertPendingApprovalCard } from "./ApprovalHistory";
+
+/**
+ * The pure state machine for one chat session's live event stream.
+ *
+ * Everything the stream mutates lives here so the transition logic is testable
+ * without React: the transcript, the streaming buffer and its marker scrubber,
+ * the seq cursor, and the bookkeeping sets. Side requirements that belong to
+ * the host component (polling refreshes, terminal-transcript hydration,
+ * cancel/steer cleanup) are returned as declarative [`ChatSessionEffect`]s.
+ *
+ * Purity caveat: the marker scrubber is a stateful stream processor, so a
+ * transition may advance the scrubber held by its *input* state. Treat every
+ * state value as consumed by the transition that receives it — never reduce
+ * from a stale snapshot. Reset points always install a fresh scrubber.
+ */
+export type ChatSessionState = {
+  /** Highest event seq applied; events at or below it are duplicates. */
+  lastSeq: number;
+  messages: ChatMessage[];
+  busy: boolean;
+  activeTurnId: string | null;
+  /** Scrubbed text accumulated for the trailing assistant bubble. */
+  assistantBuffer: string;
+  markerScrubber: AssistantSourceMarkerStreamScrubber;
+  /** Tool calls streamed in the current step; discarded on interruption. */
+  provisionalToolCallIds: ReadonlySet<string>;
+  /** Message ids already present via hydration; used to dedup steered echoes. */
+  hydratedMessageIds: ReadonlySet<string>;
+};
+
+export type ChatSessionEffect =
+  | { type: "refresh_agent_runs" }
+  | { type: "refresh_folder_access" }
+  /** A turn began; the host resets cancel state (and steer state when asked). */
+  | { type: "turn_began"; turnId: string; startsDifferentTurn: boolean }
+  /** A turn reached a terminal event; the host clears cancel/steer state. */
+  | { type: "turn_resolved" }
+  /** Replace the optimistic transcript with the authoritative one. */
+  | { type: "hydrate_terminal_transcript" }
+  /** A terminal boundary passed without hydration; stale loads must not land. */
+  | { type: "invalidate_terminal_hydration" };
+
+export type ChatSessionTransition = {
+  state: ChatSessionState;
+  effects: ChatSessionEffect[];
+};
+
+/** Injected id/clock dependencies so transitions are deterministic in tests. */
+export type ChatSessionDeps = {
+  nextId: () => string;
+  now: () => string;
+};
+
+export function initialChatSessionState(): ChatSessionState {
+  return {
+    lastSeq: 0,
+    messages: [],
+    busy: false,
+    activeTurnId: null,
+    assistantBuffer: "",
+    markerScrubber: new AssistantSourceMarkerStreamScrubber(),
+    provisionalToolCallIds: new Set(),
+    hydratedMessageIds: new Set(),
+  };
+}
+
+export function reduceChatSessionEvent(
+  state: ChatSessionState,
+  framed: SequencedEvent,
+  deps: ChatSessionDeps,
+): ChatSessionTransition {
+  if (framed.seq <= state.lastSeq) return { state, effects: [] };
+  state = { ...state, lastSeq: framed.seq };
+  const event = framed.event;
+  const effects: ChatSessionEffect[] = [];
+
+  if (shouldRefreshAgentRunsAfterToolEvent(event)) {
+    effects.push({ type: "refresh_agent_runs" });
+  }
+
+  switch (event.type) {
+    case "turn_started": {
+      effects.push(
+        { type: "refresh_agent_runs" },
+        { type: "invalidate_terminal_hydration" },
+        {
+          type: "turn_began",
+          turnId: event.turn_id,
+          startsDifferentTurn: state.activeTurnId !== event.turn_id,
+        },
+      );
+      return {
+        state: {
+          ...state,
+          busy: true,
+          activeTurnId: event.turn_id,
+          assistantBuffer: "",
+          markerScrubber: new AssistantSourceMarkerStreamScrubber(),
+          provisionalToolCallIds: new Set(),
+          messages: [
+            ...state.messages,
+            {
+              id: deps.nextId(),
+              role: "assistant",
+              text: "",
+              sources: [],
+              createdAt: deps.now(),
+            },
+          ],
+        },
+        effects,
+      };
+    }
+
+    case "text_delta": {
+      const assistantBuffer =
+        state.assistantBuffer + state.markerScrubber.push(event.text);
+      return {
+        state: {
+          ...state,
+          assistantBuffer,
+          messages: withTrailingAssistantText(
+            state.messages,
+            assistantBuffer,
+            deps,
+          ),
+        },
+        effects,
+      };
+    }
+
+    case "stream_interrupted": {
+      // The whole optimistic candidate is invalidated at this boundary. Finish
+      // clears any withheld marker-like tail before the replacement starts.
+      state.markerScrubber.finish();
+      const messages = discardToolCalls(
+        state.messages,
+        state.provisionalToolCallIds,
+      );
+      if (messages[messages.length - 1]?.role === "assistant") {
+        messages.pop();
+      }
+      return {
+        state: {
+          ...state,
+          assistantBuffer: "",
+          provisionalToolCallIds: new Set(),
+          messages,
+        },
+        effects,
+      };
+    }
+
+    case "tool_call_started": {
+      state = flushMarkerTail(state, deps);
+      if (state.provisionalToolCallIds.size === 0) {
+        state = {
+          ...state,
+          assistantBuffer: "",
+          markerScrubber: new AssistantSourceMarkerStreamScrubber(),
+        };
+      }
+      if (event.name === "request_folder_access") {
+        effects.push({ type: "refresh_folder_access" });
+      }
+      const provisionalToolCallIds = new Set(state.provisionalToolCallIds);
+      provisionalToolCallIds.add(event.call_id);
+      return {
+        state: {
+          ...state,
+          provisionalToolCallIds,
+          messages: upsertToolCall(
+            state.messages,
+            event.call_id,
+            event.name,
+            "running",
+            deps,
+          ),
+        },
+        effects,
+      };
+    }
+
+    case "tool_call_args_delta": {
+      // Arguments are intentionally not retained in renderer state. They can
+      // contain paths, file content, credentials, or provider-specific data.
+      return {
+        state: {
+          ...state,
+          messages: updateToolCall(state.messages, event.call_id, (tool) => ({
+            ...tool,
+            status:
+              tool.status === "waiting_approval" ? tool.status : "running",
+          })),
+        },
+        effects,
+      };
+    }
+
+    case "approval_required": {
+      const approval = toolApprovalPresentation(event.approval);
+      const provisionalToolCallIds = new Set(state.provisionalToolCallIds);
+      provisionalToolCallIds.delete(event.call_id);
+      return {
+        state: {
+          ...state,
+          provisionalToolCallIds,
+          messages: upsertPendingApprovalCard(state.messages, {
+            callId: event.call_id,
+            action: event.action,
+            approval: event.approval,
+            canApprove: approval.canApprove,
+          }),
+        },
+        effects,
+      };
+    }
+
+    case "approval_decided": {
+      return {
+        state: {
+          ...state,
+          messages: updateApprovalAndToolCall(
+            state.messages,
+            event.call_id,
+            event.approved,
+          ),
+        },
+        effects,
+      };
+    }
+
+    case "tool_call_completed": {
+      const provisionalToolCallIds = new Set(state.provisionalToolCallIds);
+      provisionalToolCallIds.delete(event.call_id);
+      return {
+        state: {
+          ...state,
+          provisionalToolCallIds,
+          messages: updateToolCall(state.messages, event.call_id, (tool) => ({
+            ...tool,
+            status:
+              tool.status === "cancelled"
+                ? "cancelled"
+                : event.status === "failed"
+                  ? "failed"
+                  : "completed",
+          })),
+        },
+        effects,
+      };
+    }
+
+    case "user_steered": {
+      if (state.hydratedMessageIds.has(event.message_id)) {
+        return { state, effects };
+      }
+      const hydratedMessageIds = new Set(state.hydratedMessageIds);
+      hydratedMessageIds.add(event.message_id);
+      return {
+        state: {
+          ...state,
+          hydratedMessageIds,
+          messages: [
+            ...state.messages,
+            {
+              id: event.message_id,
+              role: "user",
+              text: event.text,
+              createdAt: deps.now(),
+            },
+          ],
+        },
+        effects,
+      };
+    }
+
+    case "turn_completed": {
+      state = flushMarkerTail(state, deps);
+      effects.push(
+        { type: "turn_resolved" },
+        { type: "refresh_agent_runs" },
+        { type: "hydrate_terminal_transcript" },
+      );
+      return {
+        state: {
+          ...state,
+          busy: false,
+          activeTurnId: null,
+          provisionalToolCallIds: new Set(),
+        },
+        effects,
+      };
+    }
+
+    case "turn_cancelled": {
+      state = flushMarkerTail(state, deps);
+      effects.push(
+        { type: "invalidate_terminal_hydration" },
+        { type: "turn_resolved" },
+        { type: "refresh_agent_runs" },
+      );
+      return {
+        state: {
+          ...state,
+          busy: false,
+          activeTurnId: null,
+          provisionalToolCallIds: new Set(),
+          messages: [
+            ...settleActiveToolCalls(state.messages, "cancelled"),
+            { id: deps.nextId(), role: "system", text: "turn cancelled" },
+          ],
+        },
+        effects,
+      };
+    }
+
+    case "turn_failed": {
+      state = flushMarkerTail(state, deps);
+      effects.push(
+        { type: "invalidate_terminal_hydration" },
+        { type: "turn_resolved" },
+        { type: "refresh_agent_runs" },
+      );
+      return {
+        state: {
+          ...state,
+          busy: false,
+          activeTurnId: null,
+          provisionalToolCallIds: new Set(),
+          messages: [
+            ...settleActiveToolCalls(state.messages, "failed"),
+            {
+              id: deps.nextId(),
+              role: "error",
+              text: "The turn could not be completed.",
+            },
+          ],
+        },
+        effects,
+      };
+    }
+
+    // Decoded but not yet presented; they still advance the seq cursor.
+    case "reasoning_delta":
+    case "context_truncated":
+    case "event_omitted":
+      return { state, effects };
+  }
+}
+
+/**
+ * Fold an authoritative terminal transcript into the session, replacing the
+ * optimistic stream. The seq cursor only moves forward: a snapshot can trail
+ * events that arrived while it loaded.
+ */
+export function applyTerminalHydration(
+  state: ChatSessionState,
+  hydration: {
+    messages: ChatMessage[];
+    messageIds: ReadonlySet<string>;
+    lastEventSeq: number;
+  },
+): ChatSessionState {
+  return {
+    ...state,
+    lastSeq: Math.max(state.lastSeq, hydration.lastEventSeq),
+    hydratedMessageIds: hydration.messageIds,
+    messages: hydration.messages,
+  };
+}
+
+/** Append any withheld marker-like tail to the trailing assistant bubble. */
+function flushMarkerTail(
+  state: ChatSessionState,
+  deps: ChatSessionDeps,
+): ChatSessionState {
+  const tail = state.markerScrubber.finish();
+  if (!tail) return state;
+  const assistantBuffer = state.assistantBuffer + tail;
+  return {
+    ...state,
+    assistantBuffer,
+    messages: withTrailingAssistantText(state.messages, assistantBuffer, deps),
+  };
+}
+
+function withTrailingAssistantText(
+  messages: ChatMessage[],
+  text: string,
+  deps: ChatSessionDeps,
+): ChatMessage[] {
+  const copy = [...messages];
+  const last = copy[copy.length - 1];
+  if (last?.role === "assistant") {
+    copy[copy.length - 1] = { ...last, text };
+  } else {
+    copy.push({
+      id: deps.nextId(),
+      role: "assistant",
+      text,
+      sources: [],
+      createdAt: deps.now(),
+    });
+  }
+  return copy;
+}
+
+export function upsertToolCall(
+  messages: ChatMessage[],
+  callId: string,
+  name: string,
+  status: ToolCallStatus,
+  deps: ChatSessionDeps,
+): ChatMessage[] {
+  const existing = messages.findIndex(
+    (message) => message.role === "tool" && message.callId === callId,
+  );
+  if (existing >= 0) {
+    return messages.map((message, index) =>
+      index === existing && message.role === "tool"
+        ? { ...message, status }
+        : message,
+    );
+  }
+  return [
+    ...messages,
+    { id: deps.nextId(), role: "tool", callId, name, status },
+  ];
+}
+
+export function updateToolCall(
+  messages: ChatMessage[],
+  callId: string,
+  update: (
+    tool: Extract<ChatMessage, { role: "tool" }>,
+  ) => Extract<ChatMessage, { role: "tool" }>,
+): ChatMessage[] {
+  return messages.map((message) =>
+    message.role === "tool" && message.callId === callId
+      ? update(message)
+      : message,
+  );
+}
+
+export function updateApprovalAndToolCall(
+  messages: ChatMessage[],
+  callId: string,
+  approved: boolean,
+): ChatMessage[] {
+  return messages.map((message) => {
+    if (message.role === "approval" && message.callId === callId) {
+      return { ...message, resolved: true };
+    }
+    if (message.role === "tool" && message.callId === callId) {
+      return {
+        ...message,
+        status: approved ? "running" : "cancelled",
+      };
+    }
+    return message;
+  });
+}
+
+export function settleActiveToolCalls(
+  messages: ChatMessage[],
+  status: Extract<ToolCallStatus, "failed" | "cancelled">,
+): ChatMessage[] {
+  const activeCallIds = new Set(
+    messages.flatMap((message) =>
+      message.role === "tool" &&
+      (message.status === "running" || message.status === "waiting_approval")
+        ? [message.callId]
+        : [],
+    ),
+  );
+  return messages.map((message) =>
+    message.role === "tool" &&
+    (message.status === "running" || message.status === "waiting_approval")
+      ? { ...message, status }
+      : message.role === "approval" &&
+          !message.resolved &&
+          activeCallIds.has(message.callId)
+        ? { ...message, resolved: true }
+        : message,
+  );
+}
+
+export function discardToolCalls(
+  messages: ChatMessage[],
+  callIds: ReadonlySet<string>,
+): ChatMessage[] {
+  return messages.filter(
+    (message) => message.role !== "tool" || !callIds.has(message.callId),
+  );
+}
+


### PR DESCRIPTION
Closes #381.

## What

Slice 1 of the client-state refactor: `App.tsx`'s ~200-line `handleEvent` — the untested state machine interpreting all thirteen chat-stream event types — becomes a pure `reduceChatSessionEvent(state, event, deps) → { state, effects }` in the new `ChatSessionReducer.ts`, along with the transcript helpers it uses.

- One `ChatSessionState` owns the session: transcript, seq cursor, streaming buffer + marker scrubber, provisional/hydrated id sets, busy/active turn. Five session refs collapse into a single `sessionRef` (a `lastSeq` number mirror remains only because `useChatEventStream`'s API takes a number ref; it goes away with the planned session controller).
- Side requirements (agent-run/folder-access refreshes, terminal-transcript hydration, cancel/steer cleanup) return as declarative `ChatSessionEffect`s that the component applies.
- Every session-state writer — hydration, send, chat-switch resets, approval resolution — now flows through one `commitSession` path, so the reducer's state can't diverge from what renders.
- Injected `nextId`/`now` deps make transitions deterministic under test.

**No behavior change intended.** App.tsx shrinks by ~380 net lines.

## Tests

21 new deterministic reducer tests (189 total passing): every event type, seq dedup, source-marker withholding and terminal flushes, provisional discard on `stream_interrupted`, sticky cancellation, approval transitions, steered-echo dedup, terminal settling, and hydration cursor monotonicity. `tsc`, vitest, and the production build are green; smoke-tested streaming, tool cards, cancel, steer, and mid-stream chat switching in the native app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)