### PR TITLE
fix(desktop): decide an imported document's type from its bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6682,6 +6682,7 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "chrono",
+ "infer",
  "openwave-core",
  "openwave-host-broker",
  "openwave-server",

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 cap-fs-ext.workspace = true
 cap-std.workspace = true
+infer = { version = "=0.19.0", default-features = false }
 openwave-core = { path = "../openwave-core", default-features = false }
 openwave-host-broker = { path = "../openwave-host-broker" }
 openwave-server = { path = "../openwave-server" }

--- a/crates/openwave-desktop/src/documents.rs
+++ b/crates/openwave-desktop/src/documents.rs
@@ -222,13 +222,17 @@ pub(crate) async fn import_library_document(
     let Some(path) = pick_document(&app).await? else {
         return Ok(None);
     };
-    let (media_type, display_name) = import_metadata(&path)?;
+    let display_name = import_display_name(&path)?;
+    let sniff_path = path.clone();
     let source_bytes = tauri::async_runtime::spawn_blocking(move || read_selected_document(&path))
         .await
         .map_err(|_| "Could not read the selected document".to_owned())??;
     if source_bytes.is_empty() {
         return Err("The selected document is empty".to_owned());
     }
+    // Decided from the bytes, not the name the file happens to carry, so the
+    // server routes the source to the parser that can actually read it.
+    let media_type = crate::media_type::sniff_media_type_for_path(&source_bytes, &sniff_path);
 
     let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
     let info = wait_server_info(app_state.inner()).await?;
@@ -329,36 +333,17 @@ async fn pick_document(app: &AppHandle) -> Result<Option<PathBuf>, String> {
         .map_err(|_| "The document picker returned an invalid file".to_owned())
 }
 
-fn import_metadata(path: &Path) -> Result<(&'static str, String), String> {
+fn import_display_name(path: &Path) -> Result<String, String> {
     if !path.is_absolute() {
         return Err("The document picker returned an invalid file".to_owned());
     }
-    let extension = path
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map(str::to_ascii_lowercase);
-    // Map common extensions to a media type; anything else is imported as opaque
-    // bytes (`application/octet-stream`). The server accepts every type — text is
-    // indexed, binary is stored — so an unknown extension is never an error here.
-    let media_type = match extension.as_deref() {
-        Some("md" | "markdown") => "text/markdown",
-        Some("txt" | "text" | "log") => "text/plain",
-        Some("csv") => "text/csv",
-        Some("html" | "htm") => "text/html",
-        Some("json") => "application/json",
-        Some("xml") => "application/xml",
-        Some("yaml" | "yml") => "application/yaml",
-        Some("pdf") => "application/pdf",
-        _ => "application/octet-stream",
-    };
-    let display_name = path
-        .file_name()
+    path.file_name()
         .and_then(|name| name.to_str())
         .filter(|name| {
             !name.is_empty() && name.chars().count() <= 255 && name.chars().all(is_safe_title_char)
         })
-        .ok_or_else(|| "The selected document has an invalid name".to_owned())?;
-    Ok((media_type, display_name.to_owned()))
+        .map(str::to_owned)
+        .ok_or_else(|| "The selected document has an invalid name".to_owned())
 }
 
 fn read_selected_document(path: &Path) -> Result<Vec<u8>, String> {
@@ -518,44 +503,26 @@ mod tests {
     }
 
     #[test]
-    fn import_metadata_exposes_only_a_bounded_filename() {
-        let (media_type, name) =
-            import_metadata(Path::new("/Users/private/notes/plan.md")).unwrap();
-        assert_eq!(media_type, "text/markdown");
+    fn import_display_name_exposes_only_a_bounded_filename() {
+        let name = import_display_name(Path::new("/Users/private/notes/plan.md")).unwrap();
         assert_eq!(name, "plan.md");
         assert!(!name.contains("private"));
-        // Known extensions map to their media type…
+        // The title is the only thing the name decides. Media type comes from
+        // the bytes, so an unfamiliar extension is never a reason to refuse.
         assert_eq!(
-            import_metadata(Path::new("/Users/private/plan.pdf"))
-                .unwrap()
-                .0,
-            "application/pdf"
+            import_display_name(Path::new("/Users/private/archive.bin")).unwrap(),
+            "archive.bin"
         );
         assert_eq!(
-            import_metadata(Path::new("/Users/private/sheet.csv"))
-                .unwrap()
-                .0,
-            "text/csv"
-        );
-        // …and any other file is imported as opaque bytes rather than rejected.
-        assert_eq!(
-            import_metadata(Path::new("/Users/private/archive.bin"))
-                .unwrap()
-                .0,
-            "application/octet-stream"
-        );
-        assert_eq!(
-            import_metadata(Path::new("/Users/private/no_extension"))
-                .unwrap()
-                .0,
-            "application/octet-stream"
+            import_display_name(Path::new("/Users/private/no_extension")).unwrap(),
+            "no_extension"
         );
         // Path and filename safety still apply regardless of type.
-        assert!(import_metadata(Path::new("relative.md")).is_err());
-        assert!(import_metadata(Path::new("/Users/private/bad\u{202e}txt.md")).is_err());
+        assert!(import_display_name(Path::new("relative.md")).is_err());
+        assert!(import_display_name(Path::new("/Users/private/bad\u{202e}txt.md")).is_err());
         for unsafe_character in ['\u{200d}', '\u{206a}', '\u{206f}', '\u{2028}', '\u{2029}'] {
             let path = format!("/Users/private/bad{unsafe_character}.md");
-            assert!(import_metadata(Path::new(&path)).is_err());
+            assert!(import_display_name(Path::new(&path)).is_err());
         }
     }
 

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -19,6 +19,7 @@ mod client_execution;
 mod deliverables;
 mod documents;
 mod host_access;
+mod media_type;
 mod updater;
 
 /// Connection details the webview needs to reach the in-process API.

--- a/crates/openwave-desktop/src/media_type.rs
+++ b/crates/openwave-desktop/src/media_type.rs
@@ -1,0 +1,240 @@
+//! Trusted native decision about what an imported document actually is.
+//!
+//! Everything downstream keys off the media type: which parser runs, whether
+//! the source ends up searchable, and how the renderer labels it. Nothing that
+//! chose the file gets to decide that answer. A picker selection and an
+//! agent-named path under a connected folder both arrive here as bytes plus an
+//! untrusted filename, and the bytes win wherever they identify themselves.
+
+use std::path::Path;
+
+/// Media type used when nothing identifies the bytes. The server accepts it and
+/// stores the source; it simply will not be searchable.
+pub(crate) const OPAQUE_MEDIA_TYPE: &str = "application/octet-stream";
+
+/// Bytes inspected when deciding a media type.
+///
+/// Every format that matters here is identified by a magic number within the
+/// first few hundred bytes, except the Zip-container formats, whose central
+/// directory `infer` reads from the local file header near the start. Bounding
+/// the window keeps sniffing cheap for a multi-megabyte document.
+const SNIFF_WINDOW_BYTES: usize = 8_192;
+
+/// Text formats that carry no magic number, so only the name can distinguish
+/// them. All of these reach the same plain-text parser, so a wrong guess here
+/// changes the stored label rather than whether the source is searchable.
+const TEXT_EXTENSIONS: &[(&str, &str)] = &[
+    ("md", "text/markdown"),
+    ("markdown", "text/markdown"),
+    ("txt", "text/plain"),
+    ("text", "text/plain"),
+    ("log", "text/plain"),
+    ("csv", "text/csv"),
+    ("tsv", "text/tab-separated-values"),
+    ("html", "text/html"),
+    ("htm", "text/html"),
+    ("json", "application/json"),
+    ("xml", "application/xml"),
+    ("yaml", "application/yaml"),
+    ("yml", "application/yaml"),
+];
+
+/// Office formats that are Zip containers. `infer` reads their content types
+/// out of the archive, but a container it cannot classify is reported as plain
+/// Zip; for those the extension is the only remaining signal.
+const ZIP_CONTAINER_EXTENSIONS: &[(&str, &str)] = &[
+    (
+        "docx",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ),
+    (
+        "xlsx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ),
+    (
+        "pptx",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ),
+    ("odt", "application/vnd.oasis.opendocument.text"),
+    ("ods", "application/vnd.oasis.opendocument.spreadsheet"),
+    ("odp", "application/vnd.oasis.opendocument.presentation"),
+];
+
+/// Decide the media type of imported bytes without trusting whoever named them.
+///
+/// Content is authoritative wherever it identifies itself, so a `.pdf` that is
+/// really a Zip archive is never handed to the PDF parser, and a document with
+/// a meaningless extension is still parsed as what it is. The filename is
+/// consulted only where content genuinely cannot answer: text formats have no
+/// magic number at all, and a Zip container that `infer` cannot classify could
+/// be any of the Office formats built on Zip.
+///
+/// `infer`'s own text heuristics are deliberately ignored. They match on
+/// leading tags, so a Markdown file that opens with an HTML comment sniffs as
+/// HTML. The extension is the better signal there, and both answers reach the
+/// same parser regardless.
+pub(crate) fn sniff_media_type(bytes: &[u8], file_name: Option<&str>) -> String {
+    let extension = extension_of(file_name);
+    let window = &bytes[..bytes.len().min(SNIFF_WINDOW_BYTES)];
+
+    if let Some(detected) = infer::get(window) {
+        match detected.matcher_type() {
+            // Heuristic, and weaker than the filename. Fall through.
+            infer::MatcherType::Text => {}
+            _ if is_unclassified_zip(detected.mime_type()) => {
+                if let Some(refined) = lookup(ZIP_CONTAINER_EXTENSIONS, extension.as_deref()) {
+                    return refined.to_owned();
+                }
+                return detected.mime_type().to_owned();
+            }
+            _ => return detected.mime_type().to_owned(),
+        }
+    }
+
+    if let Some(text) = lookup(TEXT_EXTENSIONS, extension.as_deref()) {
+        return text.to_owned();
+    }
+    // Nothing named it and nothing in it identified it. Decodable bytes are
+    // still worth indexing; the rest are stored as opaque.
+    if std::str::from_utf8(window).is_ok() {
+        "text/plain".to_owned()
+    } else {
+        OPAQUE_MEDIA_TYPE.to_owned()
+    }
+}
+
+/// Media type for a file chosen from the local picker, where the absolute path
+/// is available but only its final component may inform the answer.
+pub(crate) fn sniff_media_type_for_path(bytes: &[u8], path: &Path) -> String {
+    sniff_media_type(bytes, path.file_name().and_then(|name| name.to_str()))
+}
+
+fn extension_of(file_name: Option<&str>) -> Option<String> {
+    Path::new(file_name?)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+}
+
+fn lookup(table: &[(&str, &'static str)], extension: Option<&str>) -> Option<&'static str> {
+    let extension = extension?;
+    table
+        .iter()
+        .find(|(candidate, _)| *candidate == extension)
+        .map(|(_, media_type)| *media_type)
+}
+
+fn is_unclassified_zip(mime_type: &str) -> bool {
+    matches!(mime_type, "application/zip" | "application/epub+zip")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smallest byte sequences that the real matchers accept, so these tests
+    /// exercise sniffing rather than a stubbed table.
+    const PDF: &[u8] = b"%PDF-1.7\n1 0 obj\n";
+    const PNG: &[u8] = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR";
+
+    /// A Zip whose first entry lives under `word/`, which is how the OOXML
+    /// matcher recognizes a Word document.
+    fn docx() -> Vec<u8> {
+        zip_header("word/document.xml")
+    }
+
+    /// A Zip local file header, whose filename field begins at offset 0x1E —
+    /// exactly where the OOXML matcher reads it.
+    fn zip_header(name: &str) -> Vec<u8> {
+        let mut bytes = vec![0x50, 0x4b, 0x03, 0x04];
+        bytes.extend_from_slice(&[0x14, 0x00, 0x06, 0x00, 0x08, 0x00, 0x00, 0x00, 0x21, 0x00]);
+        bytes.extend_from_slice(&[0u8; 12]);
+        bytes.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(name.as_bytes());
+        bytes
+    }
+
+    #[test]
+    fn content_overrides_a_misleading_or_missing_extension() {
+        // The whole point: a name cannot route bytes to the wrong parser.
+        assert_eq!(
+            sniff_media_type(PDF, Some("invoice.txt")),
+            "application/pdf"
+        );
+        assert_eq!(sniff_media_type(PDF, Some("invoice")), "application/pdf");
+        assert_eq!(sniff_media_type(PDF, None), "application/pdf");
+        assert_eq!(sniff_media_type(PNG, Some("diagram.pdf")), "image/png");
+        // ...and a real document with a meaningless name is still identified.
+        assert_eq!(
+            sniff_media_type(&docx(), Some("attachment.bin")),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        );
+    }
+
+    #[test]
+    fn text_formats_fall_back_to_the_name_they_were_given() {
+        let markdown = b"# Notes\n\nA plain document.\n";
+        assert_eq!(
+            sniff_media_type(markdown, Some("notes.md")),
+            "text/markdown"
+        );
+        assert_eq!(
+            sniff_media_type(markdown, Some("notes.MD")),
+            "text/markdown"
+        );
+        assert_eq!(
+            sniff_media_type(b"a,b,c\n1,2,3\n", Some("t.csv")),
+            "text/csv"
+        );
+        // infer's text matchers would call this HTML; the extension is better,
+        // and both answers reach the same parser anyway.
+        assert_eq!(
+            sniff_media_type(b"<!-- a comment -->\n# Notes\n", Some("notes.md")),
+            "text/markdown"
+        );
+    }
+
+    #[test]
+    fn unidentifiable_bytes_are_text_only_when_they_decode() {
+        assert_eq!(sniff_media_type(b"just some prose", None), "text/plain");
+        assert_eq!(
+            sniff_media_type(b"just some prose", Some("notes.unknown")),
+            "text/plain"
+        );
+        assert_eq!(
+            sniff_media_type(&[0xff, 0xfe, 0x00, 0x80], Some("blob.unknown")),
+            OPAQUE_MEDIA_TYPE
+        );
+        assert_eq!(sniff_media_type(&[], None), "text/plain");
+    }
+
+    #[test]
+    fn an_unclassified_zip_defers_to_the_extension_only_among_office_types() {
+        let plain_zip = zip_header("readme.txt");
+        assert_eq!(
+            sniff_media_type(&plain_zip, Some("report.docx")),
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        );
+        // An archive that claims no Office extension stays an archive rather
+        // than being guessed into a parser that would fail on it.
+        assert_eq!(
+            sniff_media_type(&plain_zip, Some("bundle.zip")),
+            "application/zip"
+        );
+        assert_eq!(sniff_media_type(&plain_zip, None), "application/zip");
+    }
+
+    #[test]
+    fn sniffing_reads_only_a_bounded_prefix() {
+        // A magic number past the window is not searched for, so a huge file
+        // never costs more than the window to classify.
+        let mut buried = vec![b' '; SNIFF_WINDOW_BYTES];
+        buried.extend_from_slice(PDF);
+        assert_eq!(sniff_media_type(&buried, None), "text/plain");
+        assert_eq!(
+            sniff_media_type_for_path(PDF, Path::new("/tmp/x.bin")),
+            "application/pdf"
+        );
+    }
+}

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -570,10 +570,18 @@ byte length and SHA-256 digest, and parses it into:
 - canonical UTF-8 text, the text-of-record used by indexing;
 - source regions that map text byte ranges back to locations such as pages.
 
-The parse completion and creation of the matching `Index` job are atomic. Today
-the configured parser registry handles `text/*` content. Richer PDF and office
-parsers are future work. The model can represent page provenance, but the
-production plain-text parser does not emit page regions today.
+The parse completion and creation of the matching `Index` job are atomic. The
+configured registry selects a parser by media type: liteparse handles PDF,
+Office, and raster image formats, a plain-text parser handles `text/*`, and a
+fallback keeps anything else storable by indexing it when it decodes as UTF-8
+and leaving it empty when it does not. The model can represent page provenance,
+but the parsers do not emit page regions today.
+
+Because that selection is by media type, the media type has to be right. The
+trusted native side decides it from the bytes rather than from the filename, so
+a document cannot be routed to a parser that cannot read it — and a parser that
+produces no text yields a source the catalog reports as stored but not
+searchable rather than as ready.
 
 ### 4. Chunk, embed, and stage
 


### PR DESCRIPTION
Part of #414.

## Why

Media type was derived purely from the file extension, and the table omitted every Office and image format:

```rust
Some("pdf") => "application/pdf",
_ => "application/octet-stream",
```

So a `.docx` arrived as `application/octet-stream`, missed the liteparse Office parser that already exists and is enabled by default, and fell through to the UTF-8 fallback — durably stored and silently unsearchable. The same applied to `.xlsx`, `.pptx`, and every image format. In the other direction, a file that merely happened to be *named* `.pdf` was handed to the PDF parser regardless of what was actually in it.

That extension trust is also the thing #414 cannot ship on: an agent that names a path under a connected folder must not be able to pick which parser runs.

## What changed

A new `media_type` module decides the type from the bytes. Content is authoritative wherever it identifies itself, so a name can no longer route a document to a parser that cannot read it, and a document with a meaningless extension is still parsed as what it is.

The filename is consulted only where content genuinely cannot answer, which is two specific cases:

- **Text formats carry no magic number.** The extension is the only way to tell `.md` from `.csv`. `infer`'s own text heuristics are deliberately ignored here — they match on leading tags, so a Markdown file opening with an HTML comment sniffs as HTML. Every one of these reaches the same plain-text parser anyway, so the extension is both the better signal and the lower-stakes one.
- **A Zip container `infer` cannot classify** could be any of the Office formats built on Zip, so the extension breaks that tie. An archive claiming no Office extension stays an archive rather than being guessed into a parser that would fail on it.

`infer`'s mime strings happen to match the liteparse parsers' supported-type lists exactly, so detection lands on a type that a parser actually claims rather than one that merely looks right.

Sniffing reads a bounded 8 KiB prefix, so classifying a multi-megabyte document costs the same as a small one.

`import_metadata` becomes `import_display_name`. The filename's only remaining job is the title, so an unfamiliar extension is no longer a reason to guess at a type.

`docs/how-openwave-works.md` said the registry "handles `text/*` content" and that "richer PDF and office parsers are future work", which stopped being true when the liteparse parsers landed. Corrected, with a note on why media type has to be right for parser selection to mean anything.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` — all green. `infer 0.19.0` was already resolved in the lockfile through liteparse, so pinning it as a direct dependency left every version unchanged; the only lock diff is the new dependency edge.

Tests build real byte sequences the actual matchers accept rather than stubbing a table, and cover: content overriding a misleading extension, content overriding a *missing* extension, a real document with a meaningless name, text formats falling back to the name, the Markdown-that-looks-like-HTML case, an unclassified Zip deferring to the extension only among Office types, undecodable bytes staying opaque, and the sniff window bound.
