### PR TITLE
feat(desktop): rebuild tool and approval cards on one card grammar

### DIFF
--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import type { ToolApprovalPreview } from "./api";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ToolPreviewBlock } from "./ToolPreview";
+
+export type ApprovalDecision = "approve" | "reject";
+
+export type ApprovalOption = {
+  key: string;
+  label: string;
+  decision: ApprovalDecision;
+  remember: boolean;
+};
+
+type ApprovalCardProps = {
+  callId: string;
+  /** Fixed copy naming the class of action under review. */
+  summary: string;
+  /** The tool's own view of the concrete action, when it projects one. */
+  preview: ToolApprovalPreview | null;
+  canApprove: boolean;
+  canRemember: boolean;
+  deciding: boolean;
+  error?: string;
+  onDecide: (
+    callId: string,
+    decision: ApprovalDecision,
+    remember?: boolean,
+  ) => void;
+};
+
+/**
+ * The consent panel for a parked tool call.
+ *
+ * The options are a keyboard-navigable list rather than a row of buttons, and
+ * they are ordered narrowest grant first with the decline last. Scope is easy
+ * to widen by accident and hard to notice afterwards, so the cheapest keystroke
+ * has to be the one that grants the least.
+ */
+export function ApprovalCard({
+  callId,
+  summary,
+  preview,
+  canApprove,
+  canRemember,
+  deciding,
+  error,
+  onDecide,
+}: ApprovalCardProps) {
+  const options = approvalOptions(canApprove, canRemember);
+  const [highlight, setHighlight] = useState(0);
+  const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const safeHighlight = Math.min(highlight, options.length - 1);
+
+  useEffect(() => {
+    rowRefs.current = rowRefs.current.slice(0, options.length);
+  }, [options.length]);
+
+  const commit = (index: number) => {
+    const option = options[index];
+    if (!option || deciding) return;
+    onDecide(callId, option.decision, option.remember);
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>, index: number) => {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const delta = event.key === "ArrowDown" ? 1 : -1;
+      const next = (index + delta + options.length) % options.length;
+      setHighlight(next);
+      rowRefs.current[next]?.focus();
+      return;
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      commit(index);
+      return;
+    }
+    const digit = Number.parseInt(event.key, 10);
+    if (Number.isInteger(digit) && digit >= 1 && digit <= options.length) {
+      event.preventDefault();
+      setHighlight(digit - 1);
+      rowRefs.current[digit - 1]?.focus();
+    }
+  };
+
+  return (
+    <section
+      className="bg-card text-card-foreground flex w-[min(100%,38rem)] flex-col gap-3 self-start rounded-lg border p-4"
+      aria-label="Approval needed"
+      aria-busy={deciding}
+    >
+      <h3 className="text-sm font-medium break-words">{summary}</h3>
+      {preview && <ToolPreviewBlock preview={preview} />}
+      <div
+        role="listbox"
+        aria-label="What should happen"
+        className="flex flex-col gap-0.5"
+      >
+        {options.map((option, index) => (
+          <div
+            key={option.key}
+            ref={(node) => {
+              rowRefs.current[index] = node;
+            }}
+            role="option"
+            aria-selected={index === safeHighlight}
+            tabIndex={deciding ? -1 : 0}
+            onClick={() => commit(index)}
+            onFocus={() => setHighlight(index)}
+            onKeyDown={(event) => onKeyDown(event, index)}
+            className={cn(
+              "focus-visible:ring-ring flex cursor-pointer items-baseline gap-2.5 rounded-md px-3 py-2 text-sm outline-hidden focus-visible:ring-2",
+              index === safeHighlight ? "bg-muted" : "hover:bg-muted/60",
+              deciding && "pointer-events-none opacity-60",
+            )}
+          >
+            <span className="text-muted-foreground w-4 shrink-0 text-xs tabular-nums">
+              {index + 1}.
+            </span>
+            <span
+              className={cn(
+                "flex-1",
+                option.decision === "reject" && "text-muted-foreground",
+              )}
+            >
+              {option.label}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center justify-between gap-2 text-xs">
+        <span className="text-muted-foreground">
+          ↑↓ choose · 1–{options.length} jump · ↵ submit
+        </span>
+        <Button
+          size="sm"
+          disabled={deciding}
+          onClick={() => commit(safeHighlight)}
+        >
+          Submit
+        </Button>
+      </div>
+      {error && (
+        <p className="text-destructive text-xs break-words" role="alert">
+          {error}
+        </p>
+      )}
+    </section>
+  );
+}
+
+/**
+ * Narrowest grant first, decline last.
+ *
+ * A kind the server will not let the renderer approve offers only the decline,
+ * so an unpresentable action can never be waved through from here.
+ */
+export function approvalOptions(
+  canApprove: boolean,
+  canRemember: boolean,
+): ApprovalOption[] {
+  const options: ApprovalOption[] = [];
+  if (canApprove) {
+    options.push({
+      key: "once",
+      label: "Yes, allow it once",
+      decision: "approve",
+      remember: false,
+    });
+    if (canRemember) {
+      options.push({
+        key: "chat",
+        label: "Yes, and don't ask again in this chat",
+        decision: "approve",
+        remember: true,
+      });
+    }
+  }
+  options.push({
+    key: "decline",
+    label: "No, don't allow this",
+    decision: "reject",
+    remember: false,
+  });
+  return options;
+}

--- a/crates/openwave-desktop/ui/src/ApprovalHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/ApprovalHistory.test.ts
@@ -24,6 +24,7 @@ describe("reconcilePendingApprovalCards", () => {
         callId: "call-search",
         name: "search",
         status: "waiting_approval",
+        preview: null,
       },
       {
         id: "approval-call-search",
@@ -31,6 +32,7 @@ describe("reconcilePendingApprovalCards", () => {
         callId: "call-search",
         summary:
           "Allow search to send your query and potentially matching document excerpts to configured AI services outside OpenWave?",
+        preview: null,
         canApprove: true,
         canRemember: true,
       },

--- a/crates/openwave-desktop/ui/src/ApprovalHistory.ts
+++ b/crates/openwave-desktop/ui/src/ApprovalHistory.ts
@@ -31,10 +31,12 @@ export function upsertPendingApprovalCard(
   approval: Pick<
     PendingToolApproval,
     "callId" | "action" | "approval" | "canApprove" | "canRemember"
-  >,
+  > &
+    Partial<Pick<PendingToolApproval, "preview">>,
 ): ChatMessage[] {
     let next = messages;
     const presentation = toolApprovalPresentation(approval.approval);
+    const preview = approval.preview ?? null;
     const toolIndex = next.findIndex(
       (message) =>
         message.role === "tool" && message.callId === approval.callId,
@@ -46,6 +48,7 @@ export function upsertPendingApprovalCard(
               ...message,
               name: approval.action,
               status: "waiting_approval",
+              preview,
             }
           : message,
       );
@@ -58,6 +61,7 @@ export function upsertPendingApprovalCard(
           callId: approval.callId,
           name: approval.action,
           status: "waiting_approval",
+          preview,
         },
       ];
     }
@@ -71,6 +75,7 @@ export function upsertPendingApprovalCard(
       role: "approval",
       callId: approval.callId,
       summary: presentation.summary,
+      preview,
       canApprove: approval.canApprove && presentation.canApprove,
       canRemember: approval.canRemember && presentation.canRemember,
     };

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -1,4 +1,5 @@
 import type { SequencedEvent } from "./api";
+import { parseToolApprovalPreview } from "./api";
 import { shouldRefreshAgentRunsAfterToolEvent } from "./AgentRunRefresh";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
 import type { ChatMessage } from "./MessageList";
@@ -241,6 +242,10 @@ export function reduceChatSessionEvent(
             callId: event.call_id,
             action: event.action,
             approval: event.approval,
+            // Validated here rather than trusted: the socket frame is the one
+            // place a preview arrives without having gone through the HTTP
+            // recovery parser.
+            preview: parseToolApprovalPreview(event.preview),
             canApprove: approval.canApprove,
             canRemember: approval.canRemember,
           }),

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -13,6 +13,9 @@ const approval: ChatMessage = {
   canRemember: true,
 };
 
+const ONCE = "1.Yes, allow it once";
+const REMEMBER = "2.Yes, and don't ask again in this chat";
+
 afterEach(cleanup);
 
 describe("approval card interactions", () => {
@@ -23,16 +26,47 @@ describe("approval card interactions", () => {
       <MessageBubble message={approval} busy={false} onApproval={onApproval} />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Approve once" }));
-    expect(onApproval).toHaveBeenLastCalledWith("call-1", "approve");
+    const options = screen.getAllByRole("option");
+    expect(options.map((option) => option.textContent)).toEqual([
+      ONCE,
+      REMEMBER,
+      "3.No, don't allow this",
+    ]);
 
-    await user.click(
-      screen.getByRole("button", { name: "Allow for this chat" }),
-    );
+    await user.click(options[0]!);
+    expect(onApproval).toHaveBeenLastCalledWith("call-1", "approve", false);
+
+    await user.click(options[1]!);
     expect(onApproval).toHaveBeenLastCalledWith("call-1", "approve", true);
 
-    await user.click(screen.getByRole("button", { name: "Reject" }));
-    expect(onApproval).toHaveBeenLastCalledWith("call-1", "reject");
+    await user.click(options[2]!);
+    expect(onApproval).toHaveBeenLastCalledWith("call-1", "reject", false);
+  });
+
+  it("starts on the narrowest grant so a stray Enter cannot widen scope", () => {
+    render(
+      <MessageBubble message={approval} busy={false} onApproval={vi.fn()} />,
+    );
+
+    const options = screen.getAllByRole("option");
+    expect(options[0]).toHaveAttribute("aria-selected", "true");
+    expect(options[0]?.textContent).toBe(ONCE);
+  });
+
+  it("submits the highlighted option from the keyboard", async () => {
+    const user = userEvent.setup();
+    const onApproval = vi.fn();
+    render(
+      <MessageBubble message={approval} busy={false} onApproval={onApproval} />,
+    );
+
+    const options = screen.getAllByRole("option");
+    options[0]!.focus();
+    await user.keyboard("{ArrowDown}{Enter}");
+    expect(onApproval).toHaveBeenLastCalledWith("call-1", "approve", true);
+
+    await user.keyboard("3{Enter}");
+    expect(onApproval).toHaveBeenLastCalledWith("call-1", "reject", false);
   });
 
   it("blocks every decision while one is in flight", async () => {
@@ -50,11 +84,10 @@ describe("approval card interactions", () => {
       />,
     );
 
-    for (const name of ["Approve once", "Allow for this chat", "Reject"]) {
-      const button = screen.getByRole("button", { name });
-      expect(button).toBeDisabled();
-      await user.click(button);
+    for (const option of screen.getAllByRole("option")) {
+      await user.click(option);
     }
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
     expect(onApproval).not.toHaveBeenCalled();
   });
 
@@ -78,8 +111,8 @@ describe("approval card interactions", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Could not send your decision",
     );
-    await user.click(screen.getByRole("button", { name: "Approve once" }));
-    expect(onApproval).toHaveBeenCalledWith("call-1", "approve");
+    await user.click(screen.getAllByRole("option")[0]!);
+    expect(onApproval).toHaveBeenCalledWith("call-1", "approve", false);
   });
 
   it("offers only rejection when the action kind is not approvable", () => {
@@ -92,12 +125,8 @@ describe("approval card interactions", () => {
     );
 
     expect(
-      screen.queryByRole("button", { name: "Approve once" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Allow for this chat" }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Reject" })).toBeInTheDocument();
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual(["1.No, don't allow this"]);
   });
 
   it("offers one-shot approval but no remembered grant for MCP", () => {
@@ -110,11 +139,33 @@ describe("approval card interactions", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: "Approve once" }),
-    ).toBeInTheDocument();
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual([ONCE, "2.No, don't allow this"]);
+  });
+
+  it("shows the command an exec approval is granting", () => {
+    render(
+      <MessageBubble
+        message={{
+          ...approval,
+          summary:
+            "Allow OpenWave to run a command that leaves the chat workspace and may reach the network?",
+          preview: {
+            tool: "exec",
+            command: "cargo",
+            args: ["test", "--workspace"],
+            cwd: "checkout",
+          },
+        }}
+        busy={false}
+        onApproval={() => undefined}
+      />,
+    );
+
+    expect(screen.getByText(/cargo test --workspace/)).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Allow for this chat" }),
-    ).not.toBeInTheDocument();
+      screen.getByText(/# working directory: checkout/),
+    ).toBeInTheDocument();
   });
 });
 

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -68,11 +68,83 @@ describe("MessageBubble", () => {
     expect(markup.indexOf("Search the web")).toBeLessThan(
       markup.indexOf("Approval needed"),
     );
-    expect(markup).toContain("message-approval");
-    expect(markup).toContain(">Approve once<");
-    expect(markup).toContain(">Allow for this chat<");
+    expect(markup).toContain('aria-label="Approval needed"');
+    expect(markup).toContain("Yes, allow it once");
+    expect(markup).toContain("Yes, and don&#x27;t ask again in this chat");
     expect(markup).not.toContain("Working");
     expect(markup).toContain('aria-live="polite"');
+  });
+
+  it("lets the approval card own the slot while its call is parked", () => {
+    const preview = {
+      tool: "exec" as const,
+      command: "cargo",
+      args: ["build"],
+      cwd: ".",
+    };
+    const tool = {
+      id: "tool-1",
+      role: "tool",
+      callId: "call-1",
+      name: "exec",
+      preview,
+    } as const;
+    const card = {
+      id: "approval-1",
+      role: "approval",
+      callId: "call-1",
+      summary: "Run this command?",
+      preview,
+      canApprove: true,
+      canRemember: true,
+    } as const;
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={[{ ...tool, status: "waiting_approval" }, card]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    // One copy of the command, on the card that can actually act on it.
+    expect(markup.match(/cargo build/g)).toHaveLength(1);
+    expect(markup).not.toContain("Waiting for approval");
+
+    // Once decided, the tool card comes back to carry the outcome.
+    const decided = renderToStaticMarkup(
+      <MessageList
+        messages={[
+          { ...tool, status: "completed" },
+          { ...card, resolved: true },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+    expect(decided).toContain("cargo build");
+    expect(decided).toContain(">Done<");
   });
 
   it("replaces an empty active assistant placeholder with one worker status", () => {
@@ -152,8 +224,8 @@ describe("MessageBubble", () => {
     );
 
     expect(markup).toContain("The exact action cannot be safely described.");
-    expect(markup).not.toContain(">Approve<");
-    expect(markup).toContain(">Reject<");
+    expect(markup).not.toContain("Yes,");
+    expect(markup).toContain("No, don&#x27;t allow this");
   });
 
   it("collapses only contiguous terminal tool activity using safe card copy", () => {
@@ -264,7 +336,7 @@ describe("MessageBubble", () => {
     );
 
     expect(markup).toContain("Used a tool and searched the web");
-    expect(markup).toContain("Use a tool");
+    expect(markup).toContain("Used a tool");
     expect(markup).toContain("Tool complete");
     expect(markup).not.toContain("private_server");
     expect(markup).not.toContain("sensitive_path");
@@ -470,7 +542,10 @@ describe("approval decision feedback", () => {
     );
 
     expect(markup).toContain('aria-busy="true"');
-    expect((markup.match(/disabled=""/g) ?? []).length).toBe(3);
+    // Every option is untabbable and the submit control is disabled, so no
+    // second decision can be sent while the first is in flight.
+    expect(markup.match(/tabindex="-1"/g)).toHaveLength(3);
+    expect(markup).toContain("disabled=\"\"");
   });
 
   it("renders a per-card error and keeps the buttons actionable for retry", () => {
@@ -488,10 +563,9 @@ describe("approval decision feedback", () => {
       />,
     );
 
-    expect(markup).toContain('class="approval-error"');
     expect(markup).toContain('role="alert"');
     expect(markup).toContain("Could not send your decision");
-    expect(markup).not.toContain("disabled");
+    expect(markup).not.toContain('disabled=""');
   });
 
   it("hides the error once the approval is resolved", () => {
@@ -507,7 +581,7 @@ describe("approval decision feedback", () => {
       />,
     );
 
-    expect(markup).not.toContain("approval-error");
+    expect(markup).not.toContain('role="alert"');
     expect(markup).not.toContain("Could not send your decision");
   });
 
@@ -524,8 +598,8 @@ describe("approval decision feedback", () => {
       />,
     );
 
-    expect(markup).not.toContain("approval-error");
-    expect(markup).not.toContain("disabled");
+    expect(markup).not.toContain('role="alert"');
+    expect(markup).not.toContain('disabled=""');
   });
 });
 

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -3,8 +3,10 @@ import type { ReactNode, RefObject, UIEvent } from "react";
 import type {
   PendingFolderAccessRequest,
   PendingUserQuestions,
+  ToolApprovalPreview,
   UserQuestionAnswer,
 } from "./api";
+import { ApprovalCard } from "./ApprovalCard";
 import { AssistantWorkingIndicator } from "./AssistantWorkingIndicator";
 import { FolderAccessCard } from "./FolderAccessCard";
 import type { FolderAccessDecision } from "./host";
@@ -35,12 +37,15 @@ export type ChatMessage =
       callId: string;
       name: string;
       status: ToolCallStatus;
+      /** The tool's own closed view of what it is doing, when it has one. */
+      preview?: ToolApprovalPreview | null;
     }
   | {
       id: string;
       role: "approval";
       callId: string;
       summary: string;
+      preview?: ToolApprovalPreview | null;
       canApprove: boolean;
       canRemember: boolean;
       resolved?: boolean;
@@ -204,17 +209,34 @@ export function groupMessageItems(
     approvalErrors: Record<string, string>;
   },
 ) {
+  // While a call is parked, its approval card already names the action and
+  // carries the controls. Showing the tool card beside it says the same thing
+  // twice and puts a second, inert copy of the command on screen.
+  const parkedOnApproval = new Set(
+    messages.flatMap((message) =>
+      message.role === "approval" && !message.resolved ? [message.callId] : [],
+    ),
+  );
+  const visible = messages.filter(
+    (message) =>
+      !(
+        message.role === "tool" &&
+        message.status === "waiting_approval" &&
+        parkedOnApproval.has(message.callId)
+      ),
+  );
+
   const items: ReactNode[] = [];
   let index = 0;
   let groupIndex = 0;
   let streamingAssistantId: string | undefined;
   if (busy) {
     for (
-      let messageIndex = messages.length - 1;
+      let messageIndex = visible.length - 1;
       messageIndex >= 0;
       messageIndex -= 1
     ) {
-      const candidate = messages[messageIndex];
+      const candidate = visible[messageIndex];
       if (candidate?.role === "assistant" && !candidate.superseded) {
         streamingAssistantId = candidate.id;
         break;
@@ -225,8 +247,8 @@ export function groupMessageItems(
     }
   }
 
-  while (index < messages.length) {
-    const message = messages[index];
+  while (index < visible.length) {
+    const message = visible[index];
 
     if (!isGroupableTerminalTool(message)) {
       items.push(
@@ -244,8 +266,8 @@ export function groupMessageItems(
 
     const activities = [message];
     index += 1;
-    while (index < messages.length) {
-      const nextMessage = messages[index];
+    while (index < visible.length) {
+      const nextMessage = visible[index];
       if (!isGroupableTerminalTool(nextMessage)) {
         break;
       }
@@ -306,60 +328,41 @@ function MessageBubbleImpl({
   };
 }) {
   if (message.role === "tool") {
-    return <ToolCallCard name={message.name} status={message.status} />;
+    return (
+      <ToolCallCard
+        name={message.name}
+        status={message.status}
+        preview={message.preview}
+      />
+    );
   }
 
   if (message.role === "approval") {
     const deciding =
       approvalState?.decidingApprovalCalls.has(message.callId) ?? false;
-    const error = approvalState?.approvalErrors[message.callId];
+    // A decided card keeps its question so the transcript still records what
+    // was asked, but drops the controls that would imply it is still open.
+    if (message.resolved) {
+      return (
+        <section
+          className="bg-card text-muted-foreground w-[min(100%,38rem)] self-start rounded-lg border p-4 text-sm"
+          aria-label="Approval needed"
+        >
+          {message.summary}
+        </section>
+      );
+    }
     return (
-      <section
-        className="message-approval"
-        aria-label="Approval needed"
-        aria-busy={deciding}
-      >
-        <p>Approval needed: {message.summary}</p>
-        {!message.resolved && (
-          <div className="approval">
-            {message.canApprove && (
-              <>
-                <button
-                  type="button"
-                  className="btn btn-primary"
-                  disabled={deciding}
-                  onClick={() => onApproval(message.callId, "approve")}
-                >
-                  Approve once
-                </button>
-                {message.canRemember && (
-                  <button
-                    type="button"
-                    className="btn"
-                    disabled={deciding}
-                    onClick={() => onApproval(message.callId, "approve", true)}
-                  >
-                    Allow for this chat
-                  </button>
-                )}
-              </>
-            )}
-            <button
-              type="button"
-              className="btn"
-              disabled={deciding}
-              onClick={() => onApproval(message.callId, "reject")}
-            >
-              Reject
-            </button>
-          </div>
-        )}
-        {!message.resolved && error && (
-          <p className="approval-error" role="alert">
-            {error}
-          </p>
-        )}
-      </section>
+      <ApprovalCard
+        callId={message.callId}
+        summary={message.summary}
+        preview={message.preview ?? null}
+        canApprove={message.canApprove}
+        canRemember={message.canRemember}
+        deciding={deciding}
+        error={approvalState?.approvalErrors[message.callId]}
+        onDecide={onApproval}
+      />
     );
   }
 

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
@@ -85,7 +85,7 @@ export function ToolActivityGroup({
                 <ToolStatusIcon tone={presentation.tone} size={12} />
               </span>
               <span className="tool-activity-timeline-copy">
-                <strong>{presentation.label}</strong>
+                <strong>{presentation.title}</strong>
                 <span>{presentation.statusLabel}</span>
               </span>
             </div>

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -173,3 +173,51 @@ describe("ToolCallCard", () => {
     });
   });
 });
+
+describe("command cards", () => {
+  const preview = {
+    tool: "exec" as const,
+    command: "cargo",
+    args: ["test", "--workspace"],
+    cwd: "checkout",
+  };
+
+  it("titles itself with the command instead of a generic phrase", () => {
+    const markup = renderToStaticMarkup(
+      <ToolCallCard name="exec" status="completed" preview={preview} />,
+    );
+
+    expect(visibleText(markup)).toContain("cargo test --workspace");
+    expect(visibleText(markup)).not.toContain("Ran a command");
+    // The allowlisted phrase still names the card for assistive technology.
+    expect(markup).toContain('aria-label="Run a command: Command complete"');
+  });
+
+  it("opens onto the command only when there is a command to open onto", () => {
+    const withCommand = renderToStaticMarkup(
+      <ToolCallCard name="exec" status="running" preview={preview} />,
+    );
+    const withoutCommand = renderToStaticMarkup(
+      <ToolCallCard name="exec" status="running" />,
+    );
+
+    expect(withCommand).toContain('aria-expanded="false"');
+    expect(withoutCommand).not.toContain("aria-expanded");
+    expect(visibleText(withoutCommand)).toContain("Running a command");
+  });
+
+  it("carries the status in a badge rather than a second line of prose", () => {
+    for (const [status, badge] of [
+      ["running", "Running…"],
+      ["waiting_approval", "Waiting for approval"],
+      ["completed", "Done"],
+      ["failed", "Failed"],
+      ["cancelled", "Not run"],
+    ] as const) {
+      const markup = renderToStaticMarkup(
+        <ToolCallCard name="exec" status={status} preview={preview} />,
+      );
+      expect(visibleText(markup)).toContain(badge);
+    }
+  });
+});

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,4 +1,10 @@
-import { ToolStatusIcon } from "./ToolStatusIcon";
+import { useState } from "react";
+import { ChevronDown, Loader2, Terminal } from "lucide-react";
+import type { ToolApprovalPreview } from "./api";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { ToolStatusIcon, type ToolTone } from "./ToolStatusIcon";
+import { ToolPreviewBlock, toolPreviewPresentation } from "./ToolPreview";
 
 export type ToolCallStatus =
   | "running"
@@ -10,6 +16,8 @@ export type ToolCallStatus =
 type ToolCallCardProps = {
   name: string;
   status: ToolCallStatus;
+  /** The tool's own view of what it is doing, when it projects one. */
+  preview?: ToolApprovalPreview | null;
 };
 
 type ToolPresentation = {
@@ -21,15 +29,14 @@ type ToolPresentation = {
 
 export type ToolCallPresentation = {
   label: string;
+  /** Tense-aware headline for this status. */
+  title: string;
+  /** Short status word for the card's badge. */
+  badgeLabel: string;
+  /** Full status sentence, used for assistive text and activity summaries. */
   statusLabel: string;
   settledLabel: string;
-  tone:
-    | "running"
-    | "waiting_approval"
-    | "completed"
-    | "failed"
-    | "cancelled"
-    | "unknown";
+  tone: ToolTone;
 };
 
 export type ToolApprovalPresentation = {
@@ -41,7 +48,8 @@ export type ToolApprovalPresentation = {
 // This is deliberately an allowlist rather than a display transformation of a
 // tool name. Tool events come from providers, and a card should never become a
 // side channel for an unexpected tool name, arguments, output, file path, or
-// provider diagnostic.
+// provider diagnostic. The one exception is a tool's own `preview`, a closed
+// per-tool projection built server-side.
 const TOOL_PRESENTATIONS: Record<string, ToolPresentation> = {
   search: {
     label: "Search sources",
@@ -154,28 +162,118 @@ const FALLBACK_TOOL: ToolPresentation = {
   settled: "Used a tool",
 };
 
-export function ToolCallCard({ name, status }: ToolCallCardProps) {
+/**
+ * One tool call in the transcript, as a one-line card that opens onto whatever
+ * the tool was willing to show.
+ *
+ * A command card titles itself with the command it ran, because "Ran a command"
+ * is the same sentence whether the agent listed a directory or built the
+ * workspace. Every other tool keeps its allowlisted phrase: the renderer has no
+ * detail for those, and inventing one would mean reading provider payloads.
+ */
+export function ToolCallCard({ name, status, preview }: ToolCallCardProps) {
   const presentation = toolCallPresentation(name, status);
+  const command = preview ? toolPreviewPresentation(preview) : null;
+  const [expanded, setExpanded] = useState(false);
+  // A card opens only when the body says something the title didn't. Tools
+  // whose payloads never cross the boundary have nothing to show at all, and a
+  // command run in the default directory is already fully stated by its title.
+  const expandable = command !== null && command.detail !== command.headline;
+
+  const header = (
+    <>
+      <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs font-medium">
+        {expandable && (
+          <ChevronDown
+            className={cn(
+              "size-3.5 shrink-0 transition-transform",
+              !expanded && "-rotate-90",
+            )}
+            aria-hidden="true"
+          />
+        )}
+        <span className="shrink-0" aria-hidden="true">
+          {command ? (
+            <Terminal size={14} />
+          ) : (
+            <ToolStatusIcon tone={presentation.tone} size={14} />
+          )}
+        </span>
+        <span className={cn("truncate", command && "font-mono")}>
+          {command ? command.headline : presentation.title}
+        </span>
+      </span>
+      <ToolStatusBadge presentation={presentation} />
+    </>
+  );
 
   return (
     <section
-      className={`tool-call-card is-${presentation.tone}`}
+      className={cn(
+        "bg-card text-card-foreground w-[min(100%,38rem)] self-start overflow-hidden rounded-lg border",
+        `is-${presentation.tone}`,
+        presentation.tone === "cancelled" && "opacity-70",
+      )}
       aria-label={`${presentation.label}: ${presentation.statusLabel}`}
       role="status"
       aria-live="polite"
       aria-atomic="true"
     >
-      <span className="tool-call-icon" aria-hidden="true">
-        <ToolStatusIcon tone={presentation.tone} />
-      </span>
-      <div className="tool-call-copy">
-        <strong>{presentation.label}</strong>
-        <span>{presentation.statusLabel}</span>
-      </div>
-      {presentation.tone === "running" && (
-        <span className="tool-call-spinner" aria-hidden="true" />
+      {expandable ? (
+        <button
+          type="button"
+          className="hover:bg-muted/50 focus-visible:ring-ring flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((current) => !current)}
+        >
+          {header}
+        </button>
+      ) : (
+        <div className="flex w-full items-center justify-between gap-2 px-2.5 py-1.5">
+          {header}
+        </div>
+      )}
+      {expandable && expanded && preview && (
+        <div className="border-t p-1">
+          <ToolPreviewBlock preview={preview} />
+        </div>
       )}
     </section>
+  );
+}
+
+function ToolStatusBadge({
+  presentation,
+}: {
+  presentation: ToolCallPresentation;
+}) {
+  if (presentation.tone === "running") {
+    return (
+      <Badge variant="outline" size="sm" className="shrink-0">
+        <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+        {presentation.badgeLabel}
+      </Badge>
+    );
+  }
+  if (presentation.tone === "completed") {
+    return (
+      <Badge variant="success" size="sm" className="shrink-0">
+        {presentation.badgeLabel}
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      size="sm"
+      className={cn(
+        "shrink-0",
+        (presentation.tone === "failed" || presentation.tone === "unknown") &&
+          "text-critical",
+      )}
+    >
+      {presentation.badgeLabel}
+    </Badge>
   );
 }
 
@@ -191,6 +289,8 @@ export function toolCallPresentation(
 
   return {
     label: tool.label,
+    title: statusPresentationResult.title,
+    badgeLabel: statusPresentationResult.badge,
     statusLabel: statusPresentationResult.label,
     settledLabel: tool.settled,
     tone: statusPresentationResult.tone,
@@ -246,29 +346,55 @@ function statusPresentation(tool: ToolPresentation, status: ToolCallStatus) {
     case "waiting_approval":
       return {
         icon: "…",
+        title: tool.label,
+        badge: "Waiting for approval",
         label: "Waiting for approval",
         tone: "waiting_approval" as const,
       };
     case "completed":
       return {
         icon: "✓",
+        title: tool.settled,
+        badge: "Done",
         label: tool.complete,
         tone: "completed" as const,
       };
     case "failed":
       return {
         icon: "!",
+        // A failure keeps the untensed phrase: the tool did not do the thing,
+        // so naming it in the past would overstate what happened.
+        title: tool.label,
+        badge: "Failed",
         label: "Tool could not complete",
         tone: "failed" as const,
       };
     case "cancelled":
-      return { icon: "–", label: "Not run", tone: "cancelled" as const };
+      return {
+        icon: "–",
+        title: tool.label,
+        badge: "Not run",
+        label: "Not run",
+        tone: "cancelled" as const,
+      };
     case "running":
-      return { icon: "↗", label: tool.active, tone: "running" as const };
+      return {
+        icon: "↗",
+        title: tool.active,
+        badge: "Running…",
+        label: tool.active,
+        tone: "running" as const,
+      };
   }
 
   // Renderer projections are a closed vocabulary, but a future or malformed
   // payload must degrade to fixed copy rather than reaching a dynamic class or
   // throwing while conversation history renders.
-  return { icon: "?", label: "Status unavailable", tone: "unknown" as const };
+  return {
+    icon: "?",
+    title: tool.label,
+    badge: "Status unavailable",
+    label: "Status unavailable",
+    tone: "unknown" as const,
+  };
 }

--- a/crates/openwave-desktop/ui/src/ToolPreview.test.ts
+++ b/crates/openwave-desktop/ui/src/ToolPreview.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { toolPreviewPresentation } from "./ToolPreview";
+
+describe("toolPreviewPresentation", () => {
+  it("reads a command back as the argument vector it will run", () => {
+    expect(
+      toolPreviewPresentation({
+        tool: "exec",
+        command: "cargo",
+        args: ["test", "--workspace"],
+        cwd: ".",
+      }),
+    ).toMatchObject({
+      headline: "cargo test --workspace",
+      detail: "cargo test --workspace",
+    });
+  });
+
+  it("names a working directory as a fact about the command, not part of it", () => {
+    expect(
+      toolPreviewPresentation({
+        tool: "exec",
+        command: "ls",
+        args: [],
+        cwd: "checkout/crates",
+      }).detail,
+    ).toBe("ls\n# working directory: checkout/crates");
+  });
+
+  it("quotes an argument whose boundaries would otherwise be invisible", () => {
+    // One vector element containing a space is one argument. Printed bare it
+    // would read as two, which is exactly the misreading an approval can least
+    // afford.
+    expect(
+      toolPreviewPresentation({
+        tool: "exec",
+        command: "python3",
+        args: ["-c", "print('two words')", "", "a;rm -rf /"],
+        cwd: ".",
+      }).headline,
+    ).toBe(`python3 -c 'print('\\''two words'\\'')' '' 'a;rm -rf /'`);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ToolPreview.tsx
+++ b/crates/openwave-desktop/ui/src/ToolPreview.tsx
@@ -1,0 +1,61 @@
+import { Terminal } from "lucide-react";
+import type { ToolApprovalPreview } from "./api";
+
+/**
+ * Presentation of a tool's own preview of the action it is about to take.
+ *
+ * Renderer state holds no tool arguments; a preview is the narrow exception a
+ * tool opts into so a human can see what they are approving. Formatting stays
+ * here so the approval card and the tool card describe one action identically.
+ */
+export type ToolPreviewPresentation = {
+  /** One-line form, used as a card title. */
+  headline: string;
+  /** Full form, one fact per line, used in a monospace block. */
+  detail: string;
+  icon: typeof Terminal;
+};
+
+export function toolPreviewPresentation(
+  preview: ToolApprovalPreview,
+): ToolPreviewPresentation {
+  const headline = [preview.command, ...preview.args]
+    .map(quoteArgument)
+    .join(" ");
+  // The working directory is a fact about the command, not part of it, so it
+  // reads as a comment rather than as something the shell would run. There is
+  // no shell here at all — this is an argument vector.
+  const detail =
+    preview.cwd === "."
+      ? headline
+      : `${headline}\n# working directory: ${preview.cwd}`;
+  return { headline, detail, icon: Terminal };
+}
+
+/**
+ * Quote an argument only when leaving it bare would misrepresent where its
+ * boundaries are. A vector element containing a space is one argument, and the
+ * card must not read as though it were two.
+ */
+function quoteArgument(value: string): string {
+  if (value.length === 0) return "''";
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/** The monospace block both cards use to show an action under review. */
+export function ToolPreviewBlock({
+  preview,
+  className,
+}: {
+  preview: ToolApprovalPreview;
+  className?: string;
+}) {
+  return (
+    <pre
+      className={`bg-muted text-muted-foreground max-h-48 overflow-auto rounded-md p-3 text-xs break-words whitespace-pre-wrap ${className ?? ""}`}
+    >
+      {toolPreviewPresentation(preview).detail}
+    </pre>
+  );
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1300,30 +1300,6 @@ body {
   }
 }
 
-/* ---------- Approval ---------- */
-
-.message-approval {
-  width: min(100%, 38rem);
-  align-self: flex-start;
-  border: 1px solid color-mix(in srgb, var(--color-openwave) 45%, var(--line));
-  border-radius: 8px;
-  padding: 0.7rem 0.8rem;
-  background: var(--card);
-}
-
-.message-approval p {
-  margin: 0;
-  color: var(--ink);
-  font-size: 0.84rem;
-}
-
-.message-approval .approval-error {
-  margin-top: 0.5rem;
-  color: var(--danger);
-  font-size: 0.82rem;
-  overflow-wrap: anywhere;
-}
-
 /* ---------- Markdown ---------- */
 
 .message-markdown {
@@ -1606,75 +1582,6 @@ body {
   font-size: 0.82em;
 }
 
-/* ---------- Tool call cards ---------- */
-
-.tool-call-card {
-  display: flex;
-  width: min(100%, 31rem);
-  align-self: flex-start;
-  align-items: center;
-  gap: 0.65rem;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 0.6rem 0.7rem;
-  color: var(--muted-foreground);
-  background: var(--card);
-}
-
-.tool-call-icon {
-  display: grid;
-  width: 1.55rem;
-  height: 1.55rem;
-  flex: 0 0 auto;
-  place-items: center;
-  border-radius: 5px;
-  color: var(--ink);
-  background: var(--muted);
-  font-size: 0.82rem;
-  font-weight: 600;
-}
-
-.tool-call-copy {
-  display: grid;
-  min-width: 0;
-  gap: 0.03rem;
-}
-
-.tool-call-copy strong {
-  color: var(--ink);
-  font-size: 0.82rem;
-  font-weight: 600;
-}
-
-.tool-call-copy span {
-  font-size: 0.75rem;
-}
-
-.tool-call-spinner {
-  width: 0.8rem;
-  height: 0.8rem;
-  flex: 0 0 auto;
-  margin-left: auto;
-  border: 2px solid color-mix(in srgb, var(--muted-foreground) 25%, transparent);
-  border-top-color: var(--muted-foreground);
-  border-radius: 999px;
-  animation: tool-call-spin 800ms linear infinite;
-}
-
-.tool-call-card.is-completed .tool-call-icon {
-  color: var(--success-foreground);
-  background: var(--success-background);
-}
-
-.tool-call-card.is-failed .tool-call-icon {
-  color: var(--danger);
-  background: var(--critical-background);
-}
-
-.tool-call-card.is-cancelled {
-  opacity: 0.7;
-}
-
 /* ---------- Tool activity groups ---------- */
 
 .tool-activity-group {
@@ -1723,7 +1630,9 @@ body {
 
 .tool-activity-group-status.is-failed,
 .tool-activity-group-status.is-unknown {
-  color: var(--danger);
+  /* Paired with its own background so the glyph keeps its contrast in dark
+     mode, where `--danger` and `--critical-background` are both mid reds. */
+  color: var(--critical-foreground);
   background: var(--critical-background);
 }
 
@@ -1814,14 +1723,7 @@ body {
   font-size: 0.8rem;
 }
 
-@keyframes tool-call-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .tool-call-spinner,
   .assistant-sources-chevron,
   .message-footer,
   .tool-activity-group-chevron,
@@ -2445,14 +2347,6 @@ body {
 
 .boot .btn {
   margin-top: 0.75rem;
-}
-
-.approval {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-  margin-top: 0.5rem;
 }
 
 /* ---------- Documents view ---------- */


### PR DESCRIPTION
Closes #445 — stacked on #451, which supplies the command an approval is granting.

Tool cards and approval cards weren't carrying their weight. A tool card was a static two-line block that nothing could open; an `exec` card read "Run a command" whether the agent listed a directory or built the workspace; the approval card was a paragraph and three buttons with no view of the action under review.

Every card is now the same shape — `[chevron] [icon] [title] ……… [status badge]` on one line.

## Command cards

A command titles itself with the command it ran, in monospace, and opens onto its working directory when there is one to name. A command run in the default directory already says everything in its title, so that card doesn't open at all — an expander that reveals a copy of the line above it is worse than no expander.

Arguments are quoted only where leaving them bare would misrepresent where they end: one vector element containing a space is one argument, and printed bare it would read as two. That's exactly the misreading an approval can least afford.

## Status

Status moved out of a second line of prose and into a badge: `Running…`, `Waiting for approval`, `Done`, `Failed`, `Not run`. The full status sentence stays in `aria-label` and in activity-group summaries, so nothing is lost to assistive technology.

## Approvals

The card leads with its question, shows the command in the same monospace block the tool card uses, and replaces the button row with a keyboard-navigable list — ↑↓ to choose, 1–3 to jump, ↵ to submit.

Options are ordered narrowest grant first with the decline last, and the highlight starts on "Yes, allow it once". Scope is easy to widen by accident and hard to notice afterwards, so the cheapest keystroke has to be the one that grants the least. A kind the server won't let the renderer approve offers only the decline.

## One slot per call

While a call is parked, the approval card owns the slot. The tool card would otherwise sit directly above it saying the same thing, with a second, inert copy of the command. It returns once the call is decided, carrying the outcome.

Also fixes the activity-group failure glyph, which paired `--danger` with `--critical-background` — two mid reds in dark mode — and was effectively invisible there.

## Verification

`tsc`, the vitest suite (292 passing), and a production build all pass. Rendered every card state in both themes and read them side by side; screenshot at `.context/screenshots/tool-cards.png`.