### PR TITLE
feat(desktop): syntax-highlight code blocks and add per-block copy

### DIFF
--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -24,6 +24,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-markdown": "10.1.0",
+    "rehype-highlight": "7.0.2",
     "remark-gfm": "4.0.1",
     "tailwind-merge": "3.6.0",
     "tailwindcss-animate": "1.0.7",

--- a/crates/openwave-desktop/ui/pnpm-lock.yaml
+++ b/crates/openwave-desktop/ui/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       react-markdown:
         specifier: 10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      rehype-highlight:
+        specifier: 7.0.2
+        version: 7.0.2
       remark-gfm:
         specifier: 4.0.1
         version: 4.0.1
@@ -1295,11 +1298,21 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -1438,6 +1451,9 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
@@ -1700,6 +1716,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -1839,6 +1858,9 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -3076,6 +3098,10 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -3096,9 +3122,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
+
+  highlight.js@11.11.1: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -3215,6 +3250,12 @@ snapshots:
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@11.5.2: {}
 
@@ -3687,6 +3728,14 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -3853,6 +3902,11 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
     dependencies:

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.dom.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { MessageMarkdown } from "./MessageMarkdown";
+
+afterEach(cleanup);
+
+describe("code block copy", () => {
+  it("copies the raw source, not the highlighted markup", async () => {
+    const user = userEvent.setup();
+    render(
+      <MessageMarkdown>{"```ts\nconst x: number = 1;\n```"}</MessageMarkdown>,
+    );
+    await user.click(screen.getByRole("button", { name: "Copy code" }));
+    expect(await window.navigator.clipboard.readText()).toBe(
+      "const x: number = 1;\n",
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   MessageMarkdown,
   preserveLineBreaks,
+  rawCodeText,
   safeMarkdownUrl,
 } from "./MessageMarkdown";
 
@@ -74,5 +75,64 @@ describe("MessageMarkdown", () => {
     );
 
     expect(markup.match(/<p>/g)).toHaveLength(2);
+  });
+});
+
+describe("code blocks", () => {
+  const FENCED = "```ts\nconst x: number = 1;\n```";
+
+  it("highlights fence-tagged code and passes token classes through", () => {
+    const markup = renderToStaticMarkup(<MessageMarkdown>{FENCED}</MessageMarkdown>);
+    expect(markup).toContain("hljs-keyword");
+    expect(markup).toContain('class="code-block"');
+  });
+
+  it("leaves unlabeled fences unhighlighted rather than guessing", () => {
+    const markup = renderToStaticMarkup(
+      <MessageMarkdown>{"```\nplain block\n```"}</MessageMarkdown>,
+    );
+    expect(markup).not.toContain("hljs-keyword");
+    expect(markup).toContain("plain block");
+  });
+
+  it("adds a copy control to blocks but not inline code", () => {
+    const block = renderToStaticMarkup(<MessageMarkdown>{FENCED}</MessageMarkdown>);
+    expect(block).toContain('aria-label="Copy code"');
+    const inline = renderToStaticMarkup(
+      <MessageMarkdown>{"use `inline()` here"}</MessageMarkdown>,
+    );
+    expect(inline).not.toContain('aria-label="Copy code"');
+  });
+
+  it("recovers the raw source from a highlighted tree", () => {
+    expect(
+      rawCodeText({
+        type: "element",
+        children: [
+          { type: "text", value: "const " },
+          {
+            type: "element",
+            children: [{ type: "text", value: "x" }],
+          },
+          { type: "text", value: " = 1;" },
+        ],
+      }),
+    ).toBe("const x = 1;");
+  });
+});
+
+describe("preserveLineBreaks and code fences", () => {
+  it("never injects hard-break spaces into fenced code", () => {
+    const input = "before\n```ts\nline one\nline two\n```\nafter\nend";
+    const output = preserveLineBreaks(input);
+    expect(output).toContain("line one\nline two");
+    expect(output).toContain("before  \n");
+    expect(output).toContain("after  \nend");
+  });
+
+  it("leaves a still-streaming unclosed fence untouched", () => {
+    const output = preserveLineBreaks("intro\n```py\npartial\nstream");
+    expect(output).toContain("partial\nstream");
+    expect(output).toContain("intro  \n");
   });
 });

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
@@ -1,6 +1,8 @@
 import { memo } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import { ClipboardCopyButton } from "./ClipboardCopyButton";
 import { MarkdownTable } from "./MarkdownTable";
 
 /**
@@ -17,7 +19,36 @@ import { MarkdownTable } from "./MarkdownTable";
  * indentation no longer leaks and the parsed block structure renders cleanly.
  */
 export function preserveLineBreaks(input: string): string {
-  return input.replace(/([^\n])\n(?!\n)/g, "$1  \n");
+  // Fenced code is source text: hard-break spaces would corrupt what the
+  // block renders and what the copy control yields. The `$` alternative keeps
+  // a still-streaming, unclosed fence untouched too.
+  return input
+    .split(/(```[\s\S]*?(?:```|$))/)
+    .map((segment) =>
+      segment.startsWith("```")
+        ? segment
+        : segment.replace(/([^\n])\n(?!\n)/g, "$1  \n"),
+    )
+    .join("");
+}
+
+/**
+ * The raw source of a code block: concatenated text descendants of the hast
+ * node, ignoring the token spans highlighting wraps them in. What the copy
+ * button writes — never the highlighted markup.
+ */
+export function rawCodeText(node: {
+  children?: unknown[];
+  value?: unknown;
+  type?: unknown;
+}): string {
+  if (node.type === "text" && typeof node.value === "string") {
+    return node.value;
+  }
+  if (!Array.isArray(node.children)) return "";
+  return node.children
+    .map((child) => rawCodeText(child as { children?: unknown[] }))
+    .join("");
 }
 
 export function safeMarkdownUrl(url: string | undefined): string | undefined {
@@ -56,8 +87,28 @@ const components: Components = {
       {alt ? `Image omitted: ${alt}` : "Image omitted"}
     </span>
   ),
-  code: ({ children }) => <code>{children}</code>,
-  pre: ({ children }) => <pre>{children}</pre>,
+  // className carries the fence language plus highlight token classes; the
+  // spans rehype-highlight nests inside render through the defaults.
+  code: ({ children, className }) => (
+    <code className={className}>{children}</code>
+  ),
+  pre: ({ children, node }) => {
+    const source = node ? rawCodeText(node) : "";
+    return (
+      <div className="code-block">
+        {source && (
+          <ClipboardCopyButton
+            value={source}
+            label="Copy code"
+            copiedAnnouncement="Code copied"
+            failedAnnouncement="Copy failed"
+            className="code-block-copy"
+          />
+        )}
+        <pre>{children}</pre>
+      </div>
+    );
+  },
   blockquote: ({ children }) => <blockquote>{children}</blockquote>,
   table: ({ children }) => <MarkdownTable>{children}</MarkdownTable>,
 };
