### PR TITLE
feat(desktop): show a superseded response instead of vanishing it

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -279,7 +279,7 @@ describe("approvals", () => {
 });
 
 describe("stream_interrupted", () => {
-  it("discards the optimistic candidate but keeps settled work", () => {
+  it("keeps a visible partial as superseded and discards provisional tools", () => {
     const { state } = play([
       TURN,
       { type: "tool_call_started", call_id: "done", name: "search" },
@@ -288,14 +288,39 @@ describe("stream_interrupted", () => {
       { type: "tool_call_started", call_id: "pending", name: "search" },
       { type: "stream_interrupted" },
     ]);
-    // The empty bubble minted at turn start survives (it renders as nothing);
-    // the streamed partial answer and the pending tool card are discarded.
     const roles = state.messages.map((m) => m.role);
-    expect(roles).toEqual(["assistant", "tool"]);
-    expect(state.messages[0]).toMatchObject({ role: "assistant", text: "" });
-    expect(state.messages[1]).toMatchObject({ callId: "done" });
+    expect(roles).toEqual(["assistant", "tool", "assistant"]);
+    expect(state.messages[2]).toMatchObject({
+      text: "partial answer",
+      superseded: true,
+    });
+    expect(state.messages.find((m) => m.role === "tool")).toMatchObject({
+      callId: "done",
+    });
     expect(state.assistantBuffer).toBe("");
     expect(state.provisionalToolCallIds.size).toBe(0);
+  });
+
+  it("streams the replacement into a fresh bubble beneath the superseded one", () => {
+    const { state } = play([
+      TURN,
+      { type: "text_delta", text: "first try" },
+      { type: "stream_interrupted" },
+      { type: "text_delta", text: "second try" },
+    ]);
+    const assistants = state.messages.filter((m) => m.role === "assistant");
+    expect(assistants).toHaveLength(2);
+    expect(assistants[0]).toMatchObject({
+      text: "first try",
+      superseded: true,
+    });
+    expect(assistants[1]).toMatchObject({ text: "second try" });
+    expect(assistants[1]).not.toHaveProperty("superseded", true);
+  });
+
+  it("still drops an empty streaming bubble outright", () => {
+    const { state } = play([TURN, { type: "stream_interrupted" }]);
+    expect(state.messages).toEqual([]);
   });
 });
 

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -553,3 +553,35 @@ describe("context truncation notice", () => {
     expect(notices).toHaveLength(2);
   });
 });
+
+describe("replaying an active turn over a hydrated transcript", () => {
+  it("keeps the superseded partial and steer message in journal order", () => {
+    // Re-entering a chat mid-turn: hydration placed the persisted messages,
+    // then the journal replays the in-flight turn's events from the top.
+    const hydrated = applyTerminalHydration(initialChatSessionState(), {
+      messages: [
+        { id: "u1", role: "user", text: "write about birds" },
+        { id: "steer-1", role: "user", text: "make it volcanos" },
+      ],
+      messageIds: new Set(["u1", "steer-1"]),
+      lastEventSeq: 0,
+    });
+    const { state } = play(
+      [
+        { type: "turn_started", turn_id: "t1" },
+        { type: "text_delta", text: "Birds are great" },
+        { type: "stream_interrupted" },
+        { type: "user_steered", message_id: "steer-1", text: "make it volcanos" },
+        { type: "text_delta", text: "Volcanoes erupt" },
+      ],
+      hydrated,
+    );
+    const order = state.messages.map((m) =>
+      m.role === "assistant" ? `${m.superseded ? "superseded" : "live"}` : m.id,
+    );
+    expect(order).toEqual(["u1", "superseded", "steer-1", "live"]);
+    const assistants = state.messages.filter((m) => m.role === "assistant");
+    expect(assistants[0]).toMatchObject({ text: "Birds are great" });
+    expect(assistants[1]).toMatchObject({ text: "Volcanoes erupt" });
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -279,7 +279,19 @@ export function reduceChatSessionEvent(
 
     case "user_steered": {
       if (state.hydratedMessageIds.has(event.message_id)) {
-        return { state, effects };
+        // Replay after hydration: the transcript already holds this message,
+        // but hydration placed it before any replayed stream content. Journal
+        // order is the true order, so move it to its replay position.
+        const index = state.messages.findIndex(
+          (message) => message.id === event.message_id,
+        );
+        if (index < 0 || index === state.messages.length - 1) {
+          return { state, effects };
+        }
+        const messages = [...state.messages];
+        const [moved] = messages.splice(index, 1);
+        messages.push(moved);
+        return { state: { ...state, messages }, effects };
       }
       const hydratedMessageIds = new Set(state.hydratedMessageIds);
       hydratedMessageIds.add(event.message_id);

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -153,8 +153,16 @@ export function reduceChatSessionEvent(
         state.messages,
         state.provisionalToolCallIds,
       );
-      if (messages[messages.length - 1]?.role === "assistant") {
-        messages.pop();
+      // A visible partial stays on screen as superseded — dimmed until the
+      // replacement streams beneath it and the authoritative transcript
+      // sweeps it at turn completion. Empty bubbles just drop.
+      const last = messages[messages.length - 1];
+      if (last?.role === "assistant") {
+        if (last.text) {
+          messages[messages.length - 1] = { ...last, superseded: true };
+        } else {
+          messages.pop();
+        }
       }
       return {
         state: {
@@ -441,7 +449,7 @@ function withTrailingAssistantText(
 ): ChatMessage[] {
   const copy = [...messages];
   const last = copy[copy.length - 1];
-  if (last?.role === "assistant") {
+  if (last?.role === "assistant" && !last.superseded) {
     copy[copy.length - 1] = { ...last, text };
   } else {
     copy.push({

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -525,3 +525,24 @@ describe("approval decision feedback", () => {
     expect(markup).not.toContain("disabled");
   });
 });
+
+describe("superseded responses", () => {
+  it("renders a superseded bubble dimmed with an accessible label", () => {
+    const markup = renderToStaticMarkup(
+      <MessageBubble
+        message={{
+          id: "a1",
+          role: "assistant",
+          text: "abandoned partial",
+          sources: [],
+          superseded: true,
+        }}
+        busy={false}
+        onApproval={noop}
+      />,
+    );
+    expect(markup).toContain("message-superseded");
+    expect(markup).toContain("Superseded response");
+    expect(markup).toContain("abandoned partial");
+  });
+});

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -19,6 +19,9 @@ export type ChatMessage =
       text: string;
       sources: AssistantSource[];
       createdAt?: string;
+      /** Interrupted mid-stream and replaced; rendered dimmed until the
+       *  authoritative transcript sweeps it. */
+      superseded?: boolean;
     }
   | { id: string; role: "system"; text: string }
   | {
@@ -180,7 +183,7 @@ export function groupMessageItems(
       messageIndex -= 1
     ) {
       const candidate = messages[messageIndex];
-      if (candidate?.role === "assistant") {
+      if (candidate?.role === "assistant" && !candidate.superseded) {
         streamingAssistantId = candidate.id;
         break;
       }
@@ -328,6 +331,17 @@ function MessageBubbleImpl({
 
   if (message.role === "assistant") {
     if (!message.text && message.sources.length === 0) return null;
+
+    if (message.superseded) {
+      return (
+        <article
+          className="message message-assistant message-superseded"
+          aria-label="Superseded response, replaced below"
+        >
+          <MessageMarkdown>{message.text}</MessageMarkdown>
+        </article>
+      );
+    }
 
     return (
       <article className="message message-assistant" aria-label="Assistant">

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -3150,3 +3150,9 @@ body {
   min-height: 0;
   width: 100%;
 }
+
+/* A response interrupted mid-stream (a steer, a step retry) stays visible
+   but recedes; the replacement streams in beneath it. */
+.message-superseded {
+  opacity: 0.5;
+}


### PR DESCRIPTION
Closes #437.

The "steer vaporizes my half-written answer" moment: correct data handling (the server never persisted the interrupted step) presented as a bug. Now:

- `stream_interrupted` marks a non-empty streaming bubble `superseded` instead of removing it — rendered at half opacity with the accessible label "Superseded response, replaced below". Replacement text streams into a fresh bubble beneath it (superseded bubbles are never extended and never picked as the live streaming bubble).
- Turn completion re-hydrates from the authoritative transcript, which never contained the partial — so the dimmed bubble is swept naturally, and cancelled/failed turns keep it visible as honest history.
- Empty bubbles still drop outright; provisional tool cards are discarded exactly as before.

## Tests

Reducer: visible partial preserved as superseded with tools discarded, replacement opens a fresh bubble, empty bubbles drop. Markup: dimmed rendering + label. 271 tests, `tsc`, and the production build are green.

**Held for smoke test before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)