### PR TITLE
fix(desktop): harden approved folder reuse

### DIFF
--- a/crates/openwave-desktop/src/client_execution/product_sync.rs
+++ b/crates/openwave-desktop/src/client_execution/product_sync.rs
@@ -6,7 +6,7 @@ use openwave_core::{
     RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentSubjectKind,
 };
 use openwave_host_broker::{
-    ControlRequest, ControlResult, LookupRegisterRootReceiptRequest,
+    ConsentMethod, ControlRequest, ControlResult, LookupRegisterRootReceiptRequest,
     LookupRootAttachmentReceiptRequest, OperationId, RegisterRootReceipt,
     RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
     RootId, RootSummary, SubjectKind,
@@ -253,6 +253,7 @@ async fn cleanup_rejected_registration(
                     subject: context.subject,
                     conversation_id: context.chat_id,
                     root_id: broker_root_id,
+                    consent_method: None,
                 }),
                 deadline,
             )
@@ -451,6 +452,7 @@ async fn reconcile_broker_attachment(
                 subject: context.subject,
                 conversation_id: context.chat_id,
                 root_id: broker_root_id,
+                consent_method: Some(ConsentMethod::PermissionDialog),
             }),
             dispatch_deadline,
         )

--- a/crates/openwave-desktop/src/client_execution/root_attachment_reconciliation.rs
+++ b/crates/openwave-desktop/src/client_execution/root_attachment_reconciliation.rs
@@ -627,6 +627,10 @@ async fn dispatch_mutation(
         subject: context.subject,
         conversation_id: context.chat_id,
         root_id,
+        consent_method: match action {
+            RootAttachmentChangeAction::Attach => Some(ConsentMethod::PermissionDialog),
+            RootAttachmentChangeAction::Detach => None,
+        },
     };
     let control = match action {
         RootAttachmentChangeAction::Attach => ControlRequest::AttachRoot(request),

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, State};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 use tokio::sync::{oneshot, Mutex, OnceCell};
+use unicode_general_category::{get_general_category, GeneralCategory};
 use uuid::Uuid;
 
 use crate::broker::BrokerClient;