@@ -73,6 +124,9 @@ export const MessageMarkdown = memo(function MessageMarkdown({
     <div className="message-markdown">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        // Highlight only fence-tagged languages; auto-detection on unlabeled
+        // blocks guesses wrong too often to be worth it.
+        rehypePlugins={[[rehypeHighlight, { detect: false }]]}
         components={components}
         skipHtml
         urlTransform={(url) => safeMarkdownUrl(url) ?? ""}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1436,6 +1436,81 @@ body {
   font-family: inherit;
 }
 
+/* Code blocks are dark-surfaced in both themes, so one syntax palette serves
+   both. Tokens are emitted by rehype-highlight for fence-tagged languages. */
+.message-markdown pre code .hljs-keyword,
+.message-markdown pre code .hljs-doctag,
+.message-markdown pre code .hljs-template-tag,
+.message-markdown pre code .hljs-type {
+  color: oklch(0.78 0.12 300);
+}
+
+.message-markdown pre code .hljs-string,
+.message-markdown pre code .hljs-regexp,
+.message-markdown pre code .hljs-quote {
+  color: oklch(0.8 0.1 150);
+}
+
+.message-markdown pre code .hljs-comment {
+  color: oklch(0.62 0.01 285);
+  font-style: italic;
+}
+
+.message-markdown pre code .hljs-number,
+.message-markdown pre code .hljs-literal,
+.message-markdown pre code .hljs-symbol,
+.message-markdown pre code .hljs-bullet {
+  color: oklch(0.8 0.11 70);
+}
+
+.message-markdown pre code .hljs-title,
+.message-markdown pre code .hljs-section,
+.message-markdown pre code .hljs-built_in {
+  color: oklch(0.78 0.1 240);
+}
+
+.message-markdown pre code .hljs-attr,
+.message-markdown pre code .hljs-attribute,
+.message-markdown pre code .hljs-variable,
+.message-markdown pre code .hljs-selector-class,
+.message-markdown pre code .hljs-selector-id {
+  color: oklch(0.8 0.09 200);
+}
+
+.message-markdown pre code .hljs-emphasis {
+  font-style: italic;
+}
+
+.message-markdown pre code .hljs-strong {
+  font-weight: 600;
+}
+
+.code-block {
+  position: relative;
+}
+
+.code-block .code-block-copy {
+  position: absolute;
+  top: 0.45rem;
+  right: 0.45rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid oklch(0.32 0.01 285);
+  border-radius: 6px;
+  background: var(--code-block-bg);
+  color: var(--code-block-ink);
+  font-size: 0.72rem;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.code-block:hover .code-block-copy,
+.code-block:focus-within .code-block-copy {
+  opacity: 1;
+}
+
 .message-markdown blockquote {
   border-left: 2px solid var(--color-openwave);
   padding-left: 0.75rem;


### PR DESCRIPTION
Closes #423.

- Fence-tagged code blocks are highlighted via `rehype-highlight` (`7.0.2`, exact-pinned); unlabeled fences stay plain — no auto-detection guessing.
- Token classes are themed in `styles.css` on the existing `--code-block-*` surface (dark in both themes, so a single palette serves both) — no vendored highlight.js stylesheet.
- Each block gets a hover/focus-revealed copy control reusing `ClipboardCopyButton`; it copies the **raw source** walked out of the syntax tree, never the highlighted markup. Inline code is untouched, and the markdown security posture (no raw HTML, `skipHtml`, link/image policies) is unchanged.
- **Discovered bug, fixed in passing** (caught by the new clipboard test): `preserveLineBreaks` was injecting hard-break trailing spaces into fenced code content — every line of every code block rendered and copied with invisible trailing whitespace. It now skips fenced regions, including still-streaming unclosed fences.

## Tests

Markup tests for token emission, className passthrough, no-detection on unlabeled fences, and copy-control presence (blocks) vs absence (inline); a DOM clipboard test asserting the copied text is byte-exact source; fence-skipping tests for `preserveLineBreaks` including the mid-stream unclosed case. 249 tests, `tsc`, and the production build are green.

**Held for smoke test before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)