### PR TITLE
perf(desktop): memoize message rows so streaming re-renders only the live bubble

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -424,3 +424,28 @@ describe("applyTerminalHydration", () => {
     expect(ahead.lastSeq).toBe(99);
   });
 });
+
+describe("referential stability for memoized rows", () => {
+  it("text_delta preserves the identity of every settled message", () => {
+    const base = play([
+      TURN,
+      { type: "tool_call_started", call_id: "c1", name: "search" },
+      { type: "tool_call_completed", call_id: "c1", status: "completed" },
+      { type: "text_delta", text: "first" },
+    ]);
+    const settled = base.state.messages.slice(0, -1);
+    const next = reduceChatSessionEvent(
+      base.state,
+      framed(base.state.lastSeq + 1, { type: "text_delta", text: " second" }),
+      makeDeps(),
+    );
+    // Only the streaming tail changed; every settled row is the same object,
+    // which is what lets React.memo skip re-rendering them per token.
+    next.state.messages.slice(0, -1).forEach((message, index) => {
+      expect(message).toBe(settled[index]);
+    });
+    expect(next.state.messages[next.state.messages.length - 1]).not.toBe(
+      base.state.messages[base.state.messages.length - 1],
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -99,3 +99,11 @@ describe("approval card interactions", () => {
     expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument();
   });
 });
+
+describe("row memoization", () => {
+  it("MessageBubble is a memoized component", () => {
+    expect(
+      (MessageBubble as unknown as { $$typeof: symbol }).$$typeof,
+    ).toBe(Symbol.for("react.memo"));
+  });
+});

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import type { ReactNode, RefObject, UIEvent } from "react";
 import type { PendingFolderAccessRequest } from "./api";
 import { AssistantWorkingIndicator } from "./AssistantWorkingIndicator";
@@ -81,10 +82,18 @@ export function MessageList({
   onSelectPrompt,
   hydrated = true,
 }: MessageListProps) {
-  const messageItems = groupMessageItems(messages, busy, onApproval, {
-    decidingApprovalCalls,
-    approvalErrors,
-  });
+  // Stable identity between renders so memoized rows only re-render when the
+  // approval state itself changes, not on every streamed token.
+  const approvalState = useMemo(
+    () => ({ decidingApprovalCalls, approvalErrors }),
+    [decidingApprovalCalls, approvalErrors],
+  );
+  const messageItems = groupMessageItems(
+    messages,
+    busy,
+    onApproval,
+    approvalState,
+  );
   // Only greet a genuinely empty, fully-hydrated conversation. While an
   // existing chat's transcript is still loading it is transiently empty; showing
   // the welcome there would flash "How can I help?" before its history renders.
@@ -234,7 +243,14 @@ export function groupMessageItems(
   return items;
 }
 
-export function MessageBubble({
+/**
+ * Memoized row: settled messages keep referential identity across reducer
+ * transitions, so during streaming only the live assistant bubble (whose
+ * message object changes each token) re-renders.
+ */
+export const MessageBubble = memo(MessageBubbleImpl);
+
+function MessageBubbleImpl({
   message,
   busy,
   onApproval,


### PR DESCRIPTION
Closes #394. Slice 6 — the last of the client-state refactor series (#381, #384, #387, #389, #392).

`MessageMarkdown` was already memoized on its source string, but every streamed token still re-rendered every settled row (bubble wrapper, footer, tool cards). Now:

- `MessageBubble` is wrapped in `React.memo`; settled messages keep referential identity across reducer transitions, so only the live streaming bubble re-renders per token.
- `MessageList` builds the `approvalState` object with `useMemo` so its identity doesn't defeat the memo on approval rows.

## Tests

A reducer test pins the load-bearing invariant (settled message objects are reference-identical across `text_delta` transitions; only the streaming tail changes), and a DOM test pins that `MessageBubble` is a memo component. 220 tests, `tsc`, and the production build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)