### PR TITLE
feat(core): give outputs durable records and immutable revisions

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1070,6 +1070,78 @@ pub mod setting {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod output {
+    use sea_orm::entity::prelude::*;
+
+    // `current_revision_id` and `revision_count` are maintained in the same
+    // transaction that inserts a revision. They are deliberately not a foreign
+    // key: `output_revision` already references `output`, and closing the cycle
+    // would order the two inserts against each other for no added safety.
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "output")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub chat_id: Uuid,
+        pub filename: String,
+        pub media_type: String,
+        pub current_revision_id: Uuid,
+        pub revision_count: i32,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+        pub deleted_at: Option<DateTimeUtc>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod output_revision {
+    use sea_orm::entity::prelude::*;
+
+    // Rows are insert-only. The bytes live in conversation-private scratch
+    // under the revision id, so a revision row and its content are both
+    // write-once and can never disagree.
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "output_revision")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub output_id: Uuid,
+        pub ordinal: i32,
+        pub byte_len: i64,
+        pub sha256: Vec<u8>,
+        pub turn_id: Option<Uuid>,
+        pub created_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter)]
+    pub enum Relation {
+        Output,
+    }
+
+    impl RelationTrait for Relation {
+        fn def(&self) -> RelationDef {
+            match self {
+                Self::Output => Entity::belongs_to(super::output::Entity)
+                    .from(Column::OutputId)
+                    .to(super::output::Column::Id)
+                    .into(),
+            }
+        }
+    }
+
+    impl Related<super::output::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Output.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod event {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -26,6 +26,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddChatReasoningEffort),
             Box::new(AddDocumentChatScope),
             Box::new(AddUserQuestions),
+            Box::new(AddConversationOutputs),
         ]
     }
 }
