### PR TITLE
feat(host-broker): read connected files as bounded opaque bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6706,6 +6706,7 @@ dependencies = [
 name = "openwave-host-broker"
 version = "0.0.0"
 dependencies = [
+ "base64 0.22.1",
  "cap-fs-ext",
  "cap-std",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ sea-orm-migration = { version = "=2.0.0", default-features = false, features = [
 tokio = { version = "=1.53.1", features = ["rt", "macros", "fs"] }
 reqwest = { version = "=0.12.28", default-features = false, features = ["json", "stream", "rustls-tls"] }
 sha2 = "=0.11.0"
+base64 = "=0.22.1"
 libc = "=0.2.186"
 async-stream = "=0.3.6"
 axum = { version = "=0.8.9", features = ["ws"] }

--- a/crates/openwave-host-broker/Cargo.toml
+++ b/crates/openwave-host-broker/Cargo.toml
@@ -13,6 +13,7 @@ name = "openwave-host-broker"
 path = "src/bin/openwave-host-broker.rs"
 
 [dependencies]
+base64.workspace = true
 cap-fs-ext.workspace = true
 cap-std.workspace = true
 chrono.workspace = true

--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -69,6 +69,7 @@ pub enum AuditOperation {
     ListRoots,
     ListDirectory,
     ReadFile,
+    ReadFileBinary,
     ProtocolVersionMismatch,
 }
 

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -16,6 +16,7 @@ use std::{
     },
 };
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use cap_fs_ext::OpenOptionsSyncExt;
 use cap_std::fs::{Dir, OpenOptions};
 use chrono::Utc;
@@ -33,11 +34,11 @@ use crate::{
         EntryKind, ErrorCode, ErrorResponse, HelloResult, LookupRegisterRootReceiptRequest,
         LookupRegisterRootReceiptResult, LookupRootAttachmentReceiptRequest,
         LookupRootAttachmentReceiptResult, OperationEnvelope, OperationRequest,
-        OperationResponseEnvelope, OperationResult, PathRequest, ReadFileResult,
-        RegisterRootReceipt, RegisterRootRequest, RegisterRootResult, Response, ResponseEnvelope,
-        RevokeRootRequest, RevokeRootResult, RootAttachmentMutationKind,
+        OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult,
+        ReadFileResult, RegisterRootReceipt, RegisterRootRequest, RegisterRootResult, Response,
+        ResponseEnvelope, RevokeRootRequest, RevokeRootResult, RootAttachmentMutationKind,
         RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootAttachmentMutationResult,
-        RootSummary, PROTOCOL_VERSION,
+        RootSummary, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
     },
     Capability, ConsentMethod, ConsentRecord, ExecutionContext, Grant, GrantError, GrantId,
     GrantSubject, OperationId, RelativePath, RootAttachment, RootId, RootPolicy, RootPolicyError,
@@ -78,8 +79,8 @@ pub enum BrokerError {
     StateTooLarge,
     #[error("path is not a regular file")]
     NotRegularFile,
-    #[error("file is too large (maximum {MAX_READ_FILE_BYTES} bytes)")]
-    FileTooLarge,
+    #[error("file is too large (maximum {maximum} bytes)")]
+    FileTooLarge { maximum: usize },
     #[error("file is not valid UTF-8")]
     NotUtf8,
     #[error("directory listing exceeds broker limits")]
@@ -306,6 +307,11 @@ impl OperationAudit {
             ),
             OperationRequest::ReadFile(request) => (
                 AuditOperation::ReadFile,
+                Capability::ReadFiles,
+                AuditTarget::path(request.root_id, &request.path),
+            ),
+            OperationRequest::ReadFileBinary(request) => (
+                AuditOperation::ReadFileBinary,
                 Capability::ReadFiles,
                 AuditTarget::path(request.root_id, &request.path),
             ),
@@ -844,6 +850,14 @@ impl Operator {
                     grant_id = Some(self.reauthorize(envelope.context, root_id, &path)?);
                     Ok(result)
                 }
+                OperationRequest::ReadFileBinary(PathRequest { root_id, path }) => {
+                    let (directory, authorized_by) =
+                        self.authorized_root(envelope.context, root_id, &path)?;
+                    grant_id = Some(authorized_by);
+                    let result = read_file_binary(&directory, &path)?;
+                    grant_id = Some(self.reauthorize(envelope.context, root_id, &path)?);
+                    Ok(result)
+                }
             }
         })();
         (result, grant_id)
@@ -866,6 +880,7 @@ impl Operator {
             Some(OperationResult::ListRoots { roots }) => (Some(roots.len()), None),
             Some(OperationResult::ListDirectory { entries }) => (Some(entries.len()), None),
             Some(OperationResult::ReadFile(result)) => (None, Some(result.bytes)),
+            Some(OperationResult::ReadFileBinary(result)) => (None, Some(result.bytes)),
             None => (None, None),
         };
         let event = AuditEvent {
@@ -956,6 +971,7 @@ fn hello() -> HelloResult {
             "list_roots".to_owned(),
             "list_directory".to_owned(),
             "read_file".to_owned(),
+            "read_file_binary".to_owned(),
         ],
     }
 }
