### PR TITLE
feat(models): enforce provider-scoped registry policy

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -281,8 +281,12 @@ pub const DEFAULT_MAX_TOOL_RESULT_BYTES: usize = 64 * 1024;
 /// Per-turn tuning for an [`Agent`].
 #[derive(Debug, Clone)]
 pub struct AgentConfig {
+    /// Explicit provider route resolved from the host model registry.
+    pub provider: Option<crate::provider::ProviderId>,
     /// Provider model identifier (e.g. `claude-opus-4-8`).
     pub model: String,
+    /// Whether this model uses the provider's reasoning request shape.
+    pub reasoning_model: bool,
     /// Reasoning-effort hint for models that expose the control; ignored by the
     /// rest. `None` leaves the provider default in force.
     pub reasoning_effort: Option<crate::model::ReasoningEffort>,
@@ -312,7 +316,9 @@ pub const DEFAULT_CONTEXT_WINDOW: usize = 200_000;
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
+            provider: None,
             model: String::new(),
+            reasoning_model: false,
             reasoning_effort: None,
             system_prompt: None,
             max_tokens: None,
@@ -1006,7 +1012,9 @@ impl Agent {
                 let (fitted, reduced) = self.fit_transcript(&transcript, reduction_level);
                 let fitted_tokens = context::estimate_transcript_tokens(&fitted);
                 let request = ChatRequest {
+                    provider: self.config.provider.clone(),
                     model: self.config.model.clone(),
+                    reasoning_model: self.config.reasoning_model,
                     system: self.config.system_prompt.clone(),
                     messages: fitted,
                     tools: self

--- a/crates/openwave-core/src/error.rs
+++ b/crates/openwave-core/src/error.rs
@@ -37,6 +37,26 @@ pub enum AgentError {
     #[error("provider error: {0}")]
     Provider(String),
 
+    /// The provider rejected the configured credential.
+    #[error("provider authentication failed: {0}")]
+    Authentication(String),
+
+    /// The provider is rate limiting requests.
+    #[error("provider rate limited the request: {0}")]
+    RateLimited(String),
+
+    /// The provider is temporarily overloaded or unavailable.
+    #[error("provider overloaded: {0}")]
+    Overloaded(String),
+
+    /// The provider rejected a request that is invalid for the selected model.
+    #[error("invalid provider request: {0}")]
+    InvalidRequest(String),
+
+    /// The provider refused the requested content.
+    #[error("provider refused the request: {0}")]
+    Refusal(String),
+
     /// The prompt exceeded the model's context window. The agent loop retries
     /// with a tighter context budget before giving up.
     #[error("prompt too long: {0}")]
@@ -73,6 +93,11 @@ impl AgentError {
             Self::ProjectNotFound(_) => "not_found",
             Self::Secret(_) => "secret",
             Self::Provider(_) => "provider",
+            Self::Authentication(_) => "authentication",
+            Self::RateLimited(_) => "rate_limited",
+            Self::Overloaded(_) => "overloaded",
+            Self::InvalidRequest(_) => "invalid_request",
+            Self::Refusal(_) => "refusal",
             Self::PromptTooLong(_) => "prompt_too_long",
             Self::Message(_) => "message",
             Self::Serde(_) => "serde",

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -87,8 +87,19 @@ impl ChatMessage {
 /// A request for one streamed model completion.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChatRequest {
+    /// Explicit provider route selected by the host. Composite routers must
+    /// honor this hint exactly and must not silently fall back to another
+    /// provider. Direct adapters may ignore it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<ProviderId>,
     /// Provider-specific model identifier (e.g. `claude-opus-4-8`).
     pub model: String,
+    /// Whether the resolved model uses a reasoning-model request shape.
+    ///
+    /// This is host-owned registry policy, rather than an adapter guess based
+    /// on the model name.
+    #[serde(default)]
+    pub reasoning_model: bool,
     /// System prompt, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub system: Option<String>,
@@ -251,7 +262,9 @@ mod tests {
     fn provider_stream_outlives_the_provider_borrow() {
         let provider: Arc<dyn ModelProvider> = Arc::new(Dummy);
         let stream = futures::executor::block_on(provider.stream(ChatRequest {
+            provider: None,
             model: "m".into(),
+            reasoning_model: false,
             system: None,
             messages: vec![],
             tools: vec![],
@@ -276,7 +289,9 @@ mod tests {
     #[test]
     fn chat_request_omits_empty_optionals() {
         let req = ChatRequest {
+            provider: None,
             model: "m".into(),
+            reasoning_model: false,
             system: None,
             messages: vec![ChatMessage::text(Role::User, "hello")],
             tools: vec![],

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -4,12 +4,14 @@ import {
   type AgentRun,
   type Chat,
   type ModelInfo,
+  type ModelSelectionKey,
   type PendingFolderAccessRequest,
   type ProviderInfo,
   type ReasoningEffort,
   type SequencedEvent,
   type ServerInfo,
 } from "./api";
+import { modelForSelection } from "./ModelSelection";
 import { resolveServerInfo } from "./boot";
 import {
   hasNativeHost,
@@ -199,7 +201,7 @@ export default function App() {
         chatListActions.setChats(existingChats);
         const created =
           existingChats[0] ??
-          (await client.createChat(catalog.models[0]?.id));
+          (await client.createChat());
         if (cancelled) return;
         if (existingChats.length === 0) chatListActions.setChats([created]);
         activateChat(created);
@@ -716,10 +718,7 @@ export default function App() {
     chatListActions.setCreatingChat(true);
     uiActions.showChat();
     try {
-      const created = await client.createChat(
-        chat?.model ?? models[0]?.id,
-        null,
-      );
+      const created = await client.createChat();
       openCreatedChat(created);
     } catch (err) {
       updateSession((session) => ({
@@ -798,7 +797,7 @@ export default function App() {
 
       let next: Chat | undefined = refreshed[0];
       if (!next) {
-        next = await client.createChat(models[0]?.id, null);
+        next = await client.createChat();
         refreshed = prependReplacementChat(refreshed, next);
       }
       chatListActions.setChats(refreshed);
@@ -900,7 +899,7 @@ export default function App() {
     }
   }
 
-  async function onModelChange(modelId: string | null) {
+  async function onModelChange(modelId: ModelSelectionKey | null) {
     if (!client || !chat || deletionInFlightRef.current) return;
     const chatId = chat.id;
     const selection = chatSelectionRef.current;
@@ -1142,8 +1141,7 @@ export default function App() {
                 disabled={deletingChatId !== null}
                 onChange={onModelChange}
               />
-              {models.find((model) => model.id === chat.model)
-                ?.supports_reasoning_effort && (
+              {modelForSelection(models, chat.model)?.supports_reasoning_effort && (
                 <ReasoningEffortMenu
                   value={chat.reasoning_effort}
                   disabled={deletingChatId !== null}

--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -11,6 +11,7 @@ import type { ModelInfo } from "./api";
 
 const MODELS: ModelInfo[] = [
   {
+    key: "anthropic::claude-sonnet-4",
     id: "claude-sonnet-4",
     display_name: "Claude Sonnet 4",
     provider: "anthropic",
@@ -20,8 +21,10 @@ const MODELS: ModelInfo[] = [
     supports_reasoning: true,
     supports_reasoning_effort: true,
     multimodal: true,
+    available: true,
   },
   {
+    key: "openai::gpt-4o",
     id: "gpt-4o",
     display_name: "GPT-4o",
     provider: "openai",
@@ -31,6 +34,7 @@ const MODELS: ModelInfo[] = [
     supports_reasoning: false,
     supports_reasoning_effort: false,
     multimodal: true,
+    available: true,
   },
 ];
 
@@ -48,15 +52,17 @@ describe("ModelMenu", () => {
   });
 
   it("labels the trigger with a selected model's display name", () => {
-    const markup = triggerMarkup("gpt-4o");
+    const markup = triggerMarkup("openai::gpt-4o");
     expect(markup).toContain('aria-label="Model: GPT-4o"');
     expect(markup).toContain(">GPT-4o<");
   });
 
   it("labels the trigger with an unknown (custom) override verbatim", () => {
     const markup = triggerMarkup("local-model:latest");
-    expect(markup).toContain('aria-label="Model: local-model:latest"');
-    expect(markup).toContain(">local-model:latest<");
+    expect(markup).toContain(
+      'aria-label="Model: local-model:latest (unavailable)"',
+    );
+    expect(markup).toContain(">local-model:latest (unavailable)<");
   });
 
   it("disables the trigger when asked", () => {

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -1,5 +1,14 @@
 import { Bot, Brain, Check, ChevronDown, Image as ImageIcon } from "lucide-react";
-import type { ModelInfo, ReasoningEffort } from "./api";
+import type {
+  ModelInfo,
+  ModelSelectionKey,
+  ReasoningEffort,
+} from "./api";
+import {
+  canonicalModelSelection,
+  modelForSelection,
+  providerLabel,
+} from "./ModelSelection";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -93,14 +102,15 @@ export function ModelMenu({
   models: ModelInfo[];
   value: string | null;
   disabled?: boolean;
-  onChange: (id: string | null) => void | Promise<void>;
+  onChange: (key: ModelSelectionKey | null) => void | Promise<void>;
 }) {
-  const known = models.find((m) => m.id === value);
-  const label = value ? (known?.display_name ?? value) : "Default";
+  const known = modelForSelection(models, value);
+  const canonical = canonicalModelSelection(models, value);
+  const label = value ? (known?.display_name ?? `${value} (unavailable)`) : "Default";
 
   // Group by provider, preserving first-seen order.
-  const groups: { provider: string; models: ModelInfo[] }[] = [];
-  const byProvider = new Map<string, ModelInfo[]>();
+  const groups: { provider: ModelInfo["provider"]; models: ModelInfo[] }[] = [];
+  const byProvider = new Map<ModelInfo["provider"], ModelInfo[]>();
   for (const model of models) {
     const existing = byProvider.get(model.provider);
     if (existing) {
@@ -145,15 +155,16 @@ export function ModelMenu({
             <DropdownMenuSeparator />
             <div className="model-menu-group-label">
               <ProviderIcon provider={group.provider} size={12} />
-              <span>{group.provider}</span>
+              <span>{providerLabel(group.provider)}</span>
             </div>
             {group.models.map((model) => {
-              const selected = value === model.id;
+              const selected = canonical === model.key;
               return (
                 <DropdownMenuItem
-                  key={model.id}
+                  key={model.key}
+                  disabled={!model.available}
                   onSelect={() => {
-                    if (!selected) void onChange(model.id);
+                    if (!selected && model.available) void onChange(model.key);
                   }}
                 >
                   <ProviderIcon provider={model.provider} />
@@ -172,7 +183,7 @@ export function ModelMenu({
         {value !== null && !known && (
           <>
             <DropdownMenuSeparator />
-            <div className="model-menu-group-label">custom</div>
+            <div className="model-menu-group-label">Unavailable legacy selection</div>
             <DropdownMenuItem disabled>
               <span className="model-menu-item-label">{value}</span>
               <Check className="ml-auto" />

--- a/crates/openwave-desktop/ui/src/ModelSelection.test.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { ModelInfo } from "./api";
+import {
+  canonicalModelSelection,
+  modelForSelection,
+  providerLabel,
+} from "./ModelSelection";
+
+const base = {
+  display_name: "Shared",
+  context_window: 32_000,
+  max_output_tokens: 4_000,
+  input_modalities: ["text"] as const,
+  supports_reasoning: false,
+  supports_reasoning_effort: false,
+  multimodal: false,
+  available: true,
+};
+
+const models: ModelInfo[] = [
+  {
+    ...base,
+    key: "openai::shared",
+    id: "shared",
+    provider: "openai",
+    input_modalities: ["text"],
+  },
+  {
+    ...base,
+    key: "openai_compatible::shared",
+    id: "shared",
+    provider: "openai_compatible",
+    input_modalities: ["text"],
+  },
+  {
+    ...base,
+    key: "anthropic::unique",
+    id: "unique",
+    provider: "anthropic",
+    input_modalities: ["text"],
+  },
+];
+
+describe("typed model selection", () => {
+  it("resolves provider-qualified keys exactly", () => {
+    expect(modelForSelection(models, "openai_compatible::shared")?.provider).toBe(
+      "openai_compatible",
+    );
+    expect(modelForSelection(models, "anthropic::shared")).toBeNull();
+  });
+
+  it("migrates only unambiguous legacy ids", () => {
+    expect(canonicalModelSelection(models, "unique")).toBe("anthropic::unique");
+    expect(canonicalModelSelection(models, "shared")).toBeNull();
+  });
+
+  it("uses product-facing provider labels", () => {
+    expect(providerLabel("openai")).toBe("OpenAI");
+    expect(providerLabel("openai_compatible")).toBe("OpenAI-compatible");
+  });
+});

--- a/crates/openwave-desktop/ui/src/ModelSelection.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.ts
@@ -1,0 +1,44 @@
+import type {
+  ModelInfo,
+  ModelSelectionKey,
+  ProviderKind,
+} from "./api";
+
+/**
+ * Resolve a stored selection against the typed catalog.
+ *
+ * New values match only their provider-qualified key. Old bare ids are
+ * accepted only when the catalog has exactly one owner, so migration can never
+ * silently change providers.
+ */
+export function modelForSelection(
+  models: ModelInfo[],
+  value: string | null,
+): ModelInfo | null {
+  if (!value) return null;
+  const exact = models.find((model) => model.key === value);
+  if (exact) return exact;
+  if (value.includes("::")) return null;
+  const legacy = models.filter((model) => model.id === value);
+  return legacy.length === 1 ? legacy[0] : null;
+}
+
+/** Canonical provider-qualified key for a current or legacy selection. */
+export function canonicalModelSelection(
+  models: ModelInfo[],
+  value: string | null,
+): ModelSelectionKey | null {
+  return modelForSelection(models, value)?.key ?? null;
+}
+
+/** Provider display label shared by settings and the composer. */
+export function providerLabel(provider: ProviderKind): string {
+  switch (provider) {
+    case "anthropic":
+      return "Anthropic";
+    case "openai":
+      return "OpenAI";
+    case "openai_compatible":
+      return "OpenAI-compatible";
+  }
+}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -292,7 +292,7 @@ describe("project-scoped conversation API", () => {
     const client = new ApiClient("http://127.0.0.1", "token");
 
     await client.createProject("Research");
-    await client.createChat("model-1", "project-1");
+    await client.createChat("anthropic::model-1", "project-1");
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
@@ -307,7 +307,10 @@ describe("project-scoped conversation API", () => {
       "http://127.0.0.1/chats",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ model: "model-1", project_id: "project-1" }),
+        body: JSON.stringify({
+          model: "anthropic::model-1",
+          project_id: "project-1",
+        }),
       }),
     );
   });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -5,6 +5,8 @@ export type ServerInfo = {
 };
 
 export type ProviderKind = "anthropic" | "openai" | "openai_compatible";
+/** Stable provider-scoped key used for new settings and chat overrides. */
+export type ModelSelectionKey = `${ProviderKind}::${string}`;
 
 /** How hard a reasoning-capable model should think before answering. */
 export type ReasoningEffort = "low" | "medium" | "high";
@@ -14,13 +16,25 @@ export type ProviderInfo = {
   enabled: boolean;
   has_credential: boolean;
   base_url: string | null;
+  models: CustomModelConfig[];
+};
+
+export type CustomModelConfig = {
+  id: string;
+  display_name: string | null;
+  context_window: number;
+  max_output_tokens: number;
 };
 
 export type ModelInfo = {
+  /** Stable provider-qualified selection key. */
+  key: ModelSelectionKey;
   id: string;
   /** Human-readable label for the selector (e.g. "Claude Opus 4.8"). */
   display_name: string;
-  provider: string;
+  provider: ProviderKind;
+  /** Provider is enabled, configured, and credentialed. */
+  available: boolean;
   /** Approximate context window in tokens. */
   context_window: number;
   /** Maximum response size in tokens. */
@@ -330,6 +344,7 @@ export class ApiClient {
       enabled?: boolean;
       base_url?: string | null;
       credential?: { type: "api_key"; key: string };
+      models?: CustomModelConfig[];
     },
   ): Promise<ProviderInfo> {
     return this.json(`/providers/${kind}`, {
@@ -359,7 +374,7 @@ export class ApiClient {
    * it to the server default, and a value sets it (matching the double-option
    * body the server expects).
    */
-  putSettings(body: { model?: string | null }): Promise<RuntimeSettings> {
+  putSettings(body: { model?: ModelSelectionKey | null }): Promise<RuntimeSettings> {
     return this.json("/settings", {
       method: "PUT",
       headers: this.headers(true),
@@ -450,7 +465,7 @@ export class ApiClient {
     });
   }
 
-  createChat(model?: string, projectId?: string | null): Promise<Chat> {
+  createChat(model?: ModelSelectionKey, projectId?: string | null): Promise<Chat> {
     return this.json("/chats", {
       method: "POST",
       headers: this.headers(true),
@@ -486,7 +501,10 @@ export class ApiClient {
     });
   }
 
-  patchChatModel(chatId: string, model: string | null): Promise<Chat> {
+  patchChatModel(
+    chatId: string,
+    model: ModelSelectionKey | null,
+  ): Promise<Chat> {
     return this.json(`/chats/${chatId}`, {
       method: "PATCH",
       headers: this.headers(true),

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ApiClient, ModelInfo } from "../api";
+import { ModelsPanel } from "./ModelsPanel";
+
+const models: ModelInfo[] = [
+  {
+    key: "anthropic::claude-opus-4-8",
+    id: "claude-opus-4-8",
+    display_name: "Claude Opus 4.8",
+    provider: "anthropic",
+    available: false,
+    context_window: 1_000_000,
+    max_output_tokens: 128_000,
+    input_modalities: ["text"],
+    supports_reasoning: true,
+    supports_reasoning_effort: false,
+    multimodal: false,
+  },
+  {
+    key: "openai::gpt-4o",
+    id: "gpt-4o",
+    display_name: "GPT-4o",
+    provider: "openai",
+    available: true,
+    context_window: 128_000,
+    max_output_tokens: 16_384,
+    input_modalities: ["text"],
+    supports_reasoning: false,
+    supports_reasoning_effort: false,
+    multimodal: false,
+  },
+];
+
+describe("ModelsPanel", () => {
+  it("shows provider-first typed selection and never saves a provider alone", async () => {
+    const getSettings = vi.fn().mockResolvedValue({
+      model: "gpt-4o", // legacy bare id migrates in the view
+      has_api_key: true,
+    });
+    const putSettings = vi.fn().mockResolvedValue({
+      model: null,
+      has_api_key: true,
+    });
+    const client = { getSettings, putSettings } as unknown as ApiClient;
+
+    render(<ModelsPanel client={client} models={models} />);
+
+    const provider = await screen.findByLabelText("Provider");
+    await waitFor(() => expect(provider).toHaveValue("openai"));
+    const model = screen.getAllByRole("combobox")[1];
+    expect(model).toHaveValue("openai::gpt-4o");
+    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+
+    fireEvent.change(provider, { target: { value: "anthropic" } });
+    expect(putSettings).not.toHaveBeenCalled();
+    const unavailable = screen.getByRole("option", {
+      name: "Claude Opus 4.8 — unavailable",
+    });
+    expect(unavailable).toBeDisabled();
+
+    fireEvent.change(model, {
+      target: { value: "" },
+    });
+    await waitFor(() => expect(putSettings).toHaveBeenCalledWith({ model: null }));
+  });
+});

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
@@ -1,6 +1,15 @@
-import { useEffect, useState } from "react";
-import type { ApiClient, ModelInfo } from "../api";
-import { Input } from "@/components/ui/input";
+import { useEffect, useMemo, useState } from "react";
+import type {
+  ApiClient,
+  ModelInfo,
+  ModelSelectionKey,
+  ProviderKind,
+} from "../api";
+import {
+  canonicalModelSelection,
+  modelForSelection,
+  providerLabel,
+} from "../ModelSelection";
 import {
   SETTINGS_SELECT_CLASS,
   SettingsError,
@@ -17,9 +26,20 @@ export function ModelsPanel({
   models: ModelInfo[];
 }) {
   const [defaultModel, setDefaultModel] = useState<string | null>(null);
+  const [provider, setProvider] = useState<ProviderKind | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const providers = useMemo(
+    () =>
+      [...new Set(models.map((model) => model.provider))] as ProviderKind[],
+    [models],
+  );
+  const selected = modelForSelection(models, defaultModel);
+  const providerModels = provider
+    ? models.filter((model) => model.provider === provider)
+    : [];
 
   useEffect(() => {
     let cancelled = false;
@@ -30,6 +50,15 @@ export function ModelsPanel({
         const settings = await client.getSettings();
         if (cancelled) return;
         setDefaultModel(settings.model);
+        const resolved = modelForSelection(models, settings.model);
+        setProvider(
+          resolved?.provider ??
+            providers.find((kind) =>
+              models.some((model) => model.provider === kind && model.available),
+            ) ??
+            providers[0] ??
+            null,
+        );
       } catch (err) {
         if (!cancelled) setError(String(err));
       } finally {
@@ -39,14 +68,16 @@ export function ModelsPanel({
     return () => {
       cancelled = true;
     };
-  }, [client]);
+  }, [client, models, providers]);
 
-  async function save(model: string | null) {
+  async function save(model: ModelSelectionKey | null) {
     setSaving(true);
     setError(null);
     try {
       const next = await client.putSettings({ model });
       setDefaultModel(next.model);
+      const resolved = modelForSelection(models, next.model);
+      if (resolved) setProvider(resolved.provider);
     } catch (err) {
       setError(String(err));
     } finally {
@@ -54,14 +85,15 @@ export function ModelsPanel({
     }
   }
 
-  const isCustom = Boolean(
-    defaultModel && !models.some((m) => m.id === defaultModel),
-  );
+  const canonical = canonicalModelSelection(models, defaultModel);
+  const selectedValue =
+    selected?.provider === provider ? (canonical ?? "") : "";
+  const legacyUnavailable = defaultModel !== null && selected === null;
 
   return (
     <SettingsPanel
       title="Models"
-      description="Pick the default model for new chats. Any chat left on “Default” uses this. Individual chats can override it from the model menu in the message bar."
+      description="Choose the provider first, then a model that provider is configured to serve. New chats inherit this default; each conversation can still override it."
       busy={loading}
     >
       {loading ? (
@@ -69,48 +101,67 @@ export function ModelsPanel({
       ) : (
         <>
           <SettingsSection title="Default model">
-            <SettingsField label="Model">
+            <SettingsField label="Provider">
               <select
                 className={SETTINGS_SELECT_CLASS}
-                value={defaultModel ?? ""}
-                disabled={saving}
-                onChange={(e) => void save(e.target.value || null)}
+                value={provider ?? ""}
+                disabled={saving || providers.length === 0}
+                onChange={(event) =>
+                  setProvider((event.target.value || null) as ProviderKind | null)
+                }
               >
-                <option value="">Server default</option>
-                {models.map((m) => (
-                  <option key={m.id} value={m.id}>
-                    {m.id} ({m.provider})
-                  </option>
-                ))}
-                {isCustom && defaultModel && (
-                  <option value={defaultModel}>{defaultModel} (custom)</option>
+                {providers.length === 0 && (
+                  <option value="">No providers configured</option>
                 )}
+                {providers.map((kind) => {
+                  const usable = models.some(
+                    (model) => model.provider === kind && model.available,
+                  );
+                  return (
+                    <option key={kind} value={kind}>
+                      {providerLabel(kind)}
+                      {usable ? "" : " — unavailable"}
+                    </option>
+                  );
+                })}
               </select>
             </SettingsField>
             <SettingsField
-              label="Custom model ID"
-              hint="Select a listed model above, or type any model ID your enabled providers support."
+              label="Model"
+              hint="Unavailable models remain visible for clarity but cannot be selected until their provider is enabled and credentialed."
             >
-              <Input
-                type="text"
-                placeholder="e.g. claude-sonnet-4-20250514"
-                defaultValue={isCustom && defaultModel ? defaultModel : ""}
-                key={defaultModel ?? "none"}
-                disabled={saving}
-                onBlur={(e) => {
-                  const next = e.target.value.trim();
-                  if (next && next !== (defaultModel ?? "")) void save(next);
+              <select
+                className={SETTINGS_SELECT_CLASS}
+                value={selectedValue}
+                disabled={saving || provider === null}
+                onChange={(event) => {
+                  const value = event.target.value as ModelSelectionKey | "";
+                  void save(value || null);
                 }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") e.currentTarget.blur();
-                }}
-              />
+              >
+                <option value="">Server default</option>
+                {providerModels.map((model) => (
+                  <option
+                    key={model.key}
+                    value={model.key}
+                    disabled={!model.available}
+                  >
+                    {model.display_name}
+                    {model.available ? "" : " — unavailable"}
+                  </option>
+                ))}
+              </select>
             </SettingsField>
+            {legacyUnavailable && (
+              <SettingsError>
+                The saved legacy model “{defaultModel}” is not uniquely registered.
+                Add it under the OpenAI-compatible provider, then choose it here.
+              </SettingsError>
+            )}
           </SettingsSection>
           {models.length === 0 && (
             <p className="text-sm text-muted-foreground">
-              No models are available yet. Add a provider credential on the
-              Providers page to populate the catalog.
+              No models are registered yet. Configure a provider first.
             </p>
           )}
         </>

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient, ProviderInfo } from "../api";
+import { ProvidersPanel } from "./ProvidersPanel";
+
+const compatible: ProviderInfo = {
+  kind: "openai_compatible",
+  enabled: true,
+  has_credential: true,
+  base_url: "http://127.0.0.1:1234/v1",
+  models: [],
+};
+
+afterEach(cleanup);
+
+describe("ProvidersPanel", () => {
+  it("registers custom compatible models with explicit runtime limits", async () => {
+    const putProvider = vi.fn().mockResolvedValue(compatible);
+    const client = { putProvider } as unknown as ApiClient;
+
+    render(
+      <ProvidersPanel
+        providers={[compatible]}
+        client={client}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add model" }));
+    fireEvent.change(screen.getByLabelText("Custom model 1 ID"), {
+      target: { value: " vendor/model " },
+    });
+    fireEvent.change(screen.getByLabelText("Custom model 1 display name"), {
+      target: { value: " Vendor Model " },
+    });
+    fireEvent.change(screen.getByLabelText("Custom model 1 context tokens"), {
+      target: { value: "65536" },
+    });
+    fireEvent.change(screen.getByLabelText("Custom model 1 max output"), {
+      target: { value: "8192" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+
+    await waitFor(() =>
+      expect(putProvider).toHaveBeenCalledWith("openai_compatible", {
+        enabled: true,
+        base_url: "http://127.0.0.1:1234/v1",
+        models: [
+          {
+            id: "vendor/model",
+            display_name: "Vendor Model",
+            context_window: 65_536,
+            max_output_tokens: 8_192,
+          },
+        ],
+      }),
+    );
+  });
+
+  it("does not expose custom model registration for curated providers", () => {
+    render(
+      <ProvidersPanel
+        providers={[
+          {
+            kind: "anthropic",
+            enabled: false,
+            has_credential: false,
+            base_url: null,
+            models: [],
+          },
+        ]}
+        client={{} as ApiClient}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Add model" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
-import type { ApiClient, ProviderInfo, ProviderKind } from "../api";
+import type {
+  ApiClient,
+  CustomModelConfig,
+  ProviderInfo,
+  ProviderKind,
+} from "../api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
@@ -36,6 +41,7 @@ function ProviderRow({
 }) {
   const [key, setKey] = useState("");
   const [baseUrl, setBaseUrl] = useState(info.base_url ?? "");
+  const [models, setModels] = useState<CustomModelConfig[]>(info.models);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -47,9 +53,15 @@ function ProviderRow({
         enabled: boolean;
         base_url?: string | null;
         credential?: { type: "api_key"; key: string };
+        models?: CustomModelConfig[];
       } = { enabled };
       if (info.kind === "openai_compatible") {
         body.base_url = baseUrl.trim() || null;
+        body.models = models.map((model) => ({
+          ...model,
+          id: model.id.trim(),
+          display_name: model.display_name?.trim() || null,
+        }));
       }
       if (key.trim()) {
         body.credential = { type: "api_key", key: key.trim() };
@@ -95,12 +107,139 @@ function ProviderRow({
         </span>
       </div>
       {info.kind === "openai_compatible" && (
-        <Input
-          type="text"
-          placeholder="base URL (e.g. http://127.0.0.1:1234/v1)"
-          value={baseUrl}
-          onChange={(e) => setBaseUrl(e.target.value)}
-        />
+        <>
+          <Input
+            type="text"
+            placeholder="base URL (e.g. http://127.0.0.1:1234/v1)"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+          />
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-sm font-medium">Models</span>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={saving}
+                onClick={() =>
+                  setModels((current) => [
+                    ...current,
+                    {
+                      id: "",
+                      display_name: null,
+                      context_window: 32_768,
+                      max_output_tokens: 4_096,
+                    },
+                  ])
+                }
+              >
+                Add model
+              </Button>
+            </div>
+            {models.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                Add each model this endpoint serves. Custom models start with
+                conservative text-only, non-reasoning capabilities.
+              </p>
+            )}
+            {models.map((model, index) => (
+              <div
+                className="grid gap-2 rounded-md border border-border p-3"
+                key={index}
+              >
+                <Input
+                  type="text"
+                  aria-label={`Custom model ${index + 1} ID`}
+                  placeholder="model ID"
+                  value={model.id}
+                  onChange={(event) =>
+                    setModels((current) =>
+                      current.map((item, itemIndex) =>
+                        itemIndex === index
+                          ? { ...item, id: event.target.value }
+                          : item,
+                      ),
+                    )
+                  }
+                />
+                <Input
+                  type="text"
+                  aria-label={`Custom model ${index + 1} display name`}
+                  placeholder="display name (optional)"
+                  value={model.display_name ?? ""}
+                  onChange={(event) =>
+                    setModels((current) =>
+                      current.map((item, itemIndex) =>
+                        itemIndex === index
+                          ? {
+                              ...item,
+                              display_name: event.target.value || null,
+                            }
+                          : item,
+                      ),
+                    )
+                  }
+                />
+                <div className="grid grid-cols-2 gap-2">
+                  <label className="grid gap-1 text-xs text-muted-foreground">
+                    Context tokens
+                    <Input
+                      type="number"
+                      min={1024}
+                      aria-label={`Custom model ${index + 1} context tokens`}
+                      value={model.context_window}
+                      onChange={(event) =>
+                        setModels((current) =>
+                          current.map((item, itemIndex) =>
+                            itemIndex === index
+                              ? {
+                                  ...item,
+                                  context_window: Number(event.target.value),
+                                }
+                              : item,
+                          ),
+                        )
+                      }
+                    />
+                  </label>
+                  <label className="grid gap-1 text-xs text-muted-foreground">
+                    Max output
+                    <Input
+                      type="number"
+                      min={1}
+                      aria-label={`Custom model ${index + 1} max output`}
+                      value={model.max_output_tokens}
+                      onChange={(event) =>
+                        setModels((current) =>
+                          current.map((item, itemIndex) =>
+                            itemIndex === index
+                              ? {
+                                  ...item,
+                                  max_output_tokens: Number(event.target.value),
+                                }
+                              : item,
+                          ),
+                        )
+                      }
+                    />
+                  </label>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={saving}
+                  onClick={() =>
+                    setModels((current) =>
+                      current.filter((_, itemIndex) => itemIndex !== index),
+                    )
+                  }
+                >
+                  Remove model
+                </Button>
+              </div>
+            ))}
+          </div>
+        </>
       )}
       <Input
         type="password"
@@ -112,10 +251,15 @@ function ProviderRow({
       <div className="flex flex-wrap gap-2">
         <Button
           type="button"
-          disabled={saving || !key.trim()}
+          disabled={
+            saving ||
+            (info.kind !== "openai_compatible" && !key.trim()) ||
+            (info.kind === "openai_compatible" &&
+              models.some((model) => !model.id.trim()))
+          }
           onClick={() => void save(true)}
         >
-          Save
+          Save configuration
         </Button>
         {info.has_credential && (
           <Button

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -16,7 +16,7 @@ use openwave_core::provider::{
 };
 use openwave_core::Role;
 
-use crate::sse::{classify_provider_error, drain_frames, frame_data};
+use crate::sse::{classify_provider_error, drain_frames, frame_data, read_bounded_error_body};
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -82,7 +82,7 @@ impl ModelProvider for AnthropicProvider {
         // stable error type/code when present) is enough for classification.
         let status = response.status();
         if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_error_body(response.bytes_stream()).await;
             return Err(classify_provider_error("anthropic", status.as_u16(), &body));
         }
 
@@ -284,7 +284,9 @@ mod tests {
     #[test]
     fn request_maps_system_messages_and_tools() {
         let req = ChatRequest {
+            provider: Some(ProviderId::new("anthropic")),
             model: "claude-opus-4-8".into(),
+            reasoning_model: true,
             system: Some("be brief".into()),
             messages: vec![ChatMessage::text(Role::User, "hi")],
             tools: vec![ToolSpec {

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -18,7 +18,7 @@ use openwave_core::provider::{
 };
 use openwave_core::Role;
 
-use crate::sse::{classify_provider_error, drain_frames, frame_data};
+use crate::sse::{classify_provider_error, drain_frames, frame_data, read_bounded_error_body};
 
 const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
@@ -104,7 +104,7 @@ impl ModelProvider for OpenAiCompatProvider {
         if !status.is_success() {
             // Never forward the raw body — gateways sometimes echo key material
             // or request fragments, and `AgentError` strings reach the client.
-            let body = response.text().await.unwrap_or_default();
+            let body = read_bounded_error_body(response.bytes_stream()).await;
             return Err(classify_provider_error(
                 "openai-compat",
                 status.as_u16(),
@@ -172,7 +172,7 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
     });
     // Reasoning models (o-series) reject `max_tokens` — they want
     // `max_completion_tokens`. Everything else still speaks `max_tokens`.
-    if is_reasoning_model(&req.model) {
+    if req.reasoning_model {
         body["max_completion_tokens"] = json!(max_tokens);
         // Only reasoning models understand `reasoning_effort`; forwarding it to a
         // plain chat model would be rejected. Absent, the provider's default holds.
@@ -204,15 +204,6 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         body["temperature"] = json!(temperature);
     }
     Ok(body)
-}
-
-/// OpenAI reasoning models reject `max_tokens` in favor of
-/// `max_completion_tokens`. Match the common `o`-prefix ids (o1, o3, o4-mini, …).
-fn is_reasoning_model(model: &str) -> bool {
-    let base = model.split('/').next_back().unwrap_or(model);
-    let base = base.strip_prefix("openai.").unwrap_or(base);
-    matches!(base.as_bytes().first(), Some(b'o'))
-        && base.as_bytes().get(1).is_some_and(|b| b.is_ascii_digit())
 }
 
 /// Append one normalized message as one or more OpenAI Chat Completions messages.
@@ -455,7 +446,9 @@ mod tests {
     #[test]
     fn request_maps_system_tools_and_messages() {
         let req = ChatRequest {
+            provider: Some(ProviderId::new("openai")),
             model: "gpt-4o".into(),
+            reasoning_model: false,
             system: Some("be brief".into()),
             messages: vec![ChatMessage::text(Role::User, "hi")],
             tools: vec![ToolSpec {
@@ -485,7 +478,9 @@ mod tests {
     #[test]
     fn reasoning_models_use_max_completion_tokens() {
         let req = ChatRequest {
+            provider: Some(ProviderId::new("openai")),
             model: "o3".into(),
+            reasoning_model: true,
             system: None,
             messages: vec![ChatMessage::text(Role::User, "hi")],
             tools: vec![],
@@ -498,16 +493,14 @@ mod tests {
         assert!(body.get("max_tokens").is_none());
         // Absent an override, the request carries no `reasoning_effort`.
         assert!(body.get("reasoning_effort").is_none());
-        assert!(is_reasoning_model("o4-mini"));
-        assert!(is_reasoning_model("o1-preview"));
-        assert!(!is_reasoning_model("gpt-4o"));
-        assert!(!is_reasoning_model("claude-opus-4-8"));
     }
 
     #[test]
     fn reasoning_models_forward_reasoning_effort() {
         let req = ChatRequest {
+            provider: Some(ProviderId::new("openai")),
             model: "o3".into(),
+            reasoning_model: true,
             system: None,
             messages: vec![ChatMessage::text(Role::User, "hi")],
             tools: vec![],

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -43,6 +43,15 @@ impl RouteKind {
             RouteKind::OpenaiCompatible => "openai_compatible",
         }
     }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "anthropic" => Some(Self::Anthropic),
+            "openai" => Some(Self::Openai),
+            "openai_compatible" => Some(Self::OpenaiCompatible),
+            _ => None,
+        }
+    }
 }
 
 /// One enabled, credentialed provider endpoint the router may select.
@@ -79,7 +88,8 @@ impl std::fmt::Debug for Route {
 /// 3. Else fail closed — no network call.
 pub struct Router {
     adapters: HashMap<RouteKind, Arc<dyn ModelProvider>>,
-    /// model id → preferred route kind (first curated claim wins).
+    /// provider + model claims. The provider dimension is intentional: two
+    /// endpoints may expose the same raw model id without becoming ambiguous.
     curated: HashMap<String, RouteKind>,
     has_openai_compat: bool,
     /// Fingerprint of the routes this was built from, for cache invalidation.
@@ -100,7 +110,7 @@ impl Router {
                 has_openai_compat = true;
             }
             for model in &route.curated_models {
-                curated.entry(model.clone()).or_insert(route.kind);
+                curated.insert(format!("{}::{model}", route.kind.as_str()), route.kind);
             }
             if let Some(adapter) = build_adapter(&route) {
                 adapters.insert(route.kind, adapter);
@@ -123,15 +133,45 @@ impl Router {
 
     /// Select the route kind for `model`, if any candidate can serve it.
     pub fn select(&self, model: &str) -> Option<RouteKind> {
-        if let Some(kind) = self.curated.get(model) {
-            if self.adapters.contains_key(kind) {
-                return Some(*kind);
+        for kind in [
+            RouteKind::Anthropic,
+            RouteKind::Openai,
+            RouteKind::OpenaiCompatible,
+        ] {
+            if self
+                .curated
+                .contains_key(&format!("{}::{model}", kind.as_str()))
+                && self.adapters.contains_key(&kind)
+            {
+                return Some(kind);
             }
         }
         if self.has_openai_compat && self.adapters.contains_key(&RouteKind::OpenaiCompatible) {
             return Some(RouteKind::OpenaiCompatible);
         }
         None
+    }
+
+    /// Select the exact provider requested by the host model registry.
+    ///
+    /// Curated Anthropic/OpenAI routes must claim the model. A custom
+    /// OpenAI-compatible route accepts a legacy free-form model id so existing
+    /// pre-registry settings continue to work; new API writes require an
+    /// explicit configured custom entry before they can reach this boundary.
+    pub fn select_for(&self, provider: Option<&ProviderId>, model: &str) -> Option<RouteKind> {
+        let Some(provider) = provider else {
+            return self.select(model);
+        };
+        let kind = RouteKind::parse(&provider.0)?;
+        if !self.adapters.contains_key(&kind) {
+            return None;
+        }
+        if kind == RouteKind::OpenaiCompatible {
+            return Some(kind);
+        }
+        self.curated
+            .contains_key(&format!("{}::{model}", kind.as_str()))
+            .then_some(kind)
     }
 }
 
@@ -141,11 +181,14 @@ impl ModelProvider for Router {
         ProviderId::new("router")
     }
 
-    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
-        let Some(kind) = self.select(&req.model) else {
+    async fn stream(&self, mut req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let Some(kind) = self.select_for(req.provider.as_ref(), &req.model) else {
             return Err(AgentError::config(format!(
-                "no enabled provider can serve model `{}`",
-                req.model
+                "provider `{}` is unavailable or cannot serve model `{}`",
+                req.provider
+                    .as_ref()
+                    .map_or("unspecified", |provider| provider.0.as_str()),
+                req.model,
             )));
         };
         let Some(adapter) = self.adapters.get(&kind) else {
@@ -154,6 +197,8 @@ impl ModelProvider for Router {
                 req.model
             )));
         };
+        // The route hint is host policy, not provider wire data.
+        req.provider = None;
         adapter.stream(req).await
     }
 }
@@ -207,10 +252,15 @@ fn fingerprint_routes(routes: &[Route]) -> String {
         .iter()
         .map(|r| {
             format!(
-                "{}|{:x}|{}",
+                "{}|{:x}|{}|{}",
                 r.kind.as_str(),
                 fnv1a64(&r.api_key),
-                r.base_url.as_deref().unwrap_or("")
+                r.base_url.as_deref().unwrap_or(""),
+                {
+                    let mut models = r.curated_models.clone();
+                    models.sort();
+                    models.join(",")
+                }
             )
         })
         .collect();
@@ -266,6 +316,30 @@ mod tests {
     }
 
     #[test]
+    fn explicit_provider_never_cross_routes_an_ambiguous_model() {
+        let router = Router::build(vec![
+            route(RouteKind::Anthropic, "sk-a", &["shared"], None),
+            route(RouteKind::Openai, "sk-o", &["shared"], None),
+        ]);
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("anthropic")), "shared"),
+            Some(RouteKind::Anthropic)
+        );
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("openai")), "shared"),
+            Some(RouteKind::Openai)
+        );
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("anthropic")), "openai-only"),
+            None
+        );
+        assert_eq!(
+            router.select_for(Some(&ProviderId::new("unknown")), "shared"),
+            None
+        );
+    }
+
+    #[test]
     fn empty_router_selects_nothing() {
         let router = Router::build(vec![]);
         assert_eq!(router.select("claude-opus-4-8"), None);
@@ -311,7 +385,9 @@ mod tests {
         let router = Router::build(vec![]);
         let result = router
             .stream(ChatRequest {
+                provider: Some(ProviderId::new("anthropic")),
                 model: "nope".into(),
+                reasoning_model: false,
                 system: None,
                 messages: vec![],
                 tools: vec![],
@@ -321,7 +397,7 @@ mod tests {
             })
             .await;
         match result {
-            Err(err) => assert!(err.to_string().contains("no enabled provider")),
+            Err(err) => assert!(err.to_string().contains("unavailable")),
             Ok(_) => panic!("expected fail-closed error"),
         }
     }

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -5,6 +5,41 @@
 //! extract the `data:` JSON payload — the same shape Anthropic and OpenAI-compat
 //! both speak.
 
+use futures::{Stream, StreamExt};
+
+/// Maximum provider error bytes inspected for classification.
+///
+/// Error responses are untrusted and may be arbitrarily large. The adapters
+/// stop reading at this boundary before parsing or constructing a durable
+/// client-visible failure.
+pub const MAX_PROVIDER_ERROR_BODY_BYTES: usize = 8 * 1024;
+
+/// Consume at most [`MAX_PROVIDER_ERROR_BODY_BYTES`] from an HTTP byte stream.
+///
+/// The caller drops the remaining response stream after this returns. Invalid
+/// or truncated UTF-8 is tolerated because the result is only an untrusted
+/// classification hint and is never forwarded verbatim.
+pub async fn read_bounded_error_body<S, B, E>(chunks: S) -> String
+where
+    S: Stream<Item = Result<B, E>>,
+    B: AsRef<[u8]>,
+{
+    futures::pin_mut!(chunks);
+    let mut body = Vec::with_capacity(MAX_PROVIDER_ERROR_BODY_BYTES);
+    while body.len() < MAX_PROVIDER_ERROR_BODY_BYTES {
+        let Some(Ok(chunk)) = chunks.next().await else {
+            break;
+        };
+        let bytes = chunk.as_ref();
+        let take = bytes.len().min(MAX_PROVIDER_ERROR_BODY_BYTES - body.len());
+        body.extend_from_slice(&bytes[..take]);
+        if take < bytes.len() {
+            break;
+        }
+    }
+    String::from_utf8_lossy(&body).into_owned()
+}
+
 /// Naive byte-substring search.
 fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     if needle.is_empty() || haystack.len() < needle.len() {
@@ -75,12 +110,26 @@ pub fn safe_http_error(provider: &str, status: u16, body: &str) -> String {
             err.get("type")
                 .or_else(|| err.get("code"))
                 .and_then(serde_json::Value::as_str)
+                .filter(|code| safe_error_code(code))
                 .map(str::to_owned)
         });
     match detail {
         Some(code) => format!("{provider} returned {status} ({code})"),
         None => format!("{provider} returned {status}"),
     }
+}
+
+/// Accept only a compact enum-style token. Error fields come from an
+/// untrusted gateway and may otherwise contain echoed credentials, prompts, or
+/// control characters that would reach the renderer through `TurnFailed`.
+fn safe_error_code(code: &str) -> bool {
+    const MAX_ERROR_CODE_BYTES: usize = 48;
+    let bytes = code.as_bytes();
+    matches!(bytes.first(), Some(b'a'..=b'z'))
+        && bytes.len() <= MAX_ERROR_CODE_BYTES
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'_')
 }
 
 /// Classify a provider HTTP error, detecting prompt-too-long patterns that the
@@ -92,29 +141,64 @@ pub fn classify_provider_error(
 ) -> openwave_core::error::AgentError {
     use openwave_core::error::AgentError;
 
-    if status == 400 {
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
-            let err = parsed.get("error").unwrap_or(&parsed);
-            let code = err
-                .get("code")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("");
-            let message = err
-                .get("message")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("");
+    let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
+    let error = parsed
+        .as_ref()
+        .map(|value| value.get("error").unwrap_or(value));
+    let code = error
+        .and_then(|error| error.get("code").or_else(|| error.get("type")))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let message = error
+        .and_then(|error| error.get("message"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let safe = || safe_http_error(provider, status, body);
 
-            if code == "context_length_exceeded" || message.contains("prompt is too long") {
-                return AgentError::PromptTooLong(safe_http_error(provider, status, body));
-            }
-        }
+    if status == 400
+        && (code == "context_length_exceeded" || message.contains("prompt is too long"))
+    {
+        return AgentError::PromptTooLong(safe());
     }
-    AgentError::Provider(safe_http_error(provider, status, body))
+    if matches!(status, 401 | 403) || matches!(code, "authentication_error" | "invalid_api_key") {
+        return AgentError::Authentication(safe());
+    }
+    if status == 429 || code == "rate_limit_error" {
+        return AgentError::RateLimited(safe());
+    }
+    if matches!(status, 502 | 503 | 504 | 529)
+        || matches!(code, "overloaded_error" | "server_overloaded")
+    {
+        return AgentError::Overloaded(safe());
+    }
+    if matches!(
+        code,
+        "content_policy_violation" | "content_filter" | "refusal"
+    ) {
+        return AgentError::Refusal(safe());
+    }
+    if status == 400 || status == 422 || code == "invalid_request_error" {
+        return AgentError::InvalidRequest(safe());
+    }
+    AgentError::Provider(safe())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn provider_error_body_reader_stops_at_the_fixed_byte_limit() {
+        let chunks = futures::stream::iter([
+            Ok::<_, ()>(vec![b'a'; MAX_PROVIDER_ERROR_BODY_BYTES - 2]),
+            Ok(vec![b'b'; 16 * 1024]),
+            Ok(b"must not be consumed".to_vec()),
+        ]);
+        let body = read_bounded_error_body(chunks).await;
+        assert_eq!(body.len(), MAX_PROVIDER_ERROR_BODY_BYTES);
+        assert!(body.ends_with("bb"));
+        assert!(!body.contains("must not be consumed"));
+    }
 
     #[test]
     fn drain_frames_handles_lf_crlf_and_partial_tail() {
@@ -174,24 +258,55 @@ mod tests {
     }
 
     #[test]
-    fn classify_returns_provider_for_other_400s() {
+    fn classify_returns_invalid_request_for_other_400s() {
         use openwave_core::error::AgentError;
         let body = r#"{"error":{"type":"invalid_request_error","message":"invalid api key"}}"#;
         let err = classify_provider_error("anthropic", 400, body);
         assert!(
-            matches!(err, AgentError::Provider(_)),
-            "expected Provider, got {err:?}"
+            matches!(err, AgentError::InvalidRequest(_)),
+            "expected InvalidRequest, got {err:?}"
         );
     }
 
     #[test]
-    fn classify_returns_provider_for_non_400_status() {
+    fn classify_distinguishes_auth_rate_limit_overload_and_refusal() {
         use openwave_core::error::AgentError;
-        let body = r#"{"error":{"type":"overloaded_error"}}"#;
-        let err = classify_provider_error("anthropic", 529, body);
-        assert!(
-            matches!(err, AgentError::Provider(_)),
-            "expected Provider, got {err:?}"
+        assert!(matches!(
+            classify_provider_error("provider", 401, "{}"),
+            AgentError::Authentication(_)
+        ));
+        assert!(matches!(
+            classify_provider_error("provider", 429, "{}"),
+            AgentError::RateLimited(_)
+        ));
+        assert!(matches!(
+            classify_provider_error("anthropic", 529, r#"{"error":{"type":"overloaded_error"}}"#),
+            AgentError::Overloaded(_)
+        ));
+        assert!(matches!(
+            classify_provider_error("provider", 400, r#"{"error":{"code":"content_filter"}}"#),
+            AgentError::Refusal(_)
+        ));
+    }
+
+    #[test]
+    fn safe_http_error_rejects_untrusted_code_text() {
+        let raw = "sk-secret request fragment\nnext";
+        let body = serde_json::json!({
+            "error": {
+                "code": raw,
+                "message": "another secret"
+            }
+        })
+        .to_string();
+        let error = safe_http_error("openai-compat", 401, &body);
+        assert_eq!(error, "openai-compat returned 401");
+        assert!(!error.contains("secret"));
+        assert!(!error.contains("fragment"));
+
+        assert_eq!(
+            safe_http_error("anthropic", 429, r#"{"error":{"type":"rate_limit_error"}}"#),
+            "anthropic returned 429 (rate_limit_error)"
         );
     }
 }

--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -43,6 +43,17 @@ impl ServerError {
         }
     }
 
+    /// A `400 Bad Request` with a route-specific stable machine-readable kind.
+    pub(crate) fn bad_request_kind(kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            info: AgentErrorInfo {
+                kind: kind.to_owned(),
+                message: message.into(),
+            },
+        }
+    }
+
     /// A `413 Payload Too Large` for a request that exceeds an endpoint's
     /// explicit body-size limit.
     pub fn payload_too_large(message: impl Into<String>) -> Self {

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -25,7 +25,11 @@ impl InputModality {
     }
 }
 
-const TEXT_AND_IMAGE: &[InputModality] = &[InputModality::Text, InputModality::Image];
+const TEXT_ONLY: &[InputModality] = &[InputModality::Text];
+
+/// Separator in the stable provider-scoped selection key persisted for new
+/// defaults, chat overrides, and turn receipts.
+pub const MODEL_KEY_SEPARATOR: &str = "::";
 
 /// Capability and presentation metadata for a curated model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,6 +54,7 @@ pub struct ModelSpec {
 
 impl ModelSpec {
     /// Whether this model accepts `modality`.
+    #[cfg(test)]
     pub fn accepts(&self, modality: InputModality) -> bool {
         self.input_modalities.contains(&modality)
     }
@@ -63,7 +68,10 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 1_000_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_AND_IMAGE,
+        // The upstream model accepts images, but OpenWave's normalized content
+        // contract is text/tool-only today. Do not advertise a capability that
+        // cannot make it through the complete request path.
+        input_modalities: TEXT_ONLY,
         supports_reasoning: true,
         // The Anthropic adapter can stream thinking blocks, but it does not
         // currently send a caller-selected effort or thinking budget.
@@ -75,7 +83,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 1_000_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_AND_IMAGE,
+        input_modalities: TEXT_ONLY,
         supports_reasoning: true,
         supports_reasoning_effort: false,
     },
@@ -85,7 +93,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 200_000,
         max_output_tokens: 64_000,
-        input_modalities: TEXT_AND_IMAGE,
+        input_modalities: TEXT_ONLY,
         supports_reasoning: true,
         supports_reasoning_effort: false,
     },
@@ -95,7 +103,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Openai,
         context_window: 128_000,
         max_output_tokens: 16_384,
-        input_modalities: TEXT_AND_IMAGE,
+        input_modalities: TEXT_ONLY,
         supports_reasoning: false,
         supports_reasoning_effort: false,
     },
@@ -105,7 +113,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Openai,
         context_window: 128_000,
         max_output_tokens: 16_384,
-        input_modalities: TEXT_AND_IMAGE,
+        input_modalities: TEXT_ONLY,
         supports_reasoning: false,
         supports_reasoning_effort: false,
     },
@@ -115,7 +123,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Openai,
         context_window: 200_000,
         max_output_tokens: 100_000,
-        input_modalities: TEXT_AND_IMAGE,
+        input_modalities: TEXT_ONLY,
         supports_reasoning: true,
         supports_reasoning_effort: true,
     },
@@ -125,7 +133,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Openai,
         context_window: 200_000,
         max_output_tokens: 100_000,
-        input_modalities: TEXT_AND_IMAGE,
+        input_modalities: TEXT_ONLY,
         supports_reasoning: true,
         supports_reasoning_effort: true,
     },
@@ -138,9 +146,49 @@ pub fn models_for(provider: ProviderKind) -> impl Iterator<Item = &'static Model
         .filter(move |spec| spec.provider == provider)
 }
 
-/// Find an exact curated model id.
+/// Find a bare curated model id only when exactly one provider owns it.
 pub fn find(id: &str) -> Option<&'static ModelSpec> {
-    MODEL_REGISTRY.iter().find(|spec| spec.id == id)
+    let mut matches = models_named(id);
+    let first = matches.next()?;
+    matches.next().is_none().then_some(first)
+}
+
+/// Curated provider owners for a raw model id.
+pub fn models_named(id: &str) -> impl Iterator<Item = &'static ModelSpec> + Clone + '_ {
+    MODEL_REGISTRY.iter().filter(move |spec| spec.id == id)
+}
+
+/// Find an exact curated model under the provider that owns it.
+pub fn find_for(provider: ProviderKind, id: &str) -> Option<&'static ModelSpec> {
+    MODEL_REGISTRY
+        .iter()
+        .find(|spec| spec.provider == provider && spec.id == id)
+}
+
+/// Build the stable provider-scoped key used at all public selection
+/// boundaries. The provider is never inferred again after this point.
+pub fn selection_key(provider: ProviderKind, id: &str) -> String {
+    format!("{}{MODEL_KEY_SEPARATOR}{id}", provider.as_str())
+}
+
+/// Parse a provider-scoped selection key. Model ids may themselves contain the
+/// separator; only the first separator is structural.
+pub fn parse_selection_key(value: &str) -> Option<(ProviderKind, &str)> {
+    let (provider, id) = value.split_once(MODEL_KEY_SEPARATOR)?;
+    let provider = ProviderKind::parse(provider)?;
+    if id.is_empty() {
+        return None;
+    }
+    Some((provider, id))
+}
+
+/// Canonicalize an old bare curated id without changing which provider owns it.
+#[cfg(test)]
+pub fn migrate_curated_selection(value: &str) -> Option<String> {
+    if let Some((provider, id)) = parse_selection_key(value) {
+        return find_for(provider, id).map(|_| selection_key(provider, id));
+    }
+    find(value).map(|spec| selection_key(spec.provider, spec.id))
 }
 
 /// Human label for a model id, including a readable fallback for custom ids.
@@ -209,14 +257,24 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
-    fn registry_ids_are_unique_and_capabilities_are_well_formed() {
-        let mut ids = HashSet::new();
+    fn registry_provider_model_keys_are_unique_and_capabilities_are_well_formed() {
+        let mut keys = HashSet::new();
         for spec in MODEL_REGISTRY {
-            assert!(ids.insert(spec.id), "duplicate model id {}", spec.id);
+            assert!(
+                keys.insert((spec.provider, spec.id)),
+                "duplicate provider/model key {}::{}",
+                spec.provider,
+                spec.id
+            );
             assert!(spec.context_window > 0);
             assert!(spec.max_output_tokens > 0);
             assert!(spec.context_window >= spec.max_output_tokens);
             assert!(spec.accepts(InputModality::Text));
+            assert!(
+                !spec.accepts(InputModality::Image),
+                "{} advertises image input before the provider contract supports it",
+                spec.id
+            );
             assert!(
                 !spec.supports_reasoning_effort || spec.supports_reasoning,
                 "{} exposes reasoning effort without reasoning",
@@ -260,5 +318,25 @@ mod tests {
         );
         assert_eq!(display_name_for("gpt-6-2026-01-01"), "GPT 6");
         assert_eq!(display_name_for("local-model"), "Local Model");
+    }
+
+    #[test]
+    fn selection_keys_are_provider_scoped_and_legacy_ids_migrate_losslessly() {
+        let key = selection_key(ProviderKind::Openai, "gpt-4o");
+        assert_eq!(key, "openai::gpt-4o");
+        assert_eq!(
+            parse_selection_key(&key),
+            Some((ProviderKind::Openai, "gpt-4o"))
+        );
+        assert_eq!(
+            parse_selection_key("openai_compatible::vendor::model"),
+            Some((ProviderKind::OpenaiCompatible, "vendor::model"))
+        );
+        assert_eq!(
+            migrate_curated_selection("gpt-4o").as_deref(),
+            Some("openai::gpt-4o")
+        );
+        assert!(migrate_curated_selection("anthropic::gpt-4o").is_none());
+        assert!(parse_selection_key("unknown::gpt-4o").is_none());
     }
 }

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -12,10 +12,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use openwave_core::{Result, SecretProvider, Store};
+use openwave_core::{AgentConfig, ProviderId, ReasoningEffort, Result, SecretProvider, Store};
 
 use crate::error::ServerError;
-use crate::model_registry::{self, ModelSpec};
+use crate::model_registry::{self, InputModality, ModelSpec};
 
 /// Setting-key prefix for per-provider non-secret config (`provider.<kind>`).
 const PROVIDER_SETTING_PREFIX: &str = "provider.";
@@ -131,6 +131,13 @@ pub struct ProviderConfig {
     /// Optional base URL override (required for `openai_compatible`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+    /// Explicit model ids served by a custom OpenAI-compatible endpoint.
+    ///
+    /// Curated providers ignore this field and obtain their models from the
+    /// host registry. Keeping custom entries beside the endpoint removes the
+    /// old ambiguous global free-form model setting.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<CustomModelConfig>,
 }
 
 impl ProviderConfig {
@@ -139,8 +146,135 @@ impl ProviderConfig {
         Self {
             enabled: false,
             base_url: None,
+            models: Vec::new(),
         }
     }
+}
+
+fn default_custom_context_window() -> u32 {
+    32_768
+}
+
+fn default_custom_max_output_tokens() -> u32 {
+    4_096
+}
+
+/// Conservative, user-inspectable capabilities for one model served by an
+/// OpenAI-compatible endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CustomModelConfig {
+    /// Exact model id sent to the endpoint.
+    pub id: String,
+    /// Optional human-facing label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    /// Context limit used by OpenWave's reducer.
+    #[serde(default = "default_custom_context_window")]
+    pub context_window: u32,
+    /// Maximum output sent to the endpoint.
+    #[serde(default = "default_custom_max_output_tokens")]
+    pub max_output_tokens: u32,
+}
+
+/// Owned runtime policy resolved from a provider-qualified selection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedModelPolicy {
+    /// Stable provider-qualified selection key.
+    pub key: String,
+    /// Raw model id sent to the provider.
+    pub id: String,
+    /// Human-readable label.
+    pub display_name: String,
+    /// Exact provider route.
+    pub provider: ProviderKind,
+    /// Runtime context reduction limit.
+    pub context_window: u32,
+    /// Runtime output cap.
+    pub max_output_tokens: u32,
+    /// End-to-end supported input modalities.
+    pub input_modalities: Vec<InputModality>,
+    /// Whether the provider request uses a reasoning-model shape.
+    pub supports_reasoning: bool,
+    /// Whether the chat may set a reasoning-effort override.
+    pub supports_reasoning_effort: bool,
+}
+
+impl ResolvedModelPolicy {
+    fn curated(spec: &ModelSpec) -> Self {
+        Self {
+            key: model_registry::selection_key(spec.provider, spec.id),
+            id: spec.id.to_owned(),
+            display_name: spec.display_name.to_owned(),
+            provider: spec.provider,
+            context_window: spec.context_window,
+            max_output_tokens: spec.max_output_tokens,
+            input_modalities: spec.input_modalities.to_vec(),
+            supports_reasoning: spec.supports_reasoning,
+            supports_reasoning_effort: spec.supports_reasoning_effort,
+        }
+    }
+
+    fn custom(model: &CustomModelConfig) -> Self {
+        Self {
+            key: model_registry::selection_key(ProviderKind::OpenaiCompatible, &model.id),
+            id: model.id.clone(),
+            display_name: model
+                .display_name
+                .clone()
+                .unwrap_or_else(|| model_registry::display_name_for(&model.id)),
+            provider: ProviderKind::OpenaiCompatible,
+            context_window: model.context_window,
+            max_output_tokens: model.max_output_tokens,
+            input_modalities: vec![InputModality::Text],
+            // Unknown endpoints get deliberately conservative request shaping.
+            // Capability editing can be added later without changing the key.
+            supports_reasoning: false,
+            supports_reasoning_effort: false,
+        }
+    }
+
+    fn legacy_custom(id: &str) -> Self {
+        Self::custom(&CustomModelConfig {
+            id: id.to_owned(),
+            display_name: None,
+            context_window: default_custom_context_window(),
+            max_output_tokens: default_custom_max_output_tokens(),
+        })
+    }
+}
+
+/// Apply one resolved registry row to the provider-neutral agent config.
+///
+/// The stored selection key never reaches an adapter: requests carry the raw
+/// model id plus the exact provider hint. Unsupported reasoning controls are
+/// normalized away before provider dispatch.
+pub fn apply_model_policy(
+    config: &mut AgentConfig,
+    policy: &ResolvedModelPolicy,
+    reasoning_effort: Option<ReasoningEffort>,
+) -> Result<()> {
+    config.provider = Some(ProviderId::new(policy.provider.as_str()));
+    config.model = policy.id.clone();
+    config.reasoning_model = policy.supports_reasoning;
+    config.context_window = usize::try_from(policy.context_window)
+        .map_err(|_| openwave_core::AgentError::config("model context window is unsupported"))?;
+    config.max_tokens = Some(policy.max_output_tokens);
+    config.reasoning_effort = policy
+        .supports_reasoning_effort
+        .then_some(reasoning_effort)
+        .flatten();
+    if policy.supports_reasoning {
+        config.temperature = None;
+    }
+    Ok(())
+}
+
+/// Public catalog row plus current provider readiness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogModel {
+    pub policy: ResolvedModelPolicy,
+    pub available: bool,
 }
 
 /// Public view of a provider — never includes the credential itself.
@@ -155,6 +289,8 @@ pub struct ProviderInfo {
     pub base_url: Option<String>,
     /// Whether a credential is stored (never the credential itself).
     pub has_credential: bool,
+    /// Explicit custom model entries for this endpoint.
+    pub models: Vec<CustomModelConfig>,
 }
 
 /// Deserialize a present field (including JSON `null`) as `Some(..)`;
@@ -178,6 +314,9 @@ pub struct ProviderUpdate {
     pub base_url: Option<Option<String>>,
     #[serde(default)]
     pub credential: Option<ProviderCredential>,
+    /// Replacement custom-model list. Only valid for `openai_compatible`.
+    #[serde(default)]
+    pub models: Option<Vec<CustomModelConfig>>,
 }
 
 /// Read the stored config for `kind`, or the disabled default.
@@ -275,8 +414,9 @@ pub async fn list_providers(
         out.push(ProviderInfo {
             kind,
             enabled: config.enabled,
-            base_url: config.base_url,
+            base_url: config.base_url.clone(),
             has_credential: has_credential(secrets, kind).await,
+            models: config.models,
         });
     }
     Ok(out)
@@ -304,6 +444,15 @@ pub async fn update_provider(
             config.base_url = Some(url);
         }
     }
+    if let Some(models) = update.models {
+        if kind != ProviderKind::OpenaiCompatible {
+            return Err(ServerError::bad_request(
+                "custom models are only supported by openai_compatible",
+            ));
+        }
+        validate_custom_models(&models)?;
+        config.models = models;
+    }
 
     // openai_compatible needs a base URL to be useful when enabled.
     if kind == ProviderKind::OpenaiCompatible && config.enabled && config.base_url.is_none() {
@@ -327,9 +476,81 @@ pub async fn update_provider(
     Ok(ProviderInfo {
         kind,
         enabled: config.enabled,
-        base_url: config.base_url,
+        base_url: config.base_url.clone(),
         has_credential: has_credential(secrets, kind).await,
+        models: config.models,
     })
+}
+
+fn validate_custom_models(models: &[CustomModelConfig]) -> std::result::Result<(), ServerError> {
+    validate_custom_models_against(models, |id| {
+        model_registry::find_for(ProviderKind::OpenaiCompatible, id).is_some()
+    })
+}
+
+fn validate_custom_models_against(
+    models: &[CustomModelConfig],
+    is_curated: impl Fn(&str) -> bool,
+) -> std::result::Result<(), ServerError> {
+    const MAX_CUSTOM_MODELS: usize = 64;
+    const MAX_MODEL_ID_CHARS: usize = 240;
+    const MAX_DISPLAY_NAME_CHARS: usize = 120;
+    const MAX_CONTEXT_WINDOW: u32 = 4_000_000;
+
+    if models.len() > MAX_CUSTOM_MODELS {
+        return Err(ServerError::bad_request(format!(
+            "openai_compatible supports at most {MAX_CUSTOM_MODELS} custom models"
+        )));
+    }
+    let mut ids = std::collections::HashSet::new();
+    for model in models {
+        let id = model.id.trim();
+        if id.is_empty()
+            || id.chars().count() > MAX_MODEL_ID_CHARS
+            || id.chars().any(char::is_whitespace)
+            || id.chars().any(char::is_control)
+        {
+            return Err(ServerError::bad_request(
+                "custom model id must be non-empty, bounded, and contain no whitespace or control characters",
+            ));
+        }
+        if id != model.id {
+            return Err(ServerError::bad_request(
+                "custom model id must not have leading or trailing whitespace",
+            ));
+        }
+        if !ids.insert(id) {
+            return Err(ServerError::bad_request(format!(
+                "duplicate custom model id `{id}`"
+            )));
+        }
+        if is_curated(id) {
+            return Err(ServerError::bad_request(format!(
+                "custom model id `{id}` conflicts with a curated openai_compatible model"
+            )));
+        }
+        if model.display_name.as_ref().is_some_and(|name| {
+            name.trim().is_empty()
+                || name.trim() != name
+                || name.chars().count() > MAX_DISPLAY_NAME_CHARS
+                || name.chars().any(char::is_control)
+        }) {
+            return Err(ServerError::bad_request(
+                "custom model display_name must be non-empty, bounded, and contain no control characters",
+            ));
+        }
+        if !(1_024..=MAX_CONTEXT_WINDOW).contains(&model.context_window) {
+            return Err(ServerError::bad_request(format!(
+                "custom model `{id}` context_window must be between 1024 and {MAX_CONTEXT_WINDOW}"
+            )));
+        }
+        if model.max_output_tokens == 0 || model.max_output_tokens > model.context_window {
+            return Err(ServerError::bad_request(format!(
+                "custom model `{id}` max_output_tokens must be positive and not exceed context_window"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Resolve an API-key credential for `kind`: stored blob (or Anthropic legacy),
@@ -404,6 +625,7 @@ pub async fn collect_routes(
             base_url: config.base_url,
             curated_models: model_registry::models_for(kind)
                 .map(|spec| spec.id.to_string())
+                .chain(config.models.into_iter().map(|model| model.id))
                 .collect(),
         });
     }
@@ -434,6 +656,7 @@ pub async fn migrate_legacy_anthropic(
             &ProviderConfig {
                 enabled: true,
                 base_url: None,
+                models: Vec::new(),
             },
         )
         .await?;
@@ -441,27 +664,92 @@ pub async fn migrate_legacy_anthropic(
     Ok(())
 }
 
-/// Model specs from providers that are both enabled and credentialed.
+/// Resolve a stored or wire selection into an authoritative runtime policy.
+///
+/// Bare curated ids are migrated losslessly to their owning provider. Bare
+/// custom ids resolve only when explicitly configured, except when
+/// `allow_legacy_custom` is true: that narrow path preserves pre-registry rows
+/// which historically routed unknown ids to OpenAI-compatible.
+pub async fn resolve_model_policy(
+    store: &dyn Store,
+    value: &str,
+    allow_legacy_custom: bool,
+) -> Result<Option<ResolvedModelPolicy>> {
+    if let Some((provider, id)) = model_registry::parse_selection_key(value) {
+        if let Some(spec) = model_registry::find_for(provider, id) {
+            return Ok(Some(ResolvedModelPolicy::curated(spec)));
+        }
+        if provider != ProviderKind::OpenaiCompatible {
+            return Ok(None);
+        }
+        let config = read_config(store, provider).await?;
+        return Ok(config
+            .models
+            .iter()
+            .find(|model| model.id == id)
+            .map(ResolvedModelPolicy::custom));
+    }
+
+    let config = read_config(store, ProviderKind::OpenaiCompatible).await?;
+    let mut owners = model_registry::models_named(value)
+        .map(ResolvedModelPolicy::curated)
+        .collect::<Vec<_>>();
+    owners.extend(
+        config
+            .models
+            .iter()
+            .filter(|model| model.id == value)
+            .map(ResolvedModelPolicy::custom),
+    );
+    match owners.len() {
+        1 => return Ok(owners.pop()),
+        count if count > 1 => return Ok(None),
+        _ => {}
+    }
+    Ok(allow_legacy_custom.then(|| ResolvedModelPolicy::legacy_custom(value)))
+}
+
+/// Whether the provider can accept a new turn right now.
+pub async fn provider_is_usable(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    kind: ProviderKind,
+) -> Result<bool> {
+    let config = read_config(store, kind).await?;
+    if !config.enabled || !has_credential(secrets, kind).await {
+        return Ok(false);
+    }
+    if kind == ProviderKind::OpenaiCompatible {
+        let Some(base) = config.base_url.as_deref() else {
+            return Ok(false);
+        };
+        if !(base.starts_with("https://") || base.starts_with("http://")) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Full typed catalog. Unavailable rows remain visible for provider-scoped
+/// settings, but clients must not offer them as usable selections.
 pub async fn catalog_models(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
-) -> Result<Vec<&'static ModelSpec>> {
-    let mut models: Vec<&'static ModelSpec> = Vec::new();
+) -> Result<Vec<CatalogModel>> {
+    let mut models = Vec::new();
     for &kind in ProviderKind::ALL {
         let config = read_config(store, kind).await?;
-        if !config.enabled {
-            continue;
+        let available = provider_is_usable(store, secrets, kind).await?;
+        models.extend(model_registry::models_for(kind).map(|spec| CatalogModel {
+            policy: ResolvedModelPolicy::curated(spec),
+            available,
+        }));
+        if kind == ProviderKind::OpenaiCompatible {
+            models.extend(config.models.iter().map(|model| CatalogModel {
+                policy: ResolvedModelPolicy::custom(model),
+                available,
+            }));
         }
-        if !has_credential(secrets, kind).await {
-            continue;
-        }
-        models.extend(model_registry::models_for(kind));
-    }
-    // If nothing is enabled+credentialed yet, still surface Anthropic's curated
-    // list so a fresh install's model selector isn't empty before the user
-    // finishes provider setup (turns still fail-closed without a key).
-    if models.is_empty() {
-        models.extend(model_registry::models_for(ProviderKind::Anthropic));
     }
     Ok(models)
 }
@@ -492,5 +780,107 @@ mod tests {
             "provider.anthropic.credential"
         );
         assert_eq!(ProviderKind::Openai.setting_key(), "provider.openai");
+    }
+
+    #[test]
+    fn custom_model_validation_is_conservative_and_rejects_duplicates() {
+        let valid = CustomModelConfig {
+            id: "local/model".into(),
+            display_name: Some("Local Model".into()),
+            context_window: 32_768,
+            max_output_tokens: 4_096,
+        };
+        assert!(validate_custom_models(std::slice::from_ref(&valid)).is_ok());
+        assert!(validate_custom_models(&[valid.clone(), valid.clone()]).is_err());
+        assert!(
+            validate_custom_models_against(std::slice::from_ref(&valid), |id| id == "local/model")
+                .is_err(),
+            "custom ids must not shadow a curated id under the same provider"
+        );
+        assert!(validate_custom_models(&[CustomModelConfig {
+            id: "bad model".into(),
+            display_name: None,
+            context_window: 32_768,
+            max_output_tokens: 4_096,
+        }])
+        .is_err());
+        assert!(validate_custom_models(&[CustomModelConfig {
+            id: "bad".into(),
+            display_name: None,
+            context_window: 1_000,
+            max_output_tokens: 4_096,
+        }])
+        .is_err());
+    }
+
+    #[test]
+    fn registry_policy_controls_context_output_provider_and_reasoning() {
+        let mut config = AgentConfig {
+            temperature: Some(0.7),
+            reasoning_effort: Some(ReasoningEffort::High),
+            ..AgentConfig::default()
+        };
+        let opus = ResolvedModelPolicy::curated(
+            model_registry::find_for(ProviderKind::Anthropic, "claude-opus-4-8").unwrap(),
+        );
+        apply_model_policy(&mut config, &opus, Some(ReasoningEffort::High)).unwrap();
+        assert_eq!(config.provider, Some(ProviderId::new("anthropic")));
+        assert_eq!(config.model, "claude-opus-4-8");
+        assert_eq!(config.context_window, 1_000_000);
+        assert_eq!(config.max_tokens, Some(128_000));
+        assert_eq!(config.reasoning_effort, None);
+        assert_eq!(config.temperature, None);
+
+        let mut config = AgentConfig::default();
+        let gpt = ResolvedModelPolicy::curated(
+            model_registry::find_for(ProviderKind::Openai, "gpt-4o").unwrap(),
+        );
+        apply_model_policy(&mut config, &gpt, Some(ReasoningEffort::High)).unwrap();
+        assert_eq!(config.provider, Some(ProviderId::new("openai")));
+        assert_eq!(config.context_window, 128_000);
+        assert_eq!(config.max_tokens, Some(16_384));
+        assert!(!config.reasoning_model);
+        assert_eq!(config.reasoning_effort, None);
+
+        let mut config = AgentConfig::default();
+        let o3 = ResolvedModelPolicy::curated(
+            model_registry::find_for(ProviderKind::Openai, "o3").unwrap(),
+        );
+        apply_model_policy(&mut config, &o3, Some(ReasoningEffort::Low)).unwrap();
+        assert!(config.reasoning_model);
+        assert_eq!(config.reasoning_effort, Some(ReasoningEffort::Low));
+    }
+
+    #[test]
+    fn every_curated_model_applies_its_exact_runtime_contract() {
+        for &provider in ProviderKind::ALL {
+            for spec in model_registry::models_for(provider) {
+                let mut config = AgentConfig {
+                    temperature: Some(0.7),
+                    reasoning_effort: Some(ReasoningEffort::High),
+                    ..AgentConfig::default()
+                };
+                let policy = ResolvedModelPolicy::curated(spec);
+                apply_model_policy(&mut config, &policy, Some(ReasoningEffort::Low)).unwrap();
+
+                assert_eq!(config.provider, Some(ProviderId::new(provider.as_str())));
+                assert_eq!(config.model, spec.id);
+                assert_eq!(
+                    config.context_window,
+                    usize::try_from(spec.context_window).unwrap()
+                );
+                assert_eq!(config.max_tokens, Some(spec.max_output_tokens));
+                assert_eq!(config.reasoning_model, spec.supports_reasoning);
+                assert_eq!(
+                    config.reasoning_effort,
+                    spec.supports_reasoning_effort
+                        .then_some(ReasoningEffort::Low)
+                );
+                assert_eq!(
+                    config.temperature,
+                    (!spec.supports_reasoning).then_some(0.7)
+                );
+            }
+        }
     }
 }

--- a/crates/openwave-server/src/resolver.rs
+++ b/crates/openwave-server/src/resolver.rs
@@ -28,14 +28,24 @@ pub trait ProviderResolver: Send + Sync {
     /// Resolve the provider. Infallible: with no credentials it returns a
     /// fail-closed provider, so a turn surfaces `TurnFailed` instead of egressing.
     async fn resolve(&self) -> Arc<dyn ModelProvider>;
+
+    /// Whether public model selections must resolve through the host registry.
+    ///
+    /// Production configured routing returns true. Test/custom embedders that
+    /// inject one provider keep their existing free-form model contract.
+    fn enforces_model_registry(&self) -> bool {
+        false
+    }
 }
 
 /// Resolves a composite [`Router`] from enabled, credentialed providers — or a
 /// fail-closed provider when none are configured.
 ///
-/// Selection happens inside the router on `stream(req)` from `req.model`
-/// (curated catalog match, else openai_compatible free-form fallback). No
-/// default provider: empty config ⇒ no egress.
+/// Selection happens inside the router from the host-resolved provider hint and
+/// raw provider model ID. It never crosses to another provider implicitly. The
+/// OpenAI-compatible free-form fallback remains only for legacy stored rows;
+/// new public selections must be registered first. No default provider: empty
+/// config ⇒ no egress.
 pub struct ConfiguredResolver {
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
@@ -81,5 +91,9 @@ impl ProviderResolver for ConfiguredResolver {
         };
         *cached = Some((fingerprint, provider.clone()));
         provider
+    }
+
+    fn enforces_model_registry(&self) -> bool {
+        true
     }
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -95,8 +95,11 @@ pub async fn get_settings(State(state): State<AppState>) -> Result<Json<Settings
 /// fields present in the body are touched.
 pub async fn put_settings(
     State(state): State<AppState>,
-    Json(body): Json<SettingsUpdate>,
+    Json(mut body): Json<SettingsUpdate>,
 ) -> Result<Json<Settings>, ServerError> {
+    if let Some(Some(model)) = body.model.as_mut() {
+        *model = validate_model_selection(&state, model, false).await?;
+    }
     match body.model {
         // Absent: leave the model unchanged.
         None => {}
@@ -249,6 +252,43 @@ async fn read_model(store: &dyn Store) -> Result<Option<String>, ServerError> {
         .and_then(|value| value.as_str().map(str::to_owned)))
 }
 
+/// Resolve, canonicalize, and availability-check a model selection before it
+/// crosses a persistence boundary. Custom embedders with an injected provider
+/// retain their free-form model contract; the production configured resolver
+/// always enforces the typed registry.
+async fn validate_model_selection(
+    state: &AppState,
+    value: &str,
+    allow_legacy_custom: bool,
+) -> Result<String, ServerError> {
+    if value.is_empty() {
+        return Err(ServerError::bad_request("model must not be empty"));
+    }
+    if !state.resolver.enforces_model_registry() {
+        return Ok(value.to_owned());
+    }
+    let Some(policy) =
+        providers::resolve_model_policy(&*state.store, value, allow_legacy_custom).await?
+    else {
+        return Err(ServerError::bad_request_kind(
+            "unknown_model",
+            format!(
+                "model `{value}` is not registered for that provider; configure it under OpenAI-compatible models first"
+            ),
+        ));
+    };
+    if !providers::provider_is_usable(&*state.store, &*state.secrets, policy.provider).await? {
+        return Err(ServerError::conflict_kind(
+            "model_provider_unavailable",
+            format!(
+                "provider `{}` for model `{}` is disabled, unconfigured, or missing a credential",
+                policy.provider, policy.id
+            ),
+        ));
+    }
+    Ok(policy.key)
+}
+
 /// Whether any model provider credential is configured — stored or via the
 /// env fallbacks the resolver also honors. Prefer `GET /providers` for
 /// per-kind detail; this field is the legacy "is anything ready?" signal.
@@ -353,12 +393,16 @@ pub async fn delete_provider_credential(
 /// A selectable model in the catalog.
 #[derive(Debug, Serialize)]
 pub struct ModelInfo {
+    /// Stable provider-qualified selection key used by settings and chats.
+    pub key: String,
     /// The identifier passed to the provider and stored as `chat.model`.
     pub id: String,
     /// Human-readable label for the selector (e.g. `"Claude Opus 4.8"`).
     pub display_name: String,
     /// The provider that serves the model.
-    pub provider: String,
+    pub provider: ProviderKind,
+    /// Whether the provider is enabled, configured, and credentialed.
+    pub available: bool,
     /// Approximate context window in tokens.
     pub context_window: u32,
     /// Maximum model output in tokens.
@@ -382,26 +426,32 @@ pub struct ModelCatalog {
 
 /// `GET /models` — the catalog a chat's model selector chooses from.
 ///
-/// Models of enabled, credentialed providers. Falls back to Anthropic's curated
-/// list when nothing is configured yet so the selector isn't empty on first run.
+/// All typed registry rows plus current availability. Clients may explain
+/// unavailable rows, but must never offer them as usable selections.
 pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCatalog>, ServerError> {
     let models = providers::catalog_models(&*state.store, &*state.secrets)
         .await?
         .into_iter()
-        .map(|spec| ModelInfo {
-            id: spec.id.to_string(),
-            display_name: crate::model_registry::display_name_for(spec.id),
-            provider: spec.provider.as_str().to_string(),
-            context_window: spec.context_window,
-            max_output_tokens: spec.max_output_tokens,
-            input_modalities: spec
+        .map(|entry| ModelInfo {
+            key: entry.policy.key,
+            id: entry.policy.id,
+            display_name: entry.policy.display_name,
+            provider: entry.policy.provider,
+            available: entry.available,
+            context_window: entry.policy.context_window,
+            max_output_tokens: entry.policy.max_output_tokens,
+            input_modalities: entry
+                .policy
                 .input_modalities
                 .iter()
                 .map(|modality| modality.as_str().to_string())
                 .collect(),
-            supports_reasoning: spec.supports_reasoning,
-            supports_reasoning_effort: spec.supports_reasoning_effort,
-            multimodal: spec.accepts(crate::model_registry::InputModality::Image),
+            supports_reasoning: entry.policy.supports_reasoning,
+            supports_reasoning_effort: entry.policy.supports_reasoning_effort,
+            multimodal: entry
+                .policy
+                .input_modalities
+                .contains(&crate::model_registry::InputModality::Image),
         })
         .collect();
     Ok(Json(ModelCatalog { models }))
@@ -537,7 +587,7 @@ pub struct CreateChat {
 /// `POST /chats` — create a chat and return it (`201 Created`).
 pub async fn create_chat(
     State(state): State<AppState>,
-    Json(body): Json<CreateChat>,
+    Json(mut body): Json<CreateChat>,
 ) -> Result<impl IntoResponse, ServerError> {
     // Return a product-facing 400 for an unknown project. The Store and schema
     // independently enforce the same membership invariant inside insertion.
@@ -548,8 +598,8 @@ pub async fn create_chat(
             .await?
             .ok_or_else(|| ServerError::not_found(format!("project {project_id} not found")))?;
     }
-    if body.model.as_deref().is_some_and(str::is_empty) {
-        return Err(ServerError::bad_request("model must not be empty"));
+    if let Some(model) = body.model.as_mut() {
+        *model = validate_model_selection(&state, model, false).await?;
     }
     let chat = Chat {
         id: ChatId::new(),
@@ -586,16 +636,12 @@ pub struct ChatUpdate {
 pub async fn patch_chat(
     State(state): State<AppState>,
     Path(id): Path<ChatId>,
-    Json(body): Json<ChatUpdate>,
+    Json(mut body): Json<ChatUpdate>,
 ) -> Result<Json<Chat>, ServerError> {
     // Validate every supplied field before touching durable state. This keeps a
     // mixed request all-or-nothing from the user's point of view.
-    if body
-        .model
-        .as_ref()
-        .is_some_and(|model| model.as_deref().is_some_and(str::is_empty))
-    {
-        return Err(ServerError::bad_request("model must not be empty"));
+    if let Some(Some(model)) = body.model.as_mut() {
+        *model = validate_model_selection(&state, model, false).await?;
     }
     let title = body.title.map(|title| {
         title
@@ -1237,12 +1283,13 @@ pub async fn post_message(
         existing.model
     } else {
         // New-turn resolution order: chat override, global default, boot default.
-        match chat.model.clone() {
+        let selected = match chat.model.clone() {
             Some(model) => model,
             None => read_model(&*state.store)
                 .await?
                 .unwrap_or_else(|| state.agent_config.model.clone()),
-        }
+        };
+        validate_model_selection(&state, &selected, true).await?
     };
     match state
         .store

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -479,8 +479,21 @@ impl SandboxAgentRunWorker {
         } else {
             false
         };
+        let mut agent_config = self.agent_config.clone();
+        if let Some(policy) = if self.resolver.enforces_model_registry() {
+            crate::providers::resolve_model_policy(&*self.store, &agent_config.model, true).await?
+        } else {
+            None
+        } {
+            let reasoning_effort = agent_config.reasoning_effort;
+            crate::providers::apply_model_policy(&mut agent_config, &policy, reasoning_effort)?;
+        } else if self.resolver.enforces_model_registry() {
+            return Err(AgentError::config(
+                "sandbox model is not registered for its provider",
+            ));
+        }
         let request = sandbox_request(
-            &self.agent_config,
+            &agent_config,
             task,
             &previous_calls,
             &*self.store,
@@ -927,7 +940,9 @@ async fn sandbox_request(
         });
     }
     Ok(ChatRequest {
+        provider: config.provider.clone(),
         model: config.model.clone(),
+        reasoning_model: config.reasoning_model,
         system: Some(
             if delegated_file_available {
                 SANDBOX_DELEGATED_FILE_SYSTEM_PROMPT
@@ -1635,7 +1650,9 @@ mod tests {
     #[tokio::test]
     async fn refuses_ambiguous_or_unavailable_sandbox_tool_events_without_checkpointing() {
         let request = ChatRequest {
+            provider: None,
             model: "m".into(),
+            reasoning_model: false,
             system: None,
             messages: vec![],
             tools: vec![],
@@ -2630,7 +2647,9 @@ mod tests {
     #[tokio::test]
     async fn delegated_file_read_rejects_nonempty_arguments() {
         let request = ChatRequest {
+            provider: None,
             model: "m".into(),
+            reasoning_model: false,
             system: Some(SANDBOX_DELEGATED_FILE_SYSTEM_PROMPT.into()),
             messages: vec![ChatMessage::text(Role::User, "task")],
             tools: vec![sandbox_read_delegated_file_tool_spec()],

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -6506,6 +6506,7 @@ async fn resolve_embedder_uses_openai_only_when_enabled_and_keyed() {
         &providers::ProviderConfig {
             enabled: true,
             base_url: None,
+            models: Vec::new(),
         },
     )
     .await
@@ -6523,6 +6524,7 @@ async fn resolve_embedder_uses_openai_only_when_enabled_and_keyed() {
         &providers::ProviderConfig {
             enabled: false,
             base_url: None,
+            models: Vec::new(),
         },
     )
     .await
@@ -8097,14 +8099,13 @@ async fn models_catalog_is_served() {
         .find(|m| m["id"] == "claude-opus-4-8")
         .expect("curated Anthropic model is present");
     assert_eq!(opus["display_name"], "Claude Opus 4.8");
+    assert_eq!(opus["key"], "anthropic::claude-opus-4-8");
     assert_eq!(opus["context_window"], 1_000_000);
     assert_eq!(opus["max_output_tokens"], 128_000);
-    assert_eq!(
-        opus["input_modalities"],
-        serde_json::json!(["text", "image"])
-    );
+    assert_eq!(opus["input_modalities"], serde_json::json!(["text"]));
     assert!(opus["supports_reasoning"].as_bool().unwrap());
-    assert!(opus["multimodal"].as_bool().unwrap());
+    assert!(!opus["multimodal"].as_bool().unwrap());
+    assert!(!opus["available"].as_bool().unwrap());
     // Capabilities describe what the current adapter implements, not only
     // what the upstream model could support with a different request shape.
     assert!(!opus["supports_reasoning_effort"].as_bool().unwrap());
@@ -9424,7 +9425,213 @@ async fn models_catalog_includes_enabled_credentialed_providers() {
     assert_eq!(response.status(), StatusCode::OK);
     let catalog: serde_json::Value = json_body(response).await;
     let models = catalog["models"].as_array().unwrap();
-    assert!(models.iter().any(|m| m["provider"] == "openai"));
+    assert!(models
+        .iter()
+        .any(|m| m["provider"] == "openai" && m["available"] == true));
+}
+
+#[tokio::test]
+async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unavailable_providers() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("typed-models.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Openai,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+    providers::write_credential(
+        &*secrets,
+        providers::ProviderKind::Openai,
+        &providers::ProviderCredential::api_key("sk-openai"),
+    )
+    .await
+    .unwrap();
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(resolver::ConfiguredResolver::new(
+            store.clone(),
+            secrets.clone(),
+        )),
+        secrets,
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "gpt-4o".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let bearer = format!("Bearer {}", state.token);
+    let router = app(state);
+
+    // Old bare curated ids are accepted but persisted under their exact owner.
+    let configured = put_settings(&router, &bearer, serde_json::json!({"model": "gpt-4o"})).await;
+    assert_eq!(configured.status(), StatusCode::OK);
+    let settings: serde_json::Value = json_body(configured).await;
+    assert_eq!(settings["model"], "openai::gpt-4o");
+
+    let wrong_provider = put_settings(
+        &router,
+        &bearer,
+        serde_json::json!({"model": "anthropic::gpt-4o"}),
+    )
+    .await;
+    assert_eq!(wrong_provider.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(wrong_provider).await;
+    assert_eq!(error.kind, "unknown_model");
+
+    let unavailable = put_settings(
+        &router,
+        &bearer,
+        serde_json::json!({"model": "anthropic::claude-opus-4-8"}),
+    )
+    .await;
+    assert_eq!(unavailable.status(), StatusCode::CONFLICT);
+    let error: AgentErrorInfo = json_body(unavailable).await;
+    assert_eq!(error.kind, "model_provider_unavailable");
+
+    let chat_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chats")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"model": "openai::gpt-4o"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(chat_response.status(), StatusCode::CREATED);
+    let chat: Chat = json_body(chat_response).await;
+    assert_eq!(chat.model.as_deref(), Some("openai::gpt-4o"));
+
+    let turn_id = TurnId::new();
+    let accepted = send_message_with_id(&router, &bearer, chat.id, turn_id, "hello").await;
+    assert_eq!(accepted, StatusCode::ACCEPTED);
+    assert_eq!(
+        store.get_turn_run(turn_id).await.unwrap().unwrap().model,
+        "openai::gpt-4o"
+    );
+
+    // The same raw id may be explicitly configured under another provider.
+    // Once two owners exist, the old bare value is ambiguous and fails closed.
+    let configure_compatible = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/openai_compatible")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "enabled": true,
+                        "base_url": "http://127.0.0.1:1234/v1",
+                        "credential": {"type": "api_key", "key": "sk-local"},
+                        "models": [{
+                            "id": "gpt-4o",
+                            "context_window": 32768,
+                            "max_output_tokens": 4096
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(configure_compatible.status(), StatusCode::OK);
+
+    let ambiguous = put_settings(&router, &bearer, serde_json::json!({"model": "gpt-4o"})).await;
+    assert_eq!(ambiguous.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(ambiguous).await;
+    assert_eq!(error.kind, "unknown_model");
+
+    for qualified in ["openai::gpt-4o", "openai_compatible::gpt-4o"] {
+        let exact = put_settings(&router, &bearer, serde_json::json!({"model": qualified})).await;
+        assert_eq!(exact.status(), StatusCode::OK);
+        let settings: serde_json::Value = json_body(exact).await;
+        assert_eq!(settings["model"], qualified);
+    }
+}
+
+#[tokio::test]
+async fn custom_models_live_under_openai_compatible_with_conservative_capabilities() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/providers/openai_compatible")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "enabled": true,
+                        "base_url": "http://127.0.0.1:1234/v1",
+                        "credential": {"type": "api_key", "key": "sk-local"},
+                        "models": [{
+                            "id": "vendor/model",
+                            "display_name": "Vendor Model",
+                            "context_window": 65536,
+                            "max_output_tokens": 8192
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/models")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let catalog: serde_json::Value = json_body(response).await;
+    let custom = catalog["models"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|model| model["key"] == "openai_compatible::vendor/model")
+        .unwrap();
+    assert_eq!(custom["display_name"], "Vendor Model");
+    assert_eq!(custom["context_window"], 65_536);
+    assert_eq!(custom["max_output_tokens"], 8_192);
+    assert_eq!(custom["input_modalities"], serde_json::json!(["text"]));
+    assert!(!custom["supports_reasoning"].as_bool().unwrap());
+    assert!(custom["available"].as_bool().unwrap());
 }
 
 #[tokio::test]
@@ -9452,6 +9659,7 @@ async fn resolver_builds_a_router_from_enabled_providers() {
         &providers::ProviderConfig {
             enabled: true,
             base_url: None,
+            models: Vec::new(),
         },
     )
     .await
@@ -9485,6 +9693,7 @@ async fn resolver_builds_a_router_from_enabled_providers() {
         &providers::ProviderConfig {
             enabled: false,
             base_url: None,
+            models: Vec::new(),
         },
     )
     .await
@@ -9517,6 +9726,7 @@ async fn resolver_includes_openai_when_enabled() {
         &providers::ProviderConfig {
             enabled: true,
             base_url: None,
+            models: Vec::new(),
         },
     )
     .await
@@ -9565,6 +9775,7 @@ async fn openai_compatible_route_is_free_form_fallback() {
         &providers::ProviderConfig {
             enabled: true,
             base_url: Some("http://127.0.0.1:1234/v1".into()),
+            models: Vec::new(),
         },
     )
     .await

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -410,6 +410,23 @@ impl TurnWorker {
                 )
                 .await;
         };
+        let model_policy = if self.resolver.enforces_model_registry() {
+            crate::providers::resolve_model_policy(&*self.store, &turn.model, true).await?
+        } else {
+            None
+        };
+        if model_policy.is_none() && self.resolver.enforces_model_registry() {
+            return self
+                .record_failure(
+                    &turn,
+                    lease_token,
+                    total_model_steps,
+                    total_usage,
+                    "unknown_model",
+                    "the turn's model is no longer registered for its provider",
+                )
+                .await;
+        }
         let active = loop {
             if let Some(active) = self.signals.register(turn.chat_id, turn.id, lease_token) {
                 break active;
@@ -464,8 +481,12 @@ impl TurnWorker {
             )));
             let mut heartbeat_open = true;
             let mut config = self.agent_config.clone();
-            config.model = turn.model.clone();
-            config.reasoning_effort = chat.reasoning_effort;
+            if let Some(policy) = model_policy.as_ref() {
+                crate::providers::apply_model_policy(&mut config, policy, chat.reasoning_effort)?;
+            } else {
+                config.model = turn.model.clone();
+                config.reasoning_effort = chat.reasoning_effort;
+            }
             config.max_steps = remaining_steps;
             config.tool_scratch = self.private_scratch_root.as_deref().and_then(|root| {
                 match private_chat_scratch(root, chat.id) {
@@ -1920,7 +1941,10 @@ impl TurnWorker {
         code: &str,
         detail: &str,
     ) -> Result<TurnWorkerOutcome> {
-        let retry = if matches!(code, "provider" | "store" | "secret") {
+        let retry = if matches!(
+            code,
+            "provider" | "rate_limited" | "overloaded" | "store" | "secret"
+        ) {
             TurnFailureRetry::RetryAt(Utc::now() + chrono_duration(self.config.failure_delay)?)
         } else {
             TurnFailureRetry::Permanent

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -140,12 +140,19 @@ closed until a matching provider is enabled and credentialed. OpenAI-compatible
 routes currently require a nonempty credential even when a local endpoint would
 otherwise accept unauthenticated requests.
 
-Curated model metadata has one server-owned registry. It records the canonical
-provider ID, display name, token limits, accepted input modalities, and reasoning
-capabilities used by both `GET /models` and model-to-provider routing. Provider
-configuration filters that registry; it does not maintain a second list of model
-IDs. Custom OpenAI-compatible model IDs remain allowed outside the curated
-registry and receive a derived display name.
+Model metadata has one server-owned registry. Every selection uses a
+provider-qualified key (`provider::model`) and records the provider ID, display
+name, token limits, accepted input modalities, and reasoning capabilities used
+by both `GET /models` and model-to-provider routing. The host applies that
+metadata to the runtime request; clients cannot override token or capability
+policy.
+
+OpenAI-compatible endpoints can register custom model IDs and their context and
+output limits in provider settings. Those models enter the same catalog with
+conservative text-only, non-reasoning capabilities. Existing unqualified model
+settings are migrated at the API boundary when exactly one configured provider
+owns the ID. Ambiguous IDs fail closed and must be reselected with their
+provider, so routing never depends on registry order.
 
 ## What happens during a chat turn
 
@@ -162,6 +169,12 @@ The operational store commits the user message and a queued `TurnRun` together.
 Only then does the API return `202 Accepted`. Repeating the same `turn_id`, chat,
 and text returns the existing accepted turn. Reusing the identity for different
 input is a conflict.
+
+Before that commit, the server canonicalizes the chosen model to its
+provider-qualified registry key and verifies that the provider is enabled and
+credentialed. The worker later resolves that key back to the same immutable
+model policy. Authentication and invalid-request failures are terminal; rate
+limits and provider overload remain retryable.
 
 Each chat has one live durable turn slot. This makes ordering and transcript
 construction straightforward. A second turn is not queued behind the first; the


### PR DESCRIPTION
## Summary
- replace ambiguous bare model selection with stable `provider::model` keys across Settings, chat overrides, turn receipts, and exact router dispatch
- make the server-owned model registry authoritative for context/output limits, reasoning request shape, supported modalities, availability, and typed provider failures
- move OpenAI-compatible custom models into provider configuration with explicit context/output limits and conservative text-only, non-reasoning defaults
- migrate legacy bare selections only when ownership is unique; preserve legacy compatible rows at turn execution while new writes fail closed on unknown, ambiguous, wrong-provider, or unavailable selections
- bound and sanitize untrusted provider error responses before any durable/client-visible failure

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p openwave-server --locked -- --test-threads=4` (297 passed)
- `cargo test -p openwave-router --locked` (32 passed)
- `cargo test -p openwave-desktop --locked` (51 passed)
- PostgreSQL state-machine suite (25 passed)
- `pnpm test` (261 passed), TypeScript check, and production UI build

## Notes
- Catalog image capability is intentionally not advertised until OpenWave can carry image blocks end to end.
- Sandbox runs apply the same registry policy to their configured sandbox model; selecting the foreground turn model for child runs remains a separate orchestration design decision.

Closes #412
Closes #413