@@ -271,6 +272,143 @@ impl MigrationTrait for AddUserQuestions {
             .await?;
         manager
             .drop_table(Table::drop().table(UserQuestionRequest::Table).to_owned())
+            .await
+    }
+}
+
+/// Gives conversation outputs a durable record with an opaque identity and an
+/// append-only revision history.
+///
+/// Before this, an output was a filename in private scratch and an update
+/// replaced the previous bytes in place. Existing loose files stay on disk but
+/// are no longer a catalog: the record is authoritative from here on.
+struct AddConversationOutputs;
+
+impl MigrationName for AddConversationOutputs {
+    fn name(&self) -> &str {
+        "m20260724_000013_add_conversation_outputs"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddConversationOutputs {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Output::Table)
+                    .col(ColumnDef::new(Output::Id).uuid().not_null().primary_key())
+                    .col(ColumnDef::new(Output::ChatId).uuid().not_null())
+                    .col(ColumnDef::new(Output::Filename).text().not_null())
+                    .col(ColumnDef::new(Output::MediaType).text().not_null())
+                    .col(ColumnDef::new(Output::CurrentRevisionId).uuid().not_null())
+                    .col(ColumnDef::new(Output::RevisionCount).integer().not_null())
+                    .col(
+                        ColumnDef::new(Output::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(Output::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(Output::DeletedAt).timestamp_with_time_zone())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_output_chat")
+                            .from_tbl(Output::Table)
+                            .from_col(Output::ChatId)
+                            .to_tbl(Chat::Table)
+                            .to_col(Chat::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .check(
+                        Expr::col(Output::RevisionCount)
+                            .between(1, crate::deliverable::MAX_OUTPUT_REVISIONS as i32),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_output_chat_created")
+                    .table(Output::Table)
+                    .col(Output::ChatId)
+                    .col(Output::CreatedAt)
+                    .col(Output::Id)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_table(
+                Table::create()
+                    .table(OutputRevision::Table)
+                    .col(
+                        ColumnDef::new(OutputRevision::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(OutputRevision::OutputId).uuid().not_null())
+                    .col(ColumnDef::new(OutputRevision::Ordinal).integer().not_null())
+                    .col(
+                        ColumnDef::new(OutputRevision::ByteLen)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutputRevision::Sha256)
+                            .binary_len(32)
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(OutputRevision::TurnId).uuid())
+                    .col(
+                        ColumnDef::new(OutputRevision::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_output_revision_output")
+                            .from_tbl(OutputRevision::Table)
+                            .from_col(OutputRevision::OutputId)
+                            .to_tbl(Output::Table)
+                            .to_col(Output::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .check(
+                        Expr::col(OutputRevision::Ordinal)
+                            .between(1, crate::deliverable::MAX_OUTPUT_REVISIONS as i32),
+                    )
+                    .check(Expr::col(OutputRevision::ByteLen).gte(0))
+                    .check(
+                        Expr::col(OutputRevision::ByteLen)
+                            .lte(crate::deliverable::MAX_DELIVERABLE_BYTES as i64),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_output_revision_ordinal")
+                    .table(OutputRevision::Table)
+                    .col(OutputRevision::OutputId)
+                    .col(OutputRevision::Ordinal)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(OutputRevision::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Output::Table).to_owned())
             .await
     }
 }
@@ -5353,6 +5491,32 @@ enum AssistantCitation {
     TurnId,
     EvidenceCallId,
     EvidenceRank,
+}
+
+#[derive(DeriveIden)]
+enum Output {
+    Table,
+    Id,
+    ChatId,
+    Filename,
+    MediaType,
+    CurrentRevisionId,
+    RevisionCount,
+    CreatedAt,
+    UpdatedAt,
+    DeletedAt,
+}
+
+#[derive(DeriveIden)]
+enum OutputRevision {
+    Table,
+    Id,
+    OutputId,
+    Ordinal,
+    ByteLen,
+    Sha256,
+    TurnId,
+    CreatedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -17,13 +17,14 @@ use sea_orm_migration::MigratorTrait;
 use serde_json::Value;
 
 use crate::approval::{ApprovalDecision, ApprovalRequest, ToolApproval};
+use crate::deliverable::{CreateOutput, NewOutputRevision, OutputRecord, OutputRevision};
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 #[cfg(test)]
 use crate::id::MessageId;
 use crate::id::{
-    AgentRunId, CallId, ChatId, DocumentId, DocumentJobId, HostRootId, ProjectId,
-    RootAttachmentChangeId, TurnId, TurnSteerId,
+    AgentRunId, CallId, ChatId, DocumentId, DocumentJobId, HostRootId, OutputId, OutputRevisionId,
+    ProjectId, RootAttachmentChangeId, TurnId, TurnSteerId,
 };
 #[cfg(test)]
 use crate::model::Role;
@@ -1810,6 +1811,38 @@ impl Store for DbStore {
         id: ChatId,
     ) -> Result<Option<crate::storage::ChatTranscriptSnapshot>> {
         ops::conversation::get_chat_transcript(self, id).await
+    }
+
+    async fn create_output(&self, request: &CreateOutput) -> Result<OutputRecord> {
+        ops::output::create_output(self, request).await
+    }
+
+    async fn append_output_revision(
+        &self,
+        output_id: OutputId,
+        revision: &NewOutputRevision,
+    ) -> Result<OutputRecord> {
+        ops::output::append_output_revision(self, output_id, revision).await
+    }
+
+    async fn get_output(&self, id: OutputId) -> Result<Option<OutputRecord>> {
+        ops::output::get_output(self, id).await
+    }
+
+    async fn list_outputs(&self, chat_id: ChatId, limit: u64) -> Result<Vec<OutputRecord>> {
+        ops::output::list_outputs(self, chat_id, limit).await
+    }
+
+    async fn list_output_revisions(&self, output_id: OutputId) -> Result<Vec<OutputRevision>> {
+        ops::output::list_output_revisions(self, output_id).await
+    }
+
+    async fn get_output_revision(&self, id: OutputRevisionId) -> Result<Option<OutputRevision>> {
+        ops::output::get_output_revision(self, id).await
+    }
+
+    async fn delete_output(&self, id: OutputId, deleted_at: chrono::DateTime<Utc>) -> Result<bool> {
+        ops::output::delete_output(self, id, deleted_at).await
     }
 
     async fn begin_root_attachment_change(

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -12,6 +12,7 @@ pub(in crate::db) mod citation;
 pub(in crate::db) mod client_execution;
 pub(in crate::db) mod conversation;
 pub(in crate::db) mod document;
+pub(in crate::db) mod output;
 pub(in crate::db) mod root_attachment;
 pub(in crate::db) mod sandbox_tool;
 pub(in crate::db) mod turn;

--- a/crates/openwave-core/src/db/ops/output.rs
+++ b/crates/openwave-core/src/db/ops/output.rs
@@ -1,0 +1,331 @@
+//! Durable conversation outputs and their append-only revision history.
+//!
+//! Every mutation is keyed by a caller-minted identity so an ambiguous store
+//! response can be retried without creating a second output or a second
+//! revision. Revisions are insert-only: an update appends, and the previous
+//! bytes stay addressable by their own revision id.
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, Set, TransactionTrait,
+};
+
+use crate::deliverable::{
+    deliverable_media_type, validate_deliverable_name, CreateOutput, NewOutputRevision,
+    OutputRecord, OutputRevision, MAX_DELIVERABLE_BYTES, MAX_OUTPUT_REVISIONS,
+};
+use crate::error::{AgentError, Result};
+use crate::id::{ChatId, OutputId, OutputRevisionId};
+
+use super::super::{entities, store_err, DbStore};
+use super::acquire_chat_write_lock;
+use super::turn::canonical_db_timestamp;
+
+pub(in crate::db) async fn create_output(
+    store: &DbStore,
+    request: &CreateOutput,
+) -> Result<OutputRecord> {
+    let media_type = validate_new_output(request)?;
+    let created_at = canonical_db_timestamp(request.revision.created_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, request.chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "chat {} does not exist",
+            request.chat_id
+        )));
+    }
+    if let Some(existing) = find_output_on(&transaction, request.id).await? {
+        // An exact retry must return the original record rather than fail. A
+        // reused id that describes different content is a caller bug.
+        transaction.rollback().await.map_err(store_err)?;
+        return if existing.chat_id == request.chat_id
+            && existing.filename == request.filename
+            && existing.current_revision == request.revision.id
+            && existing.revision_count == 1
+        {
+            Ok(existing)
+        } else {
+            Err(AgentError::Store(format!(
+                "output {} already exists with different content",
+                request.id
+            )))
+        };
+    }
+    entities::output::ActiveModel {
+        id: Set(request.id.0),
+        chat_id: Set(request.chat_id.0),
+        filename: Set(request.filename.clone()),
+        media_type: Set(media_type.to_owned()),
+        current_revision_id: Set(request.revision.id.0),
+        revision_count: Set(1),
+        created_at: Set(created_at),
+        updated_at: Set(created_at),
+        deleted_at: Set(None),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    insert_revision_on(&transaction, request.id, 1, &request.revision, created_at).await?;
+    let record = require_output_on(&transaction, request.id).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(record)
+}
+
+pub(in crate::db) async fn append_output_revision(
+    store: &DbStore,
+    output_id: OutputId,
+    revision: &NewOutputRevision,
+) -> Result<OutputRecord> {
+    validate_revision(revision)?;
+    let created_at = canonical_db_timestamp(revision.created_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let Some(existing) = find_output_on(&transaction, output_id).await? else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!("output {output_id} not found")));
+    };
+    // Take the owning chat's write lock so two concurrent revisions cannot
+    // both read the same ordinal and race to publish a current revision.
+    if !acquire_chat_write_lock(&transaction, existing.chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "chat {} does not exist",
+            existing.chat_id
+        )));
+    }
+    if existing.deleted_at.is_some() {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!("output {output_id} is deleted")));
+    }
+    if let Some(recorded) = find_revision_on(&transaction, revision.id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return if recorded.output_id == output_id
+            && recorded.byte_len == revision.byte_len
+            && recorded.sha256 == revision.sha256
+        {
+            require_output(store, output_id).await
+        } else {
+            Err(AgentError::Store(format!(
+                "output revision {} already exists with different content",
+                revision.id
+            )))
+        };
+    }
+    let existing = require_output_on(&transaction, output_id).await?;
+    let ordinal = existing.revision_count + 1;
+    if ordinal > MAX_OUTPUT_REVISIONS {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "output {output_id} has reached its {MAX_OUTPUT_REVISIONS}-revision limit"
+        )));
+    }
+    insert_revision_on(&transaction, output_id, ordinal, revision, created_at).await?;
+    entities::output::ActiveModel {
+        id: Set(output_id.0),
+        current_revision_id: Set(revision.id.0),
+        revision_count: Set(i32::try_from(ordinal).map_err(|_| {
+            AgentError::Store("output revision count is outside the database range".into())
+        })?),
+        updated_at: Set(created_at),
+        ..Default::default()
+    }
+    .update(&transaction)
+    .await
+    .map_err(store_err)?;
+    let record = require_output_on(&transaction, output_id).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(record)
+}
+
+pub(in crate::db) async fn get_output(
+    store: &DbStore,
+    id: OutputId,
+) -> Result<Option<OutputRecord>> {
+    find_output_on(&store.conn, id).await
+}
+
+pub(in crate::db) async fn list_outputs(
+    store: &DbStore,
+    chat_id: ChatId,
+    limit: u64,
+) -> Result<Vec<OutputRecord>> {
+    entities::output::Entity::find()
+        .filter(entities::output::Column::ChatId.eq(chat_id.0))
+        .filter(entities::output::Column::DeletedAt.is_null())
+        .order_by_desc(entities::output::Column::UpdatedAt)
+        .order_by_desc(entities::output::Column::Id)
+        .limit(limit)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(output_from_model)
+        .collect()
+}
+
+pub(in crate::db) async fn list_output_revisions(
+    store: &DbStore,
+    output_id: OutputId,
+) -> Result<Vec<OutputRevision>> {
+    entities::output_revision::Entity::find()
+        .filter(entities::output_revision::Column::OutputId.eq(output_id.0))
+        .order_by_desc(entities::output_revision::Column::Ordinal)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(revision_from_model)
+        .collect()
+}
+
+pub(in crate::db) async fn get_output_revision(
+    store: &DbStore,
+    id: OutputRevisionId,
+) -> Result<Option<OutputRevision>> {
+    find_revision_on(&store.conn, id).await
+}
+
+pub(in crate::db) async fn delete_output(
+    store: &DbStore,
+    id: OutputId,
+    deleted_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool> {
+    let deleted_at = canonical_db_timestamp(deleted_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let Some(existing) = find_output_on(&transaction, id).await? else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(false);
+    };
+    if existing.deleted_at.is_some() {
+        // Deleting twice is the same durable outcome, not a conflict.
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(true);
+    }
+    entities::output::ActiveModel {
+        id: Set(id.0),
+        deleted_at: Set(Some(deleted_at)),
+        ..Default::default()
+    }
+    .update(&transaction)
+    .await
+    .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(true)
+}
+
+fn validate_new_output(request: &CreateOutput) -> Result<&'static str> {
+    validate_deliverable_name(&request.filename)
+        .map_err(|message| AgentError::Store(format!("invalid output filename: {message}")))?;
+    let media_type = deliverable_media_type(&request.filename)
+        .ok_or_else(|| AgentError::Store("output filename has no supported media type".into()))?;
+    validate_revision(&request.revision)?;
+    Ok(media_type)
+}
+
+fn validate_revision(revision: &NewOutputRevision) -> Result<()> {
+    if revision.byte_len > MAX_DELIVERABLE_BYTES as u64 {
+        return Err(AgentError::Store(format!(
+            "output revision is too large (maximum {MAX_DELIVERABLE_BYTES} bytes)"
+        )));
+    }
+    Ok(())
+}
+
+async fn insert_revision_on<C>(
+    conn: &C,
+    output_id: OutputId,
+    ordinal: u32,
+    revision: &NewOutputRevision,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    entities::output_revision::ActiveModel {
+        id: Set(revision.id.0),
+        output_id: Set(output_id.0),
+        ordinal: Set(i32::try_from(ordinal).map_err(|_| {
+            AgentError::Store("output revision ordinal is outside the database range".into())
+        })?),
+        byte_len: Set(i64::try_from(revision.byte_len).map_err(|_| {
+            AgentError::Store("output revision length is outside the database range".into())
+        })?),
+        sha256: Set(revision.sha256.to_vec()),
+        turn_id: Set(revision.turn_id.map(|turn_id| turn_id.0)),
+        created_at: Set(created_at),
+    }
+    .insert(conn)
+    .await
+    .map_err(store_err)?;
+    Ok(())
+}
+
+async fn find_output_on<C>(conn: &C, id: OutputId) -> Result<Option<OutputRecord>>
+where
+    C: ConnectionTrait,
+{
+    entities::output::Entity::find_by_id(id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .map(output_from_model)
+        .transpose()
+}
+
+async fn require_output_on<C>(conn: &C, id: OutputId) -> Result<OutputRecord>
+where
+    C: ConnectionTrait,
+{
+    find_output_on(conn, id)
+        .await?
+        .ok_or_else(|| AgentError::Store(format!("output {id} not found")))
+}
+
+async fn require_output(store: &DbStore, id: OutputId) -> Result<OutputRecord> {
+    require_output_on(&store.conn, id).await
+}
+
+async fn find_revision_on<C>(conn: &C, id: OutputRevisionId) -> Result<Option<OutputRevision>>
+where
+    C: ConnectionTrait,
+{
+    entities::output_revision::Entity::find_by_id(id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .map(revision_from_model)
+        .transpose()
+}
+
+fn output_from_model(model: entities::output::Model) -> Result<OutputRecord> {
+    Ok(OutputRecord {
+        id: OutputId(model.id),
+        chat_id: ChatId(model.chat_id),
+        filename: model.filename,
+        media_type: model.media_type,
+        current_revision: OutputRevisionId(model.current_revision_id),
+        revision_count: u32::try_from(model.revision_count)
+            .map_err(|_| AgentError::Store("stored output revision count is negative".into()))?,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+        deleted_at: model.deleted_at,
+    })
+}
+
+fn revision_from_model(model: entities::output_revision::Model) -> Result<OutputRevision> {
+    let sha256: [u8; 32] = model
+        .sha256
+        .try_into()
+        .map_err(|_| AgentError::Store("stored output revision digest is malformed".into()))?;
+    Ok(OutputRevision {
+        id: OutputRevisionId(model.id),
+        output_id: OutputId(model.output_id),
+        ordinal: u32::try_from(model.ordinal)
+            .map_err(|_| AgentError::Store("stored output revision ordinal is negative".into()))?,
+        byte_len: u64::try_from(model.byte_len)
+            .map_err(|_| AgentError::Store("stored output revision length is negative".into()))?,
+        sha256,
+        turn_id: model.turn_id.map(crate::id::TurnId),
+        created_at: model.created_at,
+    })
+}

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -13,6 +13,7 @@ use chrono::{DateTime, Utc};
 mod agent_run;
 mod delegated_file_read;
 mod multi_agent_wait;
+mod output;
 mod parent_terminal_guard;
 mod root_attachment;
 mod sandbox_spawn_checkpoint;
@@ -5220,6 +5221,43 @@ async fn m0011_preserves_legacy_documents_as_conversationless() {
         row.try_get::<String>("", "name")
             .is_ok_and(|name| name == "chat_id")
     }));
