### PR TITLE
feat(core): carry image content blocks through the provider adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6761,12 +6761,14 @@ version = "0.0.0"
 dependencies = [
  "async-stream",
  "async-trait",
+ "base64 0.22.1",
  "futures",
  "openwave-core",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1073,6 +1073,10 @@ impl Agent {
                     max_tokens: self.config.max_tokens,
                     temperature: self.config.temperature,
                     reasoning_effort: self.config.reasoning_effort,
+                    // Empty until message attachments are persisted and the
+                    // transcript can carry image blocks; hydration from the
+                    // blob store hangs here.
+                    images: crate::image::ImageAttachments::new(),
                 };
 
                 progress.model_steps = step + 1;

--- a/crates/openwave-core/src/context.rs
+++ b/crates/openwave-core/src/context.rs
@@ -15,6 +15,7 @@ use crate::provider::{ChatMessage, ContentBlock};
 const TEXT_OVERHEAD: usize = 7;
 const TOOL_USE_OVERHEAD: usize = 30;
 const TOOL_RESULT_OVERHEAD: usize = 20;
+const IMAGE_OVERHEAD: usize = 10;
 const ROLE_OVERHEAD: usize = 4;
 const MAX_SINGLE_BLOCK_TOKENS: usize = 25_000;
 const TRUNCATION_SUFFIX: &str = "\n… [truncated]";
@@ -36,12 +37,104 @@ pub fn estimate_block_tokens(block: &ContentBlock) -> usize {
                 + estimate_tokens(name)
                 + estimate_tokens(&input.to_string())
         }
+        ContentBlock::Image { image } => IMAGE_OVERHEAD + image.estimated_tokens(),
         ContentBlock::ToolResult {
             tool_use_id,
             content,
             ..
         } => TOOL_RESULT_OVERHEAD + estimate_tokens(tool_use_id) + estimate_tokens(content),
     }
+}
+
+/// Whether this message can anchor the start of a request.
+///
+/// The Messages API requires a conversation to open with a `user` message that
+/// carries real content, so a message holding only tool results cannot lead.
+/// Text and images both qualify: an image-only turn ("what is in this
+/// screenshot?" with the question in the image) is a legitimate opening, and
+/// treating it as unanchored would silently discard the user's actual request.
+fn is_user_anchor(msg: &ChatMessage) -> bool {
+    msg.role == Role::User
+        && msg
+            .content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::Text { .. } | ContentBlock::Image { .. }))
+}
+
+/// Replace an image block with a short text stand-in.
+///
+/// Dropping an image silently would leave the model answering a question about
+/// something it cannot see, with no way to tell that from a question about
+/// nothing. The stand-in keeps the turn coherent and lets the model say it no
+/// longer has the image instead of guessing.
+///
+/// This is also what makes the adapter contract unambiguous: every
+/// [`ContentBlock::Image`] that survives reduction is expected to have
+/// hydrated bytes, so an adapter finding none is a real error rather than an
+/// intended eviction.
+#[must_use]
+pub fn evict_image_block(block: &ContentBlock) -> ContentBlock {
+    match block {
+        ContentBlock::Image { image } => ContentBlock::Text {
+            text: format!(
+                "[image omitted from context: {} {}×{}]",
+                image.media_type, image.width, image.height
+            ),
+        },
+        other => other.clone(),
+    }
+}
+
+/// Replace every image block in `messages` with its text stand-in.
+///
+/// A coarse degradation lever for when a request must shed pixels wholesale —
+/// for example after a provider refuses an oversized body.
+pub fn evict_all_images(messages: &mut [ChatMessage]) {
+    for message in messages.iter_mut() {
+        for block in message.content.iter_mut() {
+            if matches!(block, ContentBlock::Image { .. }) {
+                *block = evict_image_block(block);
+            }
+        }
+    }
+}
+
+/// Keep pixels on only the newest `keep_last_n` image blocks, evicting older
+/// ones to text stand-ins.
+///
+/// Bounds outbound body growth over a long chat. Newest-first because recent
+/// images are the ones a turn is usually about.
+///
+/// Evicting rewrites the bytes of an already-sent message, which invalidates a
+/// provider prompt cache from that position onward. Callers should therefore
+/// keep `keep_last_n` generous enough to span a typical back-and-forth about
+/// one image and tighten it only when the context budget actually demands it.
+pub fn evict_images_beyond(messages: &mut [ChatMessage], keep_last_n: usize) {
+    let mut seen = 0usize;
+    for message in messages.iter_mut().rev() {
+        for block in message.content.iter_mut().rev() {
+            if !matches!(block, ContentBlock::Image { .. }) {
+                continue;
+            }
+            if seen < keep_last_n {
+                seen += 1;
+                continue;
+            }
+            *block = evict_image_block(block);
+        }
+    }
+}
+
+/// Whether a block can be shrunk to fit a budget.
+///
+/// Text and tool payloads compress by dropping characters. An image cannot:
+/// the provider needs whole bytes, so the only choices are send it or drop the
+/// message carrying it. Treating an image as compressible would let a message
+/// claim a small floor and then serialize at full cost, which is how an
+/// image-heavy transcript slips past the budget gate and overflows the context
+/// window.
+const fn is_compressible(block: &ContentBlock) -> bool {
+    !matches!(block, ContentBlock::Image { .. })
 }
 
 /// Estimate tokens for a full message (role overhead + blocks).