@@ -1025,7 +1041,7 @@ fn error_response(error: BrokerError) -> ErrorResponse {
             "selected folder is not an allowed connected root",
             false,
         ),
-        BrokerError::FileTooLarge
+        BrokerError::FileTooLarge { .. }
         | BrokerError::DirectoryTooLarge
         | BrokerError::RootListTooLarge
         | BrokerError::StateTooLarge => (
@@ -1565,6 +1581,34 @@ fn list_directory(root: &Dir, path: &RelativePath) -> Result<OperationResult, Br
 }
 
 fn read_file(root: &Dir, path: &RelativePath) -> Result<OperationResult, BrokerError> {
+    let bytes = read_bounded(root, path, MAX_READ_FILE_BYTES)?;
+    let bytes_read = bytes.len();
+    let content = String::from_utf8(bytes).map_err(|_| BrokerError::NotUtf8)?;
+    Ok(OperationResult::ReadFile(ReadFileResult {
+        content,
+        bytes: bytes_read,
+    }))
+}
+
+/// Read one file as opaque bytes under the same read authority as [`read_file`].
+///
+/// The UTF-8 requirement is deliberately absent: the caller is handing the file
+/// to a trusted product pipeline rather than returning text to an agent. The
+/// larger bound reflects that a PDF or Office document is routinely megabytes.
+fn read_file_binary(root: &Dir, path: &RelativePath) -> Result<OperationResult, BrokerError> {
+    let bytes = read_bounded(root, path, MAX_READ_FILE_BINARY_BYTES)?;
+    Ok(OperationResult::ReadFileBinary(ReadFileBinaryResult {
+        bytes: bytes.len(),
+        content_base64: BASE64.encode(&bytes),
+    }))
+}
+
+/// Read a whole regular file in one open, refusing anything over `maximum`.
+///
+/// The length is checked twice: once from metadata to avoid buffering a file the
+/// caller will reject anyway, and once after reading one byte past the bound so
+/// a file that grows between the two checks is refused rather than truncated.
+fn read_bounded(root: &Dir, path: &RelativePath, maximum: usize) -> Result<Vec<u8>, BrokerError> {
     let mut options = OpenOptions::new();
     options.read(true).nonblock(true);
     let file = root.open_with(Path::new(path.as_str()), &options)?;
@@ -1572,21 +1616,15 @@ fn read_file(root: &Dir, path: &RelativePath) -> Result<OperationResult, BrokerE
     if !metadata.is_file() {
         return Err(BrokerError::NotRegularFile);
     }
-    if metadata.len() > MAX_READ_FILE_BYTES as u64 {
-        return Err(BrokerError::FileTooLarge);
+    if metadata.len() > maximum as u64 {
+        return Err(BrokerError::FileTooLarge { maximum });
     }
     let mut bytes = Vec::with_capacity(metadata.len() as usize);
-    file.take((MAX_READ_FILE_BYTES + 1) as u64)
-        .read_to_end(&mut bytes)?;
-    if bytes.len() > MAX_READ_FILE_BYTES {
-        return Err(BrokerError::FileTooLarge);
+    file.take((maximum + 1) as u64).read_to_end(&mut bytes)?;
+    if bytes.len() > maximum {
+        return Err(BrokerError::FileTooLarge { maximum });
     }
-    let bytes_read = bytes.len();
-    let content = String::from_utf8(bytes).map_err(|_| BrokerError::NotUtf8)?;
-    Ok(OperationResult::ReadFile(ReadFileResult {
-        content,
-        bytes: bytes_read,
-    }))
+    Ok(bytes)
 }
 
 #[derive(Clone, Copy)]

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -2349,3 +2349,114 @@ fn restart_rejects_an_oversized_state_file_before_parsing_it() {
         Err(BrokerError::StateTooLarge)
     ));
 }
