### PR TITLE
feat: show the command an exec approval is granting

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -33,7 +33,7 @@ use crate::agent_tools::{
 };
 use crate::approval::{
     ApprovalDecision, ApprovalGate, ApprovalJournalIdentity, ApprovalRequest,
-    ApprovalRequiredPublication, RefuseGate, StandingGrants, ToolApprovalKind,
+    ApprovalRequiredPublication, RefuseGate, StandingGrants, ToolApprovalKind, ToolApprovalPreview,
 };
 use crate::cancel::CancelToken;
 use crate::citation::{
@@ -2072,6 +2072,15 @@ impl Agent {
             let kind = durable_approval
                 .map(|approval| approval.kind)
                 .unwrap_or_else(|| ToolApprovalKind::for_tool_name(&call.name));
+            // A recovered call re-presents the preview durable state already
+            // holds, so a reconnecting client sees the same command it was
+            // asked about before the restart.
+            let preview = match durable_approval {
+                Some(approval) => approval.preview.clone(),
+                None => serde_json::from_str(&call.args)
+                    .ok()
+                    .and_then(|args| ToolApprovalPreview::build(&call.name, &args)),
+            };
             if self.durable_steer_lease.is_some() && events.flush().await.is_err() {
                 return ToolOutput::error("approval event journal is unavailable");
             }
@@ -2092,6 +2101,7 @@ impl Agent {
                     tool_name: call.name.clone(),
                     class: ApprovalClass::Sensitive,
                     kind,
+                    preview: preview.clone(),
                     summary: summary.clone(),
                 },
                 journal,
@@ -2107,6 +2117,7 @@ impl Agent {
                 tool_name: call.name.clone(),
                 class: ApprovalClass::Sensitive,
                 kind,
+                preview,
                 summary,
             };
             match registration.publication {
@@ -5986,6 +5997,7 @@ mod tests {
                     tool_name: call.name.clone(),
                     class: ApprovalClass::Sensitive,
                     kind: ToolApprovalKind::for_tool_name(&call.name),
+                    preview: None,
                     summary: "search requires approval".into(),
                 },
                 Utc::now(),
@@ -6182,6 +6194,7 @@ mod tests {
                     tool_name: call.name.clone(),
                     class: ApprovalClass::Sensitive,
                     kind: ToolApprovalKind::for_tool_name(&call.name),
+                    preview: None,
                     summary: "persisted write requires approval".into(),
                 },
                 Utc::now(),

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -140,6 +140,83 @@ impl ToolApprovalKind {
     }
 }
 
+/// The exact action a parked call will take, in a form a human can inspect.
+///
+/// [`ToolApprovalKind`] names the *class* of egress being consented to; it
+/// cannot say which command is about to run. Consent that cannot be inspected
+/// is not consent, so a tool may additionally project a preview.
+///
+/// This is not an arguments passthrough. Each variant enumerates exactly the
+/// fields a decision needs, a tool without a variant projects nothing, and
+/// values are clamped so a model cannot use the card as an unbounded canvas.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "tool", rename_all = "snake_case")]
+pub enum ToolApprovalPreview {
+    /// A command execution, as the argument vector it will actually run. There
+    /// is no shell string to show because no shell parses it.
+    Exec {
+        /// Executable name or path the model chose.
+        command: String,
+        /// Arguments passed directly to the executable.
+        args: Vec<String>,
+        /// Working directory relative to the chat's private scratch, never a
+        /// host path.
+        cwd: String,
+    },
+}
+
+impl ToolApprovalPreview {
+    /// Longest command, argument, or directory string a preview carries.
+    pub const MAX_FIELD_CHARS: usize = 512;
+
+    /// Most arguments a preview carries before it elides the tail.
+    pub const MAX_ARGS: usize = 32;
+
+    /// Project the preview for a call, or `None` when the tool has none.
+    ///
+    /// `arguments` are the canonical model-authored arguments. Only the fields
+    /// named by a variant are read; malformed arguments simply yield `None`
+    /// rather than degrading the card into a raw JSON dump.
+    #[must_use]
+    pub fn build(tool_name: &str, arguments: &serde_json::Value) -> Option<Self> {
+        match tool_name {
+            // Kept beside `ToolApprovalKind::for_tool_name`, which already owns
+            // the closed mapping from tool name to consent semantics.
+            "exec" => {
+                let command = clamp(arguments.get("command")?.as_str()?)?;
+                let args = arguments
+                    .get("args")
+                    .and_then(serde_json::Value::as_array)
+                    .map(|args| {
+                        args.iter()
+                            .take(Self::MAX_ARGS)
+                            .filter_map(|arg| arg.as_str().and_then(clamp))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let cwd = arguments
+                    .get("cwd")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(clamp)
+                    .unwrap_or_else(|| ".".into());
+                Some(Self::Exec { command, args, cwd })
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Bound one preview field, dropping control characters that could forge card
+/// structure. An empty or all-control field is not presentable.
+fn clamp(value: &str) -> Option<String> {
+    let cleaned: String = value
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(ToolApprovalPreview::MAX_FIELD_CHARS)
+        .collect();
+    (!cleaned.is_empty()).then_some(cleaned)
+}
+
 impl ToolApprovalStatus {
     /// Stable database representation.
     #[must_use]
@@ -153,7 +230,8 @@ impl ToolApprovalStatus {
 }
 
 /// Private durable approval state. Canonical tool arguments and model summaries
-/// deliberately remain outside this read model.
+/// deliberately remain outside this read model; only the closed
+/// [`ToolApprovalPreview`] projection of those arguments is presentable.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolApproval {
     pub call_id: CallId,
@@ -162,6 +240,8 @@ pub struct ToolApproval {
     pub tool_name: String,
     pub class: ApprovalClass,
     pub kind: ToolApprovalKind,
+    /// What the call will do, when the tool projects it.
+    pub preview: Option<ToolApprovalPreview>,
     pub status: ToolApprovalStatus,
     pub reason: Option<String>,
     pub requested_at: DateTime<Utc>,
@@ -356,6 +436,9 @@ pub struct ApprovalRequest {
     pub class: ApprovalClass,
     /// Closed server-owned consent semantics, frozen at first registration.
     pub kind: ToolApprovalKind,
+    /// Closed projection of the arguments this call will run with, when the
+    /// tool has one. Registration ignores it; it exists to be presented.
+    pub preview: Option<ToolApprovalPreview>,
     /// Short human-readable summary of what will happen.
     pub summary: String,
 }
@@ -577,5 +660,73 @@ mod standing_grant_tests {
 
         grants.clear();
         assert!(!grants.covers(chat, "search", kind));
+    }
+
+    #[test]
+    fn exec_preview_carries_the_argument_vector_and_defaults_its_directory() {
+        let preview = ToolApprovalPreview::build(
+            "exec",
+            &serde_json::json!({ "command": "python3", "args": ["-c", "print(1)"] }),
+        );
+        assert_eq!(
+            preview,
+            Some(ToolApprovalPreview::Exec {
+                command: "python3".into(),
+                args: vec!["-c".into(), "print(1)".into()],
+                cwd: ".".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn only_tools_with_a_variant_project_a_preview() {
+        for (tool, arguments) in [
+            ("search", serde_json::json!({ "query": "private" })),
+            ("web_search", serde_json::json!({ "query": "private" })),
+            (
+                "write_file",
+                serde_json::json!({ "path": "/Users/private" }),
+            ),
+            ("mcp__server__tool", serde_json::json!({ "any": "thing" })),
+        ] {
+            assert_eq!(ToolApprovalPreview::build(tool, &arguments), None);
+        }
+    }
+
+    #[test]
+    fn malformed_exec_arguments_yield_no_preview_rather_than_a_raw_dump() {
+        for arguments in [
+            serde_json::json!({}),
+            serde_json::json!({ "command": "" }),
+            serde_json::json!({ "command": 7 }),
+            serde_json::json!("not an object"),
+        ] {
+            assert_eq!(ToolApprovalPreview::build("exec", &arguments), None);
+        }
+    }
+
+    #[test]
+    fn exec_preview_bounds_the_card_a_model_can_paint() {
+        let long = "a".repeat(ToolApprovalPreview::MAX_FIELD_CHARS * 2);
+        let many: Vec<_> = (0..ToolApprovalPreview::MAX_ARGS * 2)
+            .map(|index| index.to_string())
+            .collect();
+        let Some(ToolApprovalPreview::Exec { command, args, cwd }) = ToolApprovalPreview::build(
+            "exec",
+            &serde_json::json!({
+                "command": long,
+                "args": many,
+                // Control characters could otherwise forge card structure.
+                "cwd": "scratch\n\u{1b}[31mapproved",
+            }),
+        ) else {
+            panic!("exec projects a preview");
+        };
+        assert_eq!(
+            command.chars().count(),
+            ToolApprovalPreview::MAX_FIELD_CHARS
+        );
+        assert_eq!(args.len(), ToolApprovalPreview::MAX_ARGS);
+        assert_eq!(cwd, "scratch[31mapproved");
     }
 }

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -5,7 +5,8 @@ use sea_orm::{
 };
 
 use crate::approval::{
-    ApprovalDecision, ApprovalRequest, ToolApproval, ToolApprovalKind, ToolApprovalStatus,
+    ApprovalDecision, ApprovalRequest, ToolApproval, ToolApprovalKind, ToolApprovalPreview,
+    ToolApprovalStatus,
 };
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
@@ -38,6 +39,7 @@ pub(in crate::db) async fn request_and_append_event(
         tool_name: request.tool_name.clone(),
         class: request.class,
         kind: request.kind,
+        preview: request.preview.clone(),
         summary: request.summary.clone(),
     };
     let transaction = store.conn.begin().await.map_err(store_err)?;
@@ -483,6 +485,10 @@ fn approval_from_model(model: &entities::tool_call::Model) -> Result<ToolApprova
         tool_name: model.name.clone(),
         class,
         kind,
+        // Rebuilt from the arguments the call is durably parked on rather than
+        // stored separately, so a recovered card can never describe a different
+        // action from the one that will run.
+        preview: ToolApprovalPreview::build(&model.name, &model.arguments),
         status,
         reason: model.approval_reason.clone(),
         requested_at: model

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -11345,6 +11345,21 @@ async fn claimed_sensitive_call_named(
     chat: &Chat,
     tool_name: &str,
 ) -> (TurnId, uuid::Uuid, ToolCallRecord, ApprovalRequest) {
+    claimed_sensitive_call_with(
+        store,
+        chat,
+        tool_name,
+        serde_json::json!({"query": "private"}),
+    )
+    .await
+}
+
+async fn claimed_sensitive_call_with(
+    store: &DbStore,
+    chat: &Chat,
+    tool_name: &str,
+    arguments: serde_json::Value,
+) -> (TurnId, uuid::Uuid, ToolCallRecord, ApprovalRequest) {
     let turn_id = TurnId::new();
     let accepted = match store
         .accept_turn(turn_id, chat.id, "gpt-5", "search")
@@ -11382,7 +11397,7 @@ async fn claimed_sensitive_call_named(
         turn_id,
         provider_id: "approval-call".into(),
         name: tool_name.into(),
-        arguments: serde_json::json!({"query": "private"}),
+        arguments,
         execution: ToolCallExecution::Server,
         status: ToolCallStatus::Pending,
         result: None,
@@ -11404,9 +11419,51 @@ async fn claimed_sensitive_call_named(
         tool_name: call.name.clone(),
         class: ApprovalClass::Sensitive,
         kind: crate::ToolApprovalKind::for_tool_name(&call.name),
+        preview: None,
         summary: "search requires approval".into(),
     };
     (turn_id, lease_token, call, request)
+}
+
+#[tokio::test]
+async fn recovered_exec_approval_still_names_the_command_it_will_run() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (_turn_id, lease_token, _call, request) = claimed_sensitive_call_with(
+        &store,
+        &chat,
+        "exec",
+        serde_json::json!({ "command": "cargo", "args": ["build"], "cwd": "checkout" }),
+    )
+    .await;
+
+    store
+        .request_tool_call_approval_and_append_event(
+            &request,
+            lease_token,
+            1,
+            DateTime::<Utc>::from_timestamp(1, 0).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // The preview is rebuilt from the arguments the call is parked on, so a
+    // card recovered after a restart describes the command that will actually
+    // run rather than whatever was in flight when the process died.
+    let recovered = store
+        .get_tool_call_approval(request.call_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        recovered.preview,
+        Some(crate::ToolApprovalPreview::Exec {
+            command: "cargo".into(),
+            args: vec!["build".into()],
+            cwd: "checkout".into(),
+        })
+    );
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -78,6 +78,10 @@ pub enum AgentEvent {
         /// The approval class that triggered the prompt.
         class: ApprovalClass,
         kind: crate::approval::ToolApprovalKind,
+        /// Closed projection of what the call will do, when its tool has one.
+        /// Absent on journal rows written before previews existed.
+        #[serde(default)]
+        preview: Option<crate::approval::ToolApprovalPreview>,
         /// A short, human-readable summary of what will happen.
         summary: String,
     },

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -67,7 +67,8 @@ pub use agent_tools::{
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
     ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, AutoApproveGate,
-    RefuseGate, StandingGrant, StandingGrants, ToolApproval, ToolApprovalKind, ToolApprovalStatus,
+    RefuseGate, StandingGrant, StandingGrants, ToolApproval, ToolApprovalKind, ToolApprovalPreview,
+    ToolApprovalStatus,
 };
 #[cfg(feature = "blob-fs")]
 pub use blob::FsBlobStore;

--- a/crates/openwave-desktop/ui/src/ApprovalHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/ApprovalHistory.test.ts
@@ -10,6 +10,7 @@ const pending = {
   action: "search" as const,
   approval: "search_may_share_query_and_excerpts" as const,
   class: "sensitive" as const,
+  preview: null,
   canApprove: true,
   canRemember: true,
 };

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -189,12 +189,52 @@ describe("pending approval recovery", () => {
       action: "search",
       approval: "search_may_share_query_and_excerpts",
       class: "sensitive",
+      preview: null,
       canApprove: true,
       canRemember: true,
     });
     expect(parsePendingToolApproval({ ...safe, arguments: { query: "private" } })).toBeNull();
     expect(parsePendingToolApproval({ ...safe, can_approve: false })).toBeNull();
     expect(parsePendingToolApproval({ ...safe, action: "private_plugin" })).toBeNull();
+  });
+
+  it("recovers the command an exec approval is granting", () => {
+    expect(
+      parsePendingToolApproval({
+        ...safe,
+        action: "exec",
+        approval: "exec_may_run_networked_command",
+        preview: {
+          tool: "exec",
+          command: "cargo",
+          args: ["test", "--workspace"],
+          cwd: "checkout",
+        },
+      })?.preview,
+    ).toEqual({
+      tool: "exec",
+      command: "cargo",
+      args: ["test", "--workspace"],
+      cwd: "checkout",
+    });
+  });
+
+  it("drops a preview it cannot fully validate rather than half-rendering it", () => {
+    const exec = {
+      ...safe,
+      action: "exec",
+      approval: "exec_may_run_networked_command",
+    };
+    for (const preview of [
+      { tool: "shell", command: "rm", args: [], cwd: "." },
+      { tool: "exec", command: "", args: [], cwd: "." },
+      { tool: "exec", command: "cargo", args: "test", cwd: "." },
+      { tool: "exec", command: "cargo", args: [{ hidden: true }], cwd: "." },
+      { tool: "exec", command: "cargo", args: [] },
+      "cargo test",
+    ]) {
+      expect(parsePendingToolApproval({ ...exec, preview })?.preview).toBeNull();
+    }
   });
 
   it("recovers an approvable escaping exec action", () => {

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -250,6 +250,7 @@ export type AgentEvent =
       action: RendererToolName;
       approval: RendererApprovalKind;
       class: "read_only" | "workspace" | "sensitive";
+      preview?: ToolApprovalPreview;
     }
   | { type: "approval_decided"; call_id: string; approved: boolean }
   | {
@@ -285,6 +286,21 @@ export type RendererToolName =
   | "exec"
   | "other";
 
+/**
+ * The action a parked call will take, in a form a human can inspect.
+ *
+ * The renderer boundary otherwise carries no tool arguments. This is the one
+ * exception: a tool may project a closed, field-by-field view of what it is
+ * about to do, because consent to an action you cannot see is not consent.
+ * Tools without a variant send nothing.
+ */
+export type ToolApprovalPreview = {
+  tool: "exec";
+  command: string;
+  args: string[];
+  cwd: string;
+};
+
 export type RendererApprovalKind =
   | "search_may_share_query_and_excerpts"
   | "web_search_may_share_query"
@@ -314,6 +330,8 @@ export type PendingToolApproval = {
   action: RendererToolName;
   approval: RendererApprovalKind;
   class: "read_only" | "workspace" | "sensitive";
+  /** What the parked call will do, when its tool projects a preview. */
+  preview: ToolApprovalPreview | null;
   canApprove: boolean;
   canRemember: boolean;
 };
@@ -948,6 +966,7 @@ export function parsePendingToolApproval(
         key !== "action" &&
         key !== "approval" &&
         key !== "class" &&
+        key !== "preview" &&
         key !== "can_approve" &&
         key !== "can_remember",
     ) ||
@@ -973,9 +992,34 @@ export function parsePendingToolApproval(
     action: value.action,
     approval: value.approval,
     class: value.class,
+    preview: parseToolApprovalPreview(value.preview),
     canApprove: value.can_approve,
     canRemember: value.can_remember,
   };
+}
+
+/**
+ * Validate a preview field by field. A malformed or unrecognized preview is
+ * dropped rather than partially rendered: an approval card that describes the
+ * wrong action is worse than one that describes no action.
+ */
+export function parseToolApprovalPreview(
+  value: unknown,
+): ToolApprovalPreview | null {
+  if (value === undefined || value === null) return null;
+  if (!isRecord(value) || value.tool !== "exec") return null;
+  const { command, args, cwd } = value;
+  if (
+    typeof command !== "string" ||
+    command.length === 0 ||
+    !Array.isArray(args) ||
+    !args.every((arg): arg is string => typeof arg === "string") ||
+    typeof cwd !== "string" ||
+    cwd.length === 0
+  ) {
+    return null;
+  }
+  return { tool: "exec", command, args, cwd };
 }
 
 function isRendererToolName(value: unknown): value is RendererToolName {

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -18,7 +18,7 @@ use std::sync::{
 
 use openwave_core::{
     ApprovalClass, ApprovalDecision, ApprovalGate, ApprovalRequest, CallId, ChatId, StandingGrants,
-    ToolApprovalKind, ToolCtx, ToolOutput, ToolRegistry, TurnId, VERSION,
+    ToolApprovalKind, ToolApprovalPreview, ToolCtx, ToolOutput, ToolRegistry, TurnId, VERSION,
 };
 use serde_json::Value;
 
@@ -66,6 +66,7 @@ impl ApprovalBridge {
         chat_id: ChatId,
         tool_name: &str,
         class: ApprovalClass,
+        arguments: &Value,
     ) -> Option<String> {
         let kind = ToolApprovalKind::for_tool_name(tool_name);
         if self.grants.covers(chat_id, tool_name, kind) {
@@ -78,6 +79,7 @@ impl ApprovalBridge {
             tool_name: tool_name.to_string(),
             class,
             kind,
+            preview: ToolApprovalPreview::build(tool_name, arguments),
             summary: format!("{tool_name} requires approval"),
         };
         // MCP has no durable steer journal, so register without a journal identity.
@@ -292,7 +294,10 @@ impl McpServer {
         let class = tool.approval_class();
         if class != ApprovalClass::ReadOnly {
             if let Some(bridge) = self.approval.as_ref() {
-                if let Some(reason) = bridge.decide(self.ctx.chat_id, &params.name, class).await {
+                if let Some(reason) = bridge
+                    .decide(self.ctx.chat_id, &params.name, class, &params.arguments)
+                    .await
+                {
                     // Denied or unpresentable: a clear error result, not a
                     // silent drop and not a protocol error.
                     return tool_result(ToolOutput::error(reason));

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -305,6 +305,7 @@ mod tests {
                 tool_name: tool_name.into(),
                 class: ApprovalClass::Sensitive,
                 kind: openwave_core::ToolApprovalKind::for_tool_name(tool_name),
+                preview: None,
                 summary: "private summary".into(),
             },
         )
@@ -533,6 +534,7 @@ mod tests {
             tool_name: "search".into(),
             class: ApprovalClass::Sensitive,
             kind: openwave_core::ToolApprovalKind::for_tool_name("search"),
+            preview: None,
             summary: "search requires approval".into(),
         };
         assert!(matches!(

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -6,7 +6,8 @@
 //! projection instead.
 
 use openwave_core::{
-    AgentEvent, ApprovalClass, CallId, MessageId, SequencedEvent, ToolApprovalKind, TurnId,
+    AgentEvent, ApprovalClass, CallId, MessageId, SequencedEvent, ToolApprovalKind,
+    ToolApprovalPreview, TurnId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -45,6 +46,12 @@ pub(crate) enum RendererAgentEvent {
         action: RendererToolName,
         approval: ToolApprovalKind,
         class: ApprovalClass,
+        /// The one deliberate opening in this boundary. A human cannot consent
+        /// to a command they are not shown, so a tool may project a closed,
+        /// field-by-field view of the action under review. Tools without one
+        /// send nothing, as every tool did before.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        preview: Option<ToolApprovalPreview>,
     },
     ApprovalDecided {
         call_id: CallId,
@@ -155,12 +162,14 @@ impl From<&SequencedEvent> for RendererSequencedEvent {
                 tool_name,
                 class,
                 kind,
+                preview,
                 ..
             } => RendererAgentEvent::ApprovalRequired {
                 call_id: *call_id,
                 action: tool_name.as_str().into(),
                 approval: *kind,
                 class: *class,
+                preview: preview.clone(),
             },
             AgentEvent::ApprovalDecided { call_id, approved } => {
                 RendererAgentEvent::ApprovalDecided {
@@ -225,6 +234,7 @@ mod tests {
                 tool_name: "provider_tool_with_secret".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::Unsupported,
+                preview: None,
                 summary: "upload /Users/private/document.txt".into(),
             },
             AgentEvent::ToolCallCompleted {
@@ -292,6 +302,57 @@ mod tests {
         let encoded = serde_json::to_value(projected).unwrap();
         assert_eq!(encoded["event"]["type"], "user_questions_asked");
         assert_eq!(encoded["event"].as_object().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn exec_approval_projects_the_command_under_review() {
+        let projected = RendererSequencedEvent::from(&SequencedEvent {
+            seq: 10,
+            event: AgentEvent::ApprovalRequired {
+                call_id: CallId::new(),
+                tool_name: "exec".into(),
+                class: ApprovalClass::Sensitive,
+                kind: ToolApprovalKind::ExecMayRunNetworkedCommand,
+                preview: ToolApprovalPreview::build(
+                    "exec",
+                    &serde_json::json!({
+                        "command": "cargo",
+                        "args": ["test", "--workspace"],
+                        "cwd": "checkout",
+                    }),
+                ),
+                summary: "private model-authored summary".into(),
+            },
+        });
+        let json = serde_json::to_string(&projected).unwrap();
+        assert!(json.contains(r#""action":"exec""#));
+        assert!(json.contains(r#""tool":"exec""#));
+        assert!(json.contains(r#""command":"cargo""#));
+        assert!(json.contains(r#""args":["test","--workspace"]"#));
+        assert!(json.contains(r#""cwd":"checkout""#));
+        // The preview replaces the model-authored summary; it does not join it.
+        assert!(!json.contains("private model-authored summary"));
+    }
+
+    #[test]
+    fn approvals_without_a_preview_stay_closed() {
+        let projected = RendererSequencedEvent::from(&SequencedEvent {
+            seq: 11,
+            event: AgentEvent::ApprovalRequired {
+                call_id: CallId::new(),
+                tool_name: "web_search".into(),
+                class: ApprovalClass::Sensitive,
+                kind: ToolApprovalKind::WebSearchMayShareQuery,
+                preview: ToolApprovalPreview::build(
+                    "web_search",
+                    &serde_json::json!({ "query": "private query" }),
+                ),
+                summary: "private query".into(),
+            },
+        });
+        let json = serde_json::to_string(&projected).unwrap();
+        assert!(!json.contains("preview"));
+        assert!(!json.contains("private query"));
     }
 
     #[test]
@@ -364,6 +425,7 @@ mod tests {
                 tool_name: "search".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::SearchMayShareQueryAndExcerpts,
+                preview: None,
                 summary: "private query and document title".into(),
             },
         });
@@ -382,6 +444,7 @@ mod tests {
                 tool_name: "web_search".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::WebSearchMayShareQuery,
+                preview: None,
                 summary: "private query and domain filters".into(),
             },
         });
@@ -401,6 +464,7 @@ mod tests {
                 tool_name: "mcp__private_server__private_tool".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::ExternalMcpMayCallServer,
+                preview: None,
                 summary: "private model-authored arguments".into(),
             },
         });

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1573,7 +1573,8 @@ fn default_pending_approvals_limit() -> u64 {
 }
 
 /// Closed renderer-safe pending approval projection. Canonical arguments,
-/// model-authored summaries, and unknown tool names never cross this boundary.
+/// model-authored summaries, and unknown tool names never cross this boundary;
+/// only a tool's own closed preview of the action under review does.
 #[derive(Debug, Serialize)]
 pub(crate) struct PendingApprovalSnapshot {
     pub call_id: CallId,
@@ -1581,6 +1582,8 @@ pub(crate) struct PendingApprovalSnapshot {
     pub action: crate::event_projection::RendererToolName,
     pub approval: openwave_core::ToolApprovalKind,
     pub class: openwave_core::ApprovalClass,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preview: Option<openwave_core::ToolApprovalPreview>,
     pub can_approve: bool,
     pub can_remember: bool,
 }
@@ -1616,6 +1619,7 @@ pub(crate) async fn list_pending_approvals(
                     action,
                     approval: kind,
                     class: approval.class,
+                    preview: approval.preview,
                     can_approve: kind.is_approvable(),
                     can_remember: kind.is_standing_grantable(),
                 }

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -12034,6 +12034,9 @@ async fn foreground_web_search_runs_end_to_end_through_durable_approval() {
     assert_eq!(pending[0]["class"], "sensitive");
     assert_eq!(pending[0]["can_approve"], true);
     assert_eq!(pending[0]["can_remember"], true);
+    // Web search consents to an egress class, not to an inspectable action, so
+    // recovery carries no preview of the query.
+    assert!(pending[0].get("preview").is_none());
     let pending_json = pending.to_string();
     assert!(!pending_json.contains("OpenWave release"));
     assert!(!pending_json.contains("Example.com"));


### PR DESCRIPTION
Closes #444

The renderer boundary strips every tool argument, so an `exec` approval card could only say that *some* command wanted to run:

> Approval needed: Allow OpenWave to run a command that leaves the chat workspace and may reach the network?

Asking someone to consent to an action they cannot see isn't consent.

## The carve-out

`ToolApprovalKind` names the *class* of egress under review; it structurally cannot say which command is about to run. This adds `ToolApprovalPreview` alongside it — a closed, per-tool projection of the concrete action.

It is deliberately not an arguments passthrough:

- Each variant enumerates exactly the fields a decision needs. `exec` is the only one today: `command`, `args`, `cwd`.
- A tool without a variant projects nothing, exactly as every tool did before. Search and web search still carry no query; MCP still carries no server or tool name.
- Fields are clamped to 512 characters and 32 arguments, and control characters are stripped, so a model can't use the card as an unbounded canvas or forge card structure with escape sequences.
- Malformed arguments yield no preview rather than degrading into a raw JSON dump.

## Flow

The preview rides on `AgentEvent::ApprovalRequired` (additive, `serde(default)`, so existing journal rows still deserialize), through `RendererAgentEvent::ApprovalRequired`, and on `GET /chats/{id}/approvals`.

It's rebuilt from the arguments the call is durably parked on rather than stored beside them, so a card recovered after a restart can't describe a different action from the one that will run. The MCP server face threads its own call arguments through the same builder.

The desktop UI validates a preview field by field and drops anything it cannot fully verify — an approval card that describes the wrong action is worse than one that describes no action. Rendering it is the next slice (#445).

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, `cargo check --workspace --locked` all clean; `tsc` and the vitest suite pass.