### PR TITLE
feat(desktop): add conversation outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,19 @@ Pre-alpha, built in the open. The current product is conversation-first: each
 chat is its own workspace, with exact conversation-scoped sources and retrieval
 rather than a shared fallback corpus. Sources can be added from the composer,
 read directly after parsing, or searched semantically at corpus scale, with
-grounded citations in each path. The stack includes local file tools,
-multi-provider model routing, a turn engine with live journaled WebSocket events,
-a workspace-style desktop conversation shell, a bounded foreground/sandbox
-agent-run foundation, and durable asynchronous source ingestion/retrieval with
-grounded citations — all behind `openwave serve`. Project records and APIs remain
-dormant for compatibility and future design work, but Projects are not surfaced
-in the desktop and are not required to start working.
+grounded citations in each path. Foreground agents can also create bounded text
+deliverables that remain private to the conversation until the user previews
+and explicitly exports them from the native Outputs view. The stack includes
+local file tools, multi-provider model routing, a turn engine with live
+journaled WebSocket events, a workspace-style desktop conversation shell, a
+bounded foreground/sandbox agent-run foundation, and durable asynchronous
+source ingestion/retrieval with grounded citations — all behind `openwave serve`.
+Project records and APIs remain dormant for compatibility and future design
+work, but Projects are not surfaced in the desktop and are not required to
+start working.
+
+See [`docs/deliverables.md`](docs/deliverables.md) for the generated-output and
+native export boundary.
 
 Connectors, richer document parsers, indexed-search MCP wiring, and MCP
 configuration UI remain in development. Expect rapid change and rough edges —

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -693,6 +693,7 @@ fn historical_tool_title(name: &str) -> &'static str {
         "read_file" | "read_connected_file" => "Read a file",
         "list_dir" => "Browse files",
         "write_file" => "Update a file",
+        "create_deliverable" => "Create an output",
         "request_folder_access" => "Request folder access",
         "connect_folder" => "Connect a folder",
         "list_connected_folders" => "Check connected folders",
@@ -1129,5 +1130,9 @@ mod historical_tool_title_tests {
         assert_eq!(historical_tool_title("search"), "Search sources");
         assert_eq!(historical_tool_title("list_sources"), "Check sources");
         assert_eq!(historical_tool_title("read_source"), "Read a source");
+        assert_eq!(
+            historical_tool_title("create_deliverable"),
+            "Create an output"
+        );
     }
 }

