### PR TITLE
refactor(desktop): move view and chat-list state into uiStore and chatListStore

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -22,6 +22,8 @@ import { SettingsView } from "./SettingsView";
 import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
 import { ChatSessionController } from "./ChatSessionController";
 import { useChatSessionStore } from "./ChatSessionStore";
+import { useChatListStore } from "./ChatListStore";
+import { useUiStore } from "./UiStore";
 import { DocumentsView } from "./DocumentsView";
 import { reconcilePendingApprovalCards } from "./ApprovalHistory";
 import { loadChatApprovalHydration } from "./ChatApprovalHydration";
@@ -66,14 +68,23 @@ const sessionDeps = {
   now: () => new Date().toISOString(),
 };
 
+// Store actions are stable for the store's lifetime; these handles are for
+// calling actions only — never read state fields from them.
+const chatListActions = useChatListStore.getState();
+const uiActions = useUiStore.getState();
+
 export default function App() {
   const [bootError, setBootError] = useState<string | null>(null);
   const [info, setInfo] = useState<ServerInfo | null>(null);
   const [client, setClient] = useState<ApiClient | null>(null);
-  const [chat, setChat] = useState<Chat | null>(null);
   const [hydratedChatId, setHydratedChatId] = useState<string | null>(null);
-  const [chats, setChats] = useState<Chat[]>([]);
-  const [chatsError, setChatsError] = useState<string | null>(null);
+  const chat = useChatListStore((state) => state.selected);
+  const creatingChat = useChatListStore((state) => state.creatingChat);
+  const deletingChatId = useChatListStore((state) => state.deletingChatId);
+  const savingTitle = useChatListStore((state) => state.savingTitle);
+  const renameChatDraft = useChatListStore((state) => state.renameChatDraft);
+  const primaryView = useUiStore((state) => state.primaryView);
+  const settingsPanel = useUiStore((state) => state.settingsPanel);
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const busy = useChatSessionStore((session) => session.busy);
@@ -113,16 +124,7 @@ export default function App() {
   );
   const [steerError, setSteerError] = useState<string | null>(null);
   const [steerStatus, setSteerStatus] = useState<string | null>(null);
-  const [creatingChat, setCreatingChat] = useState(false);
-  const [deletingChatId, setDeletingChatId] = useState<string | null>(null);
-  const [savingTitle, setSavingTitle] = useState(false);
-  const [renamingChatId, setRenamingChatId] = useState<string | null>(null);
-  const [renameChatDraft, setRenameChatDraft] = useState("");
   const skipRenameCommitRef = useRef(false);
-  const [settingsPanel, setSettingsPanel] = useState<"folders" | null>(null);
-  const [primaryView, setPrimaryView] = useState<
-    "chat" | "documents" | "settings"
-  >("chat");
   const [status, setStatus] = useState("starting…");
   // Owns the selected chat's event socket; chat switches dispose it eagerly
   // and the connection effect below constructs a fresh one.
@@ -179,12 +181,12 @@ export default function App() {
         if (cancelled) return;
         setModels(catalog.models);
         setProviders(providerList.providers);
-        setChats(existingChats);
+        chatListActions.setChats(existingChats);
         const created =
           existingChats[0] ??
           (await client.createChat(catalog.models[0]?.id));
         if (cancelled) return;
-        if (existingChats.length === 0) setChats([created]);
+        if (existingChats.length === 0) chatListActions.setChats([created]);
         activateChat(created);
         setStatus(`chat ${created.id.slice(0, 8)}…`);
       } catch (err) {
@@ -672,8 +674,8 @@ export default function App() {
   async function onNewChat() {
     if (!client || creationInFlightRef.current || deletionInFlightRef.current) return;
     creationInFlightRef.current = true;
-    setCreatingChat(true);
-    setPrimaryView("chat");
+    chatListActions.setCreatingChat(true);
+    uiActions.showChat({ keepPanels: true });
     try {
       const created = await client.createChat(
         chat?.model ?? models[0]?.id,
@@ -694,12 +696,12 @@ export default function App() {
       }));
     } finally {
       creationInFlightRef.current = false;
-      setCreatingChat(false);
+      chatListActions.setCreatingChat(false);
     }
   }
 
   function openCreatedChat(created: Chat) {
-    setPrimaryView("chat");
+    uiActions.showChat({ keepPanels: true });
     controllerRef.current?.dispose();
     controllerRef.current = null;
     useChatSessionStore.getState().reset();
@@ -716,8 +718,8 @@ export default function App() {
     cancelRequestTurnRef.current = null;
     clearSteerRequestState();
     activateChat(created);
-    setChats((current) => [created, ...current]);
-    setChatsError(null);
+    chatListActions.prependChat(created);
+    chatListActions.setChatsError(null);
     setStatus(`chat ${created.id.slice(0, 8)}…`);
   }
 
@@ -733,8 +735,8 @@ export default function App() {
     if (!confirmed) return;
 
     deletionInFlightRef.current = true;
-    setDeletingChatId(target.id);
-    setChatsError(null);
+    chatListActions.setDeletingChatId(target.id);
+    chatListActions.setChatsError(null);
     const deletingSelectedChat = chat?.id === target.id;
     if (deletingSelectedChat) {
       // This invalidates callbacks that captured the deleted selection. The
@@ -749,7 +751,7 @@ export default function App() {
       await client.deleteChat(target.id);
       let refreshed = await client.listChats();
       if (!deletingSelectedChat) {
-        setChats(refreshed);
+        chatListActions.setChats(refreshed);
         return;
       }
 
@@ -758,13 +760,13 @@ export default function App() {
         next = await client.createChat(models[0]?.id, null);
         refreshed = prependReplacementChat(refreshed, next);
       }
-      setChats(refreshed);
+      chatListActions.setChats(refreshed);
       selectChat(next, true);
     } catch (err) {
-      setChatsError(`Could not delete chat: ${String(err)}`);
+      chatListActions.setChatsError(`Could not delete chat: ${String(err)}`);
     } finally {
       deletionInFlightRef.current = false;
-      setDeletingChatId(null);
+      chatListActions.setDeletingChatId(null);
     }
   }
 
@@ -779,12 +781,11 @@ export default function App() {
       ...session,
       markerScrubber: new AssistantSourceMarkerStreamScrubber(),
     }));
-    setChat(next);
+    chatListActions.setSelected(next);
   }
 
   function selectChat(next: Chat, force = false) {
-    setPrimaryView("chat");
-    setSettingsPanel(null);
+    uiActions.showChat();
     if (
       next.id === chat?.id ||
       creatingChat ||
@@ -814,14 +815,12 @@ export default function App() {
 
   function startChatRename(target: Chat) {
     skipRenameCommitRef.current = false;
-    setRenameChatDraft(target.title ?? "");
-    setRenamingChatId(target.id);
+    chatListActions.beginRename(target);
   }
 
   function cancelChatRename() {
     skipRenameCommitRef.current = true;
-    setRenamingChatId(null);
-    setRenameChatDraft("");
+    chatListActions.endRename();
   }
 
   async function commitChatRename(target: Chat) {
@@ -835,34 +834,26 @@ export default function App() {
     if (!client || savingTitle || deletionInFlightRef.current) return;
     const trimmed = renameChatDraft.trim();
     if (trimmed === (target.title?.trim() ?? "")) {
-      setRenamingChatId(null);
-      setRenameChatDraft("");
+      chatListActions.endRename();
       return;
     }
     const selection = chatSelectionRef.current;
-    setSavingTitle(true);
+    chatListActions.setSavingTitle(true);
     try {
       const updated = await client.patchChatTitle(target.id, trimmed || null);
-      setChats((current) =>
-        current.map((item) => (item.id === updated.id ? updated : item)),
-      );
-      if (chat?.id === updated.id && chatSelectionRef.current === selection) {
-        setChat(updated);
-      }
-      setRenamingChatId(null);
-      setRenameChatDraft("");
+      chatListActions.replaceChat(updated);
+      chatListActions.endRename();
     } catch (err) {
       // If the user has since switched conversations, abandon this stale edit
       // silently. Otherwise keep the editor open with the typed draft so the
       // rename can be retried instead of being discarded.
       if (chatSelectionRef.current === selection) {
-        setChatsError(`Could not rename chat: ${String(err)}`);
+        chatListActions.setChatsError(`Could not rename chat: ${String(err)}`);
       } else {
-        setRenamingChatId(null);
-        setRenameChatDraft("");
+        chatListActions.endRename();
       }
     } finally {
-      setSavingTitle(false);
+      chatListActions.setSavingTitle(false);
     }
   }
 
@@ -871,16 +862,10 @@ export default function App() {
     const chatId = chat.id;
     const selection = chatSelectionRef.current;
     const updated = await client.patchChatModel(chatId, modelId || null);
-    if (chatSelectionRef.current !== selection) {
-      setChats((current) =>
-        current.map((item) => (item.id === updated.id ? updated : item)),
-      );
-      return;
-    }
-    setChat(updated);
-    setChats((current) =>
-      current.map((item) => (item.id === updated.id ? updated : item)),
-    );
+    // replaceChat updates the list and, when ids match, the selection too;
+    // after a selection change the ids differ, so this stays fence-safe.
+    chatListActions.replaceChat(updated);
+    void selection;
   }
 
   async function onReasoningEffortChange(effort: ReasoningEffort | null) {
@@ -888,16 +873,10 @@ export default function App() {
     const chatId = chat.id;
     const selection = chatSelectionRef.current;
     const updated = await client.patchChatReasoningEffort(chatId, effort);
-    if (chatSelectionRef.current !== selection) {
-      setChats((current) =>
-        current.map((item) => (item.id === updated.id ? updated : item)),
-      );
-      return;
-    }
-    setChat(updated);
-    setChats((current) =>
-      current.map((item) => (item.id === updated.id ? updated : item)),
-    );
+    // replaceChat updates the list and, when ids match, the selection too;
+    // after a selection change the ids differ, so this stays fence-safe.
+    chatListActions.replaceChat(updated);
+    void selection;
   }
 
   async function onApproval(
@@ -1031,23 +1010,12 @@ export default function App() {
     );
   }
 
-  const visibleChats = chats;
 
   return (
     <div className="app-shell">
       {confirmDialog}
       <Sidebar
-        chats={visibleChats}
-        activeChatId={chat.id}
-        chatsError={chatsError}
-        primaryView={primaryView}
-        foldersPanelOpen={settingsPanel === "folders"}
         nativeHost={hasNativeHost()}
-        creatingChat={creatingChat}
-        deletingChatId={deletingChatId}
-        renamingChatId={renamingChatId}
-        renameChatDraft={renameChatDraft}
-        savingTitle={savingTitle}
         themeMode={themeMode}
         updateReady={desktopUpdates.state.status === "ready"}
         updateVersion={desktopUpdates.state.version ?? null}
@@ -1055,22 +1023,9 @@ export default function App() {
         onNewChat={() => void onNewChat()}
         onSelectChat={selectChat}
         onStartRename={startChatRename}
-        onRenameDraftChange={setRenameChatDraft}
         onCommitRename={(target) => void commitChatRename(target)}
         onCancelRename={cancelChatRename}
         onDeleteChat={(target) => void onDeleteChat(target)}
-        onShowDocuments={() => {
-          setSettingsPanel(null);
-          setPrimaryView("documents");
-        }}
-        onToggleFolders={() => {
-          setPrimaryView("chat");
-          setSettingsPanel((panel) => (panel === "folders" ? null : "folders"));
-        }}
-        onShowSettings={() => {
-          setSettingsPanel(null);
-          setPrimaryView("settings");
-        }}
         onRestartForUpdate={() => void onRestartForUpdate()}
       />
 
@@ -1078,14 +1033,14 @@ export default function App() {
         className={`main${primaryView === "chat" && settingsPanel ? " with-settings" : ""}`}
       >
         {primaryView === "documents" ? (
-          <DocumentsView chatId={chat.id} onBack={() => setPrimaryView("chat")} />
+          <DocumentsView chatId={chat.id} onBack={() => uiActions.showChat({ keepPanels: true })} />
         ) : primaryView === "settings" ? (
           <SettingsView
             client={client}
             models={models}
             providers={providers}
             onProvidersChanged={() => void refreshCatalog()}
-            onBack={() => setPrimaryView("chat")}
+            onBack={() => uiActions.showChat({ keepPanels: true })}
             themeMode={themeMode}
             onThemeChange={setThemeMode}
             updateState={desktopUpdates.state}
@@ -1100,7 +1055,6 @@ export default function App() {
           status={status}
           hydrated={hydratedChatId === chat.id}
           nativeHost={hasNativeHost()}
-          foldersPanelOpen={settingsPanel === "folders"}
           deletingChat={deletingChatId !== null}
           agentRuns={visibleAgentRuns}
           agentRunsLoading={
@@ -1154,17 +1108,6 @@ export default function App() {
           onSend={onSend}
           onSteer={onSteerActiveTurn}
           onStop={onCancelActiveTurn}
-          onShowDocuments={() => {
-            setSettingsPanel(null);
-            setPrimaryView("documents");
-          }}
-          onToggleFolders={() =>
-            setSettingsPanel((panel) => (panel === "folders" ? null : "folders"))
-          }
-          onShowSettings={() => {
-            setSettingsPanel(null);
-            setPrimaryView("settings");
-          }}
         />
 
         {settingsPanel === "folders" && (

--- a/crates/openwave-desktop/ui/src/ChatListStore.ts
+++ b/crates/openwave-desktop/ui/src/ChatListStore.ts
@@ -1,0 +1,64 @@
+import { create } from "zustand";
+import type { Chat } from "./api";
+
+/**
+ * The chat list and its mutation progress. State only — the async mutations
+ * (create/delete/rename/select orchestration with the confirm dialog, fences,
+ * and session lifecycle) stay with the caller, which reads and writes here so
+ * the sidebar can subscribe directly instead of receiving drilled props.
+ */
+export type ChatListStore = {
+  chats: Chat[];
+  /** The selected chat; `null` only before the first chat resolves at boot. */
+  selected: Chat | null;
+  chatsError: string | null;
+  creatingChat: boolean;
+  deletingChatId: string | null;
+  renamingChatId: string | null;
+  renameChatDraft: string;
+  savingTitle: boolean;
+  setChats: (chats: Chat[]) => void;
+  setSelected: (chat: Chat | null) => void;
+  /** Replace a chat everywhere it appears (list and selection) by id. */
+  replaceChat: (chat: Chat) => void;
+  prependChat: (chat: Chat) => void;
+  setChatsError: (error: string | null) => void;
+  setCreatingChat: (creating: boolean) => void;
+  setDeletingChatId: (chatId: string | null) => void;
+  beginRename: (chat: Chat) => void;
+  setRenameDraft: (draft: string) => void;
+  setSavingTitle: (saving: boolean) => void;
+  endRename: () => void;
+};
+
+export function createChatListStore() {
+  return create<ChatListStore>()((set) => ({
+    chats: [],
+    selected: null,
+    chatsError: null,
+    creatingChat: false,
+    deletingChatId: null,
+    renamingChatId: null,
+    renameChatDraft: "",
+    savingTitle: false,
+    setChats: (chats) => set({ chats }),
+    setSelected: (selected) => set({ selected }),
+    replaceChat: (chat) =>
+      set((state) => ({
+        chats: state.chats.map((item) => (item.id === chat.id ? chat : item)),
+        selected: state.selected?.id === chat.id ? chat : state.selected,
+      })),
+    prependChat: (chat) => set((state) => ({ chats: [chat, ...state.chats] })),
+    setChatsError: (chatsError) => set({ chatsError }),
+    setCreatingChat: (creatingChat) => set({ creatingChat }),
+    setDeletingChatId: (deletingChatId) => set({ deletingChatId }),
+    beginRename: (chat) =>
+      set({ renamingChatId: chat.id, renameChatDraft: chat.title ?? "" }),
+    setRenameDraft: (renameChatDraft) => set({ renameChatDraft }),
+    setSavingTitle: (savingTitle) => set({ savingTitle }),
+    endRename: () =>
+      set({ renamingChatId: null, renameChatDraft: "", savingTitle: false }),
+  }));
+}
+
+export const useChatListStore = createChatListStore();

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -13,7 +13,6 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
     status: "chat chat-1 · live",
     hydrated: true,
     nativeHost: false,
-    foldersPanelOpen: false,
     deletingChat: false,
     agentRuns: [],
     agentRunsLoading: false,
@@ -42,9 +41,6 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
     onSend: vi.fn(async () => {}),
     onSteer: vi.fn(async () => {}),
     onStop: vi.fn(async () => {}),
-    onShowDocuments: vi.fn(),
-    onToggleFolders: vi.fn(),
-    onShowSettings: vi.fn(),
     ...overrides,
   };
   render(<ChatView {...props} />);

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -7,6 +7,7 @@ import type {
 import { AgentActivityPanel } from "./AgentActivityPanel";
 import { isNearBottom, scrollToLatest } from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
+import { useUiStore } from "./UiStore";
 import { Composer } from "./Composer";
 import type { FolderAccessDecision } from "./host";
 import { MessageList } from "./MessageList";
@@ -17,7 +18,6 @@ export type ChatViewProps = {
   status: string;
   hydrated: boolean;
   nativeHost: boolean;
-  foldersPanelOpen: boolean;
   deletingChat: boolean;
   agentRuns: AgentRun[];
   agentRunsLoading: boolean;
@@ -53,9 +53,6 @@ export type ChatViewProps = {
   onSend: () => Promise<void>;
   onSteer: () => Promise<void>;
   onStop: () => Promise<void>;
-  onShowDocuments: () => void;
-  onToggleFolders: () => void;
-  onShowSettings: () => void;
 };
 
 /**
@@ -68,7 +65,6 @@ export function ChatView({
   status,
   hydrated,
   nativeHost,
-  foldersPanelOpen,
   deletingChat,
   agentRuns,
   agentRunsLoading,
@@ -97,10 +93,13 @@ export function ChatView({
   onSend,
   onSteer,
   onStop,
-  onShowDocuments,
-  onToggleFolders,
-  onShowSettings,
 }: ChatViewProps) {
+  const foldersPanelOpen = useUiStore(
+    (state) => state.settingsPanel === "folders",
+  );
+  const showDocuments = useUiStore((state) => state.showDocuments);
+  const showSettings = useUiStore((state) => state.showSettings);
+  const toggleFoldersPanel = useUiStore((state) => state.toggleFoldersPanel);
   const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);
   const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
@@ -149,7 +148,7 @@ export function ChatView({
                 type="button"
                 className="btn"
                 aria-label="Sources"
-                onClick={onShowDocuments}
+                onClick={showDocuments}
               >
                 <LibraryBig size={14} />
               </button>
@@ -159,7 +158,7 @@ export function ChatView({
                 type="button"
                 className={`btn${foldersPanelOpen ? " is-active" : ""}`}
                 aria-label="Folders"
-                onClick={onToggleFolders}
+                onClick={() => toggleFoldersPanel()}
               >
                 <FolderOpen size={14} />
               </button>
@@ -168,7 +167,7 @@ export function ChatView({
               type="button"
               className="btn"
               aria-label="Settings"
-              onClick={onShowSettings}
+              onClick={showSettings}
             >
               <Settings size={14} />
             </button>

--- a/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
@@ -1,28 +1,35 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Chat } from "./api";
+import { useChatListStore, type ChatListStore } from "./ChatListStore";
 import { Sidebar, type SidebarProps } from "./Sidebar";
+import { useUiStore } from "./UiStore";
 
 const chats: Chat[] = [
   { id: "chat-1", title: "Roadmap", project_id: null } as unknown as Chat,
   { id: "chat-2", title: null, project_id: null } as unknown as Chat,
 ];
 
-function renderSidebar(overrides: Partial<SidebarProps> = {}) {
-  const props: SidebarProps = {
+function seedStores(overrides: Partial<ChatListStore> = {}) {
+  useChatListStore.setState({
     chats,
-    activeChatId: "chat-1",
+    selected: chats[0],
     chatsError: null,
-    primaryView: "chat",
-    foldersPanelOpen: false,
-    nativeHost: false,
     creatingChat: false,
     deletingChatId: null,
     renamingChatId: null,
     renameChatDraft: "",
     savingTitle: false,
+    ...overrides,
+  });
+  useUiStore.setState({ primaryView: "chat", settingsPanel: null });
+}
+
+function renderSidebar(overrides: Partial<SidebarProps> = {}) {
+  const props: SidebarProps = {
+    nativeHost: false,
     themeMode: "light",
     updateReady: false,
     updateVersion: null,
@@ -30,13 +37,9 @@ function renderSidebar(overrides: Partial<SidebarProps> = {}) {
     onNewChat: vi.fn(),
     onSelectChat: vi.fn(),
     onStartRename: vi.fn(),
-    onRenameDraftChange: vi.fn(),
     onCommitRename: vi.fn(),
     onCancelRename: vi.fn(),
     onDeleteChat: vi.fn(),
-    onShowDocuments: vi.fn(),
-    onToggleFolders: vi.fn(),
-    onShowSettings: vi.fn(),
     onRestartForUpdate: vi.fn(),
     ...overrides,
   };
@@ -44,10 +47,11 @@ function renderSidebar(overrides: Partial<SidebarProps> = {}) {
   return props;
 }
 
+beforeEach(() => seedStores());
 afterEach(cleanup);
 
 describe("Sidebar", () => {
-  it("lists chats with the active one marked and selects on click", async () => {
+  it("lists chats from the store with the active one marked", async () => {
     const user = userEvent.setup();
     const props = renderSidebar();
     const active = screen.getByRole("button", { name: "Roadmap" });
@@ -58,15 +62,13 @@ describe("Sidebar", () => {
     expect(props.onNewChat).not.toHaveBeenCalled();
   });
 
-  it("drives the rename flow through commit and cancel", async () => {
+  it("drives the rename flow: draft edits hit the store, commit and cancel the owner", async () => {
     const user = userEvent.setup();
-    const props = renderSidebar({
-      renamingChatId: "chat-1",
-      renameChatDraft: "Roadmap",
-    });
+    seedStores({ renamingChatId: "chat-1", renameChatDraft: "Roadmap" });
+    const props = renderSidebar();
     const input = screen.getByRole("textbox", { name: "Chat title" });
     await user.type(input, "!");
-    expect(props.onRenameDraftChange).toHaveBeenCalledWith("Roadmap!");
+    expect(useChatListStore.getState().renameChatDraft).toBe("Roadmap!");
 
     await user.keyboard("{Enter}");
     expect(props.onCommitRename).toHaveBeenCalledWith(chats[0]);
@@ -77,23 +79,48 @@ describe("Sidebar", () => {
   });
 
   it("disables chat interaction while a mutation is in flight", () => {
-    renderSidebar({ deletingChatId: "chat-2" });
+    seedStores({ deletingChatId: "chat-2" });
+    renderSidebar();
     expect(screen.getByRole("button", { name: "Roadmap" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Deleting…" })).toBeDisabled();
   });
 
-  it("shows native-host and update affordances only when available", () => {
+  it("re-renders when the store's chat list changes", () => {
     renderSidebar();
-    expect(screen.queryByText("Sources")).not.toBeInTheDocument();
+    expect(screen.queryByText("Retro notes")).not.toBeInTheDocument();
+    act(() => {
+      useChatListStore
+        .getState()
+        .prependChat({
+          id: "chat-3",
+          title: "Retro notes",
+          project_id: null,
+        } as unknown as Chat);
+    });
+    expect(screen.getByText("Retro notes")).toBeInTheDocument();
+  });
+
+  it("navigates through the UI store for documents, folders, and settings", async () => {
+    const user = userEvent.setup();
+    renderSidebar({ nativeHost: true });
+    await user.click(screen.getByText("Sources"));
+    expect(useUiStore.getState().primaryView).toBe("documents");
+
+    await user.click(screen.getByText("Folders"));
+    expect(useUiStore.getState().primaryView).toBe("chat");
+    expect(useUiStore.getState().settingsPanel).toBe("folders");
+
+    await user.click(screen.getByText("Settings"));
+    expect(useUiStore.getState().primaryView).toBe("settings");
+    expect(useUiStore.getState().settingsPanel).toBeNull();
+  });
+
+  it("shows update affordances only when an update is ready", () => {
+    renderSidebar();
     expect(screen.queryByText("Restart to update")).not.toBeInTheDocument();
     cleanup();
 
-    renderSidebar({
-      nativeHost: true,
-      updateReady: true,
-      updateVersion: "1.2.3",
-    });
-    expect(screen.getByText("Sources")).toBeInTheDocument();
+    renderSidebar({ updateReady: true, updateVersion: "1.2.3" });
     expect(screen.getByText("Restart to update")).toBeInTheDocument();
     expect(screen.getByText("v1.2.3")).toBeInTheDocument();
   });

--- a/crates/openwave-desktop/ui/src/Sidebar.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.tsx
@@ -22,19 +22,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
 import type { ThemeMode } from "./theme";
+import { useChatListStore } from "./ChatListStore";
+import { useUiStore } from "./UiStore";
 
 export type SidebarProps = {
-  chats: Chat[];
-  activeChatId: string;
-  chatsError: string | null;
-  primaryView: "chat" | "documents" | "settings";
-  foldersPanelOpen: boolean;
   nativeHost: boolean;
-  creatingChat: boolean;
-  deletingChatId: string | null;
-  renamingChatId: string | null;
-  renameChatDraft: string;
-  savingTitle: boolean;
   themeMode: ThemeMode;
   updateReady: boolean;
   updateVersion: string | null;
@@ -42,29 +34,20 @@ export type SidebarProps = {
   onNewChat: () => void;
   onSelectChat: (chat: Chat) => void;
   onStartRename: (chat: Chat) => void;
-  onRenameDraftChange: (value: string) => void;
   onCommitRename: (chat: Chat) => void;
   onCancelRename: () => void;
   onDeleteChat: (chat: Chat) => void;
-  onShowDocuments: () => void;
-  onToggleFolders: () => void;
-  onShowSettings: () => void;
   onRestartForUpdate: () => void;
 };
 
-/** The navigation aside: brand/theme, chat list, and footer actions. */
+/**
+ * The navigation aside: brand/theme, chat list, and footer actions. List and
+ * view state come straight from the chat-list and UI stores; the callback
+ * props are the mutations whose orchestration (fences, confirm dialog,
+ * session lifecycle) lives with the owner.
+ */
 export function Sidebar({
-  chats,
-  activeChatId,
-  chatsError,
-  primaryView,
-  foldersPanelOpen,
   nativeHost,
-  creatingChat,
-  deletingChatId,
-  renamingChatId,
-  renameChatDraft,
-  savingTitle,
   themeMode,
   updateReady,
   updateVersion,
@@ -72,15 +55,27 @@ export function Sidebar({
   onNewChat,
   onSelectChat,
   onStartRename,
-  onRenameDraftChange,
   onCommitRename,
   onCancelRename,
   onDeleteChat,
-  onShowDocuments,
-  onToggleFolders,
-  onShowSettings,
   onRestartForUpdate,
 }: SidebarProps) {
+  const chats = useChatListStore((state) => state.chats);
+  const activeChatId = useChatListStore((state) => state.selected?.id ?? null);
+  const chatsError = useChatListStore((state) => state.chatsError);
+  const creatingChat = useChatListStore((state) => state.creatingChat);
+  const deletingChatId = useChatListStore((state) => state.deletingChatId);
+  const renamingChatId = useChatListStore((state) => state.renamingChatId);
+  const renameChatDraft = useChatListStore((state) => state.renameChatDraft);
+  const savingTitle = useChatListStore((state) => state.savingTitle);
+  const setRenameDraft = useChatListStore((state) => state.setRenameDraft);
+  const primaryView = useUiStore((state) => state.primaryView);
+  const foldersPanelOpen = useUiStore(
+    (state) => state.settingsPanel === "folders",
+  );
+  const showDocuments = useUiStore((state) => state.showDocuments);
+  const showSettings = useUiStore((state) => state.showSettings);
+  const toggleFoldersPanel = useUiStore((state) => state.toggleFoldersPanel);
   return (
     <aside className="sidebar">
       <div className="sidebar-brand">
@@ -125,7 +120,7 @@ export function Sidebar({
         <button
           type="button"
           className={`sidebar-action sidebar-library${primaryView === "documents" ? " is-active" : ""}`}
-          onClick={onShowDocuments}
+          onClick={showDocuments}
         >
           <LibraryBig size={16} />
           Sources
@@ -149,9 +144,7 @@ export function Sidebar({
                     aria-label="Chat title"
                     value={renameChatDraft}
                     disabled={savingTitle}
-                    onChange={(event) =>
-                      onRenameDraftChange(event.target.value)
-                    }
+                    onChange={(event) => setRenameDraft(event.target.value)}
                     onBlur={() => onCommitRename(item)}
                     onKeyDown={(event) => {
                       if (event.key === "Enter") {
@@ -234,7 +227,7 @@ export function Sidebar({
           <button
             type="button"
             className={`sidebar-action${primaryView === "chat" && foldersPanelOpen ? " is-active" : ""}`}
-            onClick={onToggleFolders}
+            onClick={() => toggleFoldersPanel({ showChat: true })}
           >
             <FolderOpen size={16} />
             Folders
@@ -243,7 +236,7 @@ export function Sidebar({
         <button
           type="button"
           className={`sidebar-action${primaryView === "settings" ? " is-active" : ""}`}
-          onClick={onShowSettings}
+          onClick={showSettings}
         >
           <Settings size={16} />
           Settings

--- a/crates/openwave-desktop/ui/src/UiStore.test.ts
+++ b/crates/openwave-desktop/ui/src/UiStore.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createUiStore } from "./UiStore";
+
+describe("UiStore", () => {
+  it("showChat closes panels by default but preserves them when asked", () => {
+    const store = createUiStore();
+    store.getState().toggleFoldersPanel();
+    expect(store.getState().settingsPanel).toBe("folders");
+
+    // Back-navigation and new-chat historically left the panel alone.
+    store.getState().showChat({ keepPanels: true });
+    expect(store.getState().primaryView).toBe("chat");
+    expect(store.getState().settingsPanel).toBe("folders");
+
+    // Selecting a chat clears it.
+    store.getState().showChat();
+    expect(store.getState().settingsPanel).toBeNull();
+  });
+
+  it("documents and settings views always close the folders panel", () => {
+    const store = createUiStore();
+    store.getState().toggleFoldersPanel();
+    store.getState().showDocuments();
+    expect(store.getState()).toMatchObject({
+      primaryView: "documents",
+      settingsPanel: null,
+    });
+
+    store.getState().toggleFoldersPanel();
+    store.getState().showSettings();
+    expect(store.getState()).toMatchObject({
+      primaryView: "settings",
+      settingsPanel: null,
+    });
+  });
+
+  it("toggleFoldersPanel flips the panel and can force the chat view", () => {
+    const store = createUiStore();
+    store.getState().showSettings();
+    store.getState().toggleFoldersPanel({ showChat: true });
+    expect(store.getState()).toMatchObject({
+      primaryView: "chat",
+      settingsPanel: "folders",
+    });
+    store.getState().toggleFoldersPanel();
+    expect(store.getState().settingsPanel).toBeNull();
+  });
+});

--- a/crates/openwave-desktop/ui/src/UiStore.ts
+++ b/crates/openwave-desktop/ui/src/UiStore.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+
+export type PrimaryView = "chat" | "documents" | "settings";
+export type SettingsPanel = "folders" | null;
+
+/**
+ * App-level view state: which primary surface is showing and whether the
+ * folders side panel is open. Actions are named for intent so call sites
+ * read as navigation, not state plumbing.
+ */
+export type UiStore = {
+  primaryView: PrimaryView;
+  settingsPanel: SettingsPanel;
+  /**
+   * Return to the chat view. By default any open side panel closes (chat
+   * selection); `keepPanels` preserves it (new-chat and back navigation,
+   * which historically left the panel alone).
+   */
+  showChat: (options?: { keepPanels?: boolean }) => void;
+  showDocuments: () => void;
+  showSettings: () => void;
+  /** Toggle the folders panel; optionally force the chat view first. */
+  toggleFoldersPanel: (options?: { showChat?: boolean }) => void;
+};
+
+export function createUiStore() {
+  return create<UiStore>()((set) => ({
+    primaryView: "chat",
+    settingsPanel: null,
+    showChat: (options) =>
+      set((state) => ({
+        primaryView: "chat",
+        settingsPanel: options?.keepPanels ? state.settingsPanel : null,
+      })),
+    showDocuments: () => set({ primaryView: "documents", settingsPanel: null }),
+    showSettings: () => set({ primaryView: "settings", settingsPanel: null }),
+    toggleFoldersPanel: (options) =>
+      set((state) => ({
+        primaryView: options?.showChat ? "chat" : state.primaryView,
+        settingsPanel: state.settingsPanel === "folders" ? null : "folders",
+      })),
+  }));
+}
+
+export const useUiStore = createUiStore();


### PR DESCRIPTION
Closes #392. Slice 5 of the client-state refactor (#381, #384, #387, #389).

- **`UiStore`**: `primaryView` + `settingsPanel` with intent-named actions. `showChat()` clears the folders panel (chat selection) while `showChat({keepPanels: true})` preserves it (new-chat, back navigation) — pinned by unit tests because that asymmetry existed in the original `setPrimaryView`/`setSettingsPanel` call sites.
- **`ChatListStore`**: chats, selection, list error, and create/delete/rename progress with plain state actions. Async mutation orchestration (confirm dialog, fences, session reset, controller lifecycle) intentionally stays in App, reading and writing through the store; `replaceChat` updates list + matching selection together.
- **Sidebar** subscribes directly (−16 props); **ChatView** subscribes for panel state (−4 props); App drops its `chat`/`chats`/view component state and is down to ~1,130 lines from the original 1,748.

## Tests

UiStore unit tests (keepPanels semantics, panel-clearing on documents/settings, toggle+force-chat). Sidebar DOM tests rewritten store-driven: draft edits land in the store, store list changes re-render the component, and navigation flows through UI-store actions end-to-end. 218 tests, `tsc`, and the production build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)