### PR TITLE
feat(desktop): add a top-level error boundary

### DIFF
--- a/crates/openwave-desktop/ui/src/ErrorBoundary.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ErrorBoundary.dom.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function Bomb(): never {
+  throw new Error("kaboom in render");
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("ErrorBoundary", () => {
+  it("renders healthy children untouched", () => {
+    render(
+      <ErrorBoundary>
+        <p>all good</p>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("all good")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("catches a render throw and shows the fallback with the message", () => {
+    // React logs caught errors loudly; keep the test output readable.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+    const fallback = screen.getByRole("alert");
+    expect(fallback).toHaveTextContent("OpenWave hit an unexpected error.");
+    expect(fallback).toHaveTextContent("kaboom in render");
+  });
+
+  it("offers reload as recovery", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const user = userEvent.setup();
+    const onReload = vi.fn();
+    render(
+      <ErrorBoundary onReload={onReload}>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+    await user.click(screen.getByRole("button", { name: "Reload" }));
+    expect(onReload).toHaveBeenCalledOnce();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ErrorBoundary.tsx
+++ b/crates/openwave-desktop/ui/src/ErrorBoundary.tsx
@@ -1,0 +1,57 @@
+import { Component, type ReactNode } from "react";
+import { Logomark } from "./Logomark";
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+  /** Injectable for tests; defaults to a real page reload. */
+  onReload?: () => void;
+};
+
+type ErrorBoundaryState = {
+  error: Error | null;
+};
+
+/**
+ * Last-resort catch for render and lifecycle throws anywhere in the tree.
+ * Without it a single throw unmounts everything into a blank window. Chat
+ * data is durable in the embedded server, so a reload is a safe recovery.
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: { componentStack?: string | null }) {
+    console.error("unhandled render error", error, info.componentStack);
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div className="boot" role="alert">
+        <div className="boot-brand">
+          <Logomark />
+          <h1>OpenWave</h1>
+        </div>
+        <p>OpenWave hit an unexpected error.</p>
+        <p className="boot-error-detail">{String(this.state.error.message)}</p>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() =>
+            this.props.onReload
+              ? this.props.onReload()
+              : window.location.reload()
+          }
+        >
+          Reload
+        </button>
+      </div>
+    );
+  }
+}

--- a/crates/openwave-desktop/ui/src/main.tsx
+++ b/crates/openwave-desktop/ui/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { ErrorBoundary } from "./ErrorBoundary";
 import { initTheme } from "./theme";
 import "./styles.css";
 
@@ -8,6 +9,8 @@ initTheme();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -2336,6 +2336,17 @@ body {
   margin: 0;
 }
 
+.boot .boot-error-detail {
+  max-width: 34rem;
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+.boot .btn {
+  margin-top: 0.75rem;
+}
+
 .approval {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Closes #426.

`main.tsx` rendered `<App/>` bare: one uncaught render throw anywhere in the tree and the window went blank — no message, no recovery. This wraps the app in an `ErrorBoundary` (class component, the one case React still reserves for them) that logs the error with its component stack and renders a boot-styled fallback: brand mark, "OpenWave hit an unexpected error" with the message in monospace, and a **Reload** button (`window.location.reload`; injectable for tests). Chat data lives durably in the embedded server, so reload is an honest recovery, not data loss.

## Tests

DOM suite: healthy children render untouched with no alert; a throwing child produces the `role="alert"` fallback carrying the error message; Reload invokes the injected handler exactly once. 252 tests, `tsc`, and the production build are green.

**Held for smoke test before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)