### PR TITLE
fix(ci): model stale postgres cancellation race

### DIFF
--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -601,7 +601,7 @@ async fn postgres_nonblocking_spawn_and_parent_cancellation_are_one_ordered_tran
         })
     };
     let checkpoint = checkpoint_task.await.unwrap();
-    cancellation_task.await.unwrap();
+    let cancellation = cancellation_task.await.unwrap();
     let parent = store.get_turn_run(turn.id).await.unwrap().unwrap();
     let children = store
         .list_agent_runs(chat.id)
@@ -610,14 +610,30 @@ async fn postgres_nonblocking_spawn_and_parent_cancellation_are_one_ordered_tran
         .into_iter()
         .filter(|run| run.execution == AgentRunExecution::Sandbox)
         .collect::<Vec<_>>();
-    match checkpoint {
-        CheckpointSandboxSpawnOutcome::Checkpointed { .. } => {
+    match (checkpoint, cancellation) {
+        (
+            CheckpointSandboxSpawnOutcome::Checkpointed { .. },
+            Some(RequestTurnCancellationOutcome::Cancelled(_)),
+        ) => {
             assert_eq!(parent.status, TurnRunStatus::Cancelled);
             assert_eq!(children.len(), 1);
             assert_eq!(children[0].status, AgentRunStatus::Cancelled);
             assert_eq!(store.list_tool_calls(chat.id).await.unwrap().len(), 1);
         }
-        CheckpointSandboxSpawnOutcome::LeaseLost => {
+        // Cancellation timestamps are mutation fences. If the checkpoint
+        // commits after the request timestamp was captured, rejecting that
+        // stale request is correct even though it wins the scheduler lock
+        // second.
+        (CheckpointSandboxSpawnOutcome::Checkpointed { .. }, None) => {
+            assert_eq!(parent.status, TurnRunStatus::Resuming);
+            assert_eq!(children.len(), 1);
+            assert_eq!(children[0].status, AgentRunStatus::Queued);
+            assert_eq!(store.list_tool_calls(chat.id).await.unwrap().len(), 1);
+        }
+        (
+            CheckpointSandboxSpawnOutcome::LeaseLost,
+            Some(RequestTurnCancellationOutcome::Requested(_)),
+        ) => {
             assert_eq!(parent.status, TurnRunStatus::Cancelling);
             assert!(children.is_empty());
             assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -76,18 +76,27 @@ test("workflow container images are pinned by digest", () => {
   assert.doesNotMatch(workflows["ci.yml"], /gitleaks\/gitleaks:latest/);
 });
 
-test("Rust CI makes PostgreSQL required without a redundant build lane", () => {
+test("Rust CI requires the same PostgreSQL lane on pull requests and main", () => {
   const ci = workflows["ci.yml"];
   const postgres = workflowJob(ci, "postgres");
   const testJob = workflowJob(ci, "test");
   const aggregate = workflowJob(ci, "rust");
 
+  assert.match(
+    ci,
+    /^on:\n  push:\n    branches: \[main\]\n  pull_request:/m,
+  );
   assert.doesNotMatch(ci, /^  build:$/m);
   assert.match(postgres, /if:.*needs\.changes\.outputs\.rust == 'true'/);
   assert.doesNotMatch(postgres, /github\.event_name != 'pull_request'/);
   assert.match(postgres, /OPENWAVE_REQUIRE_POSTGRES_TEST: "true"/);
   assert.match(aggregate, /^\s+postgres,$/m);
   assert.match(aggregate, /test "\$POSTGRES_RESULT" = success/);
+  assert.match(
+    aggregate,
+    /pull_request\) test "\$PR_TITLE_RESULT" = success ;;/,
+  );
+  assert.match(aggregate, /\*\) test "\$PR_TITLE_RESULT" = skipped ;;/);
 
   for (const job of [
     workflowJob(ci, "lint"),


### PR DESCRIPTION
## Summary
- model the valid stale-cancellation outcome in the PostgreSQL spawn/checkpoint race
- keep the existing strict assertions for committed cancellation outcomes
- lock in that PR and `main` CI both require the same PostgreSQL lane

## Root cause
The cancellation API treats its caller timestamp as a mutation fence. On a slower `main` runner, the spawn checkpoint could commit after the cancellation timestamp was captured but before cancellation acquired the scheduler lock. The store correctly returned `None` and left the parent `Resuming`; the test incorrectly required `Cancelled`, then leaked state that caused a downstream race test to fail too.

## Validation
- `bw dev lint --rust --check`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `node --test scripts/*.test.mjs`
- affected PostgreSQL race: 100 consecutive passes
- full PostgreSQL lane: 25 passed
- `cargo test --workspace --exclude openwave-desktop --locked`
- `cargo test -p openwave-desktop --locked`