+
+#[test]
+fn binary_reads_return_bytes_that_text_reads_refuse() {
+    let (_temp, broker, path, audit) = audited_setup();
+    // A minimal PDF header followed by a byte sequence that is not valid UTF-8.
+    let document: Vec<u8> = [b"%PDF-1.7\n".as_slice(), &[0xff, 0xfe, 0x00, 0x80]].concat();
+    std::fs::write(path.join("report.pdf"), &document).unwrap();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let registered = register(
+        &broker.controller(),
+        subject,
+        conversation,
+        path,
+        OperationId::new(),
+    );
+    let context = ExecutionContext::standalone(conversation).unwrap();
+    let request = || PathRequest {
+        root_id: registered.root.root_id,
+        path: RelativePath::parse("report.pdf").unwrap(),
+    };
+
+    assert!(matches!(
+        operate(
+            &broker.operator(),
+            context,
+            OperationRequest::ReadFile(request()),
+        ),
+        Err(ErrorResponse {
+            code: ErrorCode::UnsupportedContent,
+            ..
+        })
+    ));
+    let result = operate(
+        &broker.operator(),
+        context,
+        OperationRequest::ReadFileBinary(request()),
+    )
+    .unwrap();
+    let OperationResult::ReadFileBinary(result) = result else {
+        panic!("expected binary content")
+    };
+    assert_eq!(result.bytes, document.len());
+    assert_eq!(BASE64.decode(&result.content_base64).unwrap(), document);
+    // Content must not leak through Debug, which is where audit and log
+    // formatting would otherwise pick it up.
+    assert!(!format!("{result:?}").contains(&result.content_base64));
+
+    let events = audit.events.lock().unwrap();
+    let recorded = events
+        .iter()
+        .find(|event| event.operation == AuditOperation::ReadFileBinary)
+        .expect("binary reads are audited under their own operation name");
+    assert_eq!(recorded.capability, Some(Capability::ReadFiles));
+    assert_eq!(recorded.outcome, AuditOutcome::Allowed);
+    assert_eq!(recorded.bytes, Some(document.len()));
+}
+
+#[test]
+fn binary_reads_are_bounded_and_fenced_by_revocation() {
+    let (_temp, broker, path) = setup();
+    std::fs::write(
+        path.join("huge.bin"),
+        vec![0u8; MAX_READ_FILE_BINARY_BYTES + 1],
+    )
+    .unwrap();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let registered = register(
+        &broker.controller(),
+        subject,
+        conversation,
+        path,
+        OperationId::new(),
+    );
+    let context = ExecutionContext::standalone(conversation).unwrap();
+    let binary_request = |name: &str| {
+        OperationRequest::ReadFileBinary(PathRequest {
+            root_id: registered.root.root_id,
+            path: RelativePath::parse(name).unwrap(),
+        })
+    };
+
+    assert!(matches!(
+        operate(&broker.operator(), context, binary_request("huge.bin")),
+        Err(ErrorResponse {
+            code: ErrorCode::TooLarge,
+            ..
+        })
+    ));
+    // A directory is not a document, and the larger bound must not relax that.
+    assert!(matches!(
+        operate(&broker.operator(), context, binary_request("reports")),
+        Err(ErrorResponse { .. })
+    ));
+    assert!(operate(&broker.operator(), context, binary_request("note.txt")).is_ok());
+
+    revoke(
+        &broker.controller(),
+        OperationId::new(),
+        subject,
+        registered.root.root_id,
+    );
+    assert!(matches!(
+        operate(&broker.operator(), context, binary_request("note.txt")),
+        Err(ErrorResponse {
+            code: ErrorCode::Denied,
+            ..
+        })
+    ));
+}

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -34,9 +34,10 @@ pub use protocol::{
     EntryKind, ErrorCode, ErrorResponse, HelloResult, LookupRegisterRootReceiptRequest,
     LookupRegisterRootReceiptResult, LookupRootAttachmentReceiptRequest,
     LookupRootAttachmentReceiptResult, OperationEnvelope, OperationRequest,
-    OperationResponseEnvelope, OperationResult, PathRequest, ReadFileResult, RegisterRootReceipt,
-    RegisterRootRequest, RegisterRootResult, Response, ResponseEnvelope, RevokeRootRequest,
-    RevokeRootResult, RootAttachmentMutationKind, RootAttachmentMutationReceipt,
-    RootAttachmentMutationRequest, RootAttachmentMutationResult, RootSummary, PROTOCOL_VERSION,
+    OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult, ReadFileResult,
+    RegisterRootReceipt, RegisterRootRequest, RegisterRootResult, Response, ResponseEnvelope,
+    RevokeRootRequest, RevokeRootResult, RootAttachmentMutationKind, RootAttachmentMutationReceipt,
+    RootAttachmentMutationRequest, RootAttachmentMutationResult, RootSummary,
+    MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
 };
 pub use relative_path::{RelativePath, RelativePathError};

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -14,7 +14,16 @@ use crate::{
 };
 
 /// Current pre-v1 broker protocol. Bump this for incompatible wire changes.
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
+
+/// Largest file the broker returns as opaque bytes.
+///
+/// Binary reads exist so trusted native code can hand a document the agent
+/// cannot read as text — a PDF or an Office file — to a product ingest
+/// pipeline. The bytes travel base64-encoded over the newline-delimited JSON
+/// transport, so [`crate::sidecar::MAX_RESPONSE_BYTES`] is derived from this
+/// bound rather than chosen independently.
+pub const MAX_READ_FILE_BINARY_BYTES: usize = 8 * 1024 * 1024;
 
 /// Host-originated request envelope.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -158,6 +167,14 @@ pub enum OperationRequest {
     ListDirectory(PathRequest),
     /// Read one bounded UTF-8 file under an explicitly selected root.
     ReadFile(PathRequest),
