### PR TITLE
refactor(desktop): make the selected view an addressable panel descriptor

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -93,7 +93,7 @@ export default function App() {
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const savingTitle = useChatListStore((state) => state.savingTitle);
   const renameChatDraft = useChatListStore((state) => state.renameChatDraft);
-  const primaryView = useUiStore((state) => state.primaryView);
+  const surface = useUiStore((state) => state.surface);
   const sidebarCollapsed = useUiStore((state) => state.sidebarCollapsed);
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
@@ -1256,7 +1256,7 @@ export default function App() {
       />}
 
       <div className="main">
-        {primaryView === "settings" ? (
+        {surface.kind === "settings" ? (
           <SettingsView
             client={client}
             models={models}

--- a/crates/openwave-desktop/ui/src/ChatTabs.tsx
+++ b/crates/openwave-desktop/ui/src/ChatTabs.tsx
@@ -1,8 +1,9 @@
 import { FileOutput, FolderOpen, LibraryBig, MessageSquare } from "lucide-react";
-import { useUiStore, type PrimaryView } from "./UiStore";
+import { useUiStore } from "./UiStore";
+import type { SurfaceKind } from "./Surface";
 
 /** Surfaces whose catalogs are served by the native host rather than the API. */
-const NATIVE_HOST_SURFACES: ReadonlySet<PrimaryView> = new Set([
+const NATIVE_HOST_SURFACES: ReadonlySet<SurfaceKind> = new Set([
   "documents",
   "deliverables",
   "folders",
@@ -10,8 +11,8 @@ const NATIVE_HOST_SURFACES: ReadonlySet<PrimaryView> = new Set([
 
 const UNAVAILABLE_HINT = "Available in the OpenWave desktop app";
 
-export function requiresNativeHost(view: PrimaryView): boolean {
-  return NATIVE_HOST_SURFACES.has(view);
+export function requiresNativeHost(kind: SurfaceKind): boolean {
+  return NATIVE_HOST_SURFACES.has(kind);
 }
 
 export type ChatTabsProps = {
@@ -27,7 +28,7 @@ export type ChatTabsProps = {
  * chat-scoped destinations.
  */
 export function ChatTabs({ nativeHost }: ChatTabsProps) {
-  const primaryView = useUiStore((state) => state.primaryView);
+  const surface = useUiStore((state) => state.surface);
   const showChat = useUiStore((state) => state.showChat);
   const showDocuments = useUiStore((state) => state.showDocuments);
   const showDeliverables = useUiStore((state) => state.showDeliverables);
@@ -44,13 +45,13 @@ export function ChatTabs({ nativeHost }: ChatTabsProps) {
       key: "documents" as const,
       label: "Sources",
       icon: LibraryBig,
-      onSelect: showDocuments,
+      onSelect: () => showDocuments(),
     },
     {
       key: "deliverables" as const,
       label: "Outputs",
       icon: FileOutput,
-      onSelect: showDeliverables,
+      onSelect: () => showDeliverables(),
     },
     {
       key: "folders" as const,
@@ -64,7 +65,7 @@ export function ChatTabs({ nativeHost }: ChatTabsProps) {
     <div className="chat-tabs" role="tablist" aria-label="Chat views">
       {tabs.map((tab) => {
         const unavailable = !nativeHost && requiresNativeHost(tab.key);
-        const active = primaryView === tab.key;
+        const active = surface.kind === tab.key;
         const Icon = tab.icon;
         return (
           <button

--- a/crates/openwave-desktop/ui/src/ChatWorkspace.tsx
+++ b/crates/openwave-desktop/ui/src/ChatWorkspace.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Settings } from "lucide-react";
 import type { Chat } from "./api";
 import { ChatTabs, requiresNativeHost } from "./ChatTabs";
+import { CHAT_SURFACE } from "./Surface";
 import { DeliverablesView } from "./DeliverablesView";
 import { DocumentsView } from "./DocumentsView";
 import { FoldersView } from "./FoldersView";
@@ -27,12 +28,12 @@ export function ChatWorkspace({
   nativeHost,
   transcript,
 }: ChatWorkspaceProps) {
-  const selected = useUiStore((state) => state.primaryView);
+  const selected = useUiStore((state) => state.surface);
   const showSettings = useUiStore((state) => state.showSettings);
   // A surface the host cannot serve is offered as disabled in the switcher, so
   // reaching one here means the host went away underneath the selection.
-  const primaryView =
-    !nativeHost && requiresNativeHost(selected) ? "chat" : selected;
+  const surface =
+    !nativeHost && requiresNativeHost(selected.kind) ? CHAT_SURFACE : selected;
 
   return (
     <div className="chat-workspace">
@@ -59,11 +60,11 @@ export function ChatWorkspace({
       </header>
 
       <div className="workspace-body">
-        {primaryView === "documents" ? (
+        {surface.kind === "documents" ? (
           <DocumentsView chatId={chat.id} />
-        ) : primaryView === "deliverables" ? (
-          <DeliverablesView chatId={chat.id} />
-        ) : primaryView === "folders" ? (
+        ) : surface.kind === "deliverables" ? (
+          <DeliverablesView chatId={chat.id} initialFilename={surface.itemId} />
+        ) : surface.kind === "folders" ? (
           <FoldersView chat={chat} />
         ) : (
           transcript

--- a/crates/openwave-desktop/ui/src/DeliverablesView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.dom.test.tsx
@@ -42,6 +42,64 @@ describe("DeliverablesView", () => {
     expect(await screen.findByText("Research brief.md was saved.")).toBeVisible();
   });
 
+  it("previews the output it was pointed at, not the first one", async () => {
+    const apis = twoOutputApis();
+
+    render(
+      <DeliverablesView
+        chatId="chat-1"
+        initialFilename="Second.md"
+        apis={apis}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(apis.read).toHaveBeenCalledWith("chat-1", "Second.md"),
+    );
+    expect(apis.read).not.toHaveBeenCalledWith("chat-1", "First.md");
+  });
+
+  it("falls back to the list when it is pointed at an output this chat lacks", async () => {
+    const apis = twoOutputApis();
+
+    render(
+      <DeliverablesView
+        chatId="chat-1"
+        initialFilename="Missing.md"
+        apis={apis}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(apis.read).toHaveBeenCalledWith("chat-1", "First.md"),
+    );
+    expect(apis.read).not.toHaveBeenCalledWith("chat-1", "Missing.md");
+  });
+
+  it("stops steering once the reader chooses another output", async () => {
+    const apis = twoOutputApis();
+
+    render(
+      <DeliverablesView
+        chatId="chat-1"
+        initialFilename="Second.md"
+        apis={apis}
+      />,
+    );
+    await waitFor(() =>
+      expect(apis.read).toHaveBeenCalledWith("chat-1", "Second.md"),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /First\.md/ }));
+    await waitFor(() =>
+      expect(apis.read).toHaveBeenCalledWith("chat-1", "First.md"),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => expect(apis.list).toHaveBeenCalledTimes(2));
+    expect(apis.read).toHaveBeenLastCalledWith("chat-1", "First.md");
+  });
+
   it("explains how to create the first output", async () => {
     render(
       <DeliverablesView
@@ -154,3 +212,27 @@ describe("DeliverablesView", () => {
     expect(screen.queryByText("stale")).not.toBeInTheDocument();
   });
 });
+
+function twoOutputApis() {
+  const outputs = ["First.md", "Second.md"];
+  return {
+    list: vi.fn().mockResolvedValue({
+      deliverables: outputs.map((filename) => ({
+        filename,
+        mediaType: "text/markdown" as const,
+        sizeBytes: 12,
+        updatedAt: "2026-07-24T00:00:00Z",
+      })),
+      truncated: false,
+    }),
+    read: vi.fn().mockImplementation((_chatId: string, filename: string) =>
+      Promise.resolve({
+        filename,
+        mediaType: "text/markdown" as const,
+        content: `# ${filename}`,
+        truncated: false,
+      }),
+    ),
+    export: vi.fn().mockResolvedValue(true),
+  };
+}

--- a/crates/openwave-desktop/ui/src/DeliverablesView.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.tsx
@@ -23,9 +23,12 @@ const defaultApis: DeliverableApis = {
 
 export function DeliverablesView({
   chatId,
+  initialFilename,
   apis = defaultApis,
 }: {
   chatId: string;
+  /** Output to preview on arrival; ignored when this chat has no such file. */
+  initialFilename?: string;
   apis?: DeliverableApis;
 }) {
   const [catalog, setCatalog] = useState<DeliverablesCatalog>({
@@ -46,6 +49,7 @@ export function DeliverablesView({
   const [previewVersion, setPreviewVersion] = useState(0);
   const catalogGenerationRef = useRef(0);
   const previewGenerationRef = useRef(0);
+  const pendingFilenameRef = useRef<string | null>(initialFilename ?? null);
 
   async function refresh(showLoading = false) {
     const generation = ++catalogGenerationRef.current;
@@ -54,11 +58,21 @@ export function DeliverablesView({
     try {
       const next = await apis.list(chatId);
       if (generation !== catalogGenerationRef.current) return;
+      // Steer the first catalog that arrives, then step aside: a later refresh
+      // or a choice from the list must not snap back to where the caller
+      // pointed. Resolving here rather than after the fact means an output the
+      // chat does not own never gets read.
+      const target = pendingFilenameRef.current;
+      pendingFilenameRef.current = null;
+      const owns = (filename: string | null | undefined) =>
+        !!filename && next.deliverables.some((item) => item.filename === filename);
       setCatalog(next);
       setSelected((current) =>
-        current && next.deliverables.some((item) => item.filename === current)
-          ? current
-          : (next.deliverables[0]?.filename ?? null),
+        owns(target)
+          ? target
+          : owns(current)
+            ? current
+            : (next.deliverables[0]?.filename ?? null),
       );
       setPreviewVersion((current) => current + 1);
     } catch (caught) {
@@ -82,6 +96,18 @@ export function DeliverablesView({
       previewGenerationRef.current += 1;
     };
   }, [chatId, apis]);
+
+  // Being pointed somewhere new while the surface is already open resolves
+  // against the catalog in hand, and otherwise waits for the next one.
+  useEffect(() => {
+    if (!initialFilename) return;
+    if (catalog.deliverables.some((item) => item.filename === initialFilename)) {
+      pendingFilenameRef.current = null;
+      setSelected(initialFilename);
+    } else {
+      pendingFilenameRef.current = initialFilename;
+    }
+  }, [initialFilename]);
 
   useEffect(() => {
     if (!selected) {

--- a/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
@@ -24,7 +24,7 @@ function seedStores(overrides: Partial<ChatListStore> = {}) {
     savingTitle: false,
     ...overrides,
   });
-  useUiStore.setState({ primaryView: "chat" });
+  useUiStore.getState().showChat();
 }
 
 function renderSidebar(overrides: Partial<SidebarProps> = {}) {
@@ -110,7 +110,7 @@ describe("Sidebar", () => {
     const user = userEvent.setup();
     renderSidebar();
     await user.click(screen.getByText("Settings"));
-    expect(useUiStore.getState().primaryView).toBe("settings");
+    expect(useUiStore.getState().surface).toEqual({ kind: "settings" });
   });
 
   it("shows update affordances only when an update is ready", () => {

--- a/crates/openwave-desktop/ui/src/Sidebar.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.tsx
@@ -69,7 +69,7 @@ export function Sidebar({
   const renameChatDraft = useChatListStore((state) => state.renameChatDraft);
   const savingTitle = useChatListStore((state) => state.savingTitle);
   const setRenameDraft = useChatListStore((state) => state.setRenameDraft);
-  const primaryView = useUiStore((state) => state.primaryView);
+  const surface = useUiStore((state) => state.surface);
   const showSettings = useUiStore((state) => state.showSettings);
   const toggleSidebar = useUiStore((state) => state.toggleSidebar);
   return (
@@ -129,7 +129,7 @@ export function Sidebar({
         <div className="conversation-list" aria-label="Chats">
           {chats.map((item) => {
             const chatTitle = item.title?.trim() || "New chat";
-            const isActive = primaryView === "chat" && item.id === activeChatId;
+            const isActive = surface.kind === "chat" && item.id === activeChatId;
             const mutating = deletingChatId !== null || creatingChat;
 
             if (renamingChatId === item.id) {
@@ -222,7 +222,7 @@ export function Sidebar({
         )}
         <button
           type="button"
-          className={`sidebar-action${primaryView === "settings" ? " is-active" : ""}`}
+          className={`sidebar-action${surface.kind === "settings" ? " is-active" : ""}`}
           onClick={showSettings}
         >
           <Settings size={16} />

--- a/crates/openwave-desktop/ui/src/Surface.test.ts
+++ b/crates/openwave-desktop/ui/src/Surface.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHAT_SURFACE,
+  isSurfaceKind,
+  normalizeSurface,
+  sameSurface,
+} from "./Surface";
+
+describe("normalizeSurface", () => {
+  it("keeps a surface with no target", () => {
+    expect(normalizeSurface({ kind: "folders" })).toEqual({ kind: "folders" });
+  });
+
+  it("keeps an item and its anchor where both are accepted", () => {
+    expect(
+      normalizeSurface({ kind: "documents", itemId: "doc-1", anchor: "c-2" }),
+    ).toEqual({ kind: "documents", itemId: "doc-1", anchor: "c-2" });
+  });
+
+  it("drops an anchor from a surface that only addresses items", () => {
+    expect(
+      normalizeSurface({
+        kind: "deliverables",
+        itemId: "report.md",
+        anchor: "c-2",
+      }),
+    ).toEqual({ kind: "deliverables", itemId: "report.md" });
+  });
+
+  it("drops a target from a surface that accepts none", () => {
+    expect(normalizeSurface({ kind: "chat", itemId: "doc-1" })).toEqual({
+      kind: "chat",
+    });
+  });
+
+  it("drops an anchor with no item to anchor to", () => {
+    expect(normalizeSurface({ kind: "documents", anchor: "c-2" })).toEqual({
+      kind: "documents",
+    });
+  });
+
+  it("ignores blank and non-string identifiers", () => {
+    expect(normalizeSurface({ kind: "documents", itemId: "   " })).toEqual({
+      kind: "documents",
+    });
+    expect(normalizeSurface({ kind: "documents", itemId: 7 })).toEqual({
+      kind: "documents",
+    });
+  });
+
+  it("trims surrounding whitespace from identifiers", () => {
+    expect(
+      normalizeSurface({ kind: "deliverables", itemId: " notes.md " }),
+    ).toEqual({ kind: "deliverables", itemId: "notes.md" });
+  });
+
+  it("falls back to the transcript for anything unrecognisable", () => {
+    for (const value of [
+      undefined,
+      null,
+      "documents",
+      [],
+      {},
+      { kind: "audit" },
+      { kind: 3 },
+    ]) {
+      expect(normalizeSurface(value)).toEqual(CHAT_SURFACE);
+    }
+  });
+
+  it("survives a round trip through storage", () => {
+    const surface = { kind: "documents", itemId: "doc-1", anchor: "c-2" };
+    expect(normalizeSurface(JSON.parse(JSON.stringify(surface)))).toEqual(
+      surface,
+    );
+  });
+
+  it("does not inherit object prototype keys as surfaces", () => {
+    expect(isSurfaceKind("toString")).toBe(false);
+    expect(isSurfaceKind("constructor")).toBe(false);
+  });
+});
+
+describe("sameSurface", () => {
+  it("compares kind and target together", () => {
+    expect(
+      sameSurface({ kind: "documents", itemId: "a" }, { kind: "documents", itemId: "a" }),
+    ).toBe(true);
+    expect(
+      sameSurface({ kind: "documents", itemId: "a" }, { kind: "documents", itemId: "b" }),
+    ).toBe(false);
+    expect(sameSurface({ kind: "documents" }, { kind: "folders" })).toBe(false);
+  });
+});

--- a/crates/openwave-desktop/ui/src/Surface.ts
+++ b/crates/openwave-desktop/ui/src/Surface.ts
@@ -1,0 +1,78 @@
+/**
+ * Where the chat workspace is pointed.
+ *
+ * A surface name alone cannot express "open this source at this citation" or
+ * "open this output", so the selection is a descriptor: a surface, optionally
+ * an item owned by that surface, and optionally a position within that item.
+ * Identifiers are opaque and come from the API or the native catalog — never a
+ * host path.
+ */
+export type SurfaceKind =
+  | "chat"
+  | "documents"
+  | "deliverables"
+  | "folders"
+  | "settings";
+
+export type Surface = {
+  kind: SurfaceKind;
+  itemId?: string;
+  anchor?: string;
+};
+
+type TargetSupport = { item: boolean; anchor: boolean };
+
+/**
+ * What each surface can be pointed at. Surfaces gain targets as the views that
+ * resolve them land, so this table is the single place that has to change.
+ */
+const SURFACE_TARGETS: Record<SurfaceKind, TargetSupport> = {
+  chat: { item: false, anchor: false },
+  documents: { item: true, anchor: true },
+  deliverables: { item: true, anchor: false },
+  folders: { item: false, anchor: false },
+  settings: { item: false, anchor: false },
+};
+
+export const CHAT_SURFACE: Surface = { kind: "chat" };
+
+export function isSurfaceKind(value: unknown): value is SurfaceKind {
+  return typeof value === "string" && Object.hasOwn(SURFACE_TARGETS, value);
+}
+
+/**
+ * Reduce an arbitrary value — a caller's argument, or a descriptor restored
+ * from storage — to one the workspace can render. An unrecognised surface
+ * falls back to the transcript. A target the surface does not accept, or an
+ * anchor with no item to anchor to, is dropped so the surface opens on its own
+ * list instead of an empty pane.
+ */
+export function normalizeSurface(value: unknown): Surface {
+  if (!isRecord(value) || !isSurfaceKind(value.kind)) return CHAT_SURFACE;
+
+  const kind = value.kind;
+  const supports = SURFACE_TARGETS[kind];
+  const itemId = supports.item ? nonEmptyString(value.itemId) : null;
+  if (!itemId) return { kind };
+
+  const anchor = supports.anchor ? nonEmptyString(value.anchor) : null;
+  return anchor ? { kind, itemId, anchor } : { kind, itemId };
+}
+
+export function sameSurface(left: Surface, right: Surface): boolean {
+  return (
+    left.kind === right.kind &&
+    left.itemId === right.itemId &&
+    left.anchor === right.anchor
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/crates/openwave-desktop/ui/src/UiStore.test.ts
+++ b/crates/openwave-desktop/ui/src/UiStore.test.ts
@@ -2,24 +2,60 @@ import { describe, expect, it } from "vitest";
 import { createUiStore } from "./UiStore";
 
 describe("UiStore", () => {
-  it("each navigation action selects its primary view", () => {
+  it("each navigation action selects its surface", () => {
     const store = createUiStore();
-    expect(store.getState().primaryView).toBe("chat");
+    expect(store.getState().surface).toEqual({ kind: "chat" });
 
     store.getState().showDocuments();
-    expect(store.getState().primaryView).toBe("documents");
+    expect(store.getState().surface).toEqual({ kind: "documents" });
 
     store.getState().showDeliverables();
-    expect(store.getState().primaryView).toBe("deliverables");
+    expect(store.getState().surface).toEqual({ kind: "deliverables" });
 
     store.getState().showFolders();
-    expect(store.getState().primaryView).toBe("folders");
+    expect(store.getState().surface).toEqual({ kind: "folders" });
 
     store.getState().showSettings();
-    expect(store.getState().primaryView).toBe("settings");
+    expect(store.getState().surface).toEqual({ kind: "settings" });
 
     store.getState().showChat();
-    expect(store.getState().primaryView).toBe("chat");
+    expect(store.getState().surface).toEqual({ kind: "chat" });
+  });
+
+  it("carries a target into the surface that accepts it", () => {
+    const store = createUiStore();
+
+    store.getState().showDocuments({ documentId: "doc-1", citationId: "c-4" });
+    expect(store.getState().surface).toEqual({
+      kind: "documents",
+      itemId: "doc-1",
+      anchor: "c-4",
+    });
+
+    store.getState().showDeliverables({ filename: "summary.md" });
+    expect(store.getState().surface).toEqual({
+      kind: "deliverables",
+      itemId: "summary.md",
+    });
+  });
+
+  it("drops a citation that has no source to anchor to", () => {
+    const store = createUiStore();
+    store.getState().showDocuments({ citationId: "c-4" });
+    expect(store.getState().surface).toEqual({ kind: "documents" });
+  });
+
+  it("validates a descriptor opened directly", () => {
+    const store = createUiStore();
+
+    store.getState().openSurface({ kind: "deliverables", itemId: "notes.md" });
+    expect(store.getState().surface).toEqual({
+      kind: "deliverables",
+      itemId: "notes.md",
+    });
+
+    store.getState().openSurface({ kind: "nope" } as never);
+    expect(store.getState().surface).toEqual({ kind: "chat" });
   });
 });
 

--- a/crates/openwave-desktop/ui/src/UiStore.ts
+++ b/crates/openwave-desktop/ui/src/UiStore.ts
@@ -1,11 +1,5 @@
 import { create } from "zustand";
-
-export type PrimaryView =
-  | "chat"
-  | "documents"
-  | "deliverables"
-  | "folders"
-  | "settings";
+import { CHAT_SURFACE, normalizeSurface, type Surface } from "./Surface";
 
 const SIDEBAR_COLLAPSED_KEY = "openwave.sidebar-collapsed";
 
@@ -26,16 +20,20 @@ function storeSidebarCollapsed(collapsed: boolean): void {
 }
 
 /**
- * App-level view state: which primary surface is showing. Actions are named
- * for intent so call sites read as navigation, not state plumbing. The
- * chat-scoped surfaces (documents, deliverables, folders) are reached from the
- * per-chat tab control; settings is global.
+ * App-level view state: which surface the workspace is showing, and where in
+ * it. Actions are named for intent so call sites read as navigation, not state
+ * plumbing. The chat-scoped surfaces (documents, deliverables, folders) are
+ * reached from the per-chat tab control; settings is global.
  */
 export type UiStore = {
-  primaryView: PrimaryView;
+  surface: Surface;
+  openSurface: (surface: Surface) => void;
   showChat: () => void;
-  showDocuments: () => void;
-  showDeliverables: () => void;
+  showDocuments: (target?: {
+    documentId?: string;
+    citationId?: string;
+  }) => void;
+  showDeliverables: (target?: { filename?: string }) => void;
   showFolders: () => void;
   showSettings: () => void;
   sidebarCollapsed: boolean;
@@ -44,12 +42,26 @@ export type UiStore = {
 
 export function createUiStore() {
   return create<UiStore>()((set) => ({
-    primaryView: "chat",
-    showChat: () => set({ primaryView: "chat" }),
-    showDocuments: () => set({ primaryView: "documents" }),
-    showDeliverables: () => set({ primaryView: "deliverables" }),
-    showFolders: () => set({ primaryView: "folders" }),
-    showSettings: () => set({ primaryView: "settings" }),
+    surface: CHAT_SURFACE,
+    openSurface: (surface) => set({ surface: normalizeSurface(surface) }),
+    showChat: () => set({ surface: CHAT_SURFACE }),
+    showDocuments: (target) =>
+      set({
+        surface: normalizeSurface({
+          kind: "documents",
+          itemId: target?.documentId,
+          anchor: target?.citationId,
+        }),
+      }),
+    showDeliverables: (target) =>
+      set({
+        surface: normalizeSurface({
+          kind: "deliverables",
+          itemId: target?.filename,
+        }),
+      }),
+    showFolders: () => set({ surface: { kind: "folders" } }),
+    showSettings: () => set({ surface: { kind: "settings" } }),
     sidebarCollapsed: readStoredSidebarCollapsed(),
     toggleSidebar: () =>
       set((state) => {


### PR DESCRIPTION
Navigation state was `PrimaryView`, a bare string enum mutated through five `show*` actions. It could name a surface but carry nothing else, so it had no way to express "open this source at this citation" or "open this output" — the two navigations #416 and #417 both need. Without this they would each invent their own target plumbing.

The selection is now a descriptor: a surface, optionally an item owned by it, and optionally a position within that item. A single table records which surfaces accept which, so surfaces gain targets in one place as the views that resolve them land. Normalization drops what a surface cannot use — an unaccepted target, an anchor with no item to anchor to, a blank or non-string id — and falls back to the transcript for a descriptor it does not recognize. A descriptor restored from storage goes through the same gate, which is what keeps an unresolvable target from rendering an empty pane.

Outputs resolves its target today: arriving with a filename previews that file rather than the first one. Writing the test surfaced a flaw in my first attempt — applying the target after the catalog resolved meant reading the default output first and then replacing it, so a bad target still triggered a read and a good one flashed the wrong file. It now resolves during the catalog read, in one pass. The steer is also spent once, so a later refresh or a choice from the list stays where the reader put it.

Sources accepts a document plus citation, which #416 will resolve; there is no consumer for it yet, so it is covered by normalization tests only.

Verified with `tsc`, the vitest suite (307 passing — 17 new, covering normalization, the store's helpers, and the three Outputs targeting behaviors), and a production build.

Closes #448