### PR TITLE
feat(desktop): present reasoning and context-truncation stream events

### DIFF
--- a/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
@@ -134,3 +134,14 @@ describe("AssistantWorkingIndicator", () => {
     expect(shouldShowAssistantWorking(messages, true, 0)).toBe(true);
   });
 });
+
+describe("thinking variant", () => {
+  it("announces thinking while reasoning is active", () => {
+    expect(
+      renderToStaticMarkup(<AssistantWorkingIndicator thinking />),
+    ).toContain("Thinking…");
+    expect(renderToStaticMarkup(<AssistantWorkingIndicator />)).toContain(
+      "Working",
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.tsx
@@ -1,7 +1,12 @@
 import { Logomark } from "./Logomark";
 
-/** One fixed, renderer-owned status for an open foreground turn. */
-export function AssistantWorkingIndicator() {
+/** One renderer-owned status for an open foreground turn. */
+export function AssistantWorkingIndicator({
+  thinking = false,
+}: {
+  /** The model is emitting reasoning rather than visible output. */
+  thinking?: boolean;
+}) {
   return (
     <div
       className="assistant-working"
@@ -10,7 +15,7 @@ export function AssistantWorkingIndicator() {
       aria-atomic="true"
     >
       <Logomark className="assistant-working-mark" />
-      <span>Working</span>
+      <span>{thinking ? "Thinking…" : "Working"}</span>
     </div>
   );
 }

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -57,20 +57,14 @@ describe("seq cursor", () => {
   });
 
   it("advances the cursor for decoded-but-unrendered events", () => {
-    for (const type of [
-      "reasoning_delta",
-      "context_truncated",
-      "event_omitted",
-    ] as const) {
-      const { state, effects } = reduceChatSessionEvent(
-        initialChatSessionState(),
-        framed(7, { type }),
-        makeDeps(),
-      );
-      expect(state.lastSeq).toBe(7);
-      expect(state.messages).toEqual([]);
-      expect(effects).toEqual([]);
-    }
+    const { state, effects } = reduceChatSessionEvent(
+      initialChatSessionState(),
+      framed(7, { type: "event_omitted" }),
+      makeDeps(),
+    );
+    expect(state.lastSeq).toBe(7);
+    expect(state.messages).toEqual([]);
+    expect(effects).toEqual([]);
   });
 });
 
@@ -463,5 +457,74 @@ describe("forward compatibility", () => {
     expect(state.lastSeq).toBe(9);
     expect(state.messages).toEqual([]);
     expect(effects).toEqual([]);
+  });
+});
+
+describe("reasoning presentation", () => {
+  it("marks reasoning active and clears it when visible output starts", () => {
+    const thinking = play([TURN, { type: "reasoning_delta" }]);
+    expect(thinking.state.reasoningActive).toBe(true);
+
+    const speaking = reduceChatSessionEvent(
+      thinking.state,
+      framed(thinking.state.lastSeq + 1, { type: "text_delta", text: "hi" }),
+      makeDeps(),
+    );
+    expect(speaking.state.reasoningActive).toBe(false);
+  });
+
+  it("clears reasoning at tool starts, interruptions, and terminals", () => {
+    for (const event of [
+      { type: "tool_call_started", call_id: "c", name: "search" },
+      { type: "stream_interrupted" },
+      { type: "turn_completed" },
+      { type: "turn_failed" },
+    ] as AgentEvent[]) {
+      const thinking = play([TURN, { type: "reasoning_delta" }]);
+      const next = reduceChatSessionEvent(
+        thinking.state,
+        framed(thinking.state.lastSeq + 1, event),
+        makeDeps(),
+      );
+      expect(next.state.reasoningActive).toBe(false);
+    }
+  });
+});
+
+describe("context truncation notice", () => {
+  const NOTICE = "Earlier conversation was trimmed";
+
+  it("inserts one notice above the streaming bubble and keeps the answer whole", () => {
+    const { state } = play([
+      TURN,
+      { type: "context_truncated" },
+      { type: "text_delta", text: "the answer" },
+      { type: "context_truncated" },
+      { type: "text_delta", text: " continues" },
+    ]);
+    const notices = state.messages.filter(
+      (m) => m.role === "system" && m.text.includes(NOTICE),
+    );
+    expect(notices).toHaveLength(1);
+    const last = state.messages[state.messages.length - 1];
+    expect(last).toMatchObject({
+      role: "assistant",
+      text: "the answer continues",
+    });
+  });
+
+  it("resets the once-per-turn dedup at the next turn", () => {
+    const first = play([TURN, { type: "context_truncated" }]);
+    const second = play(
+      [
+        { type: "turn_started", turn_id: "turn-2" },
+        { type: "context_truncated" },
+      ],
+      first.state,
+    );
+    const notices = second.state.messages.filter(
+      (m) => m.role === "system" && m.text.includes(NOTICE),
+    );
+    expect(notices).toHaveLength(2);
   });
 });

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -33,6 +33,10 @@ export type ChatSessionState = {
   provisionalToolCallIds: ReadonlySet<string>;
   /** Message ids already present via hydration; used to dedup steered echoes. */
   hydratedMessageIds: ReadonlySet<string>;
+  /** The model is emitting reasoning; cleared once visible output starts. */
+  reasoningActive: boolean;
+  /** One truncation notice per turn, however many truncation events arrive. */
+  contextTruncationNoted: boolean;
 };
 
 export type ChatSessionEffect =
@@ -68,6 +72,8 @@ export function initialChatSessionState(): ChatSessionState {
     markerScrubber: new AssistantSourceMarkerStreamScrubber(),
     provisionalToolCallIds: new Set(),
     hydratedMessageIds: new Set(),
+    reasoningActive: false,
+    contextTruncationNoted: false,
   };
 }
 
@@ -101,6 +107,8 @@ export function reduceChatSessionEvent(
           ...state,
           busy: true,
           activeTurnId: event.turn_id,
+          reasoningActive: false,
+          contextTruncationNoted: false,
           assistantBuffer: "",
           markerScrubber: new AssistantSourceMarkerStreamScrubber(),
           provisionalToolCallIds: new Set(),
@@ -125,6 +133,7 @@ export function reduceChatSessionEvent(
       return {
         state: {
           ...state,
+          reasoningActive: false,
           assistantBuffer,
           messages: withTrailingAssistantText(
             state.messages,
@@ -150,6 +159,7 @@ export function reduceChatSessionEvent(
       return {
         state: {
           ...state,
+          reasoningActive: false,
           assistantBuffer: "",
           provisionalToolCallIds: new Set(),
           messages,
@@ -175,6 +185,7 @@ export function reduceChatSessionEvent(
       return {
         state: {
           ...state,
+          reasoningActive: false,
           provisionalToolCallIds,
           messages: upsertToolCall(
             state.messages,
@@ -294,6 +305,7 @@ export function reduceChatSessionEvent(
           ...state,
           busy: false,
           activeTurnId: null,
+          reasoningActive: false,
           provisionalToolCallIds: new Set(),
         },
         effects,
@@ -312,6 +324,7 @@ export function reduceChatSessionEvent(
           ...state,
           busy: false,
           activeTurnId: null,
+          reasoningActive: false,
           provisionalToolCallIds: new Set(),
           messages: [
             ...settleActiveToolCalls(state.messages, "cancelled"),
@@ -334,6 +347,7 @@ export function reduceChatSessionEvent(
           ...state,
           busy: false,
           activeTurnId: null,
+          reasoningActive: false,
           provisionalToolCallIds: new Set(),
           messages: [
             ...settleActiveToolCalls(state.messages, "failed"),
@@ -348,9 +362,31 @@ export function reduceChatSessionEvent(
       };
     }
 
-    // Decoded but not yet presented; they still advance the seq cursor.
-    case "reasoning_delta":
-    case "context_truncated":
+    case "reasoning_delta": {
+      return { state: { ...state, reasoningActive: true }, effects };
+    }
+
+    case "context_truncated": {
+      if (state.contextTruncationNoted) return { state, effects };
+      // Insert above the trailing assistant bubble (if streaming has begun)
+      // so subsequent deltas keep extending one answer under the notice.
+      const messages = [...state.messages];
+      const insertAt =
+        messages[messages.length - 1]?.role === "assistant"
+          ? messages.length - 1
+          : messages.length;
+      messages.splice(insertAt, 0, {
+        id: deps.nextId(),
+        role: "system",
+        text: "Earlier conversation was trimmed to fit the model's context.",
+      });
+      return {
+        state: { ...state, contextTruncationNoted: true, messages },
+        effects,
+      };
+    }
+
+    // Decoded but not presented; still advances the seq cursor.
     case "event_omitted":
       return { state, effects };
 

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -113,6 +113,9 @@ export function ChatView({
   const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);
   const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
+  const reasoningActive = useChatSessionStore(
+    (session) => session.reasoningActive,
+  );
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const followsLatestRef = useRef(true);
@@ -200,6 +203,7 @@ export function ChatView({
           decidingApprovalCalls={decidingApprovalCalls}
           approvalErrors={approvalErrors}
           busy={busy}
+          reasoningActive={reasoningActive}
           scrollRef={scrollRef}
           onScroll={(event) => {
             const followsLatest = isNearBottom(event.currentTarget);

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -48,6 +48,7 @@ type MessageListProps = {
   decidingApprovalCalls: Set<string>;
   approvalErrors: Record<string, string>;
   busy: boolean;
+  reasoningActive?: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
   onScroll: (event: UIEvent<HTMLDivElement>) => void;
   onApproval: (
@@ -74,6 +75,7 @@ export function MessageList({
   decidingApprovalCalls,
   approvalErrors,
   busy,
+  reasoningActive = false,
   scrollRef,
   onScroll,
   onApproval,
@@ -133,7 +135,7 @@ export function MessageList({
           messages,
           busy,
           folderAccessRequests.length,
-        ) && <AssistantWorkingIndicator />}
+        ) && <AssistantWorkingIndicator thinking={reasoningActive} />}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #428.

Two stream events were decoded but dropped on the floor:

- **`reasoning_delta`** — the session reducer now tracks a `reasoningActive` flag (set on reasoning, cleared when visible output starts: text, tool starts, interruptions, terminals, next turn), and the working indicator reads **Thinking…** while it holds. The renderer projection carries no reasoning text by design, so the fact of thinking is exactly what there is to show.
- **`context_truncated`** — appends a once-per-turn system notice, "Earlier conversation was trimmed to fit the model's context." It inserts *above* the trailing streaming bubble so subsequent deltas keep extending a single answer under the notice (pinned by test — a mid-stream truncation previously would have split the reply).

## Tests

Reducer: set/clear lifecycle across all clearing events, once-per-turn notice dedup with reset on the next turn, and answer-integrity around a mid-stream notice. Markup: the Thinking…/Working indicator variants. 257 tests, `tsc`, and the production build are green.

**Held for smoke test before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)