@@ -166,6 +259,12 @@ fn message_floor(msg: &ChatMessage, content_floor: usize) -> usize {
             .content
             .iter()
             .map(|block| {
+                if !is_compressible(block) {
+                    // Charged in full: shrinking is not an option for this
+                    // block, so a smaller floor would be a promise the
+                    // serializer cannot keep.
+                    return estimate_block_tokens(block);
+                }
                 let overhead = block_overhead(block);
                 let content = estimate_block_tokens(block).saturating_sub(overhead);
                 overhead + content.min(content_floor)
@@ -176,6 +275,7 @@ fn message_floor(msg: &ChatMessage, content_floor: usize) -> usize {
 fn block_overhead(block: &ContentBlock) -> usize {
     match block {
         ContentBlock::Text { .. } => TEXT_OVERHEAD,
+        ContentBlock::Image { .. } => IMAGE_OVERHEAD,
         ContentBlock::ToolUse { .. } => TOOL_USE_OVERHEAD,
         ContentBlock::ToolResult { .. } => TOOL_RESULT_OVERHEAD,
     }
@@ -221,22 +321,13 @@ fn select_newest_to_fit(entries: &mut [Entry], budget: usize, messages: &[ChatMe
     // conversations to start with `user`). If none was selected, force-keep
     // the most recent one — slightly exceeding the budget is better than an
     // empty or invalid transcript.
-    let has_user_text = entries.iter().enumerate().any(|(i, e)| {
-        e.kept
-            && messages[i].role == Role::User
-            && messages[i]
-                .content
-                .iter()
-                .any(|b| matches!(b, ContentBlock::Text { .. }))
-    });
-    if !has_user_text {
+    let has_user_anchor = entries
+        .iter()
+        .enumerate()
+        .any(|(i, e)| e.kept && is_user_anchor(&messages[i]));
+    if !has_user_anchor {
         for i in (0..entries.len()).rev() {
-            if messages[i].role == Role::User
-                && messages[i]
-                    .content
-                    .iter()
-                    .any(|b| matches!(b, ContentBlock::Text { .. }))
-            {
+            if is_user_anchor(&messages[i]) {
                 mark_pair_kept(i, entries, messages, &use_to_msg, &result_to_msg);
                 break;
             }
@@ -358,6 +449,9 @@ fn truncate_message(msg: &ChatMessage, target_tokens: usize) -> ChatMessage {
 
 fn truncate_block(block: &ContentBlock, target_tokens: usize) -> ContentBlock {
     match block {
+        // Incompressible: the floor already charges the full cost, so this is
+        // only ever reached with a budget the image already fits.
+        ContentBlock::Image { .. } => block.clone(),
         ContentBlock::Text { text } => {
             let budget = target_tokens.saturating_sub(TEXT_OVERHEAD);
             ContentBlock::Text {
@@ -479,12 +573,7 @@ fn merge_adjacent_roles(messages: &mut Vec<ChatMessage>) {
 /// content. The Messages API requires the conversation to start with `user`.
 fn ensure_starts_with_user(messages: &mut Vec<ChatMessage>) {
     while let Some(first) = messages.first() {
-        if first.role == Role::User
-            && first
-                .content
-                .iter()
-                .any(|b| matches!(b, ContentBlock::Text { .. }))
-        {
+        if is_user_anchor(first) {
             break;
         }
         messages.remove(0);
@@ -917,5 +1006,112 @@ mod tests {
         ensure_starts_with_user(&mut msgs);
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[0].role, Role::User);
+    }
+
+    // ── Image blocks ───────────────────────────────────────────────
+
+    fn image_block(width: u32, height: u32) -> ContentBlock {
+        ContentBlock::Image {
+            image: crate::image::ImageRef {
+                blob_id: uuid::Uuid::from_u128(u128::from(width) << 32 | u128::from(height)),
+                media_type: crate::image::ImageMediaType::Png,
+                width,
+                height,
+                byte_len: 4_096,
+            },
+        }
+    }
+
+    fn image_only_user_msg(width: u32, height: u32) -> ChatMessage {
+        ChatMessage {
+            role: Role::User,
+            content: vec![image_block(width, height)],
+        }
+    }
+
+    #[test]
+    fn an_image_is_charged_tokens_rather_than_riding_along_free() {
+        // A 1024×1024 image is four 512-px tiles.
+        let tokens = estimate_block_tokens(&image_block(1_024, 1_024));
+        assert_eq!(tokens, IMAGE_OVERHEAD + 4 * 1_600);
+        // Comfortably more than a short text block, which is the whole point:
+        // budgeting must not treat pixels as nearly free.
+        assert!(tokens > estimate_block_tokens(&ContentBlock::Text { text: "hi".into() }));
+    }
+
+    #[test]
+    fn an_image_message_floor_is_its_full_cost_not_a_stub() {
+        let msg = image_only_user_msg(1_024, 1_024);
+        let full = estimate_message_tokens(&msg);
+        // Even at an aggressively small content floor, an image cannot shrink,
+        // so its floor must still equal the full cost. Reporting a smaller
+        // floor is what lets an image-heavy transcript slip past the budget
+        // gate and overflow the context window.
+        assert_eq!(message_floor(&msg, 10), full);
+    }
+
+    #[test]
+    fn truncating_an_image_block_leaves_it_byte_identical() {
+        let block = image_block(800, 600);
+        assert_eq!(truncate_block(&block, 1), block);
+    }
+
+    #[test]
+    fn an_image_only_user_turn_can_anchor_the_transcript() {
+        // "What is in this screenshot?" where the question is the image.
+        let mut msgs = vec![image_only_user_msg(800, 600), assistant_msg("a chart")];
+        ensure_starts_with_user(&mut msgs);
+        assert_eq!(msgs.len(), 2, "the image-only turn must not be discarded");
+        assert!(matches!(msgs[0].content[0], ContentBlock::Image { .. }));
+    }
+
+    #[test]
+    fn reduction_keeps_an_image_only_turn_instead_of_emptying_the_transcript() {
+        let msgs = vec![image_only_user_msg(2_048, 2_048)];
+        // A budget far below the image's cost: the transcript cannot be made
+        // to fit, but returning nothing would be worse than overshooting.
+        let (fitted, _) = fit_to_budget(&msgs, 10, 0);
+        assert!(
+            !fitted.is_empty(),
+            "reduction must not discard the only user turn"
+        );
+    }
+
+    #[test]
+    fn evicting_an_image_leaves_a_stand_in_the_model_can_read() {
+        let evicted = evict_image_block(&image_block(800, 600));
+        let ContentBlock::Text { text } = &evicted else {
+            panic!("expected a text stand-in, got {evicted:?}");
+        };
+        assert!(text.contains("image/png"), "{text}");
+        assert!(text.contains("800"), "{text}");
+        assert!(text.contains("600"), "{text}");
+        // Cheap enough that eviction actually reclaims budget.
+        assert!(estimate_block_tokens(&evicted) < estimate_block_tokens(&image_block(800, 600)));
+    }
+
+    #[test]
+    fn eviction_keeps_the_newest_images_and_stands_in_for_the_rest() {
+        let mut msgs = vec![
+            image_only_user_msg(100, 100),
+            assistant_msg("first"),
+            image_only_user_msg(200, 200),
+            assistant_msg("second"),
+            image_only_user_msg(300, 300),
+        ];
+        evict_images_beyond(&mut msgs, 2);
+
+        // Oldest loses its pixels; the two newest keep theirs.
+        assert!(matches!(msgs[0].content[0], ContentBlock::Text { .. }));
+        assert!(matches!(msgs[2].content[0], ContentBlock::Image { .. }));
+        assert!(matches!(msgs[4].content[0], ContentBlock::Image { .. }));
+
+        evict_all_images(&mut msgs);
+        assert!(
+            msgs.iter()
+                .flat_map(|m| &m.content)
+                .all(|b| !matches!(b, ContentBlock::Image { .. })),
+            "evict_all_images must leave no image blocks"
+        );
     }
 }

--- a/crates/openwave-core/src/image.rs
+++ b/crates/openwave-core/src/image.rs
@@ -1,0 +1,440 @@
+//! Provider-neutral image attachment identity and the ephemeral bytes that
+//! back it for exactly one request.
+//!
+//! The split here is deliberate and load-bearing. [`ImageRef`] is *durable
+//! identity*: a blob id, a bounded media type, and bounded dimensions. It is
+//! cheap to clone, safe to log, safe to persist, and safe to hand to a
+//! renderer. [`ImageAttachments`] is *ephemeral bytes*: the pixels for one
+//! outbound request, hydrated from the blob store just before the adapter
+//! serializes and dropped immediately after.
+//!
+//! Keeping the two apart is what makes "image bytes never enter transcript
+//! text, logs, tool arguments, or renderer-safe event payloads" a structural
+//! property rather than a rule contributors have to remember. A
+//! [`ContentBlock::Image`](crate::ContentBlock::Image) carries only an
+//! `ImageRef`, so every existing path that serializes, stores, or debug-prints
+//! a content block stays byte-free by construction. The bytes ride beside the
+//! request in a field that is `#[serde(skip)]` and whose [`Debug`] is written
+//! by hand to print sizes instead of contents.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Largest attachment accepted in either dimension.
+///
+/// Anthropic documents 8000×8000 as the hard ceiling for a single image, and
+/// OpenAI's limits sit below that, so this is the tightest bound that both
+/// providers will always accept. Refusing here means an oversized image fails
+/// at ingest, where the user can still do something about it, rather than as a
+/// provider 400 in the middle of a turn. It also bounds the tile arithmetic in
+/// [`ImageRef::estimated_tokens`].
+///
+/// Note that Anthropic tightens this to roughly 2000px once a request carries
+/// many images; downscaling to fit that case belongs to the ingest path, not
+/// to this bound.
+pub const MAX_IMAGE_DIMENSION: u32 = 8_000;
+
+/// Largest attachment accepted, in bytes.
+///
+/// Matches the existing raw-document import ceiling so one attachment can
+/// never be accepted by one path and refused by the other.
+pub const MAX_IMAGE_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Image formats OpenWave will send to a provider.
+///
+/// Deliberately closed. Every variant here is accepted by both the Anthropic
+/// and OpenAI image APIs, so a value of this type can always be shaped for the
+/// selected provider — adapters never have to reject a media type at send time.
+/// Vector and exotic raster formats are excluded rather than passed through:
+/// an unsupported type must fail at the trusted ingest boundary, where the user
+/// can still act on it, not deep inside a turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImageMediaType {
+    /// `image/png`
+    Png,
+    /// `image/jpeg`
+    Jpeg,
+    /// `image/webp`
+    Webp,
+    /// `image/gif`
+    Gif,
+}
+
+impl ImageMediaType {
+    /// The IANA media type, as both providers expect to receive it.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Png => "image/png",
+            Self::Jpeg => "image/jpeg",
+            Self::Webp => "image/webp",
+            Self::Gif => "image/gif",
+        }
+    }
+
+    /// Parse an IANA media type, ignoring case and any parameters.
+    ///
+    /// Returns `None` for anything outside the closed set above, including
+    /// types a provider might tolerate but OpenWave does not vouch for.
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        let base = value.split(';').next()?.trim();
+        // Media types are case-insensitive; compare without allocating for the
+        // already-lowercase common case.
+        let matches = |candidate: &str| base.eq_ignore_ascii_case(candidate);
+        if matches("image/png") {
+            Some(Self::Png)
+        } else if matches("image/jpeg") {
+            Some(Self::Jpeg)
+        } else if matches("image/webp") {
+            Some(Self::Webp)
+        } else if matches("image/gif") {
+            Some(Self::Gif)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for ImageMediaType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Durable identity of one image attachment.
+///
+/// Everything here is safe to persist, log, and expose to a renderer. The blob
+/// id is an opaque content-derived UUID, never a filesystem path, so it reveals
+/// nothing about where the bytes live on disk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImageRef {
+    /// Content-addressed blob holding the pixels.
+    pub blob_id: Uuid,
+    /// Format the bytes were sniffed as at ingest.
+    pub media_type: ImageMediaType,
+    /// Pixel width, read from the image header.
+    pub width: u32,
+    /// Pixel height, read from the image header.
+    pub height: u32,
+    /// Size of the stored bytes.
+    pub byte_len: u64,
+}
+
+impl ImageRef {
+    /// Validate the bounds every trusted ingest path must enforce.
+    ///
+    /// # Errors
+    ///
+    /// Returns a static reason when a dimension is zero or past
+    /// [`MAX_IMAGE_DIMENSION`], or the byte length is zero or past
+    /// [`MAX_IMAGE_BYTES`].
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.width == 0 || self.height == 0 {
+            return Err("image attachment has a zero dimension");
+        }
+        if self.width > MAX_IMAGE_DIMENSION || self.height > MAX_IMAGE_DIMENSION {
+            return Err("image attachment exceeds the maximum dimension");
+        }
+        if self.byte_len == 0 {
+            return Err("image attachment is empty");
+        }
+        if self.byte_len > MAX_IMAGE_BYTES {
+            return Err("image attachment exceeds the maximum size");
+        }
+        Ok(())
+    }
+
+    /// Estimated prompt tokens this image costs.
+    ///
+    /// Tile-based: a `512×512` tile is charged a flat rate and partial tiles
+    /// round up. This is an approximation — Anthropic documents roughly
+    /// `width × height / 750` and OpenAI charges a base plus per-tile cost —
+    /// and it is chosen to sit at or above both so context budgeting errs
+    /// toward sending less. Budgeting only needs a bound it will not undershoot;
+    /// an exact per-provider count is not worth diverging the estimate for.
+    ///
+    /// Dimensions are validated at ingest, but a zero here still falls back to
+    /// a single tile rather than reporting a free image.
+    #[must_use]
+    pub const fn estimated_tokens(&self) -> usize {
+        if self.width == 0 || self.height == 0 {
+            return TILE_TOKENS;
+        }
+        let tiles_x = (self.width as usize).div_ceil(TILE_EDGE);
+        let tiles_y = (self.height as usize).div_ceil(TILE_EDGE);
+        tiles_x * tiles_y * TILE_TOKENS
+    }
+}
+
+/// Edge length in pixels of one billing tile.
+const TILE_EDGE: usize = 512;
+
+/// Estimated prompt tokens charged for one `512×512` tile.
+const TILE_TOKENS: usize = 1_600;
+
+/// Raw bytes for one attachment, held only for the duration of a request.
+///
+/// The hand-written [`Debug`] is the point: a derived one would dump megabytes
+/// of pixels into any log line that formats a [`ChatRequest`](crate::ChatRequest).
+#[derive(Clone, PartialEq, Eq)]
+pub struct ImageData {
+    media_type: ImageMediaType,
+    bytes: Vec<u8>,
+}
+
+impl ImageData {
+    /// Wrap hydrated bytes with the media type they were sniffed as.
+    #[must_use]
+    pub fn new(media_type: ImageMediaType, bytes: Vec<u8>) -> Self {
+        Self { media_type, bytes }
+    }
+
+    /// Format of these bytes.
+    #[must_use]
+    pub const fn media_type(&self) -> ImageMediaType {
+        self.media_type
+    }
+
+    /// The raw pixels.
+    #[must_use]
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Number of bytes held.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Whether no bytes are held.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+impl fmt::Debug for ImageData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ImageData")
+            .field("media_type", &self.media_type)
+            .field("bytes", &format_args!("<{} bytes>", self.bytes.len()))
+            .finish()
+    }
+}
+
+/// Bytes for the [`ImageRef`]s appearing in one request, keyed by blob id.
+///
+/// Attached to [`ChatRequest`](crate::ChatRequest) out of band and skipped by
+/// serde, so no serialization of a request — a debug log, an error payload, a
+/// journal entry — can carry pixels. Adapters resolve each block's blob id
+/// here and fail closed when it is absent; silently dropping the block would
+/// send the model a question about an image it was never given.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct ImageAttachments {
+    by_blob: BTreeMap<Uuid, ImageData>,
+}
+
+impl ImageAttachments {
+    /// An empty set.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add or replace the bytes for `blob_id`.
+    pub fn insert(&mut self, blob_id: Uuid, data: ImageData) {
+        self.by_blob.insert(blob_id, data);
+    }
+
+    /// Bytes for `blob_id`, if hydrated.
+    #[must_use]
+    pub fn get(&self, blob_id: Uuid) -> Option<&ImageData> {
+        self.by_blob.get(&blob_id)
+    }
+
+    /// Whether `blob_id` has hydrated bytes.
+    #[must_use]
+    pub fn contains(&self, blob_id: Uuid) -> bool {
+        self.by_blob.contains_key(&blob_id)
+    }
+
+    /// How many attachments are hydrated.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_blob.len()
+    }
+
+    /// Whether nothing is hydrated.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_blob.is_empty()
+    }
+
+    /// Total bytes held across every attachment.
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.by_blob.values().map(ImageData::len).sum()
+    }
+
+    /// Drop every hydrated attachment, keeping the referring blocks intact.
+    ///
+    /// Used as a degradation step when a provider refuses a request in a way
+    /// that dropping pixels can fix.
+    pub fn clear(&mut self) {
+        self.by_blob.clear();
+    }
+
+    /// Keep only the attachments named by `keep`, dropping the rest.
+    ///
+    /// The caller decides which references still deserve pixels — typically
+    /// the most recent few, to bound outbound body growth over a long chat.
+    pub fn retain_only(&mut self, keep: &std::collections::HashSet<Uuid>) {
+        self.by_blob.retain(|blob_id, _| keep.contains(blob_id));
+    }
+}
+
+impl fmt::Debug for ImageAttachments {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ImageAttachments")
+            .field("count", &self.by_blob.len())
+            .field("total_bytes", &self.total_bytes())
+            .finish()
+    }
+}
+
+impl FromIterator<(Uuid, ImageData)> for ImageAttachments {
+    fn from_iter<T: IntoIterator<Item = (Uuid, ImageData)>>(iter: T) -> Self {
+        Self {
+            by_blob: iter.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn image_ref(width: u32, height: u32) -> ImageRef {
+        ImageRef {
+            blob_id: Uuid::from_u128(1),
+            media_type: ImageMediaType::Png,
+            width,
+            height,
+            byte_len: 1_024,
+        }
+    }
+
+    #[test]
+    fn media_types_round_trip_and_reject_unsupported_formats() {
+        for media_type in [
+            ImageMediaType::Png,
+            ImageMediaType::Jpeg,
+            ImageMediaType::Webp,
+            ImageMediaType::Gif,
+        ] {
+            assert_eq!(ImageMediaType::parse(media_type.as_str()), Some(media_type));
+        }
+        assert_eq!(
+            ImageMediaType::parse("IMAGE/PNG"),
+            Some(ImageMediaType::Png)
+        );
+        assert_eq!(
+            ImageMediaType::parse("image/jpeg; charset=binary"),
+            Some(ImageMediaType::Jpeg)
+        );
+        // Vector and unknown raster formats stay out of the closed set so they
+        // fail at ingest rather than at send time.
+        assert_eq!(ImageMediaType::parse("image/svg+xml"), None);
+        assert_eq!(ImageMediaType::parse("image/tiff"), None);
+        assert_eq!(ImageMediaType::parse("application/pdf"), None);
+        assert_eq!(ImageMediaType::parse(""), None);
+    }
+
+    #[test]
+    fn token_estimate_rounds_partial_tiles_up_and_never_reports_a_free_image() {
+        // Exactly one tile.
+        assert_eq!(image_ref(512, 512).estimated_tokens(), TILE_TOKENS);
+        // A single pixel still occupies a whole tile.
+        assert_eq!(image_ref(1, 1).estimated_tokens(), TILE_TOKENS);
+        // Partial tiles round up in both axes: 3 × 2 tiles.
+        assert_eq!(image_ref(1_025, 600).estimated_tokens(), 6 * TILE_TOKENS);
+        // A degenerate dimension must not price the image at zero.
+        assert_eq!(image_ref(0, 0).estimated_tokens(), TILE_TOKENS);
+    }
+
+    #[test]
+    fn validation_rejects_degenerate_and_oversized_attachments() {
+        assert!(image_ref(800, 600).validate().is_ok());
+        assert!(image_ref(0, 600).validate().is_err());
+        assert!(image_ref(800, 0).validate().is_err());
+        assert!(image_ref(MAX_IMAGE_DIMENSION + 1, 600).validate().is_err());
+        assert!(image_ref(800, MAX_IMAGE_DIMENSION + 1).validate().is_err());
+
+        let mut empty = image_ref(800, 600);
+        empty.byte_len = 0;
+        assert!(empty.validate().is_err());
+
+        let mut oversized = image_ref(800, 600);
+        oversized.byte_len = MAX_IMAGE_BYTES + 1;
+        assert!(oversized.validate().is_err());
+    }
+
+    #[test]
+    fn debug_output_reports_sizes_and_never_leaks_bytes() {
+        let secret = vec![0xAB; 32];
+        let data = ImageData::new(ImageMediaType::Png, secret);
+        let rendered = format!("{data:?}");
+        assert!(rendered.contains("32 bytes"), "{rendered}");
+        assert!(!rendered.contains("171"), "{rendered}");
+        assert!(!rendered.contains("ab"), "{rendered}");
+
+        let attachments: ImageAttachments = [(
+            Uuid::from_u128(1),
+            ImageData::new(ImageMediaType::Png, vec![0xCD; 16]),
+        )]
+        .into_iter()
+        .collect();
+        let rendered = format!("{attachments:?}");
+        assert!(rendered.contains("total_bytes"), "{rendered}");
+        assert!(rendered.contains("16"), "{rendered}");
+        assert!(!rendered.contains("205"), "{rendered}");
+    }
+
+    #[test]
+    fn image_ref_serialization_carries_identity_and_no_pixels() {
+        let value = serde_json::to_value(image_ref(800, 600)).unwrap();
+        assert_eq!(value["media_type"], "png");
+        assert_eq!(value["width"], 800);
+        assert_eq!(value["byte_len"], 1_024);
+        assert!(value.get("bytes").is_none());
+        let restored: ImageRef = serde_json::from_value(value).unwrap();
+        assert_eq!(restored, image_ref(800, 600));
+    }
+
+    #[test]
+    fn retain_only_and_clear_drop_pixels_without_touching_identity() {
+        let kept = Uuid::from_u128(1);
+        let dropped = Uuid::from_u128(2);
+        let mut attachments: ImageAttachments = [
+            (kept, ImageData::new(ImageMediaType::Png, vec![1; 8])),
+            (dropped, ImageData::new(ImageMediaType::Jpeg, vec![2; 8])),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(attachments.total_bytes(), 16);
+
+        attachments.retain_only(&std::iter::once(kept).collect());
+        assert!(attachments.contains(kept));
+        assert!(!attachments.contains(dropped));
+        assert_eq!(attachments.len(), 1);
+
+        attachments.clear();
+        assert!(attachments.is_empty());
+    }
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod deliverable;
 pub mod error;
 pub mod event;
 pub mod id;
+pub mod image;
 #[cfg(feature = "keychain")]
 pub mod keychain;
 pub mod model;
@@ -104,6 +105,9 @@ pub use id::{
     AgentRunId, AssistantCitationId, CallId, ChatId, ChunkId, DocumentId, DocumentJobId,
     HostRootId, HostRootIdError, MessageId, OutputId, OutputRevisionId, ProjectId,
     RootAttachmentChangeId, RootAttachmentChangeIdError, StepId, TurnId, TurnSteerId,
+};
+pub use image::{
+    ImageAttachments, ImageData, ImageMediaType, ImageRef, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION,
 };
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::error::Result;
+use crate::image::{ImageAttachments, ImageRef};
 use crate::model::Role;
 
 /// Stable identifier for a provider adapter (e.g. `anthropic`, `openai-compat`).
@@ -52,6 +53,15 @@ pub enum ContentBlock {
         name: String,
         /// The arguments (JSON) the model produced.
         input: Value,
+    },
+    /// An image attached to the message.
+    ///
+    /// Carries identity only — the pixels travel out of band on
+    /// [`ChatRequest::images`], so no path that serializes, stores, or
+    /// debug-prints a content block can leak them.
+    Image {
+        /// Blob identity, media type, and bounded dimensions.
+        image: ImageRef,
     },
     /// The result of a tool call, fed back to the model.
     ToolResult {
@@ -118,6 +128,15 @@ pub struct ChatRequest {
     /// control and ignore it otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<crate::model::ReasoningEffort>,
+    /// Pixels for the [`ContentBlock::Image`] blocks in `messages`.
+    ///
+    /// Hydrated from the blob store for exactly this request. Skipped by serde
+    /// so no serialized request — a debug log, an error payload, a journal
+    /// entry — can carry image bytes, and dropped as soon as the request is
+    /// built. Adapters resolve each block's blob id here and fail when it is
+    /// missing rather than quietly sending a question about an absent image.
+    #[serde(skip)]
+    pub images: ImageAttachments,
 }
 
 /// Token accounting for a completion.
@@ -282,6 +301,7 @@ mod tests {
             max_tokens: None,
             temperature: None,
             reasoning_effort: None,
+            images: ImageAttachments::new(),
         }))
         .unwrap();
         drop(provider);
@@ -309,6 +329,7 @@ mod tests {
             max_tokens: None,
             temperature: None,
             reasoning_effort: None,
+            images: ImageAttachments::new(),
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("system"), "{json}");

--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -20,6 +20,7 @@ openai-compat = ["dep:reqwest", "dep:async-stream"]
 [dependencies]
 openwave-core = { path = "../openwave-core", default-features = false }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -28,3 +29,4 @@ async-stream = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+uuid = { workspace = true }

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -10,11 +10,13 @@ use async_trait::async_trait;
 use futures::stream::{BoxStream, StreamExt};
 use serde_json::{json, Value};
 
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
 use openwave_core::error::{AgentError, Result};
 use openwave_core::provider::{
-    ChatRequest, ModelProvider, ProviderEvent, ProviderId, StopReason, Usage,
+    ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason, Usage,
 };
-use openwave_core::Role;
+use openwave_core::{ImageAttachments, Role};
 
 use crate::sse::{classify_provider_error, drain_frames, frame_data, read_bounded_error_body};
 
@@ -130,10 +132,12 @@ impl ModelProvider for AnthropicProvider {
 
 /// Build the Anthropic request body from a normalized [`ChatRequest`].
 ///
-/// Our [`ContentBlock`](openwave_core::ContentBlock) serialization already
-/// matches Anthropic's content-block shape, so message content passes through
-/// as-is; the system prompt becomes a top-level field, and only `user`/
-/// `assistant` roles are valid on messages.
+/// Text, tool-use, and tool-result blocks serialize to exactly Anthropic's
+/// content-block shape, so they pass through untouched. Image blocks do not:
+/// they carry blob identity rather than pixels, so they are shaped explicitly
+/// against the bytes hydrated on [`ChatRequest::images`]. The system prompt
+/// becomes a top-level field, and only `user`/`assistant` roles are valid on
+/// messages.
 fn build_request_json(req: &ChatRequest) -> Result<Value> {
     let messages = req
         .messages
@@ -141,7 +145,7 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         .map(|message| {
             Ok(json!({
                 "role": anthropic_role(message.role),
-                "content": serde_json::to_value(&message.content)?,
+                "content": anthropic_content(&message.content, &req.images)?,
             }))
         })
         .collect::<Result<Vec<_>>>()?;
@@ -174,6 +178,54 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         body["temperature"] = json!(temperature);
     }
     Ok(body)
+}
+
+/// Shape one message's blocks into Anthropic's `content` array.
+///
+/// When a message carries more than one image, each is preceded by an
+/// `Image N:` label. Anthropic's vision guidance calls for this in multi-image
+/// prompts so the model can refer to a specific image unambiguously; with a
+/// single image the label is noise and is omitted.
+fn anthropic_content(blocks: &[ContentBlock], images: &ImageAttachments) -> Result<Value> {
+    let image_count = blocks
+        .iter()
+        .filter(|block| matches!(block, ContentBlock::Image { .. }))
+        .count();
+    let label_images = image_count > 1;
+
+    let mut out: Vec<Value> = Vec::with_capacity(blocks.len());
+    let mut image_index = 0usize;
+    for block in blocks {
+        match block {
+            ContentBlock::Image { image } => {
+                let data = images.get(image.blob_id).ok_or_else(|| {
+                    // Reduction rewrites a deliberately dropped image into a
+                    // text stand-in, so an unhydrated image block here means
+                    // the bytes were lost, not omitted on purpose. Sending the
+                    // turn anyway would ask the model about an image it never
+                    // received.
+                    AgentError::Provider(format!(
+                        "image attachment {} has no hydrated bytes",
+                        image.blob_id
+                    ))
+                })?;
+                image_index += 1;
+                if label_images {
+                    out.push(json!({ "type": "text", "text": format!("Image {image_index}:") }));
+                }
+                out.push(json!({
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": data.media_type().as_str(),
+                        "data": BASE64.encode(data.bytes()),
+                    }
+                }));
+            }
+            other => out.push(serde_json::to_value(other)?),
+        }
+    }
+    Ok(Value::Array(out))
 }
 
 fn anthropic_role(role: Role) -> &'static str {
@@ -308,6 +360,7 @@ mod tests {
             max_tokens: None,
             temperature: Some(0.5),
             reasoning_effort: None,
+            images: ImageAttachments::new(),
         };
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["model"], "claude-opus-4-8");
@@ -383,5 +436,120 @@ mod tests {
         assert_eq!(map_stop_reason("tool_use"), StopReason::ToolUse);
         assert_eq!(map_stop_reason("max_tokens"), StopReason::MaxTokens);
         assert_eq!(map_stop_reason("refusal"), StopReason::EndTurn);
+    }
+
+    // ── Image blocks ───────────────────────────────────────────────
+
+    fn png_ref(blob: u128) -> openwave_core::ImageRef {
+        openwave_core::ImageRef {
+            blob_id: uuid::Uuid::from_u128(blob),
+            media_type: openwave_core::ImageMediaType::Png,
+            width: 800,
+            height: 600,
+            byte_len: 3,
+        }
+    }
+
+    fn request_with(content: Vec<ContentBlock>, images: ImageAttachments) -> ChatRequest {
+        ChatRequest {
+            provider: Some(ProviderId::new("anthropic")),
+            model: "claude-opus-4-8".into(),
+            reasoning_model: false,
+            system: None,
+            messages: vec![ChatMessage {
+                role: Role::User,
+                content,
+            }],
+            tools: vec![],
+            max_tokens: None,
+            temperature: None,
+            reasoning_effort: None,
+            images,
+        }
+    }
+
+    #[test]
+    fn an_image_block_becomes_a_base64_source_block() {
+        let image = png_ref(1);
+        let mut images = ImageAttachments::new();
+        images.insert(
+            image.blob_id,
+            openwave_core::ImageData::new(openwave_core::ImageMediaType::Png, vec![1, 2, 3]),
+        );
+        let req = request_with(
+            vec![
+                ContentBlock::Text {
+                    text: "what is this?".into(),
+                },
+                ContentBlock::Image { image },
+            ],
+            images,
+        );
+
+        let body = build_request_json(&req).unwrap();
+        let content = &body["messages"][0]["content"];
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[1]["source"]["type"], "base64");
+        assert_eq!(content[1]["source"]["media_type"], "image/png");
+        assert_eq!(content[1]["source"]["data"], BASE64.encode([1, 2, 3]));
+        // A single image needs no ordinal label.
+        assert_eq!(content.as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn multiple_images_are_labelled_so_the_model_can_refer_to_each() {
+        let (first, second) = (png_ref(1), png_ref(2));
+        let mut images = ImageAttachments::new();
+        for image in [&first, &second] {
+            images.insert(
+                image.blob_id,
+                openwave_core::ImageData::new(openwave_core::ImageMediaType::Png, vec![7]),
+            );
+        }
+        let req = request_with(
+            vec![
+                ContentBlock::Image { image: first },
+                ContentBlock::Image { image: second },
+            ],
+            images,
+        );
+
+        let body = build_request_json(&req).unwrap();
+        let content = body["messages"][0]["content"].as_array().unwrap().clone();
+        assert_eq!(content.len(), 4);
+        assert_eq!(content[0]["text"], "Image 1:");
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[2]["text"], "Image 2:");
+        assert_eq!(content[3]["type"], "image");
+    }
+
+    #[test]
+    fn an_unhydrated_image_fails_the_request_instead_of_being_dropped() {
+        // Reduction rewrites intentionally dropped images into text, so bytes
+        // missing here mean something went wrong. Silently sending the turn
+        // would ask the model about an image it never received.
+        let req = request_with(
+            vec![ContentBlock::Image { image: png_ref(9) }],
+            ImageAttachments::new(),
+        );
+        let err = build_request_json(&req).unwrap_err();
+        assert!(err.to_string().contains("no hydrated bytes"), "{err}");
+    }
+
+    #[test]
+    fn text_and_tool_blocks_keep_their_existing_wire_shape() {
+        // Guards the refactor away from blanket passthrough: non-image blocks
+        // must serialize exactly as before.
+        let blocks = vec![
+            ContentBlock::Text { text: "hi".into() },
+            ContentBlock::ToolResult {
+                tool_use_id: "toolu_1".into(),
+                content: "done".into(),
+                is_error: false,
+            },
+        ];
+        let shaped = anthropic_content(&blocks, &ImageAttachments::new()).unwrap();
+        assert_eq!(shaped, serde_json::to_value(&blocks).unwrap());
     }
 }

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -9,6 +9,8 @@
 //! targets the Chat Completions shape that local and third-party runtimes share.
 
 use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
 use futures::stream::{BoxStream, StreamExt};
 use serde_json::{json, Value};
 
@@ -16,7 +18,7 @@ use openwave_core::error::{AgentError, Result};
 use openwave_core::provider::{
     ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason, Usage,
 };
-use openwave_core::Role;
+use openwave_core::{ImageAttachments, Role};
 
 use crate::sse::{classify_provider_error, drain_frames, frame_data, read_bounded_error_body};
 
@@ -172,7 +174,7 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         }));
     }
     for message in &req.messages {
-        extend_openai_messages(&mut messages, message)?;
+        extend_openai_messages(&mut messages, message, &req.images)?;
     }
 
     let max_tokens = req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS);
@@ -221,9 +223,14 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
 ///
 /// Tool results become individual `role: tool` messages (the wire format requires
 /// one per `tool_call_id`); everything else collapses into a single message.
+///
+/// A message carrying images cannot use the plain string `content` form —
+/// Chat Completions requires an array of typed parts, with each image as an
+/// `image_url` part holding a `data:` URL.
 fn extend_openai_messages(
     out: &mut Vec<Value>,
     message: &openwave_core::ChatMessage,
+    images: &ImageAttachments,
 ) -> Result<()> {
     let tool_results: Vec<_> = message
         .content
@@ -290,11 +297,51 @@ fn extend_openai_messages(
         Role::User | Role::System | Role::Tool => "user",
     };
 
+    let image_blocks: Vec<&openwave_core::ImageRef> = message
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Image { image } => Some(image),
+            _ => None,
+        })
+        .collect();
+
     let mut msg = json!({ "role": role });
-    if !text.is_empty() {
-        msg["content"] = json!(text);
-    } else if tool_calls.is_empty() {
-        msg["content"] = json!("");
+    if image_blocks.is_empty() {
+        if !text.is_empty() {
+            msg["content"] = json!(text);
+        } else if tool_calls.is_empty() {
+            msg["content"] = json!("");
+        }
+    } else {
+        // Text first, then images, mirroring the block order a caller built.
+        let mut parts: Vec<Value> = Vec::with_capacity(image_blocks.len() + 1);
+        if !text.is_empty() {
+            parts.push(json!({ "type": "text", "text": text }));
+        }
+        for image in image_blocks {
+            let data = images.get(image.blob_id).ok_or_else(|| {
+                // Reduction turns a deliberately dropped image into a text
+                // stand-in, so a missing hydration here is lost bytes rather
+                // than an intended omission — fail instead of asking the model
+                // about an image it was never sent.
+                AgentError::Provider(format!(
+                    "image attachment {} has no hydrated bytes",
+                    image.blob_id
+                ))
+            })?;
+            parts.push(json!({
+                "type": "image_url",
+                "image_url": {
+                    "url": format!(
+                        "data:{};base64,{}",
+                        data.media_type().as_str(),
+                        BASE64.encode(data.bytes())
+                    )
+                }
+            }));
+        }
+        msg["content"] = Value::Array(parts);
     }
     if !tool_calls.is_empty() {
         msg["tool_calls"] = Value::Array(tool_calls);
@@ -470,6 +517,7 @@ mod tests {
             max_tokens: None,
             temperature: Some(0.2),
             reasoning_effort: Some(ReasoningEffort::High),
+            images: ImageAttachments::new(),
         };
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["model"], "gpt-4o");
@@ -498,6 +546,7 @@ mod tests {
             max_tokens: Some(1024),
             temperature: None,
             reasoning_effort: None,
+            images: ImageAttachments::new(),
         };
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["max_completion_tokens"], 1024);
@@ -518,6 +567,7 @@ mod tests {
             max_tokens: Some(1024),
             temperature: None,
             reasoning_effort: Some(ReasoningEffort::Low),
+            images: ImageAttachments::new(),
         };
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["reasoning_effort"], "low");
@@ -539,7 +589,7 @@ mod tests {
             ],
         };
         let mut out = Vec::new();
-        extend_openai_messages(&mut out, &msg).unwrap();
+        extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap();
         assert_eq!(out.len(), 1);
         assert_eq!(out[0]["role"], "assistant");
         assert_eq!(out[0]["content"], "calling");
@@ -558,7 +608,7 @@ mod tests {
             }],
         };
         let mut out = Vec::new();
