### PR TITLE
refactor(desktop): give a chat one workspace shell for its scoped surfaces

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -30,8 +30,6 @@ import { ChatSessionController } from "./ChatSessionController";
 import { useChatSessionStore } from "./ChatSessionStore";
 import { useChatListStore } from "./ChatListStore";
 import { useUiStore } from "./UiStore";
-import { DocumentsView } from "./DocumentsView";
-import { DeliverablesView } from "./DeliverablesView";
 import {
   importLibraryDocument,
   type ImportedDocument,
@@ -65,7 +63,7 @@ import { useConfirm } from "./components/ConfirmDialog";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { useDesktopUpdates } from "./updates";
 import { ChatView } from "./ChatView";
-import { FoldersView } from "./FoldersView";
+import { ChatWorkspace } from "./ChatWorkspace";
 import { Sidebar } from "./Sidebar";
 
 let msgSeq = 0;
@@ -1258,13 +1256,7 @@ export default function App() {
       />}
 
       <div className="main">
-        {primaryView === "documents" ? (
-          <DocumentsView chatId={chat.id} />
-        ) : primaryView === "deliverables" ? (
-          <DeliverablesView chatId={chat.id} />
-        ) : primaryView === "folders" ? (
-          <FoldersView chat={chat} />
-        ) : primaryView === "settings" ? (
+        {primaryView === "settings" ? (
           <SettingsView
             client={client}
             models={models}
@@ -1278,87 +1270,93 @@ export default function App() {
             onRestartForUpdate={onRestartForUpdate}
           />
         ) : (
-          <ChatView
-          key={chat.id}
-          chat={chat}
-          status={status}
-          hydrated={hydratedChatId === chat.id}
-          nativeHost={hasNativeHost()}
-          deletingChat={deletingChatId !== null}
-          agentRuns={visibleAgentRuns}
-          agentRunsLoading={
-            agentRunsChatId === chat.id ? agentRunsLoading : true
-          }
-          agentRunsError={agentRunsChatId === chat.id ? agentRunsError : null}
-          stoppingRunIds={visibleStoppingSandboxRunIds}
-          stopErrorRunIds={visibleSandboxStopErrorRunIds}
-          onRetryAgentRuns={() => refreshAgentRunsRef.current?.()}
-          onStopSandboxRun={(runId) => void onStopSandboxAgentRun(runId)}
-          folderAccessRequests={folderAccessRequests}
-          userQuestionRequests={userQuestionRequests}
-          resolvingFolderCalls={resolvingFolderCalls}
-          folderAccessErrors={folderAccessErrors}
-          answeringQuestionCalls={answeringQuestionCalls}
-          userQuestionErrors={userQuestionErrors}
-          decidingApprovalCalls={decidingApprovalCalls}
-          approvalErrors={approvalErrors}
-          onApproval={(callId, decision, remember) =>
-            void onApproval(callId, decision, remember)
-          }
-          onFolderAccessDecision={(callId, decision) =>
-            void onFolderAccessDecision(callId, decision)
-          }
-          onFolderAccessCancel={(callId, turnId) =>
-            void onFolderAccessCancel(callId, turnId)
-          }
-          onAnswerUserQuestions={(callId, answers) =>
-            void onAnswerUserQuestions(callId, answers)
-          }
-          onUserQuestionsCancel={(turnId) =>
-            void onUserQuestionsCancel(turnId)
-          }
-          draft={draft}
-          attachingSource={addingSourceChatId !== null}
-          attachedSourceName={
-            recentSource && recentSource.chatId === chat.id
-              ? recentSource.source.displayName
-              : null
-          }
-          sourceAttachmentError={
-            sourceAttachmentError && sourceAttachmentError.chatId === chat.id
-              ? sourceAttachmentError.message
-              : null
-          }
-          composerModelMenu={
-            <>
-              <ModelMenu
-                models={models}
-                value={chat.model}
-                disabled={deletingChatId !== null}
-                onChange={onModelChange}
+          <ChatWorkspace
+            chat={chat}
+            status={status}
+            nativeHost={hasNativeHost()}
+            transcript={
+              <ChatView
+                key={chat.id}
+                chat={chat}
+                hydrated={hydratedChatId === chat.id}
+                nativeHost={hasNativeHost()}
+                deletingChat={deletingChatId !== null}
+                agentRuns={visibleAgentRuns}
+                agentRunsLoading={
+                  agentRunsChatId === chat.id ? agentRunsLoading : true
+                }
+                agentRunsError={agentRunsChatId === chat.id ? agentRunsError : null}
+                stoppingRunIds={visibleStoppingSandboxRunIds}
+                stopErrorRunIds={visibleSandboxStopErrorRunIds}
+                onRetryAgentRuns={() => refreshAgentRunsRef.current?.()}
+                onStopSandboxRun={(runId) => void onStopSandboxAgentRun(runId)}
+                folderAccessRequests={folderAccessRequests}
+                userQuestionRequests={userQuestionRequests}
+                resolvingFolderCalls={resolvingFolderCalls}
+                folderAccessErrors={folderAccessErrors}
+                answeringQuestionCalls={answeringQuestionCalls}
+                userQuestionErrors={userQuestionErrors}
+                decidingApprovalCalls={decidingApprovalCalls}
+                approvalErrors={approvalErrors}
+                onApproval={(callId, decision, remember) =>
+                  void onApproval(callId, decision, remember)
+                }
+                onFolderAccessDecision={(callId, decision) =>
+                  void onFolderAccessDecision(callId, decision)
+                }
+                onFolderAccessCancel={(callId, turnId) =>
+                  void onFolderAccessCancel(callId, turnId)
+                }
+                onAnswerUserQuestions={(callId, answers) =>
+                  void onAnswerUserQuestions(callId, answers)
+                }
+                onUserQuestionsCancel={(turnId) =>
+                  void onUserQuestionsCancel(turnId)
+                }
+                draft={draft}
+                attachingSource={addingSourceChatId !== null}
+                attachedSourceName={
+                  recentSource && recentSource.chatId === chat.id
+                    ? recentSource.source.displayName
+                    : null
+                }
+                sourceAttachmentError={
+                  sourceAttachmentError && sourceAttachmentError.chatId === chat.id
+                    ? sourceAttachmentError.message
+                    : null
+                }
+                composerModelMenu={
+                  <>
+                    <ModelMenu
+                      models={models}
+                      value={chat.model}
+                      disabled={deletingChatId !== null}
+                      onChange={onModelChange}
               />
-              {modelForSelection(models, chat.model)?.supports_reasoning_effort && (
-                <ReasoningEffortMenu
-                  value={chat.reasoning_effort}
-                  disabled={deletingChatId !== null}
-                  onChange={onReasoningEffortChange}
-                />
-              )}
-            </>
-          }
-          cancelError={cancelError}
-          cancelPendingTurnId={cancelPendingTurnId}
-          steerError={steerError}
-          steerStatus={steerStatus}
-          steerPendingTurnId={steerPendingTurnId}
-          onDraftChange={onComposerDraftChange}
-          onAddSource={onAddSource}
-          onDismissAttachedSource={() => setRecentSource(null)}
-          onSelectPrompt={setComposerDraft}
-          onSend={onSend}
-          onSteer={onSteerActiveTurn}
-          onStop={onCancelActiveTurn}
-        />
+                    {modelForSelection(models, chat.model)?.supports_reasoning_effort && (
+                      <ReasoningEffortMenu
+                        value={chat.reasoning_effort}
+                        disabled={deletingChatId !== null}
+                        onChange={onReasoningEffortChange}
+              />
+                    )}
+                  </>
+                }
+                cancelError={cancelError}
+                cancelPendingTurnId={cancelPendingTurnId}
+                steerError={steerError}
+                steerStatus={steerStatus}
+                steerPendingTurnId={steerPendingTurnId}
+                onDraftChange={onComposerDraftChange}
+                onAddSource={onAddSource}
+                onDismissAttachedSource={() => setRecentSource(null)}
+                onSelectPrompt={setComposerDraft}
+                onSend={onSend}
+                onSteer={onSteerActiveTurn}
+                onStop={onCancelActiveTurn}
+              />
+            }
+          />
         )}
       </div>
       </div>

--- a/crates/openwave-desktop/ui/src/ChatTabs.tsx
+++ b/crates/openwave-desktop/ui/src/ChatTabs.tsx
@@ -1,14 +1,32 @@
 import { FileOutput, FolderOpen, LibraryBig, MessageSquare } from "lucide-react";
-import { useUiStore } from "./UiStore";
+import { useUiStore, type PrimaryView } from "./UiStore";
+
+/** Surfaces whose catalogs are served by the native host rather than the API. */
+const NATIVE_HOST_SURFACES: ReadonlySet<PrimaryView> = new Set([
+  "documents",
+  "deliverables",
+  "folders",
+]);
+
+const UNAVAILABLE_HINT = "Available in the OpenWave desktop app";
+
+export function requiresNativeHost(view: PrimaryView): boolean {
+  return NATIVE_HOST_SURFACES.has(view);
+}
+
+export type ChatTabsProps = {
+  /** Native-host surfaces render disabled and explained when this is false. */
+  nativeHost: boolean;
+};
 
 /**
  * Segmented control for a chat's per-conversation surfaces: the transcript
- * ("Chat") and its scoped Sources / Outputs. These views are keyed on the
- * selected chat, so the switcher lives in the chat headers rather than the
- * sidebar — the sidebar stays a list of chats, not a mix of global and
+ * ("Chat") and its scoped Sources / Outputs / Folders. These views are keyed on
+ * the selected chat, so the switcher lives in the chat workspace header rather
+ * than the sidebar — the sidebar stays a list of chats, not a mix of global and
  * chat-scoped destinations.
  */
-export function ChatTabs() {
+export function ChatTabs({ nativeHost }: ChatTabsProps) {
   const primaryView = useUiStore((state) => state.primaryView);
   const showChat = useUiStore((state) => state.showChat);
   const showDocuments = useUiStore((state) => state.showDocuments);
@@ -45,6 +63,7 @@ export function ChatTabs() {
   return (
     <div className="chat-tabs" role="tablist" aria-label="Chat views">
       {tabs.map((tab) => {
+        const unavailable = !nativeHost && requiresNativeHost(tab.key);
         const active = primaryView === tab.key;
         const Icon = tab.icon;
         return (
@@ -53,6 +72,9 @@ export function ChatTabs() {
             type="button"
             role="tab"
             aria-selected={active}
+            aria-disabled={unavailable || undefined}
+            disabled={unavailable}
+            title={unavailable ? UNAVAILABLE_HINT : undefined}
             className={`chat-tab${active ? " is-active" : ""}`}
             onClick={tab.onSelect}
           >

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -10,7 +10,6 @@ const chat = { id: "chat-1", title: "Roadmap", project_id: null } as unknown as 
 function renderChatView(overrides: Partial<ChatViewProps> = {}) {
   const props: ChatViewProps = {
     chat,
-    status: "chat chat-1 · live",
     hydrated: true,
     nativeHost: false,
     deletingChat: false,
@@ -93,13 +92,5 @@ describe("ChatView", () => {
         );
     });
     expect(screen.getByText("streamed answer")).toBeInTheDocument();
-  });
-
-  it("shows the chat title and connection status", () => {
-    renderChatView();
-    expect(
-      screen.getByRole("heading", { name: "Roadmap" }),
-    ).toBeInTheDocument();
-    expect(screen.getByText("chat chat-1 · live")).toBeInTheDocument();
   });
 });

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -7,18 +7,15 @@ import type {
   UserQuestionAnswer,
 } from "./api";
 import { AgentActivityPanel } from "./AgentActivityPanel";
-import { ChatTabs } from "./ChatTabs";
 import { followScrollBehavior, isNearBottom, scrollToLatest } from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
-import { useUiStore } from "./UiStore";
 import { Composer } from "./Composer";
 import type { FolderAccessDecision } from "./host";
 import { MessageList } from "./MessageList";
-import { ArrowDown, Settings } from "lucide-react";
+import { ArrowDown } from "lucide-react";
 
 export type ChatViewProps = {
   chat: Chat;
-  status: string;
   hydrated: boolean;
   nativeHost: boolean;
   deletingChat: boolean;
@@ -72,13 +69,13 @@ export type ChatViewProps = {
 };
 
 /**
- * The chat pane: header, agent activity, transcript, and composer. Reads the
- * live session (messages, busy, active turn) straight from the session store.
+ * The chat pane: agent activity, transcript, and composer, rendered as the
+ * body of the chat workspace. Reads the live session (messages, busy, active
+ * turn) straight from the session store.
  * Mount with `key={chat.id}` so scroll-follow state resets per conversation.
  */
 export function ChatView({
   chat,
-  status,
   hydrated,
   nativeHost,
   deletingChat,
@@ -120,7 +117,6 @@ export function ChatView({
   onSteer,
   onStop,
 }: ChatViewProps) {
-  const showSettings = useUiStore((state) => state.showSettings);
   const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);
   const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
@@ -164,28 +160,6 @@ export function ChatView({
 
   return (
     <section className="chat-pane">
-      <header className="conversation-header">
-        <div className="conversation-title-row">
-          <h1>{chat.title?.trim() || "New chat"}</h1>
-        </div>
-        {nativeHost && <ChatTabs />}
-        <div className="conversation-header-actions">
-          <div className="mobile-settings-actions">
-            <button
-              type="button"
-              className="btn"
-              aria-label="Settings"
-              onClick={showSettings}
-            >
-              <Settings size={14} />
-            </button>
-          </div>
-          <span className="status" title={status}>
-            {status}
-          </span>
-        </div>
-      </header>
-
       <AgentActivityPanel
         runs={agentRuns}
         loading={agentRunsLoading}

--- a/crates/openwave-desktop/ui/src/ChatWorkspace.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatWorkspace.dom.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Chat } from "./api";
+import { ChatWorkspace } from "./ChatWorkspace";
+import { useUiStore } from "./UiStore";
+
+vi.mock("./documents", () => ({
+  listLibraryDocuments: vi.fn().mockResolvedValue({
+    documents: [],
+    truncated: false,
+  }),
+  importLibraryDocument: vi.fn(),
+  searchLibraryDocuments: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("./deliverables", () => ({
+  listDeliverables: vi.fn().mockResolvedValue({
+    deliverables: [],
+    truncated: false,
+  }),
+  readDeliverable: vi.fn(),
+  exportDeliverable: vi.fn(),
+}));
+
+vi.mock("./host", () => ({
+  hasNativeHost: () => true,
+  listConnectedFolders: vi.fn().mockResolvedValue([]),
+  listApprovedFolders: vi.fn().mockResolvedValue([]),
+  connectFolder: vi.fn(),
+  connectApprovedFolder: vi.fn(),
+  disconnectFolder: vi.fn(),
+}));
+
+const chat = {
+  id: "chat-1",
+  title: "Roadmap",
+  project_id: null,
+} as unknown as Chat;
+
+function renderWorkspace(nativeHost = true) {
+  return render(
+    <ChatWorkspace
+      chat={chat}
+      status="chat chat-1 · live"
+      nativeHost={nativeHost}
+      transcript={<div data-testid="transcript" />}
+    />,
+  );
+}
+
+beforeEach(() => {
+  useUiStore.getState().showChat();
+});
+
+afterEach(() => {
+  cleanup();
+  useUiStore.getState().showChat();
+});
+
+describe("ChatWorkspace", () => {
+  it("shows the chat title and connection status above the surface", () => {
+    renderWorkspace();
+
+    expect(
+      screen.getByRole("heading", { name: "Roadmap" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("chat chat-1 · live")).toBeInTheDocument();
+    expect(screen.getByTestId("transcript")).toBeInTheDocument();
+  });
+
+  it("keeps one switcher in place when the surface changes", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    expect(screen.getAllByRole("tablist")).toHaveLength(1);
+
+    await user.click(screen.getByRole("tab", { name: "Sources" }));
+
+    expect(screen.getAllByRole("tablist")).toHaveLength(1);
+    expect(
+      screen.getByRole("heading", { name: "Roadmap" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("transcript")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Sources" }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers native-host surfaces as unavailable rather than hiding them", () => {
+    renderWorkspace(false);
+
+    expect(screen.getByRole("tab", { name: "Chat" })).toBeEnabled();
+    for (const label of ["Sources", "Outputs", "Folders"]) {
+      const tab = screen.getByRole("tab", { name: label });
+      expect(tab).toBeDisabled();
+      expect(tab).toHaveAttribute(
+        "title",
+        "Available in the OpenWave desktop app",
+      );
+    }
+  });
+
+  it("falls back to the transcript when the selected surface needs a host", () => {
+    useUiStore.getState().showDocuments();
+    renderWorkspace(false);
+
+    expect(screen.getByTestId("transcript")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Sources" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatWorkspace.tsx
+++ b/crates/openwave-desktop/ui/src/ChatWorkspace.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+import { Settings } from "lucide-react";
+import type { Chat } from "./api";
+import { ChatTabs, requiresNativeHost } from "./ChatTabs";
+import { DeliverablesView } from "./DeliverablesView";
+import { DocumentsView } from "./DocumentsView";
+import { FoldersView } from "./FoldersView";
+import { useUiStore } from "./UiStore";
+
+export type ChatWorkspaceProps = {
+  chat: Chat;
+  status: string;
+  nativeHost: boolean;
+  /** The transcript surface, supplied by the owner that holds session state. */
+  transcript: ReactNode;
+};
+
+/**
+ * The workspace for the selected chat: one header carrying the conversation
+ * title, the surface switcher, and status, over whichever scoped surface is
+ * selected. The header lives here rather than inside each surface so the
+ * switcher keeps its position when the body changes.
+ */
+export function ChatWorkspace({
+  chat,
+  status,
+  nativeHost,
+  transcript,
+}: ChatWorkspaceProps) {
+  const selected = useUiStore((state) => state.primaryView);
+  const showSettings = useUiStore((state) => state.showSettings);
+  // A surface the host cannot serve is offered as disabled in the switcher, so
+  // reaching one here means the host went away underneath the selection.
+  const primaryView =
+    !nativeHost && requiresNativeHost(selected) ? "chat" : selected;
+
+  return (
+    <div className="chat-workspace">
+      <header className="conversation-header">
+        <div className="conversation-title-row">
+          <h1>{chat.title?.trim() || "New chat"}</h1>
+        </div>
+        <ChatTabs nativeHost={nativeHost} />
+        <div className="conversation-header-actions">
+          <div className="mobile-settings-actions">
+            <button
+              type="button"
+              className="btn"
+              aria-label="Settings"
+              onClick={showSettings}
+            >
+              <Settings size={14} />
+            </button>
+          </div>
+          <span className="status" title={status}>
+            {status}
+          </span>
+        </div>
+      </header>
+
+      <div className="workspace-body">
+        {primaryView === "documents" ? (
+          <DocumentsView chatId={chat.id} />
+        ) : primaryView === "deliverables" ? (
+          <DeliverablesView chatId={chat.id} />
+        ) : primaryView === "folders" ? (
+          <FoldersView chat={chat} />
+        ) : (
+          transcript
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/DeliverablesView.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { Download, FileOutput, RefreshCw } from "lucide-react";
-import { ChatTabs } from "./ChatTabs";
 import {
   exportDeliverable,
   listDeliverables,
@@ -133,7 +132,6 @@ export function DeliverablesView({
     <section className="deliverables-view" aria-labelledby="deliverables-title">
       <header className="deliverables-header">
         <div>
-          <p className="eyebrow">This conversation</p>
           <h1 id="deliverables-title">Outputs</h1>
           <p>
             Files OpenWave creates for you stay private until you choose where to
@@ -141,7 +139,6 @@ export function DeliverablesView({
           </p>
         </div>
         <div className="deliverables-header-actions">
-          <ChatTabs />
           <button
             type="button"
             className="btn"

--- a/crates/openwave-desktop/ui/src/DocumentsView.test.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.test.tsx
@@ -8,7 +8,6 @@ describe("DocumentsView", () => {
       <DocumentsView chatId="chat-1" />,
     );
 
-    expect(markup).toContain("This conversation");
     expect(markup).toContain(">Sources<");
     expect(markup).toContain(
       "Add files for OpenWave to use in this conversation.",

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { FileText } from "lucide-react";
-import { ChatTabs } from "./ChatTabs";
 import {
   importLibraryDocument,
   listLibraryDocuments,
@@ -127,7 +126,6 @@ export function DocumentsView({
     <section className="documents-view" aria-labelledby="documents-title">
       <header className="documents-header">
         <div>
-          <p className="eyebrow">This conversation</p>
           <h1 id="documents-title">Sources</h1>
           <p>
             Add files for OpenWave to use in this conversation. Supported sources
@@ -135,7 +133,6 @@ export function DocumentsView({
           </p>
         </div>
         <div className="documents-header-actions">
-          <ChatTabs />
           <button
             type="button"
             className="btn btn-primary"

--- a/crates/openwave-desktop/ui/src/FoldersView.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.tsx
@@ -8,7 +8,6 @@ import {
   listConnectedFolders,
   type ConnectedFolder,
 } from "./host";
-import { ChatTabs } from "./ChatTabs";
 
 /**
  * A chat's connected folders: the directories the native host may read on this
@@ -99,7 +98,6 @@ export function FoldersView({ chat }: { chat: Chat }) {
     <section className="folders-view" aria-labelledby="folders-title">
       <header className="folders-header">
         <div>
-          <p className="eyebrow">This conversation</p>
           <h1 id="folders-title">Folders</h1>
           <p>
             OpenWave can read only the folders attached to this chat. Folders
@@ -107,7 +105,6 @@ export function FoldersView({ chat }: { chat: Chat }) {
           </p>
         </div>
         <div className="folders-header-actions">
-          <ChatTabs />
           <button
             type="button"
             className="btn btn-primary"

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -578,6 +578,23 @@ body {
   overflow: hidden;
 }
 
+.chat-workspace {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* Each surface scrolls inside the body; the header above it stays put. */
+.workspace-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
 .chat-pane {
   display: flex;
   flex-direction: column;
@@ -663,8 +680,13 @@ body {
   flex: 0 0 auto;
 }
 
-.chat-tab:hover {
+.chat-tab:hover:not(:disabled) {
   color: var(--ink);
+}
+
+.chat-tab:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .chat-tab.is-active {


### PR DESCRIPTION
The chat title, surface switcher, and connection status lived inside the transcript, and Sources, Outputs, and Folders each rendered their own copy of the switcher in their own header. `App` swapped one top-level component for another, so those four copies existed only to make the strip look continuous.

This adds a workspace that owns the header and renders the selected surface as its body. The switcher exists once; each surface keeps its own title, description, and actions. The "This conversation" eyebrow goes away with it, since the header directly above now names the conversation.

The transcript's copy was gated on the native host while the other three were not, so on a non-native host the strip never rendered and Sources/Outputs/Folders were unreachable rather than merely unavailable. All three read their catalogs through the native host, so they are now disabled with an explanation, and a selection that outlives its host falls back to the transcript rather than rendering a pane that cannot load.

Verified with `tsc`, the vitest suite (290 passing, four new cases covering the header, the single switcher, the capability gate, and the fallback), and a production build. Layout checked by rendering the real components under the compiled stylesheet at 1280px and 560px: the header holds position while the surface scrolls beneath it, and the narrow breakpoint collapses tab labels to icons without overflow.

Closes #447