### PR TITLE
fix(sources): distinguish a stored source from a searchable one

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -85,6 +85,9 @@ struct DocumentSummaryRow {
     title: Option<String>,
     content_revision: i64,
     processing_status: String,
+    /// Emptiness of the canonical text, evaluated in the database so a listing
+    /// still never transfers the text itself.
+    has_canonical_text: bool,
     indexed_revision: Option<i64>,
     index_fingerprint: Option<String>,
     created_at: chrono::DateTime<Utc>,
@@ -366,6 +369,13 @@ impl Store for DbStore {
                 entities::document::Column::UpdatedAt,
                 entities::document::Column::IndexedAt,
             ])
+            .column_as(
+                sea_orm::sea_query::ExprTrait::ne(
+                    sea_orm::sea_query::Expr::col(entities::document::Column::CanonicalText),
+                    "",
+                ),
+                "has_canonical_text",
+            )
             .order_by_desc(entities::document::Column::CreatedAt)
             .order_by_desc(entities::document::Column::Id)
             .limit(limit)
@@ -3645,6 +3655,7 @@ fn document_from_model(model: entities::document::Model) -> Result<DocumentRecor
 }
 
 fn document_summary_from_row(row: DocumentSummaryRow) -> Result<DocumentSummaryRecord> {
+    let processing_status = document_processing_status_from_db(&row.processing_status)?;
     Ok(DocumentSummaryRecord {
         id: DocumentId(row.id),
         chat_id: row.chat_id.map(ChatId),
@@ -3653,7 +3664,8 @@ fn document_summary_from_row(row: DocumentSummaryRow) -> Result<DocumentSummaryR
         media_type: row.media_type,
         title: row.title,
         content_revision: row.content_revision,
-        processing_status: document_processing_status_from_db(&row.processing_status)?,
+        processing_status,
+        searchable: processing_status == DocumentProcessingStatus::Ready && row.has_canonical_text,
         indexed_revision: row.indexed_revision,
         index_fingerprint: row.index_fingerprint,
         created_at: row.created_at,

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -829,6 +829,58 @@ async fn document_summaries_page_by_created_at_then_id_without_gaps() {
 }
 
 #[tokio::test]
+async fn ready_summaries_report_whether_anything_is_actually_searchable() {
+    let (_dir, store) = temp_store().await;
+    let indexed_at = DateTime::<Utc>::from_timestamp(1_700_000_200, 0).unwrap();
+    let ready = |raw_id: u128, canonical_text: &str| {
+        let mut document = sample_document(None);
+        document.id = DocumentId(uuid::Uuid::from_u128(raw_id));
+        document.canonical_text = canonical_text.to_owned();
+        document.processing_status = DocumentProcessingStatus::Ready;
+        document.indexed_revision = Some(document.content_revision);
+        document.index_fingerprint = Some("chunker=test;embedder=test".to_owned());
+        document.indexed_at = Some(indexed_at);
+        document
+    };
+    // A parser can succeed and still produce nothing to index: an image with
+    // no OCR, or a format whose parser is not installed on this host.
+    let with_text = ready(2, "売上 grew by 10%.");
+    let without_text = ready(1, "");
+    let mut still_queued = sample_document(None);
+    still_queued.id = DocumentId(uuid::Uuid::from_u128(3));
+    for document in [&with_text, &without_text, &still_queued] {
+        store.create_document(document).await.unwrap();
+    }
+
+    let searchable = store
+        .list_document_summaries(DocumentScope::All, None, 10)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|document| (document.id, document.processing_status, document.searchable))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        searchable,
+        vec![
+            (
+                still_queued.id,
+                DocumentProcessingStatus::Queued,
+                // Not yet searchable, but for a reason the caller must not
+                // confuse with a parser that found nothing.
+                false
+            ),
+            (with_text.id, DocumentProcessingStatus::Ready, true),
+            (without_text.id, DocumentProcessingStatus::Ready, false),
+        ]
+    );
+    // The listing decides emptiness in the database, so it must still never
+    // carry the text itself.
+    assert!(with_text.is_searchable());
+    assert!(!without_text.is_searchable());
+    assert!(!still_queued.is_searchable());
+}
+
+#[tokio::test]
 async fn document_project_fk_rejects_orphans_and_direct_project_deletion() {
     let (_dir, store) = temp_store().await;
     let orphan = sample_document(Some(ProjectId::new()));

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -764,6 +764,16 @@ impl DocumentRecord {
             revision_token: self.revision_token,
         }
     }
+
+    /// Whether this revision contributed text a search can match.
+    ///
+    /// Empty canonical text means the parser ran and found nothing to index —
+    /// an image without OCR, or a format whose parser is not installed. The
+    /// bytes are still retained, so a later reprocess can change this answer.
+    #[must_use]
+    pub fn is_searchable(&self) -> bool {
+        self.processing_status == DocumentProcessingStatus::Ready && !self.canonical_text.is_empty()
+    }
 }
 
 /// One durable semantic processing stage bound to an exact document revision.