+}
+
+#[tokio::test]
+async fn m0013_adds_outputs_to_an_existing_conversation_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        dir.path().join("output-upgrade.db").display()
+    );
+    let conn = Database::connect(&url).await.unwrap();
+    conn.execute_unprepared("PRAGMA foreign_keys=ON;")
+        .await
+        .unwrap();
+    migration::Migrator::up(&conn, Some(12)).await.unwrap();
+    let store = DbStore { conn: conn.clone() };
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+
+    migration::Migrator::up(&conn, None).await.unwrap();
+
+    // The conversation survives, and it can now own outputs.
+    assert_eq!(store.get_chat(chat.id).await.unwrap().as_ref(), Some(&chat));
+    assert!(store.list_outputs(chat.id, 10).await.unwrap().is_empty());
+    let request = crate::deliverable::CreateOutput {
+        id: crate::id::OutputId::new(),
+        chat_id: chat.id,
+        filename: "brief.md".into(),
+        revision: crate::deliverable::NewOutputRevision {
+            id: crate::id::OutputRevisionId::new(),
+            byte_len: 7,
+            sha256: [3; 32],
+            turn_id: None,
+            created_at: DateTime::<Utc>::from_timestamp(1_710_000_000, 0).unwrap(),
+        },
+    };
+    let created = store.create_output(&request).await.unwrap();
+    assert_eq!(store.list_outputs(chat.id, 10).await.unwrap(), [created]);
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -1,0 +1,307 @@
+use super::*;
+use crate::deliverable::{
+    CreateOutput, NewOutputRevision, OutputRecord, MAX_DELIVERABLE_BYTES, MAX_OUTPUT_REVISIONS,
+};
+use crate::id::{OutputId, OutputRevisionId};
+
+fn at(second: i64) -> DateTime<Utc> {
+    DateTime::<Utc>::from_timestamp(1_710_000_000 + second, 0).unwrap()
+}
+
+fn digest(seed: u8) -> [u8; 32] {
+    [seed; 32]
+}
+
+fn revision(seed: u8, second: i64) -> NewOutputRevision {
+    NewOutputRevision {
+        id: OutputRevisionId::new(),
+        byte_len: u64::from(seed) + 1,
+        sha256: digest(seed),
+        turn_id: None,
+        created_at: at(second),
+    }
+}
+
+fn create_request(chat_id: ChatId, filename: &str, seed: u8) -> CreateOutput {
+    CreateOutput {
+        id: OutputId::new(),
+        chat_id,
+        filename: filename.to_owned(),
+        revision: revision(seed, 0),
+    }
+}
+
+async fn store_with_chat() -> (tempfile::TempDir, DbStore, Chat) {
+    let (dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    (dir, store, chat)
+}
+
+#[tokio::test]
+async fn creating_an_output_records_its_first_revision() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let request = create_request(chat.id, "brief.md", 1);
+
+    let record = store.create_output(&request).await.unwrap();
+
+    assert_eq!(record.id, request.id);
+    assert_eq!(record.chat_id, chat.id);
+    assert_eq!(record.filename, "brief.md");
+    assert_eq!(record.media_type, "text/markdown");
+    assert_eq!(record.current_revision, request.revision.id);
+    assert_eq!(record.revision_count, 1);
+    assert_eq!(record.created_at, at(0));
+    assert_eq!(record.updated_at, at(0));
+    assert!(record.deleted_at.is_none());
+
+    let revisions = store.list_output_revisions(record.id).await.unwrap();
+    assert_eq!(revisions.len(), 1);
+    assert_eq!(revisions[0].id, request.revision.id);
+    assert_eq!(revisions[0].ordinal, 1);
+    assert_eq!(revisions[0].sha256, digest(1));
+    assert_eq!(revisions[0].byte_len, request.revision.byte_len);
+}
+
+#[tokio::test]
+async fn updating_an_output_keeps_the_replaced_revision_addressable() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let request = create_request(chat.id, "brief.md", 1);
+    let first = store.create_output(&request).await.unwrap();
+    let second = revision(2, 30);
+
+    let updated = store
+        .append_output_revision(first.id, &second)
+        .await
+        .unwrap();
+
+    assert_eq!(updated.current_revision, second.id);
+    assert_eq!(updated.revision_count, 2);
+    assert_eq!(updated.created_at, at(0), "creation time is immutable");
+    assert_eq!(updated.updated_at, at(30));
+
+    // The point of the whole slice: the prior revision still resolves.
+    let replaced = store
+        .get_output_revision(first.current_revision)
+        .await
+        .unwrap()
+        .expect("the replaced revision is retained");
+    assert_eq!(replaced.ordinal, 1);
+    assert_eq!(replaced.sha256, digest(1));
+
+    let revisions = store.list_output_revisions(first.id).await.unwrap();
+    assert_eq!(
+        revisions
+            .iter()
+            .map(|entry| entry.ordinal)
+            .collect::<Vec<_>>(),
+        [2, 1],
+        "revisions list newest first"
+    );
+}
+
+#[tokio::test]
+async fn an_exact_retry_never_creates_a_second_output_or_revision() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let request = create_request(chat.id, "brief.md", 1);
+    let created = store.create_output(&request).await.unwrap();
+
+    let retried = store.create_output(&request).await.unwrap();
+    assert_eq!(retried, created);
+
+    let second = revision(2, 30);
+    let appended = store
+        .append_output_revision(created.id, &second)
+        .await
+        .unwrap();
+    let appended_again = store
+        .append_output_revision(created.id, &second)
+        .await
+        .unwrap();
+    assert_eq!(appended_again, appended);
+    assert_eq!(appended_again.revision_count, 2);
+    assert_eq!(
+        store.list_output_revisions(created.id).await.unwrap().len(),
+        2
+    );
+    assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn reusing_an_identity_for_different_content_is_rejected() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let request = create_request(chat.id, "brief.md", 1);
+    let created = store.create_output(&request).await.unwrap();
+
+    let mut conflicting = request.clone();
+    conflicting.filename = "other.md".to_owned();
+    assert!(store.create_output(&conflicting).await.is_err());
+
+    let second = revision(2, 30);
+    store
+        .append_output_revision(created.id, &second)
+        .await
+        .unwrap();
+    let mut conflicting_revision = second.clone();
+    conflicting_revision.sha256 = digest(9);
+    assert!(store
+        .append_output_revision(created.id, &conflicting_revision)
+        .await
+        .is_err());
+
+    // The rejected retries left exactly the original history behind.
+    let revisions = store.list_output_revisions(created.id).await.unwrap();
+    assert_eq!(revisions.len(), 2);
+}
+
+#[tokio::test]
+async fn outputs_are_exactly_conversation_scoped() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let other = sample_chat();
+    store.create_chat(&other).await.unwrap();
+    let mine = store
+        .create_output(&create_request(chat.id, "brief.md", 1))
+        .await
+        .unwrap();
+    store
+        .create_output(&create_request(other.id, "theirs.md", 2))
+        .await
+        .unwrap();
+
+    let listed = store.list_outputs(chat.id, 10).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id, mine.id);
+}
+
+#[tokio::test]
+async fn deleting_an_output_hides_it_but_retains_its_revisions() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let created = store
+        .create_output(&create_request(chat.id, "brief.md", 1))
+        .await
+        .unwrap();
+
+    assert!(store.delete_output(created.id, at(60)).await.unwrap());
+    assert!(
+        store.delete_output(created.id, at(90)).await.unwrap(),
+        "deleting twice is the same durable outcome"
+    );
+    assert!(store.list_outputs(chat.id, 10).await.unwrap().is_empty());
+
+    let record = store.get_output(created.id).await.unwrap().unwrap();
+    assert_eq!(record.deleted_at, Some(at(60)), "the first deletion stands");
+    assert_eq!(
+        store.list_output_revisions(created.id).await.unwrap().len(),
+        1
+    );
+
+    assert!(
+        !store.delete_output(OutputId::new(), at(60)).await.unwrap(),
+        "an unknown output reports no deletion"
+    );
+}
+
+#[tokio::test]
+async fn a_deleted_output_refuses_further_revisions() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let created = store
+        .create_output(&create_request(chat.id, "brief.md", 1))
+        .await
+        .unwrap();
+    store.delete_output(created.id, at(60)).await.unwrap();
+
+    assert!(store
+        .append_output_revision(created.id, &revision(2, 90))
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn revision_history_is_bounded_without_losing_content() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let created = store
+        .create_output(&create_request(chat.id, "brief.md", 1))
+        .await
+        .unwrap();
+    for ordinal in 2..=MAX_OUTPUT_REVISIONS {
+        store
+            .append_output_revision(created.id, &revision(2, i64::from(ordinal)))
+            .await
+            .unwrap();
+    }
+
+    // Refusing the write is deliberate: silently dropping the oldest revision
+    // would reintroduce the data loss this record exists to prevent.
+    let over_limit = store
+        .append_output_revision(created.id, &revision(3, 1_000))
+        .await;
+    assert!(over_limit.is_err());
+    assert_eq!(
+        store.list_output_revisions(created.id).await.unwrap().len() as u32,
+        MAX_OUTPUT_REVISIONS
+    );
+}
+
+#[tokio::test]
+async fn outputs_reject_unusable_names_and_oversized_revisions() {
+    let (_dir, store, chat) = store_with_chat().await;
+
+    for filename in ["../escape.md", "report.pdf", "", ".hidden.md"] {
+        assert!(
+            store
+                .create_output(&create_request(chat.id, filename, 1))
+                .await
+                .is_err(),
+            "{filename}"
+        );
+    }
+
+    let mut oversized = create_request(chat.id, "brief.md", 1);
+    oversized.revision.byte_len = MAX_DELIVERABLE_BYTES as u64 + 1;
+    assert!(store.create_output(&oversized).await.is_err());
+}
+
+#[tokio::test]
+async fn an_output_requires_an_existing_conversation() {
+    let (_dir, store) = temp_store().await;
+
+    assert!(store
+        .create_output(&create_request(ChatId::new(), "brief.md", 1))
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn deleting_a_conversation_removes_its_outputs() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let created = store
+        .create_output(&create_request(chat.id, "brief.md", 1))
+        .await
+        .unwrap();
+
+    store.delete_chat(chat.id).await.unwrap();
+
+    assert!(store.get_output(created.id).await.unwrap().is_none());
+    assert!(store
+        .get_output_revision(created.current_revision)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn a_revision_records_the_turn_that_produced_it() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let turn_id = TurnId::new();
+    let mut request = create_request(chat.id, "brief.md", 1);
+    request.revision.turn_id = Some(turn_id);
+
+    let created: OutputRecord = store.create_output(&request).await.unwrap();
+
+    let stored = store
+        .get_output_revision(created.current_revision)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.turn_id, Some(turn_id));
+}

--- a/crates/openwave-core/src/deliverable.rs
+++ b/crates/openwave-core/src/deliverable.rs
@@ -1,11 +1,119 @@
 //! Closed contract for user-visible files created in conversation-private scratch.
+//!
+//! An output is a conversation-owned record with an opaque [`OutputId`] and an
+//! ordered history of immutable revisions. The record is authoritative: the
+//! filename is display metadata, not identity, so re-creating the same
+//! filename adds a revision instead of destroying the previous bytes.
 
-/// Private-scratch directory reserved for user-visible outputs.
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+
+use crate::id::{ChatId, OutputId, OutputRevisionId, TurnId};
+
+/// Private-scratch directory holding the pre-record output files.
+///
+/// Files written here predate durable output records and are no longer part of
+/// the catalog. [`OUTPUTS_DIRECTORY`] holds every recorded revision.
 pub const DELIVERABLES_DIRECTORY: &str = "artifacts";
+/// Private-scratch directory holding immutable revision bytes.
+pub const OUTPUTS_DIRECTORY: &str = "outputs";
 /// Largest text artifact the foreground agent may create.
 pub const MAX_DELIVERABLE_BYTES: usize = 512 * 1024;
 /// Largest filename accepted by the model-facing and native boundaries.
 pub const MAX_DELIVERABLE_NAME_CHARS: usize = 120;
+/// Largest number of revisions one output retains.
+///
+/// Reaching the bound is a product decision rather than a storage failure: the
+/// store refuses a further revision so no caller can silently lose history.
+pub const MAX_OUTPUT_REVISIONS: u32 = 100;
+
+/// Private-scratch location of one immutable revision's bytes.
+///
+/// Revision files are written once and never replaced, so the path is derived
+/// entirely from durable identity. Callers resolve it below the exact chat's
+/// private scratch directory; it is never returned to a model or renderer.
+#[must_use]
+pub fn output_revision_relative_path(
+    output_id: OutputId,
+    revision_id: OutputRevisionId,
+) -> PathBuf {
+    PathBuf::from(OUTPUTS_DIRECTORY)
+        .join(output_id.to_string())
+        .join(revision_id.to_string())
+}
+
+/// One conversation-owned output and its current revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputRecord {
+    /// Durable opaque identity, stable across every revision.
+    pub id: OutputId,
+    /// Conversation that exclusively owns this output.
+    pub chat_id: ChatId,
+    /// Display filename. Not identity, and not unique within a chat.
+    pub filename: String,
+    /// Fixed media type derived from `filename` when the output was created.
+    pub media_type: String,
+    /// Revision currently presented as the output's content.
+    pub current_revision: OutputRevisionId,
+    /// Number of retained revisions, always at least one.
+    pub revision_count: u32,
+    /// Creation time of the first revision.
+    pub created_at: DateTime<Utc>,
+    /// Creation time of the current revision.
+    pub updated_at: DateTime<Utc>,
+    /// Set when the user deleted the output. Revisions are retained until the
+    /// conversation itself is deleted so a deletion stays recoverable.
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+/// One immutable revision of an output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputRevision {
+    /// Durable identity, also the private-scratch filename of its bytes.
+    pub id: OutputRevisionId,
+    /// Output this revision belongs to.
+    pub output_id: OutputId,
+    /// One-based position in the output's revision history.
+    pub ordinal: u32,
+    /// Exact byte length of the revision's content.
+    pub byte_len: u64,
+    /// SHA-256 of the revision's content, used to recognize an exact retry.
+    pub sha256: [u8; 32],
+    /// Turn that produced the revision, when it came from an agent turn.
+    pub turn_id: Option<TurnId>,
+    /// Host-stamped creation time.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Content-identifying fields of a revision the caller has already written.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewOutputRevision {
+    /// Caller-minted identity. Reusing it with the same content is an exact
+    /// retry; reusing it with different content is rejected.
+    pub id: OutputRevisionId,
+    /// Exact byte length of the content already written to private scratch.
+    pub byte_len: u64,
+    /// SHA-256 of that content.
+    pub sha256: [u8; 32],
+    /// Turn that produced the revision, when it came from an agent turn.
+    pub turn_id: Option<TurnId>,
+    /// Host-stamped creation time.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Request to create an output together with its first revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateOutput {
+    /// Caller-minted identity, so an ambiguous store response can be retried.
+    pub id: OutputId,
+    /// Conversation that will own the output.
+    pub chat_id: ChatId,
+    /// Display filename, validated by [`validate_deliverable_name`].
+    pub filename: String,
+    /// The output's first revision.
+    pub revision: NewOutputRevision,
+}
 
 /// Validate one portable, renderer-safe deliverable filename.
 ///
