### PR TITLE
feat(desktop): manage local MCP servers at runtime

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -60,13 +60,14 @@ use crate::storage::{
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
 
 /// A name-keyed registry of the tools available to the agent.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ToolRegistry {
     tools: HashMap<String, RegisteredTool>,
 }
 
+#[derive(Clone)]
 enum RegisteredTool {
-    Server(Box<dyn Tool>),
+    Server(Arc<dyn Tool>),
     Client {
         spec: ToolSpec,
         validate_arguments: Option<fn(&Value) -> bool>,
@@ -93,7 +94,7 @@ impl ToolRegistry {
     /// Register a tool under its advertised name (replacing any existing one).
     pub fn register(&mut self, tool: Box<dyn Tool>) {
         self.tools
-            .insert(tool.spec().name, RegisteredTool::Server(tool));
+            .insert(tool.spec().name, RegisteredTool::Server(Arc::from(tool)));
     }
 
     /// Register a client-owned tool contract with no server-side executor.

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -78,6 +78,11 @@ pub enum ToolApprovalKind {
     WebSearchMayShareQuery,
     /// A command execution escapes the chat workspace and may reach the network.
     ExecMayRunNetworkedCommand,
+    /// An external MCP process may receive the call and act with its own local
+    /// or remote authority. Calls are approvable once but never standing-
+    /// grantable because a Settings edit can replace the process behind a
+    /// stable tool namespace.
+    ExternalMcpMayCallServer,
     /// A Sensitive action with no presentable consent semantics: rejectable but
     /// not approvable from the renderer.
     Unsupported,
@@ -90,6 +95,7 @@ impl ToolApprovalKind {
             "search" => Self::SearchMayShareQueryAndExcerpts,
             "web_search" => Self::WebSearchMayShareQuery,
             "exec" => Self::ExecMayRunNetworkedCommand,
+            name if name.starts_with("mcp__") => Self::ExternalMcpMayCallServer,
             _ => Self::Unsupported,
         }
     }
@@ -104,6 +110,10 @@ impl ToolApprovalKind {
             // serde still exposes the narrower renderer kind.
             Self::WebSearchMayShareQuery => "search_may_share_query_and_excerpts",
             Self::ExecMayRunNetworkedCommand => "exec_may_run_networked_command",
+            // Existing databases have a closed approval-kind constraint. The
+            // exact namespaced tool name disambiguates this renderer kind when
+            // durable state is read, as it already does for web search.
+            Self::ExternalMcpMayCallServer => "search_may_share_query_and_excerpts",
             Self::Unsupported => "unsupported",
         }
     }
@@ -115,7 +125,18 @@ impl ToolApprovalKind {
             Self::SearchMayShareQueryAndExcerpts
                 | Self::WebSearchMayShareQuery
                 | Self::ExecMayRunNetworkedCommand
+                | Self::ExternalMcpMayCallServer
         )
+    }
+
+    /// Whether approval may be remembered for later calls in the same chat.
+    ///
+    /// MCP is intentionally one-shot: its configured executable can change
+    /// while retaining a model-visible namespace, so reusing consent by name
+    /// would silently widen authority.
+    #[must_use]
+    pub const fn is_standing_grantable(self) -> bool {
+        self.is_approvable() && !matches!(self, Self::ExternalMcpMayCallServer)
     }
 }
 