-        extend_openai_messages(&mut out, &msg).unwrap();
+        extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap();
         assert_eq!(out.len(), 1);
         assert_eq!(out[0]["role"], "tool");
         assert_eq!(out[0]["tool_call_id"], "call_1");
@@ -673,5 +723,71 @@ mod tests {
         assert_eq!(map_stop_reason("tool_calls"), StopReason::ToolUse);
         assert_eq!(map_stop_reason("length"), StopReason::MaxTokens);
         assert_eq!(map_stop_reason("stop"), StopReason::EndTurn);
+    }
+
+    // ── Image blocks ───────────────────────────────────────────────
+
+    fn png_ref(blob: u128) -> openwave_core::ImageRef {
+        openwave_core::ImageRef {
+            blob_id: uuid::Uuid::from_u128(blob),
+            media_type: openwave_core::ImageMediaType::Png,
+            width: 800,
+            height: 600,
+            byte_len: 3,
+        }
+    }
+
+    #[test]
+    fn an_image_turns_content_into_typed_parts_with_a_data_url() {
+        // Chat Completions cannot express an image with the plain string
+        // `content` form; it must become an array of typed parts.
+        let image = png_ref(1);
+        let mut images = ImageAttachments::new();
+        images.insert(
+            image.blob_id,
+            openwave_core::ImageData::new(openwave_core::ImageMediaType::Png, vec![1, 2, 3]),
+        );
+        let msg = ChatMessage {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text {
+                    text: "what is this?".into(),
+                },
+                ContentBlock::Image { image },
+            ],
+        };
+
+        let mut out = Vec::new();
+        extend_openai_messages(&mut out, &msg, &images).unwrap();
+        assert_eq!(out.len(), 1);
+        let parts = out[0]["content"].as_array().unwrap();
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[0]["text"], "what is this?");
+        assert_eq!(parts[1]["type"], "image_url");
+        assert_eq!(
+            parts[1]["image_url"]["url"],
+            format!("data:image/png;base64,{}", BASE64.encode([1, 2, 3]))
+        );
+    }
+
+    #[test]
+    fn an_unhydrated_image_fails_the_request_instead_of_being_dropped() {
+        let msg = ChatMessage {
+            role: Role::User,
+            content: vec![ContentBlock::Image { image: png_ref(9) }],
+        };
+        let mut out = Vec::new();
+        let err = extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap_err();
+        assert!(err.to_string().contains("no hydrated bytes"), "{err}");
+    }
+
+    #[test]
+    fn a_message_without_images_keeps_the_plain_string_content_form() {
+        // Guards against regressing every existing text-only request into the
+        // parts form, which some OpenAI-compatible servers do not accept.
+        let msg = ChatMessage::text(Role::User, "hi");
+        let mut out = Vec::new();
+        extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap();
+        assert_eq!(out[0]["content"], "hi");
     }
 }

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -282,6 +282,7 @@ fn fnv1a64(s: &str) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use openwave_core::ImageAttachments;
 
     fn route(kind: RouteKind, key: &str, models: &[&str], base: Option<&str>) -> Route {
         Route {
@@ -394,6 +395,7 @@ mod tests {
                 max_tokens: None,
                 temperature: None,
                 reasoning_effort: None,
+                images: ImageAttachments::new(),
             })
             .await;
         match result {

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -975,6 +975,9 @@ async fn sandbox_request(
         max_tokens: config.max_tokens,
         temperature: config.temperature,
         reasoning_effort: config.reasoning_effort,
+        // Sandbox runs replay text and tool blocks from checkpoints; no path
+        // puts an image block in this transcript.
+        images: openwave_core::ImageAttachments::new(),
     })
 }
 