@@ -317,7 +318,13 @@ fn safe_dialog_label(value: &str) -> String {
         .chars()
         .take(80)
         .map(|character| {
-            if character.is_control() {
+            if matches!(
+                get_general_category(character),
+                GeneralCategory::Control
+                    | GeneralCategory::Format
+                    | GeneralCategory::LineSeparator
+                    | GeneralCategory::ParagraphSeparator
+            ) {
                 '\u{fffd}'
             } else {
                 character
@@ -414,9 +421,10 @@ mod tests {
 
     #[test]
     fn native_confirmation_labels_are_bounded_and_strip_controls() {
-        let label = safe_dialog_label(&format!("Research\n{}", "x".repeat(100)));
+        let label = safe_dialog_label(&format!("Research\n\u{202e}{}", "x".repeat(100)));
         assert!(!label.contains('\n'));
+        assert!(!label.contains('\u{202e}'));
         assert_eq!(label.chars().count(), 80);
-        assert!(label.starts_with("Research\u{fffd}"));
+        assert!(label.starts_with("Research\u{fffd}\u{fffd}"));
     }
 }

--- a/crates/openwave-desktop/ui/src/FoldersView.test.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.test.tsx
@@ -20,6 +20,14 @@ const chat = {
   project_id: null,
 } as unknown as Chat;
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
   vi.mocked(host.listConnectedFolders).mockResolvedValue([]);
   vi.mocked(host.listApprovedFolders).mockResolvedValue([]);
@@ -46,9 +54,14 @@ describe("FoldersView", () => {
   });
 
   it("offers approved folders that are not already connected", async () => {
-    vi.mocked(host.listConnectedFolders).mockResolvedValue([
-      { rootId: "connected", displayName: "Current project" },
-    ]);
+    vi.mocked(host.listConnectedFolders)
+      .mockResolvedValueOnce([
+        { rootId: "connected", displayName: "Current project" },
+      ])
+      .mockResolvedValueOnce([
+        { rootId: "connected", displayName: "Current project" },
+        { rootId: "available", displayName: "Research" },
+      ]);
     vi.mocked(host.listApprovedFolders).mockResolvedValue([
       { rootId: "connected", displayName: "Current project" },
       { rootId: "available", displayName: "Research" },
@@ -70,5 +83,50 @@ describe("FoldersView", () => {
     await waitFor(() =>
       expect(host.listConnectedFolders).toHaveBeenCalledTimes(2),
     );
+    expect(screen.queryByText("Available on this Mac")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Research")).toHaveLength(1);
+  });
+
+  it("leaves an approved folder unattached when native consent is canceled", async () => {
+    vi.mocked(host.listApprovedFolders).mockResolvedValue([
+      { rootId: "available", displayName: "Research" },
+    ]);
+    const user = userEvent.setup();
+    render(<FoldersView chat={chat} />);
+
+    await user.click(await screen.findByRole("button", { name: "Connect" }));
+
+    expect(host.connectApprovedFolder).toHaveBeenCalledWith(chat, "available");
+    expect(host.listConnectedFolders).toHaveBeenCalledOnce();
+    expect(screen.getByText("Research")).toBeInTheDocument();
+  });
+
+  it("ignores a late folder response after switching chats", async () => {
+    const firstChat = { ...chat, id: "chat-a", title: "Chat A" };
+    const secondChat = { ...chat, id: "chat-b", title: "Chat B" };
+    const firstResponse = deferred<host.ConnectedFolder[]>();
+    const secondResponse = deferred<host.ConnectedFolder[]>();
+    vi.mocked(host.listConnectedFolders).mockImplementation(
+      (requestedChat) =>
+        requestedChat.id === firstChat.id
+          ? firstResponse.promise
+          : secondResponse.promise,
+    );
+
+    const { rerender } = render(<FoldersView chat={firstChat} />);
+    rerender(<FoldersView chat={secondChat} />);
+
+    secondResponse.resolve([
+      { rootId: "chat-b-root", displayName: "Chat B folder" },
+    ]);
+    expect(await screen.findByText("Chat B folder")).toBeInTheDocument();
+
+    firstResponse.resolve([
+      { rootId: "chat-a-root", displayName: "Chat A folder" },
+    ]);
+    await waitFor(() =>
+      expect(screen.queryByText("Chat A folder")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Chat B folder")).toBeInTheDocument();
   });
 });

--- a/crates/openwave-desktop/ui/src/FoldersView.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Chat } from "./api";
 import {
   connectApprovedFolder,
@@ -22,27 +22,38 @@ export function FoldersView({ chat }: { chat: Chat }) {
   const [approvedFolders, setApprovedFolders] = useState<ConnectedFolder[]>([]);
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const refreshGeneration = useRef(0);
   const connectedIds = new Set(folders.map((folder) => folder.rootId));
   const availableFolders = approvedFolders.filter(
     (folder) => !connectedIds.has(folder.rootId),
   );
 
   async function refresh() {
+    const generation = ++refreshGeneration.current;
     setError(null);
     try {
       const [connected, approved] = await Promise.all([
         listConnectedFolders(chat),
         listApprovedFolders(),
       ]);
+      if (generation !== refreshGeneration.current) return;
       setFolders(connected);
       setApprovedFolders(approved);
     } catch (err) {
+      if (generation !== refreshGeneration.current) return;
       setError(String(err));
     }
   }
 
   useEffect(() => {
+    setFolders([]);
+    setApprovedFolders([]);
+    setWorking(false);
+    setError(null);
     void refresh();
+    return () => {
+      refreshGeneration.current += 1;
+    };
   }, [chat.id, chat.project_id]);
 
   async function addFolder() {

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -195,6 +195,8 @@ struct AttachmentFingerprint {
     conversation_id: Uuid,
     root_id: RootId,
     mutation: RootAttachmentMutationKind,
+    #[serde(default)]
+    consent_method: Option<ConsentMethod>,
 }
 
 struct PreparedRegistration {
@@ -494,10 +496,7 @@ impl Controller {
         let mut next = state.clone();
         let outcome = match prepared {
             Ok(prepared) => {
-                let existing = next.roots.iter().find_map(|(root_id, root)| {
-                    (root.root.identity() == prepared.root.root.identity())
-                        .then(|| (*root_id, root.display_name.clone()))
-                });
+                let existing = preferred_root_alias(&next, &prepared.root);
                 if let Some((root_id, display_name)) = existing {
                     ensure_subject_grants(
                         &mut next,
@@ -660,6 +659,7 @@ impl Controller {
             conversation_id: request.conversation_id,
             root_id: request.root_id,
             mutation,
+            consent_method: request.consent_method,
         };
         let mut state = self.lock_state().map_err(error_response)?;
         let mut next = state.clone();
@@ -689,6 +689,9 @@ impl Controller {
             conversation_id: request.conversation_id,
             root_id: request.root_id,
             mutation: request.mutation,
+            // Receipt lookup does not recreate consent. None is a wildcard for
+            // both legacy v2 records and current method-bound mutations.
+            consent_method: None,
         };
         let state = self.lock_state().map_err(error_response)?;
         let receipt = match state.mutations.get(&request.operation_id) {
@@ -696,26 +699,30 @@ impl Controller {
             Some(MutationRecord::Attachment {
                 request: existing,
                 outcome: MutationOutcome::Pending,
-            }) if *existing == expected => {
+            }) if attachment_lookup_matches(existing, &expected) => {
                 return Err(error_response(BrokerError::OperationInProgress));
             }
             Some(MutationRecord::Attachment {
                 request: existing,
                 outcome: MutationOutcome::Complete(Ok(result)),
-            }) if *existing == expected => RootAttachmentMutationReceipt::Completed {
-                result: *result,
-                currently_attached: has_root_attachment(
-                    &state,
-                    request.conversation_id,
-                    request.root_id,
-                ),
-            },
+            }) if attachment_lookup_matches(existing, &expected) => {
+                RootAttachmentMutationReceipt::Completed {
+                    result: *result,
+                    currently_attached: has_root_attachment(
+                        &state,
+                        request.conversation_id,
+                        request.root_id,
+                    ),
+                }
+            }
             Some(MutationRecord::Attachment {
                 request: existing,
                 outcome: MutationOutcome::Complete(Err(error)),
-            }) if *existing == expected => RootAttachmentMutationReceipt::Failed {
-                error: error.clone(),
-            },
+            }) if attachment_lookup_matches(existing, &expected) => {
+                RootAttachmentMutationReceipt::Failed {
+                    error: error.clone(),
+                }
+            }
             Some(_) => return Err(error_response(BrokerError::OperationIdConflict)),
         };
         Ok(LookupRootAttachmentReceiptResult {
@@ -740,14 +747,21 @@ impl Controller {
             .roots
             .get(&request.root_id)
             .is_some_and(|root| root.owner == request.subject);
-        if owned {
+        // State version 2 could persist one physical directory under multiple
+        // product root IDs when separate subjects selected it. Removing only
+        // the requested ID would falsely claim global approval was gone, while
+        // deleting every alias would invalidate durable receipts and product
+        // projections that still name those IDs. Preserve that legacy state
+        // and report that no global revocation occurred.
+        let revoked = owned && !has_physical_root_alias(&next, request.root_id);
+        if revoked {
             next.roots.remove(&request.root_id);
             next.grants
                 .retain(|grant| !scope_targets_root(grant.scope(), request.root_id));
             next.attachments
                 .retain(|attachment| attachment.root_id() != request.root_id);
         }
-        let result = Ok(RevokeRootResult { revoked: owned });
+        let result = Ok(RevokeRootResult { revoked });
         complete_revoke(&mut next, operation_id, fingerprint, result.clone())
             .map_err(error_response)?;
         self.commit_state(&mut state, next)
@@ -1233,11 +1247,13 @@ fn claim_attachment(
         Some(MutationRecord::Attachment {
             request: existing,
             outcome: MutationOutcome::Complete(result),
-        }) if *existing == request => Ok(Claim::Complete(result.clone())),
+        }) if attachment_mutation_matches(existing, &request) => {
+            Ok(Claim::Complete(result.clone()))
+        }
         Some(MutationRecord::Attachment {
             request: existing,
             outcome: MutationOutcome::Pending,
-        }) if *existing == request => {
+        }) if attachment_mutation_matches(existing, &request) => {
             if state.active_mutations.insert(operation_id) {
                 Ok(Claim::Start)
             } else {
@@ -1258,7 +1274,9 @@ fn complete_attachment(
         Some(MutationRecord::Attachment {
             request: existing,
             outcome,
-        }) if *existing == request && matches!(outcome, MutationOutcome::Pending) => {
+        }) if attachment_mutation_matches(existing, &request)
+            && matches!(outcome, MutationOutcome::Pending) =>
+        {
             *outcome = MutationOutcome::Complete(result);
             state.active_mutations.remove(&operation_id);
             Ok(())
@@ -1278,7 +1296,12 @@ fn apply_root_attachment(
                 .roots
                 .get(&request.root_id)
                 .ok_or(BrokerError::UnknownRoot)?;
-            let consent = root_consent(state, request.root_id).ok_or(BrokerError::Denied)?;
+            let consent = ConsentRecord::new(
+                request
+                    .consent_method
+                    .ok_or(BrokerError::InvalidConsentMethod)?,
+                Utc::now(),
+            );
             ensure_subject_grants(state, request.subject, request.root_id, consent)?;
             if has_root_attachment(state, request.conversation_id, request.root_id) {
                 false
@@ -1291,6 +1314,9 @@ fn apply_root_attachment(
             }
         }
         RootAttachmentMutationKind::Detach => {
+            if request.consent_method.is_some() {
+                return Err(BrokerError::InvalidConsentMethod);
+            }
             if state.roots.contains_key(&request.root_id)
                 && !subject_has_root_grant(state, request.subject, request.root_id)
             {
@@ -1311,6 +1337,34 @@ fn apply_root_attachment(
     })
 }
 
+fn attachment_mutation_matches(
+    stored: &AttachmentFingerprint,
+    requested: &AttachmentFingerprint,
+) -> bool {
+    attachment_target_matches(stored, requested)
+        && (stored.consent_method == requested.consent_method
+            || (stored.mutation == RootAttachmentMutationKind::Attach
+                && stored.consent_method.is_none()
+                && requested.consent_method.is_some()))
+}
+
+fn attachment_lookup_matches(
+    stored: &AttachmentFingerprint,
+    requested: &AttachmentFingerprint,
+) -> bool {
+    attachment_target_matches(stored, requested)
+}
+
+fn attachment_target_matches(
+    stored: &AttachmentFingerprint,
+    requested: &AttachmentFingerprint,
+) -> bool {
+    stored.subject == requested.subject
+        && stored.conversation_id == requested.conversation_id
+        && stored.root_id == requested.root_id
+        && stored.mutation == requested.mutation
+}
+
 fn validate_subject_conversation(
     subject: GrantSubject,
     conversation_id: Uuid,
@@ -1327,17 +1381,6 @@ fn has_root_attachment(state: &State, conversation_id: Uuid, root_id: RootId) ->
     state.attachments.iter().any(|attachment| {
         attachment.conversation_id() == conversation_id && attachment.root_id() == root_id
     })
-}
-
-fn root_consent(state: &State, root_id: RootId) -> Option<ConsentRecord> {
-    state
-        .grants
-        .iter()
-        .find(|grant| {
-            grant.capability() == Capability::ReadFiles
-                && matches!(grant.scope(), Scope::Root { root_id: granted } if *granted == root_id)
-        })
-        .map(|grant| grant.consent().clone())
 }
 
 fn subject_has_root_grant(state: &State, subject: GrantSubject, root_id: RootId) -> bool {
@@ -1379,19 +1422,49 @@ fn ensure_subject_grants(
     Ok(())
 }
 
+fn preferred_root_alias(state: &State, candidate: &RegisteredRoot) -> Option<(RootId, String)> {
+    state
+        .roots
+        .iter()
+        .filter(|(_, root)| root.root.identity() == candidate.root.identity())
+        // Preserve an existing subject's legacy product root ID when possible,
+        // then use the opaque UUID as the host-wide deterministic tie-breaker.
+        .min_by_key(|(root_id, root)| (root.owner != candidate.owner, root_id.as_uuid()))
+        .map(|(root_id, root)| (*root_id, root.display_name.clone()))
+}
+
+fn has_physical_root_alias(state: &State, root_id: RootId) -> bool {
+    let Some(identity) = state.roots.get(&root_id).map(|root| root.root.identity()) else {
+        return false;
+    };
+    state
+        .roots
+        .iter()
+        .any(|(candidate_id, root)| *candidate_id != root_id && root.root.identity() == identity)
+}
+
 fn list_approved_roots(state: &State) -> Result<Vec<RootSummary>, ErrorResponse> {
+    if state.roots.len() > MAX_LIST_ROOTS {
+        return Err(error_response(BrokerError::RootListTooLarge));
+    }
+    let mut display_name_counts = HashMap::new();
+    for root in state.roots.values() {
+        *display_name_counts
+            .entry(root.display_name.as_str())
+            .or_insert(0usize) += 1;
+    }
     let mut roots = state
         .roots
         .iter()
+        // A basename is the only folder identity the native reuse prompt can
+        // safely expose. If it is not unique, offer none of the colliding roots
+        // and require the unambiguous native picker path instead.
+        .filter(|(_, root)| display_name_counts.get(root.display_name.as_str()) == Some(&1))
         .map(|(root_id, root)| RootSummary {
             root_id: *root_id,
             display_name: root.display_name.clone(),
         })
-        .take(MAX_LIST_ROOTS + 1)
         .collect::<Vec<_>>();
-    if roots.len() > MAX_LIST_ROOTS {
-        return Err(error_response(BrokerError::RootListTooLarge));
-    }
     roots.sort_by(|left, right| {
         left.display_name
             .cmp(&right.display_name)

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -13,7 +13,9 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 use serde::{Deserialize, Serialize};
 
-use super::{root_display_name, BrokerError, MutationRecord, RegisteredRoot, State};
+use super::{
+    has_physical_root_alias, root_display_name, BrokerError, MutationRecord, RegisteredRoot, State,
+};
 use crate::{
     path_policy::RootIdentity, Grant, GrantSubject, OperationId, RootAttachment, RootId,
     RootPolicy, Scope,
@@ -376,6 +378,8 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
                     .get(&request.root_id)
                     .is_some_and(|root| root.owner == request.subject);
                 let root_still_exists = state.roots.contains_key(&request.root_id);
+                let blocked_by_legacy_alias =
+                    still_owned && has_physical_root_alias(state, request.root_id);
                 let was_registered = state.mutations.values().any(|record| {
                     matches!(
                         record,
@@ -387,7 +391,7 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
                     )
                 });
                 if (result.revoked && (root_still_exists || !was_registered))
-                    || (!result.revoked && still_owned)
+                    || (!result.revoked && still_owned && !blocked_by_legacy_alias)
                 {
                     return Err(invalid_data(
                         "successful revoke receipt does not match authoritative state",

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -98,6 +98,10 @@ fn mutate_attachment(
         subject,
         conversation_id,
         root_id,
+        consent_method: match mutation {
+            RootAttachmentMutationKind::Attach => Some(ConsentMethod::PermissionDialog),
+            RootAttachmentMutationKind::Detach => None,
+        },
     };
     let control = match mutation {
         RootAttachmentMutationKind::Attach => ControlRequest::AttachRoot(request),
@@ -176,6 +180,102 @@ fn list_approved(controller: &Controller) -> Vec<RootSummary> {
     roots
 }
 
+fn revoke(
+    controller: &Controller,
+    operation_id: OperationId,
+    subject: GrantSubject,
+    root_id: RootId,
+) -> RevokeRootResult {
+    let result = unwrap_response(controller.handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::RevokeRoot(RevokeRootRequest {
+            operation_id,
+            subject,
+            root_id,
+        }),
+    }))
+    .unwrap();
+    let ControlResult::RevokeRoot(result) = result else {
+        panic!("unexpected control result")
+    };
+    result
+}
+
+fn install_legacy_alias(
+    broker: &Broker,
+    source_root_id: RootId,
+    alias_root_id: RootId,
+    subject: GrantSubject,
+    conversation_id: Uuid,
+    selected_path: PathBuf,
+    operation_id: OperationId,
+) {
+    let consent = ConsentRecord::new(ConsentMethod::FolderPicker, Utc::now());
+    let mut state = broker.shared.state.lock().unwrap();
+    let source = state.roots.get(&source_root_id).unwrap().clone();
+    let display_name = source.display_name.clone();
+    assert!(state
+        .roots
+        .insert(
+            alias_root_id,
+            RegisteredRoot {
+                owner: subject,
+                display_name: display_name.clone(),
+                root: source.root,
+            },
+        )
+        .is_none());
+    state.grants.push(
+        Grant::from_consent(
+            GrantId::new(),
+            subject,
+            Capability::ListRoots,
+            Scope::Subject,
+            consent.clone(),
+        )
+        .unwrap(),
+    );
+    state.grants.push(
+        Grant::from_consent(
+            GrantId::new(),
+            subject,
+            Capability::ReadFiles,
+            Scope::Root {
+                root_id: alias_root_id,
+            },
+            consent,
+        )
+        .unwrap(),
+    );
+    state
+        .attachments
+        .push(RootAttachment::new(conversation_id, alias_root_id).unwrap());
+    assert!(state
+        .mutations
+        .insert(
+            operation_id,
+            MutationRecord::Register {
+                request: RegisterFingerprint {
+                    subject,
+                    conversation_id,
+                    path: selected_path,
+                    consent_method: ConsentMethod::FolderPicker,
+                },
+                outcome: MutationOutcome::Complete(Ok(RegisterRootResult {
+                    root: RootSummary {
+                        root_id: alias_root_id,
+                        display_name,
+                    },
+                })),
+            },
+        )
+        .is_none());
+    if let Some(state_file) = broker.shared.state_file.as_ref() {
+        state_file.save(&state).unwrap();
+    }
+}
+
 fn unwrap_response<T>(envelope: ResponseEnvelope<T>) -> Result<T, ErrorResponse> {
     match envelope.response {
         Response::Ok(result) => Ok(result),
@@ -233,15 +333,65 @@ fn approved_roots_can_be_explicitly_attached_to_another_standalone_conversation(
 
     let second_conversation = Uuid::new_v4();
     let second_subject = GrantSubject::conversation(second_conversation).unwrap();
+    let attach_id = OperationId::new();
     mutate_attachment(
         &broker.controller(),
-        OperationId::new(),
+        attach_id,
         second_subject,
         second_conversation,
         root_id,
         RootAttachmentMutationKind::Attach,
     )
     .unwrap();
+    assert!(broker
+        .shared
+        .state
+        .lock()
+        .unwrap()
+        .grants
+        .iter()
+        .any(|grant| {
+            grant.subject() == second_subject
+                && grant.capability() == Capability::ReadFiles
+                && matches!(grant.scope(), Scope::Root { root_id: granted } if *granted == root_id)
+                && grant.consent().method() == ConsentMethod::PermissionDialog
+        }));
+    let conflicting_consent = broker.controller().handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::AttachRoot(RootAttachmentMutationRequest {
+            operation_id: attach_id,
+            subject: second_subject,
+            conversation_id: second_conversation,
+            root_id,
+            consent_method: Some(ConsentMethod::OperatorConfig),
+        }),
+    });
+    assert!(matches!(
+        conflicting_consent.response,
+        Response::Error(ErrorResponse {
+            code: ErrorCode::OperationIdConflict,
+            ..
+        })
+    ));
+    let missing_consent = broker.controller().handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::AttachRoot(RootAttachmentMutationRequest {
+            operation_id: attach_id,
+            subject: second_subject,
+            conversation_id: second_conversation,
+            root_id,
+            consent_method: None,
+        }),
+    });
+    assert!(matches!(
+        missing_consent.response,
+        Response::Error(ErrorResponse {
+            code: ErrorCode::OperationIdConflict,
+            ..
+        })
+    ));
     let second_context = ExecutionContext::standalone(second_conversation).unwrap();
     assert_eq!(
         operate(
@@ -359,6 +509,182 @@ fn choosing_the_same_approved_folder_again_reuses_its_host_identity() {
         .unwrap(),
         OperationResult::ListRoots {
             roots: vec![first.root]
+        }
+    );
+}
+
+#[test]
+fn legacy_physical_aliases_are_hidden_and_reused_deterministically_after_restart() {
+    let (temp, broker, path, state_dir) = durable_setup();
+    let first_conversation = Uuid::new_v4();
+    let first_subject = GrantSubject::conversation(first_conversation).unwrap();
+    let first = register(
+        &broker.controller(),
+        first_subject,
+        first_conversation,
+        path.clone(),
+        OperationId::new(),
+    );
+    let alias_root_id = RootId::from_uuid(Uuid::from_u128(1)).unwrap();
+    let alias_conversation = Uuid::new_v4();
+    let alias_subject = GrantSubject::conversation(alias_conversation).unwrap();
+    install_legacy_alias(
+        &broker,
+        first.root.root_id,
+        alias_root_id,
+        alias_subject,
+        alias_conversation,
+        path.clone(),
+        OperationId::new(),
+    );
+    assert!(list_approved(&broker.controller()).is_empty());
+    drop(broker);
+
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    assert!(list_approved(&broker.controller()).is_empty());
+
+    let first_again = register(
+        &broker.controller(),
+        first_subject,
+        first_conversation,
+        path.clone(),
+        OperationId::new(),
+    );
+    assert_eq!(first_again.root.root_id, first.root.root_id);
+
+    let new_conversation = Uuid::new_v4();
+    let new_subject = GrantSubject::conversation(new_conversation).unwrap();
+    let new_registration = register(
+        &broker.controller(),
+        new_subject,
+        new_conversation,
+        path,
+        OperationId::new(),
+    );
+    assert_eq!(new_registration.root.root_id, alias_root_id);
+}
+
+#[test]
+fn legacy_physical_aliases_block_global_revoke_and_remain_valid_after_restart() {
+    let (temp, broker, path, state_dir) = durable_setup();
+    let first_conversation = Uuid::new_v4();
+    let first_subject = GrantSubject::conversation(first_conversation).unwrap();
+    let first = register(
+        &broker.controller(),
+        first_subject,
+        first_conversation,
+        path.clone(),
+        OperationId::new(),
+    );
+    let alias_root_id = RootId::from_uuid(Uuid::from_u128(1)).unwrap();
+    let alias_conversation = Uuid::new_v4();
+    let alias_subject = GrantSubject::conversation(alias_conversation).unwrap();
+    install_legacy_alias(
+        &broker,
+        first.root.root_id,
+        alias_root_id,
+        alias_subject,
+        alias_conversation,
+        path,
+        OperationId::new(),
+    );
+
+    let revoke_id = OperationId::new();
+    assert_eq!(
+        revoke(
+            &broker.controller(),
+            revoke_id,
+            alias_subject,
+            alias_root_id,
+        ),
+        RevokeRootResult { revoked: false }
+    );
+    assert!(operate(
+        &broker.operator(),
+        ExecutionContext::standalone(first_conversation).unwrap(),
+        OperationRequest::ReadFile(PathRequest {
+            root_id: first.root.root_id,
+            path: RelativePath::parse("note.txt").unwrap(),
+        }),
+    )
+    .is_ok());
+    assert!(operate(
+        &broker.operator(),
+        ExecutionContext::standalone(alias_conversation).unwrap(),
+        OperationRequest::ReadFile(PathRequest {
+            root_id: alias_root_id,
+            path: RelativePath::parse("note.txt").unwrap(),
+        }),
+    )
+    .is_ok());
+    drop(broker);
+
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    assert_eq!(
+        revoke(
+            &broker.controller(),
+            revoke_id,
+            alias_subject,
+            alias_root_id,
+        ),
+        RevokeRootResult { revoked: false }
+    );
+    assert!(operate(
+        &broker.operator(),
+        ExecutionContext::standalone(alias_conversation).unwrap(),
+        OperationRequest::ReadFile(PathRequest {
+            root_id: alias_root_id,
+            path: RelativePath::parse("note.txt").unwrap(),
+        }),
+    )
+    .is_ok());
+}
+
+#[test]
+fn basename_collisions_are_not_offered_as_approved_roots() {
+    let temp = tempfile::tempdir().unwrap();
+    let first_path = temp.path().join("home/first/Documents");
+    let second_path = temp.path().join("home/second/Documents");
+    let unique_path = temp.path().join("home/third/Reports");
+    for path in [&first_path, &second_path, &unique_path] {
+        std::fs::create_dir_all(path).unwrap();
+    }
+    let broker = Broker::new(test_policy(&temp));
+    let first_conversation = Uuid::new_v4();
+    let first = register(
+        &broker.controller(),
+        GrantSubject::conversation(first_conversation).unwrap(),
+        first_conversation,
+        first_path,
+        OperationId::new(),
+    );
+    let second_conversation = Uuid::new_v4();
+    register(
+        &broker.controller(),
+        GrantSubject::conversation(second_conversation).unwrap(),
+        second_conversation,
+        second_path,
+        OperationId::new(),
+    );
+    let unique_conversation = Uuid::new_v4();
+    let unique = register(
+        &broker.controller(),
+        GrantSubject::conversation(unique_conversation).unwrap(),
+        unique_conversation,
+        unique_path,
+        OperationId::new(),
+    );
+
+    assert_eq!(list_approved(&broker.controller()), vec![unique.root]);
+    assert_eq!(
+        operate(
+            &broker.operator(),
+            ExecutionContext::standalone(first_conversation).unwrap(),
+            OperationRequest::ListRoots,
+        )
+        .unwrap(),
+        OperationResult::ListRoots {
+            roots: vec![first.root],
         }
     );
 }
@@ -1940,6 +2266,7 @@ fn persisted_attachments_must_be_unique_and_match_subject_grants() {
                 conversation_id: conversation,
                 root_id,
                 mutation: RootAttachmentMutationKind::Detach,
+                consent_method: None,
             },
             outcome: MutationOutcome::Pending,
         },
@@ -1956,10 +2283,26 @@ fn persisted_attachment_ledger_rejects_unknown_nested_fields() {
             conversation_id,
             root_id: RootId::new(),
             mutation: RootAttachmentMutationKind::Attach,
+            consent_method: Some(ConsentMethod::PermissionDialog),
         },
         outcome: MutationOutcome::Pending,
     };
     let mut encoded = serde_json::to_value(record).unwrap();
+    let mut legacy = encoded.clone();
+    legacy["Attachment"]["request"]
+        .as_object_mut()
+        .unwrap()
+        .remove("consent_method");
+    assert!(matches!(
+        serde_json::from_value::<MutationRecord>(legacy).unwrap(),
+        MutationRecord::Attachment {
+            request: AttachmentFingerprint {
+                consent_method: None,
+                ..
+            },
+            ..
+        }
+    ));
     encoded["Attachment"]["request"]["unexpected"] = serde_json::Value::Bool(true);
     assert!(serde_json::from_value::<MutationRecord>(encoded).is_err());
 }

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Current pre-v1 broker protocol. Bump this for incompatible wire changes.
-pub const PROTOCOL_VERSION: u32 = 3;
+pub const PROTOCOL_VERSION: u32 = 4;
 
 /// Host-originated request envelope.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -107,6 +107,8 @@ pub struct RootAttachmentMutationRequest {
     /// Exact conversation whose live broker attachment changes.
     pub conversation_id: Uuid,
     pub root_id: RootId,
+    /// Fresh trusted consent for an attach; detach requests carry no consent.
+    pub consent_method: Option<ConsentMethod>,
 }
 
 /// Desired state used to fence recovery-only attachment receipt lookup.
@@ -409,6 +411,7 @@ mod tests {
                 subject: GrantSubject::conversation(conversation_id).unwrap(),
                 conversation_id,
                 root_id: RootId::new(),
+                consent_method: Some(ConsentMethod::PermissionDialog),
             }),
         };
         let mut encoded = serde_json::to_value(attachment).unwrap();

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -31,6 +31,9 @@ In practical terms:
 - Previously approved roots may be offered by safe display name in another
   conversation. Attaching one requires a trusted native confirmation, but not
   another folder picker.
+- If multiple approved roots have the same safe display name, none of those
+  ambiguous roots are offered for reuse; the user must identify one through
+  the native picker.
 - The model sees an opaque root identifier, a display name, and root-relative
   paths. It never receives authority by naming an absolute host path.
 - Connecting one folder never grants access to its siblings, the user's whole
@@ -206,9 +209,12 @@ picker result. Current desktop chats use their conversation subject; dormant
 project-scoped API chats retain their legacy project subject. Re-registering the
 same pinned filesystem object reuses the host-approved root. The host can return
 bounded safe summaries of approved roots to the management UI; it never returns
-their paths. Reusing an approved root in another chat requires a native
-confirmation, after which a separate product attachment change confirms the
-exact conversation attachment before the renderer sees it as connected.
+their paths. Roots whose safe display names collide are omitted so a native
+confirmation never asks the user to distinguish two folders with the same
+label; those folders remain available through the picker. Reusing an approved
+root in another chat requires a native confirmation, after which a separate
+product attachment change confirms the exact conversation attachment before
+the renderer sees it as connected.
 
 The **renderer** presents connected folders and permission choices. It receives
 safe summaries, not the broker's persisted absolute-path registry.
@@ -238,12 +244,21 @@ the attachment for the selected conversation. Detaching a root from one
 conversation leaves the host approval, its grants, and every other
 conversation's attachment intact. Revocation is deliberately broader: it
 forgets the root and removes all of its grants and attachments. Both mutation
-kinds bind a stable operation identity to their original request, so an exact
-retry is idempotent and identity reuse with different inputs is rejected. A
-read-only attachment receipt lets a recovering native client distinguish
-unknown, completed, and failed work without starting or replaying the mutation.
-Attachment changes are computed and published in one durable state replacement,
-so they do not expose a recoverable intermediate phase.
+kinds bind a stable operation identity to their original request, including the
+trusted consent method for an attach, so an exact retry is idempotent and
+identity reuse with different inputs is rejected. The broker stamps new
+subject grants with that current attachment consent instead of copying another
+subject's earlier consent record. A read-only attachment receipt lets a
+recovering native client distinguish unknown, completed, and failed work
+without starting or replaying the mutation. Attachment changes are computed and
+published in one durable state replacement, so they do not expose a recoverable
+intermediate phase.
+
+Legacy version-2 state may contain multiple product root IDs for one pinned
+filesystem object. Those IDs remain valid so existing product projections and
+receipts do not break. Registration selects among them deterministically, and
+global revocation reports no change while an equivalent alias remains instead
+of claiming the physical approval was removed.
 
 The desktop's manual Disconnect action uses this conversation-only detach; it
 does not invoke global revocation. The connected-folder list is the intersection

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -242,8 +242,10 @@ desktop can approve multiple folders through a native picker and a
 capability-gated host-broker sidecar; it exposes only opaque root IDs and
 display names to the renderer. A host-approved root can later be attached to
 another chat after a native confirmation, without locating it in the picker
-again. Foreground tool calls can list/read only roots attached to their stored
-chat context. An approved agent folder request now converges through the durable
+again. Approved roots with colliding safe display names are omitted from reuse
+and must be identified through the native picker. Foreground tool calls can
+list/read only roots attached to their stored chat context. An approved agent
+folder request now converges through the durable
 product root-attachment state machine before it can report `connected`. The
 same state machine backs the manual Connected folders UI: Connect and
 Disconnect are conversation-scoped instead of global authorization changes,


### PR DESCRIPTION
Prevents stale folder responses from crossing chat switches and adds cancel and post-connect UI coverage.

Makes approved-root reuse deterministic for legacy duplicate identities, hides ambiguous same-name roots behind the native picker, and refuses misleading revocation while physical aliases remain.

Records fresh attachment-consent provenance, bumps the broker protocol, strengthens native label sanitization, and updates the host-access documentation.

Validated with broker and desktop Rust tests, the full UI test and production build, formatting, and strict Rust lint.