@@ -84,6 +192,33 @@ mod tests {
         ] {
             assert!(validate_deliverable_name(invalid).is_err(), "{invalid}");
         }
+    }
+
+    #[test]
+    fn revision_paths_are_derived_only_from_durable_identity() {
+        let output_id = OutputId::new();
+        let revision_id = OutputRevisionId::new();
+        let path = output_revision_relative_path(output_id, revision_id);
+
+        assert_eq!(
+            path,
+            PathBuf::from(OUTPUTS_DIRECTORY)
+                .join(output_id.to_string())
+                .join(revision_id.to_string())
+        );
+        assert!(path.is_relative());
+        // A revision path carries no filename, so a display name can never
+        // steer where bytes are written or read.
+        assert_eq!(
+            path,
+            output_revision_relative_path(output_id, revision_id),
+            "the same identity always resolves to the same path"
+        );
+        assert_ne!(
+            path,
+            output_revision_relative_path(output_id, OutputRevisionId::new()),
+            "each revision owns a distinct, write-once path"
+        );
     }
 
     #[test]

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -344,6 +344,18 @@ id_type!(
     /// Identifies one tool call, stable across its request/approval/result.
     CallId
 );
+id_type!(
+    /// Identifies one conversation-owned output across all of its revisions.
+    ///
+    /// This is the durable handle a model, renderer, or export names. It is
+    /// deliberately opaque: possession of an id is not authority, and it never
+    /// encodes a filename or a host path.
+    OutputId
+);
+id_type!(
+    /// Identifies one immutable revision of an output.
+    OutputRevisionId
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -92,15 +92,16 @@ pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub use db::DbStore;
 pub use deliverable::{
-    deliverable_media_type, validate_deliverable_name, DELIVERABLES_DIRECTORY,
-    MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_NAME_CHARS,
+    deliverable_media_type, output_revision_relative_path, validate_deliverable_name, CreateOutput,
+    NewOutputRevision, OutputRecord, OutputRevision, DELIVERABLES_DIRECTORY, MAX_DELIVERABLE_BYTES,
+    MAX_DELIVERABLE_NAME_CHARS, MAX_OUTPUT_REVISIONS, OUTPUTS_DIRECTORY,
 };
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{
     AgentRunId, AssistantCitationId, CallId, ChatId, ChunkId, DocumentId, DocumentJobId,
-    HostRootId, HostRootIdError, MessageId, ProjectId, RootAttachmentChangeId,
-    RootAttachmentChangeIdError, StepId, TurnId, TurnSteerId,
+    HostRootId, HostRootIdError, MessageId, OutputId, OutputRevisionId, ProjectId,
+    RootAttachmentChangeId, RootAttachmentChangeIdError, StepId, TurnId, TurnSteerId,
 };
 #[cfg(feature = "keychain")]
 pub use keychain::KeychainSecretProvider;

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -20,11 +20,12 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::approval::{ApprovalDecision, ApprovalRequest, ToolApproval};
+use crate::deliverable::{CreateOutput, NewOutputRevision, OutputRecord, OutputRevision};
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{
-    AgentRunId, CallId, ChatId, DocumentId, DocumentJobId, ProjectId, RootAttachmentChangeId,
-    TurnId, TurnSteerId,
+    AgentRunId, CallId, ChatId, DocumentId, DocumentJobId, OutputId, OutputRevisionId, ProjectId,
+    RootAttachmentChangeId, TurnId, TurnSteerId,
 };
 use crate::model::{
     AgentRun, AgentRunExecution, AgentRunInboxEntry, AgentRunResult, AgentRunWaitSetCandidate,
@@ -859,6 +860,12 @@ fn document_storage_unavailable<T>() -> Result<T> {
     ))
 }
 