@@ -198,9 +219,10 @@ pub struct StandingGrant {
 impl StandingGrant {
     /// Record consent to stop re-prompting `tool_name` in `chat_id`.
     ///
-    /// Returns `None` for a tool whose consent semantics are not standing-
-    /// grantable (mirrors [`ToolApprovalKind::is_approvable`]); an unknown or
-    /// non-approvable action must keep parking on the gate every call.
+    /// Returns `None` for a tool whose consent semantics are not
+    /// [`ToolApprovalKind::is_standing_grantable`]. An unknown action, an
+    /// unapprovable action, or a replaceable MCP namespace must keep parking on
+    /// the gate every call.
     #[must_use]
     pub fn new(
         chat_id: ChatId,
@@ -208,7 +230,7 @@ impl StandingGrant {
         kind: ToolApprovalKind,
         granted_at: DateTime<Utc>,
     ) -> Option<Self> {
-        if !kind.is_approvable() {
+        if !kind.is_standing_grantable() {
             return None;
         }
         Some(Self {
@@ -495,6 +517,18 @@ mod standing_grant_tests {
         assert!(grants.covers(chat, "exec", kind));
         // Deny-by-default still holds for a different chat.
         assert!(!grants.covers(ChatId::new(), "exec", kind));
+    }
+
+    #[test]
+    fn external_mcp_is_approvable_once_but_never_standing_grantable() {
+        let kind = ToolApprovalKind::for_tool_name("mcp__documents__search");
+        assert_eq!(kind, ToolApprovalKind::ExternalMcpMayCallServer);
+        assert!(kind.is_approvable());
+        assert!(!kind.is_standing_grantable());
+        assert!(
+            StandingGrant::new(ChatId::new(), "mcp__documents__search", kind, Utc::now(),)
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -456,6 +456,9 @@ fn approval_from_model(model: &entities::tool_call::Model) -> Result<ToolApprova
         }
     };
     let kind = match model.approval_kind.as_deref() {
+        Some("search_may_share_query_and_excerpts") if model.name.starts_with("mcp__") => {
+            ToolApprovalKind::ExternalMcpMayCallServer
+        }
         Some("search_may_share_query_and_excerpts") if model.name == "web_search" => {
             ToolApprovalKind::WebSearchMayShareQuery
         }

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -10757,6 +10757,14 @@ async fn claimed_sensitive_call(
     store: &DbStore,
     chat: &Chat,
 ) -> (TurnId, uuid::Uuid, ToolCallRecord, ApprovalRequest) {
+    claimed_sensitive_call_named(store, chat, "search").await
+}
+
+async fn claimed_sensitive_call_named(
+    store: &DbStore,
+    chat: &Chat,
+    tool_name: &str,
+) -> (TurnId, uuid::Uuid, ToolCallRecord, ApprovalRequest) {
     let turn_id = TurnId::new();
     let accepted = match store
         .accept_turn(turn_id, chat.id, "gpt-5", "search")
@@ -10793,7 +10801,7 @@ async fn claimed_sensitive_call(
         chat_id: chat.id,
         turn_id,
         provider_id: "approval-call".into(),
-        name: "search".into(),
+        name: tool_name.into(),
         arguments: serde_json::json!({"query": "private"}),
         execution: ToolCallExecution::Server,
         status: ToolCallStatus::Pending,
@@ -10819,6 +10827,42 @@ async fn claimed_sensitive_call(
         summary: "search requires approval".into(),
     };
     (turn_id, lease_token, call, request)
+}
+
+#[tokio::test]
+async fn external_mcp_approval_roundtrips_as_one_shot_consent() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (_turn_id, lease_token, _call, request) =
+        claimed_sensitive_call_named(&store, &chat, "mcp__documents__search").await;
+
+    let registered = store
+        .request_tool_call_approval_and_append_event(
+            &request,
+            lease_token,
+            1,
+            DateTime::<Utc>::from_timestamp(1, 0).unwrap(),
+        )
+        .await
+        .unwrap();
+    let approval = match registered.outcome {
+        RequestToolApprovalOutcome::Requested(approval) => approval,
+        outcome => panic!("unexpected approval request outcome: {outcome:?}"),
+    };
+    assert_eq!(
+        approval.kind,
+        crate::ToolApprovalKind::ExternalMcpMayCallServer
+    );
+    assert!(approval.kind.is_approvable());
+    assert!(!approval.kind.is_standing_grantable());
+
+    let recovered = store
+        .get_tool_call_approval(request.call_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(recovered.kind, approval.kind);
 }
 
 #[tokio::test]

--- a/crates/openwave-desktop/ui/src/ApprovalHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/ApprovalHistory.test.ts
@@ -11,6 +11,7 @@ const pending = {
   approval: "search_may_share_query_and_excerpts" as const,
   class: "sensitive" as const,
   canApprove: true,
+  canRemember: true,
 };
 
 describe("reconcilePendingApprovalCards", () => {
@@ -30,6 +31,7 @@ describe("reconcilePendingApprovalCards", () => {
         summary:
           "Allow search to send your query and potentially matching document excerpts to configured AI services outside OpenWave?",
         canApprove: true,
+        canRemember: true,
       },
     ]);
   });
@@ -50,6 +52,7 @@ describe("reconcilePendingApprovalCards", () => {
           callId: "call-old",
           summary: "old",
           canApprove: true,
+          canRemember: true,
         },
         { id: "message-new", role: "user", text: "new chat" },
       ],

--- a/crates/openwave-desktop/ui/src/ApprovalHistory.ts
+++ b/crates/openwave-desktop/ui/src/ApprovalHistory.ts
@@ -30,7 +30,7 @@ export function upsertPendingApprovalCard(
   messages: ChatMessage[],
   approval: Pick<
     PendingToolApproval,
-    "callId" | "action" | "approval" | "canApprove"
+    "callId" | "action" | "approval" | "canApprove" | "canRemember"
   >,
 ): ChatMessage[] {
     let next = messages;
@@ -72,6 +72,7 @@ export function upsertPendingApprovalCard(
       callId: approval.callId,
       summary: presentation.summary,
       canApprove: approval.canApprove && presentation.canApprove,
+      canRemember: approval.canRemember && presentation.canRemember,
     };
     if (cardIndex >= 0) {
       next = next.map((message, index) => (index === cardIndex ? card : message));

--- a/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
@@ -87,6 +87,7 @@ describe("AssistantWorkingIndicator", () => {
       callId: "call",
       summary: "Safe approval copy",
       canApprove: true,
+      canRemember: true,
     };
 
     expect(shouldShowAssistantWorking([runningTool], true, 0)).toBe(false);
@@ -127,6 +128,7 @@ describe("AssistantWorkingIndicator", () => {
         callId: "call",
         summary: "private-provider-diagnostic",
         canApprove: false,
+        canRemember: false,
         resolved: true,
       },
     ];

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -236,6 +236,7 @@ export function reduceChatSessionEvent(
             action: event.action,
             approval: event.approval,
             canApprove: approval.canApprove,
+            canRemember: approval.canRemember,
           }),
         },
         effects,
@@ -563,4 +564,3 @@ export function discardToolCalls(
     (message) => message.role !== "tool" || !callIds.has(message.callId),
   );
 }
-

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -10,6 +10,7 @@ const approval: ChatMessage = {
   callId: "call-1",
   summary: "Search a site",
   canApprove: true,
+  canRemember: true,
 };
 
 afterEach(cleanup);
@@ -97,6 +98,23 @@ describe("approval card interactions", () => {
       screen.queryByRole("button", { name: "Allow for this chat" }),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument();
+  });
+
+  it("offers one-shot approval but no remembered grant for MCP", () => {
+    render(
+      <MessageBubble
+        message={{ ...approval, canRemember: false }}
+        busy={false}
+        onApproval={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Approve once" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Allow for this chat" }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -42,6 +42,7 @@ describe("MessageBubble", () => {
         callId: "call-1",
         summary: "Search a site",
         canApprove: true,
+        canRemember: true,
       },
       { id: "assistant-2", role: "assistant", text: "", sources: [] },
     ];
@@ -143,6 +144,7 @@ describe("MessageBubble", () => {
           callId: "call-unknown",
           summary: "The exact action cannot be safely described.",
           canApprove: false,
+          canRemember: false,
         }}
         busy
         onApproval={noop}
@@ -451,6 +453,7 @@ describe("approval decision feedback", () => {
     callId: "call-1",
     summary: "Search a site",
     canApprove: true,
+    canRemember: true,
   };
 
   it("disables the decision buttons while a decision is in flight", () => {

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -37,6 +37,7 @@ export type ChatMessage =
       callId: string;
       summary: string;
       canApprove: boolean;
+      canRemember: boolean;
       resolved?: boolean;
     }
   | { id: string; role: "error"; text: string };
@@ -300,14 +301,16 @@ function MessageBubbleImpl({
                 >
                   Approve once
                 </button>
-                <button
-                  type="button"
-                  className="btn"
-                  disabled={deciding}
-                  onClick={() => onApproval(message.callId, "approve", true)}
-                >
-                  Allow for this chat
-                </button>
+                {message.canRemember && (
+                  <button
+                    type="button"
+                    className="btn"
+                    disabled={deciding}
+                    onClick={() => onApproval(message.callId, "approve", true)}
+                  >
+                    Allow for this chat
+                  </button>
+                )}
               </>
             )}
             <button

--- a/crates/openwave-desktop/ui/src/SettingsView.tsx
+++ b/crates/openwave-desktop/ui/src/SettingsView.tsx
@@ -5,6 +5,7 @@ import {
   Globe,
   KeyRound,
   Palette,
+  PlugZap,
   RefreshCw,
   SquareTerminal,
 } from "lucide-react";
@@ -17,12 +18,14 @@ import { ModelsPanel } from "./settings/ModelsPanel";
 import { AppearancePanel } from "./settings/AppearancePanel";
 import { CodeExecutionPanel } from "./settings/CodeExecutionPanel";
 import { UpdatesPanel } from "./settings/UpdatesPanel";
+import { McpPanel } from "./settings/McpPanel";
 
 type SettingsSectionKey =
   | "providers"
   | "models"
   | "web-search"
   | "code-execution"
+  | "mcp"
   | "appearance"
   | "updates";
 
@@ -35,6 +38,7 @@ const SECTIONS: {
   { key: "models", label: "Models", icon: Cpu },
   { key: "web-search", label: "Web search", icon: Globe },
   { key: "code-execution", label: "Code execution", icon: SquareTerminal },
+  { key: "mcp", label: "MCP servers", icon: PlugZap },
   { key: "appearance", label: "Appearance", icon: Palette },
   { key: "updates", label: "Updates", icon: RefreshCw },
 ];
@@ -109,6 +113,7 @@ export function SettingsView({
         {section === "code-execution" && (
           <CodeExecutionPanel client={client} />
         )}
+        {section === "mcp" && <McpPanel client={client} />}
         {section === "appearance" && (
           <AppearancePanel mode={themeMode} onChange={onThemeChange} />
         )}

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -132,11 +132,13 @@ describe("ToolCallCard", () => {
       summary:
         "Allow search to send your query and potentially matching document excerpts to configured AI services outside OpenWave?",
       canApprove: true,
+      canRemember: true,
     });
     expect(toolApprovalPresentation("web_search_may_share_query")).toEqual({
       summary:
         "Allow web search to send this query and its explicit filters to the configured search provider outside OpenWave?",
       canApprove: true,
+      canRemember: true,
     });
     expect(
       toolApprovalPresentation("exec_may_run_networked_command"),
@@ -144,10 +146,18 @@ describe("ToolCallCard", () => {
       summary:
         "Allow OpenWave to run a command that leaves the chat workspace and may reach the network?",
       canApprove: true,
+      canRemember: true,
+    });
+    expect(toolApprovalPresentation("external_mcp_may_call_server")).toEqual({
+      summary:
+        "Allow this external MCP server to receive the call and act with its own local or remote permissions?",
+      canApprove: true,
+      canRemember: false,
     });
     expect(toolApprovalPresentation("unsupported")).toEqual({
       summary: "The exact action cannot be safely described.",
       canApprove: false,
+      canRemember: false,
     });
   });
 });

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -35,6 +35,7 @@ export type ToolCallPresentation = {
 export type ToolApprovalPresentation = {
   summary: string;
   canApprove: boolean;
+  canRemember: boolean;
 };
 
 // This is deliberately an allowlist rather than a display transformation of a
@@ -199,6 +200,7 @@ export function toolApprovalPresentation(
       summary:
         "Allow search to send your query and potentially matching document excerpts to configured AI services outside OpenWave?",
       canApprove: true,
+      canRemember: true,
     };
   }
   if (kind === "web_search_may_share_query") {
@@ -206,6 +208,7 @@ export function toolApprovalPresentation(
       summary:
         "Allow web search to send this query and its explicit filters to the configured search provider outside OpenWave?",
       canApprove: true,
+      canRemember: true,
     };
   }
   if (kind === "exec_may_run_networked_command") {
@@ -213,11 +216,22 @@ export function toolApprovalPresentation(
       summary:
         "Allow OpenWave to run a command that leaves the chat workspace and may reach the network?",
       canApprove: true,
+      canRemember: true,
+    };
+  }
+  if (kind === "external_mcp_may_call_server") {
+    return {
+      summary:
+        "Allow this external MCP server to receive the call and act with its own local or remote permissions?",
+      canApprove: true,
+      // The executable behind a stable MCP namespace can change in Settings.
+      canRemember: false,
     };
   }
   return {
     summary: "The exact action cannot be safely described.",
     canApprove: false,
+    canRemember: false,
   };
 }
 

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -106,6 +106,7 @@ describe("pending approval recovery", () => {
     approval: "search_may_share_query_and_excerpts",
     class: "sensitive",
     can_approve: true,
+    can_remember: true,
   };
 
   it("parses only the closed renderer projection", () => {
@@ -116,6 +117,7 @@ describe("pending approval recovery", () => {
       approval: "search_may_share_query_and_excerpts",
       class: "sensitive",
       canApprove: true,
+      canRemember: true,
     });
     expect(parsePendingToolApproval({ ...safe, arguments: { query: "private" } })).toBeNull();
     expect(parsePendingToolApproval({ ...safe, can_approve: false })).toBeNull();
@@ -169,6 +171,29 @@ describe("pending approval recovery", () => {
     ).toBeNull();
   });
 
+  it("recovers one-shot MCP approval without a standing grant", () => {
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "other",
+        approval: "external_mcp_may_call_server",
+        can_remember: false,
+      }),
+    ).toMatchObject({
+      action: "other",
+      approval: "external_mcp_may_call_server",
+      canApprove: true,
+      canRemember: false,
+    });
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "other",
+        approval: "external_mcp_may_call_server",
+      }),
+    ).toBeNull();
+  });
+
   it("recognizes the fixed background wait name without accepting extensions", () => {
     expect(
       parsePendingToolApproval({
@@ -176,6 +201,7 @@ describe("pending approval recovery", () => {
         action: "wait_for_agents",
         approval: "unsupported",
         can_approve: false,
+        can_remember: false,
       }),
     ).toMatchObject({ action: "wait_for_agents", canApprove: false });
     expect(
@@ -184,6 +210,7 @@ describe("pending approval recovery", () => {
         action: "wait_for_agents_with_private_results",
         approval: "unsupported",
         can_approve: false,
+        can_remember: false,
       }),
     ).toBeNull();
   });
@@ -195,6 +222,7 @@ describe("pending approval recovery", () => {
         action: "read_delegated_file",
         approval: "unsupported",
         can_approve: false,
+        can_remember: false,
       }),
     ).toMatchObject({ action: "read_delegated_file", canApprove: false });
     expect(
@@ -203,6 +231,7 @@ describe("pending approval recovery", () => {
         action: "read_delegated_file:/Users/private/document.txt",
         approval: "unsupported",
         can_approve: false,
+        can_remember: false,
       }),
     ).toBeNull();
   });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -90,6 +90,37 @@ export type CodeExecutionConfigInfo = {
   available: boolean;
 };
 
+export type McpHealth =
+  | "initializing"
+  | "healthy"
+  | "degraded"
+  | "reconnecting"
+  | "disabled";
+
+/** Typed stdio process data. Values are argv entries, never shell source. */
+export type McpServerDefinition = {
+  name: string;
+  command: string;
+  args: string[];
+  /** Literal values must be non-secret; credentials use `env_from` names. */
+  env: Record<string, string>;
+  env_from: string[];
+  cwd: string | null;
+  request_timeout_ms: number;
+  enabled: boolean;
+};
+
+/** Renderer-safe health projection. Resolved `env_from` values are never sent. */
+export type McpServerInfo = McpServerDefinition & {
+  health: McpHealth;
+  tool_count: number;
+  diagnostic: string | null;
+};
+
+export type McpServersInfo = {
+  servers: McpServerInfo[];
+};
+
 export type Chat = {
   id: string;
   title: string | null;
@@ -255,6 +286,7 @@ export type RendererApprovalKind =
   | "search_may_share_query_and_excerpts"
   | "web_search_may_share_query"
   | "exec_may_run_networked_command"
+  | "external_mcp_may_call_server"
   | "unsupported";
 
 /** Approval kinds a human may approve from the renderer. */
@@ -262,8 +294,14 @@ export function isApprovableKind(kind: RendererApprovalKind): boolean {
   return (
     kind === "search_may_share_query_and_excerpts" ||
     kind === "web_search_may_share_query" ||
-    kind === "exec_may_run_networked_command"
+    kind === "exec_may_run_networked_command" ||
+    kind === "external_mcp_may_call_server"
   );
+}
+
+/** Approval kinds whose authority is stable enough to remember by tool name. */
+export function isRememberableKind(kind: RendererApprovalKind): boolean {
+  return isApprovableKind(kind) && kind !== "external_mcp_may_call_server";
 }
 
 /** A strict renderer-safe snapshot used to recover a parked approval. */
@@ -274,6 +312,7 @@ export type PendingToolApproval = {
   approval: RendererApprovalKind;
   class: "read_only" | "workspace" | "sensitive";
   canApprove: boolean;
+  canRemember: boolean;
 };
 
 export type FolderAccessHint = "documents" | "downloads";
@@ -435,6 +474,25 @@ export class ApiClient {
       method: "PUT",
       headers: this.headers(true),
       body: JSON.stringify(body),
+    });
+  }
+
+  listMcpServers(): Promise<McpServersInfo> {
+    return this.json("/mcp/servers", { headers: this.headers() });
+  }
+
+  putMcpServers(servers: McpServerDefinition[]): Promise<McpServersInfo> {
+    return this.json("/mcp/servers", {
+      method: "PUT",
+      headers: this.headers(true),
+      body: JSON.stringify({ servers }),
+    });
+  }
+
+  reconnectMcpServer(name: string): Promise<McpServersInfo> {
+    return this.json(`/mcp/servers/${encodeURIComponent(name)}/reconnect`, {
+      method: "POST",
+      headers: this.headers(),
     });
   }
 
@@ -724,7 +782,8 @@ export function parsePendingToolApproval(
         key !== "action" &&
         key !== "approval" &&
         key !== "class" &&
-        key !== "can_approve",
+        key !== "can_approve" &&
+        key !== "can_remember",
     ) ||
     typeof value.call_id !== "string" ||
     value.call_id.length === 0 ||
@@ -736,7 +795,9 @@ export function parsePendingToolApproval(
       value.class !== "workspace" &&
       value.class !== "sensitive") ||
     typeof value.can_approve !== "boolean" ||
-    value.can_approve !== isApprovableKind(value.approval)
+    value.can_approve !== isApprovableKind(value.approval) ||
+    typeof value.can_remember !== "boolean" ||
+    value.can_remember !== isRememberableKind(value.approval)
   ) {
     return null;
   }
@@ -747,6 +808,7 @@ export function parsePendingToolApproval(
     approval: value.approval,
     class: value.class,
     canApprove: value.can_approve,
+    canRemember: value.can_remember,
   };
 }
 
@@ -778,6 +840,7 @@ function isRendererApprovalKind(value: unknown): value is RendererApprovalKind {
     value === "search_may_share_query_and_excerpts" ||
     value === "web_search_may_share_query" ||
     value === "exec_may_run_networked_command" ||
+    value === "external_mcp_may_call_server" ||
     value === "unsupported"
   );
 }

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient, McpServersInfo } from "../api";
+import { McpPanel } from "./McpPanel";
+
+const healthy: McpServersInfo = {
+  servers: [
+    {
+      name: "private_docs",
+      command: "/opt/mcp/docs",
+      args: ["--stdio"],
+      env: { LOG_LEVEL: "info" },
+      env_from: ["PRIVATE_DOCS_TOKEN"],
+      cwd: "/tmp/docs",
+      request_timeout_ms: 60_000,
+      enabled: true,
+      health: "healthy",
+      tool_count: 2,
+      diagnostic: null,
+    },
+  ],
+};
+
+function api(result = healthy) {
+  return {
+    listMcpServers: vi.fn().mockResolvedValue(result),
+    putMcpServers: vi.fn().mockResolvedValue(result),
+    reconnectMcpServer: vi.fn().mockResolvedValue(result),
+  } as unknown as ApiClient;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("McpPanel", () => {
+  it("shows bounded health and never asks for a credential value", async () => {
+    render(<McpPanel client={api()} />);
+
+    expect(await screen.findByText("Healthy")).toBeInTheDocument();
+    expect(screen.getByText("2 tools available to new turns.")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("PRIVATE_DOCS_TOKEN")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/API key/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/values are resolved in the host process/i)).toBeInTheDocument();
+  });
+
+  it("sends argv and selected environment names as typed arrays", async () => {
+    const client = api({ servers: [] });
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await screen.findByText(/No MCP servers configured/);
+    await user.click(screen.getByRole("button", { name: "Add server" }));
+    const namespace = screen.getByRole("textbox", { name: /^Namespace/ });
+    await user.clear(namespace);
+    await user.type(namespace, "documents_server");
+    expect(namespace).toHaveValue("documents_server");
+    await user.type(
+      screen.getByPlaceholderText("/absolute/path/to/server"),
+      "/opt/mcp/docs",
+    );
+    await user.click(screen.getByRole("button", { name: "Add argument" }));
+    await user.type(screen.getByLabelText("Arguments 1"), "--stdio");
+    await user.click(
+      screen.getByRole("button", { name: "Add variable name" }),
+    );
+    await user.type(
+      screen.getByLabelText("Forward environment names 1"),
+      "DOCS_TOKEN",
+    );
+    await user.click(screen.getByRole("button", { name: "Save and verify" }));
+
+    await waitFor(() =>
+      expect(client.putMcpServers).toHaveBeenCalledWith([
+        expect.objectContaining({
+          command: "/opt/mcp/docs",
+          name: "documents_server",
+          args: ["--stdio"],
+          env_from: ["DOCS_TOKEN"],
+        }),
+      ]),
+    );
+  });
+
+  it("reconnects by namespace and replaces the displayed health snapshot", async () => {
+    const client = api();
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await screen.findByText("Healthy");
+    await user.click(
+      screen.getByRole("button", { name: /Reconnect and refresh tools/ }),
+    );
+    await waitFor(() =>
+      expect(client.reconnectMcpServer).toHaveBeenCalledWith("private_docs"),
+    );
+
+    await user.type(
+      screen.getByPlaceholderText("/absolute/path/to/server"),
+      "-edited",
+    );
+    expect(
+      screen.queryByRole("button", { name: /Reconnect and refresh tools/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Save and verify changes before reconnecting/),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces secret-free degraded diagnostics", async () => {
+    render(
+      <McpPanel
+        client={api({
+          servers: [
+            {
+              ...healthy.servers[0],
+              health: "degraded",
+              tool_count: 0,
+              diagnostic:
+                'required parent environment variable "DOCS_TOKEN" is not set',
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(await screen.findByText("Needs attention")).toBeInTheDocument();
+    expect(screen.getByText(/DOCS_TOKEN/)).toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -1,0 +1,518 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Plus, RefreshCw, Trash2 } from "lucide-react";
+import type {
+  ApiClient,
+  McpServerDefinition,
+  McpServerInfo,
+} from "../api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  SettingsError,
+  SettingsField,
+  SettingsPanel,
+  SettingsSection,
+} from "./primitives";
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const MAX_TIMEOUT_MS = 3_600_000;
+
+function emptyServer(index: number): McpServerInfo {
+  return {
+    name: `server_${index + 1}`,
+    command: "",
+    args: [],
+    env: {},
+    env_from: [],
+    cwd: null,
+    request_timeout_ms: DEFAULT_TIMEOUT_MS,
+    enabled: true,
+    health: "initializing",
+    tool_count: 0,
+    diagnostic: null,
+  };
+}
+
+function definition(server: McpServerInfo): McpServerDefinition {
+  const { health: _, tool_count: __, diagnostic: ___, ...value } = server;
+  return value;
+}
+
+export function McpPanel({ client }: { client: ApiClient }) {
+  const [servers, setServers] = useState<McpServerInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [reconnecting, setReconnecting] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void client
+      .listMcpServers()
+      .then((result) => {
+        if (!cancelled) {
+          setServers(result.servers);
+          setDirty(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  function update(index: number, change: Partial<McpServerInfo>) {
+    setDirty(true);
+    setServers((current) =>
+      current.map((server, itemIndex) =>
+        itemIndex === index ? { ...server, ...change } : server,
+      ),
+    );
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      const result = await client.putMcpServers(servers.map(definition));
+      setServers(result.servers);
+      setDirty(false);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function reconnect(name: string) {
+    setReconnecting(name);
+    setError(null);
+    setServers((current) =>
+      current.map((server) =>
+        server.name === name
+          ? { ...server, health: "reconnecting", diagnostic: null }
+          : server,
+      ),
+    );
+    try {
+      const result = await client.reconnectMcpServer(name);
+      setServers(result.servers);
+    } catch (err) {
+      setError(String(err));
+      try {
+        const result = await client.listMcpServers();
+        setServers(result.servers);
+      } catch {
+        // Preserve the reconnect error; reopening Settings performs a full load.
+      }
+    } finally {
+      setReconnecting(null);
+    }
+  }
+
+  const working = saving || reconnecting !== null;
+
+  return (
+    <SettingsPanel
+      title="MCP servers"
+      description="Connect local stdio tool servers without a shell or a desktop restart."
+      busy={loading || working}
+    >
+      {loading ? (
+        <p className="text-sm text-muted-foreground">
+          Loading MCP servers…
+        </p>
+      ) : (
+        <>
+          {servers.length === 0 && (
+            <SettingsSection>
+              <p className="text-sm text-muted-foreground">
+                No MCP servers configured. Add one to make its tools available
+                to new conversations.
+              </p>
+            </SettingsSection>
+          )}
+
+          {servers.map((server, index) => (
+            <SettingsSection
+              key={index}
+              title={server.name || `Server ${index + 1}`}
+            >
+              <div
+                className={`web-search-state is-${healthTone(server.health)}`}
+                role="status"
+              >
+                <strong>{healthLabel(server.health)}</strong>
+                <span>
+                  {server.health === "healthy"
+                    ? `${server.tool_count} tool${server.tool_count === 1 ? "" : "s"} available to new turns.`
+                    : server.diagnostic ??
+                      "Save the configuration to verify this server."}
+                </span>
+              </div>
+
+              <label className="flex items-center gap-2 text-sm font-medium">
+                <input
+                  type="checkbox"
+                  checked={server.enabled}
+                  disabled={working}
+                  onChange={(event) =>
+                    update(index, { enabled: event.target.checked })
+                  }
+                />
+                Enabled
+              </label>
+
+              <SettingsField
+                label="Namespace"
+                hint="ASCII letters, numbers, underscores, and hyphens only."
+              >
+                <Input
+                  value={server.name}
+                  disabled={working}
+                  autoComplete="off"
+                  spellCheck={false}
+                  onChange={(event) =>
+                    update(index, { name: event.target.value })
+                  }
+                />
+              </SettingsField>
+
+              <SettingsField
+                label="Executable"
+                hint="An executable path or command name. OpenWave never invokes a shell."
+              >
+                <Input
+                  value={server.command}
+                  disabled={working}
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="/absolute/path/to/server"
+                  onChange={(event) =>
+                    update(index, { command: event.target.value })
+                  }
+                />
+              </SettingsField>
+
+              <StringListEditor
+                label="Arguments"
+                values={server.args}
+                disabled={working}
+                addLabel="Add argument"
+                onChange={(args) => update(index, { args })}
+              />
+
+              <SettingsField
+                label="Working directory"
+                hint="Optional. It does not grant the server any OpenWave folder capability."
+              >
+                <Input
+                  value={server.cwd ?? ""}
+                  disabled={working}
+                  autoComplete="off"
+                  spellCheck={false}
+                  placeholder="Optional"
+                  onChange={(event) =>
+                    update(index, { cwd: event.target.value || null })
+                  }
+                />
+              </SettingsField>
+
+              <SettingsField
+                label="Request timeout (ms)"
+                hint={`A whole number from 1 to ${MAX_TIMEOUT_MS.toLocaleString()}.`}
+              >
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  max={MAX_TIMEOUT_MS}
+                  value={server.request_timeout_ms}
+                  disabled={working}
+                  onChange={(event) =>
+                    update(index, {
+                      request_timeout_ms: Number(event.target.value),
+                    })
+                  }
+                />
+              </SettingsField>
+
+              <EnvironmentEditor
+                values={server.env}
+                disabled={working}
+                onChange={(env) => update(index, { env })}
+              />
+
+              <StringListEditor
+                label="Forward environment names"
+                hint="Only names are saved or displayed. Their values are resolved in the host process and never returned to the app."
+                values={server.env_from}
+                disabled={working}
+                addLabel="Add variable name"
+                onChange={(env_from) => update(index, { env_from })}
+              />
+
+              <div className="flex flex-wrap gap-2">
+                {server.enabled &&
+                  server.health !== "initializing" &&
+                  !dirty && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={working}
+                    onClick={() => void reconnect(server.name)}
+                  >
+                    <RefreshCw size={14} />
+                    {reconnecting === server.name
+                      ? "Reconnecting…"
+                      : "Reconnect and refresh tools"}
+                  </Button>
+                )}
+                <Button
+                  type="button"
+                  variant="destructive"
+                  disabled={working}
+                  onClick={() =>
+                    setServers((current) => {
+                      setDirty(true);
+                      return current.filter(
+                        (_, itemIndex) => itemIndex !== index,
+                      );
+                    })
+                  }
+                >
+                  <Trash2 size={14} />
+                  Remove
+                </Button>
+              </div>
+            </SettingsSection>
+          ))}
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={working}
+              onClick={() =>
+                setServers((current) => {
+                  setDirty(true);
+                  return [...current, emptyServer(current.length)];
+                })
+              }
+            >
+              <Plus size={14} />
+              Add server
+            </Button>
+            <Button type="button" disabled={working} onClick={() => void save()}>
+              {saving ? "Verifying…" : "Save and verify"}
+            </Button>
+          </div>
+
+          {dirty && (
+            <p className="text-xs text-muted-foreground">
+              Save and verify changes before reconnecting a server.
+            </p>
+          )}
+
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            MCP tools are always sensitive and keep OpenWave’s existing approval
+            boundary. Child environments start empty. Put credentials in the
+            host environment and select only their variable names above; do not
+            enter secrets in the executable, arguments, working directory, or
+            literal values.
+          </p>
+        </>
+      )}
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsPanel>
+  );
+}
+
+function StringListEditor({
+  label,
+  hint,
+  values,
+  disabled,
+  addLabel,
+  onChange,
+}: {
+  label: string;
+  hint?: string;
+  values: string[];
+  disabled: boolean;
+  addLabel: string;
+  onChange: (values: string[]) => void;
+}) {
+  return (
+    <FieldGroup label={label} hint={hint}>
+      <div className="flex flex-col gap-2">
+        {values.map((value, index) => (
+          <div className="flex gap-2" key={index}>
+            <Input
+              aria-label={`${label} ${index + 1}`}
+              value={value}
+              disabled={disabled}
+              autoComplete="off"
+              spellCheck={false}
+              onChange={(event) =>
+                onChange(
+                  values.map((item, itemIndex) =>
+                    itemIndex === index ? event.target.value : item,
+                  ),
+                )
+              }
+            />
+            <Button
+              type="button"
+              variant="outline"
+              aria-label={`Remove ${label.toLowerCase()} ${index + 1}`}
+              disabled={disabled}
+              onClick={() =>
+                onChange(values.filter((_, itemIndex) => itemIndex !== index))
+              }
+            >
+              <Trash2 size={14} />
+            </Button>
+          </div>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          className="self-start"
+          disabled={disabled}
+          onClick={() => onChange([...values, ""])}
+        >
+          <Plus size={14} />
+          {addLabel}
+        </Button>
+      </div>
+    </FieldGroup>
+  );
+}
+
+function EnvironmentEditor({
+  values,
+  disabled,
+  onChange,
+}: {
+  values: Record<string, string>;
+  disabled: boolean;
+  onChange: (values: Record<string, string>) => void;
+}) {
+  const rows = Object.entries(values);
+  function replaceRow(index: number, name: string, value: string) {
+    const next = rows.map(([key, item], itemIndex) =>
+      itemIndex === index ? ([name, value] as const) : ([key, item] as const),
+    );
+    onChange(Object.fromEntries(next));
+  }
+  return (
+    <FieldGroup
+      label="Literal non-secret environment"
+      hint="These values are displayed and stored as ordinary settings. Never put credentials here."
+    >
+      <div className="flex flex-col gap-2">
+        {rows.map(([name, value], index) => (
+          <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2" key={index}>
+            <Input
+              aria-label={`Environment name ${index + 1}`}
+              placeholder="NAME"
+              value={name}
+              disabled={disabled}
+              autoComplete="off"
+              spellCheck={false}
+              onChange={(event) =>
+                replaceRow(index, event.target.value, value)
+              }
+            />
+            <Input
+              aria-label={`Environment value ${index + 1}`}
+              placeholder="non-secret value"
+              value={value}
+              disabled={disabled}
+              autoComplete="off"
+              spellCheck={false}
+              onChange={(event) =>
+                replaceRow(index, name, event.target.value)
+              }
+            />
+            <Button
+              type="button"
+              variant="outline"
+              aria-label={`Remove environment value ${index + 1}`}
+              disabled={disabled}
+              onClick={() =>
+                onChange(
+                  Object.fromEntries(
+                    rows.filter((_, itemIndex) => itemIndex !== index),
+                  ),
+                )
+              }
+            >
+              <Trash2 size={14} />
+            </Button>
+          </div>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          className="self-start"
+          disabled={disabled}
+          onClick={() => onChange({ ...values, "": "" })}
+        >
+          <Plus size={14} />
+          Add literal value
+        </Button>
+      </div>
+    </FieldGroup>
+  );
+}
+
+function FieldGroup({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+      {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
+    </div>
+  );
+}
+
+function healthLabel(health: McpServerInfo["health"]): string {
+  switch (health) {
+    case "healthy":
+      return "Healthy";
+    case "degraded":
+      return "Needs attention";
+    case "reconnecting":
+      return "Reconnecting";
+    case "disabled":
+      return "Disabled";
+    case "initializing":
+      return "Not verified";
+  }
+}
+
+function healthTone(
+  health: McpServerInfo["health"],
+): "ready" | "not-configured" | "disabled" {
+  if (health === "healthy") return "ready";
+  if (health === "disabled") return "disabled";
+  return "not-configured";
+}

--- a/crates/openwave-mcp/src/client.rs
+++ b/crates/openwave-mcp/src/client.rs
@@ -19,6 +19,18 @@ use tokio::time::timeout;
 use crate::protocol::{Response, RpcError, PROTOCOL_VERSION};
 
 const CLIENT_NAME: &str = "openwave";
+/// Provider-safe mounted function-name limit shared by OpenAI and Anthropic.
+pub const MAX_MOUNTED_TOOL_NAME_BYTES: usize = 64;
+/// Leaves useful room for the remote name inside `mcp__{server}__{tool}`.
+pub const MAX_SERVER_NAME_BYTES: usize = 32;
+const MAX_SERVER_INFO_BYTES: usize = 256;
+const MAX_TOOLS_PER_SERVER: usize = 128;
+const MAX_TOOL_DESCRIPTION_BYTES: usize = 8 * 1024;
+const MAX_TOOL_SCHEMA_BYTES: usize = 64 * 1024;
+const MAX_TOOL_METADATA_BYTES: usize = 512 * 1024;
+const MAX_TOOL_LIST_PAGES: usize = 64;
+const MAX_CURSOR_BYTES: usize = 4 * 1024;
+const MAX_JSON_RPC_FRAME_BYTES: usize = 2 * 1024 * 1024;
 
 /// Default maximum time to wait for one external MCP request.
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
@@ -40,6 +52,7 @@ pub struct McpServerInfo {
 /// The configured `server_name` is a stable local namespace, independent of the
 /// server's self-reported identity. A remote tool named `search` on a configured
 /// server named `docs` is advertised as `mcp__docs__search`.
+#[derive(Clone)]
 pub struct McpClient {
     server_name: String,
     server_info: McpServerInfo,
@@ -87,7 +100,8 @@ impl McpClient {
     /// Spawn and connect to an external MCP stdio server.
     ///
     /// Callers configure the executable, arguments, environment, and working
-    /// directory on `command`; this method owns stdin/stdout and inherits stderr.
+    /// directory on `command`; this method owns stdin/stdout and discards stderr
+    /// so an untrusted child cannot copy a selected credential into host logs.
     /// The child is terminated if the client session is dropped.
     pub async fn spawn(server_name: impl Into<String>, command: Command) -> Result<Self> {
         Self::spawn_with_timeout(server_name, command, DEFAULT_REQUEST_TIMEOUT).await
@@ -96,7 +110,19 @@ impl McpClient {
     /// Spawn a server with an explicit per-request timeout.
     pub async fn spawn_with_timeout(
         server_name: impl Into<String>,
+        command: Command,
+        request_timeout: Duration,
+    ) -> Result<Self> {
+        Self::spawn_with_timeouts(server_name, command, request_timeout, request_timeout).await
+    }
+
+    /// Spawn with a separately bounded initialization timeout. The established
+    /// session switches to `request_timeout` only after initialize and initial
+    /// tool discovery succeed.
+    pub async fn spawn_with_timeouts(
+        server_name: impl Into<String>,
         mut command: Command,
+        initialization_timeout: Duration,
         request_timeout: Duration,
     ) -> Result<Self> {
         let server_name = server_name.into();
@@ -104,7 +130,7 @@ impl McpClient {
         command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::null())
             .kill_on_drop(true);
         let mut child = command
             .spawn()
@@ -118,16 +144,18 @@ impl McpClient {
             .take()
             .ok_or_else(|| mcp_message("external server did not provide stdout"))?;
 
-        Self::connect_session(
+        let client = Self::connect_session(
             server_name,
             Session::new(
                 Box::new(BufReader::new(stdout)),
                 Box::new(stdin),
                 Some(child),
-                request_timeout,
+                initialization_timeout,
             ),
         )
-        .await
+        .await?;
+        client.session.lock().await.request_timeout = request_timeout;
+        Ok(client)
     }
 
     async fn connect_session(server_name: String, mut session: Session) -> Result<Self> {
@@ -158,11 +186,18 @@ impl McpClient {
                 "external server did not advertise the tools capability",
             ));
         }
+        if initialized.server_info.name.len() > MAX_SERVER_INFO_BYTES
+            || initialized.server_info.version.len() > MAX_SERVER_INFO_BYTES
+        {
+            return Err(mcp_message(
+                "external server identity exceeds the metadata limit",
+            ));
+        }
         session
             .notify("notifications/initialized", json!({}))
             .await?;
 
-        let descriptors = discover_tools(&mut session).await?;
+        let descriptors = discover_tools(&server_name, &mut session).await?;
         let tools = build_mounted_tools(&server_name, descriptors)?;
         Ok(Self {
             server_name,
@@ -189,6 +224,24 @@ impl McpClient {
         self.tools.iter().map(|tool| &tool.spec)
     }
 
+    /// Check that an idle session still responds and report whether the server
+    /// asked the client to refresh its tool list. A session owned by a live tool
+    /// call returns [`McpProbe::Busy`] immediately.
+    ///
+    /// MCP stdio is serialized per server, so the ping also drains notifications
+    /// that arrived while no tool call was active. Callers should establish a
+    /// fresh connection before publishing a changed tool surface; existing
+    /// registry snapshots may continue using this session until their turn ends.
+    pub async fn probe(&self) -> Result<McpProbe> {
+        let Ok(mut session) = self.session.try_lock() else {
+            return Ok(McpProbe::Busy);
+        };
+        session.request("ping", json!({})).await?;
+        Ok(McpProbe::Ready {
+            tools_list_changed: session.take_tools_list_changed(),
+        })
+    }
+
     /// Register namespaced proxies for all discovered tools.
     ///
     /// Registry registration follows [`ToolRegistry::register`] semantics, so a
@@ -210,6 +263,7 @@ struct Session {
     writer: BoxWriter,
     next_id: u64,
     request_timeout: Duration,
+    tools_list_changed: bool,
     // Keeping the child owns its lifecycle; `kill_on_drop(true)` handles both a
     // normal registry teardown and a failed initialization.
     _child: Option<Child>,
@@ -227,8 +281,13 @@ impl Session {
             writer,
             next_id: 1,
             request_timeout,
+            tools_list_changed: false,
             _child: child,
         }
+    }
+
+    fn take_tools_list_changed(&mut self) -> bool {
+        std::mem::take(&mut self.tools_list_changed)
     }
 
     async fn request(&mut self, method: &str, params: Value) -> Result<Value> {
@@ -288,19 +347,13 @@ impl Session {
 
     async fn read_response(&mut self, expected_id: u64) -> Result<Value> {
         loop {
-            let mut line = String::new();
-            let read = self
-                .reader
-                .read_line(&mut line)
-                .await
-                .map_err(|error| mcp_error("could not read from external server", error))?;
-            if read == 0 {
+            let Some(line) = read_bounded_line(&mut self.reader).await? else {
                 return Err(mcp_message("external server closed stdout before replying"));
-            }
-            if line.trim().is_empty() {
+            };
+            if line.iter().all(u8::is_ascii_whitespace) {
                 continue;
             }
-            let value: Value = serde_json::from_str(&line)
+            let value: Value = serde_json::from_slice(&line)
                 .map_err(|error| mcp_error("external server returned malformed JSON-RPC", error))?;
 
             // Server notifications are asynchronous and need no response. Ping
@@ -308,6 +361,9 @@ impl Session {
             // advertises no other request-producing capabilities, so fail closed
             // for any other server request.
             if let Some(method) = value.get("method").and_then(Value::as_str) {
+                if method == "notifications/tools/list_changed" && value.get("id").is_none() {
+                    self.tools_list_changed = true;
+                }
                 if let Some(id) = value.get("id") {
                     self.write_server_request_response(id.clone(), method)
                         .await?;
@@ -362,6 +418,44 @@ impl Session {
     }
 }
 
+async fn read_bounded_line(reader: &mut BoxReader) -> Result<Option<Vec<u8>>> {
+    let mut line = Vec::new();
+    loop {
+        let available = reader
+            .fill_buf()
+            .await
+            .map_err(|error| mcp_error("could not read from external server", error))?;
+        if available.is_empty() {
+            return Ok((!line.is_empty()).then_some(line));
+        }
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let consumed = newline.map_or(available.len(), |index| index + 1);
+        if line.len().saturating_add(consumed) > MAX_JSON_RPC_FRAME_BYTES {
+            return Err(mcp_message(
+                "external server JSON-RPC frame exceeds the limit",
+            ));
+        }
+        line.extend_from_slice(&available[..consumed]);
+        reader.consume(consumed);
+        if newline.is_some() {
+            return Ok(Some(line));
+        }
+    }
+}
+
+/// Result of one non-mutating MCP health probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpProbe {
+    /// A tool call already owns the serialized stdio session. Health supervision
+    /// must skip this cycle rather than time out legitimate work.
+    Busy,
+    /// The ping completed on an otherwise idle session.
+    Ready {
+        /// The server emitted `notifications/tools/list_changed`.
+        tools_list_changed: bool,
+    },
+}
+
 #[derive(Deserialize)]
 struct IncomingResponse {
     jsonrpc: String,
@@ -408,8 +502,10 @@ struct ListToolsResponse {
     next_cursor: Option<String>,
 }
 
-async fn discover_tools(session: &mut Session) -> Result<Vec<RemoteTool>> {
+async fn discover_tools(server_name: &str, session: &mut Session) -> Result<Vec<RemoteTool>> {
     let mut tools = Vec::new();
+    let mut metadata_bytes = 0_usize;
+    let mut pages = 0_usize;
     let mut cursor: Option<String> = None;
     let mut seen_cursors = HashSet::new();
     loop {
@@ -418,9 +514,33 @@ async fn discover_tools(session: &mut Session) -> Result<Vec<RemoteTool>> {
             .map_or_else(|| json!({}), |cursor| json!({"cursor": cursor}));
         let result = session.request("tools/list", params).await?;
         let page: ListToolsResponse = decode_result("tools/list", result)?;
-        tools.extend(page.tools);
+        pages += 1;
+        if pages > MAX_TOOL_LIST_PAGES {
+            return Err(mcp_message("external server tool list has too many pages"));
+        }
+        if tools.len().saturating_add(page.tools.len()) > MAX_TOOLS_PER_SERVER {
+            return Err(mcp_message("external server advertises too many tools"));
+        }
+        for tool in page.tools {
+            metadata_bytes = metadata_bytes
+                .checked_add(validate_remote_tool(server_name, &tool)?)
+                .ok_or_else(|| mcp_message("external server tool metadata exceeds the limit"))?;
+            if metadata_bytes > MAX_TOOL_METADATA_BYTES {
+                return Err(mcp_message(
+                    "external server tool metadata exceeds the limit",
+                ));
+            }
+            tools.push(tool);
+        }
         match page.next_cursor.filter(|cursor| !cursor.is_empty()) {
-            Some(next) if seen_cursors.insert(next.clone()) => cursor = Some(next),
+            Some(next) if next.len() <= MAX_CURSOR_BYTES && seen_cursors.insert(next.clone()) => {
+                cursor = Some(next)
+            }
+            Some(next) if next.len() > MAX_CURSOR_BYTES => {
+                return Err(mcp_message(
+                    "external server tool-list cursor exceeds the limit",
+                ))
+            }
             Some(_) => {
                 return Err(mcp_message(
                     "external server repeated a tools/list pagination cursor",
@@ -431,24 +551,33 @@ async fn discover_tools(session: &mut Session) -> Result<Vec<RemoteTool>> {
     }
 }
 
+#[derive(Clone)]
 struct MountedTool {
     spec: ToolSpec,
     remote_name: String,
 }
 
 fn build_mounted_tools(server_name: &str, tools: Vec<RemoteTool>) -> Result<Vec<MountedTool>> {
+    if tools.len() > MAX_TOOLS_PER_SERVER {
+        return Err(mcp_message("external server advertises too many tools"));
+    }
     let mut remote_names = HashSet::new();
+    let mut metadata_bytes = 0_usize;
     tools
         .into_iter()
         .map(|tool| {
-            if tool.name.is_empty() {
-                return Err(mcp_message("external server advertised an empty tool name"));
+            metadata_bytes = metadata_bytes
+                .checked_add(validate_remote_tool(server_name, &tool)?)
+                .ok_or_else(|| mcp_message("external server tool metadata exceeds the limit"))?;
+            if metadata_bytes > MAX_TOOL_METADATA_BYTES {
+                return Err(mcp_message(
+                    "external server tool metadata exceeds the limit",
+                ));
             }
             if !remote_names.insert(tool.name.clone()) {
-                return Err(mcp_message(format!(
-                    "external server advertised duplicate tool name {}",
-                    tool.name
-                )));
+                return Err(mcp_message(
+                    "external server advertised duplicate tool names",
+                ));
             }
             Ok(MountedTool {
                 spec: ToolSpec {
@@ -462,8 +591,37 @@ fn build_mounted_tools(server_name: &str, tools: Vec<RemoteTool>) -> Result<Vec<
         .collect()
 }
 
+fn validate_remote_tool(server_name: &str, tool: &RemoteTool) -> Result<usize> {
+    let mounted_name = format!("mcp__{server_name}__{}", tool.name);
+    if tool.name.is_empty()
+        || mounted_name.len() > MAX_MOUNTED_TOOL_NAME_BYTES
+        || !mounted_name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        return Err(mcp_message(
+            "external server advertised a provider-incompatible tool name",
+        ));
+    }
+    if tool.description.len() > MAX_TOOL_DESCRIPTION_BYTES {
+        return Err(mcp_message(
+            "external server tool description exceeds the limit",
+        ));
+    }
+    let schema_bytes = serde_json::to_vec(&tool.input_schema)?.len();
+    if schema_bytes > MAX_TOOL_SCHEMA_BYTES {
+        return Err(mcp_message("external server tool schema exceeds the limit"));
+    }
+    mounted_name
+        .len()
+        .checked_add(tool.description.len())
+        .and_then(|size| size.checked_add(schema_bytes))
+        .ok_or_else(|| mcp_message("external server tool metadata exceeds the limit"))
+}
+
 fn validate_server_name(server_name: &str) -> Result<()> {
     if server_name.is_empty()
+        || server_name.len() > MAX_SERVER_NAME_BYTES
         || !server_name
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
@@ -612,6 +770,13 @@ mod tests {
         assert_eq!(output.content, "found waves");
         assert_eq!(output.data, Some(json!({"matches": 1})));
         assert!(!output.is_error);
+        let probe = client.probe().await.unwrap();
+        assert_eq!(
+            probe,
+            McpProbe::Ready {
+                tools_list_changed: true
+            }
+        );
 
         drop(registry);
         drop(client);
@@ -650,6 +815,207 @@ mod tests {
             .expect("invalid name must fail before spawn");
         assert!(error.to_string().contains("ASCII letters"));
         assert!(!error.to_string().contains("could not spawn"));
+    }
+
+    fn remote_tool(name: impl Into<String>) -> RemoteTool {
+        RemoteTool {
+            name: name.into(),
+            description: "fixture".to_string(),
+            input_schema: json!({"type": "object"}).as_object().unwrap().clone(),
+        }
+    }
+
+    #[test]
+    fn mounted_tool_names_use_the_shared_provider_safe_contract() {
+        for name in ["", "bad tool", "bad/tool", "bad.tool"] {
+            let error = build_mounted_tools("docs", vec![remote_tool(name)])
+                .err()
+                .expect("unsafe remote tool name must fail");
+            assert!(error.to_string().contains("provider-incompatible"));
+            if !name.is_empty() {
+                assert!(!error.to_string().contains(name));
+            }
+        }
+
+        let error = build_mounted_tools("docs", vec![remote_tool("x".repeat(64))])
+            .err()
+            .expect("overlong mounted tool name must fail");
+        assert!(error.to_string().contains("provider-incompatible"));
+    }
+
+    #[test]
+    fn tool_discovery_metadata_is_bounded_per_tool_and_in_aggregate() {
+        let too_many = (0..=MAX_TOOLS_PER_SERVER)
+            .map(|index| remote_tool(format!("tool_{index}")))
+            .collect();
+        assert!(build_mounted_tools("docs", too_many)
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("too many tools"));
+
+        let mut description = remote_tool("description");
+        description.description = "x".repeat(MAX_TOOL_DESCRIPTION_BYTES + 1);
+        assert!(build_mounted_tools("docs", vec![description])
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("description exceeds"));
+
+        let mut schema = remote_tool("schema");
+        schema.input_schema = json!({
+            "type": "object",
+            "description": "x".repeat(MAX_TOOL_SCHEMA_BYTES)
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        assert!(build_mounted_tools("docs", vec![schema])
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("schema exceeds"));
+
+        let aggregate = (0..MAX_TOOLS_PER_SERVER)
+            .map(|index| {
+                let mut tool = remote_tool(format!("tool_{index}"));
+                tool.description = "x".repeat(MAX_TOOL_METADATA_BYTES / MAX_TOOLS_PER_SERVER);
+                tool
+            })
+            .collect();
+        assert!(build_mounted_tools("docs", aggregate)
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("metadata exceeds"));
+    }
+
+    #[tokio::test]
+    async fn rejects_an_oversized_json_rpc_frame_before_decoding_it() {
+        let (client_stream, server_stream) = duplex(MAX_JSON_RPC_FRAME_BYTES + 1024);
+        let (client_reader, client_writer) = split(client_stream);
+        let server = tokio::spawn(async move {
+            let (reader, mut writer) = split(server_stream);
+            let mut lines = BufReader::new(reader).lines();
+            let _request = lines.next_line().await.unwrap().unwrap();
+            writer
+                .write_all(&vec![b'x'; MAX_JSON_RPC_FRAME_BYTES + 1])
+                .await
+                .unwrap();
+            writer.write_all(b"\n").await.unwrap();
+        });
+        let error = McpClient::connect_with_timeout(
+            "docs",
+            client_reader,
+            client_writer,
+            Duration::from_secs(5),
+        )
+        .await
+        .err()
+        .expect("oversized frame must fail");
+        assert!(error.to_string().contains("frame exceeds"));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn health_probe_skips_a_session_owned_by_a_long_running_tool_call() {
+        let (client_stream, server_stream) = duplex(16 * 1024);
+        let (client_reader, client_writer) = split(client_stream);
+        let call_started = Arc::new(tokio::sync::Notify::new());
+        let release_call = Arc::new(tokio::sync::Notify::new());
+        let server = tokio::spawn(blocking_tool_server(
+            server_stream,
+            call_started.clone(),
+            release_call.clone(),
+        ));
+        let client = McpClient::connect("busy", client_reader, client_writer)
+            .await
+            .unwrap();
+        let mut registry = ToolRegistry::new();
+        client.mount(&mut registry);
+        let call = tokio::spawn(async move {
+            registry
+                .get("mcp__busy__wait")
+                .unwrap()
+                .execute(
+                    &ToolCtx::new_legacy_workspace(
+                        ChatId::new(),
+                        None,
+                        PathBuf::from("unused-by-mcp"),
+                    ),
+                    json!({}),
+                )
+                .await
+        });
+        call_started.notified().await;
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_millis(50), client.probe())
+                .await
+                .expect("busy detection must not wait for the tool request")
+                .unwrap(),
+            McpProbe::Busy
+        );
+
+        release_call.notify_one();
+        assert_eq!(call.await.unwrap().unwrap().content, "finished");
+        assert_eq!(
+            client.probe().await.unwrap(),
+            McpProbe::Ready {
+                tools_list_changed: false
+            }
+        );
+        drop(client);
+        server.await.unwrap();
+    }
+
+    async fn blocking_tool_server(
+        stream: tokio::io::DuplexStream,
+        call_started: Arc<tokio::sync::Notify>,
+        release_call: Arc<tokio::sync::Notify>,
+    ) {
+        let (reader, mut writer) = split(stream);
+        let mut lines = BufReader::new(reader).lines();
+        while let Some(line) = lines.next_line().await.unwrap() {
+            let request: Value = serde_json::from_str(&line).unwrap();
+            let Some(id) = request.get("id").cloned() else {
+                assert_eq!(request["method"], "notifications/initialized");
+                continue;
+            };
+            let result = match request["method"].as_str().unwrap() {
+                "initialize" => json!({
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "blocking-fixture", "version": "1"}
+                }),
+                "tools/list" => json!({
+                    "tools": [{
+                        "name": "wait",
+                        "description": "Wait for the deterministic test",
+                        "inputSchema": {"type": "object"}
+                    }]
+                }),
+                "tools/call" => {
+                    call_started.notify_one();
+                    release_call.notified().await;
+                    json!({
+                        "content": [{"type": "text", "text": "finished"}],
+                        "isError": false
+                    })
+                }
+                "ping" => json!({}),
+                method => panic!("unexpected method: {method}"),
+            };
+            let mut response = serde_json::to_vec(&json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": result
+            }))
+            .unwrap();
+            response.push(b'\n');
+            writer.write_all(&response).await.unwrap();
+            writer.flush().await.unwrap();
+        }
     }
 
     async fn fake_server(stream: tokio::io::DuplexStream) {
@@ -718,6 +1084,17 @@ mod tests {
                         "structuredContent": {"matches": 1},
                         "isError": false
                     })
+                }
+                "ping" => {
+                    let mut notification = serde_json::to_vec(&json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/tools/list_changed"
+                    }))
+                    .unwrap();
+                    notification.push(b'\n');
+                    writer.write_all(&notification).await.unwrap();
+                    writer.flush().await.unwrap();
+                    json!({})
                 }
                 method => panic!("unexpected method: {method}"),
             };

--- a/crates/openwave-mcp/src/lib.rs
+++ b/crates/openwave-mcp/src/lib.rs
@@ -47,7 +47,9 @@ pub mod protocol;
 mod server;
 mod stdio;
 
-pub use client::{McpClient, McpServerInfo, DEFAULT_REQUEST_TIMEOUT};
+pub use client::{
+    McpClient, McpProbe, McpServerInfo, DEFAULT_REQUEST_TIMEOUT, MAX_SERVER_NAME_BYTES,
+};
 pub use protocol::PROTOCOL_VERSION;
 pub use server::McpServer;
 pub use stdio::{serve, serve_stdio};

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -364,6 +364,26 @@ mod tests {
     }
 
     #[test]
+    fn mcp_approval_projects_one_generic_action_without_remote_metadata() {
+        let projected = RendererSequencedEvent::from(&SequencedEvent {
+            seq: 9,
+            event: AgentEvent::ApprovalRequired {
+                call_id: CallId::new(),
+                tool_name: "mcp__private_server__private_tool".into(),
+                class: ApprovalClass::Sensitive,
+                kind: ToolApprovalKind::ExternalMcpMayCallServer,
+                summary: "private model-authored arguments".into(),
+            },
+        });
+        let json = serde_json::to_string(&projected).unwrap();
+        assert!(json.contains(r#""action":"other""#));
+        assert!(json.contains(r#""approval":"external_mcp_may_call_server""#));
+        assert!(!json.contains("private_server"));
+        assert!(!json.contains("private_tool"));
+        assert!(!json.contains("model-authored"));
+    }
+
+    #[test]
     fn background_agent_tools_use_fixed_renderer_names() {
         for (name, expected) in [
             ("spawn_sandbox_agent", r#""name":"spawn_sandbox_agent""#),

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -234,6 +234,16 @@ pub fn app(state: AppState) -> Router {
                 .layer(DefaultBodyLimit::max(MAX_CODE_EXECUTION_CONFIG_BODY_BYTES)),
         )
         .route(
+            "/mcp/servers",
+            get(routes::get_mcp_servers)
+                .put(routes::put_mcp_servers)
+                .layer(DefaultBodyLimit::max(mcp_config::MAX_CONFIG_BODY_BYTES)),
+        )
+        .route(
+            "/mcp/servers/{name}/reconnect",
+            post(routes::post_mcp_server_reconnect),
+        )
+        .route(
             "/web-search/credentials",
             get(routes::get_web_search_credentials),
         )
@@ -332,6 +342,7 @@ pub struct Server {
     _sandbox_web_search_worker: AbortTask,
     _blob_retirement_worker: AbortTask,
     _blob_orphan_auditor: AbortTask,
+    _mcp_supervisor: AbortTask,
     _instance_lock: InstanceLock,
 }
 
@@ -483,15 +494,13 @@ async fn bind_inner(
     ));
     let foreground_web_search =
         Box::new(web_search::foreground_tool(store.clone(), secrets.clone()));
-    let (retrieval, mut tools, mut agent_config) = agent_deps(
+    let (retrieval, tools, agent_config) = agent_deps(
         embedder,
         vector_store,
         code_execution,
         foreground_web_search,
         store.clone(),
     );
-    mcp_servers.mount(&mut tools).await?;
-    finalize_foreground_agent_config(&tools, &mut agent_config);
     let tools = Arc::new(tools);
     let state = match client_executor_id {
         Some(client_executor_id) => AppState::new_with_client_executor_id(
@@ -514,6 +523,7 @@ async fn bind_inner(
             agent_config,
         ),
     };
+    state.mcp.initialize(mcp_servers).await?;
     let token = state.token.clone();
     let client_executor_token = state.client_executor_token.clone();
     let document_worker = document_worker::DocumentWorker::new(
@@ -557,7 +567,8 @@ async fn bind_inner(
         state.agent_config.clone(),
         Some(state.config.data_dir.join("scratch")),
         turn_worker::TurnWorkerConfig::default(),
-    );
+    )
+    .with_mcp_runtime(state.mcp.clone());
     let sandbox_worker_config = sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default()
         .with_delegated_file_executor(client_executor_id.is_some());
     let sandbox_agent_run_worker = sandbox_agent_run_worker::SandboxAgentRunWorker::with_attempts(
@@ -580,6 +591,7 @@ async fn bind_inner(
             sandbox_web_search_worker::SandboxWebSearchWorkerConfig::default(),
         );
     let server_store = state.store.clone();
+    let mcp_runtime = state.mcp.clone();
     let router = app(state);
 
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
@@ -596,6 +608,7 @@ async fn bind_inner(
     let sandbox_web_search_worker = tokio::spawn(sandbox_web_search_worker.run());
     let blob_retirement_worker = tokio::spawn(blob_retirement_worker.run());
     let blob_orphan_auditor = tokio::spawn(blob_orphan_auditor.run());
+    let mcp_supervisor = tokio::spawn(mcp_runtime.supervise());
 
     Ok(Server {
         local_addr,
@@ -611,6 +624,7 @@ async fn bind_inner(
         _sandbox_web_search_worker: AbortTask(sandbox_web_search_worker),
         _blob_retirement_worker: AbortTask(blob_retirement_worker),
         _blob_orphan_auditor: AbortTask(blob_orphan_auditor),
+        _mcp_supervisor: AbortTask(mcp_supervisor),
         _instance_lock: instance_lock,
     })
 }
@@ -664,17 +678,6 @@ fn agent_deps(
         ..AgentConfig::default()
     };
     (retrieval, tools, agent_config)
-}
-
-/// Finalize the foreground prompt only after every boot-time tool is mounted.
-///
-/// The registry is immutable after this point today. A future dynamically
-/// swappable registry must run the same composition against the immutable tool
-/// snapshot selected for each turn, rather than retaining this startup value.
-fn finalize_foreground_agent_config(tools: &ToolRegistry, agent_config: &mut AgentConfig) {
-    agent_config.system_prompt = Some(foreground_prompt::compose(
-        &tools.specs_for_foreground(true),
-    ));
 }
 
 /// The embeddings model used when an OpenAI credential is configured. Its native

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -1,27 +1,46 @@
-//! Boot-time configuration for external MCP stdio servers.
+//! Runtime configuration and supervision for external MCP stdio servers.
+//!
+//! Definitions are typed data, never shell fragments. Every child starts with a
+//! cleared environment and receives only literal values explicitly marked
+//! non-secret plus values selected by *name* from the parent environment. The
+//! latter values are resolved only at the process boundary and are never stored
+//! or projected through the API.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-use openwave_core::{AgentError, Result, ToolRegistry};
-use openwave_mcp::McpClient;
-use serde::Deserialize;
+use futures::future::join_all;
+use openwave_core::{AgentError, Result, Store, ToolRegistry};
+use openwave_mcp::{McpClient, McpProbe, MAX_SERVER_NAME_BYTES};
+use serde::{Deserialize, Serialize};
 use tokio::process::Command;
+use tokio::sync::Mutex;
 
 const CONFIG_ENV: &str = "OPENWAVE_MCP_CONFIG";
+const SETTING_KEY: &str = "mcp_servers_v1";
 const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
+pub(crate) const MAX_CONFIG_BODY_BYTES: usize = 1024 * 1024;
 const MAX_SERVERS: usize = 32;
 const MAX_ARGS: usize = 128;
 const MAX_ENVIRONMENT_VARIABLES: usize = 128;
+const MAX_PROCESS_STRING_BYTES: usize = 32 * 1024;
+const MAX_ENVIRONMENT_NAME_BYTES: usize = 256;
 const MAX_REQUEST_TIMEOUT_MS: u64 = 60 * 60 * 1000;
 const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 60 * 1000;
+const HEALTH_INTERVAL: Duration = Duration::from_secs(15);
+const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+const INITIALIZATION_TIMEOUT: Duration = Duration::from_secs(10);
+const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(30);
 
-/// Validated external servers selected for one process boot.
+/// Validated external servers selected by the legacy boot file.
 #[derive(Default)]
-pub(crate) struct ConfiguredMcpServers(Vec<StdioServerConfig>);
+pub(crate) struct ConfiguredMcpServers(Vec<McpServerDefinition>);
 
 impl ConfiguredMcpServers {
     pub(crate) fn from_env() -> Result<Self> {
@@ -53,62 +72,66 @@ impl ConfiguredMcpServers {
                 path.display()
             )));
         }
-        Self::parse(path, &bytes)
-    }
-
-    fn parse(path: &Path, bytes: &[u8]) -> Result<Self> {
-        let config: ConfigFile = serde_json::from_slice(bytes).map_err(|error| {
+        let config: McpServersConfig = serde_json::from_slice(&bytes).map_err(|error| {
             AgentError::config(format!("invalid MCP config {}: {error}", path.display()))
         })?;
-        validate_servers(config.servers).map(Self)
-    }
-
-    pub(crate) async fn mount(self, registry: &mut ToolRegistry) -> Result<()> {
-        for server in self.0 {
-            let name = server.name.clone();
-            let client = server.connect().await.map_err(|error| {
-                AgentError::config(format!(
-                    "external MCP server {name} failed to start: {error}"
-                ))
-            })?;
-            client.mount(registry);
-        }
-        Ok(())
+        validate_servers(&config.servers)?;
+        Ok(Self(config.servers))
     }
 }
 
-#[derive(Deserialize)]
+/// Complete persisted MCP configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct ConfigFile {
-    servers: Vec<StdioServerConfig>,
+pub(crate) struct McpServersConfig {
+    pub(crate) servers: Vec<McpServerDefinition>,
 }
 
-#[derive(Deserialize)]
+/// One local stdio MCP process definition.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct StdioServerConfig {
-    name: String,
-    command: String,
+pub(crate) struct McpServerDefinition {
+    pub(crate) name: String,
+    pub(crate) command: String,
     #[serde(default)]
-    args: Vec<String>,
+    pub(crate) args: Vec<String>,
+    /// Explicit literal values. The UI labels these as non-secret.
     #[serde(default)]
-    env: BTreeMap<String, String>,
+    pub(crate) env: BTreeMap<String, String>,
+    /// Parent environment names to forward. Their values never enter this type.
     #[serde(default)]
-    env_from: Vec<String>,
+    pub(crate) env_from: Vec<String>,
     #[serde(default)]
-    inherit_env: bool,
-    #[serde(default)]
-    cwd: Option<PathBuf>,
+    pub(crate) cwd: Option<PathBuf>,
     #[serde(default = "default_request_timeout_ms")]
-    request_timeout_ms: u64,
+    pub(crate) request_timeout_ms: u64,
+    #[serde(default = "enabled_by_default")]
+    pub(crate) enabled: bool,
 }
 
-impl StdioServerConfig {
+impl std::fmt::Debug for McpServerDefinition {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("McpServerDefinition")
+            .field("name", &self.name)
+            .field("command", &self.command)
+            .field("argument_count", &self.args.len())
+            .field("env_names", &self.env.keys().collect::<Vec<_>>())
+            .field("env_from", &self.env_from)
+            .field("cwd", &self.cwd)
+            .field("request_timeout_ms", &self.request_timeout_ms)
+            .field("enabled", &self.enabled)
+            .finish()
+    }
+}
+
+impl McpServerDefinition {
     fn build_command(&self) -> Result<Command> {
         let mut command = Command::new(&self.command);
         command.args(&self.args);
-        if !self.inherit_env {
-            command.env_clear();
-        }
+        // Deliberately unconditional: a renderer cannot widen a child to the
+        // desktop's provider credentials or other ambient environment.
+        command.env_clear();
         for name in &self.env_from {
             let value = std::env::var_os(name).ok_or_else(|| {
                 AgentError::config(format!(
@@ -124,11 +147,11 @@ impl StdioServerConfig {
         Ok(command)
     }
 
-    async fn connect(self) -> Result<McpClient> {
-        let command = self.build_command()?;
-        McpClient::spawn_with_timeout(
-            self.name,
-            command,
+    async fn connect(&self) -> Result<McpClient> {
+        McpClient::spawn_with_timeouts(
+            self.name.clone(),
+            self.build_command()?,
+            INITIALIZATION_TIMEOUT,
             Duration::from_millis(self.request_timeout_ms),
         )
         .await
@@ -139,14 +162,522 @@ const fn default_request_timeout_ms() -> u64 {
     DEFAULT_REQUEST_TIMEOUT_MS
 }
 
-fn validate_servers(servers: Vec<StdioServerConfig>) -> Result<Vec<StdioServerConfig>> {
+const fn enabled_by_default() -> bool {
+    true
+}
+
+/// Renderer-safe connection lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum McpHealth {
+    Initializing,
+    Healthy,
+    Degraded,
+    Reconnecting,
+    Disabled,
+}
+
+/// One renderer-safe server projection. Resolved `env_from` values and child
+/// process details are intentionally absent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct McpServerInfo {
+    #[serde(flatten)]
+    pub(crate) definition: McpServerDefinition,
+    pub(crate) health: McpHealth,
+    pub(crate) tool_count: usize,
+    pub(crate) diagnostic: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct McpServersInfo {
+    pub(crate) servers: Vec<McpServerInfo>,
+}
+
+struct ManagedServer {
+    client: Option<McpClient>,
+    health: McpHealth,
+    diagnostic: Option<String>,
+    reconnect_backoff: Duration,
+    epoch: u64,
+    reconnect_lock: Arc<Mutex<()>>,
+}
+
+struct RuntimeState {
+    definitions: Vec<McpServerDefinition>,
+    servers: HashMap<String, ManagedServer>,
+}
+
+/// Owns the current MCP connection set and atomically published tool registry.
+///
+/// A turn asks for one [`snapshot`](Self::snapshot) and keeps that `Arc` for its
+/// entire live execution. Reconfiguration therefore affects only later turns;
+/// old sessions remain alive until their last turn snapshot is dropped.
+pub(crate) struct McpRuntime {
+    base_tools: ToolRegistry,
+    tools: RwLock<Arc<ToolRegistry>>,
+    state: Mutex<RuntimeState>,
+    mutation: Mutex<()>,
+    store: Arc<dyn Store>,
+    next_epoch: AtomicU64,
+}
+
+impl McpRuntime {
+    pub(crate) fn new(base_tools: Arc<ToolRegistry>, store: Arc<dyn Store>) -> Self {
+        Self {
+            base_tools: (*base_tools).clone(),
+            tools: RwLock::new(base_tools),
+            state: Mutex::new(RuntimeState {
+                definitions: Vec::new(),
+                servers: HashMap::new(),
+            }),
+            mutation: Mutex::new(()),
+            store,
+            next_epoch: AtomicU64::new(1),
+        }
+    }
+
+    /// Load persisted definitions when present, otherwise the legacy boot file.
+    ///
+    /// A boot file remains fail-closed. Persisted definitions degrade in place
+    /// so the Settings UI remains available to repair a missing executable or
+    /// selected environment variable.
+    pub(crate) async fn initialize(&self, boot: ConfiguredMcpServers) -> Result<()> {
+        match self.store.get_setting(SETTING_KEY).await? {
+            Some(value) => {
+                let config: McpServersConfig = serde_json::from_value(value).map_err(|error| {
+                    AgentError::config(format!("invalid saved MCP config: {error}"))
+                })?;
+                validate_servers(&config.servers)?;
+                self.replace_permissive(config.servers).await;
+                Ok(())
+            }
+            None => self.replace_strict(boot.0, false).await.map(|_| ()),
+        }
+    }
+
+    /// One immutable tool surface for a live turn.
+    pub(crate) fn snapshot(&self) -> Arc<ToolRegistry> {
+        self.tools
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    pub(crate) async fn info(&self) -> McpServersInfo {
+        let state = self.state.lock().await;
+        McpServersInfo {
+            servers: state
+                .definitions
+                .iter()
+                .map(|definition| {
+                    let managed = state.servers.get(&definition.name);
+                    McpServerInfo {
+                        definition: definition.clone(),
+                        health: managed.map_or(
+                            if definition.enabled {
+                                McpHealth::Initializing
+                            } else {
+                                McpHealth::Disabled
+                            },
+                            |server| server.health,
+                        ),
+                        tool_count: managed
+                            .and_then(|server| server.client.as_ref())
+                            .map_or(0, |client| client.tools().count()),
+                        diagnostic: managed.and_then(|server| server.diagnostic.clone()),
+                    }
+                })
+                .collect(),
+        }
+    }
+
+    /// Validate and connect a complete candidate before atomically replacing the
+    /// active connection set. A failed candidate leaves both persisted config
+    /// and the live tool registry unchanged.
+    pub(crate) async fn replace(&self, config: McpServersConfig) -> Result<McpServersInfo> {
+        // Keep durable settings and the live projection in one commit order.
+        // Candidate startup may be slow, but concurrent replacements must not
+        // overtake one another between persistence and publication.
+        let _mutation = self.mutation.lock().await;
+        self.replace_strict(config.servers, true).await?;
+        Ok(self.info().await)
+    }
+
+    #[cfg(test)]
+    async fn replace_with_commit_pause(
+        &self,
+        config: McpServersConfig,
+        entered: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    ) -> Result<McpServersInfo> {
+        let _mutation = self.mutation.lock().await;
+        entered.notify_one();
+        release.notified().await;
+        self.replace_strict(config.servers, true).await?;
+        Ok(self.info().await)
+    }
+
+    async fn replace_strict(
+        &self,
+        definitions: Vec<McpServerDefinition>,
+        persist: bool,
+    ) -> Result<()> {
+        validate_servers(&definitions)?;
+        let mut servers = HashMap::new();
+        let connections = join_all(definitions.iter().map(|definition| async move {
+            if definition.enabled {
+                definition.connect().await.map(Some)
+            } else {
+                Ok(None)
+            }
+        }))
+        .await;
+        for (definition, connection) in definitions.iter().zip(connections) {
+            let Some(client) = connection.map_err(|_| {
+                AgentError::config(format!(
+                    "external MCP server {} failed to start: {}",
+                    definition.name,
+                    connection_diagnostic(definition)
+                ))
+            })?
+            else {
+                servers.insert(
+                    definition.name.clone(),
+                    ManagedServer {
+                        client: None,
+                        health: McpHealth::Disabled,
+                        diagnostic: None,
+                        reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
+                        epoch: self.fresh_epoch(),
+                        reconnect_lock: Arc::new(Mutex::new(())),
+                    },
+                );
+                continue;
+            };
+            servers.insert(
+                definition.name.clone(),
+                ManagedServer {
+                    client: Some(client),
+                    health: McpHealth::Healthy,
+                    diagnostic: None,
+                    reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
+                    epoch: self.fresh_epoch(),
+                    reconnect_lock: Arc::new(Mutex::new(())),
+                },
+            );
+        }
+        if persist {
+            self.store
+                .set_setting(
+                    SETTING_KEY,
+                    &serde_json::to_value(McpServersConfig {
+                        servers: definitions.clone(),
+                    })?,
+                )
+                .await?;
+        }
+        self.publish(definitions, servers).await;
+        Ok(())
+    }
+
+    async fn replace_permissive(&self, definitions: Vec<McpServerDefinition>) {
+        let mut servers = HashMap::new();
+        let connections = join_all(definitions.iter().map(|definition| async move {
+            if definition.enabled {
+                definition.connect().await.map(Some)
+            } else {
+                Ok(None)
+            }
+        }))
+        .await;
+        for (definition, connection) in definitions.iter().zip(connections) {
+            let managed = match connection {
+                Ok(None) => ManagedServer {
+                    client: None,
+                    health: McpHealth::Disabled,
+                    diagnostic: None,
+                    reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
+                    epoch: self.fresh_epoch(),
+                    reconnect_lock: Arc::new(Mutex::new(())),
+                },
+                Ok(Some(client)) => ManagedServer {
+                    client: Some(client),
+                    health: McpHealth::Healthy,
+                    diagnostic: None,
+                    reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
+                    epoch: self.fresh_epoch(),
+                    reconnect_lock: Arc::new(Mutex::new(())),
+                },
+                Err(_) => ManagedServer {
+                    client: None,
+                    health: McpHealth::Degraded,
+                    diagnostic: Some(connection_diagnostic(definition)),
+                    reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
+                    epoch: self.fresh_epoch(),
+                    reconnect_lock: Arc::new(Mutex::new(())),
+                },
+            };
+            servers.insert(definition.name.clone(), managed);
+        }
+        self.publish(definitions, servers).await;
+    }
+
+    async fn publish(
+        &self,
+        definitions: Vec<McpServerDefinition>,
+        servers: HashMap<String, ManagedServer>,
+    ) {
+        let registry = self.registry_for(&servers);
+        let mut state = self.state.lock().await;
+        state.definitions = definitions;
+        state.servers = servers;
+        *self
+            .tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(registry);
+    }
+
+    fn registry_for(&self, servers: &HashMap<String, ManagedServer>) -> ToolRegistry {
+        let mut registry = self.base_tools.clone();
+        for server in servers.values() {
+            if let Some(client) = &server.client {
+                client.mount(&mut registry);
+            }
+        }
+        registry
+    }
+
+    /// Force a fresh connection and tool discovery for one configured server.
+    pub(crate) async fn reconnect(&self, name: &str) -> Result<McpServersInfo> {
+        self.reconnect_if_epoch(name, None).await
+    }
+
+    async fn reconnect_if_epoch(
+        &self,
+        name: &str,
+        expected_epoch: Option<u64>,
+    ) -> Result<McpServersInfo> {
+        // Serialize connection attempts for the same published server without
+        // blocking unrelated servers. A waiter captures the current epoch, so
+        // it returns the first attempt's result instead of launching a duplicate
+        // child after the lock becomes available.
+        let (reconnect_lock, requested_epoch) = {
+            let state = self.state.lock().await;
+            let definition = state
+                .definitions
+                .iter()
+                .find(|definition| definition.name == name)
+                .ok_or_else(|| AgentError::config("MCP server not found"))?;
+            if !definition.enabled {
+                return Err(AgentError::config("disabled MCP server cannot reconnect"));
+            }
+            let server = state
+                .servers
+                .get(name)
+                .ok_or_else(|| AgentError::config("MCP server runtime is missing"))?;
+            if expected_epoch.is_some_and(|epoch| epoch != server.epoch) {
+                return Ok(self.info_locked(&state));
+            }
+            (server.reconnect_lock.clone(), server.epoch)
+        };
+        let _reconnect = reconnect_lock.lock().await;
+        let (definition, start_epoch) = {
+            let mut state = self.state.lock().await;
+            let definition = state
+                .definitions
+                .iter()
+                .find(|definition| definition.name == name)
+                .cloned()
+                .ok_or_else(|| AgentError::config("MCP server not found"))?;
+            if !definition.enabled {
+                return Err(AgentError::config("disabled MCP server cannot reconnect"));
+            }
+            let Some(server) = state.servers.get_mut(name) else {
+                return Err(AgentError::config("MCP server runtime is missing"));
+            };
+            if server.epoch != requested_epoch
+                || expected_epoch.is_some_and(|epoch| epoch != server.epoch)
+            {
+                return Ok(self.info_locked(&state));
+            }
+            server.health = McpHealth::Reconnecting;
+            server.diagnostic = None;
+            (definition, server.epoch)
+        };
+        match definition.connect().await {
+            Ok(client) => {
+                let mut state = self.state.lock().await;
+                // A settings replacement may have won while the process started.
+                if state
+                    .definitions
+                    .iter()
+                    .find(|candidate| candidate.name == name)
+                    != Some(&definition)
+                    || state
+                        .servers
+                        .get(name)
+                        .is_none_or(|server| server.epoch != start_epoch)
+                {
+                    return Ok(self.info_locked(&state));
+                }
+                let server = state
+                    .servers
+                    .entry(name.to_string())
+                    .or_insert(ManagedServer {
+                        client: None,
+                        health: McpHealth::Initializing,
+                        diagnostic: None,
+                        reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
+                        epoch: self.fresh_epoch(),
+                        reconnect_lock: Arc::new(Mutex::new(())),
+                    });
+                server.client = Some(client);
+                server.health = McpHealth::Healthy;
+                server.diagnostic = None;
+                server.reconnect_backoff = INITIAL_RECONNECT_BACKOFF;
+                server.epoch = self.fresh_epoch();
+                let registry = self.registry_for(&state.servers);
+                *self
+                    .tools
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(registry);
+                Ok(self.info_locked(&state))
+            }
+            Err(_) => {
+                let diagnostic = connection_diagnostic(&definition);
+                let mut state = self.state.lock().await;
+                if let Some(server) = state
+                    .servers
+                    .get_mut(name)
+                    .filter(|server| server.epoch == start_epoch)
+                {
+                    server.client = None;
+                    server.health = McpHealth::Degraded;
+                    server.diagnostic = Some(diagnostic.clone());
+                    server.reconnect_backoff = server
+                        .reconnect_backoff
+                        .saturating_mul(2)
+                        .min(MAX_RECONNECT_BACKOFF);
+                    server.epoch = self.fresh_epoch();
+                } else {
+                    return Ok(self.info_locked(&state));
+                }
+                let registry = self.registry_for(&state.servers);
+                *self
+                    .tools
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(registry);
+                Err(AgentError::config(format!(
+                    "external MCP server {name} failed to reconnect: {diagnostic}"
+                )))
+            }
+        }
+    }
+
+    /// Monitor healthy sessions and reconnect degraded or tool-changed servers
+    /// with capped exponential backoff.
+    pub(crate) async fn supervise(self: Arc<Self>) {
+        loop {
+            tokio::time::sleep(HEALTH_INTERVAL).await;
+            let probes = {
+                let state = self.state.lock().await;
+                state
+                    .definitions
+                    .iter()
+                    .filter(|definition| definition.enabled)
+                    .filter_map(|definition| {
+                        state.servers.get(&definition.name).map(|server| {
+                            (
+                                definition.name.clone(),
+                                server.client.clone(),
+                                server.reconnect_backoff,
+                                server.epoch,
+                            )
+                        })
+                    })
+                    .collect::<Vec<_>>()
+            };
+            join_all(probes.into_iter().map(|(name, client, backoff, epoch)| {
+                let runtime = self.clone();
+                async move {
+                    let refresh = match client {
+                        Some(client) => {
+                            match tokio::time::timeout(HEALTH_PROBE_TIMEOUT, client.probe()).await {
+                                Ok(Ok(McpProbe::Busy)) => false,
+                                Ok(Ok(McpProbe::Ready { tools_list_changed })) => {
+                                    tools_list_changed
+                                }
+                                Ok(Err(_)) | Err(_) => {
+                                    runtime.mark_degraded(&name, epoch, backoff).await;
+                                    true
+                                }
+                            }
+                        }
+                        None => true,
+                    };
+                    if refresh {
+                        tokio::time::sleep(backoff).await;
+                        let _ = runtime.reconnect_if_epoch(&name, Some(epoch)).await;
+                    }
+                }
+            }))
+            .await;
+        }
+    }
+
+    async fn mark_degraded(&self, name: &str, epoch: u64, backoff: Duration) {
+        let mut state = self.state.lock().await;
+        if let Some(server) = state
+            .servers
+            .get_mut(name)
+            .filter(|server| server.epoch == epoch)
+        {
+            server.client = None;
+            server.health = McpHealth::Degraded;
+            server.diagnostic =
+                Some("Health check failed. OpenWave will retry this server.".to_string());
+            server.reconnect_backoff = backoff;
+        }
+        let registry = self.registry_for(&state.servers);
+        *self
+            .tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(registry);
+    }
+
+    fn fresh_epoch(&self) -> u64 {
+        self.next_epoch.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn info_locked(&self, state: &RuntimeState) -> McpServersInfo {
+        McpServersInfo {
+            servers: state
+                .definitions
+                .iter()
+                .map(|definition| {
+                    let managed = state.servers.get(&definition.name);
+                    McpServerInfo {
+                        definition: definition.clone(),
+                        health: managed.map_or(McpHealth::Initializing, |server| server.health),
+                        tool_count: managed
+                            .and_then(|server| server.client.as_ref())
+                            .map_or(0, |client| client.tools().count()),
+                        diagnostic: managed.and_then(|server| server.diagnostic.clone()),
+                    }
+                })
+                .collect(),
+        }
+    }
+}
+
+fn validate_servers(servers: &[McpServerDefinition]) -> Result<()> {
     if servers.len() > MAX_SERVERS {
         return Err(AgentError::config(format!(
             "MCP config contains more than {MAX_SERVERS} servers"
         )));
     }
     let mut names = HashSet::new();
-    for server in &servers {
+    for server in servers {
         validate_name(&server.name)?;
         validate_process_string(&server.name, "command", &server.command)?;
         if server.command.is_empty() {
@@ -184,16 +715,8 @@ fn validate_servers(servers: Vec<StdioServerConfig>) -> Result<Vec<StdioServerCo
                 ));
             }
         }
-        if server
-            .cwd
-            .as_ref()
-            .and_then(|path| path.to_str())
-            .is_some_and(|path| path.contains('\0'))
-        {
-            return Err(server_error(
-                &server.name,
-                "working directory must not contain NUL",
-            ));
+        if let Some(path) = server.cwd.as_ref().and_then(|path| path.to_str()) {
+            validate_process_string(&server.name, "working directory", path)?;
         }
         if !(1..=MAX_REQUEST_TIMEOUT_MS).contains(&server.request_timeout_ms) {
             return Err(server_error(
@@ -205,11 +728,12 @@ fn validate_servers(servers: Vec<StdioServerConfig>) -> Result<Vec<StdioServerCo
             return Err(server_error(&server.name, "server name is duplicated"));
         }
     }
-    Ok(servers)
+    Ok(())
 }
 
 fn validate_name(name: &str) -> Result<()> {
     if name.is_empty()
+        || name.len() > MAX_SERVER_NAME_BYTES
         || !name
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
@@ -223,6 +747,12 @@ fn validate_name(name: &str) -> Result<()> {
 }
 
 fn validate_process_string(name: &str, field: &str, value: &str) -> Result<()> {
+    if value.len() > MAX_PROCESS_STRING_BYTES {
+        return Err(server_error(
+            name,
+            format!("{field} exceeds {MAX_PROCESS_STRING_BYTES} bytes"),
+        ));
+    }
     if value.contains('\0') {
         return Err(server_error(name, format!("{field} must not contain NUL")));
     }
@@ -230,13 +760,29 @@ fn validate_process_string(name: &str, field: &str, value: &str) -> Result<()> {
 }
 
 fn validate_environment_name(server_name: &str, name: &str) -> Result<()> {
-    if name.is_empty() || name.contains('=') || name.contains('\0') {
+    if name.is_empty()
+        || name.len() > MAX_ENVIRONMENT_NAME_BYTES
+        || name.contains('=')
+        || name.contains('\0')
+    {
         return Err(server_error(
             server_name,
             format!("invalid environment variable name {name:?}"),
         ));
     }
     Ok(())
+}
+
+fn connection_diagnostic(definition: &McpServerDefinition) -> String {
+    if let Some(name) = definition
+        .env_from
+        .iter()
+        .find(|name| std::env::var_os(name).is_none())
+    {
+        return format!("Required parent environment variable {name:?} is not set.");
+    }
+    "Could not initialize this server. Check its executable, arguments, and working directory."
+        .to_string()
 }
 
 fn server_error(name: &str, message: impl std::fmt::Display) -> AgentError {
@@ -246,9 +792,45 @@ fn server_error(name: &str, message: impl std::fmt::Display) -> AgentError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openwave_core::DbStore;
 
     fn parse(json: &str) -> Result<ConfiguredMcpServers> {
-        ConfiguredMcpServers::parse(Path::new("test-mcp.json"), json.as_bytes())
+        let config: McpServersConfig = serde_json::from_str(json)?;
+        validate_servers(&config.servers)?;
+        Ok(ConfiguredMcpServers(config.servers))
+    }
+
+    fn disabled_definition(name: &str, command: &str) -> McpServerDefinition {
+        McpServerDefinition {
+            name: name.to_string(),
+            command: command.to_string(),
+            args: Vec::new(),
+            env: BTreeMap::new(),
+            env_from: Vec::new(),
+            cwd: None,
+            request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
+            enabled: false,
+        }
+    }
+
+    async fn test_runtime() -> (Arc<McpRuntime>, Arc<dyn Store>, tempfile::TempDir) {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("mcp.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        (
+            Arc::new(McpRuntime::new(
+                Arc::new(ToolRegistry::new()),
+                store.clone(),
+            )),
+            store,
+            directory,
+        )
     }
 
     #[test]
@@ -273,24 +855,34 @@ mod tests {
         assert_eq!(server.args, ["--stdio"]);
         assert_eq!(server.env.get("LOG_LEVEL").unwrap(), "info");
         assert_eq!(server.env_from, ["DOCS_TOKEN"]);
-        assert!(!server.inherit_env);
         assert_eq!(server.cwd.as_deref(), Some(Path::new("/srv/docs")));
         assert_eq!(server.request_timeout_ms, 2500);
+        assert!(server.enabled);
     }
 
     #[test]
     fn defaults_to_an_isolated_environment_and_sixty_second_timeout() {
         let config = parse(r#"{"servers":[{"name":"docs","command":"/bin/docs"}]}"#).unwrap();
         let server = &config.0[0];
-        assert!(!server.inherit_env);
         assert!(server.args.is_empty());
         assert!(server.env.is_empty());
         assert!(server.env_from.is_empty());
         assert_eq!(server.request_timeout_ms, 60_000);
+        let command = server.build_command().unwrap();
+        assert!(command.as_std().get_envs().next().is_none());
     }
 
     #[test]
-    fn rejects_duplicate_names_and_unsafe_process_strings() {
+    fn rejects_environment_inheritance_and_unknown_fields() {
+        let error =
+            parse(r#"{"servers":[{"name":"docs","command":"/bin/docs","inherit_env":true}]}"#)
+                .err()
+                .unwrap();
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_duplicate_names_unsafe_strings_and_timeouts() {
         let duplicate = parse(
             r#"{"servers":[
                 {"name":"docs","command":"/bin/one"},
@@ -305,15 +897,6 @@ mod tests {
             .err()
             .unwrap();
         assert!(nul.to_string().contains("must not contain NUL"));
-    }
-
-    #[test]
-    fn rejects_unknown_fields_and_out_of_range_timeouts() {
-        let unknown =
-            parse(r#"{"servers":[{"name":"docs","command":"/bin/docs","transport":"http"}]}"#)
-                .err()
-                .unwrap();
-        assert!(unknown.to_string().contains("unknown field"));
 
         let timeout =
             parse(r#"{"servers":[{"name":"docs","command":"/bin/docs","request_timeout_ms":0}]}"#)
@@ -372,7 +955,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_selected_parent_environment_fails_before_spawn() {
+    async fn missing_selected_parent_environment_fails_before_spawn_without_a_value() {
         const MISSING: &str = "OPENWAVE_TEST_MCP_ENV_FROM_MUST_NOT_EXIST_46F54489";
         assert!(std::env::var_os(MISSING).is_none());
         let config = parse(&format!(
@@ -383,16 +966,166 @@ mod tests {
             }}]}}"#
         ))
         .unwrap();
-        let error = config
-            .0
-            .into_iter()
-            .next()
-            .unwrap()
-            .connect()
-            .await
-            .err()
-            .unwrap();
+        let error = config.0[0].connect().await.err().unwrap();
         assert!(error.to_string().contains(MISSING));
         assert!(error.to_string().contains("is not set"));
+        assert!(!error.to_string().contains("secret-value"));
+    }
+
+    #[test]
+    fn projected_diagnostics_are_fixed_or_name_only() {
+        const MISSING: &str = "OPENWAVE_TEST_MCP_DIAGNOSTIC_MISSING_13B2";
+        assert!(std::env::var_os(MISSING).is_none());
+        let config = parse(&format!(
+            r#"{{"servers":[{{"name":"docs","command":"/bin/docs","env_from":["{MISSING}"]}}]}}"#
+        ))
+        .unwrap();
+        let missing = connection_diagnostic(&config.0[0]);
+        assert!(missing.contains(MISSING));
+        assert!(!missing.contains('\n'));
+
+        let generic = parse(r#"{"servers":[{"name":"docs","command":"/bin/docs"}]}"#).unwrap();
+        assert_eq!(
+            connection_diagnostic(&generic.0[0]),
+            "Could not initialize this server. Check its executable, arguments, and working directory."
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_replacements_keep_durable_and_live_configuration_in_commit_order() {
+        let (runtime, store, _directory) = test_runtime().await;
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let first = {
+            let runtime = runtime.clone();
+            let entered = entered.clone();
+            let release = release.clone();
+            tokio::spawn(async move {
+                runtime
+                    .replace_with_commit_pause(
+                        McpServersConfig {
+                            servers: vec![disabled_definition("first", "/bin/first")],
+                        },
+                        entered,
+                        release,
+                    )
+                    .await
+            })
+        };
+        entered.notified().await;
+        let mut second = {
+            let runtime = runtime.clone();
+            tokio::spawn(async move {
+                runtime
+                    .replace(McpServersConfig {
+                        servers: vec![disabled_definition("second", "/bin/second")],
+                    })
+                    .await
+            })
+        };
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut second)
+                .await
+                .is_err(),
+            "second replacement bypassed the fence"
+        );
+        release.notify_one();
+        first.await.unwrap().unwrap();
+        second.await.unwrap().unwrap();
+
+        let saved: McpServersConfig =
+            serde_json::from_value(store.get_setting(SETTING_KEY).await.unwrap().unwrap()).unwrap();
+        let live = runtime.info().await;
+        assert_eq!(saved.servers[0].name, "second");
+        assert_eq!(live.servers[0].definition, saved.servers[0]);
+    }
+
+    #[tokio::test]
+    async fn stale_supervisor_result_cannot_overwrite_a_replacement() {
+        let (runtime, _store, _directory) = test_runtime().await;
+        runtime
+            .replace(McpServersConfig {
+                servers: vec![disabled_definition("docs", "/bin/old")],
+            })
+            .await
+            .unwrap();
+        let old_epoch = runtime
+            .state
+            .lock()
+            .await
+            .servers
+            .get("docs")
+            .unwrap()
+            .epoch;
+        runtime
+            .replace(McpServersConfig {
+                servers: vec![disabled_definition("docs", "/bin/new")],
+            })
+            .await
+            .unwrap();
+
+        runtime
+            .mark_degraded("docs", old_epoch, INITIAL_RECONNECT_BACKOFF)
+            .await;
+        let info = runtime.info().await;
+        assert_eq!(info.servers[0].definition.command, "/bin/new");
+        assert_eq!(info.servers[0].health, McpHealth::Disabled);
+        assert!(info.servers[0].diagnostic.is_none());
+    }
+
+    #[tokio::test]
+    async fn concurrent_reconnects_share_one_attempt_for_a_published_server() {
+        let (runtime, _store, _directory) = test_runtime().await;
+        let mut definition = disabled_definition("docs", "/usr/bin/true");
+        definition.enabled = true;
+        runtime.replace_permissive(vec![definition]).await;
+        let reconnect_lock = runtime
+            .state
+            .lock()
+            .await
+            .servers
+            .get("docs")
+            .unwrap()
+            .reconnect_lock
+            .clone();
+        let held = reconnect_lock.lock().await;
+        let first = {
+            let runtime = runtime.clone();
+            tokio::spawn(async move { runtime.reconnect("docs").await })
+        };
+        let second = {
+            let runtime = runtime.clone();
+            tokio::spawn(async move { runtime.reconnect("docs").await })
+        };
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while Arc::strong_count(&reconnect_lock) < 4 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("both reconnects should wait on the published server lock");
+        drop(held);
+
+        let first = first.await.unwrap();
+        let second = second.await.unwrap();
+        assert_ne!(
+            first.is_err(),
+            second.is_err(),
+            "exactly one caller should perform the failed connection attempt"
+        );
+        assert_eq!(runtime.info().await.servers[0].health, McpHealth::Degraded);
+    }
+
+    #[test]
+    fn debug_projection_redacts_argument_and_literal_environment_values() {
+        let mut definition = disabled_definition("docs", "/bin/docs");
+        definition.args = vec!["argument-secret".to_string()];
+        definition
+            .env
+            .insert("TOKEN".to_string(), "literal-secret".to_string());
+        let debug = format!("{definition:?}");
+        assert!(!debug.contains("argument-secret"));
+        assert!(!debug.contains("literal-secret"));
+        assert!(debug.contains("TOKEN"));
     }
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -16,9 +16,9 @@ use std::path::Path as FsPath;
 use tokio::sync::broadcast::error::RecvError;
 
 use openwave_core::{
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunExecution, AgentRunStatus,
-    ApprovalDecision, CallId, Chat, ChatId, DeleteChatOutcome, DeleteProjectOutcome,
-    Message as StoredMessage, MessageId, Project, ProjectId, ReasoningEffort,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentError, AgentRun, AgentRunExecution,
+    AgentRunStatus, ApprovalDecision, CallId, Chat, ChatId, DeleteChatOutcome,
+    DeleteProjectOutcome, Message as StoredMessage, MessageId, Project, ProjectId, ReasoningEffort,
     RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, Role, SandboxToolCall,
     SandboxToolCallStatus, SecretProvider, SequencedEvent, Store, ToolCallExecution,
     ToolCallRecord, ToolCallStatus, TurnId, TurnSteer, TurnSteerId,
@@ -29,6 +29,7 @@ use crate::code_execution::{self, CodeExecutionConfigInfo, CodeExecutionConfigUp
 use crate::error::ServerError;
 use crate::event_projection::RendererSequencedEvent;
 use crate::extract::{Json, Path, Query};
+use crate::mcp_config::{McpServersConfig, McpServersInfo};
 use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
 use crate::state::AppState;
 use crate::web_search::{
@@ -44,6 +45,56 @@ pub use client_execution::*;
 pub use delegated_file_execution::*;
 pub use document::*;
 pub use root_attachment::*;
+
+/// `GET /mcp/servers` — renderer-safe definitions and current connection health.
+pub async fn get_mcp_servers(
+    State(state): State<AppState>,
+) -> Result<Json<McpServersInfo>, ServerError> {
+    Ok(Json(state.mcp.info().await))
+}
+
+/// `PUT /mcp/servers` — atomically validate, connect, persist, and publish a
+/// complete replacement set. A failed candidate never changes active tools.
+pub async fn put_mcp_servers(
+    State(state): State<AppState>,
+    Json(body): Json<McpServersConfig>,
+) -> Result<Json<McpServersInfo>, ServerError> {
+    // Once validation/startup begins, finish the durable/live commit even if
+    // the HTTP client disconnects and drops this handler future.
+    let runtime = state.mcp.clone();
+    let mutation = tokio::spawn(async move { runtime.replace(body).await });
+    Ok(Json(
+        mutation
+            .await
+            .map_err(|_| ServerError::internal("MCP settings update task failed"))?
+            .map_err(mcp_request_error)?,
+    ))
+}
+
+/// `POST /mcp/servers/{name}/reconnect` — explicitly establish a fresh session,
+/// rediscover tools, and publish them for subsequent turns.
+pub async fn post_mcp_server_reconnect(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<McpServersInfo>, ServerError> {
+    // A dropped response must not strand the published state at
+    // `reconnecting`; Tokio tasks continue after their JoinHandle is dropped.
+    let runtime = state.mcp.clone();
+    let mutation = tokio::spawn(async move { runtime.reconnect(&name).await });
+    Ok(Json(
+        mutation
+            .await
+            .map_err(|_| ServerError::internal("MCP reconnect task failed"))?
+            .map_err(mcp_request_error)?,
+    ))
+}
+
+fn mcp_request_error(error: AgentError) -> ServerError {
+    match error {
+        AgentError::Config(message) => ServerError::bad_request(message),
+        other => other.into(),
+    }
+}
 
 /// The store-settings key for the selected model.
 const MODEL_SETTING: &str = "model";
@@ -1529,6 +1580,7 @@ pub(crate) struct PendingApprovalSnapshot {
     pub approval: openwave_core::ToolApprovalKind,
     pub class: openwave_core::ApprovalClass,
     pub can_approve: bool,
+    pub can_remember: bool,
 }
 
 /// `GET /chats/{id}/approvals` — recover a bounded page of pending cards.
@@ -1563,6 +1615,7 @@ pub(crate) async fn list_pending_approvals(
                     approval: kind,
                     class: approval.class,
                     can_approve: kind.is_approvable(),
+                    can_remember: kind.is_standing_grantable(),
                 }
             })
             .collect(),

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 
 use crate::approvals::ApprovalBroker;
 use crate::bus::EventBus;
+use crate::mcp_config::McpRuntime;
 use crate::resolver::ProviderResolver;
 
 /// The state cloned into each handler: the boot config, the durable store, the
@@ -38,6 +39,8 @@ pub struct AppState {
     pub secrets: Arc<dyn SecretProvider>,
     /// The tools available to the agent.
     pub tools: Arc<ToolRegistry>,
+    /// Runtime-managed MCP connections and immutable per-turn tool snapshots.
+    pub(crate) mcp: Arc<McpRuntime>,
     /// The retrieval pipeline used by the durable document worker and the
     /// agent's shared `search` tool.
     pub retrieval: Arc<Retriever>,
@@ -125,6 +128,7 @@ impl AppState {
         }
         let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
         let blob_writes = Arc::new(BlobWriteGuard::new(config.data_dir.join("blob-locks")));
+        let mcp = Arc::new(McpRuntime::new(tools.clone(), store.clone()));
         Ok(Self {
             config: Arc::new(config),
             store: store.clone(),
@@ -132,6 +136,7 @@ impl AppState {
             resolver,
             secrets,
             tools,
+            mcp,
             retrieval,
             document_job_wake: Arc::new(Notify::new()),
             turn_job_wake: Arc::new(Notify::new()),

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -6299,7 +6299,7 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_orchestration()
         .await
         .unwrap(),
     );
-    let (_retrieval, mut tools, mut config) = agent_deps(
+    let (_retrieval, mut tools, config) = agent_deps(
         Arc::new(HashEmbedder::default()),
         Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
         Arc::new(UnavailableCodeExecution),
@@ -6323,8 +6323,9 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_orchestration()
             }
         }),
     });
-    finalize_foreground_agent_config(&tools, &mut config);
-    let system_prompt = config
+    let surface = crate::turn_worker::freeze_foreground_turn_surface(Arc::new(tools), &config);
+    let system_prompt = surface
+        .agent_config
         .system_prompt
         .as_deref()
         .expect("production foreground turns receive an operating prompt");
@@ -6335,7 +6336,7 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_orchestration()
     assert!(system_prompt.contains("## External MCP tools"));
     assert!(!system_prompt.contains("mcp__test__lookup"));
     assert!(!system_prompt.contains("must-not-be-copied"));
-    let names: Vec<String> = tools.specs().into_iter().map(|s| s.name).collect();
+    let names: Vec<String> = surface.tools.specs().into_iter().map(|s| s.name).collect();
     assert!(
         names.iter().any(|n| n == "search"),
         "search tool registered"
@@ -6367,7 +6368,7 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_orchestration()
         "foreground web search registered"
     );
     assert_eq!(
-        tools.get("web_search").unwrap().approval_class(),
+        surface.tools.get("web_search").unwrap().approval_class(),
         ApprovalClass::Sensitive
     );
     assert!([
@@ -6376,7 +6377,8 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_orchestration()
     ]
     .iter()
     .all(|orchestration| !names.iter().any(|name| name == orchestration)));
-    let foreground = tools
+    let foreground = surface
+        .tools
         .specs_for_foreground(true)
         .into_iter()
         .map(|spec| spec.name)
@@ -6388,19 +6390,23 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_orchestration()
     .iter()
     .all(|name| foreground.contains(*name)));
     assert_eq!(
-        tools.execution(openwave_core::REQUEST_FOLDER_ACCESS_TOOL),
+        surface
+            .tools
+            .execution(openwave_core::REQUEST_FOLDER_ACCESS_TOOL),
         Some(ToolCallExecution::Client)
     );
-    assert!(tools
+    assert!(surface
+        .tools
         .get(openwave_core::REQUEST_FOLDER_ACCESS_TOOL)
         .is_none());
-    let spec = tools
+    let spec = surface
+        .tools
         .specs()
         .into_iter()
         .find(|spec| spec.name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL)
         .expect("folder consent tool is advertised");
     assert_eq!(spec, openwave_core::request_folder_access_tool_spec());
-    assert!(tools.client_arguments_are_valid(
+    assert!(surface.tools.client_arguments_are_valid(
         openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
         &serde_json::json!({
             "reason": "Read the reports needed for this project",
@@ -6408,7 +6414,7 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_orchestration()
             "folder_hint": "documents"
         })
     ));
-    assert!(!tools.client_arguments_are_valid(
+    assert!(!surface.tools.client_arguments_are_valid(
         openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
         &serde_json::json!({
             "reason": "Read reports",
@@ -8894,6 +8900,158 @@ async fn settings_default_then_update_roundtrips() {
         .unwrap();
     let settings: serde_json::Value = json_body(response).await;
     assert_eq!(settings["model"], "claude-x");
+}
+
+async fn put_mcp_servers(
+    router: &Router,
+    bearer: &str,
+    body: serde_json::Value,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/mcp/servers")
+                .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn get_mcp_servers(router: &Router, bearer: &str) -> serde_json::Value {
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/mcp/servers")
+                .header(header::AUTHORIZATION, bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    json_body(response).await
+}
+
+#[tokio::test]
+async fn mcp_settings_roundtrip_disabled_typed_definitions_without_credentials() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let unauthenticated = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/mcp/servers")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+
+    let response = put_mcp_servers(
+        &router,
+        &bearer,
+        serde_json::json!({
+            "servers": [{
+                "name": "private_docs",
+                "command": "/not/started/while/disabled",
+                "args": ["--stdio"],
+                "env": {"LOG_LEVEL": "info"},
+                "env_from": ["PATH"],
+                "cwd": "/tmp",
+                "request_timeout_ms": 2500,
+                "enabled": false
+            }]
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let info: serde_json::Value = json_body(response).await;
+    assert_eq!(info["servers"][0]["health"], "disabled");
+    assert_eq!(info["servers"][0]["tool_count"], 0);
+    assert_eq!(info["servers"][0]["env_from"], serde_json::json!(["PATH"]));
+    let encoded = info.to_string();
+    assert!(!encoded.contains("resolved_value"));
+    assert!(!encoded.contains("inherit_env"));
+    if let Ok(path) = std::env::var("PATH") {
+        assert!(
+            !encoded.contains(&path),
+            "resolved PATH leaked into renderer JSON"
+        );
+    }
+
+    let fetched = get_mcp_servers(&router, &bearer).await;
+    assert_eq!(fetched, info);
+}
+
+#[tokio::test]
+async fn failed_mcp_candidate_does_not_replace_the_active_configuration() {
+    const MISSING: &str = "OPENWAVE_TEST_MCP_ROUTE_MISSING_ENV_65B7A2";
+    assert!(std::env::var_os(MISSING).is_none());
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let initial = put_mcp_servers(
+        &router,
+        &bearer,
+        serde_json::json!({
+            "servers": [{
+                "name": "kept",
+                "command": "/not/started",
+                "enabled": false
+            }]
+        }),
+    )
+    .await;
+    assert_eq!(initial.status(), StatusCode::OK);
+
+    let failed = put_mcp_servers(
+        &router,
+        &bearer,
+        serde_json::json!({
+            "servers": [{
+                "name": "broken",
+                "command": "/not/reached",
+                "env_from": [MISSING]
+            }]
+        }),
+    )
+    .await;
+    assert_eq!(failed.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(failed).await;
+    assert_eq!(error.kind, "bad_request");
+    assert!(error.message.contains("broken"));
+    assert!(error.message.contains(MISSING));
+
+    let active = get_mcp_servers(&router, &bearer).await;
+    assert_eq!(active["servers"][0]["name"], "kept");
+}
+
+#[tokio::test]
+async fn mcp_settings_reject_environment_inheritance_and_unknown_fields() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let response = put_mcp_servers(
+        &router,
+        &bearer,
+        serde_json::json!({
+            "servers": [{
+                "name": "unsafe",
+                "command": "/bin/false",
+                "inherit_env": true
+            }]
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(response).await;
+    assert_eq!(error.kind, "bad_request");
+    assert!(error.message.contains("unknown field"));
 }
 
 /// PUT /settings with a raw JSON body, returning the response.
@@ -11706,6 +11864,7 @@ async fn foreground_web_search_runs_end_to_end_through_durable_approval() {
     assert_eq!(pending[0]["approval"], "web_search_may_share_query");
     assert_eq!(pending[0]["class"], "sensitive");
     assert_eq!(pending[0]["can_approve"], true);
+    assert_eq!(pending[0]["can_remember"], true);
     let pending_json = pending.to_string();
     assert!(!pending_json.contains("OpenWave release"));
     assert!(!pending_json.contains("Example.com"));

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -27,6 +27,7 @@ use tokio::sync::Notify;
 
 use crate::approvals::ApprovalBroker;
 use crate::bus::EventBus;
+use crate::mcp_config::McpRuntime;
 use crate::resolver::ProviderResolver;
 use crate::state::TurnGuard;
 
@@ -71,6 +72,7 @@ pub(crate) struct TurnWorker {
     store: Arc<dyn Store>,
     resolver: Arc<dyn ProviderResolver>,
     tools: Arc<ToolRegistry>,
+    mcp: Option<Arc<McpRuntime>>,
     approvals: Arc<ApprovalBroker>,
     events: Arc<EventBus>,
     signals: Arc<TurnGuard>,
@@ -96,6 +98,30 @@ enum ClaimAction {
 enum HeartbeatOutcome {
     Cancelling,
     LeaseLost,
+}
+
+/// Exact foreground capability surface retained for one live turn execution.
+///
+/// Both the provider-visible tool definitions and host-owned operating prompt
+/// derive from `tools`; runtime MCP refreshes can only produce a different
+/// surface for a later execution.
+pub(crate) struct ForegroundTurnSurface {
+    pub(crate) tools: Arc<ToolRegistry>,
+    pub(crate) agent_config: AgentConfig,
+}
+
+pub(crate) fn freeze_foreground_turn_surface(
+    tools: Arc<ToolRegistry>,
+    base_agent_config: &AgentConfig,
+) -> ForegroundTurnSurface {
+    let mut agent_config = base_agent_config.clone();
+    agent_config.system_prompt = Some(crate::foreground_prompt::compose(
+        &tools.specs_for_foreground(true),
+    ));
+    ForegroundTurnSurface {
+        tools,
+        agent_config,
+    }
 }
 
 /// Finish live publication for state transitions that committed before this
@@ -262,6 +288,7 @@ impl TurnWorker {
             store,
             resolver,
             tools,
+            mcp: None,
             approvals,
             events,
             signals,
@@ -271,6 +298,13 @@ impl TurnWorker {
             private_scratch_root,
             config,
         }
+    }
+
+    /// Resolve one immutable registry when a turn begins. Runtime MCP changes
+    /// affect later turns without changing this worker's active replay surface.
+    pub(crate) fn with_mcp_runtime(mut self, mcp: Arc<McpRuntime>) -> Self {
+        self.mcp = Some(mcp);
+        self
     }
 
     pub(crate) async fn run(self) {
@@ -362,7 +396,12 @@ impl TurnWorker {
                 turn.id
             )));
         }
-        if let Some(prompt) = self.agent_config.system_prompt.as_deref() {
+        let tools = self
+            .mcp
+            .as_ref()
+            .map_or_else(|| self.tools.clone(), |mcp| mcp.snapshot());
+        let surface = freeze_foreground_turn_surface(tools, &self.agent_config);
+        if let Some(prompt) = surface.agent_config.system_prompt.as_deref() {
             eprintln!(
                 "openwave: turn {} operating_prompt={}",
                 turn.id,
@@ -487,7 +526,7 @@ impl TurnWorker {
                 cancel.clone(),
             )));
             let mut heartbeat_open = true;
-            let mut config = self.agent_config.clone();
+            let mut config = surface.agent_config.clone();
             if let Some(policy) = model_policy.as_ref() {
                 crate::providers::apply_model_policy(&mut config, policy, chat.reasoning_effort)?;
             } else {
@@ -509,7 +548,7 @@ impl TurnWorker {
             });
             let provider = self.resolver.resolve().await;
             let steer = active.steer_inbox();
-            let agent = Agent::new(provider, self.tools.clone(), self.store.clone(), config)
+            let agent = Agent::new(provider, surface.tools.clone(), self.store.clone(), config)
                 .with_approvals(self.approvals.clone())
                 .with_standing_grants(self.approvals.standing_grants())
                 .with_cancel(cancel.clone())
@@ -937,7 +976,7 @@ impl TurnWorker {
                             .await;
                     }
                     if !client_checkpoint_is_valid(
-                        self.tools.as_ref(),
+                        surface.tools.as_ref(),
                         turn.chat_id,
                         turn.id,
                         &request,
@@ -1148,7 +1187,7 @@ impl TurnWorker {
                             )
                             .await;
                     }
-                    if !sandbox_spawn_checkpoint_is_valid(self.tools.as_ref(), &request) {
+                    if !sandbox_spawn_checkpoint_is_valid(surface.tools.as_ref(), &request) {
                         drop(active);
                         return self
                             .record_failure(
@@ -1414,7 +1453,7 @@ impl TurnWorker {
                             )
                             .await;
                     }
-                    if !agent_wait_checkpoint_is_valid(self.tools.as_ref(), &request) {
+                    if !agent_wait_checkpoint_is_valid(surface.tools.as_ref(), &request) {
                         drop(active);
                         return self
                             .record_failure(
@@ -2166,6 +2205,54 @@ fn log_turn_result(result: std::result::Result<Result<TurnWorkerOutcome>, tokio:
 #[cfg(test)]
 mod committed_event_drain_tests {
     use super::*;
+
+    #[test]
+    fn mcp_refresh_keeps_prompt_and_tools_on_one_immutable_snapshot() {
+        let original_tools = Arc::new(ToolRegistry::new());
+        let original =
+            freeze_foreground_turn_surface(original_tools.clone(), &AgentConfig::default());
+
+        let mut refreshed_registry = (*original_tools).clone();
+        refreshed_registry.register_client(openwave_core::ToolSpec {
+            name: "mcp__documents__lookup".into(),
+            description: "untrusted remote description marker".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "credential_marker": {"default": "untrusted remote schema marker"}
+                }
+            }),
+        });
+        let refreshed =
+            freeze_foreground_turn_surface(Arc::new(refreshed_registry), &AgentConfig::default());
+
+        let original_names = original
+            .tools
+            .specs_for_foreground(true)
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect::<Vec<_>>();
+        let refreshed_names = refreshed
+            .tools
+            .specs_for_foreground(true)
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect::<Vec<_>>();
+        let original_prompt = original.agent_config.system_prompt.as_deref().unwrap();
+        let refreshed_prompt = refreshed.agent_config.system_prompt.as_deref().unwrap();
+
+        assert!(!original_names.iter().any(|name| name.starts_with("mcp__")));
+        assert!(!original_prompt.contains("## External MCP tools"));
+        assert!(refreshed_names
+            .iter()
+            .any(|name| name == "mcp__documents__lookup"));
+        assert!(refreshed_prompt.contains("## External MCP tools"));
+        for prompt in [original_prompt, refreshed_prompt] {
+            assert!(!prompt.contains("mcp__documents__lookup"));
+            assert!(!prompt.contains("untrusted remote description marker"));
+            assert!(!prompt.contains("untrusted remote schema marker"));
+        }
+    }
 
     #[test]
     fn private_scratch_is_isolated_per_chat() {

--- a/docs/agent-operating-prompt.md
+++ b/docs/agent-operating-prompt.md
@@ -12,9 +12,10 @@ belongs to a project, organization, or shared workspace.
 ## Capability composition
 
 `openwave-server/src/foreground_prompt.rs` composes the prompt from the exact
-tool definitions advertised to a production foreground turn. Boot-time MCP
-servers are mounted before this composition, so their tools participate in the
-same capability snapshot. The baseline covers:
+tool definitions advertised to a production foreground turn. Each claimed turn
+selects one immutable registry snapshot, derives both its advertised definitions
+and operating prompt from that snapshot, and retains the pair for the execution.
+Runtime MCP refreshes therefore affect only later turns. The baseline covers:
 
 - calibrating effort to the request;
 - making small reversible assumptions while asking about consequential choices;
@@ -46,12 +47,11 @@ when composing the prompt because every normal chat turn is durably claimed and
 opts into those same contracts. Sandboxed background agents keep their separate,
 restricted prompt and never inherit the foreground prompt.
 
-Today the production registry becomes immutable after startup. When dynamic MCP
-configuration lands, prompt composition must move with it: select one immutable
-tool-registry snapshot for the turn, derive both the advertised definitions and
-the prompt from that same snapshot, and retain the pair for the request. A
-long-lived prompt derived from an older registry would violate the
-capability-truthfulness contract.
+The built-in registry becomes immutable after startup. Runtime MCP configuration
+publishes a replacement snapshot only after every enabled candidate validates
+and initializes successfully. A turn already holding an older snapshot keeps
+using its matching prompt and tools; it never observes a partially refreshed
+registry or a long-lived prompt derived from different capabilities.
 
 ## Versioning and diagnostics
 

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -169,9 +169,13 @@ consults. Its client
 half initializes external stdio servers, follows paginated tool discovery, and
 mounts each proxy as `mcp__{server}__{tool}` in the same registry. Mounted tools
 are classified sensitive so they cross OpenWave's approval boundary before the
-client forwards a call. The CLI and desktop boot paths load external stdio
-servers from `OPENWAVE_MCP_CONFIG`. Configuration UI, reconnect supervision,
-and dynamic tool-list refresh are still follow-up work.
+client forwards a call. Their generic approval is one-shot rather than a
+standing name-based grant, since Settings can replace the executable behind a
+stable namespace. The desktop Settings page owns typed runtime configuration
+and renderer-safe health, while `OPENWAVE_MCP_CONFIG` remains a headless
+bootstrap path. The server supervises idle-session health with bounded
+reconnect backoff and refreshes changed tool lists by publishing a fresh
+immutable registry for subsequent turns.
 
 **Depends on:** `openwave-core`.
 

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -86,10 +86,12 @@ and lazily starts its bundled host-broker sidecar. Server startup acquires
 exclusive ownership of the data directory, opens the operational database and
 Lance index, loads provider configuration, registers tools, starts the turn and
 document workers, and finally binds an ephemeral loopback port with a fresh
-bearer token. When `OPENWAVE_MCP_CONFIG` names a JSON file, startup also
-initializes every configured external stdio MCP server and registers its
-namespaced tools before accepting requests. A malformed configuration or failed
-server initialization fails startup instead of silently omitting tools.
+bearer token. Saved MCP definitions are loaded into a supervised runtime; the
+legacy `OPENWAVE_MCP_CONFIG` file supplies the initial definitions when no saved
+configuration exists. A malformed boot file or failed enabled boot server fails
+startup instead of silently omitting tools. A saved server that later becomes
+unavailable is shown as degraded and retried, leaving Settings available for
+repair.
 
 The main local data is easy to recognize:
 
@@ -779,10 +781,16 @@ workspace. It currently exposes only `read_file` and `list_dir`, and only after 
 proper MCP initialize lifecycle. Indexed search and approval-aware writable
 tools are not wired yet. The inverse client lifecycle loads external stdio
 servers from the `OPENWAVE_MCP_CONFIG` file used by the desktop and headless boot
-paths, discovers their tools, mounts namespaced sensitive proxies into
-`ToolRegistry`, and forwards approved calls over the shared MCP session. Server
-commands execute directly rather than through a shell, and receive only their
-literal environment plus specifically selected parent variables by default.
+paths or the desktop Settings API, discovers their tools, mounts namespaced
+sensitive proxies into an immutable per-turn `ToolRegistry` snapshot, and
+forwards approved calls over the shared MCP session. Server commands execute
+directly rather than through a shell. Their environment is always cleared and
+then populated only with literal non-secret values plus specifically selected
+parent variables. Each external call needs one explicit approval; approval is
+not remembered by tool name because the process behind a stable namespace can
+change. Health probes skip sessions busy with a live call. Capped reconnect
+backoff, explicit refresh, and `notifications/tools/list_changed` establish a
+new session and publish its tool surface only for subsequent turns.
 
 ### Self-host
 
@@ -863,8 +871,6 @@ The main next steps are:
   sandbox-safe capabilities without widening exact delegated-file or spawn
   authority;
 - add richer parsers and wire indexed search into MCP;
-- add MCP configuration UI, health/reconnect supervision, and dynamic tool-list
-  refresh;
 - finish the self-host profile rather than only testing Postgres state logic;
 - add health-aware provider failover;
 - add output deletion, version history, richer formats, and durable export

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -1,0 +1,85 @@
+# Local MCP servers
+
+OpenWave connects to local MCP servers over stdio. In the desktop app, open
+**Settings → MCP servers**, add a definition, and choose **Save and verify**.
+OpenWave starts the executable directly with the argument array shown in the
+form; it never joins the fields into a shell command.
+
+Each server has:
+
+- a stable namespace containing ASCII letters, numbers, `_`, or `-`;
+- an executable and zero or more individual arguments;
+- an optional working directory;
+- a request timeout from 1 to 3,600,000 milliseconds;
+- optional literal **non-secret** environment values;
+- optional `env_from` names selected from the OpenWave host environment; and
+- an enabled switch.
+
+The child environment starts empty. Literal values are ordinary settings and
+are visible in the Settings form. Executables, arguments, and working
+directories are also ordinary displayed settings, so do not put credentials in
+any of those fields. For a credential, set it in the environment that launches
+OpenWave and enter only its variable name under **Forward environment names**.
+OpenWave resolves that value at process launch; it does not store it in SQLite
+or return it to the renderer. A missing selected name produces a server-specific
+error containing the name, not a value. Child stderr is discarded so a server
+cannot copy a forwarded credential into OpenWave's host logs.
+
+All mounted names use `mcp__{namespace}__{remote_tool}`. MCP tools are sensitive:
+the existing OpenWave approval gate must approve each call before it crosses
+the process boundary. MCP approvals cannot be remembered for the chat. A server
+definition can change behind a stable namespace, so reusing a name-based grant
+would silently widen its authority.
+
+## Health and refresh
+
+Settings reports `initializing`, `healthy`, `degraded`, `reconnecting`, or
+`disabled` plus a bounded diagnostic and tool count. The runtime periodically
+pings enabled servers with a fixed health deadline and retries unavailable
+sessions with capped exponential backoff. Health checks and reconnects run
+independently across servers, while duplicate reconnects for one server share a
+single attempt. A server busy with a tool call is skipped for that health cycle,
+not treated as degraded. **Reconnect and refresh tools** explicitly starts a
+fresh session and rediscovers its tool list. The runtime does the same after the
+server emits `notifications/tools/list_changed`.
+
+Saving a candidate connects every enabled server before replacing the current
+set. If validation or initialization fails, the previous set remains active.
+Each running turn holds an immutable registry snapshot, so a configuration or
+tool-list change applies only to subsequent turns.
+
+Discovery is fail-closed and bounded. Mounted names must fit the provider-safe
+64-byte `[A-Za-z0-9_-]` contract after namespacing. OpenWave caps JSON-RPC frame
+size, tool count, pagination, cursors, descriptions, individual schemas, and
+aggregate tool metadata before publishing a connection. A server that exceeds a
+limit stays out of the active tool set and receives only a fixed diagnostic in
+Settings.
+
+## Headless bootstrap
+
+`openwave serve` can still read an initial configuration from the JSON file
+named by `OPENWAVE_MCP_CONFIG`:
+
+```json
+{
+  "servers": [
+    {
+      "name": "documents",
+      "command": "/absolute/path/to/documents-mcp",
+      "args": ["--stdio"],
+      "cwd": "/absolute/path/to/workspace",
+      "env": {
+        "LOG_LEVEL": "info"
+      },
+      "env_from": ["DOCUMENTS_TOKEN"],
+      "request_timeout_ms": 60000,
+      "enabled": true
+    }
+  ]
+}
+```
+
+The schema is closed, including at the API boundary. Broad process-environment
+inheritance is not supported. When there is no saved desktop configuration, a
+malformed bootstrap file, missing selected environment name, or failed enabled
+server makes startup fail rather than silently narrowing the advertised tools.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -102,18 +102,32 @@ before its proxies are registered. Each remote name is locally namespaced as
 serialized per external server and their text, structured content, and error
 flag are translated back into `ToolOutput`. Because MCP tools can cross both the
 workspace and process boundary, every mounted proxy is classified `Sensitive`.
+Each call needs one explicit approval; MCP approval is never remembered by tool
+name because Settings can replace the process behind a stable namespace.
 
-The desktop and `openwave serve` boot paths read external stdio servers from the
-JSON file named by `OPENWAVE_MCP_CONFIG`. Each entry declares a unique namespace,
-an executable plus argument array, an optional working directory and explicit
-environment, and an optional bounded request timeout. No shell interprets these
-values. Child environments are cleared by default to avoid leaking provider or
-host credentials; `env_from` selectively forwards named parent variables without
-putting their values in JSON, while `inherit_env` remains an explicit broad
-opt-in. A missing selected variable fails startup. Initialization is fail-closed
-so the advertised tool surface never silently differs from the boot
-configuration. Configuration UI, reconnect supervision, and MCP
-`tools/list_changed` refresh remain future work.
+The desktop Settings page manages external stdio servers at runtime. Each entry
+declares a unique namespace, executable, argument array, optional working
+directory, explicit non-secret environment, selected `env_from` names, and a
+bounded request timeout. No shell interprets any field. Child environments are
+always cleared before the selected names and literal values are added, so an MCP
+process cannot inherit provider credentials or other desktop secrets by
+accident. Resolved `env_from` values never enter the database or renderer, and
+child stderr is discarded instead of being copied into host logs.
+
+Saving first validates and connects the complete candidate set, then atomically
+publishes it for later turns. A failure leaves the prior connection set active.
+Active turns retain their immutable registry snapshot, so reconnect or tool
+refresh cannot change a replaying turn's schema or executor. A supervisor probes
+idle sessions, skips sessions busy with a live call, reconnects with capped
+backoff, and establishes a fresh connection after
+`notifications/tools/list_changed` before publishing the new tool list.
+Provider-safe names plus per-frame, per-tool, count, pagination, and aggregate
+metadata limits keep a malformed server from breaking or bloating later model
+requests.
+The legacy `OPENWAVE_MCP_CONFIG` JSON file remains available for headless boot;
+when no saved configuration exists it uses the same closed schema and fails
+startup if an enabled server cannot initialize.
+See [Local MCP servers](mcp-servers.md) for the field contract and setup flow.
 
 ## Foreground and sandbox surfaces
 


### PR DESCRIPTION
## Summary

- add typed desktop Settings CRUD for local stdio MCP servers, including argv, cwd, timeouts, literal non-secret environment values, selected host environment names, enable/disable, health, and reconnect/tool refresh
- validate and initialize complete candidates before atomically persisting/publishing immutable tool-registry snapshots; supervise health with bounded diagnostics, backoff, duplicate-attempt fencing, and tools/list_changed refresh
- freeze each foreground turn's advertised tools and capability-aware prompt from the exact same registry snapshot
- make external MCP calls one-shot Sensitive approvals that cannot become standing grants, and keep server/tool metadata out of renderer approval surfaces
- bound MCP frames, discovery metadata, pagination, names, and initialization; clear child environments and never persist or project resolved selected values
- document configuration, security boundaries, health behavior, and headless bootstrap

## Adversarial coverage

- failed candidates preserve the prior durable/live configuration
- concurrent replacements, reconnects, stale supervisor results, long-running calls, and mid-turn refreshes are fenced
- unknown/broad environment inheritance is rejected; missing selected values reveal names only
- hostile MCP descriptions/schemas cannot enter the operating prompt
- settings endpoints require bearer authentication; exact patch passes gitleaks

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm test` (274 tests after latest-main rebase)
- `pnpm build`
- `gitleaks stdin` over `git diff origin/main...HEAD`

Closes #419