@@ -945,6 +955,15 @@ pub struct DocumentSummaryRecord {
     pub content_revision: i64,
     /// Processing lifecycle of the current authoritative revision.
     pub processing_status: DocumentProcessingStatus,
+    /// Whether the current revision contributed text a search can match.
+    ///
+    /// Processing that finishes is not the same as processing that found
+    /// something. A scanned image, or a format whose parser is not installed on
+    /// this host, produces a document that is durably stored and citable by
+    /// name but that no query will ever return. Keeping this separate from
+    /// [`DocumentProcessingStatus::Ready`] stops that outcome from being
+    /// presented as a fully usable source.
+    pub searchable: bool,
     /// Revision currently represented in the retrieval index, if any.
     pub indexed_revision: Option<i64>,
     /// Chunker/embedder fingerprint for the indexed revision.

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -1982,6 +1982,7 @@ fn document_summary(document: &DocumentRecord) -> DocumentSummaryRecord {
         title: document.title.clone(),
         content_revision: document.content_revision,
         processing_status: document.processing_status,
+        searchable: document.is_searchable(),
         indexed_revision: document.indexed_revision,
         index_fingerprint: document.index_fingerprint.clone(),
         created_at: document.created_at,

--- a/crates/openwave-desktop/src/documents.rs
+++ b/crates/openwave-desktop/src/documents.rs
@@ -41,6 +41,7 @@ struct CatalogDocument {
     title: Option<String>,
     media_type: String,
     processing_status: DocumentProcessingStatus,
+    searchable: bool,
     updated_at: String,
 }
 
@@ -51,6 +52,7 @@ pub(crate) struct LibraryDocument {
     title: Option<String>,
     media_type: String,
     processing_status: DocumentProcessingStatus,
+    searchable: bool,
     updated_at: String,
 }
 
@@ -70,6 +72,7 @@ impl From<CatalogDocument> for LibraryDocument {
                 .and_then(|title| is_safe_renderer_text(&title, 255, false).then_some(title)),
             media_type: document.media_type,
             processing_status: document.processing_status,
+            searchable: document.searchable,
             updated_at: document.updated_at,
         }
     }
@@ -606,6 +609,7 @@ mod tests {
             title: Some("notes.md".to_owned()),
             media_type: "text/markdown".to_owned(),
             processing_status: DocumentProcessingStatus::Ready,
+            searchable: true,
             updated_at: "2026-07-18T00:00:00Z".to_owned(),
         });
         let json = serde_json::to_value(document).unwrap();
@@ -621,6 +625,7 @@ mod tests {
                 "documentId",
                 "mediaType",
                 "processingStatus",
+                "searchable",
                 "title",
                 "updatedAt"
             ]

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -251,7 +251,7 @@ export function DocumentsView({
                       {mediaTypeLabel(document.mediaType)} · Updated {formatDate(document.updatedAt)}
                     </span>
                   </div>
-                  <DocumentStatus status={document.processingStatus} />
+                  <DocumentStatus document={document} />
                 </article>
               ))}
             </div>