+    /// Read one bounded file under an explicitly selected root as opaque bytes.
+    ///
+    /// This carries the same [`crate::Capability::ReadFiles`] authority as
+    /// [`OperationRequest::ReadFile`] — the user consented to reading files
+    /// below the root, not to a particular encoding. It exists so trusted
+    /// native code can move a file the agent cannot read as text into a
+    /// product pipeline; the bytes are not agent-readable.
+    ReadFileBinary(PathRequest),
 }
 
 /// Strict root-relative payload shared by list and read operations.
@@ -238,6 +255,7 @@ pub enum OperationResult {
     ListRoots { roots: Vec<RootSummary> },
     ListDirectory { entries: Vec<DirectoryEntry> },
     ReadFile(ReadFileResult),
+    ReadFileBinary(ReadFileBinaryResult),
 }
 
 /// Version handshake response.
@@ -353,6 +371,27 @@ pub struct DirectoryEntry {
 pub struct ReadFileResult {
     pub content: String,
     pub bytes: usize,
+}
+
+/// Bounded opaque file content, base64-encoded for the JSON transport.
+///
+/// `bytes` is the decoded length, so a caller can bound its own work before
+/// decoding. Content is deliberately not logged or `Debug`-printed.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReadFileBinaryResult {
+    pub content_base64: String,
+    pub bytes: usize,
+}
+
+impl std::fmt::Debug for ReadFileBinaryResult {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ReadFileBinaryResult")
+            .field("content_base64", &"[redacted]")
+            .field("bytes", &self.bytes)
+            .finish()
+    }
 }
 
 #[cfg(test)]

--- a/crates/openwave-host-broker/src/sidecar.rs
+++ b/crates/openwave-host-broker/src/sidecar.rs
@@ -10,7 +10,12 @@ use crate::{
 };
 
 pub const MAX_REQUEST_BYTES: usize = 128 * 1024;
-pub const MAX_RESPONSE_BYTES: usize = 512 * 1024;
+
+/// Enough for a base64 [`crate::protocol::MAX_READ_FILE_BINARY_BYTES`] payload
+/// plus envelope overhead. Binary reads are the only response that approaches
+/// this bound; every other one is orders of magnitude smaller.
+pub const MAX_RESPONSE_BYTES: usize =
+    4 * crate::protocol::MAX_READ_FILE_BINARY_BYTES / 3 + 512 * 1024;
 
 /// One strictly typed request on the desktop-owned sidecar pipe.
 #[derive(Debug, Serialize, Deserialize)]
@@ -175,6 +180,31 @@ mod tests {
             Vec::new(),
         );
         (temp, Broker::new(policy))
+    }
+
+    #[test]
+    fn response_bound_admits_a_maximum_binary_read() {
+        let response = SidecarResponse::Operation(crate::OperationResponseEnvelope {
+            protocol_version: crate::PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            response: crate::Response::Ok(crate::OperationResult::ReadFileBinary(
+                crate::ReadFileBinaryResult {
+                    content_base64: base64::Engine::encode(
+                        &base64::engine::general_purpose::STANDARD,
+                        vec![0xffu8; crate::MAX_READ_FILE_BINARY_BYTES],
+                    ),
+                    bytes: crate::MAX_READ_FILE_BINARY_BYTES,
+                },
+            )),
+        });
+        // MAX_RESPONSE_BYTES is derived from the binary bound rather than chosen
+        // independently, so a full-size read must never trip ResponseTooLarge.
+        let encoded = serde_json::to_vec(&response).unwrap();
+        assert!(
+            encoded.len() <= MAX_RESPONSE_BYTES,
+            "{} exceeds {MAX_RESPONSE_BYTES}",
+            encoded.len()
+        );
     }
 
     #[test]

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -229,10 +229,23 @@ Broker requests are divided into two typed channels:
    conversation, or revoke access. Only the desktop host or an equivalent
    explicit local CLI action may send them.
 2. **Operation requests** come from agent execution. The current protocol can