+fn output_storage_unavailable<T>() -> Result<T> {
+    Err(AgentError::Store(
+        "output storage is not implemented by this Store".into(),
+    ))
+}
+
 fn turn_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "durable turn storage is not implemented by this Store".into(),
@@ -1366,6 +1373,61 @@ pub trait Store: Send + Sync {
         model: Option<Option<String>>,
         reasoning_effort: Option<Option<ReasoningEffort>>,
     ) -> Result<bool>;
+
+    /// Create a conversation output together with its first revision.
+    ///
+    /// The caller has already written the revision's bytes to conversation
+    /// private scratch under [`crate::deliverable::output_revision_relative_path`]
+    /// and supplies their exact length and digest. Reusing `request.id` with
+    /// identical content returns the original record so an ambiguous store
+    /// response can be retried; reusing it with different content is rejected.
+    async fn create_output(&self, _request: &CreateOutput) -> Result<OutputRecord> {
+        output_storage_unavailable()
+    }
+
+    /// Append an immutable revision and publish it as the output's current one.
+    ///
+    /// The previous revision is retained and stays addressable by its own id,
+    /// so an update can never destroy the bytes it replaced. Reusing
+    /// `revision.id` with identical content is an exact retry.
+    async fn append_output_revision(
+        &self,
+        _output_id: OutputId,
+        _revision: &NewOutputRevision,
+    ) -> Result<OutputRecord> {
+        output_storage_unavailable()
+    }
+
+    /// Fetch one output by opaque id, including a soft-deleted one.
+    async fn get_output(&self, _id: OutputId) -> Result<Option<OutputRecord>> {
+        output_storage_unavailable()
+    }
+
+    /// List a conversation's live outputs, most recently updated first.
+    async fn list_outputs(&self, _chat_id: ChatId, _limit: u64) -> Result<Vec<OutputRecord>> {
+        output_storage_unavailable()
+    }
+
+    /// List one output's revisions, newest first.
+    async fn list_output_revisions(&self, _output_id: OutputId) -> Result<Vec<OutputRevision>> {
+        output_storage_unavailable()
+    }
+
+    /// Fetch one revision by opaque id.
+    async fn get_output_revision(&self, _id: OutputRevisionId) -> Result<Option<OutputRevision>> {
+        output_storage_unavailable()
+    }
+
+    /// Soft-delete an output, hiding it from the catalog while retaining its
+    /// revisions. Returns `false` only when the output does not exist; deleting
+    /// an already-deleted output is the same durable outcome, not a conflict.
+    async fn delete_output(
+        &self,
+        _id: OutputId,
+        _deleted_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        output_storage_unavailable()
+    }
 
     /// Atomically begin one exact broker-backed attachment change.
     ///

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -42,13 +42,50 @@ destinations, and preserve the permissions of an existing regular destination.
 Neither the model nor renderer receives the scratch path, the selected export
 path, bearer credentials, or native-executor credentials.
 
