### PR TITLE
feat(desktop): reuse approved folders across chats

### DIFF
--- a/crates/openwave-desktop/src/client_execution/root_attachment_reconciliation.rs
+++ b/crates/openwave-desktop/src/client_execution/root_attachment_reconciliation.rs
@@ -66,6 +66,58 @@ pub(crate) async fn connect_selected_folder(
     drive_manual_connect(state, &mut receipt, ConnectMode::Interactive).await
 }
 
+/// Attach a host-approved root to one exact conversation after native consent.
+///
+/// The root summary carries no path or authority. The broker creates the
+/// conversation grant only when the durable product attachment is driven.
+pub(crate) async fn connect_existing_root(
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    root: RootSummary,
+) -> Result<ConnectedFolder, String> {
+    let product_root_id = HostRootId::from_uuid(root.root_id.as_uuid())
+        .map_err(|_| "invalid approved folder identity".to_owned())?;
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let chat = store
+        .get_chat(ChatId::from(context.chat_id))
+        .await
+        .map_err(|_| "could not load connected folders".to_owned())?
+        .ok_or_else(|| "conversation not found".to_owned())?;
+    let fingerprint = BeginFingerprint {
+        id: RootAttachmentChangeId::new(),
+        chat_id: chat.id,
+        root_id: product_root_id,
+        action: RootAttachmentChangeAction::Attach,
+        expected_revision: chat.attachment_revision,
+        created_at: canonical_now(),
+    };
+    let begun = control_plane(state)?
+        .begin_root_attachment_change(
+            fingerprint.chat_id,
+            fingerprint.id,
+            fingerprint.root_id,
+            fingerprint.action,
+            fingerprint.expected_revision,
+            fingerprint.created_at,
+        )
+        .await
+        .map_err(begin_error)?;
+    validate_begin_change(&begun.change, context, fingerprint)?;
+    let finished = drive_change(state, begun.change).await?;
+    verify_product_terminal(state, &finished).await?;
+    match finished.phase {
+        RootAttachmentChangePhase::Completed => Ok(connected_folder(root)),
+        RootAttachmentChangePhase::Failed => {
+            Err("The approved folder could not be connected to this chat.".to_owned())
+        }
+        RootAttachmentChangePhase::AwaitingBroker => {
+            Err("folder attachment is still pending".to_owned())
+        }
+    }
+}
+
 /// Begin and drive an exact conversation-only detach. Global root revocation
 /// is deliberately not part of the renderer's connected-folder action.
 pub(crate) async fn disconnect_root(

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -4,11 +4,12 @@ use std::path::PathBuf;
 
 use openwave_core::{ChatId, Store};
 use openwave_host_broker::{
-    ExecutionContext, GrantSubject, OperationEnvelope, OperationRequest, OperationResult, RootId,
+    ControlRequest, ControlResult, ExecutionContext, GrantSubject, OperationEnvelope,
+    OperationRequest, OperationResult, RootId, RootSummary,
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, State};
-use tauri_plugin_dialog::DialogExt;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 use tokio::sync::{oneshot, Mutex, OnceCell};
 use uuid::Uuid;
 
@@ -133,6 +134,13 @@ pub(crate) struct DisconnectFolderRequest {
     root_id: RootId,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ConnectApprovedFolderRequest {
+    chat_id: Uuid,
+    root_id: RootId,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConnectedFolder {
@@ -181,6 +189,9 @@ pub(crate) async fn list_connected_folders(
         .await
         .map_err(|_| "could not load connected folders".to_owned())?
         .ok_or_else(|| "conversation not found".to_owned())?;
+    if chat.root_attachments.is_empty() {
+        return Ok(Vec::new());
+    }
     let request_id = openwave_host_broker::RequestId::new();
     let result = state
         .broker
@@ -211,6 +222,45 @@ pub(crate) async fn list_connected_folders(
 }
 
 #[tauri::command]
+pub(crate) async fn list_approved_folders(
+    state: State<'_, HostAccess>,
+) -> Result<Vec<ConnectedFolder>, String> {
+    approved_folders(&state).await
+}
+
+#[tauri::command]
+pub(crate) async fn connect_approved_folder(
+    app: AppHandle,
+    state: State<'_, HostAccess>,
+    request: ConnectApprovedFolderRequest,
+) -> Result<Option<ConnectedFolder>, String> {
+    state.context(request.chat_id).await?;
+    let chat_label = conversation_label(&state, request.chat_id).await?;
+    let root = approved_roots(&state)
+        .await?
+        .into_iter()
+        .find(|root| root.root_id == request.root_id)
+        .ok_or_else(|| "the approved folder is no longer available".to_owned())?;
+    let _consent = state
+        .picker
+        .try_lock()
+        .map_err(|_| "a folder permission prompt is already open".to_owned())?;
+    if !confirm_folder_attachment(&app, &chat_label, &root.display_name).await? {
+        return Ok(None);
+    }
+
+    // Resolve authority again after the user responds so a deleted or changed
+    // conversation cannot reuse the earlier context.
+    let _root_change = state.root_changes.lock().await;
+    let context = state.context(request.chat_id).await?;
+    crate::client_execution::root_attachment_reconciliation::connect_existing_root(
+        &state, context, root,
+    )
+    .await
+    .map(Some)
+}
+
+#[tauri::command]
 pub(crate) async fn disconnect_folder(
     state: State<'_, HostAccess>,
     request: DisconnectFolderRequest,
@@ -223,6 +273,84 @@ pub(crate) async fn disconnect_folder(
         request.root_id,
     )
     .await
+}
+
+async fn approved_folders(state: &HostAccess) -> Result<Vec<ConnectedFolder>, String> {
+    Ok(approved_roots(state)
+        .await?
+        .into_iter()
+        .map(|root| ConnectedFolder {
+            root_id: root.root_id,
+            display_name: root.display_name,
+        })
+        .collect())
+}
+
+async fn approved_roots(state: &HostAccess) -> Result<Vec<RootSummary>, String> {
+    let result = state
+        .broker
+        .control(ControlRequest::ListApprovedRoots)
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::ListApprovedRoots { roots } = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+    Ok(roots)
+}
+
+async fn conversation_label(state: &HostAccess, chat_id: Uuid) -> Result<String, String> {
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let chat = store
+        .get_chat(ChatId::from(chat_id))
+        .await
+        .map_err(|_| "could not load the conversation".to_owned())?
+        .ok_or_else(|| "conversation not found".to_owned())?;
+    Ok(safe_dialog_label(
+        chat.title.as_deref().unwrap_or("Untitled chat"),
+    ))
+}
+
+fn safe_dialog_label(value: &str) -> String {
+    value
+        .chars()
+        .take(80)
+        .map(|character| {
+            if character.is_control() {
+                '\u{fffd}'
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+async fn confirm_folder_attachment(
+    app: &AppHandle,
+    chat_label: &str,
+    display_name: &str,
+) -> Result<bool, String> {
+    let folder_label = safe_dialog_label(display_name);
+    let (tx, rx) = oneshot::channel();
+    let mut dialog = app
+        .dialog()
+        .message(format!(
+            "Allow the chat “{chat_label}” to read the previously approved folder “{folder_label}”?"
+        ))
+        .title("Connect folder")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Connect".to_owned(),
+            "Cancel".to_owned(),
+        ));
+    if let Some(window) = app.get_webview_window("main") {
+        dialog = dialog.parent(&window);
+    }
+    dialog.show(move |approved| {
+        let _ = tx.send(approved);
+    });
+    rx.await
+        .map_err(|_| "folder permission prompt closed unexpectedly".to_owned())
 }
 
 pub(super) async fn pick_folder(
@@ -282,5 +410,13 @@ mod tests {
         });
         assert!(serde_json::from_value::<ConnectFolderRequest>(injected).is_err());
         assert!(authoritative_context(Uuid::nil(), None).is_err());
+    }
+
+    #[test]
+    fn native_confirmation_labels_are_bounded_and_strip_controls() {
+        let label = safe_dialog_label(&format!("Research\n{}", "x".repeat(100)));
+        assert!(!label.contains('\n'));
+        assert_eq!(label.chars().count(), 80);
+        assert!(label.starts_with("Research\u{fffd}"));
     }
 }

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -155,6 +155,8 @@ pub fn run() {
             deliverables::export_deliverable,
             client_execution::resolve_folder_access_request,
             host_access::connect_folder,
+            host_access::connect_approved_folder,
+            host_access::list_approved_folders,
             host_access::list_connected_folders,
             host_access::disconnect_folder,
             updater::desktop_update_state,

--- a/crates/openwave-desktop/ui/src/FoldersPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersPanel.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Chat } from "./api";
+import { FoldersPanel } from "./FoldersPanel";
+import * as host from "./host";
+
+vi.mock("./host", () => ({
+  connectApprovedFolder: vi.fn(),
+  connectFolder: vi.fn(),
+  disconnectFolder: vi.fn(),
+  listApprovedFolders: vi.fn(),
+  listConnectedFolders: vi.fn(),
+}));
+
+const chat = {
+  id: "chat-1",
+  title: "Folder test",
+  project_id: null,
+} as unknown as Chat;
+
+beforeEach(() => {
+  vi.mocked(host.listConnectedFolders).mockResolvedValue([]);
+  vi.mocked(host.listApprovedFolders).mockResolvedValue([]);
+  vi.mocked(host.connectApprovedFolder).mockResolvedValue(null);
+  vi.mocked(host.connectFolder).mockResolvedValue(null);
+  vi.mocked(host.disconnectFolder).mockResolvedValue(false);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("FoldersPanel", () => {
+  it("renders an empty chat without treating the missing grant as an error", async () => {
+    render(<FoldersPanel chat={chat} />);
+
+    expect(
+      await screen.findByText("No folders connected to this chat."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(host.listConnectedFolders).toHaveBeenCalledWith(chat);
+    expect(host.listApprovedFolders).toHaveBeenCalledOnce();
+  });
+
+  it("offers approved folders that are not already connected", async () => {
+    vi.mocked(host.listConnectedFolders).mockResolvedValue([
+      { rootId: "connected", displayName: "Current project" },
+    ]);
+    vi.mocked(host.listApprovedFolders).mockResolvedValue([
+      { rootId: "connected", displayName: "Current project" },
+      { rootId: "available", displayName: "Research" },
+    ]);
+    vi.mocked(host.connectApprovedFolder).mockResolvedValue({
+      rootId: "available",
+      displayName: "Research",
+    });
+    const user = userEvent.setup();
+    render(<FoldersPanel chat={chat} />);
+
+    expect(await screen.findByText("Available on this Mac")).toBeInTheDocument();
+    expect(screen.getByText("Current project")).toBeInTheDocument();
+    expect(screen.getByText("Research")).toBeInTheDocument();
+    expect(screen.getAllByText("Current project")).toHaveLength(1);
+
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+    expect(host.connectApprovedFolder).toHaveBeenCalledWith(chat, "available");
+    await waitFor(() =>
+      expect(host.listConnectedFolders).toHaveBeenCalledTimes(2),
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/FoldersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersPanel.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import type { Chat } from "./api";
 import {
+  connectApprovedFolder,
   connectFolder,
   disconnectFolder,
+  listApprovedFolders,
   listConnectedFolders,
   type ConnectedFolder,
 } from "./host";
@@ -11,14 +13,24 @@ import { Button } from "@/components/ui/button";
 
 export function FoldersPanel({ chat }: { chat: Chat }) {
   const [folders, setFolders] = useState<ConnectedFolder[]>([]);
+  const [approvedFolders, setApprovedFolders] = useState<ConnectedFolder[]>([]);
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const scopeLabel = "chat";
+  const connectedIds = new Set(folders.map((folder) => folder.rootId));
+  const availableFolders = approvedFolders.filter(
+    (folder) => !connectedIds.has(folder.rootId),
+  );
 
   async function refresh() {
     setError(null);
     try {
-      setFolders(await listConnectedFolders(chat));
+      const [connected, approved] = await Promise.all([
+        listConnectedFolders(chat),
+        listApprovedFolders(),
+      ]);
+      setFolders(connected);
+      setApprovedFolders(approved);
     } catch (err) {
       setError(String(err));
     }
@@ -33,6 +45,19 @@ export function FoldersPanel({ chat }: { chat: Chat }) {
     setError(null);
     try {
       const connected = await connectFolder(chat);
+      if (connected) await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function addApprovedFolder(rootId: string) {
+    setWorking(true);
+    setError(null);
+    try {
+      const connected = await connectApprovedFolder(chat, rootId);
       if (connected) await refresh();
     } catch (err) {
       setError(String(err));
@@ -57,7 +82,7 @@ export function FoldersPanel({ chat }: { chat: Chat }) {
   return (
     <SettingsPanel
       title="Connected folders"
-      description={`OpenWave can read only folders you choose for this ${scopeLabel}. Folder locations stay with the native host.`}
+      description={`OpenWave can read only folders attached to this ${scopeLabel}. Previously approved folders can be reused without choosing them again.`}
     >
       <Button
         type="button"
@@ -66,9 +91,12 @@ export function FoldersPanel({ chat }: { chat: Chat }) {
         disabled={working}
         onClick={() => void addFolder()}
       >
-        Choose folder…
+        Choose another folder…
       </Button>
       <div className="flex flex-col gap-2">
+        {folders.length > 0 && (
+          <p className="text-xs font-medium text-muted-foreground">Connected</p>
+        )}
         {folders.length === 0 && !error && (
           <p className="text-sm text-muted-foreground">
             No folders connected to this {scopeLabel}.
@@ -97,6 +125,37 @@ export function FoldersPanel({ chat }: { chat: Chat }) {
           </div>
         ))}
       </div>
+      {availableFolders.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <p className="text-xs font-medium text-muted-foreground">
+            Available on this Mac
+          </p>
+          {availableFolders.map((folder) => (
+            <div
+              className="flex items-center justify-between gap-3 rounded-lg border border-border p-3"
+              key={folder.rootId}
+            >
+              <div className="min-w-0">
+                <strong className="block truncate text-sm font-medium">
+                  {folder.displayName}
+                </strong>
+                <span className="text-xs text-muted-foreground">
+                  previously approved
+                </span>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={working}
+                onClick={() => void addApprovedFolder(folder.rootId)}
+              >
+                Connect
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
       {error && <SettingsError>{error}</SettingsError>}
     </SettingsPanel>
   );

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -16,9 +16,22 @@ export function listConnectedFolders(chat: Chat): Promise<ConnectedFolder[]> {
   return invoke("list_connected_folders", { chatId: chat.id });
 }
 
+export function listApprovedFolders(): Promise<ConnectedFolder[]> {
+  return invoke("list_approved_folders");
+}
+
 export function connectFolder(chat: Chat): Promise<ConnectedFolder | null> {
   return invoke("connect_folder", {
     request: { chatId: chat.id },
+  });
+}
+
+export function connectApprovedFolder(
+  chat: Chat,
+  rootId: string,
+): Promise<ConnectedFolder | null> {
+  return invoke("connect_approved_folder", {
+    request: { chatId: chat.id, rootId },
   });
 }
 

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -141,6 +141,8 @@ struct State {
 
 #[derive(Clone)]
 struct RegisteredRoot {
+    /// Subject that originally established the host approval. Other subjects
+    /// may receive grants only through trusted attachment control actions.
     owner: GrantSubject,
     display_name: String,
     root: Arc<ValidatedRoot>,
@@ -213,7 +215,7 @@ struct ControlAudit {
 impl ControlAudit {
     fn from_request(request: &ControlRequest) -> Option<Self> {
         match request {
-            ControlRequest::Hello => None,
+            ControlRequest::Hello | ControlRequest::ListApprovedRoots => None,
             ControlRequest::RegisterRoot(request) => Some(Self {
                 actor: AuditActor::Control {
                     subject: request.subject,
@@ -433,6 +435,10 @@ impl Controller {
         require_version(envelope.protocol_version).map_err(error_response)?;
         match envelope.request {
             ControlRequest::Hello => Ok(ControlResult::Hello(hello())),
+            ControlRequest::ListApprovedRoots => {
+                let state = self.lock_state().map_err(error_response)?;
+                list_approved_roots(&state).map(|roots| ControlResult::ListApprovedRoots { roots })
+            }
             ControlRequest::RegisterRoot(request) => {
                 self.register_root(request).map(ControlResult::RegisterRoot)
             }
@@ -489,11 +495,17 @@ impl Controller {
         let outcome = match prepared {
             Ok(prepared) => {
                 let existing = next.roots.iter().find_map(|(root_id, root)| {
-                    (root.owner == prepared.root.owner
-                        && root.root.identity() == prepared.root.root.identity())
-                    .then(|| (*root_id, root.display_name.clone()))
+                    (root.root.identity() == prepared.root.root.identity())
+                        .then(|| (*root_id, root.display_name.clone()))
                 });
                 if let Some((root_id, display_name)) = existing {
+                    ensure_subject_grants(
+                        &mut next,
+                        prepared.root.owner,
+                        root_id,
+                        prepared.grants[0].consent().clone(),
+                    )
+                    .map_err(error_response)?;
                     if !next.attachments.iter().any(|attachment| {
                         attachment.conversation_id() == prepared.conversation_id
                             && attachment.root_id() == root_id
@@ -799,7 +811,7 @@ impl Operator {
                 OperationRequest::ListRoots => {
                     let state = self.lock_state()?;
                     let (result, authorized_by) = list_roots(&state, envelope.context)?;
-                    grant_id = Some(authorized_by);
+                    grant_id = authorized_by;
                     Ok(result)
                 }
                 OperationRequest::ListDirectory(PathRequest { root_id, path }) => {
@@ -1073,20 +1085,24 @@ fn registration_is_connected(
     request: &RegisterFingerprint,
     root: &RootSummary,
 ) -> bool {
-    state.roots.get(&root.root_id).is_some_and(|registered| {
-        registered.owner == request.subject && registered.display_name == root.display_name
-    }) && state.attachments.iter().any(|attachment| {
-        attachment.conversation_id() == request.conversation_id
-            && attachment.root_id() == root.root_id
-    }) && state.grants.iter().any(|grant| {
-        grant.subject() == request.subject
-            && grant.capability() == Capability::ListRoots
-            && matches!(grant.scope(), Scope::Subject)
-    }) && state.grants.iter().any(|grant| {
-        grant.subject() == request.subject
-            && grant.capability() == Capability::ReadFiles
-            && matches!(grant.scope(), Scope::Root { root_id } if *root_id == root.root_id)
-    })
+    state
+        .roots
+        .get(&root.root_id)
+        .is_some_and(|registered| registered.display_name == root.display_name)
+        && state.attachments.iter().any(|attachment| {
+            attachment.conversation_id() == request.conversation_id
+                && attachment.root_id() == root.root_id
+        })
+        && state.grants.iter().any(|grant| {
+            grant.subject() == request.subject
+                && grant.capability() == Capability::ListRoots
+                && matches!(grant.scope(), Scope::Subject)
+        })
+        && state.grants.iter().any(|grant| {
+            grant.subject() == request.subject
+                && grant.capability() == Capability::ReadFiles
+                && matches!(grant.scope(), Scope::Root { root_id } if *root_id == root.root_id)
+        })
 }
 
 fn claim_register(
@@ -1258,13 +1274,12 @@ fn apply_root_attachment(
     validate_subject_conversation(request.subject, request.conversation_id)?;
     let changed = match request.mutation {
         RootAttachmentMutationKind::Attach => {
-            let root = state
+            state
                 .roots
                 .get(&request.root_id)
                 .ok_or(BrokerError::UnknownRoot)?;
-            if root.owner != request.subject {
-                return Err(BrokerError::Denied);
-            }
+            let consent = root_consent(state, request.root_id).ok_or(BrokerError::Denied)?;
+            ensure_subject_grants(state, request.subject, request.root_id, consent)?;
             if has_root_attachment(state, request.conversation_id, request.root_id) {
                 false
             } else {
@@ -1276,10 +1291,10 @@ fn apply_root_attachment(
             }
         }
         RootAttachmentMutationKind::Detach => {
-            if let Some(root) = state.roots.get(&request.root_id) {
-                if root.owner != request.subject {
-                    return Err(BrokerError::Denied);
-                }
+            if state.roots.contains_key(&request.root_id)
+                && !subject_has_root_grant(state, request.subject, request.root_id)
+            {
+                return Err(BrokerError::Denied);
             }
             let before = state.attachments.len();
             state.attachments.retain(|attachment| {
@@ -1314,23 +1329,100 @@ fn has_root_attachment(state: &State, conversation_id: Uuid, root_id: RootId) ->
     })
 }
 
+fn root_consent(state: &State, root_id: RootId) -> Option<ConsentRecord> {
+    state
+        .grants
+        .iter()
+        .find(|grant| {
+            grant.capability() == Capability::ReadFiles
+                && matches!(grant.scope(), Scope::Root { root_id: granted } if *granted == root_id)
+        })
+        .map(|grant| grant.consent().clone())
+}
+
+fn subject_has_root_grant(state: &State, subject: GrantSubject, root_id: RootId) -> bool {
+    state.grants.iter().any(|grant| {
+        grant.subject() == subject
+            && grant.capability() == Capability::ReadFiles
+            && matches!(grant.scope(), Scope::Root { root_id: granted } if *granted == root_id)
+    })
+}
+
+fn ensure_subject_grants(
+    state: &mut State,
+    subject: GrantSubject,
+    root_id: RootId,
+    consent: ConsentRecord,
+) -> Result<(), BrokerError> {
+    if !state.grants.iter().any(|grant| {
+        grant.subject() == subject
+            && grant.capability() == Capability::ListRoots
+            && matches!(grant.scope(), Scope::Subject)
+    }) {
+        state.grants.push(Grant::from_consent(
+            GrantId::new(),
+            subject,
+            Capability::ListRoots,
+            Scope::Subject,
+            consent.clone(),
+        )?);
+    }
+    if !subject_has_root_grant(state, subject, root_id) {
+        state.grants.push(Grant::from_consent(
+            GrantId::new(),
+            subject,
+            Capability::ReadFiles,
+            Scope::Root { root_id },
+            consent,
+        )?);
+    }
+    Ok(())
+}
+
+fn list_approved_roots(state: &State) -> Result<Vec<RootSummary>, ErrorResponse> {
+    let mut roots = state
+        .roots
+        .iter()
+        .map(|(root_id, root)| RootSummary {
+            root_id: *root_id,
+            display_name: root.display_name.clone(),
+        })
+        .take(MAX_LIST_ROOTS + 1)
+        .collect::<Vec<_>>();
+    if roots.len() > MAX_LIST_ROOTS {
+        return Err(error_response(BrokerError::RootListTooLarge));
+    }
+    roots.sort_by(|left, right| {
+        left.display_name
+            .cmp(&right.display_name)
+            .then_with(|| left.root_id.to_string().cmp(&right.root_id.to_string()))
+    });
+    Ok(roots)
+}
+
 fn list_roots(
     state: &State,
     context: ExecutionContext,
-) -> Result<(OperationResult, GrantId), BrokerError> {
+) -> Result<(OperationResult, Option<GrantId>), BrokerError> {
+    if !state
+        .attachments
+        .iter()
+        .any(|attachment| attachment.conversation_id() == context.conversation_id())
+    {
+        return Ok((OperationResult::ListRoots { roots: Vec::new() }, None));
+    }
     let grant_id = authorize(state, context, Capability::ListRoots, Resource::Subject)?;
     let mut roots = state
         .roots
         .iter()
-        .filter(|(root_id, root)| {
-            context.grant_subject_matches(root.owner)
-                && authorize(
-                    state,
-                    context,
-                    Capability::ReadFiles,
-                    Resource::Root(root_id),
-                )
-                .is_ok()
+        .filter(|(root_id, _root)| {
+            authorize(
+                state,
+                context,
+                Capability::ReadFiles,
+                Resource::Root(root_id),
+            )
+            .is_ok()
         })
         .map(|(root_id, root)| RootSummary {
             root_id: *root_id,
@@ -1346,7 +1438,7 @@ fn list_roots(
             .cmp(&right.display_name)
             .then_with(|| left.root_id.to_string().cmp(&right.root_id.to_string()))
     });
-    Ok((OperationResult::ListRoots { roots }, grant_id))
+    Ok((OperationResult::ListRoots { roots }, Some(grant_id)))
 }
 
 fn root_display_name(path: &Path) -> String {

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -285,27 +285,29 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
             Scope::Root { root_id } | Scope::PathSubtree { root_id, .. } => *root_id,
             Scope::Subject => continue,
         };
-        let root = state
-            .roots
-            .get(&root_id)
-            .ok_or_else(|| invalid_data("grant references an unknown root"))?;
-        if root.owner != grant.subject() {
-            return Err(invalid_data("grant subject does not own its root").into());
+        if !state.roots.contains_key(&root_id) {
+            return Err(invalid_data("grant references an unknown root").into());
         }
     }
     let mut attachment_identities = std::collections::HashSet::new();
     for attachment in &state.attachments {
-        let root = state
-            .roots
-            .get(&attachment.root_id())
-            .ok_or_else(|| invalid_data("attachment references an unknown root"))?;
-        if root.owner.kind() == crate::SubjectKind::Conversation
-            && root.owner.id() != attachment.conversation_id()
-        {
-            return Err(invalid_data(
-                "conversation-owned root is attached to another conversation",
-            )
-            .into());
+        if !state.roots.contains_key(&attachment.root_id()) {
+            return Err(invalid_data("attachment references an unknown root").into());
+        }
+        let has_matching_grant = state.grants.iter().any(|grant| {
+            matches!(
+                grant.scope(),
+                Scope::Root { root_id } | Scope::PathSubtree { root_id, .. }
+                    if *root_id == attachment.root_id()
+            ) && match grant.subject().kind() {
+                crate::SubjectKind::Project => true,
+                crate::SubjectKind::Conversation => {
+                    grant.subject().id() == attachment.conversation_id()
+                }
+            }
+        });
+        if !has_matching_grant {
+            return Err(invalid_data("attachment has no matching subject grant").into());
         }
         if !attachment_identities.insert((attachment.conversation_id(), attachment.root_id())) {
             return Err(invalid_data("duplicate persisted root attachment").into());
@@ -334,9 +336,16 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
                 outcome: super::MutationOutcome::Complete(Ok(result)),
             } => {
                 if let Some(root) = state.roots.get(&result.root.root_id) {
-                    if root.owner != request.subject
-                        || root.display_name != result.root.display_name
-                    {
+                    let subject_has_grant = state.grants.iter().any(|grant| {
+                        grant.subject() == request.subject
+                            && matches!(
+                                grant.scope(),
+                                Scope::Root { root_id }
+                                    | Scope::PathSubtree { root_id, .. }
+                                    if *root_id == result.root.root_id
+                            )
+                    });
+                    if root.display_name != result.root.display_name || !subject_has_grant {
                         return Err(invalid_data(
                             "successful register receipt does not match authoritative state",
                         )
@@ -348,10 +357,9 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
                             record,
                             MutationRecord::Revoke {
                                 request: revoke,
-                                outcome: super::MutationOutcome::Complete(Ok(revoke_result)),
-                            } if revoke_result.revoked
+                            outcome: super::MutationOutcome::Complete(Ok(revoke_result)),
+                        } if revoke_result.revoked
                                 && revoke.root_id == result.root.root_id
-                                && revoke.subject == request.subject
                         )
                     });
                     if !was_revoked {

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -163,11 +163,204 @@ fn operate(
     }))
 }
 
+fn list_approved(controller: &Controller) -> Vec<RootSummary> {
+    let result = unwrap_response(controller.handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::ListApprovedRoots,
+    }))
+    .unwrap();
+    let ControlResult::ListApprovedRoots { roots } = result else {
+        panic!("unexpected control result")
+    };
+    roots
+}
+
 fn unwrap_response<T>(envelope: ResponseEnvelope<T>) -> Result<T, ErrorResponse> {
     match envelope.response {
         Response::Ok(result) => Ok(result),
         Response::Error(error) => Err(error),
     }
+}
+
+#[test]
+fn an_empty_conversation_lists_no_roots_without_needing_a_grant() {
+    let (_temp, broker, _path) = setup();
+    let context = ExecutionContext::standalone(Uuid::new_v4()).unwrap();
+    assert_eq!(
+        operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap(),
+        OperationResult::ListRoots { roots: Vec::new() }
+    );
+    assert!(list_approved(&broker.controller()).is_empty());
+}
+
+#[test]
+fn approved_roots_can_be_explicitly_attached_to_another_standalone_conversation() {
+    let (_temp, broker, path) = setup();
+    let first_conversation = Uuid::new_v4();
+    let first_subject = GrantSubject::conversation(first_conversation).unwrap();
+    let registered = register(
+        &broker.controller(),
+        first_subject,
+        first_conversation,
+        path,
+        OperationId::new(),
+    );
+    let root_id = registered.root.root_id;
+    mutate_attachment(
+        &broker.controller(),
+        OperationId::new(),
+        first_subject,
+        first_conversation,
+        root_id,
+        RootAttachmentMutationKind::Detach,
+    )
+    .unwrap();
+
+    assert_eq!(
+        list_approved(&broker.controller()),
+        vec![registered.root.clone()]
+    );
+    assert_eq!(
+        operate(
+            &broker.operator(),
+            ExecutionContext::standalone(first_conversation).unwrap(),
+            OperationRequest::ListRoots,
+        )
+        .unwrap(),
+        OperationResult::ListRoots { roots: Vec::new() }
+    );
+
+    let second_conversation = Uuid::new_v4();
+    let second_subject = GrantSubject::conversation(second_conversation).unwrap();
+    mutate_attachment(
+        &broker.controller(),
+        OperationId::new(),
+        second_subject,
+        second_conversation,
+        root_id,
+        RootAttachmentMutationKind::Attach,
+    )
+    .unwrap();
+    let second_context = ExecutionContext::standalone(second_conversation).unwrap();
+    assert_eq!(
+        operate(
+            &broker.operator(),
+            second_context,
+            OperationRequest::ListRoots,
+        )
+        .unwrap(),
+        OperationResult::ListRoots {
+            roots: vec![registered.root]
+        }
+    );
+    assert!(matches!(
+        operate(
+            &broker.operator(),
+            second_context,
+            OperationRequest::ReadFile(PathRequest {
+                root_id,
+                path: RelativePath::parse("note.txt").unwrap(),
+            }),
+        )
+        .unwrap(),
+        OperationResult::ReadFile(_)
+    ));
+
+    let unrelated = ExecutionContext::standalone(Uuid::new_v4()).unwrap();
+    assert_eq!(
+        operate(&broker.operator(), unrelated, OperationRequest::ListRoots).unwrap(),
+        OperationResult::ListRoots { roots: Vec::new() }
+    );
+}
+
+#[test]
+fn reused_standalone_approval_and_chat_attachment_survive_restart() {
+    let (temp, broker, path, state_dir) = durable_setup();
+    let first_conversation = Uuid::new_v4();
+    let first_subject = GrantSubject::conversation(first_conversation).unwrap();
+    let registered = register(
+        &broker.controller(),
+        first_subject,
+        first_conversation,
+        path,
+        OperationId::new(),
+    );
+    mutate_attachment(
+        &broker.controller(),
+        OperationId::new(),
+        first_subject,
+        first_conversation,
+        registered.root.root_id,
+        RootAttachmentMutationKind::Detach,
+    )
+    .unwrap();
+    let second_conversation = Uuid::new_v4();
+    mutate_attachment(
+        &broker.controller(),
+        OperationId::new(),
+        GrantSubject::conversation(second_conversation).unwrap(),
+        second_conversation,
+        registered.root.root_id,
+        RootAttachmentMutationKind::Attach,
+    )
+    .unwrap();
+    drop(broker);
+
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    assert_eq!(
+        list_approved(&broker.controller()),
+        vec![registered.root.clone()]
+    );
+    assert_eq!(
+        operate(
+            &broker.operator(),
+            ExecutionContext::standalone(second_conversation).unwrap(),
+            OperationRequest::ListRoots,
+        )
+        .unwrap(),
+        OperationResult::ListRoots {
+            roots: vec![registered.root]
+        }
+    );
+}
+
+#[test]
+fn choosing_the_same_approved_folder_again_reuses_its_host_identity() {
+    let (_temp, broker, path) = setup();
+    let first_conversation = Uuid::new_v4();
+    let first = register(
+        &broker.controller(),
+        GrantSubject::conversation(first_conversation).unwrap(),
+        first_conversation,
+        path.clone(),
+        OperationId::new(),
+    );
+    let second_conversation = Uuid::new_v4();
+    let second = register(
+        &broker.controller(),
+        GrantSubject::conversation(second_conversation).unwrap(),
+        second_conversation,
+        path,
+        OperationId::new(),
+    );
+
+    assert_eq!(second.root, first.root);
+    assert_eq!(
+        list_approved(&broker.controller()),
+        vec![first.root.clone()]
+    );
+    assert_eq!(
+        operate(
+            &broker.operator(),
+            ExecutionContext::standalone(second_conversation).unwrap(),
+            OperationRequest::ListRoots,
+        )
+        .unwrap(),
+        OperationResult::ListRoots {
+            roots: vec![first.root]
+        }
+    );
 }
 
 #[test]
@@ -1716,7 +1909,7 @@ fn persisted_receipts_must_match_authoritative_state() {
 }
 
 #[test]
-fn persisted_attachments_must_be_unique_and_respect_conversation_ownership() {
+fn persisted_attachments_must_be_unique_and_match_subject_grants() {
     let (_temp, broker, path, _state_dir) = durable_setup();
     let conversation = Uuid::new_v4();
     register(

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -51,6 +51,11 @@ pub enum ControlRequest {
     /// Version negotiation. This request is accepted even when its envelope
     /// version differs so the host can discover the broker's version.
     Hello,
+    /// List safe summaries of folders previously approved on this host.
+    ///
+    /// This is a trusted-host management operation, not an agent operation.
+    /// It exposes neither absolute paths nor attachment authority.
+    ListApprovedRoots,
     /// Register the exact folder returned by a native picker and attach it to
     /// the conversation that initiated the trusted interaction.
     RegisterRoot(RegisterRootRequest),
@@ -97,7 +102,7 @@ pub struct LookupRegisterRootReceiptRequest {
 pub struct RootAttachmentMutationRequest {
     /// Stable idempotency identity for this mutation.
     pub operation_id: OperationId,
-    /// Trusted owner of the registered root.
+    /// Trusted product subject receiving or removing the conversation grant.
     pub subject: GrantSubject,
     /// Exact conversation whose live broker attachment changes.
     pub conversation_id: Uuid,
@@ -130,6 +135,7 @@ pub struct RevokeRootRequest {
     /// Stable idempotency identity for this mutation, independent of transport
     /// request/retry correlation.
     pub operation_id: OperationId,
+    /// Original registering subject allowed to forget this host approval.
     pub subject: GrantSubject,
     pub root_id: RootId,
 }
@@ -213,6 +219,7 @@ pub type OperationResponseEnvelope = ResponseEnvelope<OperationResult>;
 #[non_exhaustive]
 pub enum ControlResult {
     Hello(HelloResult),
+    ListApprovedRoots { roots: Vec<RootSummary> },
     RegisterRoot(RegisterRootResult),
     LookupRegisterRootReceipt(LookupRegisterRootReceiptResult),
     AttachRoot(RootAttachmentMutationResult),

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -18,8 +18,9 @@ one folder all conversations work in.
 
 A folder elsewhere on the machine is a **connected root**. It becomes available
 only after the user chooses it through a trusted desktop action, such as a native
-folder picker. The current product resolves that access through the exact
-conversation, and each conversation can contain more than one connected root.
+folder picker. The broker remembers that host approval so the user does not have
+to locate the same folder again, but usable authority is attached through the
+exact conversation. Each conversation can contain more than one connected root.
 
 In practical terms:
 
@@ -27,6 +28,9 @@ In practical terms:
 - Each conversation has its own ordered set of connected folders.
 - A new conversation does not inherit another conversation's roots or fall back
   to a shared workspace.
+- Previously approved roots may be offered by safe display name in another
+  conversation. Attaching one requires a trusted native confirmation, but not
+  another folder picker.
 - The model sees an opaque root identifier, a display name, and root-relative
   paths. It never receives authority by naming an absolute host path.
 - Connecting one folder never grants access to its siblings, the user's whole
@@ -200,9 +204,11 @@ folder picker, resolves the renderer's chat ID against the server's authoritativ
 store, derives the trusted ownership subject from that record, and forwards the
 picker result. Current desktop chats use their conversation subject; dormant
 project-scoped API chats retain their legacy project subject. Re-registering the
-same pinned filesystem object for the same subject reuses the root. A separate
-product attachment change then confirms the exact conversation attachment before
-the renderer sees it as connected.
+same pinned filesystem object reuses the host-approved root. The host can return
+bounded safe summaries of approved roots to the management UI; it never returns
+their paths. Reusing an approved root in another chat requires a native
+confirmation, after which a separate product attachment change confirms the
+exact conversation attachment before the renderer sees it as connected.
 
 The **renderer** presents connected folders and permission choices. It receives
 safe summaries, not the broker's persisted absolute-path registry.
@@ -212,28 +218,32 @@ safe summaries, not the broker's persisted absolute-path registry.
 Broker requests are divided into two typed channels:
 
 1. **Control requests** record trusted user actions: negotiate a protocol
-   version, register a folder returned by the native picker, attach or detach an
-   existing root for one conversation, or revoke access. Only the desktop host
-   or an equivalent explicit local CLI action may send them.
+   version, list safe summaries of host-approved roots, register a folder
+   returned by the native picker, attach or detach an existing root for one
+   conversation, or revoke access. Only the desktop host or an equivalent
+   explicit local CLI action may send them.
 2. **Operation requests** come from agent execution. The current protocol can
    list connected roots, list a directory, and read a file; bounded import,
    writes, and confined commands are later capability slices. Every operation
-   is denied unless a matching grant exists.
+   that can expose a host resource is denied unless a matching grant exists; an
+   unattached conversation may safely receive an empty root list.
 
 Code should expose different controller and operator interfaces so an agent
 executor cannot accidentally call the control channel. The broker still
 validates every request; the type split is defense in depth, not the only check.
 
-Attaching and detaching are exact conversation mutations. Detaching a root from
-one conversation leaves the root, its grant, and every other conversation's
-attachment intact. Revocation is deliberately broader: it forgets the root and
-removes all of its grants and attachments. Both mutation kinds bind a stable
-operation identity to their original request, so an exact retry is idempotent
-and identity reuse with different inputs is rejected. A read-only attachment
-receipt lets a recovering native client distinguish unknown, completed, and
-failed work without starting or replaying the mutation. Attachment changes are
-computed and published in one durable state replacement, so they do not expose
-a recoverable intermediate phase.
+Attaching and detaching are exact conversation mutations. Attaching a
+host-approved root installs only the grant needed by that product subject and
+the attachment for the selected conversation. Detaching a root from one
+conversation leaves the host approval, its grants, and every other
+conversation's attachment intact. Revocation is deliberately broader: it
+forgets the root and removes all of its grants and attachments. Both mutation
+kinds bind a stable operation identity to their original request, so an exact
+retry is idempotent and identity reuse with different inputs is rejected. A
+read-only attachment receipt lets a recovering native client distinguish
+unknown, completed, and failed work without starting or replaying the mutation.
+Attachment changes are computed and published in one durable state replacement,
+so they do not expose a recoverable intermediate phase.
 
 The desktop's manual Disconnect action uses this conversation-only detach; it
 does not invoke global revocation. The connected-folder list is the intersection

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -225,15 +225,17 @@ headless server does not advertise it.
 The built-in `read_file`, `list_dir`, `write_file`, and `create_deliverable`
 tools operate only inside a server-derived, pinned per-chat scratch capability.
 Its path is neither persisted on the chat nor returned by the product API. The
-desktop can connect, list, and revoke multiple folders
-through a native picker and capability-gated host-broker sidecar; it exposes only
-opaque root IDs and display names to the renderer. Foreground tool calls can now
-list/read roots already attached to their stored chat context. An approved
-agent folder request now converges through the durable product root-attachment
-state machine before it can report `connected`. The same state machine backs
-the manual Connected folders UI: Disconnect is conversation-scoped instead of
-global revocation, and a bounded native startup loop resumes exact pending
-attach or detach identities after a crash.
+desktop can approve multiple folders through a native picker and a
+capability-gated host-broker sidecar; it exposes only opaque root IDs and
+display names to the renderer. A host-approved root can later be attached to
+another chat after a native confirmation, without locating it in the picker
+again. Foreground tool calls can list/read only roots attached to their stored
+chat context. An approved agent folder request now converges through the durable
+product root-attachment state machine before it can report `connected`. The
+same state machine backs the manual Connected folders UI: Connect and
+Disconnect are conversation-scoped instead of global authorization changes,
+and a bounded native startup loop resumes exact pending attach or detach
+identities after a crash.
 See [Host access and connected folders](host-access.md). The agent loop can now
 produce a durable client-wait checkpoint for the registered folder-request
 contract. The desktop discovers those pending requests from durable state and


### PR DESCRIPTION
Keeps host folder approval reusable while preserving chat-scoped grants and attachments.

Adds an Available on this Mac flow with a native chat/folder confirmation, and returns an empty list for chats with no folder grants.

Updates broker persistence validation, documentation, and Rust/UI coverage.

Validated with host-broker and desktop Cargo tests, the full UI test/build, formatting, and strict Clippy.