### PR TITLE
feat(desktop): move a chat's sources and outputs into per-chat tabs

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -1077,12 +1077,9 @@ export default function App() {
         className={`main${primaryView === "chat" && settingsPanel ? " with-settings" : ""}`}
       >
         {primaryView === "documents" ? (
-          <DocumentsView chatId={chat.id} onBack={() => uiActions.showChat({ keepPanels: true })} />
+          <DocumentsView chatId={chat.id} />
         ) : primaryView === "deliverables" ? (
-          <DeliverablesView
-            chatId={chat.id}
-            onBack={() => uiActions.showChat({ keepPanels: true })}
-          />
+          <DeliverablesView chatId={chat.id} />
         ) : primaryView === "settings" ? (
           <SettingsView
             client={client}

--- a/crates/openwave-desktop/ui/src/ChatTabs.tsx
+++ b/crates/openwave-desktop/ui/src/ChatTabs.tsx
@@ -1,0 +1,59 @@
+import { FileOutput, LibraryBig, MessageSquare } from "lucide-react";
+import { useUiStore } from "./UiStore";
+
+/**
+ * Segmented control for a chat's per-conversation surfaces: the transcript
+ * ("Chat") and its scoped Sources / Outputs. These views are keyed on the
+ * selected chat, so the switcher lives in the chat headers rather than the
+ * sidebar — the sidebar stays a list of chats, not a mix of global and
+ * chat-scoped destinations.
+ */
+export function ChatTabs() {
+  const primaryView = useUiStore((state) => state.primaryView);
+  const showChat = useUiStore((state) => state.showChat);
+  const showDocuments = useUiStore((state) => state.showDocuments);
+  const showDeliverables = useUiStore((state) => state.showDeliverables);
+
+  const tabs = [
+    {
+      key: "chat" as const,
+      label: "Chat",
+      icon: MessageSquare,
+      onSelect: () => showChat({ keepPanels: true }),
+    },
+    {
+      key: "documents" as const,
+      label: "Sources",
+      icon: LibraryBig,
+      onSelect: showDocuments,
+    },
+    {
+      key: "deliverables" as const,
+      label: "Outputs",
+      icon: FileOutput,
+      onSelect: showDeliverables,
+    },
+  ];
+
+  return (
+    <div className="chat-tabs" role="tablist" aria-label="Chat views">
+      {tabs.map((tab) => {
+        const active = primaryView === tab.key;
+        const Icon = tab.icon;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            className={`chat-tab${active ? " is-active" : ""}`}
+            onClick={tab.onSelect}
+          >
+            <Icon size={14} />
+            <span className="chat-tab-label">{tab.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -5,19 +5,14 @@ import type {
   PendingFolderAccessRequest,
 } from "./api";
 import { AgentActivityPanel } from "./AgentActivityPanel";
+import { ChatTabs } from "./ChatTabs";
 import { isNearBottom, scrollToLatest } from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
 import { useUiStore } from "./UiStore";
 import { Composer } from "./Composer";
 import type { FolderAccessDecision } from "./host";
 import { MessageList } from "./MessageList";
-import {
-  ArrowDown,
-  FileOutput,
-  FolderOpen,
-  LibraryBig,
-  Settings,
-} from "lucide-react";
+import { ArrowDown, FolderOpen, Settings } from "lucide-react";
 
 export type ChatViewProps = {
   chat: Chat;
@@ -113,8 +108,6 @@ export function ChatView({
   const foldersPanelOpen = useUiStore(
     (state) => state.settingsPanel === "folders",
   );
-  const showDocuments = useUiStore((state) => state.showDocuments);
-  const showDeliverables = useUiStore((state) => state.showDeliverables);
   const showSettings = useUiStore((state) => state.showSettings);
   const toggleFoldersPanel = useUiStore((state) => state.toggleFoldersPanel);
   const messages = useChatSessionStore((session) => session.messages);
@@ -158,28 +151,9 @@ export function ChatView({
         <div className="conversation-title-row">
           <h1>{chat.title?.trim() || "New chat"}</h1>
         </div>
+        {nativeHost && <ChatTabs />}
         <div className="conversation-header-actions">
           <div className="mobile-settings-actions">
-            {nativeHost && (
-              <button
-                type="button"
-                className="btn"
-                aria-label="Sources"
-                onClick={showDocuments}
-              >
-                <LibraryBig size={14} />
-              </button>
-            )}
-            {nativeHost && (
-              <button
-                type="button"
-                className="btn"
-                aria-label="Outputs"
-                onClick={showDeliverables}
-              >
-                <FileOutput size={14} />
-              </button>
-            )}
             {nativeHost && (
               <button
                 type="button"

--- a/crates/openwave-desktop/ui/src/DeliverablesView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.dom.test.tsx
@@ -32,7 +32,7 @@ describe("DeliverablesView", () => {
     };
 
     render(
-      <DeliverablesView chatId="chat-1" onBack={() => {}} apis={apis} />,
+      <DeliverablesView chatId="chat-1" apis={apis} />,
     );
     expect(await screen.findByRole("heading", { name: "Findings" })).toBeVisible();
     await userEvent.click(screen.getByRole("button", { name: /Save As/ }));
@@ -46,7 +46,6 @@ describe("DeliverablesView", () => {
     render(
       <DeliverablesView
         chatId="chat-1"
-        onBack={() => {}}
         apis={{
           list: vi.fn().mockResolvedValue({
             deliverables: [],
@@ -86,7 +85,7 @@ describe("DeliverablesView", () => {
     };
 
     render(
-      <DeliverablesView chatId="chat-1" onBack={() => {}} apis={apis} />,
+      <DeliverablesView chatId="chat-1" apis={apis} />,
     );
     await screen.findByText("brief");
     await userEvent.click(screen.getByRole("button", { name: /Save As/ }));
@@ -137,7 +136,7 @@ describe("DeliverablesView", () => {
     };
 
     render(
-      <DeliverablesView chatId="chat-1" onBack={() => {}} apis={apis} />,
+      <DeliverablesView chatId="chat-1" apis={apis} />,
     );
     await waitFor(() => expect(apis.read).toHaveBeenCalledTimes(1));
     await userEvent.click(screen.getByRole("button", { name: "Refresh" }));

--- a/crates/openwave-desktop/ui/src/DeliverablesView.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Download, FileOutput, RefreshCw } from "lucide-react";
+import { ChatTabs } from "./ChatTabs";
 import {
   exportDeliverable,
   listDeliverables,
@@ -23,11 +24,9 @@ const defaultApis: DeliverableApis = {
 
 export function DeliverablesView({
   chatId,
-  onBack,
   apis = defaultApis,
 }: {
   chatId: string;
-  onBack: () => void;
   apis?: DeliverableApis;
 }) {
   const [catalog, setCatalog] = useState<DeliverablesCatalog>({
@@ -142,9 +141,7 @@ export function DeliverablesView({
           </p>
         </div>
         <div className="deliverables-header-actions">
-          <button type="button" className="btn deliverables-back" onClick={onBack}>
-            Back to chat
-          </button>
+          <ChatTabs />
           <button
             type="button"
             className="btn"

--- a/crates/openwave-desktop/ui/src/DocumentsView.test.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.test.tsx
@@ -1,11 +1,11 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { DocumentsView } from "./DocumentsView";
 
 describe("DocumentsView", () => {
   it("presents sources as context owned by the current conversation", () => {
     const markup = renderToStaticMarkup(
-      <DocumentsView chatId="chat-1" onBack={vi.fn()} />,
+      <DocumentsView chatId="chat-1" />,
     );
 
     expect(markup).toContain("This conversation");

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { FileText } from "lucide-react";
+import { ChatTabs } from "./ChatTabs";
 import {
   importLibraryDocument,
   listLibraryDocuments,
@@ -11,10 +12,8 @@ import {
 
 export function DocumentsView({
   chatId,
-  onBack,
 }: {
   chatId: string;
-  onBack: () => void;
 }) {
   const [documents, setDocuments] = useState<LibraryDocument[]>([]);
   const [catalogTruncated, setCatalogTruncated] = useState(false);
@@ -136,9 +135,7 @@ export function DocumentsView({
           </p>
         </div>
         <div className="documents-header-actions">
-          <button type="button" className="btn documents-back" onClick={onBack}>
-            Back to chat
-          </button>
+          <ChatTabs />
           <button
             type="button"
             className="btn btn-primary"

--- a/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
@@ -100,15 +100,15 @@ describe("Sidebar", () => {
     expect(screen.getByText("Retro notes")).toBeInTheDocument();
   });
 
-  it("navigates through the UI store for sources, outputs, folders, and settings", async () => {
+  it("keeps chat-scoped sources and outputs out of the sidebar", () => {
+    renderSidebar({ nativeHost: true });
+    expect(screen.queryByText("Sources")).not.toBeInTheDocument();
+    expect(screen.queryByText("Outputs")).not.toBeInTheDocument();
+  });
+
+  it("navigates through the UI store for folders and settings", async () => {
     const user = userEvent.setup();
     renderSidebar({ nativeHost: true });
-    await user.click(screen.getByText("Sources"));
-    expect(useUiStore.getState().primaryView).toBe("documents");
-
-    await user.click(screen.getByText("Outputs"));
-    expect(useUiStore.getState().primaryView).toBe("deliverables");
-
     await user.click(screen.getByText("Folders"));
     expect(useUiStore.getState().primaryView).toBe("chat");
     expect(useUiStore.getState().settingsPanel).toBe("folders");

--- a/crates/openwave-desktop/ui/src/Sidebar.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.tsx
@@ -2,9 +2,7 @@ import type { Chat } from "./api";
 import { Logomark } from "./Logomark";
 import {
   Ellipsis,
-  FileOutput,
   FolderOpen,
-  LibraryBig,
   Monitor,
   Moon,
   Pencil,
@@ -74,8 +72,6 @@ export function Sidebar({
   const foldersPanelOpen = useUiStore(
     (state) => state.settingsPanel === "folders",
   );
-  const showDocuments = useUiStore((state) => state.showDocuments);
-  const showDeliverables = useUiStore((state) => state.showDeliverables);
   const showSettings = useUiStore((state) => state.showSettings);
   const toggleFoldersPanel = useUiStore((state) => state.toggleFoldersPanel);
   return (
@@ -117,27 +113,6 @@ export function Sidebar({
             ? "Deleting…"
             : "New chat"}
       </button>
-
-      {nativeHost && (
-        <button
-          type="button"
-          className={`sidebar-action sidebar-library${primaryView === "documents" ? " is-active" : ""}`}
-          onClick={showDocuments}
-        >
-          <LibraryBig size={16} />
-          Sources
-        </button>
-      )}
-      {nativeHost && (
-        <button
-          type="button"
-          className={`sidebar-action sidebar-library${primaryView === "deliverables" ? " is-active" : ""}`}
-          onClick={showDeliverables}
-        >
-          <FileOutput size={16} />
-          Outputs
-        </button>
-      )}
 
       <div className="sidebar-section">
         <span className="sidebar-label">Chats</span>

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -419,13 +419,7 @@ body {
   background: var(--accent);
 }
 
-.sidebar-library {
-  margin-top: 0.15rem;
-  color: var(--ink);
-}
-
-.sidebar-action svg,
-.sidebar-library svg {
+.sidebar-action svg {
   flex: 0 0 auto;
   color: var(--muted-foreground);
 }
@@ -639,6 +633,48 @@ body {
 
 .mobile-settings-actions {
   display: none;
+}
+
+.chat-tabs {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0.15rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--muted);
+}
+
+.chat-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.3rem 0.6rem;
+  color: var(--muted-foreground);
+  background: transparent;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background-color 100ms ease,
+    color 100ms ease;
+}
+
+.chat-tab svg {
+  flex: 0 0 auto;
+}
+
+.chat-tab:hover {
+  color: var(--ink);
+}
+
+.chat-tab.is-active {
+  color: var(--ink);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-sm);
 }
 
 .mobile-settings-actions .btn.is-active {
@@ -2279,10 +2315,6 @@ body {
   gap: 0.55rem;
 }
 
-.documents-back {
-  display: none;
-}
-
 .documents-content {
   display: grid;
   width: min(100%, 68rem);
@@ -2568,10 +2600,6 @@ body {
   gap: 0.4rem;
 }
 
-.deliverables-back {
-  display: none;
-}
-
 .deliverables-content {
   width: min(100%, 76rem);
   margin: 0 auto;
@@ -2793,6 +2821,14 @@ body {
     display: flex;
   }
 
+  .chat-tab-label {
+    display: none;
+  }
+
+  .chat-tab {
+    padding: 0.35rem 0.45rem;
+  }
+
   .main {
     margin: 0;
     border: 0;
@@ -2857,10 +2893,6 @@ body {
     width: 100%;
   }
 
-  .documents-back {
-    display: block;
-  }
-
   .documents-content {
     padding: 1rem 0.75rem 2rem;
   }
@@ -2873,10 +2905,6 @@ body {
   .deliverables-header-actions,
   .deliverables-header-actions .btn {
     width: 100%;
-  }
-
-  .deliverables-back {
-    display: block;
   }
 
   .deliverables-content {


### PR DESCRIPTION
## Why

Sources and Outputs are scoped to the selected chat (each view is keyed on `chatId`), but the sidebar listed them as top-level nav *above* the chat list — so they read as global destinations. Switching chats silently re-keyed both views with no signal that what you were looking at belonged to a chat. The information architecture didn't match the ownership: chat-scoped surfaces dressed as global nav.

## What

- New `ChatTabs` segmented control — **Chat / Sources / Outputs** — that reads `primaryView` straight from the UI store and lives in the chat, document, and deliverable headers.
- Dropped Sources and Outputs from the sidebar; it's now purely a list of chats.
- On mobile the tabs go icon-only and take over navigation from the old per-view "Back to chat" button (which was desktop-hidden anyway); the now-redundant Sources/Outputs icons are removed from the mobile action row. Folders and Settings — which the hidden-on-mobile sidebar otherwise gates — stay.
- Removed the orphaned `onBack` props and `.documents-back` / `.deliverables-back` / `.sidebar-library` styles.

## Verification

- `tsc --noEmit` clean, `vitest run` 240 passed, production `vite build` green.
- Sidebar/DocumentsView/DeliverablesView tests updated for the moved navigation.

Closes #405