@@ -1663,6 +1666,7 @@ mod tests {
             max_tokens: None,
             temperature: None,
             reasoning_effort: None,
+            images: openwave_core::ImageAttachments::new(),
         };
         for events in [
             vec![
@@ -2660,6 +2664,7 @@ mod tests {
             max_tokens: Some(100),
             temperature: Some(0.0),
             reasoning_effort: None,
+            images: openwave_core::ImageAttachments::new(),
         };
         let provider = Arc::new(EventProvider(vec![
             ProviderEvent::ToolCallStarted {


### PR DESCRIPTION
First slice of #415. Adds the provider-neutral image content block and shapes it for both adapters. Nothing produces one of these blocks yet — composer attachment, persistence, and the registry capability flip land separately — so this is inert until a later slice fills it in.

## The identity/pixels split

`ContentBlock::Image` carries identity only: a blob id, a bounded media type, and dimensions. Pixels ride out of band on `ChatRequest::images`, which serde skips and whose `Debug` prints sizes rather than contents.

That split is the point. It makes "image bytes never enter transcript text, logs, tool arguments, or renderer-safe event payloads" a structural property — every existing path that serializes, stores, or debug-prints a content block stays byte-free by construction, rather than depending on each future caller to remember. `ImageMediaType` is a closed set both providers accept, so an unsupported format has to fail at the trusted ingest boundary rather than deep inside a turn.

## Adapters

The Anthropic adapter previously serialized `ContentBlock` verbatim as its wire format. That was fine while every variant happened to match Anthropic's shape, but it meant adding a variant would silently change request bodies rather than fail to compile. It now shapes blocks explicitly. Text, tool-use, and tool-result output is byte-identical, and a test pins that against the old serialization so the refactor can't drift.

Multiple images in one message get `Image N:` labels, following Anthropic's vision guidance for multi-image prompts; a single image doesn't, since the label is just noise.

The OpenAI-compatible adapter targets Chat Completions, which can't express an image with the plain string `content` form — it needs an array of typed parts with a `data:` URL. It switches to that form only when a message actually carries an image, because some OpenAI-compatible servers reject the parts form for ordinary text.

## Context reduction

This needed the most care, and it's where the real bugs were.

Images were invisible to the token estimate, so they'd budget as roughly free. Worse, reduction assigns every block a shrunken floor — but an image can't shrink. An image-heavy message could therefore claim a small floor, pass the budget gate, and then serialize at full cost, overflowing the context window. Images are now charged a tile-based estimate and treated as incompressible, so their floor is their full cost.

Reduction also dropped any leading user message that had no text block. An image-only turn — "what's in this screenshot?", where the question *is* the image — would have been silently discarded. The anchor check now treats images as real user content.

When the budget does force an image out, it's rewritten as a short text stand-in rather than vanishing, so the model can say it no longer has the image instead of guessing about one it can't see. That also makes the adapter contract unambiguous: any image block that survives reduction is expected to have bytes, so an adapter finding none fails the request rather than quietly asking the model about an image it was never sent.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, and `cargo check --workspace --locked` all pass locally. The three context-reduction tests were confirmed to fail when the corresponding fix is reverted, so they aren't vacuous.

The `Cargo.lock` change is two dependency edges only (`base64` for the adapters, `uuid` as a router dev-dependency); no versions moved.

Closes #458

Part of #415.