@@ -262,7 +262,21 @@ export function DocumentsView({
   );
 }
 
-function DocumentStatus({ status }: { status: LibraryDocument["processingStatus"] }) {
+function DocumentStatus({ document }: { document: LibraryDocument }) {
+  const { processingStatus: status, searchable } = document;
+  // A source can finish processing without producing anything to search — a
+  // scan without OCR, or a format whose parser is missing on this host. Saying
+  // "Available" there would promise a search that silently never matches.
+  if (status === "ready" && !searchable) {
+    return (
+      <span
+        className="document-status is-unsearchable"
+        title="Stored in this conversation, but nothing in it can be searched."
+      >
+        Not searchable
+      </span>
+    );
+  }
   const label =
     status === "ready"
       ? "Available"

--- a/crates/openwave-desktop/ui/src/documents.test.ts
+++ b/crates/openwave-desktop/ui/src/documents.test.ts
@@ -17,6 +17,7 @@ describe("document library renderer projections", () => {
             title: "notes.md",
             mediaType: "text/markdown",
             processingStatus: "processing",
+            searchable: false,
             updatedAt: "2026-07-18T12:00:00Z",
           },
         ],
@@ -46,6 +47,40 @@ describe("document library renderer projections", () => {
     ).toBe(unicodeName);
   });
 
+  it("keeps searchability distinct from having finished processing", () => {
+    const stored = parseLibraryCatalog({
+      documents: [
+        {
+          documentId,
+          title: "scan.pdf",
+          mediaType: "application/pdf",
+          processingStatus: "ready",
+          searchable: false,
+          updatedAt: "2026-07-18T12:00:00Z",
+        },
+      ],
+      truncated: false,
+    }).documents[0];
+    expect(stored?.processingStatus).toBe("ready");
+    expect(stored?.searchable).toBe(false);
+
+    // Omitting the flag must not silently read as searchable.
+    expect(() =>
+      parseLibraryCatalog({
+        documents: [
+          {
+            documentId,
+            title: "scan.pdf",
+            mediaType: "application/pdf",
+            processingStatus: "ready",
+            updatedAt: "2026-07-18T12:00:00Z",
+          },
+        ],
+        truncated: false,
+      }),
+    ).toThrow("Invalid document library response");
+  });
+
   it("rejects catalog fields that could reveal native or indexing details", () => {
     for (const field of [
       "uri",
@@ -64,6 +99,7 @@ describe("document library renderer projections", () => {
               title: "notes.md",
               mediaType: "text/markdown",
               processingStatus: "ready",
+              searchable: true,
               updatedAt: "2026-07-18T12:00:00Z",
               [field]: "private",
             },

--- a/crates/openwave-desktop/ui/src/documents.ts
+++ b/crates/openwave-desktop/ui/src/documents.ts
@@ -11,6 +11,8 @@ export type LibraryDocument = {
   title: string | null;
   mediaType: string;
   processingStatus: DocumentProcessingStatus;
+  /** Whether searching this conversation can actually match this source. */
+  searchable: boolean;
   updatedAt: string;
 };
 
@@ -124,6 +126,7 @@ function parseLibraryDocument(value: unknown): LibraryDocument {
       "title",
       "mediaType",
       "processingStatus",
+      "searchable",
       "updatedAt",
     ])
   ) {
@@ -138,6 +141,7 @@ function parseLibraryDocument(value: unknown): LibraryDocument {
     value.mediaType.length === 0 ||
     value.mediaType.length > 255 ||
     !isProcessingStatus(value.processingStatus) ||
+    typeof value.searchable !== "boolean" ||
     typeof value.updatedAt !== "string" ||
     !Number.isFinite(Date.parse(value.updatedAt))
   ) {
@@ -148,6 +152,7 @@ function parseLibraryDocument(value: unknown): LibraryDocument {
     title: value.title,
     mediaType: value.mediaType,
     processingStatus: value.processingStatus,
+    searchable: value.searchable,
     updatedAt: value.updatedAt,
   };
 }

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -2754,6 +2754,12 @@ body {
   background: color-mix(in srgb, var(--danger) 9%, var(--page-background));
 }
 
+/* Stored but with nothing to search: neither a success nor a failure, so it
+   keeps the neutral base and only hints that an explanation is available. */
+.document-status.is-unsearchable {
+  cursor: help;
+}
+
 .document-empty,
 .document-empty-small {
   display: grid;

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -76,6 +76,12 @@ pub struct DocumentSummary {
     pub content_revision: i64,
     /// Processing lifecycle of the current source revision.
     pub processing_status: openwave_core::DocumentProcessingStatus,
+    /// Whether a search of this conversation can actually match this source.
+    ///
+    /// A `ready` source with `searchable: false` was stored and can be opened
+    /// by name, but its parser produced no text — a scanned image, or a format
+    /// whose parser is not installed on this host.
+    pub searchable: bool,
     /// Source revision currently represented in the index.
     pub indexed_revision: Option<i64>,
     /// Parser/chunker/embedder identity for the current indexed revision.
@@ -99,6 +105,7 @@ impl From<DocumentSummaryRecord> for DocumentSummary {
             title: document.title,
             content_revision: document.content_revision,
             processing_status: document.processing_status,
+            searchable: document.searchable,
             indexed_revision: document.indexed_revision,
             index_fingerprint: document.index_fingerprint,
             created_at: document.created_at,
@@ -119,6 +126,7 @@ impl From<&DocumentRecord> for DocumentSummary {
             title: document.title.clone(),
             content_revision: document.content_revision,
             processing_status: document.processing_status,
+            searchable: document.is_searchable(),
             indexed_revision: document.indexed_revision,
             index_fingerprint: document.index_fingerprint.clone(),
             created_at: document.created_at,


### PR DESCRIPTION
Part of #414.

## Why

A source whose parser produced no text still reaches `Ready`, and the Sources list labels it **Available**. That is what happens to a scanned PDF, an image, or any format whose parser is not installed on this host: the bytes are durably stored and the source can be cited by name, but no search will ever match it. The list was promising a capability the source does not have, and the agent reading the same catalog would draw the same wrong conclusion.

This is a pre-existing gap on the composer-import path, and it is also the honesty requirement for letting the agent import connected files in #414 — an import must not report a misleading ready/searchable state.

## What changed

Processing *finishing* is not the same as processing *finding something*, so the two facts are now carried separately rather than collapsed into one status.

- `DocumentSummaryRecord` gains `searchable`. The database evaluates it as a canonical-text emptiness check via `column_as`, so a listing still never transfers the text itself — the reason that projected row type exists in the first place.
- `DocumentRecord::is_searchable()` gives the single-record paths the same answer from the same rule, so the listing and the detail view cannot drift.
- No migration. The signal is derived from state the row already holds, so there is no new column, no CHECK-constraint change, and nothing to backfill.

In the UI, that case now renders as **Not searchable** in the neutral style rather than the success one, with a tooltip saying the file is stored but has nothing to search. `Failed` and `Preparing` are unchanged, so the four states a reader needs — searchable, stored but not searchable, preparing, failed — are all distinguishable.

The renderer parser *requires* the flag instead of defaulting it. A projection that forgets to send it should fail loudly rather than quietly read as searchable, which is the exact bug being fixed.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and `cargo check --workspace --locked` — all green, no lock diff. Under `ui`: `tsc --noEmit`, `vitest run` (288 passed), and a production `vite build`.

A store test creates three documents — ready with text, ready with empty text, and still queued — and asserts the listing distinguishes all three, including that "queued and not yet searchable" is not confused with "finished and found nothing". A renderer test asserts the stored-not-searchable shape parses and that omitting the flag throws.