+## The durable output record
+
+The filename-keyed catalog above cannot express version history: writing a
+filename twice replaces the earlier bytes and there is nothing left to recover.
+The product store therefore owns an output record whose identity is an opaque
+`OutputId`, with the filename demoted to display metadata.
+
+- An output has an opaque id, an owning conversation, a display filename, a
+  fixed media type, a current revision, and a revision count.
+- A revision has its own opaque id, a one-based ordinal, an exact byte length,
+  a SHA-256 digest, and the turn that produced it. Revision rows are
+  insert-only.
+- Updating an output appends a revision and republishes the current one. The
+  replaced revision keeps its own id and stays readable, so an update can no
+  longer destroy the bytes it supersedes.
+- Revision bytes live at `outputs/<output id>/<revision id>` under the exact
+  conversation's private scratch. The path is derived only from durable
+  identity, so a display filename can never steer where bytes are written, and
+  a revision file is written once and never replaced.
+- History is bounded at 100 revisions per output. Reaching the bound refuses
+  the write rather than discarding the oldest revision, because silently
+  dropping history would reintroduce the loss the record exists to prevent.
+- Deleting an output is a soft delete: it leaves the catalog but keeps its
+  revisions until the conversation itself is deleted. Deleting the conversation
+  cascades the records away, and the existing private-scratch cleanup removes
+  the bytes with the rest of the chat directory.
+
+Every mutation is keyed by a caller-minted identity. Reusing an identity with
+identical content returns the original record, so an ambiguous store response
+can be retried without creating a second output or a second revision; reusing
+one with different content is rejected.
+
+This layer is the foundation the model-facing and native surfaces move onto. It
+is not yet wired to `create_deliverable`, which still writes a filename into
+`artifacts/`. Files already in `artifacts/` predate the record and are not
+adopted into it: they stay on disk and remain listed by the current catalog
+until that surface moves to the record.
+
 ## Deliberate limits
 