-   list connected roots, list a directory, and read a file; bounded import,
-   writes, and confined commands are later capability slices. Every operation
-   that can expose a host resource is denied unless a matching grant exists; an
-   unattached conversation may safely receive an empty root list.
+   list connected roots, list a directory, read a file as bounded UTF-8 text,
+   and read a file as bounded opaque bytes; writes and confined commands are
+   later capability slices. Every operation that can expose a host resource is
+   denied unless a matching grant exists; an unattached conversation may safely
+   receive an empty root list.
+
+The two read shapes carry the same read capability, because the user consented
+to reading files below a root rather than to a particular encoding. They differ
+in who the bytes are for. A text read returns content the agent will see, so it
+is small and refuses anything that is not valid UTF-8. A binary read returns
+opaque bytes for a trusted native handoff into a product pipeline, so it allows
+the megabytes a PDF or Office document routinely occupies and makes no claim
+about the content. Those bytes are base64-encoded on the sidecar pipe, and the
+transport's response bound is derived from the binary read bound so a
+maximum-size read can never be rejected as an oversized frame. Nothing in this
+path lets an agent read the bytes it moved; to see the content it must go
+through whatever the receiving pipeline exposes.
 
 Code should expose different controller and operator interfaces so an agent
 executor cannot accidentally call the control channel. The broker still
@@ -433,7 +446,8 @@ This will land in independently reviewable pieces:
 2. Add the versioned control/operation protocol and an owning in-memory broker
    that authorizes pinned handles, performs bounded-result I/O, and reauthorizes
    before releasing bytes so completed revocation fences in-flight results:
-   hello, register/revoke/list roots, list directory, and read file.
+   hello, register/revoke/list roots, list directory, and read file as text or
+   as opaque bytes.
 3. Persist the root/grant/attachment registry and idempotency receipts atomically
    under a broker-private, exclusively owned state directory. Restart must
    validate the bounded state file and revalidate and descriptor-pin every


### PR DESCRIPTION
Part of #414.

## Why

The broker offers exactly one read, and it returns UTF-8 text capped at 64 KiB. A PDF, Office document, or any other binary file sitting under a folder the user already approved therefore cannot be moved anywhere — the read fails as invalid UTF-8, and would exceed the bound even if it decoded. That is the blocker for letting the agent hand such a file to the conversation source pipeline.

## What changed

A second read shape, `OperationRequest::ReadFileBinary`, returns opaque bytes for a trusted native handoff.

- **Same authority.** It requires the same `ReadFiles` capability. The user consented to reading files below a root, not to a particular encoding, so this needs no new consent surface and no migration of persisted grants.
- **Same fencing.** It runs the existing `authorized_root` → read → `reauthorize` sequence, so a revocation that completes while bytes are in memory still discards the result.
- **Different bound and different audience.** 8 MiB, because that is what a PDF or Office file routinely occupies, and no UTF-8 requirement, because the bytes are for a product pipeline rather than for the agent. Nothing here lets an agent read what it moved. Audited under its own `read_file_binary` operation name with the decoded byte count.

Bytes are base64-encoded on the sidecar pipe. Rather than raise the transport's response cap to some independently chosen number, `MAX_RESPONSE_BYTES` is now *derived* from the read bound, and a test asserts that a maximum-size binary response actually encodes within it — that derivation is a claim, so it should be checked.

The text and binary paths now share one bounded read helper. It keeps the existing double length check (metadata first to avoid buffering a file that will be rejected, then one byte past the bound so a file that grows between the two checks is refused rather than silently truncated), and `FileTooLarge` now carries the limit it actually enforced instead of hardcoding the text one.

`PROTOCOL_VERSION` goes to 5; the desktop sidecar client validates it on every envelope.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (all green), and `cargo check --workspace --locked` with no lock diff beyond the new `base64` dependency edge. `base64 0.22.1` was already resolved in the lockfile transitively, so pinning it as a direct dependency left every version unchanged.

New tests cover a non-UTF-8 file that the text read refuses and the binary read returns intact, that content does not leak through `Debug`, the audit record, the size bound, refusing a directory, and revocation fencing.