### PR TITLE
fix(core): let sensitive tool calls keep their assistant preamble

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1323,14 +1323,20 @@ impl Agent {
                         .is_some_and(|tool| tool.approval_class() == ApprovalClass::Sensitive)
                 })
                 .collect::<Vec<_>>();
-            if !sensitive_calls.is_empty()
-                && (calls.len() != 1 || sensitive_calls.len() != 1 || !text.is_empty())
-            {
+            // A sensitive call may carry assistant prose ("I'll search for…"):
+            // the step then persists its message and parks exactly like any
+            // other text+tool step — three lease-fenced writes, with recovery
+            // abandoning an interrupted call behind its visible preamble. Only
+            // sibling calls stay forbidden: a multi-call sensitive batch has no
+            // unambiguous resume shape (see resume_pending_server_calls).
+            // Rejecting prose here used to burn the whole step budget on
+            // corrective retries the model never satisfied (#372).
+            if !sensitive_calls.is_empty() && (calls.len() != 1 || sensitive_calls.len() != 1) {
                 events.send(AgentEvent::StreamInterrupted);
                 transcript.push(ChatMessage {
                     role: Role::User,
                     content: vec![ContentBlock::Text {
-                        text: "A sensitive tool must be requested alone, without assistant text or sibling tool calls. Retry the request in that form.".into(),
+                        text: "A sensitive tool must be requested alone, without sibling tool calls. Retry the request in that form.".into(),
                     }],
                 });
                 continue;
@@ -4374,6 +4380,224 @@ mod tests {
             AgentEvent::ToolCallCompleted { output, .. }
                 if output.content == "boomed" && !output.is_error
         )));
+    }
+
+    /// Provider that prefaces a sensitive `boom` call with prose, then
+    /// finishes on the next step.
+    struct ProseBoomProvider {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ModelProvider for ProseBoomProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("prose-boom")
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let events = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                vec![
+                    ProviderEvent::TextDelta {
+                        text: "I'll run the sensitive tool for you.".into(),
+                    },
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "call_boom".into(),
+                        name: "boom".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: "{}".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta { text: "ok".into() },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    /// The failure that motivated #372: prose plus one sensitive call must
+    /// keep the preamble, persist it like any other text+tool step, and reach
+    /// the approval gate on the first step instead of burning the budget on
+    /// corrective retries.
+    #[tokio::test]
+    async fn sensitive_call_with_prose_keeps_the_preamble_and_parks() {
+        use crate::approval::AutoApproveGate;
+
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let tools = Arc::new(ToolRegistry::new().with(Box::new(BoomTool { ran: ran.clone() })));
+        let provider = Arc::new(ProseBoomProvider {
+            calls: AtomicUsize::new(0),
+        });
+        let agent = Agent::new(
+            provider.clone(),
+            tools,
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        )
+        .with_approvals(Arc::new(AutoApproveGate));
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        // The step is never rejected or scrubbed: the streamed preamble stands.
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::StreamInterrupted)));
+        // The call parks on the first step and runs once approved.
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ApprovalRequired { .. })));
+        assert_eq!(ran.load(Ordering::SeqCst), 1);
+        // No corrective retry: the tool step plus the closing step.
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+        // The preamble is persisted exactly once, like any other text+tool step.
+        let history = store.list_messages(chat.id).await.unwrap();
+        assert_eq!(
+            history
+                .iter()
+                .filter(|message| message.content.contains("sensitive tool for you"))
+                .count(),
+            1
+        );
+    }
+
+    /// Provider that pairs the sensitive call with a sibling call, which is
+    /// still malformed and must keep the corrective retry.
+    struct SiblingBoomProvider {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ModelProvider for SiblingBoomProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("sibling-boom")
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let events = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "call_a".into(),
+                        name: "boom".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: "{}".into(),
+                    },
+                    ProviderEvent::ToolCallStarted {
+                        index: 1,
+                        id: "call_b".into(),
+                        name: "boom".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 1,
+                        fragment: "{}".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta { text: "ok".into() },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    #[tokio::test]
+    async fn sensitive_call_with_sibling_calls_still_retries() {
+        use crate::approval::AutoApproveGate;
+
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let tools = Arc::new(ToolRegistry::new().with(Box::new(BoomTool { ran: ran.clone() })));
+        let provider = Arc::new(SiblingBoomProvider {
+            calls: AtomicUsize::new(0),
+        });
+        let agent = Agent::new(
+            provider.clone(),
+            tools,
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        )
+        .with_approvals(Arc::new(AutoApproveGate));
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::StreamInterrupted)));
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ApprovalRequired { .. })));
+        assert_eq!(ran.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
     }
 
     /// A Sensitive, standing-grantable tool (`search`) that records whether it


### PR DESCRIPTION
Closes #372.

## The failure this fixes

With a Sensitive tool available (`search` under OpenAI embeddings), asking the assistant to search usually killed the turn: the model prefaces tool calls with prose ("I'll search the library for…"), the sensitive-alone gate discarded the step and asked it to retry bare, the model re-prefaced on every one of 16 retries, and the loop guard failed the turn — no approval card, no explanation. Journal evidence in #372: 16× `tool_call_started` + 16× `stream_interrupted`, zero approvals, `max_steps_exceeded`.

## The fix: remove the special case

A read-only audit of the park/recovery machinery (findings posted on #372) established that the bare-call rule protected no real invariant: **ordinary text+tool steps already commit via three separate lease-fenced transactions** — there is no atomic step commit anywhere — and crash-while-parked recovery already has a defined answer (abandon the interrupted call with a synthetic error result behind its persisted text; fresh attempts mint new message ids, so no duplication). The rule only made Sensitive parks *stricter* than every other step.

So this PR deletes the text restriction. A prose-bearing Sensitive step now flows through the exact same persist → accept → register sequence as any other text+tool step: the preamble is persisted with its citations, stays visible in the client (no scrub, no flicker), and the approval card appears beneath it on the first model step. On rejection or crash recovery, the preamble remains as visible intent above a cancelled/interrupted call — the same shape every ordinary step already produces.

The **sibling-call** restriction stays: a multi-call batch containing a Sensitive call has no unambiguous resume shape (`resume_pending_server_calls` requires exactly one pending call for a sensitive batch), so it keeps the corrective retry.

## Verification

- New/updated agent tests: prose + one Sensitive call parks on the **first** step with **no** `StreamInterrupted`, persists the preamble **exactly once**, runs exactly once after approval, and consumes exactly two model steps; a Sensitive call with sibling calls still retries and never runs unapproved.
- `cargo fmt --check`, `clippy --workspace --all-targets --locked -D warnings`, `cargo check --workspace --locked` pass; workspace tests **1,068 passed, 0 failed** (excluding `openwave-code-execution`, whose sandbox test fails identically on unmodified main due to a broken local Xcode python shim — environmental, pre-existing).

Smoke-tested live: preamble persists and stays visible, approval card lands on the first step, rejection leaves the preamble above the cancelled call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