-This baseline derives its durable catalog from the files themselves rather than
-adding artifact database rows. An export is a synchronous user action, so it is
-not automatically retried and does not yet have a durable export receipt.
-Deleting outputs, binary formats, Office document generation, transcript-inline
-artifact cards, version history, and writing directly into connected folders
-remain later slices. Those additions should preserve the same rule: the model
-names a logical output, while a person or narrowly scoped capability chooses
-where host data is written.
+An export is a synchronous user action, so it is not automatically retried and
+does not yet have a durable export receipt. Binary formats, Office document
+generation, transcript-inline artifact cards, per-revision source references,
+and writing directly into connected folders remain later slices. Those
+additions should preserve the same rule: the model names a logical output,
+while a person or narrowly scoped capability chooses where host data is
+written.


### PR DESCRIPTION
First slice of #417.

## Why

An output is identified by its filename in a private per-chat directory, so
writing the same filename twice replaces the earlier bytes in place. An agent
iterating on a report destroys the previous draft and there is nothing left to
recover. Deriving the catalog from a directory scan also leaves no record to
hang provenance, deletion, or export state on.

## What changed

`output` and `output_revision` tables, their entities, store operations, and the
`Store` trait methods.

- An output carries an opaque `OutputId`, its owning conversation, a display
  filename, a fixed media type, and its current revision. The filename is
  display metadata, not identity.
