### PR TITLE
feat(desktop): instant auto-scroll during streaming, honor reduced motion

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatScroll.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatScroll.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   AUTO_SCROLL_THRESHOLD_PX,
+  followScrollBehavior,
   isNearBottom,
+  prefersReducedMotion,
   scrollToLatest,
 } from "./ChatScroll";
 
@@ -20,5 +22,38 @@ describe("chat scroll behavior", () => {
     const scrollTo = vi.fn();
     scrollToLatest({ scrollHeight: 2_000, scrollTo });
     expect(scrollTo).toHaveBeenCalledWith({ top: 2_000, behavior: "smooth" });
+  });
+});
+
+describe("followScrollBehavior", () => {
+  it("jumps instantly while streaming and eases for discrete follows", () => {
+    expect(followScrollBehavior(true, false)).toBe("auto");
+    expect(followScrollBehavior(false, false)).toBe("smooth");
+  });
+
+  it("collapses to instant under prefers-reduced-motion", () => {
+    expect(followScrollBehavior(false, true)).toBe("auto");
+    expect(followScrollBehavior(true, true)).toBe("auto");
+  });
+});
+
+describe("prefersReducedMotion", () => {
+  it("reads the media query and defaults to no-preference without one", () => {
+    expect(prefersReducedMotion((q) => ({ matches: q.includes("reduce") }))).toBe(
+      true,
+    );
+    expect(prefersReducedMotion(() => ({ matches: false }))).toBe(false);
+  });
+});
+
+describe("scrollToLatest", () => {
+  it("passes the chosen behavior through", () => {
+    const calls: ScrollToOptions[] = [];
+    const element = {
+      scrollHeight: 500,
+      scrollTo: (options: ScrollToOptions) => calls.push(options),
+    };
+    scrollToLatest(element as never, "auto");
+    expect(calls).toEqual([{ top: 500, behavior: "auto" }]);
   });
 });

--- a/crates/openwave-desktop/ui/src/ChatScroll.ts
+++ b/crates/openwave-desktop/ui/src/ChatScroll.ts
@@ -14,6 +14,35 @@ export function isNearBottom(
   return scrollHeight - (scrollTop + clientHeight) <= thresholdPx;
 }
 
-export function scrollToLatest(element: Pick<HTMLElement, "scrollHeight" | "scrollTo">): void {
-  element.scrollTo({ top: element.scrollHeight, behavior: "smooth" });
+/**
+ * Whether the environment asks for reduced motion. Guarded so the node test
+ * environment (no matchMedia) and older webviews behave as "no preference".
+ */
+export function prefersReducedMotion(
+  query: (q: string) => { matches: boolean } = (q) =>
+    typeof window !== "undefined" && typeof window.matchMedia === "function"
+      ? window.matchMedia(q)
+      : { matches: false },
+): boolean {
+  return query("(prefers-reduced-motion: reduce)").matches;
+}
+
+/**
+ * Pick the scroll behavior for following the transcript. Streaming follows
+ * happen every few frames — easing them stacks animations that fight the
+ * reader — so they jump instantly; discrete jumps (the "New activity" pill)
+ * ease, unless the OS asks for reduced motion.
+ */
+export function followScrollBehavior(
+  streaming: boolean,
+  reducedMotion: boolean = prefersReducedMotion(),
+): ScrollBehavior {
+  return streaming || reducedMotion ? "auto" : "smooth";
+}
+
+export function scrollToLatest(
+  element: Pick<HTMLElement, "scrollHeight" | "scrollTo">,
+  behavior: ScrollBehavior = "smooth",
+): void {
+  element.scrollTo({ top: element.scrollHeight, behavior });
 }

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -6,7 +6,7 @@ import type {
 } from "./api";
 import { AgentActivityPanel } from "./AgentActivityPanel";
 import { ChatTabs } from "./ChatTabs";
-import { isNearBottom, scrollToLatest } from "./ChatScroll";
+import { followScrollBehavior, isNearBottom, scrollToLatest } from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
 import { useUiStore } from "./UiStore";
 import { Composer } from "./Composer";
@@ -122,11 +122,11 @@ export function ChatView({
     const scroll = scrollRef.current;
     if (!scroll) return;
     if (followsLatestRef.current) {
-      scrollToLatest(scroll);
+      scrollToLatest(scroll, followScrollBehavior(busy));
     } else {
       setHasUnreadActivity(true);
     }
-  }, [messages]);
+  }, [messages, busy]);
 
   useEffect(() => {
     const next = new Set(folderAccessRequests.map((request) => request.callId));
@@ -138,7 +138,7 @@ export function ChatView({
     const scroll = scrollRef.current;
     if (!scroll) return;
     if (followsLatestRef.current) {
-      scrollToLatest(scroll);
+      scrollToLatest(scroll, followScrollBehavior(false));
     } else {
       setHasUnreadActivity(true);
     }
@@ -209,7 +209,9 @@ export function ChatView({
             onClick={() => {
               followsLatestRef.current = true;
               setHasUnreadActivity(false);
-              if (scrollRef.current) scrollToLatest(scrollRef.current);
+              if (scrollRef.current) {
+                scrollToLatest(scrollRef.current, followScrollBehavior(false));
+              }
             }}
           >
             New activity


### PR DESCRIPTION
Closes #435.

- `followScrollBehavior(streaming, reducedMotion)` picks the follow behavior: streaming follows fire every few frames, so they jump instantly (`auto`) instead of stacking eased animations that fight the reader; discrete follows (the "New activity" pill, folder-consent arrivals) keep `smooth`.
- Both collapse to instant under `prefers-reduced-motion: reduce`, read via a guarded `matchMedia` (node test env and older webviews behave as no-preference).

## Tests

Behavior-selection matrix (streaming/discrete × reduced-motion), media-query reading with a stubbed matcher, and behavior passthrough in `scrollToLatest`. 268 tests, `tsc`, and the production build are green.

**Held for smoke test before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)