### PR TITLE
feat(desktop): open chat-scoped surfaces beside the live transcript

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -780,7 +780,6 @@ export default function App() {
     if (!client || creationInFlightRef.current || deletionInFlightRef.current) return;
     creationInFlightRef.current = true;
     chatListActions.setCreatingChat(true);
-    uiActions.showChat();
     try {
       const created = await client.createChat();
       openCreatedChat(created);
@@ -803,7 +802,6 @@ export default function App() {
   }
 
   function openCreatedChat(created: Chat) {
-    uiActions.showChat();
     controllerRef.current?.dispose();
     controllerRef.current = null;
     useChatSessionStore.getState().reset();
@@ -858,6 +856,7 @@ export default function App() {
     }
     try {
       await client.deleteChat(target.id);
+      uiActions.forgetChatWorkspace(target.id);
       let refreshed = await client.listChats();
       if (!deletingSelectedChat) {
         chatListActions.setChats(refreshed);
@@ -880,6 +879,7 @@ export default function App() {
   }
 
   function activateChat(next: Chat) {
+    uiActions.selectChatWorkspace(next.id);
     chatSelectionRef.current += 1;
     terminalHydrationGenerationRef.current += 1;
     selectedChatIdRef.current = next.id;
@@ -894,7 +894,9 @@ export default function App() {
   }
 
   function selectChat(next: Chat, force = false) {
-    uiActions.showChat();
+    // Re-selecting the open chat still has work to do: it leaves a global
+    // surface like Settings and restores the layout this chat was left in.
+    if (next.id === chat?.id) uiActions.selectChatWorkspace(next.id);
     if (
       next.id === chat?.id ||
       creatingChat ||
@@ -1262,7 +1264,7 @@ export default function App() {
             models={models}
             providers={providers}
             onProvidersChanged={() => void refreshCatalog()}
-            onBack={() => uiActions.showChat()}
+            onBack={() => uiActions.selectChatWorkspace(chat.id)}
             themeMode={themeMode}
             onThemeChange={setThemeMode}
             updateState={desktopUpdates.state}

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -12,6 +12,7 @@ import { useChatSessionStore } from "./ChatSessionStore";
 import { Composer } from "./Composer";
 import type { FolderAccessDecision } from "./host";
 import { MessageList } from "./MessageList";
+import { useTranscriptVisible } from "./TranscriptVisibility";
 import { ArrowDown } from "lucide-react";
 
 export type ChatViewProps = {
@@ -117,6 +118,7 @@ export function ChatView({
   onSteer,
   onStop,
 }: ChatViewProps) {
+  const transcriptVisible = useTranscriptVisible();
   const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);
   const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
@@ -131,13 +133,15 @@ export function ChatView({
 
   useEffect(() => {
     const scroll = scrollRef.current;
-    if (!scroll) return;
+    // Scrolling a transcript that has been expanded away does nothing, so this
+    // also runs on the way back to put a following reader at the latest message.
+    if (!scroll || !transcriptVisible) return;
     if (followsLatestRef.current) {
       scrollToLatest(scroll, followScrollBehavior(busy));
     } else {
       setHasUnreadActivity(true);
     }
-  }, [messages, busy]);
+  }, [messages, busy, transcriptVisible]);
 
   useEffect(() => {
     const next = new Set([

--- a/crates/openwave-desktop/ui/src/ChatWorkspace.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatWorkspace.dom.test.tsx
@@ -51,11 +51,13 @@ function renderWorkspace(nativeHost = true) {
 }
 
 beforeEach(() => {
-  useUiStore.getState().showChat();
+  window.localStorage.clear();
+  useUiStore.getState().selectChatWorkspace(chat.id);
 });
 
 afterEach(() => {
   cleanup();
+  window.localStorage.clear();
   useUiStore.getState().showChat();
 });
 
@@ -70,7 +72,7 @@ describe("ChatWorkspace", () => {
     expect(screen.getByTestId("transcript")).toBeInTheDocument();
   });
 
-  it("keeps one switcher in place when the surface changes", async () => {
+  it("opens a surface beside the transcript, keeping one switcher in place", async () => {
     const user = userEvent.setup();
     renderWorkspace();
 
@@ -82,10 +84,68 @@ describe("ChatWorkspace", () => {
     expect(
       screen.getByRole("heading", { name: "Roadmap" }),
     ).toBeInTheDocument();
-    expect(screen.queryByTestId("transcript")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Sources" })).toBeVisible();
+    expect(screen.getByTestId("transcript")).toBeVisible();
+    expect(screen.getByRole("separator", { name: "Resize panel" })).toBeVisible();
+  });
+
+  it("expands a surface over the transcript and back", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+    await user.click(screen.getByRole("tab", { name: "Sources" }));
+
+    await user.click(screen.getByRole("button", { name: "Expand panel" }));
+    expect(screen.getByRole("heading", { name: "Sources" })).toBeVisible();
+    expect(screen.getByTestId("transcript")).not.toBeVisible();
     expect(
-      screen.getByRole("heading", { name: "Sources" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("separator", { name: "Resize panel" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show the transcript" }));
+    expect(screen.getByTestId("transcript")).toBeVisible();
+  });
+
+  it("closes the panel back to the transcript alone", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+    await user.click(screen.getByRole("tab", { name: "Outputs" }));
+    expect(screen.getByRole("heading", { name: "Outputs" })).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Close panel" }));
+
+    expect(screen.getByTestId("transcript")).toBeVisible();
+    expect(
+      screen.queryByRole("heading", { name: "Outputs" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Close panel" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the transcript mounted while a surface is open", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+    const before = screen.getByTestId("transcript");
+
+    await user.click(screen.getByRole("tab", { name: "Sources" }));
+    await user.click(screen.getByRole("button", { name: "Expand panel" }));
+    await user.click(screen.getByRole("tab", { name: "Chat" }));
+
+    expect(screen.getByTestId("transcript")).toBe(before);
+  });
+
+  it("restores the layout a chat was left in", async () => {
+    const user = userEvent.setup();
+    useUiStore.getState().selectChatWorkspace("chat-1");
+    const first = renderWorkspace();
+    await user.click(screen.getByRole("tab", { name: "Sources" }));
+    first.unmount();
+
+    useUiStore.getState().selectChatWorkspace("chat-2");
+    expect(useUiStore.getState().surface).toEqual({ kind: "chat" });
+
+    useUiStore.getState().selectChatWorkspace("chat-1");
+    expect(useUiStore.getState().surface).toEqual({ kind: "documents" });
   });
 
   it("offers native-host surfaces as unavailable rather than hiding them", () => {

--- a/crates/openwave-desktop/ui/src/ChatWorkspace.tsx
+++ b/crates/openwave-desktop/ui/src/ChatWorkspace.tsx
@@ -1,12 +1,18 @@
-import type { ReactNode } from "react";
-import { Settings } from "lucide-react";
+import { useSyncExternalStore, type ReactNode } from "react";
+import { Maximize2, Minimize2, Settings, X } from "lucide-react";
 import type { Chat } from "./api";
 import { ChatTabs, requiresNativeHost } from "./ChatTabs";
-import { CHAT_SURFACE } from "./Surface";
+import { CHAT_SURFACE, type Surface } from "./Surface";
 import { DeliverablesView } from "./DeliverablesView";
 import { DocumentsView } from "./DocumentsView";
 import { FoldersView } from "./FoldersView";
+import { PanelResizer } from "./PanelResizer";
+import { TranscriptVisibilityProvider } from "./TranscriptVisibility";
+import { opensBesideTranscript, resolveSlots } from "./WorkspaceLayout";
 import { useUiStore } from "./UiStore";
+
+/** Below this the workspace shows one surface at a time. */
+const NARROW_QUERY = "(max-width: 720px)";
 
 export type ChatWorkspaceProps = {
   chat: Chat;
@@ -18,9 +24,13 @@ export type ChatWorkspaceProps = {
 
 /**
  * The workspace for the selected chat: one header carrying the conversation
- * title, the surface switcher, and status, over whichever scoped surface is
- * selected. The header lives here rather than inside each surface so the
- * switcher keeps its position when the body changes.
+ * title, the surface switcher, and status, over a body that holds the
+ * transcript and, beside it, whichever scoped surface is open.
+ *
+ * The transcript stays mounted while a surface is open. That is the point of
+ * the arrangement — a conversation's own sources should be readable without
+ * leaving the conversation, and detail can only move out of the transcript if
+ * there is somewhere beside it to put it.
  */
 export function ChatWorkspace({
   chat,
@@ -29,11 +39,20 @@ export function ChatWorkspace({
   transcript,
 }: ChatWorkspaceProps) {
   const selected = useUiStore((state) => state.surface);
+  const expanded = useUiStore((state) => state.expanded);
+  const fraction = useUiStore((state) => state.fraction);
+  const showChat = useUiStore((state) => state.showChat);
   const showSettings = useUiStore((state) => state.showSettings);
+  const toggleExpanded = useUiStore((state) => state.toggleExpanded);
+  const setFraction = useUiStore((state) => state.setFraction);
+  const narrow = useNarrowWorkspace();
+
   // A surface the host cannot serve is offered as disabled in the switcher, so
   // reaching one here means the host went away underneath the selection.
   const surface =
     !nativeHost && requiresNativeHost(selected.kind) ? CHAT_SURFACE : selected;
+  const slots = resolveSlots({ surface, expanded, fraction, narrow });
+  const panelOpen = opensBesideTranscript(surface.kind);
 
   return (
     <div className="chat-workspace">
@@ -41,7 +60,32 @@ export function ChatWorkspace({
         <div className="conversation-title-row">
           <h1>{chat.title?.trim() || "New chat"}</h1>
         </div>
-        <ChatTabs nativeHost={nativeHost} />
+        <div className="conversation-switcher">
+          <ChatTabs nativeHost={nativeHost} />
+          {panelOpen && !narrow && (
+            <div className="panel-controls">
+              <button
+                type="button"
+                className="panel-control"
+                aria-label={expanded ? "Show the transcript" : "Expand panel"}
+                aria-pressed={expanded}
+                title={expanded ? "Show the transcript" : "Expand panel"}
+                onClick={toggleExpanded}
+              >
+                {expanded ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+              </button>
+              <button
+                type="button"
+                className="panel-control"
+                aria-label="Close panel"
+                title="Close panel"
+                onClick={showChat}
+              >
+                <X size={14} />
+              </button>
+            </div>
+          )}
+        </div>
         <div className="conversation-header-actions">
           <div className="mobile-settings-actions">
             <button
@@ -60,16 +104,74 @@ export function ChatWorkspace({
       </header>
 
       <div className="workspace-body">
-        {surface.kind === "documents" ? (
-          <DocumentsView chatId={chat.id} />
-        ) : surface.kind === "deliverables" ? (
-          <DeliverablesView chatId={chat.id} initialFilename={surface.itemId} />
-        ) : surface.kind === "folders" ? (
-          <FoldersView chat={chat} />
-        ) : (
-          transcript
+        {/*
+          Hidden rather than unmounted: an open panel must not cost the reader
+          their scroll position, and the transcript keeps streaming behind it.
+        */}
+        <div
+          className="workspace-slot workspace-transcript"
+          hidden={!slots.showTranscript}
+          style={
+            slots.showPanel
+              ? { flex: `1 1 ${(1 - slots.fraction) * 100}%` }
+              : undefined
+          }
+        >
+          <TranscriptVisibilityProvider value={slots.showTranscript}>
+            {transcript}
+          </TranscriptVisibilityProvider>
+        </div>
+
+        {slots.showTranscript && slots.showPanel && (
+          <PanelResizer fraction={slots.fraction} onFraction={setFraction} />
+        )}
+
+        {slots.showPanel && (
+          <div
+            className={`workspace-slot workspace-panel${
+              slots.showTranscript ? " is-sharing" : ""
+            }`}
+            style={
+              slots.showTranscript
+                ? { flex: `0 0 ${slots.fraction * 100}%` }
+                : undefined
+            }
+          >
+            <ScopedSurface chat={chat} surface={surface} />
+          </div>
         )}
       </div>
     </div>
   );
+}
+
+function ScopedSurface({ chat, surface }: { chat: Chat; surface: Surface }) {
+  switch (surface.kind) {
+    case "documents":
+      return <DocumentsView chatId={chat.id} />;
+    case "deliverables":
+      return (
+        <DeliverablesView chatId={chat.id} initialFilename={surface.itemId} />
+      );
+    case "folders":
+      return <FoldersView chat={chat} />;
+    default:
+      return null;
+  }
+}
+
+function useNarrowWorkspace(): boolean {
+  return useSyncExternalStore(subscribeToNarrow, isNarrow, () => false);
+}
+
+function subscribeToNarrow(onChange: () => void): () => void {
+  if (typeof window === "undefined" || !window.matchMedia) return () => {};
+  const query = window.matchMedia(NARROW_QUERY);
+  query.addEventListener("change", onChange);
+  return () => query.removeEventListener("change", onChange);
+}
+
+function isNarrow(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia(NARROW_QUERY).matches;
 }

--- a/crates/openwave-desktop/ui/src/PanelResizer.tsx
+++ b/crates/openwave-desktop/ui/src/PanelResizer.tsx
@@ -1,0 +1,65 @@
+import { useRef } from "react";
+import { DEFAULT_FRACTION, MAX_FRACTION, MIN_FRACTION } from "./WorkspaceLayout";
+
+const KEYBOARD_STEP = 0.05;
+
+export type PanelResizerProps = {
+  fraction: number;
+  onFraction: (fraction: number) => void;
+};
+
+/**
+ * The grip between the transcript and the side panel. Dragging is measured
+ * against the workspace body rather than the pointer's delta, so a drag that
+ * leaves the window and comes back does not accumulate drift.
+ */
+export function PanelResizer({ fraction, onFraction }: PanelResizerProps) {
+  const gripRef = useRef<HTMLDivElement | null>(null);
+
+  function fractionAt(clientX: number): number | null {
+    const body = gripRef.current?.parentElement;
+    if (!body) return null;
+    const bounds = body.getBoundingClientRect();
+    if (bounds.width <= 0) return null;
+    return (bounds.right - clientX) / bounds.width;
+  }
+
+  return (
+    <div
+      ref={gripRef}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize panel"
+      aria-valuemin={Math.round(MIN_FRACTION * 100)}
+      aria-valuemax={Math.round(MAX_FRACTION * 100)}
+      aria-valuenow={Math.round(fraction * 100)}
+      tabIndex={0}
+      className="panel-resizer"
+      onPointerDown={(event) => {
+        if (event.button !== 0) return;
+        event.preventDefault();
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }}
+      onPointerMove={(event) => {
+        if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+        const next = fractionAt(event.clientX);
+        if (next !== null) onFraction(next);
+      }}
+      onPointerUp={(event) => {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+      }}
+      onDoubleClick={() => onFraction(DEFAULT_FRACTION)}
+      onKeyDown={(event) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault();
+          onFraction(fraction + KEYBOARD_STEP);
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault();
+          onFraction(fraction - KEYBOARD_STEP);
+        }
+      }}
+    />
+  );
+}

--- a/crates/openwave-desktop/ui/src/TranscriptVisibility.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptVisibility.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Whether the transcript slot is on screen. Expanding a surface over the
+ * transcript leaves it mounted and streaming but without layout, so scrolling
+ * it has no effect while it is away — a reader who was following the latest
+ * message has to be returned there when it comes back.
+ */
+const TranscriptVisibilityContext = createContext(true);
+
+export const TranscriptVisibilityProvider = TranscriptVisibilityContext.Provider;
+
+export function useTranscriptVisible(): boolean {
+  return useContext(TranscriptVisibilityContext);
+}

--- a/crates/openwave-desktop/ui/src/UiStore.ts
+++ b/crates/openwave-desktop/ui/src/UiStore.ts
@@ -1,5 +1,14 @@
 import { create } from "zustand";
 import { CHAT_SURFACE, normalizeSurface, type Surface } from "./Surface";
+import {
+  EMPTY_LAYOUTS,
+  WORKSPACE_LAYOUT_KEY,
+  clampFraction,
+  layoutForChat,
+  normalizeLayouts,
+  rememberChatLayout,
+  type WorkspaceLayouts,
+} from "./WorkspaceLayout";
 
 const SIDEBAR_COLLAPSED_KEY = "openwave.sidebar-collapsed";
 
@@ -19,14 +28,34 @@ function storeSidebarCollapsed(collapsed: boolean): void {
   }
 }
 
+function readStoredLayouts(): WorkspaceLayouts {
+  try {
+    const raw = window.localStorage.getItem(WORKSPACE_LAYOUT_KEY);
+    return raw ? normalizeLayouts(JSON.parse(raw)) : EMPTY_LAYOUTS;
+  } catch {
+    return EMPTY_LAYOUTS;
+  }
+}
+
+function storeLayouts(layouts: WorkspaceLayouts): void {
+  try {
+    window.localStorage.setItem(WORKSPACE_LAYOUT_KEY, JSON.stringify(layouts));
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
 /**
- * App-level view state: which surface the workspace is showing, and where in
- * it. Actions are named for intent so call sites read as navigation, not state
- * plumbing. The chat-scoped surfaces (documents, deliverables, folders) are
- * reached from the per-chat tab control; settings is global.
+ * App-level view state: which surface the workspace is showing, where in it,
+ * and how the workspace is arranged around it. Actions are named for intent so
+ * call sites read as navigation, not state plumbing. The chat-scoped surfaces
+ * (documents, deliverables, folders) are reached from the per-chat tab control
+ * and open beside the transcript; settings is global and replaces the pane.
  */
 export type UiStore = {
   surface: Surface;
+  expanded: boolean;
+  fraction: number;
   openSurface: (surface: Surface) => void;
   showChat: () => void;
   showDocuments: (target?: {
@@ -36,40 +65,86 @@ export type UiStore = {
   showDeliverables: (target?: { filename?: string }) => void;
   showFolders: () => void;
   showSettings: () => void;
+  /** Point the workspace at a chat, restoring the layout it was left in. */
+  selectChatWorkspace: (chatId: string) => void;
+  forgetChatWorkspace: (chatId: string) => void;
+  toggleExpanded: () => void;
+  setFraction: (fraction: number) => void;
   sidebarCollapsed: boolean;
   toggleSidebar: () => void;
 };
 
 export function createUiStore() {
-  return create<UiStore>()((set) => ({
-    surface: CHAT_SURFACE,
-    openSurface: (surface) => set({ surface: normalizeSurface(surface) }),
-    showChat: () => set({ surface: CHAT_SURFACE }),
-    showDocuments: (target) =>
-      set({
-        surface: normalizeSurface({
+  return create<UiStore>()((set, get) => {
+    let layouts = readStoredLayouts();
+    let chatId: string | null = null;
+
+    // Settings replaces the whole pane and belongs to no conversation, so it
+    // is never written into a chat's remembered layout.
+    function remember(surface: Surface, expanded: boolean) {
+      if (!chatId || surface.kind === "settings") return;
+      layouts = rememberChatLayout(layouts, chatId, { surface, expanded });
+      storeLayouts(layouts);
+    }
+
+    function go(surface: Surface, expanded = get().expanded) {
+      const next = normalizeSurface(surface);
+      const nextExpanded = next.kind === "chat" ? false : expanded;
+      remember(next, nextExpanded);
+      set({ surface: next, expanded: nextExpanded });
+    }
+
+    return {
+      surface: CHAT_SURFACE,
+      expanded: false,
+      fraction: layouts.fraction,
+      openSurface: (surface) => go(surface),
+      showChat: () => go(CHAT_SURFACE),
+      showDocuments: (target) =>
+        go({
           kind: "documents",
           itemId: target?.documentId,
           anchor: target?.citationId,
         }),
-      }),
-    showDeliverables: (target) =>
-      set({
-        surface: normalizeSurface({
-          kind: "deliverables",
-          itemId: target?.filename,
+      showDeliverables: (target) =>
+        go({ kind: "deliverables", itemId: target?.filename }),
+      showFolders: () => go({ kind: "folders" }),
+      showSettings: () => set({ surface: { kind: "settings" } }),
+      selectChatWorkspace: (nextChatId) => {
+        chatId = nextChatId;
+        const restored = layoutForChat(layouts, nextChatId);
+        set({
+          surface: restored?.surface ?? CHAT_SURFACE,
+          expanded: restored?.expanded ?? false,
+        });
+      },
+      forgetChatWorkspace: (deletedChatId) => {
+        layouts = rememberChatLayout(layouts, deletedChatId, {
+          surface: CHAT_SURFACE,
+          expanded: false,
+        });
+        storeLayouts(layouts);
+      },
+      toggleExpanded: () => {
+        const expanded = !get().expanded;
+        remember(get().surface, expanded);
+        set({ expanded });
+      },
+      setFraction: (value) => {
+        const fraction = clampFraction(value);
+        layouts = { ...layouts, fraction };
+        storeLayouts(layouts);
+        set({ fraction });
+      },
+      sidebarCollapsed: readStoredSidebarCollapsed(),
+      toggleSidebar: () =>
+        set((state) => {
+          const sidebarCollapsed = !state.sidebarCollapsed;
+          storeSidebarCollapsed(sidebarCollapsed);
+          return { sidebarCollapsed };
         }),
-      }),
-    showFolders: () => set({ surface: { kind: "folders" } }),
-    showSettings: () => set({ surface: { kind: "settings" } }),
-    sidebarCollapsed: readStoredSidebarCollapsed(),
-    toggleSidebar: () =>
-      set((state) => {
-        const sidebarCollapsed = !state.sidebarCollapsed;
-        storeSidebarCollapsed(sidebarCollapsed);
-        return { sidebarCollapsed };
-      }),
-  }));
+    };
+  });
 }
 
 export const useUiStore = createUiStore();

--- a/crates/openwave-desktop/ui/src/WorkspaceLayout.test.ts
+++ b/crates/openwave-desktop/ui/src/WorkspaceLayout.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_FRACTION,
+  EMPTY_LAYOUTS,
+  MAX_FRACTION,
+  MAX_REMEMBERED_CHATS,
+  MIN_FRACTION,
+  clampFraction,
+  layoutForChat,
+  normalizeLayouts,
+  rememberChatLayout,
+  resolveSlots,
+} from "./WorkspaceLayout";
+
+const sources = { surface: { kind: "documents" as const }, expanded: false };
+
+describe("clampFraction", () => {
+  it("holds the panel between a quarter and three quarters", () => {
+    expect(clampFraction(0.05)).toBe(MIN_FRACTION);
+    expect(clampFraction(0.9)).toBe(MAX_FRACTION);
+    expect(clampFraction(0.5)).toBe(0.5);
+  });
+
+  it("falls back to the default for a value that is not a number", () => {
+    for (const value of [Number.NaN, Infinity, "0.5", null, undefined]) {
+      expect(clampFraction(value)).toBe(DEFAULT_FRACTION);
+    }
+  });
+});
+
+describe("resolveSlots", () => {
+  const wide = { expanded: false, fraction: 0.4, narrow: false };
+
+  it("shows the transcript alone when nothing is open beside it", () => {
+    expect(resolveSlots({ ...wide, surface: { kind: "chat" } })).toMatchObject({
+      showTranscript: true,
+      showPanel: false,
+    });
+  });
+
+  it("shows both when a surface is open on a wide window", () => {
+    expect(
+      resolveSlots({ ...wide, surface: { kind: "documents" } }),
+    ).toMatchObject({ showTranscript: true, showPanel: true, fraction: 0.4 });
+  });
+
+  it("shows one at a time when expanded or narrow", () => {
+    expect(
+      resolveSlots({ ...wide, surface: { kind: "folders" }, expanded: true }),
+    ).toMatchObject({ showTranscript: false, showPanel: true });
+    expect(
+      resolveSlots({ ...wide, surface: { kind: "folders" }, narrow: true }),
+    ).toMatchObject({ showTranscript: false, showPanel: true });
+  });
+
+  it("keeps the transcript on a narrow window when nothing is open", () => {
+    expect(
+      resolveSlots({ ...wide, surface: { kind: "chat" }, narrow: true }),
+    ).toMatchObject({ showTranscript: true, showPanel: false });
+  });
+});
+
+describe("rememberChatLayout", () => {
+  it("records a chat with a surface open", () => {
+    const layouts = rememberChatLayout(EMPTY_LAYOUTS, "chat-1", sources);
+    expect(layoutForChat(layouts, "chat-1")).toEqual(sources);
+  });
+
+  it("forgets a chat that is back on the transcript", () => {
+    const opened = rememberChatLayout(EMPTY_LAYOUTS, "chat-1", sources);
+    const closed = rememberChatLayout(opened, "chat-1", {
+      surface: { kind: "chat" },
+      expanded: false,
+    });
+    expect(layoutForChat(closed, "chat-1")).toBeNull();
+    expect(Object.keys(closed.chats)).toHaveLength(0);
+  });
+
+  it("drops the least recently touched chat past the cap", () => {
+    let layouts = EMPTY_LAYOUTS;
+    for (let i = 0; i < MAX_REMEMBERED_CHATS + 10; i += 1) {
+      layouts = rememberChatLayout(layouts, `chat-${i}`, sources);
+    }
+    expect(Object.keys(layouts.chats)).toHaveLength(MAX_REMEMBERED_CHATS);
+    expect(layoutForChat(layouts, "chat-0")).toBeNull();
+    expect(layoutForChat(layouts, `chat-${MAX_REMEMBERED_CHATS + 9}`)).toEqual(
+      sources,
+    );
+  });
+
+  it("moves a revisited chat back to the front", () => {
+    let layouts = rememberChatLayout(EMPTY_LAYOUTS, "chat-1", sources);
+    layouts = rememberChatLayout(layouts, "chat-2", sources);
+    layouts = rememberChatLayout(layouts, "chat-1", sources);
+    expect(Object.keys(layouts.chats)).toEqual(["chat-1", "chat-2"]);
+  });
+
+  it("leaves the width preference alone", () => {
+    const layouts = rememberChatLayout(
+      { fraction: 0.6, chats: {} },
+      "chat-1",
+      sources,
+    );
+    expect(layouts.fraction).toBe(0.6);
+  });
+});
+
+describe("normalizeLayouts", () => {
+  it("restores a stored layout", () => {
+    const stored = { fraction: 0.6, chats: { "chat-1": sources } };
+    expect(normalizeLayouts(JSON.parse(JSON.stringify(stored)))).toEqual(
+      stored,
+    );
+  });
+
+  it("drops a chat whose surface does not open beside the transcript", () => {
+    const layouts = normalizeLayouts({
+      fraction: 0.5,
+      chats: {
+        "chat-1": { surface: { kind: "settings" }, expanded: false },
+        "chat-2": { surface: { kind: "chat" }, expanded: false },
+        "chat-3": { surface: { kind: "nonsense" }, expanded: false },
+      },
+    });
+    expect(layouts.chats).toEqual({});
+  });
+
+  it("normalizes the surface it restores", () => {
+    const layouts = normalizeLayouts({
+      chats: {
+        "chat-1": {
+          surface: { kind: "deliverables", itemId: "notes.md", anchor: "c-1" },
+          expanded: "yes",
+        },
+      },
+    });
+    expect(layouts.chats["chat-1"]).toEqual({
+      surface: { kind: "deliverables", itemId: "notes.md" },
+      expanded: false,
+    });
+  });
+
+  it("falls back for anything unrecognisable", () => {
+    for (const value of [null, undefined, "{}", [], 4]) {
+      expect(normalizeLayouts(value)).toEqual(EMPTY_LAYOUTS);
+    }
+    expect(normalizeLayouts({ fraction: "wide" })).toEqual(EMPTY_LAYOUTS);
+  });
+});

--- a/crates/openwave-desktop/ui/src/WorkspaceLayout.ts
+++ b/crates/openwave-desktop/ui/src/WorkspaceLayout.ts
@@ -1,0 +1,140 @@
+import { normalizeSurface, type Surface, type SurfaceKind } from "./Surface";
+
+/**
+ * How the workspace is arranged for one chat: which surface is open beside the
+ * transcript, and whether it has been expanded over it. The transcript stays
+ * mounted while a surface is open, so this is a layout, not a selection.
+ */
+export type ChatLayout = {
+  surface: Surface;
+  expanded: boolean;
+};
+
+export type WorkspaceLayouts = {
+  /** Share of the workspace given to the side panel, as a fraction of width. */
+  fraction: number;
+  chats: Record<string, ChatLayout>;
+};
+
+/** Surfaces that open beside the transcript rather than replacing it. */
+const SIDE_PANEL_SURFACES: ReadonlySet<SurfaceKind> = new Set([
+  "documents",
+  "deliverables",
+  "folders",
+]);
+
+export const MIN_FRACTION = 0.25;
+export const MAX_FRACTION = 0.75;
+export const DEFAULT_FRACTION = 0.42;
+
+/**
+ * Layouts are remembered per chat, so the map has to be bounded — a long-lived
+ * install would otherwise accumulate an entry for every conversation ever
+ * opened, including deleted ones.
+ */
+export const MAX_REMEMBERED_CHATS = 50;
+
+export const WORKSPACE_LAYOUT_KEY = "openwave.workspace-layout";
+
+export function opensBesideTranscript(kind: SurfaceKind): boolean {
+  return SIDE_PANEL_SURFACES.has(kind);
+}
+
+export function clampFraction(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_FRACTION;
+  }
+  return Math.min(MAX_FRACTION, Math.max(MIN_FRACTION, value));
+}
+
+export const EMPTY_LAYOUTS: WorkspaceLayouts = {
+  fraction: DEFAULT_FRACTION,
+  chats: {},
+};
+
+/**
+ * Reduce stored JSON to layouts this build can render. Anything unrecognised
+ * is dropped rather than repaired: a restored layout that cannot be trusted
+ * should leave the reader on the transcript.
+ */
+export function normalizeLayouts(value: unknown): WorkspaceLayouts {
+  if (!isRecord(value)) return EMPTY_LAYOUTS;
+
+  const chats: Record<string, ChatLayout> = {};
+  const storedChats = isRecord(value.chats) ? value.chats : {};
+  for (const [chatId, layout] of Object.entries(storedChats).slice(
+    0,
+    MAX_REMEMBERED_CHATS,
+  )) {
+    if (!chatId || !isRecord(layout)) continue;
+    const surface = normalizeSurface(layout.surface);
+    if (!opensBesideTranscript(surface.kind)) continue;
+    chats[chatId] = { surface, expanded: layout.expanded === true };
+  }
+
+  return { fraction: clampFraction(value.fraction), chats };
+}
+
+/**
+ * Record a chat's layout, keeping the most recently touched chats. A layout
+ * that is back on the transcript is forgotten rather than stored, so the map
+ * only holds chats with something open.
+ */
+export function rememberChatLayout(
+  layouts: WorkspaceLayouts,
+  chatId: string,
+  layout: ChatLayout,
+): WorkspaceLayouts {
+  const chats = { ...layouts.chats };
+  delete chats[chatId];
+
+  if (opensBesideTranscript(layout.surface.kind)) {
+    const ordered = Object.entries(chats).slice(0, MAX_REMEMBERED_CHATS - 1);
+    return {
+      fraction: layouts.fraction,
+      chats: { [chatId]: layout, ...Object.fromEntries(ordered) },
+    };
+  }
+
+  return { fraction: layouts.fraction, chats };
+}
+
+export function layoutForChat(
+  layouts: WorkspaceLayouts,
+  chatId: string | null,
+): ChatLayout | null {
+  if (!chatId) return null;
+  return layouts.chats[chatId] ?? null;
+}
+
+export type WorkspaceSlots = {
+  showTranscript: boolean;
+  showPanel: boolean;
+  /** Width share for the panel; only meaningful when both slots are shown. */
+  fraction: number;
+};
+
+/**
+ * Decide what the workspace body shows. A narrow window shows one surface at a
+ * time rather than compressing both, which is also what expanding does on a
+ * wide one.
+ */
+export function resolveSlots(input: {
+  surface: Surface;
+  expanded: boolean;
+  fraction: number;
+  narrow: boolean;
+}): WorkspaceSlots {
+  const fraction = clampFraction(input.fraction);
+  if (!opensBesideTranscript(input.surface.kind)) {
+    return { showTranscript: true, showPanel: false, fraction };
+  }
+  if (input.narrow || input.expanded) {
+    return { showTranscript: false, showPanel: true, fraction };
+  }
+  return { showTranscript: true, showPanel: true, fraction };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -586,13 +586,112 @@ body {
   overflow: hidden;
 }
 
-/* Each surface scrolls inside the body; the header above it stays put. */
+/* Each surface scrolls inside its own slot; the header above stays put. */
 .workspace-body {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  display: flex;
   min-height: 0;
   min-width: 0;
   overflow: hidden;
+}
+
+.workspace-slot {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.workspace-slot[hidden] {
+  display: none;
+}
+
+.workspace-transcript {
+  flex: 1 1 auto;
+}
+
+.workspace-panel {
+  flex: 1 1 auto;
+}
+
+.workspace-panel.is-sharing {
+  border-left: 1px solid var(--line);
+}
+
+.panel-resizer {
+  flex: 0 0 auto;
+  width: 0.35rem;
+  margin: 0 -0.175rem;
+  z-index: 1;
+  cursor: col-resize;
+  background: transparent;
+  touch-action: none;
+}
+
+.panel-resizer:hover,
+.panel-resizer:focus-visible {
+  background: var(--accent);
+  outline: none;
+}
+
+.conversation-switcher {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.panel-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.panel-control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0.3rem;
+  color: var(--muted-foreground);
+  background: transparent;
+  cursor: pointer;
+}
+
+.panel-control:hover {
+  color: var(--ink);
+  background: var(--muted);
+}
+
+.panel-control[aria-pressed="true"] {
+  color: var(--ink);
+  border-color: var(--line);
+}
+
+/*
+ * Surface padding is sized against the viewport, which is too generous once a
+ * surface is only part of the width. Scale it to the slot instead.
+ */
+.workspace-panel.is-sharing .documents-header,
+.workspace-panel.is-sharing .folders-header,
+.workspace-panel.is-sharing .deliverables-header {
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.4rem 1.25rem 1.1rem;
+}
+
+.workspace-panel.is-sharing .documents-header h1,
+.workspace-panel.is-sharing .folders-header h1,
+.workspace-panel.is-sharing .deliverables-header h1 {
+  font-size: 1.2rem;
+  letter-spacing: -0.02em;
+}
+
+.workspace-panel.is-sharing .documents-content,
+.workspace-panel.is-sharing .folders-content,
+.workspace-panel.is-sharing .deliverables-content {
+  padding: 1.1rem 1.25rem 3rem;
 }
 
 .chat-pane {


### PR DESCRIPTION
Selecting Sources, Outputs, or Folders replaced the whole main pane, so reading a conversation's own sources meant leaving the conversation. The cost was not only navigational: with nowhere to put detail that did not also hide the transcript, detail had to stay inline — which is why tool results, citation strips, and agent activity all accumulate there. Nothing can move out of the transcript until something can sit beside it.

The workspace body is now a transcript slot plus a side slot. A scoped surface opens beside the transcript, which stays mounted and streaming. The grip between them resizes (drag, arrow keys, double-click to reset), and controls beside the switcher expand the panel over the transcript or close it. A narrow window shows one surface at a time rather than compressing both.

Two details worth calling out, both found while testing rather than assumed:

- The transcript is hidden, not unmounted, so its scroll position survives — I confirmed Chrome preserves `scrollTop` across a `hidden` toggle rather than taking that on faith. But scrolling an element with no layout is a no-op, so a reader who was following the latest message while the panel was expanded would come back mid-history. Scroll-follow now also runs when the transcript returns.
- Switching chats no longer routes through the "close the panel" action, which would have recorded over the layout of the chat being left. Chat selection restores that chat's layout instead; the explicit Chat tab is what closes a panel.

Layouts are remembered per chat, bounded to the 50 most recently used so the record cannot grow without limit. A chat back on its transcript is forgotten rather than stored, deleting a chat drops its entry, and stored layouts are validated on the way in.

Verified with `tsc`, the vitest suite (326 passing — 15 new covering the layout module, plus workspace cases for opening beside, expanding, closing, mount stability, and per-chat restore), and a production build. Layout checked by rendering the real components under the compiled stylesheet: side-by-side at 1440px, expanded, and the narrow breakpoint.

Closes #449