- Revision rows are insert-only. An update appends and republishes the current
  revision; the replaced one keeps its own id and stays readable.
- Revision bytes belong at `outputs/<output id>/<revision id>` under the exact
  conversation's private scratch. Deriving that path only from durable identity
  keeps a display filename from steering where bytes are written, and makes each
  revision file write-once.
- Every mutation is keyed by a caller-minted identity. An exact retry returns
  the original record; reusing an identity with different content is rejected.
- History is bounded at 100 revisions. Reaching the bound refuses the write
  rather than discarding the oldest revision, which would reintroduce the loss
  these records exist to prevent.
- Deletion is a soft delete that retains revisions. Deleting a conversation
  cascades the records away, and the existing private-scratch cleanup already
  removes the bytes with the rest of the chat directory.

`current_revision_id` and `revision_count` are maintained in the same
transaction that inserts a revision, and deliberately are not a foreign key:
`output_revision` already references `output`, and closing the cycle would order
the two inserts against each other for no added safety.

## Scope

Store layer only — no tool, route, or UI change. `create_deliverable` still
writes a filename into `artifacts/`, and files already there are not adopted
into the record. Wiring the model-facing contract, the native catalog,
transcript cards, export receipts, and connected-folder write-back are separate
slices.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -D
warnings`, `cargo test --workspace`, and `cargo check --workspace --locked` all
pass with no lockfile change.

17 new tests cover the update-retains-history guarantee, exact-retry idempotency
on both create and append, identity reuse with different content, conversation
scoping, cascade on conversation delete, the revision bound, soft-delete
semantics, name and size validation, the derived path contract, and applying the
migration to a store created before it.

Closes #469

First of several slices for #417, which stays open until the rest land.