--- a/crates/openwave-core/src/deliverable.rs
+++ b/crates/openwave-core/src/deliverable.rs
@@ -1,0 +1,95 @@
+//! Closed contract for user-visible files created in conversation-private scratch.
+
+/// Private-scratch directory reserved for user-visible outputs.
+pub const DELIVERABLES_DIRECTORY: &str = "artifacts";
+/// Largest text artifact the foreground agent may create.
+pub const MAX_DELIVERABLE_BYTES: usize = 512 * 1024;
+/// Largest filename accepted by the model-facing and native boundaries.
+pub const MAX_DELIVERABLE_NAME_CHARS: usize = 120;
+
+/// Validate one portable, renderer-safe deliverable filename.
+///
+/// Deliverables deliberately use a single ASCII filename rather than an
+/// arbitrary scratch-relative path. This keeps the catalog and native export
+/// boundary closed and makes names portable across desktop platforms.
+pub fn validate_deliverable_name(name: &str) -> Result<(), &'static str> {
+    if name.is_empty() || name.chars().count() > MAX_DELIVERABLE_NAME_CHARS {
+        return Err("filename must contain between 1 and 120 characters");
+    }
+    if name.trim() != name || name.starts_with('.') || name.ends_with('.') {
+        return Err("filename may not start with a dot or surrounding whitespace");
+    }
+    if !name
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_alphanumeric())
+    {
+        return Err("filename must start with a letter or number");
+    }
+    if !name.is_ascii()
+        || !name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || " _-.()".contains(character))
+    {
+        return Err(
+            "filename may contain only letters, numbers, spaces, dashes, underscores, and parentheses",
+        );
+    }
+    if deliverable_media_type(name).is_none() {
+        return Err("filename must end in .md, .txt, .csv, .json, or .html");
+    }
+    Ok(())
+}
+
+/// Return the fixed media type for one supported deliverable filename.
+#[must_use]
+pub fn deliverable_media_type(name: &str) -> Option<&'static str> {
+    let extension = name.rsplit_once('.')?.1.to_ascii_lowercase();
+    match extension.as_str() {
+        "md" => Some("text/markdown"),
+        "txt" => Some("text/plain"),
+        "csv" => Some("text/csv"),
+        "json" => Some("application/json"),
+        "html" => Some("text/html"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deliverable_names_are_portable_and_closed() {
+        for valid in [
+            "brief.md",
+            "Q3 summary (final).txt",
+            "forecast.csv",
+            "data.json",
+            "report.html",
+        ] {
+            assert!(validate_deliverable_name(valid).is_ok(), "{valid}");
+        }
+        for invalid in [
+            "",
+            ".hidden.md",
+            "trailing.md.",
+            " report.md",
+            "_report.md",
+            "report.md ",
+            "../report.md",
+            "folder/report.md",
+            "report.pdf",
+            "bad\u{202e}.md",
+        ] {
+            assert!(validate_deliverable_name(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn media_types_are_derived_only_from_supported_extensions() {
+        assert_eq!(deliverable_media_type("brief.MD"), Some("text/markdown"));
+        assert_eq!(deliverable_media_type("table.csv"), Some("text/csv"));
+        assert_eq!(deliverable_media_type("archive.zip"), None);
+    }
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod config;
 pub mod context;
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub mod db;
+pub mod deliverable;
 pub mod error;
 pub mod event;
 pub mod id;
@@ -88,6 +89,10 @@ pub use client_tools::{
 pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub use db::DbStore;
+pub use deliverable::{
+    deliverable_media_type, validate_deliverable_name, DELIVERABLES_DIRECTORY,
+    MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_NAME_CHARS,
+};
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{
@@ -144,4 +149,4 @@ pub use storage::{
 };
 pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
 #[cfg(feature = "tools")]
-pub use tools::{ListDir, ReadFile, WriteFile};
+pub use tools::{CreateDeliverable, ListDir, ReadFile, WriteFile};

--- a/crates/openwave-core/src/tools/create_deliverable.rs
+++ b/crates/openwave-core/src/tools/create_deliverable.rs
@@ -1,0 +1,82 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::deliverable::{
+    validate_deliverable_name, DELIVERABLES_DIRECTORY, MAX_DELIVERABLE_BYTES,
+};
+use crate::error::Result;
+use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
+
+use super::arguments;
+use super::definitions;
+use super::private_scratch::write_utf8_file;
+
+/// `create_deliverable` — create or update a user-visible text artifact.
+pub struct CreateDeliverable;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Arguments {
+    filename: String,
+    content: String,
+}
+
+#[async_trait]
+impl Tool for CreateDeliverable {
+    fn spec(&self) -> ToolSpec {
+        definitions::create_deliverable()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::Workspace
+    }
+
+    async fn execute(&self, ctx: &ToolCtx, arguments: Value) -> Result<ToolOutput> {
+        let arguments: Arguments = match arguments::parse(arguments) {
+            Ok(arguments) => arguments,
+            Err(output) => return Ok(output),
+        };
+        if let Err(message) = validate_deliverable_name(&arguments.filename) {
+            return Ok(ToolOutput::error(message));
+        }
+        if arguments.content.is_empty() {
+            return Ok(ToolOutput::error("deliverable content may not be empty"));
+        }
+        if arguments.content.contains('\0') {
+            return Ok(ToolOutput::error(
+                "deliverable content may not contain null characters",
+            ));
+        }
+        let content = arguments.content.into_bytes();
+        if content.len() > MAX_DELIVERABLE_BYTES {
+            return Ok(ToolOutput::error(format!(
+                "deliverable is too large (maximum {MAX_DELIVERABLE_BYTES} bytes)"
+            )));
+        }
+        let workspace = match ctx.workspace() {
+            Ok(workspace) => workspace,
+            Err(message) => return Ok(ToolOutput::error(message)),
+        };
+        let filename = arguments.filename;
+        let relative_path = Path::new(DELIVERABLES_DIRECTORY).join(&filename);
+        let content_len = content.len();
+        let result = tokio::task::spawn_blocking(move || {
+            write_utf8_file(&workspace, &relative_path, &content)
+        })
+        .await;
+        match result {
+            Ok(Ok(())) => Ok(ToolOutput::text(format!(
+                "Created `{filename}` ({content_len} bytes). The file is available to the user in Outputs."
+            ))),
+            Ok(Err(error)) => Ok(ToolOutput::error(format!(
+                "could not create deliverable: {error}"
+            ))),
+            Err(error) => Ok(ToolOutput::error(format!(
+                "could not create deliverable: filesystem task failed: {error}"
+            ))),
+        }
+    }
+}

--- a/crates/openwave-core/src/tools/definitions.rs
+++ b/crates/openwave-core/src/tools/definitions.rs
@@ -2,11 +2,13 @@
 
 use serde_json::json;
 
+use crate::deliverable::{MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_NAME_CHARS};
 use crate::tool::ToolSpec;
 
 pub(super) const READ_FILE: &str = "read_file";
 pub(super) const LIST_DIR: &str = "list_dir";
 pub(super) const WRITE_FILE: &str = "write_file";
+pub(super) const CREATE_DELIVERABLE: &str = "create_deliverable";
 
 pub(super) fn read_file() -> ToolSpec {
     ToolSpec {
@@ -49,6 +51,35 @@ pub(super) fn write_file() -> ToolSpec {
                 "content": { "type": "string", "description": "File contents to write." }
             },
             "required": ["path", "content"]
+        }),
+    }
+}
+
+pub(super) fn create_deliverable() -> ToolSpec {
+    ToolSpec {
+        name: CREATE_DELIVERABLE.into(),
+        description: "Create or update a user-visible text file for the current conversation. \
+                      Use this when the user asks for a report, plan, table, data file, web page, \
+                      or other file they can preview and save from OpenWave's Outputs view."
+            .into(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "type": "string",
+                    "description": "Portable output filename ending in .md, .txt, .csv, .json, or .html.",
+                    "minLength": 1,
+                    "maxLength": MAX_DELIVERABLE_NAME_CHARS
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Complete UTF-8 text contents of the output file (maximum 512 KiB).",
+                    "minLength": 1,
+                    "maxLength": MAX_DELIVERABLE_BYTES
+                }
+            },
+            "required": ["filename", "content"],
+            "additionalProperties": false
         }),
     }
 }

--- a/crates/openwave-core/src/tools/mod.rs
+++ b/crates/openwave-core/src/tools/mod.rs
@@ -5,12 +5,14 @@
 //! [`private_scratch`] owns the capability-confined filesystem primitives.
 
 mod arguments;
+mod create_deliverable;
 mod definitions;
 mod list_dir;
 mod private_scratch;
 mod read_file;
 mod write_file;
 
+pub use create_deliverable::CreateDeliverable;
 pub use list_dir::ListDir;
 pub use read_file::ReadFile;
 pub use write_file::WriteFile;

--- a/crates/openwave-core/src/tools/tests.rs
+++ b/crates/openwave-core/src/tools/tests.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use serde_json::json;
 
 use super::private_scratch::{read_utf8_file, write_utf8_file, MAX_READ_FILE_BYTES};
-use super::{ListDir, ReadFile, WriteFile};
+use super::{CreateDeliverable, ListDir, ReadFile, WriteFile};
 use crate::id::ChatId;
 use crate::tool::{Tool, ToolCtx};
 
@@ -24,10 +24,77 @@ async fn every_file_tool_fails_closed_without_private_scratch() {
         .execute(&ctx, json!({"path": "note.txt", "content": "nope"}))
         .await
         .unwrap();
+    let deliverable = CreateDeliverable
+        .execute(&ctx, json!({"filename": "brief.md", "content": "nope"}))
+        .await
+        .unwrap();
 
     assert!(read.is_error);
     assert!(list.is_error);
     assert!(write.is_error);
+    assert!(deliverable.is_error);
+}
+
+#[tokio::test]
+async fn deliverables_are_isolated_in_their_closed_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = ctx(dir.path());
+    let spec = CreateDeliverable.spec();
+    assert_eq!(
+        spec.input_schema["properties"]["filename"]["maxLength"],
+        crate::MAX_DELIVERABLE_NAME_CHARS
+    );
+    assert_eq!(
+        spec.input_schema["properties"]["content"]["maxLength"],
+        crate::MAX_DELIVERABLE_BYTES
+    );
+    assert_eq!(spec.input_schema["additionalProperties"], false);
+
+    let output = CreateDeliverable
+        .execute(
+            &ctx,
+            json!({"filename": "Research brief.md", "content": "# Findings\n\nGrounded."}),
+        )
+        .await
+        .unwrap();
+    assert!(!output.is_error, "{output:?}");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("artifacts/Research brief.md")).unwrap(),
+        "# Findings\n\nGrounded."
+    );
+    assert!(output.content.contains("Outputs"));
+
+    for arguments in [
+        json!({"filename": "../escape.md", "content": "nope"}),
+        json!({"filename": "opaque.pdf", "content": "nope"}),
+        json!({"filename": "empty.txt", "content": ""}),
+        json!({"filename": "extra.txt", "content": "x", "path": "outside"}),
+    ] {
+        assert!(
+            CreateDeliverable
+                .execute(&ctx, arguments)
+                .await
+                .unwrap()
+                .is_error
+        );
+    }
+}
+
+#[tokio::test]
+async fn deliverable_size_is_bounded_before_writing() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = CreateDeliverable
+        .execute(
+            &ctx(dir.path()),
+            json!({
+                "filename": "oversized.txt",
+                "content": "x".repeat(crate::MAX_DELIVERABLE_BYTES + 1)
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(output.is_error);
+    assert!(!dir.path().join("artifacts/oversized.txt").exists());
 }
 
 #[tokio::test]

--- a/crates/openwave-desktop/src/deliverables.rs
+++ b/crates/openwave-desktop/src/deliverables.rs
@@ -1,0 +1,516 @@
+//! Native bridge for conversation-private generated outputs.
+//!
+//! The model writes only to a closed directory inside private scratch. The
+//! renderer receives bounded text and safe metadata, while a user-selected save
+//! destination stays entirely inside this native boundary.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use cap_fs_ext::{DirExt as _, FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
+use chrono::{DateTime, Utc};
+use openwave_core::{
+    deliverable_media_type, validate_deliverable_name, ChatId, DELIVERABLES_DIRECTORY,
+    MAX_DELIVERABLE_BYTES,
+};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_dialog::DialogExt;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+use crate::documents::resolve_conversation_scope;
+use crate::host_access::HostAccess;
+
+const MAX_DELIVERABLES: usize = 100;
+const MAX_DELIVERABLE_DIRECTORY_ENTRIES: usize = 1_000;
+const MAX_PREVIEW_CHARACTERS: usize = 100_000;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DeliverablesRequest {
+    chat_id: Uuid,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DeliverableRequest {
+    chat_id: Uuid,
+    filename: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DeliverableSummary {
+    filename: String,
+    media_type: String,
+    size_bytes: u64,
+    updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DeliverablesCatalog {
+    deliverables: Vec<DeliverableSummary>,
+    truncated: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DeliverablePreview {
+    filename: String,
+    media_type: String,
+    content: String,
+    truncated: bool,
+}
+
+#[tauri::command]
+pub(crate) async fn list_deliverables(
+    app: AppHandle,
+    host_access: State<'_, HostAccess>,
+    request: DeliverablesRequest,
+) -> Result<DeliverablesCatalog, String> {
+    let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
+    let scratch_root = crate::data_dir(&app)?.join("scratch");
+    tauri::async_runtime::spawn_blocking(move || list_deliverables_in_root(&scratch_root, chat_id))
+        .await
+        .map_err(|_| "Could not load this conversation's outputs".to_owned())?
+}
+
+#[tauri::command]
+pub(crate) async fn read_deliverable(
+    app: AppHandle,
+    host_access: State<'_, HostAccess>,
+    request: DeliverableRequest,
+) -> Result<DeliverablePreview, String> {
+    let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
+    validate_deliverable_name(&request.filename)
+        .map_err(|_| "Invalid output filename".to_owned())?;
+    let scratch_root = crate::data_dir(&app)?.join("scratch");
+    let filename = request.filename;
+    tauri::async_runtime::spawn_blocking(move || {
+        let content = read_deliverable_bytes(&scratch_root, chat_id, &filename)?;
+        preview_from_bytes(filename, content)
+    })
+    .await
+    .map_err(|_| "Could not preview that output".to_owned())?
+}
+
+#[tauri::command]
+pub(crate) async fn export_deliverable(
+    app: AppHandle,
+    host_access: State<'_, HostAccess>,
+    request: DeliverableRequest,
+) -> Result<bool, String> {
+    let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
+    validate_deliverable_name(&request.filename)
+        .map_err(|_| "Invalid output filename".to_owned())?;
+    let _picker = host_access
+        .picker
+        .try_lock()
+        .map_err(|_| "A file or folder picker is already open".to_owned())?;
+    let scratch_root = crate::data_dir(&app)?.join("scratch");
+    let filename = request.filename;
+    let read_filename = filename.clone();
+    let content = tauri::async_runtime::spawn_blocking(move || {
+        read_deliverable_bytes(&scratch_root, chat_id, &read_filename)
+    })
+    .await
+    .map_err(|_| "Could not read that output".to_owned())??;
+
+    let Some(destination) = pick_export_path(&app, &filename).await? else {
+        return Ok(false);
+    };
+    // A picker may remain open while the selected conversation is deleted.
+    // Revalidate before the one user-authorized host write.
+    resolve_conversation_scope(&host_access, request.chat_id).await?;
+    tauri::async_runtime::spawn_blocking(move || {
+        write_exported_deliverable(&destination, &content)
+    })
+    .await
+    .map_err(|_| "Could not save that output".to_owned())??;
+    Ok(true)
+}
+
+fn list_deliverables_in_root(
+    scratch_root: &Path,
+    chat_id: ChatId,
+) -> Result<DeliverablesCatalog, String> {
+    let Some(directory) = open_deliverables_directory(scratch_root, chat_id)? else {
+        return Ok(DeliverablesCatalog {
+            deliverables: Vec::new(),
+            truncated: false,
+        });
+    };
+    let entries = directory
+        .read_dir(".")
+        .map_err(|_| "Could not load this conversation's outputs".to_owned())?;
+    let mut deliverables = Vec::new();
+    let mut inspected = 0usize;
+    for entry in entries {
+        inspected += 1;
+        if inspected > MAX_DELIVERABLE_DIRECTORY_ENTRIES {
+            return Err("This conversation has too many output files".to_owned());
+        }
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let Some(filename) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if validate_deliverable_name(&filename).is_err() {
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_file() || file_type.is_symlink() {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if metadata.len() > MAX_DELIVERABLE_BYTES as u64 {
+            continue;
+        }
+        let Some(media_type) = deliverable_media_type(&filename) else {
+            continue;
+        };
+        let updated_at = metadata
+            .modified()
+            .map(|time| DateTime::<Utc>::from(time.into_std()))
+            .unwrap_or_else(|_| DateTime::<Utc>::UNIX_EPOCH)
+            .to_rfc3339();
+        deliverables.push(DeliverableSummary {
+            filename,
+            media_type: media_type.to_owned(),
+            size_bytes: metadata.len(),
+            updated_at,
+        });
+    }
+    deliverables.sort_by(|left, right| {
+        right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then_with(|| left.filename.cmp(&right.filename))
+    });
+    let truncated = deliverables.len() > MAX_DELIVERABLES;
+    deliverables.truncate(MAX_DELIVERABLES);
+    Ok(DeliverablesCatalog {
+        deliverables,
+        truncated,
+    })
+}
+
+fn open_deliverables_directory(
+    scratch_root: &Path,
+    chat_id: ChatId,
+) -> Result<Option<Dir>, String> {
+    let Some(root) = open_regular_directory(scratch_root)? else {
+        return Ok(None);
+    };
+    let chat_name = chat_id.to_string();
+    if !is_regular_child_directory(&root, &chat_name)? {
+        return Ok(None);
+    }
+    let chat = root
+        .open_dir_nofollow(&chat_name)
+        .map_err(|_| "Could not open this conversation's private outputs".to_owned())?;
+    if !is_regular_child_directory(&chat, DELIVERABLES_DIRECTORY)? {
+        return Ok(None);
+    }
+    chat.open_dir_nofollow(DELIVERABLES_DIRECTORY)
+        .map(Some)
+        .map_err(|_| "Could not open this conversation's private outputs".to_owned())
+}
+
+fn open_regular_directory(path: &Path) -> Result<Option<Dir>, String> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err("Could not open private outputs".to_owned()),
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err("Private output storage is invalid".to_owned());
+    }
+    let directory = Dir::open_ambient_dir(path, ambient_authority())
+        .map_err(|_| "Could not open private outputs".to_owned())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        let opened = directory
+            .dir_metadata()
+            .map_err(|_| "Could not open private outputs".to_owned())?;
+        if metadata.dev() != cap_std::fs::MetadataExt::dev(&opened)
+            || metadata.ino() != cap_std::fs::MetadataExt::ino(&opened)
+        {
+            return Err("Private output storage changed while it was opened".to_owned());
+        }
+    }
+    Ok(Some(directory))
+}
+
+fn is_regular_child_directory(parent: &Dir, name: &str) -> Result<bool, String> {
+    match parent.symlink_metadata(name) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => Ok(true),
+        Ok(_) => Err("Private output storage is invalid".to_owned()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(_) => Err("Could not inspect private outputs".to_owned()),
+    }
+}
+
+fn read_deliverable_bytes(
+    scratch_root: &Path,
+    chat_id: ChatId,
+    filename: &str,
+) -> Result<Vec<u8>, String> {
+    validate_deliverable_name(filename).map_err(|_| "Invalid output filename".to_owned())?;
+    let directory = open_deliverables_directory(scratch_root, chat_id)?
+        .ok_or_else(|| "Output not found".to_owned())?;
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = directory
+        .open_with(filename, &options)
+        .map_err(|_| "Output not found".to_owned())?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| "Could not read that output".to_owned())?;
+    if !metadata.is_file() || metadata.len() > MAX_DELIVERABLE_BYTES as u64 {
+        return Err("Output is not a supported text file".to_owned());
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take((MAX_DELIVERABLE_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| "Could not read that output".to_owned())?;
+    if bytes.len() > MAX_DELIVERABLE_BYTES
+        || bytes.contains(&0)
+        || std::str::from_utf8(&bytes).is_err()
+    {
+        return Err("Output is not a supported text file".to_owned());
+    }
+    Ok(bytes)
+}
+
+fn preview_from_bytes(filename: String, bytes: Vec<u8>) -> Result<DeliverablePreview, String> {
+    let text =
+        String::from_utf8(bytes).map_err(|_| "Output is not a supported text file".to_owned())?;
+    if text.contains('\0') {
+        return Err("Output is not a supported text file".to_owned());
+    }
+    let mut characters = text.chars();
+    let content: String = characters.by_ref().take(MAX_PREVIEW_CHARACTERS).collect();
+    let truncated = characters.next().is_some();
+    let media_type = deliverable_media_type(&filename)
+        .ok_or_else(|| "Output is not a supported text file".to_owned())?;
+    Ok(DeliverablePreview {
+        filename,
+        media_type: media_type.to_owned(),
+        content,
+        truncated,
+    })
+}
+
+async fn pick_export_path(app: &AppHandle, filename: &str) -> Result<Option<PathBuf>, String> {
+    let (tx, rx) = oneshot::channel();
+    let mut picker = app
+        .dialog()
+        .file()
+        .set_title("Save output")
+        .set_file_name(filename);
+    if let Some(window) = app.get_webview_window("main") {
+        picker = picker.set_parent(&window);
+    }
+    picker.save_file(move |path| {
+        let _ = tx.send(path);
+    });
+    rx.await
+        .map_err(|_| "The save dialog closed unexpectedly".to_owned())?
+        .map(tauri_plugin_dialog::FilePath::into_path)
+        .transpose()
+        .map_err(|_| "The save dialog returned an invalid destination".to_owned())
+}
+
+fn write_exported_deliverable(destination: &Path, content: &[u8]) -> Result<(), String> {
+    if !destination.is_absolute() || content.len() > MAX_DELIVERABLE_BYTES {
+        return Err("The save destination is invalid".to_owned());
+    }
+    let parent = destination
+        .parent()
+        .ok_or_else(|| "The save destination is invalid".to_owned())?;
+    let filename = destination
+        .file_name()
+        .ok_or_else(|| "The save destination is invalid".to_owned())?;
+    let directory = Dir::open_ambient_dir(parent, ambient_authority())
+        .map_err(|_| "Could not open the selected folder".to_owned())?;
+    let permissions = match directory.symlink_metadata(filename) {
+        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {
+            Some(metadata.permissions())
+        }
+        Ok(_) => return Err("The selected destination is not a regular file".to_owned()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(_) => return Err("Could not inspect the selected destination".to_owned()),
+    };
+    let temporary = format!(".openwave-export-{}.tmp", Uuid::new_v4());
+    let result = (|| -> std::io::Result<()> {
+        let mut options = OpenOptions::new();
+        options
+            .write(true)
+            .create_new(true)
+            .follow(FollowSymlinks::No);
+        #[cfg(unix)]
+        {
+            use cap_std::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = directory.open_with(&temporary, &options)?;
+        file.write_all(content)?;
+        file.sync_all()?;
+        if let Some(permissions) = permissions {
+            file.set_permissions(permissions)?;
+        }
+        drop(file);
+        directory.rename(&temporary, &directory, filename)?;
+        #[cfg(unix)]
+        directory.open(".")?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = directory.remove_file(&temporary);
+    }
+    result.map_err(|_| "Could not save that output".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact_path(root: &Path, chat_id: ChatId, filename: &str) -> PathBuf {
+        root.join(chat_id.to_string())
+            .join(DELIVERABLES_DIRECTORY)
+            .join(filename)
+    }
+
+    #[test]
+    fn catalog_and_preview_are_exactly_conversation_scoped() {
+        let scratch = tempfile::tempdir().unwrap();
+        let first = ChatId::new();
+        let second = ChatId::new();
+        let first_path = artifact_path(scratch.path(), first, "brief.md");
+        let second_path = artifact_path(scratch.path(), second, "other.txt");
+        std::fs::create_dir_all(first_path.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(second_path.parent().unwrap()).unwrap();
+        std::fs::write(&first_path, "# Brief").unwrap();
+        std::fs::write(&second_path, "private").unwrap();
+
+        let catalog = list_deliverables_in_root(scratch.path(), first).unwrap();
+        assert_eq!(catalog.deliverables.len(), 1);
+        assert_eq!(catalog.deliverables[0].filename, "brief.md");
+        assert!(!catalog.truncated);
+        let preview = preview_from_bytes(
+            "brief.md".to_owned(),
+            read_deliverable_bytes(scratch.path(), first, "brief.md").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(preview.content, "# Brief");
+        assert!(read_deliverable_bytes(scratch.path(), first, "other.txt").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_catalog_and_export_reject_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let scratch = tempfile::tempdir().unwrap();
+        let chat_id = ChatId::new();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.md"), "secret").unwrap();
+        let directory = artifact_path(scratch.path(), chat_id, "link.md");
+        std::fs::create_dir_all(directory.parent().unwrap()).unwrap();
+        symlink(outside.path().join("secret.md"), &directory).unwrap();
+        assert!(read_deliverable_bytes(scratch.path(), chat_id, "link.md").is_err());
+
+        let linked_chat = ChatId::new();
+        symlink(outside.path(), scratch.path().join(linked_chat.to_string())).unwrap();
+        assert!(list_deliverables_in_root(scratch.path(), linked_chat).is_err());
+
+        let destination = outside.path().join("destination.md");
+        let target = outside.path().join("target.md");
+        std::fs::write(&target, "keep").unwrap();
+        symlink(&target, &destination).unwrap();
+        assert!(write_exported_deliverable(&destination, b"replace").is_err());
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "keep");
+    }
+
+    #[test]
+    fn export_is_atomic_and_preserves_existing_permissions() {
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("brief.md");
+        std::fs::write(&destination, "old").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&destination, std::fs::Permissions::from_mode(0o640)).unwrap();
+        }
+        write_exported_deliverable(&destination, b"new").unwrap();
+        assert_eq!(std::fs::read_to_string(&destination).unwrap(), "new");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                std::fs::metadata(destination).unwrap().permissions().mode() & 0o777,
+                0o640
+            );
+        }
+    }
+
+    #[test]
+    fn renderer_projection_is_bounded_and_pathless() {
+        let preview = preview_from_bytes(
+            "brief.md".to_owned(),
+            "x".repeat(MAX_PREVIEW_CHARACTERS + 5).into_bytes(),
+        )
+        .unwrap();
+        assert_eq!(preview.content.chars().count(), MAX_PREVIEW_CHARACTERS);
+        assert!(preview.truncated);
+        let serialized = serde_json::to_value(preview).unwrap();
+        assert_eq!(
+            serialized
+                .as_object()
+                .unwrap()
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>(),
+            ["content", "filename", "mediaType", "truncated"]
+        );
+        for forbidden in ["path", "scratch", "chatId", "token"] {
+            assert!(!serialized.to_string().contains(forbidden));
+        }
+    }
+
+    #[test]
+    fn output_reads_reject_non_text_content() {
+        let scratch = tempfile::tempdir().unwrap();
+        let chat_id = ChatId::new();
+        let nul_path = artifact_path(scratch.path(), chat_id, "nul.txt");
+        std::fs::create_dir_all(nul_path.parent().unwrap()).unwrap();
+        std::fs::write(&nul_path, b"not\0text").unwrap();
+        std::fs::write(artifact_path(scratch.path(), chat_id, "binary.txt"), [0xff]).unwrap();
+
+        assert!(read_deliverable_bytes(scratch.path(), chat_id, "nul.txt").is_err());
+        assert!(read_deliverable_bytes(scratch.path(), chat_id, "binary.txt").is_err());
+    }
+
+    #[test]
+    fn requests_reject_scope_and_path_injection() {
+        assert!(
+            serde_json::from_value::<DeliverableRequest>(serde_json::json!({
+                "chatId": Uuid::new_v4(),
+                "filename": "brief.md",
+                "path": "/tmp/private"
+            }))
+            .is_err()
+        );
+    }
+}

--- a/crates/openwave-desktop/src/documents.rs
+++ b/crates/openwave-desktop/src/documents.rs
@@ -253,7 +253,7 @@ pub(crate) async fn import_library_document(
     }))
 }
 
-async fn resolve_conversation_scope(
+pub(crate) async fn resolve_conversation_scope(
     host_access: &HostAccess,
     chat_id: Uuid,
 ) -> Result<ChatId, String> {

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -16,6 +16,7 @@ use openwave_core::Config;
 
 mod broker;
 mod client_execution;
+mod deliverables;
 mod documents;
 mod host_access;
 mod updater;
@@ -149,6 +150,9 @@ pub fn run() {
             documents::import_library_document,
             documents::list_library_documents,
             documents::search_library_documents,
+            deliverables::list_deliverables,
+            deliverables::read_deliverable,
+            deliverables::export_deliverable,
             client_execution::resolve_folder_access_request,
             host_access::connect_folder,
             host_access::list_connected_folders,

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -25,6 +25,7 @@ import { useChatSessionStore } from "./ChatSessionStore";
 import { useChatListStore } from "./ChatListStore";
 import { useUiStore } from "./UiStore";
 import { DocumentsView } from "./DocumentsView";
+import { DeliverablesView } from "./DeliverablesView";
 import {
   importLibraryDocument,
   type ImportedDocument,
@@ -1077,6 +1078,11 @@ export default function App() {
       >
         {primaryView === "documents" ? (
           <DocumentsView chatId={chat.id} onBack={() => uiActions.showChat({ keepPanels: true })} />
+        ) : primaryView === "deliverables" ? (
+          <DeliverablesView
+            chatId={chat.id}
+            onBack={() => uiActions.showChat({ keepPanels: true })}
+          />
         ) : primaryView === "settings" ? (
           <SettingsView
             client={client}

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -11,7 +11,13 @@ import { useUiStore } from "./UiStore";
 import { Composer } from "./Composer";
 import type { FolderAccessDecision } from "./host";
 import { MessageList } from "./MessageList";
-import { ArrowDown, FolderOpen, LibraryBig, Settings } from "lucide-react";
+import {
+  ArrowDown,
+  FileOutput,
+  FolderOpen,
+  LibraryBig,
+  Settings,
+} from "lucide-react";
 
 export type ChatViewProps = {
   chat: Chat;
@@ -108,6 +114,7 @@ export function ChatView({
     (state) => state.settingsPanel === "folders",
   );
   const showDocuments = useUiStore((state) => state.showDocuments);
+  const showDeliverables = useUiStore((state) => state.showDeliverables);
   const showSettings = useUiStore((state) => state.showSettings);
   const toggleFoldersPanel = useUiStore((state) => state.toggleFoldersPanel);
   const messages = useChatSessionStore((session) => session.messages);
@@ -161,6 +168,16 @@ export function ChatView({
                 onClick={showDocuments}
               >
                 <LibraryBig size={14} />
+              </button>
+            )}
+            {nativeHost && (
+              <button
+                type="button"
+                className="btn"
+                aria-label="Outputs"
+                onClick={showDeliverables}
+              >
+                <FileOutput size={14} />
               </button>
             )}
             {nativeHost && (

--- a/crates/openwave-desktop/ui/src/DeliverablesView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.dom.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DeliverablesView } from "./DeliverablesView";
+
+afterEach(cleanup);
+
+describe("DeliverablesView", () => {
+  it("previews and explicitly exports a conversation output", async () => {
+    const exportOutput = vi.fn().mockResolvedValue(true);
+    const apis = {
+      list: vi.fn().mockResolvedValue({
+        deliverables: [
+          {
+            filename: "Research brief.md",
+            mediaType: "text/markdown" as const,
+            sizeBytes: 42,
+            updatedAt: "2026-07-24T00:00:00Z",
+          },
+        ],
+        truncated: false,
+      }),
+      read: vi.fn().mockResolvedValue({
+        filename: "Research brief.md",
+        mediaType: "text/markdown" as const,
+        content: "# Findings\n\nGrounded.",
+        truncated: false,
+      }),
+      export: exportOutput,
+    };
+
+    render(
+      <DeliverablesView chatId="chat-1" onBack={() => {}} apis={apis} />,
+    );
+    expect(await screen.findByRole("heading", { name: "Findings" })).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: /Save As/ }));
+    await waitFor(() =>
+      expect(exportOutput).toHaveBeenCalledWith("chat-1", "Research brief.md"),
+    );
+    expect(await screen.findByText("Research brief.md was saved.")).toBeVisible();
+  });
+
+  it("explains how to create the first output", async () => {
+    render(
+      <DeliverablesView
+        chatId="chat-1"
+        onBack={() => {}}
+        apis={{
+          list: vi.fn().mockResolvedValue({
+            deliverables: [],
+            truncated: false,
+          }),
+          read: vi.fn(),
+          export: vi.fn(),
+        }}
+      />,
+    );
+    expect(await screen.findByText("No outputs yet")).toBeVisible();
+    expect(
+      screen.getByText(/Ask OpenWave to create a report/),
+    ).toBeVisible();
+  });
+
+  it("presents an export failure as an alert", async () => {
+    const apis = {
+      list: vi.fn().mockResolvedValue({
+        deliverables: [
+          {
+            filename: "brief.txt",
+            mediaType: "text/plain" as const,
+            sizeBytes: 5,
+            updatedAt: "2026-07-24T00:00:00Z",
+          },
+        ],
+        truncated: false,
+      }),
+      read: vi.fn().mockResolvedValue({
+        filename: "brief.txt",
+        mediaType: "text/plain" as const,
+        content: "brief",
+        truncated: false,
+      }),
+      export: vi.fn().mockRejectedValue(new Error("Selected folder is unavailable")),
+    };
+
+    render(
+      <DeliverablesView chatId="chat-1" onBack={() => {}} apis={apis} />,
+    );
+    await screen.findByText("brief");
+    await userEvent.click(screen.getByRole("button", { name: /Save As/ }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Selected folder is unavailable",
+    );
+  });
+
+  it("keeps the refreshed preview when an older read completes later", async () => {
+    let resolveStalePreview:
+      | ((preview: {
+          filename: string;
+          mediaType: "text/plain";
+          content: string;
+          truncated: boolean;
+        }) => void)
+      | undefined;
+    const stalePreview = new Promise<{
+      filename: string;
+      mediaType: "text/plain";
+      content: string;
+      truncated: boolean;
+    }>((resolve) => {
+      resolveStalePreview = resolve;
+    });
+    const apis = {
+      list: vi.fn().mockResolvedValue({
+        deliverables: [
+          {
+            filename: "status.txt",
+            mediaType: "text/plain" as const,
+            sizeBytes: 7,
+            updatedAt: "2026-07-24T00:00:00Z",
+          },
+        ],
+        truncated: false,
+      }),
+      read: vi
+        .fn()
+        .mockReturnValueOnce(stalePreview)
+        .mockResolvedValueOnce({
+          filename: "status.txt",
+          mediaType: "text/plain" as const,
+          content: "refreshed",
+          truncated: false,
+        }),
+      export: vi.fn(),
+    };
+
+    render(
+      <DeliverablesView chatId="chat-1" onBack={() => {}} apis={apis} />,
+    );
+    await waitFor(() => expect(apis.read).toHaveBeenCalledTimes(1));
+    await userEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(await screen.findByText("refreshed")).toBeVisible();
+
+    await act(async () => {
+      resolveStalePreview?.({
+        filename: "status.txt",
+        mediaType: "text/plain",
+        content: "stale",
+        truncated: false,
+      });
+    });
+    expect(screen.getByText("refreshed")).toBeVisible();
+    expect(screen.queryByText("stale")).not.toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/DeliverablesView.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.tsx
@@ -1,0 +1,304 @@
+import { useEffect, useRef, useState } from "react";
+import { Download, FileOutput, RefreshCw } from "lucide-react";
+import {
+  exportDeliverable,
+  listDeliverables,
+  readDeliverable,
+  type DeliverablePreview,
+  type DeliverablesCatalog,
+} from "./deliverables";
+import { MessageMarkdown } from "./MessageMarkdown";
+
+type DeliverableApis = {
+  list: (chatId: string) => Promise<DeliverablesCatalog>;
+  read: (chatId: string, filename: string) => Promise<DeliverablePreview>;
+  export: (chatId: string, filename: string) => Promise<boolean>;
+};
+
+const defaultApis: DeliverableApis = {
+  list: listDeliverables,
+  read: readDeliverable,
+  export: exportDeliverable,
+};
+
+export function DeliverablesView({
+  chatId,
+  onBack,
+  apis = defaultApis,
+}: {
+  chatId: string;
+  onBack: () => void;
+  apis?: DeliverableApis;
+}) {
+  const [catalog, setCatalog] = useState<DeliverablesCatalog>({
+    deliverables: [],
+    truncated: false,
+  });
+  const [selected, setSelected] = useState<string | null>(null);
+  const [preview, setPreview] = useState<DeliverablePreview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportStatus, setExportStatus] = useState<{
+    message: string;
+    error: boolean;
+  } | null>(null);
+  const [previewVersion, setPreviewVersion] = useState(0);
+  const catalogGenerationRef = useRef(0);
+  const previewGenerationRef = useRef(0);
+
+  async function refresh(showLoading = false) {
+    const generation = ++catalogGenerationRef.current;
+    if (showLoading) setLoading(true);
+    setError(null);
+    try {
+      const next = await apis.list(chatId);
+      if (generation !== catalogGenerationRef.current) return;
+      setCatalog(next);
+      setSelected((current) =>
+        current && next.deliverables.some((item) => item.filename === current)
+          ? current
+          : (next.deliverables[0]?.filename ?? null),
+      );
+      setPreviewVersion((current) => current + 1);
+    } catch (caught) {
+      if (generation !== catalogGenerationRef.current) return;
+      setError(friendlyOutputError(caught, "Could not load this conversation's outputs."));
+    } finally {
+      if (generation === catalogGenerationRef.current) setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    setCatalog({ deliverables: [], truncated: false });
+    setSelected(null);
+    setPreview(null);
+    setError(null);
+    setPreviewError(null);
+    setExportStatus(null);
+    void refresh(true);
+    return () => {
+      catalogGenerationRef.current += 1;
+      previewGenerationRef.current += 1;
+    };
+  }, [chatId, apis]);
+
+  useEffect(() => {
+    if (!selected) {
+      setPreview(null);
+      setPreviewError(null);
+      return;
+    }
+    const generation = ++previewGenerationRef.current;
+    setPreview(null);
+    setPreviewError(null);
+    setPreviewLoading(true);
+    setExportStatus(null);
+    void apis
+      .read(chatId, selected)
+      .then((next) => {
+        if (generation === previewGenerationRef.current) setPreview(next);
+      })
+      .catch((caught) => {
+        if (generation === previewGenerationRef.current) {
+          setPreviewError(friendlyOutputError(caught, "Could not preview that output."));
+        }
+      })
+      .finally(() => {
+        if (generation === previewGenerationRef.current) setPreviewLoading(false);
+      });
+  }, [chatId, selected, previewVersion, apis]);
+
+  async function onExport() {
+    if (!selected || exporting) return;
+    setExporting(true);
+    setExportStatus(null);
+    try {
+      const saved = await apis.export(chatId, selected);
+      if (saved) {
+        setExportStatus({ message: `${selected} was saved.`, error: false });
+      }
+    } catch (caught) {
+      setExportStatus({
+        message: friendlyOutputError(caught, "Could not save that output."),
+        error: true,
+      });
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <section className="deliverables-view" aria-labelledby="deliverables-title">
+      <header className="deliverables-header">
+        <div>
+          <p className="eyebrow">This conversation</p>
+          <h1 id="deliverables-title">Outputs</h1>
+          <p>
+            Files OpenWave creates for you stay private until you choose where to
+            save them.
+          </p>
+        </div>
+        <div className="deliverables-header-actions">
+          <button type="button" className="btn deliverables-back" onClick={onBack}>
+            Back to chat
+          </button>
+          <button
+            type="button"
+            className="btn"
+            disabled={loading}
+            onClick={() => void refresh(true)}
+          >
+            <RefreshCw size={14} aria-hidden="true" />
+            Refresh
+          </button>
+        </div>
+      </header>
+
+      <div className="deliverables-content">
+        {error && (
+          <div className="deliverables-error" role="alert">
+            <span>{error}</span>
+            <button type="button" className="btn" onClick={() => void refresh(true)}>
+              Try again
+            </button>
+          </div>
+        )}
+
+        {loading && catalog.deliverables.length === 0 ? (
+          <div className="deliverables-empty" role="status">
+            Loading outputs for this conversation…
+          </div>
+        ) : catalog.deliverables.length === 0 && !error ? (
+          <div className="deliverables-empty">
+            <FileOutput size={22} aria-hidden="true" />
+            <strong>No outputs yet</strong>
+            <span>
+              Ask OpenWave to create a report, plan, CSV, JSON file, or web page.
+            </span>
+          </div>
+        ) : (
+          <div className="deliverables-workspace">
+            <section className="deliverables-list-panel" aria-label="Conversation outputs">
+              <div className="deliverables-section-heading">
+                <div>
+                  <h2>Files</h2>
+                  <p>
+                    {catalog.deliverables.length}{" "}
+                    {catalog.deliverables.length === 1 ? "output" : "outputs"}
+                  </p>
+                  {catalog.truncated && <p>Showing the newest 100 outputs.</p>}
+                </div>
+              </div>
+              <div className="deliverables-list">
+                {catalog.deliverables.map((item) => (
+                  <button
+                    type="button"
+                    className={`deliverable-row${selected === item.filename ? " is-selected" : ""}`}
+                    aria-current={selected === item.filename ? "true" : undefined}
+                    key={item.filename}
+                    onClick={() => setSelected(item.filename)}
+                  >
+                    <span className="deliverable-icon" aria-hidden="true">
+                      <FileOutput size={16} />
+                    </span>
+                    <span className="deliverable-copy">
+                      <strong>{item.filename}</strong>
+                      <small>
+                        {formatBytes(item.sizeBytes)} · {formatDate(item.updatedAt)}
+                      </small>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </section>
+
+            <section className="deliverable-preview-panel" aria-label="Output preview">
+              <div className="deliverable-preview-heading">
+                <div>
+                  <h2>{selected ?? "Preview"}</h2>
+                  {preview && <p>{mediaTypeLabel(preview.mediaType)}</p>}
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  disabled={!preview || exporting}
+                  onClick={() => void onExport()}
+                >
+                  <Download size={14} aria-hidden="true" />
+                  {exporting ? "Saving…" : "Save As…"}
+                </button>
+              </div>
+              {previewLoading ? (
+                <div className="deliverable-preview-state" role="status">
+                  Loading preview…
+                </div>
+              ) : previewError ? (
+                <div className="deliverable-preview-state is-error" role="alert">
+                  {previewError}
+                </div>
+              ) : preview ? (
+                <div className="deliverable-preview">
+                  {preview.mediaType === "text/markdown" ? (
+                    <MessageMarkdown>{preview.content}</MessageMarkdown>
+                  ) : (
+                    <pre>{preview.content}</pre>
+                  )}
+                  {preview.truncated && (
+                    <p className="deliverable-preview-truncated">
+                      Preview truncated. Saving exports the complete file.
+                    </p>
+                  )}
+                </div>
+              ) : null}
+              {exportStatus && (
+                <p
+                  className={`deliverable-export-status${exportStatus.error ? " is-error" : ""}`}
+                  role={exportStatus.error ? "alert" : "status"}
+                >
+                  {exportStatus.message}
+                </p>
+              )}
+            </section>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1_000) return `${bytes} B`;
+  return `${(bytes / 1_000).toFixed(bytes < 10_000 ? 1 : 0)} KB`;
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function mediaTypeLabel(mediaType: DeliverablePreview["mediaType"]): string {
+  switch (mediaType) {
+    case "text/markdown":
+      return "Markdown";
+    case "text/csv":
+      return "CSV";
+    case "application/json":
+      return "JSON";
+    case "text/html":
+      return "HTML";
+    default:
+      return "Plain text";
+  }
+}
+
+function friendlyOutputError(error: unknown, fallback: string): string {
+  const message = String(error).replace(/^Error:\s*/, "").trim();
+  return message && message.length <= 240 ? message : fallback;
+}

--- a/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
@@ -100,11 +100,14 @@ describe("Sidebar", () => {
     expect(screen.getByText("Retro notes")).toBeInTheDocument();
   });
 
-  it("navigates through the UI store for documents, folders, and settings", async () => {
+  it("navigates through the UI store for sources, outputs, folders, and settings", async () => {
     const user = userEvent.setup();
     renderSidebar({ nativeHost: true });
     await user.click(screen.getByText("Sources"));
     expect(useUiStore.getState().primaryView).toBe("documents");
+
+    await user.click(screen.getByText("Outputs"));
+    expect(useUiStore.getState().primaryView).toBe("deliverables");
 
     await user.click(screen.getByText("Folders"));
     expect(useUiStore.getState().primaryView).toBe("chat");

--- a/crates/openwave-desktop/ui/src/Sidebar.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.tsx
@@ -2,6 +2,7 @@ import type { Chat } from "./api";
 import { Logomark } from "./Logomark";
 import {
   Ellipsis,
+  FileOutput,
   FolderOpen,
   LibraryBig,
   Monitor,
@@ -74,6 +75,7 @@ export function Sidebar({
     (state) => state.settingsPanel === "folders",
   );
   const showDocuments = useUiStore((state) => state.showDocuments);
+  const showDeliverables = useUiStore((state) => state.showDeliverables);
   const showSettings = useUiStore((state) => state.showSettings);
   const toggleFoldersPanel = useUiStore((state) => state.toggleFoldersPanel);
   return (
@@ -124,6 +126,16 @@ export function Sidebar({
         >
           <LibraryBig size={16} />
           Sources
+        </button>
+      )}
+      {nativeHost && (
+        <button
+          type="button"
+          className={`sidebar-action sidebar-library${primaryView === "deliverables" ? " is-active" : ""}`}
+          onClick={showDeliverables}
+        >
+          <FileOutput size={16} />
+          Outputs
         </button>
       )}
 

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -61,6 +61,19 @@ describe("ToolCallCard", () => {
     expect(reading).toContain("Source read complete");
   });
 
+  it("renders a fixed user-visible output presentation", () => {
+    const active = renderToStaticMarkup(
+      <ToolCallCard name="create_deliverable" status="running" />,
+    );
+    const complete = renderToStaticMarkup(
+      <ToolCallCard name="create_deliverable" status="completed" />,
+    );
+
+    expect(active).toContain("Creating an output");
+    expect(complete).toContain("Output ready");
+    expect(visibleText(complete)).not.toContain("artifacts/");
+  });
+
   it("renders a fixed delegated-file presentation without resource details", () => {
     const markup = renderToStaticMarkup(
       <ToolCallCard name="read_delegated_file" status="running" />,

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -90,6 +90,12 @@ const TOOL_PRESENTATIONS: Record<string, ToolPresentation> = {
     complete: "File update complete",
     settled: "Updated a file",
   },
+  create_deliverable: {
+    label: "Create an output",
+    active: "Creating an output",
+    complete: "Output ready",
+    settled: "Created an output",
+  },
   request_folder_access: {
     label: "Request folder access",
     active: "Requesting folder access",

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
@@ -110,6 +110,21 @@ describe("hydrateTranscriptHistory", () => {
     ]);
   });
 
+  it("hydrates generated outputs with fixed renderer copy", () => {
+    const entries = hydrateTranscriptHistory([], [
+      {
+        title: "Create an output",
+        status: "completed",
+        started_at: "2026-07-16T10:00:00Z",
+        finished_at: "2026-07-16T10:00:01Z",
+      },
+    ]);
+
+    expect(entries).toEqual([
+      expect.objectContaining({ name: "create_deliverable" }),
+    ]);
+  });
+
   it("attaches sources only to their exact owning assistant message", () => {
     const entries = hydrateTranscriptHistory(
       [

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -31,6 +31,7 @@ const HISTORY_TOOL_NAMES: Record<ChatToolActivity["title"], string> = {
   "Read a file": "read_file",
   "Browse files": "list_dir",
   "Update a file": "write_file",
+  "Create an output": "create_deliverable",
   "Request folder access": "request_folder_access",
   "Connect a folder": "connect_folder",
   "Check connected folders": "list_connected_folders",

--- a/crates/openwave-desktop/ui/src/UiStore.test.ts
+++ b/crates/openwave-desktop/ui/src/UiStore.test.ts
@@ -17,12 +17,19 @@ describe("UiStore", () => {
     expect(store.getState().settingsPanel).toBeNull();
   });
 
-  it("documents and settings views always close the folders panel", () => {
+  it("documents, outputs, and settings views always close the folders panel", () => {
     const store = createUiStore();
     store.getState().toggleFoldersPanel();
     store.getState().showDocuments();
     expect(store.getState()).toMatchObject({
       primaryView: "documents",
+      settingsPanel: null,
+    });
+
+    store.getState().toggleFoldersPanel();
+    store.getState().showDeliverables();
+    expect(store.getState()).toMatchObject({
+      primaryView: "deliverables",
       settingsPanel: null,
     });
 

--- a/crates/openwave-desktop/ui/src/UiStore.ts
+++ b/crates/openwave-desktop/ui/src/UiStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-export type PrimaryView = "chat" | "documents" | "settings";
+export type PrimaryView = "chat" | "documents" | "deliverables" | "settings";
 export type SettingsPanel = "folders" | null;
 
 /**
@@ -18,6 +18,7 @@ export type UiStore = {
    */
   showChat: (options?: { keepPanels?: boolean }) => void;
   showDocuments: () => void;
+  showDeliverables: () => void;
   showSettings: () => void;
   /** Toggle the folders panel; optionally force the chat view first. */
   toggleFoldersPanel: (options?: { showChat?: boolean }) => void;
@@ -33,6 +34,8 @@ export function createUiStore() {
         settingsPanel: options?.keepPanels ? state.settingsPanel : null,
       })),
     showDocuments: () => set({ primaryView: "documents", settingsPanel: null }),
+    showDeliverables: () =>
+      set({ primaryView: "deliverables", settingsPanel: null }),
     showSettings: () => set({ primaryView: "settings", settingsPanel: null }),
     toggleFoldersPanel: (options) =>
       set((state) => ({

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -122,6 +122,7 @@ export type ChatToolActivity = {
     | "Read a file"
     | "Browse files"
     | "Update a file"
+    | "Create an output"
     | "Request folder access"
     | "Connect a folder"
     | "Check connected folders"
@@ -225,6 +226,7 @@ export type RendererToolName =
   | "read_file"
   | "list_dir"
   | "write_file"
+  | "create_deliverable"
   | "request_folder_access"
   | "connect_folder"
   | "list_connected_folders"
@@ -740,6 +742,7 @@ function isRendererToolName(value: unknown): value is RendererToolName {
     value === "read_file" ||
     value === "list_dir" ||
     value === "write_file" ||
+    value === "create_deliverable" ||
     value === "request_folder_access" ||
     value === "connect_folder" ||
     value === "list_connected_folders" ||

--- a/crates/openwave-desktop/ui/src/deliverables.test.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseDeliverablePreview,
+  parseDeliverablesCatalog,
+} from "./deliverables";
+
+describe("deliverable renderer projections", () => {
+  it("accepts only the bounded closed catalog", () => {
+    expect(
+      parseDeliverablesCatalog({
+        deliverables: [
+          {
+            filename: "Research brief.md",
+            mediaType: "text/markdown",
+            sizeBytes: 42,
+            updatedAt: "2026-07-24T00:00:00Z",
+          },
+        ],
+        truncated: false,
+      }),
+    ).toEqual({
+      deliverables: [
+        {
+          filename: "Research brief.md",
+          mediaType: "text/markdown",
+          sizeBytes: 42,
+          updatedAt: "2026-07-24T00:00:00Z",
+        },
+      ],
+      truncated: false,
+    });
+  });
+
+  it.each([
+    "../escape.md",
+    "/tmp/private.md",
+    ".hidden.md",
+    "report.pdf",
+    "bad\u{202e}.md",
+  ])("rejects unsafe filename %s", (filename) => {
+    expect(() =>
+      parseDeliverablesCatalog({
+        deliverables: [
+          {
+            filename,
+            mediaType: "text/markdown",
+            sizeBytes: 1,
+            updatedAt: "2026-07-24T00:00:00Z",
+          },
+        ],
+        truncated: false,
+      }),
+    ).toThrow("Invalid output response");
+  });
+
+  it("rejects canonical paths and oversized previews", () => {
+    expect(() =>
+      parseDeliverablePreview({
+        filename: "brief.md",
+        mediaType: "text/markdown",
+        content: "safe",
+        truncated: false,
+        path: "/private/scratch/brief.md",
+      }),
+    ).toThrow("Invalid output preview response");
+    expect(() =>
+      parseDeliverablePreview({
+        filename: "brief.md",
+        mediaType: "text/markdown",
+        content: "x".repeat(100_001),
+        truncated: true,
+      }),
+    ).toThrow("Invalid output preview response");
+  });
+});

--- a/crates/openwave-desktop/ui/src/deliverables.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.ts
@@ -1,0 +1,161 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type DeliverableSummary = {
+  filename: string;
+  mediaType: DeliverableMediaType;
+  sizeBytes: number;
+  updatedAt: string;
+};
+
+export type DeliverablesCatalog = {
+  deliverables: DeliverableSummary[];
+  truncated: boolean;
+};
+
+export type DeliverablePreview = {
+  filename: string;
+  mediaType: DeliverableMediaType;
+  content: string;
+  truncated: boolean;
+};
+
+export type DeliverableMediaType =
+  | "text/markdown"
+  | "text/plain"
+  | "text/csv"
+  | "application/json"
+  | "text/html";
+
+const MAX_DELIVERABLES = 100;
+const MAX_FILENAME_CHARACTERS = 120;
+const MAX_PREVIEW_CHARACTERS = 100_000;
+const MAX_DELIVERABLE_BYTES = 512 * 1024;
+
+export async function listDeliverables(
+  chatId: string,
+): Promise<DeliverablesCatalog> {
+  return parseDeliverablesCatalog(
+    await invoke("list_deliverables", { request: { chatId } }),
+  );
+}
+
+export async function readDeliverable(
+  chatId: string,
+  filename: string,
+): Promise<DeliverablePreview> {
+  return parseDeliverablePreview(
+    await invoke("read_deliverable", { request: { chatId, filename } }),
+  );
+}
+
+export async function exportDeliverable(
+  chatId: string,
+  filename: string,
+): Promise<boolean> {
+  const exported = await invoke("export_deliverable", {
+    request: { chatId, filename },
+  });
+  if (typeof exported !== "boolean") {
+    throw new Error("Invalid output export response");
+  }
+  return exported;
+}
+
+export function parseDeliverablesCatalog(value: unknown): DeliverablesCatalog {
+  if (!isExactRecord(value, ["deliverables", "truncated"])) {
+    throw new Error("Invalid outputs response");
+  }
+  if (
+    !Array.isArray(value.deliverables) ||
+    value.deliverables.length > MAX_DELIVERABLES ||
+    typeof value.truncated !== "boolean"
+  ) {
+    throw new Error("Invalid outputs response");
+  }
+  return {
+    deliverables: value.deliverables.map(parseDeliverableSummary),
+    truncated: value.truncated,
+  };
+}
+
+export function parseDeliverablePreview(value: unknown): DeliverablePreview {
+  if (
+    !isExactRecord(value, ["filename", "mediaType", "content", "truncated"]) ||
+    !isDeliverableFilename(value.filename) ||
+    !isDeliverableMediaType(value.mediaType) ||
+    typeof value.content !== "string" ||
+    [...value.content].length > MAX_PREVIEW_CHARACTERS ||
+    value.content.includes("\0") ||
+    typeof value.truncated !== "boolean"
+  ) {
+    throw new Error("Invalid output preview response");
+  }
+  return {
+    filename: value.filename,
+    mediaType: value.mediaType,
+    content: value.content,
+    truncated: value.truncated,
+  };
+}
+
+function parseDeliverableSummary(value: unknown): DeliverableSummary {
+  if (
+    !isExactRecord(value, [
+      "filename",
+      "mediaType",
+      "sizeBytes",
+      "updatedAt",
+    ]) ||
+    !isDeliverableFilename(value.filename) ||
+    !isDeliverableMediaType(value.mediaType) ||
+    typeof value.sizeBytes !== "number" ||
+    !Number.isSafeInteger(value.sizeBytes) ||
+    value.sizeBytes < 0 ||
+    value.sizeBytes > MAX_DELIVERABLE_BYTES ||
+    typeof value.updatedAt !== "string" ||
+    !Number.isFinite(Date.parse(value.updatedAt))
+  ) {
+    throw new Error("Invalid output response");
+  }
+  return {
+    filename: value.filename,
+    mediaType: value.mediaType,
+    sizeBytes: value.sizeBytes,
+    updatedAt: value.updatedAt,
+  };
+}
+
+function isDeliverableFilename(value: unknown): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    [...value].length > MAX_FILENAME_CHARACTERS ||
+    !/^[A-Za-z0-9][A-Za-z0-9 _().-]*$/.test(value) ||
+    value.endsWith(".") ||
+    value.trim() !== value
+  ) {
+    return false;
+  }
+  return /\.(?:md|txt|csv|json|html)$/i.test(value);
+}
+
+function isDeliverableMediaType(value: unknown): value is DeliverableMediaType {
+  return [
+    "text/markdown",
+    "text/plain",
+    "text/csv",
+    "application/json",
+    "text/html",
+  ].includes(String(value));
+}
+
+function isExactRecord(
+  value: unknown,
+  keys: readonly string[],
+): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const actual = Object.keys(value);
+  return actual.length === keys.length && actual.every((key) => keys.includes(key));
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -2516,6 +2516,268 @@ body {
   border-top: 0;
 }
 
+/* ---------- Outputs view ---------- */
+
+.deliverables-view {
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--bg-elevated);
+}
+
+.deliverables-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 2.2rem clamp(1.25rem, 5vw, 4rem) 1.7rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.deliverables-header h1,
+.deliverables-header p,
+.deliverables-section-heading h2,
+.deliverables-section-heading p,
+.deliverable-preview-heading h2,
+.deliverable-preview-heading p {
+  margin: 0;
+}
+
+.deliverables-header h1 {
+  margin-top: 0.15rem;
+  font-size: 1.65rem;
+  font-weight: 600;
+  letter-spacing: -0.035em;
+}
+
+.deliverables-header > div > p:last-child {
+  max-width: 41rem;
+  margin-top: 0.45rem;
+  color: var(--muted-foreground);
+}
+
+.deliverables-header-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.55rem;
+}
+
+.deliverables-header-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.deliverables-back {
+  display: none;
+}
+
+.deliverables-content {
+  width: min(100%, 76rem);
+  margin: 0 auto;
+  padding: 1.6rem clamp(1.25rem, 5vw, 4rem) 4rem;
+}
+
+.deliverables-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--danger) 42%, var(--line));
+  border-radius: 8px;
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 5%, var(--bg-elevated));
+  font-size: 0.84rem;
+}
+
+.deliverables-empty {
+  display: grid;
+  min-height: 18rem;
+  place-items: center;
+  align-content: center;
+  gap: 0.4rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--muted-foreground);
+  background: var(--bg-elevated);
+  text-align: center;
+  box-shadow: var(--shadow-sm);
+}
+
+.deliverables-empty strong {
+  color: var(--ink);
+}
+
+.deliverables-empty span {
+  max-width: 30rem;
+  font-size: 0.84rem;
+}
+
+.deliverables-workspace {
+  display: grid;
+  grid-template-columns: minmax(14rem, 19rem) minmax(0, 1fr);
+  min-height: 34rem;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-sm);
+}
+
+.deliverables-list-panel {
+  min-width: 0;
+  border-right: 1px solid var(--line);
+}
+
+.deliverables-section-heading,
+.deliverable-preview-heading {
+  display: flex;
+  min-height: 4.5rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.deliverables-section-heading h2,
+.deliverable-preview-heading h2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.94rem;
+  font-weight: 600;
+}
+
+.deliverables-section-heading p,
+.deliverable-preview-heading p {
+  margin-top: 0.15rem;
+  color: var(--muted-foreground);
+  font-size: 0.74rem;
+}
+
+.deliverables-list {
+  display: grid;
+  max-height: 38rem;
+  overflow-y: auto;
+}
+
+.deliverable-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.65rem;
+  min-height: 4.25rem;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  padding: 0.7rem 0.8rem;
+  color: var(--ink);
+  background: transparent;
+  text-align: left;
+}
+
+.deliverable-row:hover,
+.deliverable-row.is-selected {
+  background: var(--accent);
+}
+
+.deliverable-icon {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--muted-foreground);
+  background: var(--page-background);
+}
+
+.deliverable-copy {
+  display: grid;
+  min-width: 0;
+  gap: 0.15rem;
+}
+
+.deliverable-copy strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.84rem;
+  font-weight: 590;
+}
+
+.deliverable-copy small {
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+}
+
+.deliverable-preview-panel {
+  display: grid;
+  min-width: 0;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+.deliverable-preview-heading .btn {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.deliverable-preview,
+.deliverable-preview-state {
+  min-height: 0;
+  padding: 1.25rem 1.4rem;
+}
+
+.deliverable-preview {
+  overflow: auto;
+}
+
+.deliverable-preview > pre {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  line-height: 1.55;
+}
+
+.deliverable-preview .message-markdown {
+  max-width: 48rem;
+  margin: 0 auto;
+}
+
+.deliverable-preview-state {
+  display: grid;
+  place-items: center;
+  color: var(--muted-foreground);
+  font-size: 0.84rem;
+}
+
+.deliverable-preview-state.is-error,
+.deliverable-export-status.is-error {
+  color: var(--danger);
+}
+
+.deliverable-preview-truncated {
+  margin: 1rem 0 0;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted-foreground);
+  font-size: 0.76rem;
+}
+
+.deliverable-export-status {
+  margin: 0;
+  border-top: 1px solid var(--line);
+  padding: 0.65rem 1rem;
+  color: var(--muted-foreground);
+  font-size: 0.76rem;
+}
+
 /* ---------- Responsive ---------- */
 
 @media (max-width: 720px) {
@@ -2601,6 +2863,37 @@ body {
 
   .documents-content {
     padding: 1rem 0.75rem 2rem;
+  }
+
+  .deliverables-header {
+    flex-direction: column;
+    padding: 1.25rem;
+  }
+
+  .deliverables-header-actions,
+  .deliverables-header-actions .btn {
+    width: 100%;
+  }
+
+  .deliverables-back {
+    display: block;
+  }
+
+  .deliverables-content {
+    padding: 1rem 0.75rem 2rem;
+  }
+
+  .deliverables-workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .deliverables-list-panel {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .deliverables-list {
+    max-height: 14rem;
   }
 
   .document-row {

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -78,6 +78,7 @@ pub(crate) enum RendererToolName {
     ReadFile,
     ListDir,
     WriteFile,
+    CreateDeliverable,
     RequestFolderAccess,
     ConnectFolder,
     ListConnectedFolders,
@@ -107,6 +108,7 @@ impl From<&str> for RendererToolName {
             "read_file" => Self::ReadFile,
             "list_dir" => Self::ListDir,
             "write_file" => Self::WriteFile,
+            "create_deliverable" => Self::CreateDeliverable,
             "request_folder_access" => Self::RequestFolderAccess,
             "connect_folder" => Self::ConnectFolder,
             "list_connected_folders" => Self::ListConnectedFolders,
@@ -272,6 +274,10 @@ mod tests {
         assert_eq!(
             RendererToolName::from(crate::source_tools::READ_SOURCE_TOOL),
             RendererToolName::ReadSource
+        );
+        assert_eq!(
+            RendererToolName::from("create_deliverable"),
+            RendererToolName::CreateDeliverable
         );
     }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -59,7 +59,7 @@ use openwave_core::{
     list_connected_folders_tool_spec, list_folder_tool_spec, read_connected_file_tool_spec,
     request_folder_access_tool_spec, validate_list_connected_folders_arguments,
     validate_list_folder_arguments, validate_read_connected_file_arguments,
-    validate_request_folder_access_arguments, AgentConfig, AgentError, Config,
+    validate_request_folder_access_arguments, AgentConfig, AgentError, Config, CreateDeliverable,
     KeychainSecretProvider, ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool,
     ToolRegistry, WriteFile,
 };
@@ -631,6 +631,7 @@ fn agent_deps(
         .with(Box::new(ReadFile))
         .with(Box::new(ListDir))
         .with(Box::new(WriteFile))
+        .with(Box::new(CreateDeliverable))
         .with(Box::new(ExecTool::new(code_execution)))
         .with(search)
         .with(Box::new(source_tools::ListSourcesTool::new(

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -8,8 +8,11 @@ use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use cap_std::ambient_authority;
+use cap_std::fs::Dir;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::path::Path as FsPath;
 use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{
@@ -727,6 +730,21 @@ pub async fn delete_chat(
         DeleteChatOutcome::Deleted => {
             state.document_job_wake.notify_one();
             state.blob_retirement_wake.notify_one();
+            let scratch_root = state.config.data_dir.join("scratch");
+            let cleanup =
+                tokio::task::spawn_blocking(move || remove_private_chat_scratch(&scratch_root, id))
+                    .await;
+            match cleanup {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    eprintln!("openwave: could not remove private scratch for chat {id}: {error}");
+                }
+                Err(error) => {
+                    eprintln!(
+                        "openwave: private scratch cleanup task stopped for chat {id}: {error}"
+                    );
+                }
+            }
             Ok(StatusCode::NO_CONTENT)
         }
         DeleteChatOutcome::NotFound => Err(ServerError::not_found(format!("chat {id} not found"))),
@@ -742,6 +760,50 @@ pub async fn delete_chat(
             "chat_root_attachment_unresolved",
             "reconcile connected-folder changes before deleting this conversation",
         )),
+    }
+}
+
+/// Remove a deleted chat's private scratch without following a replacement
+/// root or chat-directory symlink. Database deletion remains authoritative, so
+/// callers log cleanup failure rather than turning a committed delete into an
+/// ambiguous HTTP failure.
+fn remove_private_chat_scratch(root: &FsPath, id: ChatId) -> std::io::Result<()> {
+    let root_metadata = match std::fs::symlink_metadata(root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if !root_metadata.is_dir() || root_metadata.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "private scratch root is not a regular directory",
+        ));
+    }
+    let directory = Dir::open_ambient_dir(root, ambient_authority())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        let opened = directory.dir_metadata()?;
+        if root_metadata.dev() != cap_std::fs::MetadataExt::dev(&opened)
+            || root_metadata.ino() != cap_std::fs::MetadataExt::ino(&opened)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "private scratch root changed while it was opened",
+            ));
+        }
+    }
+    let chat_name = id.to_string();
+    match directory.symlink_metadata(&chat_name) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {
+            directory.remove_dir_all(chat_name)
+        }
+        Ok(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "private chat scratch is not a regular directory",
+        )),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
     }
 }
 

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -6327,6 +6327,10 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_orchestration()
         "file tools still present"
     );
     assert!(
+        names.iter().any(|n| n == "create_deliverable"),
+        "deliverable tool registered"
+    );
+    assert!(
         names
             .iter()
             .any(|n| n == openwave_code_execution::EXEC_TOOL_NAME),
@@ -8254,9 +8258,12 @@ async fn patch_chat_sets_and_clears_a_trimmed_title() {
 
 #[tokio::test]
 async fn delete_chat_removes_a_quiesced_conversation_and_reports_safe_conflicts() {
-    let (router, token, store, _dir) = test_app().await;
+    let (router, token, store, dir) = test_app().await;
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
+    let chat_scratch = dir.path().join("scratch").join(chat.id.to_string());
+    std::fs::create_dir_all(chat_scratch.join("artifacts")).unwrap();
+    std::fs::write(chat_scratch.join("artifacts/brief.md"), "private").unwrap();
 
     let deleted = router
         .clone()
@@ -8272,6 +8279,7 @@ async fn delete_chat_removes_a_quiesced_conversation_and_reports_safe_conflicts(
         .unwrap();
     assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
     assert!(store.get_chat(chat.id).await.unwrap().is_none());
+    assert!(!chat_scratch.exists());
 
     let missing = router
         .clone()
@@ -8286,6 +8294,37 @@ async fn delete_chat_removes_a_quiesced_conversation_and_reports_safe_conflicts(
         .await
         .unwrap();
     assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+
+        let linked = make_chat(&router, &bearer).await;
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("keep.txt"), "keep").unwrap();
+        symlink(
+            outside.path(),
+            dir.path().join("scratch").join(linked.id.to_string()),
+        )
+        .unwrap();
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/chats/{}", linked.id))
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            std::fs::read_to_string(outside.path().join("keep.txt")).unwrap(),
+            "keep"
+        );
+    }
 
     let active = make_chat(&router, &bearer).await;
     store

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -1,0 +1,54 @@
+# Conversation outputs
+
+OpenWave can turn a conversation into a file without giving the model an
+arbitrary host write path. The first deliverables slice is intentionally small:
+the foreground agent creates bounded UTF-8 files in conversation-private
+scratch, the desktop previews them in **Outputs**, and the user chooses a
+destination through the native **Save As…** dialog.
+
+## Product flow
+
+1. The user asks for a report, plan, table, data file, or simple web page.
+2. The foreground agent calls `create_deliverable` with a portable filename and
+   complete text content.
+3. OpenWave atomically creates or replaces that filename under the exact
+   conversation's private output directory.
+4. The native Outputs view lists safe metadata and returns a bounded preview.
+5. **Save As…** snapshots the complete file and writes it only to the path the
+   user selects.
+
+Generated outputs remain private app data until that final explicit export.
+Switching conversations switches the catalog; guessing another chat ID or a
+private scratch path does not widen access. Deleting the conversation also
+removes its private output directory; cleanup rejects replacement root or chat
+symlinks rather than following them.
+
+## Closed first-slice contract
+
+- Supported formats: Markdown, plain text, CSV, JSON, and HTML.
+- Filenames are one portable ASCII component, at most 120 characters.
+- Content is valid UTF-8, non-empty, and at most 512 KiB.
+- The catalog returns the newest 100 valid output files.
+- Previews return at most 100,000 Unicode characters. Export always uses the
+  complete file.
+- Markdown previews use the same safe renderer as assistant messages: raw HTML,
+  local-file links, executable URL schemes, and remote image loads are not
+  rendered. HTML outputs are shown as text rather than executed.
+
+The output directory is a capability-confined child of private per-chat
+scratch. Native reads reject symlinks and non-regular or oversized files.
+Exports use a temporary regular file and atomic rename, reject symlink
+destinations, and preserve the permissions of an existing regular destination.
+Neither the model nor renderer receives the scratch path, the selected export
+path, bearer credentials, or native-executor credentials.
+
+## Deliberate limits
+
+This baseline derives its durable catalog from the files themselves rather than
+adding artifact database rows. An export is a synchronous user action, so it is
+not automatically retried and does not yet have a durable export receipt.
+Deleting outputs, binary formats, Office document generation, transcript-inline
+artifact cards, version history, and writing directly into connected folders
+remain later slices. Those additions should preserve the same rule: the model
+names a logical output, while a person or narrowly scoped capability chooses
+where host data is written.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -201,6 +201,8 @@ The built-in server registry currently contains:
 - `read_file` and `list_dir`, which are read-only;
 - `write_file`, which is confined to private per-chat scratch and runs without a
   prompt;
+- `create_deliverable`, which atomically writes one bounded text output into the
+  current chat's private Outputs catalog;
 - `search`, which queries the indexed corpus and always requires approval because
   matching excerpts are returned to the selected chat model, which may be remote;
 - `request_folder_access`, a client-owned consent proposal with a bounded
@@ -220,10 +222,10 @@ named one exact attached root and relative path. The tool accepts no arguments;
 it cannot browse, choose a path, open a picker, write, or run commands. The
 headless server does not advertise it.
 
-The built-in `read_file`, `list_dir`, and `write_file` tools operate only inside
-a server-derived, pinned per-chat scratch capability. Its path is neither
-persisted on the chat nor returned by the product API. The desktop can connect,
-list, and revoke multiple folders
+The built-in `read_file`, `list_dir`, `write_file`, and `create_deliverable`
+tools operate only inside a server-derived, pinned per-chat scratch capability.
+Its path is neither persisted on the chat nor returned by the product API. The
+desktop can connect, list, and revoke multiple folders
 through a native picker and capability-gated host-broker sidecar; it exposes only
 opaque root IDs and display names to the renderer. Foreground tool calls can now
 list/read roots already attached to their stored chat context. An approved
@@ -734,6 +736,15 @@ cursor. The desktop then replays and follows later events, so durable history
 and the live stream meet at an explicit sequence boundary instead of relying on
 transient renderer state.
 
+The native **Outputs** surface completes a narrow deliverable loop. The
+foreground `create_deliverable` tool writes only a portable, bounded UTF-8 file
+below the exact chat's private output directory. The renderer receives a closed
+catalog and bounded text preview, never the scratch path. A native **Save As…**
+action snapshots the complete output and atomically writes it only to the
+user-selected destination; HTML is previewed as text and Markdown uses the same
+remote-load-blocking renderer as assistant messages. See
+[`deliverables.md`](deliverables.md).
+
 ### Headless server
 
 `openwave serve` starts the same local HTTP/WebSocket server and prints the
@@ -819,7 +830,9 @@ cancellation, reconnectable event stream, durable foreground/sandbox agent-run
 leases and result delivery, bounded non-blocking child admission, ordered
 multi-child waits, the foreground terminal guard, Markdown and tool-call
 transcript rendering, the agent activity/status-and-stop surface, and
-fail-closed provider routing.
+fail-closed provider routing. The first native Outputs loop also closes the path
+from a bounded conversation-private text file to an explicit user-selected
+export.
 
 The main next steps are:
 
@@ -837,6 +850,8 @@ The main next steps are:
   refresh;
 - finish the self-host profile rather than only testing Postgres state logic;
 - add health-aware provider failover;
+- add output deletion, version history, richer formats, and durable export
+  receipts without widening the native write boundary;
 - bound the agent-to-worker event channel and batch or page journal traffic so
   long, fast turns cannot create unbounded memory or replay work;
 - introduce ANN and maintenance policy when corpus measurements justify it;

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,13 +7,14 @@ identity.
 
 ## What exists today
 
-The current foreground agent surface contains fourteen tools:
+The current foreground agent surface contains fifteen tools:
 
 | Tool | Purpose | Execution boundary |
 | --- | --- | --- |
 | `read_file` | Read UTF-8 text from private per-chat scratch | Server, read-only |
 | `list_dir` | List a private-scratch directory | Server, read-only |
 | `write_file` | Atomically write private-scratch text | Server, workspace |
+| `create_deliverable` | Create or update a bounded user-visible text output | Server, workspace |
 | `exec` | Run a bounded command through the configured execution provider | Server, sensitive native sandbox |
 | `search` | Search sources indexed for this exact conversation | Server, read-only |
 | `list_sources` | List bounded metadata for sources in this exact conversation | Server, read-only |
@@ -56,6 +57,7 @@ tools/
 ├── definitions.rs       model-facing names, descriptions, and JSON Schemas
 ├── arguments.rs         typed argument decoding
 ├── private_scratch.rs   confined filesystem primitives and limits
+├── create_deliverable.rs bounded user-visible text output
 ├── read_file.rs         one Tool implementation
 ├── list_dir.rs          one Tool implementation
 ├── write_file.rs        one Tool implementation
@@ -114,6 +116,7 @@ advertise every installed integration to every model call.
 The foreground coordinator needs tools for:
 
 - conversation-scoped source search plus source list/read;
+- conversation-private deliverable creation for explicit native export;
 - web search and page retrieval;
 - connected-root list/read/import and explicit export;
 - asking the user a structured question;
@@ -183,9 +186,9 @@ receipt before it can finalize. Sandboxes do not receive
 `spawn_sandbox_agent` or `wait_for_agents` and cannot create further agents.
 
 Later additions may include a scratchpad, pinned context, plan/execution modes,
-deliverable export, clipboard operations, generated images, and connected apps.
-Office-suite automation, general computer control, scheduled tasks, enterprise
-database tools, and recursive fleets remain deferred.
+clipboard operations, generated images, richer deliverables, and connected
+apps. Office-suite automation, general computer control, scheduled tasks,
+enterprise database tools, and recursive fleets remain deferred.
 
 ## Web search
 


### PR DESCRIPTION
## Summary

- add a closed `create_deliverable` tool for bounded conversation-private Markdown, text, CSV, JSON, and HTML files
- add a native Outputs view with safe metadata parsing, bounded preview, and explicit atomic Save As export
- remove private scratch when its conversation is deleted without following replacement symlinks
- document the product flow, trust boundary, supported first-slice contract, and follow-up limits

## Safety

- the model receives no host destination and the renderer receives no scratch path or native credentials
- filenames, content, catalog size, directory traversal, file kind, UTF-8, and preview size are independently bounded
- native reads and exports reject symlinks; exports use a user-selected destination, temporary file, fsync, and atomic rename
- staged diff and commit pass Gitleaks with no findings
- no files overlap open PR #400 (`agent.rs` only)

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --exclude openwave-desktop --locked`
- `cargo test -p openwave-desktop --locked`
- PostgreSQL state-machine lane: 25 passed in an isolated PostgreSQL 17 container
- desktop UI: 37 files / 239 tests passed
- desktop UI production build passed
- release/workflow policy: 67 tests passed
