### PR TITLE
refactor(desktop): decompose App into Sidebar, ChatView, and FoldersPanel

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -12,46 +12,16 @@ import {
 } from "./api";
 import { resolveServerInfo } from "./boot";
 import {
-  connectFolder,
-  disconnectFolder,
   hasNativeHost,
-  listConnectedFolders,
   resolveFolderAccessRequest,
-  type ConnectedFolder,
   type FolderAccessDecision,
 } from "./host";
 import { Logomark } from "./Logomark";
-import { Composer } from "./Composer";
-import { MessageList } from "./MessageList";
-import {
-  ArrowDown,
-  Ellipsis,
-  FolderOpen,
-  LibraryBig,
-  Monitor,
-  Moon,
-  Pencil,
-  RotateCw,
-  Settings,
-  SquarePen,
-  Sun,
-  Trash2,
-} from "lucide-react";
 import { useTheme } from "./theme";
 import { SettingsView } from "./SettingsView";
 import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
-import { SettingsError, SettingsPanel } from "./settings/primitives";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { WithTooltip } from "@/components/ui/tooltip";
 import { ChatSessionController } from "./ChatSessionController";
 import { useChatSessionStore } from "./ChatSessionStore";
-import { isNearBottom, scrollToLatest } from "./ChatScroll";
 import { DocumentsView } from "./DocumentsView";
 import { reconcilePendingApprovalCards } from "./ApprovalHistory";
 import { loadChatApprovalHydration } from "./ChatApprovalHydration";
@@ -70,7 +40,7 @@ import {
   loadCurrentTerminalTranscript,
   presentChatTranscript,
 } from "./ChatTranscriptPresentation";
-import { AgentActivityPanel, agentRunsForChat } from "./AgentActivityPanel";
+import { agentRunsForChat } from "./AgentActivityPanel";
 import {
   SandboxAgentStopFence,
   canStopSandboxAgentRun,
@@ -79,8 +49,10 @@ import {
 } from "./SandboxAgentStop";
 import { prependReplacementChat } from "./ChatDeletion";
 import { useConfirm } from "./components/ConfirmDialog";
-import { Button } from "@/components/ui/button";
 import { useDesktopUpdates } from "./updates";
+import { ChatView } from "./ChatView";
+import { FoldersPanel } from "./FoldersPanel";
+import { Sidebar } from "./Sidebar";
 
 let msgSeq = 0;
 
@@ -104,7 +76,6 @@ export default function App() {
   const [chatsError, setChatsError] = useState<string | null>(null);
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
-  const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);
   const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
   const [agentRuns, setAgentRuns] = useState<AgentRun[]>([]);
@@ -153,20 +124,16 @@ export default function App() {
     "chat" | "documents" | "settings"
   >("chat");
   const [status, setStatus] = useState("starting…");
-  const [hasUnreadActivity, setHasUnreadActivity] = useState(false);
   // Owns the selected chat's event socket; chat switches dispose it eagerly
   // and the connection effect below constructs a fresh one.
   const controllerRef = useRef<ChatSessionController | null>(null);
   const handleEventRef = useRef<(event: SequencedEvent) => void>(() => {});
   const chatSelectionRef = useRef(0);
   const terminalHydrationGenerationRef = useRef(0);
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const followsLatestRef = useRef(true);
   const refreshFolderAccessRef = useRef<(() => void) | null>(null);
   const refreshAgentRunsRef = useRef<(() => void) | null>(null);
   const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
   const decidingApprovalCallsRef = useRef<Set<string>>(new Set());
-  const visibleFolderCallIdsRef = useRef<Set<string>>(new Set());
   const cancelRequestTurnRef = useRef<string | null>(null);
   const draftRef = useRef("");
   const selectedChatIdRef = useRef<string | null>(null);
@@ -448,32 +415,6 @@ export default function App() {
       setFolderAccessRequests([]);
     };
   }, [client, chat?.id]);
