### PR TITLE
fix(desktop): tolerate unknown stream event types in the session reducer

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatSessionController.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionController.test.ts
@@ -176,3 +176,24 @@ describe("ChatSessionController", () => {
     expect(h.events).toEqual([FRAME]);
   });
 });
+
+describe("frame validation", () => {
+  it("drops undecodable frames instead of forwarding them", () => {
+    const h = harness();
+    h.controller.start();
+    h.latest().emit(null as unknown as SequencedEvent);
+    h.latest().emit({ seq: Number.NaN, event: FRAME.event });
+    h.latest().emit({ seq: 2, event: "nope" } as unknown as SequencedEvent);
+    h.latest().emit({
+      seq: 3,
+      event: { type: 42 },
+    } as unknown as SequencedEvent);
+    expect(h.events).toEqual([]);
+
+    h.latest().emit({
+      seq: 4,
+      event: { type: "future_thing" },
+    } as unknown as SequencedEvent);
+    expect(h.events).toHaveLength(1);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatSessionController.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionController.ts
@@ -31,6 +31,22 @@ export type ChatSessionControllerOptions = {
  * disposing this controller and constructing a new one, which is what fences
  * stale sockets and timers (no generation counters, no borrowed refs).
  */
+/**
+ * Minimal envelope check for an incoming frame: a finite seq and an event
+ * object with a string type. Event payloads are typed downstream; unknown
+ * types are tolerated there, but a frame without this shape is undecodable.
+ */
+function isWellFormedFrame(frame: SequencedEvent): boolean {
+  return (
+    typeof frame === "object" &&
+    frame !== null &&
+    Number.isFinite(frame.seq) &&
+    typeof frame.event === "object" &&
+    frame.event !== null &&
+    typeof (frame.event as { type?: unknown }).type === "string"
+  );
+}
+
 export class ChatSessionController {
   private disposed = false;
   private socket: WebSocket | null = null;
@@ -72,9 +88,12 @@ export class ChatSessionController {
     let socket: WebSocket;
     try {
       socket = this.options.openSocket(this.options.getAfter(), (event) => {
-        if (!this.disposed && this.socket === socket) {
-          this.options.onEvent(event);
+        if (this.disposed || this.socket !== socket) return;
+        if (!isWellFormedFrame(event)) {
+          console.error("dropping malformed event frame", event);
+          return;
         }
+        this.options.onEvent(event);
       });
     } catch {
       this.scheduleReconnect();

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -449,3 +449,19 @@ describe("referential stability for memoized rows", () => {
     );
   });
 });
+
+describe("forward compatibility", () => {
+  it("tolerates event types this build does not know", () => {
+    const { state, effects } = reduceChatSessionEvent(
+      initialChatSessionState(),
+      {
+        seq: 9,
+        event: { type: "hologram_delta" } as unknown as AgentEvent,
+      },
+      makeDeps(),
+    );
+    expect(state.lastSeq).toBe(9);
+    expect(state.messages).toEqual([]);
+    expect(effects).toEqual([]);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -353,6 +353,12 @@ export function reduceChatSessionEvent(
     case "context_truncated":
     case "event_omitted":
       return { state, effects };
+
+    // Event types this build does not know (a newer server) advance the
+    // cursor and change nothing — falling off the switch would return
+    // undefined and crash the caller once per frame.
+    default:
+      return { state, effects };
   }
 }
 


### PR DESCRIPTION
Closes #398. Discovered while assessing how much frame validation the event stream actually needs.

The #381 reducer's `switch` has no default arm — exhaustive for TypeScript, but at runtime a frame with an event type this build doesn't know (any future server-side protocol addition) matches no case, the function returns `undefined`, and `applyEvent` throws on destructuring — once per frame. The pre-refactor if-chain tolerated unknown types (cursor advanced, nothing else). This restores that semantics with a default arm, and adds a minimal envelope guard at the controller boundary (finite `seq`, object `event`, string `type`) so undecodable frames are dropped with a console error. Deliberately *not* full per-field schema validation — the server is in-process, loopback, and token-authed; forward compatibility is the real risk, not adversarial frames.

Tests: reducer tolerates an unrecognized type (cursor advances, no state change, no effects); controller drops malformed frames but forwards well-formed unknown types. 222 tests, `tsc`, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)