### PR TITLE
ci(release): attach macOS downloads to the GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -918,3 +918,57 @@ jobs:
             [[ -n "$url" ]] || continue
             curl --fail --silent --show-error --head "$url" >/dev/null
           done
+
+  attach_downloads:
+    name: attach GitHub release downloads
+    needs: [validate, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      OPENWAVE_VERSION: ${{ needs.validate.outputs.version }}
+      RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+      RELEASE_BASE_URL: https://downloads.brightwave.io/openwave
+    steps:
+      # The hosted release is the only source of artifact bytes. Re-downloading
+      # it here keeps the GitHub assets a verified copy of what the CDN serves,
+      # and works the same whether this run built the release or resumed one.
+      - name: Download the published disk images
+        run: |
+          mkdir -p downloads
+          manifest="$RUNNER_TEMP/manifest.json"
+          curl --fail --silent --show-error \
+            "$RELEASE_BASE_URL/releases/v$OPENWAVE_VERSION/manifest.json" \
+            --output "$manifest"
+
+          while IFS=$'\t' read -r arch url digest; do
+            case "$arch" in
+              aarch64) name="OpenWave-macos-apple-silicon.dmg" ;;
+              x86_64) name="OpenWave-macos-intel.dmg" ;;
+              *) echo "Unsupported release architecture: $arch" >&2; exit 1 ;;
+            esac
+            curl --fail --silent --show-error --location "$url" \
+              --output "downloads/$name"
+            printf '%s  %s\n' "$digest" "$name" > "downloads/$name.sha256"
+            (cd downloads && sha256sum --check --strict "$name.sha256")
+          done < <(jq -r \
+            '.artifacts[]
+             | select(.platform == "macos" and .format == "dmg")
+             | [.arch, .url, .sha256] | @tsv' \
+            "$manifest")
+
+          dmg_count="$(find downloads -name '*.dmg' -type f | wc -l)"
+          (( dmg_count == 2 )) || {
+            echo "Expected both macOS disk images, found $dmg_count." >&2
+            exit 1
+          }
+
+      # Version-free asset names give the README permanent one-click download
+      # links through GitHub's /releases/latest/download/ redirect.
+      - name: Attach the disk images to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload "$RELEASE_TAG" downloads/*
+          --repo "$GITHUB_REPOSITORY"
+          --clobber

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
   <img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="License: Apache-2.0">
   <img src="https://img.shields.io/badge/status-pre--alpha-orange.svg" alt="Status: pre-alpha">
   <img src="https://img.shields.io/badge/built%20with-Rust-dea584.svg?logo=rust&logoColor=white" alt="Built with Rust">
+  <a href="https://github.com/brightwave-inc/openwave/releases/latest"><img src="https://img.shields.io/github/v/release/brightwave-inc/openwave?label=release&color=informational" alt="Latest release"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/brightwave-inc/openwave/releases/latest/download/OpenWave-macos-apple-silicon.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000.svg?logo=apple&logoColor=white" alt="Download for macOS, Apple Silicon"></a>
+  <a href="https://github.com/brightwave-inc/openwave/releases/latest/download/OpenWave-macos-intel.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-Intel-555555.svg?logo=apple&logoColor=white" alt="Download for macOS, Intel"></a>
 </p>
 
 ---
@@ -22,6 +28,24 @@
 > slice at a time. Interfaces, schema, and crate layout change frequently, and
 > it isn't ready for real-world use yet. Star the repo to follow along — and
 > expect rough edges.
+
+## Download
+
+The desktop app ships for macOS, signed and notarized. The two links above
+always resolve to the newest release; the
+[releases page](https://github.com/brightwave-inc/openwave/releases) has the
+notes and earlier versions. An installed build keeps itself current — it checks
+for a newer signed release in the background and asks before restarting.
+
+Each download has a `.sha256` sidecar on the same release if you want to verify
+it:
+
+```sh
+shasum -a 256 -c OpenWave-macos-apple-silicon.dmg.sha256
+```
+
+There are no Windows or Linux builds yet; on those platforms, build from source
+as described under [Building](#building).
 
 ## Where this comes from
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -131,6 +131,14 @@ the maintained draft and its proposed version automatic.
    complete immutable prefix, a new dispatch validates and reuses those bytes,
    skips both desktop builds, and resumes only mutable metadata publication,
    CDN invalidation, and smoke testing.
+8. A final job downloads both notarized disk images back from the CDN, checks
+   them against the immutable manifest digests, and attaches them to the GitHub
+   Release as `OpenWave-macos-apple-silicon.dmg` and `OpenWave-macos-intel.dmg`
+   with `.sha256` sidecars. It holds no signing or AWS credentials. The names
+   omit the version so that
+   `https://github.com/brightwave-inc/openwave/releases/latest/download/<name>`
+   stays a permanent download link for the README; the release page and the
+   app's own version string identify which build it is.
 
 Publishing the native draft is the only release boundary. Merging ordinary PRs
 updates the draft but never builds or ships a desktop version. A published

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -326,6 +326,31 @@ test("an existing immutable release resumes without rebuilding or overwriting", 
   );
 });
 
+test("GitHub release downloads are copied from the hosted release", () => {
+  const release = workflows["release.yml"];
+  const attachJob = workflowJob(release, "attach_downloads");
+
+  assert.match(attachJob, /needs: \[validate, publish\]/);
+  assert.match(attachJob, /contents: write/);
+  assert.doesNotMatch(attachJob, /^    environment:/m);
+  assert.doesNotMatch(attachJob, /secrets\./);
+  assert.doesNotMatch(attachJob, /APPLE_|TAURI_SIGNING|AWS_|DOWNLOADS_S3/);
+
+  // Assets must be the CDN's own bytes, verified against the immutable
+  // manifest, rather than a second copy built alongside the hosted release.
+  assert.match(attachJob, /releases\/v\$OPENWAVE_VERSION\/manifest\.json/);
+  assert.match(attachJob, /sha256sum --check --strict/);
+  assert.match(attachJob, /OpenWave-macos-apple-silicon\.dmg/);
+  assert.match(attachJob, /OpenWave-macos-intel\.dmg/);
+  assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
+
+  assert.match(
+    readFileSync(new URL("../README.md", import.meta.url), "utf8"),
+    /releases\/latest\/download\/OpenWave-macos-apple-silicon\.dmg/,
+    "the README download link must match the published asset name",
+  );
+});
+
 test("the updater private key is isolated from compilation", () => {
   const release = workflows["release.yml"];
   const buildStep = release.match(


### PR DESCRIPTION
Nothing in the repository points a reader at the app. The README has no download link, and published releases carry notes but no assets — the only route to a build is reading `docs/releases.md` and hand-assembling a `downloads.brightwave.io` URL from the version.

## Release workflow

A final `attach_downloads` job pulls both notarized disk images back from the CDN, checks them against the immutable manifest digests, and attaches them to the GitHub Release with `.sha256` sidecars.

Re-downloading rather than reusing the build artifacts keeps one source of artifact truth and behaves identically on the resume path, where `build_macos` is skipped entirely. The job holds no signing or AWS credentials — only `contents: write` and the default token.

Assets are named `OpenWave-macos-apple-silicon.dmg` and `OpenWave-macos-intel.dmg`. Dropping the version is deliberate: it makes `…/releases/latest/download/<name>` a permanent link, so the README buttons never need editing per release. The release page and the app's own version string still identify the build.

Only the DMGs are mirrored. The updater archives and signatures stay on the CDN, since `latest.json` is what the in-app updater reads and a second copy of signed updater bytes would only invite confusion.

## README

A download badge row under the existing badges, plus a short **Download** section covering checksum verification, the in-app updater, and the absence of Windows/Linux builds.

## Verification

- `node --test scripts/workflow-security.test.mjs` — 14 pass, including a new case asserting the job is credential-free, verifies digests, and that the README link matches the published asset name.
- `actionlint .github/workflows/release.yml` — clean.
- Ran the job's download-and-verify script locally against the hosted v0.5.0 manifest; both disk images downloaded and both digests checked `OK`.

The upload step itself can't be exercised before a real release. Until the next one publishes, the README links resolve to a GitHub 404.