-
-  useEffect(() => {
-    const scroll = scrollRef.current;
-    if (!scroll) return;
-    if (followsLatestRef.current) {
-      scrollToLatest(scroll);
-    } else {
-      setHasUnreadActivity(true);
-    }
-  }, [messages]);
-
-  useEffect(() => {
-    const next = new Set(folderAccessRequests.map((request) => request.callId));
-    const gainedRequest = [...next].some(
-      (callId) => !visibleFolderCallIdsRef.current.has(callId),
-    );
-    visibleFolderCallIdsRef.current = next;
-    if (!gainedRequest) return;
-    const scroll = scrollRef.current;
-    if (!scroll) return;
-    if (followsLatestRef.current) {
-      scrollToLatest(scroll);
-    } else {
-      setHasUnreadActivity(true);
-    }
-  }, [folderAccessRequests]);
 
   function updateSession(update: (state: ChatSessionState) => ChatSessionState) {
     useChatSessionStore.getState().update(update);
@@ -762,8 +703,6 @@ export default function App() {
     controllerRef.current?.dispose();
     controllerRef.current = null;
     useChatSessionStore.getState().reset();
-    followsLatestRef.current = true;
-    setHasUnreadActivity(false);
     setAgentRuns([]);
     setAgentRunsError(null);
     setFolderAccessRequests([]);
@@ -856,8 +795,6 @@ export default function App() {
     controllerRef.current?.dispose();
     controllerRef.current = null;
     useChatSessionStore.getState().reset();
-    followsLatestRef.current = true;
-    setHasUnreadActivity(false);
     setAgentRuns([]);
     setAgentRunsError(null);
     setFolderAccessRequests([]);
@@ -1099,192 +1036,43 @@ export default function App() {
   return (
     <div className="app-shell">
       {confirmDialog}
-      <aside className="sidebar">
-        <div className="sidebar-brand">
-          <Logomark />
-          <span>OpenWave</span>
-          <WithTooltip
-            label={`Theme: ${themeMode} — click to change`}
-            side="bottom"
-          >
-            <button
-              type="button"
-              className="theme-toggle"
-              aria-label={`Theme: ${themeMode}. Click to change.`}
-              onClick={cycleTheme}
-            >
-              {themeMode === "light" ? (
-                <Sun size={15} />
-              ) : themeMode === "dark" ? (
-                <Moon size={15} />
-              ) : (
-                <Monitor size={15} />
-              )}
-            </button>
-          </WithTooltip>
-        </div>
-
-        <button
-          type="button"
-          className="new-chat"
-          onClick={() => void onNewChat()}
-          disabled={creatingChat || deletingChatId !== null}
-        >
-          <SquarePen size={15} />
-          {creatingChat
-            ? "Starting…"
-            : deletingChatId
-              ? "Deleting…"
-              : "New chat"}
-        </button>
-
-        {hasNativeHost() && (
-          <button
-            type="button"
-            className={`sidebar-action sidebar-library${primaryView === "documents" ? " is-active" : ""}`}
-            onClick={() => {
-              setSettingsPanel(null);
-              setPrimaryView("documents");
-            }}
-          >
-            <LibraryBig size={16} />
-            Sources
-          </button>
-        )}
-
-        <div className="sidebar-section">
-          <span className="sidebar-label">Chats</span>
-          <div className="conversation-list" aria-label="Chats">
-            {visibleChats.map((item) => {
-              const chatTitle = item.title?.trim() || "New chat";
-              const isActive = primaryView === "chat" && item.id === chat.id;
-              const mutating = deletingChatId !== null || creatingChat;
-
-              if (renamingChatId === item.id) {
-                return (
-                  <div
-                    key={item.id}
-                    className="conversation-row is-renaming"
-                  >
-                    <input
-                      className="conversation-rename-input"
-                      autoFocus
-                      aria-label="Chat title"
-                      value={renameChatDraft}
-                      disabled={savingTitle}
-                      onChange={(event) =>
-                        setRenameChatDraft(event.target.value)
-                      }
-                      onBlur={() => void commitChatRename(item)}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter") {
-                          event.preventDefault();
-                          event.currentTarget.blur();
-                        }
-                        if (event.key === "Escape") {
-                          event.preventDefault();
-                          cancelChatRename();
-                        }
-                      }}
-                    />
-                  </div>
-                );
-              }
-
-              return (
-                <div
-                  key={item.id}
-                  className={`conversation-row${isActive ? " is-active" : ""}`}
-                >
-                  <button
-                    type="button"
-                    className="conversation-item"
-                    aria-current={isActive ? "page" : undefined}
-                    disabled={mutating}
-                    onClick={() => selectChat(item)}
-                  >
-                    <span className="conversation-title">{chatTitle}</span>
-                  </button>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
-                        className="conversation-menu"
-                        aria-label={`Actions for ${chatTitle}`}
-                        title="Chat actions"
-                        disabled={mutating}
-                      >
-                        <Ellipsis size={15} />
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" side="right">
-                      <DropdownMenuItem
-                        onSelect={() => startChatRename(item)}
-                      >
-                        <Pencil />
-                        Rename
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        variant="destructive"
-                        onSelect={() => void onDeleteChat(item)}
-                      >
-                        <Trash2 />
-                        Delete
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-              );
-            })}
-          </div>
-          {chatsError && <p className="sidebar-error">{chatsError}</p>}
-        </div>
-
-        <div className="sidebar-footer">
-          {desktopUpdates.state.status === "ready" && (
-            <button
-              type="button"
-              className="sidebar-action sidebar-update"
-              onClick={() => void onRestartForUpdate()}
-            >
-              <RotateCw size={16} />
-              <span>Restart to update</span>
-              {desktopUpdates.state.version && (
-                <span className="sidebar-update-version">
-                  v{desktopUpdates.state.version}
-                </span>
-              )}
-            </button>
-          )}
-          {hasNativeHost() && (
-            <button
-              type="button"
-              className={`sidebar-action${primaryView === "chat" && settingsPanel === "folders" ? " is-active" : ""}`}
-              onClick={() => {
-                setPrimaryView("chat");
-                setSettingsPanel((panel) =>
-                  panel === "folders" ? null : "folders",
-                );
-              }}
-            >
-              <FolderOpen size={16} />
-              Folders
-            </button>
-          )}
-          <button
-            type="button"
-            className={`sidebar-action${primaryView === "settings" ? " is-active" : ""}`}
-            onClick={() => {
-              setSettingsPanel(null);
-              setPrimaryView("settings");
-            }}
-          >
-            <Settings size={16} />
-            Settings
-          </button>
-        </div>
-      </aside>
+      <Sidebar
+        chats={visibleChats}
+        activeChatId={chat.id}
+        chatsError={chatsError}
+        primaryView={primaryView}
+        foldersPanelOpen={settingsPanel === "folders"}
+        nativeHost={hasNativeHost()}
+        creatingChat={creatingChat}
+        deletingChatId={deletingChatId}
+        renamingChatId={renamingChatId}
+        renameChatDraft={renameChatDraft}
+        savingTitle={savingTitle}
+        themeMode={themeMode}
+        updateReady={desktopUpdates.state.status === "ready"}
+        updateVersion={desktopUpdates.state.version ?? null}
+        onCycleTheme={cycleTheme}
+        onNewChat={() => void onNewChat()}
+        onSelectChat={selectChat}
+        onStartRename={startChatRename}
+        onRenameDraftChange={setRenameChatDraft}
+        onCommitRename={(target) => void commitChatRename(target)}
+        onCancelRename={cancelChatRename}
+        onDeleteChat={(target) => void onDeleteChat(target)}
+        onShowDocuments={() => {
+          setSettingsPanel(null);
+          setPrimaryView("documents");
+        }}
+        onToggleFolders={() => {
+          setPrimaryView("chat");
+          setSettingsPanel((panel) => (panel === "folders" ? null : "folders"));
+        }}
+        onShowSettings={() => {
+          setSettingsPanel(null);
+          setPrimaryView("settings");
+        }}
+        onRestartForUpdate={() => void onRestartForUpdate()}
+      />
 
       <div
         className={`main${primaryView === "chat" && settingsPanel ? " with-settings" : ""}`}
@@ -1306,153 +1094,78 @@ export default function App() {
           />
         ) : (
           <>
-        <section className="chat-pane">
-          <header className="conversation-header">
-            <div className="conversation-title-row">
-              <h1>{chat.title?.trim() || "New chat"}</h1>
-            </div>
-            <div className="conversation-header-actions">
-              <div className="mobile-settings-actions">
-                {hasNativeHost() && (
-                  <button
-                    type="button"
-                    className="btn"
-                    aria-label="Sources"
-                    onClick={() => {
-                      setSettingsPanel(null);
-                      setPrimaryView("documents");
-                    }}
-                  >
-                    <LibraryBig size={14} />
-                  </button>
-                )}
-                {hasNativeHost() && (
-                  <button
-                    type="button"
-                    className={`btn${settingsPanel === "folders" ? " is-active" : ""}`}
-                    aria-label="Folders"
-                    onClick={() =>
-                      setSettingsPanel((panel) =>
-                        panel === "folders" ? null : "folders",
-                      )
-                    }
-                  >
-                    <FolderOpen size={14} />
-                  </button>
-                )}
-                <button
-                  type="button"
-                  className="btn"
-                  aria-label="Settings"
-                  onClick={() => {
-                    setSettingsPanel(null);
-                    setPrimaryView("settings");
-                  }}
-                >
-                  <Settings size={14} />
-                </button>
-              </div>
-              <span className="status" title={status}>
-                {status}
-              </span>
-            </div>
-          </header>
-
-          <AgentActivityPanel
-            runs={visibleAgentRuns}
-            loading={agentRunsChatId === chat.id ? agentRunsLoading : true}
-            error={agentRunsChatId === chat.id ? agentRunsError : null}
-            onRetry={() => refreshAgentRunsRef.current?.()}
-            stoppingRunIds={visibleStoppingSandboxRunIds}
-            stopErrorRunIds={visibleSandboxStopErrorRunIds}
-            onStop={(runId) => void onStopSandboxAgentRun(runId)}
-          />
-
-          <div className="message-view">
-            <MessageList
-              key={chat.id}
-              messages={messages}
-              folderAccessRequests={folderAccessRequests}
-              nativeHost={hasNativeHost()}
-              nativeBusy={resolvingFolderCalls.size > 0}
-              resolvingFolderCalls={resolvingFolderCalls}
-              folderAccessErrors={folderAccessErrors}
-              decidingApprovalCalls={decidingApprovalCalls}
-              approvalErrors={approvalErrors}
-              busy={busy}
-              scrollRef={scrollRef}
-              onScroll={(event) => {
-                const followsLatest = isNearBottom(event.currentTarget);
-                followsLatestRef.current = followsLatest;
-                if (followsLatest) setHasUnreadActivity(false);
-              }}
-              onApproval={(callId, decision, remember) =>
-                void onApproval(callId, decision, remember)
-              }
-              onFolderAccessDecision={(callId, decision) =>
-                void onFolderAccessDecision(callId, decision)
-              }
-              onFolderAccessCancel={(callId, turnId) =>
-                void onFolderAccessCancel(callId, turnId)
-              }
-              onSelectPrompt={setComposerDraft}
-              hydrated={hydratedChatId === chat.id}
-            />
-            {hasUnreadActivity && (
-              <button
-                type="button"
-                className="new-activity"
-                onClick={() => {
-                  followsLatestRef.current = true;
-                  setHasUnreadActivity(false);
-                  if (scrollRef.current) scrollToLatest(scrollRef.current);
-                }}
-              >
-                New activity
-                <ArrowDown size={13} />
-              </button>
-            )}
-          </div>
-
-          <Composer
-            activeTurnId={activeTurnId}
-            busy={busy}
-            cancelError={cancelError}
-            cancelPending={
-              activeTurnId !== null && cancelPendingTurnId === activeTurnId
-            }
-            disabled={deletingChatId !== null}
-            draft={draft}
-            modelMenu={
-              <>
-                <ModelMenu
-                  models={models}
-                  value={chat.model}
+        <ChatView
+          key={chat.id}
+          chat={chat}
+          status={status}
+          hydrated={hydratedChatId === chat.id}
+          nativeHost={hasNativeHost()}
+          foldersPanelOpen={settingsPanel === "folders"}
+          deletingChat={deletingChatId !== null}
+          agentRuns={visibleAgentRuns}
+          agentRunsLoading={
+            agentRunsChatId === chat.id ? agentRunsLoading : true
+          }
+          agentRunsError={agentRunsChatId === chat.id ? agentRunsError : null}
+          stoppingRunIds={visibleStoppingSandboxRunIds}
+          stopErrorRunIds={visibleSandboxStopErrorRunIds}
+          onRetryAgentRuns={() => refreshAgentRunsRef.current?.()}
+          onStopSandboxRun={(runId) => void onStopSandboxAgentRun(runId)}
+          folderAccessRequests={folderAccessRequests}
+          resolvingFolderCalls={resolvingFolderCalls}
+          folderAccessErrors={folderAccessErrors}
+          decidingApprovalCalls={decidingApprovalCalls}
+          approvalErrors={approvalErrors}
+          onApproval={(callId, decision, remember) =>
+            void onApproval(callId, decision, remember)
+          }
+          onFolderAccessDecision={(callId, decision) =>
+            void onFolderAccessDecision(callId, decision)
+          }
+          onFolderAccessCancel={(callId, turnId) =>
+            void onFolderAccessCancel(callId, turnId)
+          }
+          draft={draft}
+          composerModelMenu={
+            <>
+              <ModelMenu
+                models={models}
+                value={chat.model}
+                disabled={deletingChatId !== null}
+                onChange={onModelChange}
+              />
+              {models.find((model) => model.id === chat.model)
+                ?.supports_reasoning_effort && (
+                <ReasoningEffortMenu
+                  value={chat.reasoning_effort}
                   disabled={deletingChatId !== null}
-                  onChange={onModelChange}
+                  onChange={onReasoningEffortChange}
                 />
-                {models.find((model) => model.id === chat.model)
-                  ?.supports_reasoning_effort && (
-                  <ReasoningEffortMenu
-                    value={chat.reasoning_effort}
-                    disabled={deletingChatId !== null}
-                    onChange={onReasoningEffortChange}
-                  />
-                )}
-              </>
-            }
-            onDraftChange={onComposerDraftChange}
-            onSend={onSend}
-            onSteer={onSteerActiveTurn}
-            onStop={onCancelActiveTurn}
-            resetKey={chat?.id ?? "no-chat"}
-            steerError={steerError}
-            steerPending={
-              activeTurnId !== null && steerPendingTurnId === activeTurnId
-            }
-            steerStatus={steerStatus}
-          />
-        </section>
+              )}
+            </>
+          }
+          cancelError={cancelError}
+          cancelPendingTurnId={cancelPendingTurnId}
+          steerError={steerError}
+          steerStatus={steerStatus}
+          steerPendingTurnId={steerPendingTurnId}
+          onDraftChange={onComposerDraftChange}
+          onSelectPrompt={setComposerDraft}
+          onSend={onSend}
+          onSteer={onSteerActiveTurn}
+          onStop={onCancelActiveTurn}
+          onShowDocuments={() => {
+            setSettingsPanel(null);
+            setPrimaryView("documents");
+          }}
+          onToggleFolders={() =>
+            setSettingsPanel((panel) => (panel === "folders" ? null : "folders"))
+          }
+          onShowSettings={() => {
+            setSettingsPanel(null);
+            setPrimaryView("settings");
+          }}
+        />
 
         {settingsPanel === "folders" && (
           <aside className="settings">
@@ -1468,97 +1181,4 @@ export default function App() {
 
 function withoutConnectionState(status: string): string {
   return status.replace(/ · (?:live|reconnecting)$/, "");
-}
-
-function FoldersPanel({ chat }: { chat: Chat }) {
-  const [folders, setFolders] = useState<ConnectedFolder[]>([]);
-  const [working, setWorking] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const scopeLabel = "chat";
-
-  async function refresh() {
-    setError(null);
-    try {
-      setFolders(await listConnectedFolders(chat));
-    } catch (err) {
-      setError(String(err));
-    }
-  }
-
-  useEffect(() => {
-    void refresh();
-  }, [chat.id, chat.project_id]);
-
-  async function addFolder() {
-    setWorking(true);
-    setError(null);
-    try {
-      const connected = await connectFolder(chat);
-      if (connected) await refresh();
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setWorking(false);
-    }
-  }
-
-  async function removeFolder(rootId: string) {
-    setWorking(true);
-    setError(null);
-    try {
-      await disconnectFolder(chat, rootId);
-      await refresh();
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setWorking(false);
-    }
-  }
-
-  return (
-    <SettingsPanel
-      title="Connected folders"
-      description={`OpenWave can read only folders you choose for this ${scopeLabel}. Folder locations stay with the native host.`}
-    >
-      <Button
-        type="button"
-        variant="outline"
-        className="self-start"
-        disabled={working}
-        onClick={() => void addFolder()}
-      >
-        Choose folder…
-      </Button>
-      <div className="flex flex-col gap-2">
-        {folders.length === 0 && !error && (
-          <p className="text-sm text-muted-foreground">
-            No folders connected to this {scopeLabel}.
-          </p>
-        )}
-        {folders.map((folder) => (
-          <div
-            className="flex items-center justify-between gap-3 rounded-lg border border-border p-3"
-            key={folder.rootId}
-          >
-            <div className="min-w-0">
-              <strong className="block truncate text-sm font-medium">
-                {folder.displayName}
-              </strong>
-              <span className="text-xs text-muted-foreground">read access</span>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              disabled={working}
-              onClick={() => void removeFolder(folder.rootId)}
-            >
-              Disconnect
-            </Button>
-          </div>
-        ))}
-      </div>
-      {error && <SettingsError>{error}</SettingsError>}
-    </SettingsPanel>
-  );
 }

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Chat } from "./api";
+import { ChatView, type ChatViewProps } from "./ChatView";
+import { useChatSessionStore } from "./ChatSessionStore";
+
+const chat = { id: "chat-1", title: "Roadmap", project_id: null } as unknown as Chat;
+
+function renderChatView(overrides: Partial<ChatViewProps> = {}) {
+  const props: ChatViewProps = {
+    chat,
+    status: "chat chat-1 · live",
+    hydrated: true,
+    nativeHost: false,
+    foldersPanelOpen: false,
+    deletingChat: false,
+    agentRuns: [],
+    agentRunsLoading: false,
+    agentRunsError: null,
+    stoppingRunIds: new Set(),
+    stopErrorRunIds: new Set(),
+    onRetryAgentRuns: vi.fn(),
+    onStopSandboxRun: vi.fn(),
+    folderAccessRequests: [],
+    resolvingFolderCalls: new Set(),
+    folderAccessErrors: {},
+    decidingApprovalCalls: new Set(),
+    approvalErrors: {},
+    onApproval: vi.fn(),
+    onFolderAccessDecision: vi.fn(),
+    onFolderAccessCancel: vi.fn(),
+    draft: "",
+    composerModelMenu: null,
+    cancelError: null,
+    cancelPendingTurnId: null,
+    steerError: null,
+    steerStatus: null,
+    steerPendingTurnId: null,
+    onDraftChange: vi.fn(),
+    onSelectPrompt: vi.fn(),
+    onSend: vi.fn(async () => {}),
+    onSteer: vi.fn(async () => {}),
+    onStop: vi.fn(async () => {}),
+    onShowDocuments: vi.fn(),
+    onToggleFolders: vi.fn(),
+    onShowSettings: vi.fn(),
+    ...overrides,
+  };
+  render(<ChatView {...props} />);
+  return props;
+}
+
+beforeEach(() => {
+  useChatSessionStore.getState().reset();
+});
+afterEach(cleanup);
+
+describe("ChatView", () => {
+  it("renders the live session transcript straight from the store", () => {
+    useChatSessionStore.getState().update((session) => ({
+      ...session,
+      messages: [
+        { id: "m1", role: "user", text: "hello there" },
+        { id: "m2", role: "assistant", text: "hi!", sources: [] },
+      ],
+    }));
+    renderChatView();
+    expect(screen.getByText("hello there")).toBeInTheDocument();
+    expect(screen.getByText("hi!")).toBeInTheDocument();
+  });
+
+  it("re-renders as stream events land in the store", () => {
+    renderChatView();
+    act(() => {
+      useChatSessionStore
+        .getState()
+        .applyEvent(
+          { seq: 1, event: { type: "turn_started", turn_id: "t1" } },
+          { nextId: () => "m1", now: () => "2026-07-23T12:00:00.000Z" },
+        );
+      useChatSessionStore
+        .getState()
+        .applyEvent(
+          { seq: 2, event: { type: "text_delta", text: "streamed answer" } },
+          { nextId: () => "m2", now: () => "2026-07-23T12:00:00.000Z" },
+        );
+    });
+    expect(screen.getByText("streamed answer")).toBeInTheDocument();
+  });
+
+  it("shows the chat title and connection status", () => {
+    renderChatView();
+    expect(
+      screen.getByRole("heading", { name: "Roadmap" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("chat chat-1 · live")).toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import type {
+  AgentRun,
+  Chat,
+  PendingFolderAccessRequest,
+} from "./api";
+import { AgentActivityPanel } from "./AgentActivityPanel";
+import { isNearBottom, scrollToLatest } from "./ChatScroll";
+import { useChatSessionStore } from "./ChatSessionStore";
+import { Composer } from "./Composer";
+import type { FolderAccessDecision } from "./host";
+import { MessageList } from "./MessageList";
+import { ArrowDown, FolderOpen, LibraryBig, Settings } from "lucide-react";
+
+export type ChatViewProps = {
+  chat: Chat;
+  status: string;
+  hydrated: boolean;
+  nativeHost: boolean;
+  foldersPanelOpen: boolean;
+  deletingChat: boolean;
+  agentRuns: AgentRun[];
+  agentRunsLoading: boolean;
+  agentRunsError: string | null;
+  stoppingRunIds: Set<string>;
+  stopErrorRunIds: Set<string>;
+  onRetryAgentRuns: () => void;
+  onStopSandboxRun: (runId: string) => void;
+  folderAccessRequests: PendingFolderAccessRequest[];
+  resolvingFolderCalls: Set<string>;
+  folderAccessErrors: Record<string, string>;
+  decidingApprovalCalls: Set<string>;
+  approvalErrors: Record<string, string>;
+  onApproval: (
+    callId: string,
+    decision: "approve" | "reject",
+    remember?: boolean,
+  ) => void;
+  onFolderAccessDecision: (
+    callId: string,
+    decision: FolderAccessDecision,
+  ) => void;
+  onFolderAccessCancel: (callId: string, turnId: string) => void;
+  draft: string;
+  composerModelMenu: ReactNode;
+  cancelError: string | null;
+  cancelPendingTurnId: string | null;
+  steerError: string | null;
+  steerStatus: string | null;
+  steerPendingTurnId: string | null;
+  onDraftChange: (value: string) => void;
+  onSelectPrompt: (prompt: string) => void;
+  onSend: () => Promise<void>;
+  onSteer: () => Promise<void>;
+  onStop: () => Promise<void>;
+  onShowDocuments: () => void;
+  onToggleFolders: () => void;
+  onShowSettings: () => void;
+};
+
+/**
+ * The chat pane: header, agent activity, transcript, and composer. Reads the
+ * live session (messages, busy, active turn) straight from the session store.
+ * Mount with `key={chat.id}` so scroll-follow state resets per conversation.
+ */
+export function ChatView({
+  chat,
+  status,
+  hydrated,
+  nativeHost,
+  foldersPanelOpen,
+  deletingChat,
+  agentRuns,
+  agentRunsLoading,
+  agentRunsError,
+  stoppingRunIds,
+  stopErrorRunIds,
+  onRetryAgentRuns,
+  onStopSandboxRun,
+  folderAccessRequests,
+  resolvingFolderCalls,
+  folderAccessErrors,
+  decidingApprovalCalls,
+  approvalErrors,
+  onApproval,
+  onFolderAccessDecision,
+  onFolderAccessCancel,
+  draft,
+  composerModelMenu,
+  cancelError,
+  cancelPendingTurnId,
+  steerError,
+  steerStatus,
+  steerPendingTurnId,
+  onDraftChange,
+  onSelectPrompt,
+  onSend,
+  onSteer,
+  onStop,
+  onShowDocuments,
+  onToggleFolders,
+  onShowSettings,
+}: ChatViewProps) {
+  const messages = useChatSessionStore((session) => session.messages);
+  const busy = useChatSessionStore((session) => session.busy);
+  const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
+
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const followsLatestRef = useRef(true);
+  const visibleFolderCallIdsRef = useRef<Set<string>>(new Set());
+  const [hasUnreadActivity, setHasUnreadActivity] = useState(false);
+
+  useEffect(() => {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    if (followsLatestRef.current) {
+      scrollToLatest(scroll);
+    } else {
+      setHasUnreadActivity(true);
+    }
+  }, [messages]);
+
+  useEffect(() => {
+    const next = new Set(folderAccessRequests.map((request) => request.callId));
+    const gainedRequest = [...next].some(
+      (callId) => !visibleFolderCallIdsRef.current.has(callId),
+    );
+    visibleFolderCallIdsRef.current = next;
+    if (!gainedRequest) return;
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    if (followsLatestRef.current) {
+      scrollToLatest(scroll);
+    } else {
+      setHasUnreadActivity(true);
+    }
+  }, [folderAccessRequests]);
+
+  return (
+    <section className="chat-pane">
+      <header className="conversation-header">
+        <div className="conversation-title-row">
+          <h1>{chat.title?.trim() || "New chat"}</h1>
+        </div>
+        <div className="conversation-header-actions">
+          <div className="mobile-settings-actions">
+            {nativeHost && (
+              <button
+                type="button"
+                className="btn"
+                aria-label="Sources"
+                onClick={onShowDocuments}
+              >
+                <LibraryBig size={14} />
+              </button>
+            )}
+            {nativeHost && (
+              <button
+                type="button"
+                className={`btn${foldersPanelOpen ? " is-active" : ""}`}
+                aria-label="Folders"
+                onClick={onToggleFolders}
+              >
+                <FolderOpen size={14} />
+              </button>
+            )}
+            <button
+              type="button"
+              className="btn"
+              aria-label="Settings"
+              onClick={onShowSettings}
+            >
+              <Settings size={14} />
+            </button>
+          </div>
+          <span className="status" title={status}>
+            {status}
+          </span>
+        </div>
+      </header>
+
+      <AgentActivityPanel
+        runs={agentRuns}
+        loading={agentRunsLoading}
+        error={agentRunsError}
+        onRetry={onRetryAgentRuns}
+        stoppingRunIds={stoppingRunIds}
+        stopErrorRunIds={stopErrorRunIds}
+        onStop={onStopSandboxRun}
+      />
+
+      <div className="message-view">
+        <MessageList
+          messages={messages}
+          folderAccessRequests={folderAccessRequests}
+          nativeHost={nativeHost}
+          nativeBusy={resolvingFolderCalls.size > 0}
+          resolvingFolderCalls={resolvingFolderCalls}
+          folderAccessErrors={folderAccessErrors}
+          decidingApprovalCalls={decidingApprovalCalls}
+          approvalErrors={approvalErrors}
+          busy={busy}
+          scrollRef={scrollRef}
+          onScroll={(event) => {
+            const followsLatest = isNearBottom(event.currentTarget);
+            followsLatestRef.current = followsLatest;
+            if (followsLatest) setHasUnreadActivity(false);
+          }}
+          onApproval={onApproval}
+          onFolderAccessDecision={onFolderAccessDecision}
+          onFolderAccessCancel={onFolderAccessCancel}
+          onSelectPrompt={onSelectPrompt}
+          hydrated={hydrated}
+        />
+        {hasUnreadActivity && (
+          <button
+            type="button"
+            className="new-activity"
+            onClick={() => {
+              followsLatestRef.current = true;
+              setHasUnreadActivity(false);
+              if (scrollRef.current) scrollToLatest(scrollRef.current);
+            }}
+          >
+            New activity
+            <ArrowDown size={13} />
+          </button>
+        )}
+      </div>
+
+      <Composer
+        activeTurnId={activeTurnId}
+        busy={busy}
+        cancelError={cancelError}
+        cancelPending={
+          activeTurnId !== null && cancelPendingTurnId === activeTurnId
+        }
+        disabled={deletingChat}
+        draft={draft}
+        modelMenu={composerModelMenu}
+        onDraftChange={onDraftChange}
+        onSend={onSend}
+        onSteer={onSteer}
+        onStop={onStop}
+        resetKey={chat.id}
+        steerError={steerError}
+        steerPending={
+          activeTurnId !== null && steerPendingTurnId === activeTurnId
+        }
+        steerStatus={steerStatus}
+      />
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/FoldersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersPanel.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import type { Chat } from "./api";
+import {
+  connectFolder,
+  disconnectFolder,
+  listConnectedFolders,
+  type ConnectedFolder,
+} from "./host";
+import { SettingsError, SettingsPanel } from "./settings/primitives";
+import { Button } from "@/components/ui/button";
+
+export function FoldersPanel({ chat }: { chat: Chat }) {
+  const [folders, setFolders] = useState<ConnectedFolder[]>([]);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scopeLabel = "chat";
+
+  async function refresh() {
+    setError(null);
+    try {
+      setFolders(await listConnectedFolders(chat));
+    } catch (err) {
+      setError(String(err));
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+  }, [chat.id, chat.project_id]);
+
+  async function addFolder() {
+    setWorking(true);
+    setError(null);
+    try {
+      const connected = await connectFolder(chat);
+      if (connected) await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function removeFolder(rootId: string) {
+    setWorking(true);
+    setError(null);
+    try {
+      await disconnectFolder(chat, rootId);
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return (
+    <SettingsPanel
+      title="Connected folders"
+      description={`OpenWave can read only folders you choose for this ${scopeLabel}. Folder locations stay with the native host.`}
+    >
+      <Button
+        type="button"
+        variant="outline"
+        className="self-start"
+        disabled={working}
+        onClick={() => void addFolder()}
+      >
+        Choose folder…
+      </Button>
+      <div className="flex flex-col gap-2">
+        {folders.length === 0 && !error && (
+          <p className="text-sm text-muted-foreground">
+            No folders connected to this {scopeLabel}.
+          </p>
+        )}
+        {folders.map((folder) => (
+          <div
+            className="flex items-center justify-between gap-3 rounded-lg border border-border p-3"
+            key={folder.rootId}
+          >
+            <div className="min-w-0">
+              <strong className="block truncate text-sm font-medium">
+                {folder.displayName}
+              </strong>
+              <span className="text-xs text-muted-foreground">read access</span>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={working}
+              onClick={() => void removeFolder(folder.rootId)}
+            >
+              Disconnect
+            </Button>
+          </div>
+        ))}
+      </div>
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsPanel>
+  );
+}

--- a/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Chat } from "./api";
+import { Sidebar, type SidebarProps } from "./Sidebar";
+
+const chats: Chat[] = [
+  { id: "chat-1", title: "Roadmap", project_id: null } as unknown as Chat,
+  { id: "chat-2", title: null, project_id: null } as unknown as Chat,
+];
+
+function renderSidebar(overrides: Partial<SidebarProps> = {}) {
+  const props: SidebarProps = {
+    chats,
+    activeChatId: "chat-1",
+    chatsError: null,
+    primaryView: "chat",
+    foldersPanelOpen: false,
+    nativeHost: false,
+    creatingChat: false,
+    deletingChatId: null,
+    renamingChatId: null,
+    renameChatDraft: "",
+    savingTitle: false,
+    themeMode: "light",
+    updateReady: false,
+    updateVersion: null,
+    onCycleTheme: vi.fn(),
+    onNewChat: vi.fn(),
+    onSelectChat: vi.fn(),
+    onStartRename: vi.fn(),
+    onRenameDraftChange: vi.fn(),
+    onCommitRename: vi.fn(),
+    onCancelRename: vi.fn(),
+    onDeleteChat: vi.fn(),
+    onShowDocuments: vi.fn(),
+    onToggleFolders: vi.fn(),
+    onShowSettings: vi.fn(),
+    onRestartForUpdate: vi.fn(),
+    ...overrides,
+  };
+  render(<Sidebar {...props} />);
+  return props;
+}
+
+afterEach(cleanup);
+
+describe("Sidebar", () => {
+  it("lists chats with the active one marked and selects on click", async () => {
+    const user = userEvent.setup();
+    const props = renderSidebar();
+    const active = screen.getByRole("button", { name: "Roadmap" });
+    expect(active).toHaveAttribute("aria-current", "page");
+
+    await user.click(active);
+    expect(props.onSelectChat).toHaveBeenCalledWith(chats[0]);
+    expect(props.onNewChat).not.toHaveBeenCalled();
+  });
+
+  it("drives the rename flow through commit and cancel", async () => {
+    const user = userEvent.setup();
+    const props = renderSidebar({
+      renamingChatId: "chat-1",
+      renameChatDraft: "Roadmap",
+    });
+    const input = screen.getByRole("textbox", { name: "Chat title" });
+    await user.type(input, "!");
+    expect(props.onRenameDraftChange).toHaveBeenCalledWith("Roadmap!");
+
+    await user.keyboard("{Enter}");
+    expect(props.onCommitRename).toHaveBeenCalledWith(chats[0]);
+
+    input.focus();
+    await user.keyboard("{Escape}");
+    expect(props.onCancelRename).toHaveBeenCalled();
+  });
+
+  it("disables chat interaction while a mutation is in flight", () => {
+    renderSidebar({ deletingChatId: "chat-2" });
+    expect(screen.getByRole("button", { name: "Roadmap" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Deleting…" })).toBeDisabled();
+  });
+
+  it("shows native-host and update affordances only when available", () => {
+    renderSidebar();
+    expect(screen.queryByText("Sources")).not.toBeInTheDocument();
+    expect(screen.queryByText("Restart to update")).not.toBeInTheDocument();
+    cleanup();
+
+    renderSidebar({
+      nativeHost: true,
+      updateReady: true,
+      updateVersion: "1.2.3",
+    });
+    expect(screen.getByText("Sources")).toBeInTheDocument();
+    expect(screen.getByText("Restart to update")).toBeInTheDocument();
+    expect(screen.getByText("v1.2.3")).toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/Sidebar.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.tsx
@@ -1,0 +1,254 @@
+import type { Chat } from "./api";
+import { Logomark } from "./Logomark";
+import {
+  Ellipsis,
+  FolderOpen,
+  LibraryBig,
+  Monitor,
+  Moon,
+  Pencil,
+  RotateCw,
+  Settings,
+  SquarePen,
+  Sun,
+  Trash2,
+} from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { WithTooltip } from "@/components/ui/tooltip";
+import type { ThemeMode } from "./theme";
+
+export type SidebarProps = {
+  chats: Chat[];
+  activeChatId: string;
+  chatsError: string | null;
+  primaryView: "chat" | "documents" | "settings";
+  foldersPanelOpen: boolean;
+  nativeHost: boolean;
+  creatingChat: boolean;
+  deletingChatId: string | null;
+  renamingChatId: string | null;
+  renameChatDraft: string;
+  savingTitle: boolean;
+  themeMode: ThemeMode;
+  updateReady: boolean;
+  updateVersion: string | null;
+  onCycleTheme: () => void;
+  onNewChat: () => void;
+  onSelectChat: (chat: Chat) => void;
+  onStartRename: (chat: Chat) => void;
+  onRenameDraftChange: (value: string) => void;
+  onCommitRename: (chat: Chat) => void;
+  onCancelRename: () => void;
+  onDeleteChat: (chat: Chat) => void;
+  onShowDocuments: () => void;
+  onToggleFolders: () => void;
+  onShowSettings: () => void;
+  onRestartForUpdate: () => void;
+};
+
+/** The navigation aside: brand/theme, chat list, and footer actions. */
+export function Sidebar({
+  chats,
+  activeChatId,
+  chatsError,
+  primaryView,
+  foldersPanelOpen,
+  nativeHost,
+  creatingChat,
+  deletingChatId,
+  renamingChatId,
+  renameChatDraft,
+  savingTitle,
+  themeMode,
+  updateReady,
+  updateVersion,
+  onCycleTheme,
+  onNewChat,
+  onSelectChat,
+  onStartRename,
+  onRenameDraftChange,
+  onCommitRename,
+  onCancelRename,
+  onDeleteChat,
+  onShowDocuments,
+  onToggleFolders,
+  onShowSettings,
+  onRestartForUpdate,
+}: SidebarProps) {
+  return (
+    <aside className="sidebar">
+      <div className="sidebar-brand">
+        <Logomark />
+        <span>OpenWave</span>
+        <WithTooltip
+          label={`Theme: ${themeMode} — click to change`}
+          side="bottom"
+        >
+          <button
+            type="button"
+            className="theme-toggle"
+            aria-label={`Theme: ${themeMode}. Click to change.`}
+            onClick={onCycleTheme}
+          >
+            {themeMode === "light" ? (
+              <Sun size={15} />
+            ) : themeMode === "dark" ? (
+              <Moon size={15} />
+            ) : (
+              <Monitor size={15} />
+            )}
+          </button>
+        </WithTooltip>
+      </div>
+
+      <button
+        type="button"
+        className="new-chat"
+        onClick={onNewChat}
+        disabled={creatingChat || deletingChatId !== null}
+      >
+        <SquarePen size={15} />
+        {creatingChat
+          ? "Starting…"
+          : deletingChatId
+            ? "Deleting…"
+            : "New chat"}
+      </button>
+
+      {nativeHost && (
+        <button
+          type="button"
+          className={`sidebar-action sidebar-library${primaryView === "documents" ? " is-active" : ""}`}
+          onClick={onShowDocuments}
+        >
+          <LibraryBig size={16} />
+          Sources
+        </button>
+      )}
+
+      <div className="sidebar-section">
+        <span className="sidebar-label">Chats</span>
+        <div className="conversation-list" aria-label="Chats">
+          {chats.map((item) => {
+            const chatTitle = item.title?.trim() || "New chat";
+            const isActive = primaryView === "chat" && item.id === activeChatId;
+            const mutating = deletingChatId !== null || creatingChat;
+
+            if (renamingChatId === item.id) {
+              return (
+                <div key={item.id} className="conversation-row is-renaming">
+                  <input
+                    className="conversation-rename-input"
+                    autoFocus
+                    aria-label="Chat title"
+                    value={renameChatDraft}
+                    disabled={savingTitle}
+                    onChange={(event) =>
+                      onRenameDraftChange(event.target.value)
+                    }
+                    onBlur={() => onCommitRename(item)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        event.currentTarget.blur();
+                      }
+                      if (event.key === "Escape") {
+                        event.preventDefault();
+                        onCancelRename();
+                      }
+                    }}
+                  />
+                </div>
+              );
+            }
+
+            return (
+              <div
+                key={item.id}
+                className={`conversation-row${isActive ? " is-active" : ""}`}
+              >
+                <button
+                  type="button"
+                  className="conversation-item"
+                  aria-current={isActive ? "page" : undefined}
+                  disabled={mutating}
+                  onClick={() => onSelectChat(item)}
+                >
+                  <span className="conversation-title">{chatTitle}</span>
+                </button>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="conversation-menu"
+                      aria-label={`Actions for ${chatTitle}`}
+                      title="Chat actions"
+                      disabled={mutating}
+                    >
+                      <Ellipsis size={15} />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" side="right">
+                    <DropdownMenuItem onSelect={() => onStartRename(item)}>
+                      <Pencil />
+                      Rename
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      variant="destructive"
+                      onSelect={() => onDeleteChat(item)}
+                    >
+                      <Trash2 />
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            );
+          })}
+        </div>
+        {chatsError && <p className="sidebar-error">{chatsError}</p>}
+      </div>
+
+      <div className="sidebar-footer">
+        {updateReady && (
+          <button
+            type="button"
+            className="sidebar-action sidebar-update"
+            onClick={onRestartForUpdate}
+          >
+            <RotateCw size={16} />
+            <span>Restart to update</span>
+            {updateVersion && (
+              <span className="sidebar-update-version">v{updateVersion}</span>
+            )}
+          </button>
+        )}
+        {nativeHost && (
+          <button
+            type="button"
+            className={`sidebar-action${primaryView === "chat" && foldersPanelOpen ? " is-active" : ""}`}
+            onClick={onToggleFolders}
+          >
+            <FolderOpen size={16} />
+            Folders
+          </button>
+        )}
+        <button
+          type="button"
+          className={`sidebar-action${primaryView === "settings" ? " is-active" : ""}`}
+          onClick={onShowSettings}
+        >
+          <Settings size={16} />
+          Settings
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/crates/openwave-desktop/ui/src/test/setup.ts
+++ b/crates/openwave-desktop/ui/src/test/setup.ts
@@ -2,3 +2,12 @@
 // (toBeDisabled, toHaveTextContent, …) for every test file. Harmless in the
 // node environment; meaningful in files that opt into jsdom.
 import "@testing-library/jest-dom/vitest";
+
+// jsdom implements neither scrolling API; components calling scrollTo would
+// otherwise throw inside effects. A no-op keeps scroll-follow logic testable.
+if (
+  typeof Element !== "undefined" &&
+  typeof Element.prototype.scrollTo !== "function"
+) {
+  Element.prototype.scrollTo = () => {};
+}


### PR DESCRIPTION
Closes #389. Slice 4 of the client-state refactor (#381 reducer, #384 test infra, #387 store/controller).

Mechanical extraction, no new state management:

- **`Sidebar.tsx`** — the navigation aside: brand/theme toggle, new-chat, documents entry, chat list with rename/delete menus, update/folders/settings footer.
- **`ChatView.tsx`** — chat header, agent activity panel, transcript, composer. Subscribes to the session store directly for `messages`/`busy`/`activeTurnId` (App no longer passes them), and owns the scroll-follow machinery; `key={chat.id}` resets it per conversation, replacing App's manual ref resets.
- **`FoldersPanel.tsx`** — moved verbatim out of App.tsx.

App drops from ~1,560 to ~1,180 lines and keeps orchestration only (boot, hydration, controller wiring, mutations, view switching). Slice 5 moves chat-list/view state into stores and slims the transitional props.

## Tests

New DOM suites: Sidebar (chat selection, rename flow via Enter/Escape, mutation-disabled states, conditional native-host/update affordances) and ChatView (transcript rendered from the store, live re-render on stream events applied through the store, title/status). Shared setup gains a jsdom `scrollTo` no-op. 213 tests, `tsc`, and the production build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)