### PR TITLE
refactor(desktop): give a conversation its own request state

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -1,27 +1,17 @@
 import { useEffect, useRef, useState } from "react";
 import {
   ApiClient,
-  type AgentRun,
   type Chat,
   type ModelInfo,
   type ModelSelectionKey,
-  type PendingFolderAccessRequest,
-  type PendingUserQuestions,
   type ProviderInfo,
   type ReasoningEffort,
   type SequencedEvent,
   type ServerInfo,
-  type UserQuestionAnswer,
 } from "./api";
 import { modelForSelection } from "./ModelSelection";
 import { resolveServerInfo } from "./boot";
-import {
-  hasMacOverlayTitlebar,
-  hasNativeHost,
-  requestUserAttention,
-  resolveFolderAccessRequest,
-  type FolderAccessDecision,
-} from "./host";
+import { hasMacOverlayTitlebar, hasNativeHost } from "./host";
 import { Logomark } from "./Logomark";
 import { useTheme } from "./theme";
 import { SettingsView } from "./SettingsView";
@@ -43,21 +33,13 @@ import {
   type ChatSessionState,
 } from "./ChatSessionReducer";
 import {
-  ActiveTurnSteerFence,
-  canBeginActiveTurnSteer,
-  shouldClearAcceptedSteerDraft,
-} from "./ActiveTurnSteer";
-import {
   loadCurrentTerminalTranscript,
   presentChatTranscript,
 } from "./ChatTranscriptPresentation";
-import { agentRunsForChat } from "./AgentActivityPanel";
 import {
-  SandboxAgentStopFence,
-  canStopSandboxAgentRun,
-  reconcileSandboxAgentCancellation,
-  sandboxAgentStopKey,
-} from "./SandboxAgentStop";
+  ConversationRequestsProvider,
+  type ConversationRequestsHandle,
+} from "./ConversationRequests";
 import { prependReplacementChat } from "./ChatDeletion";
 import { useConfirm } from "./components/ConfirmDialog";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
@@ -98,41 +80,6 @@ export default function App() {
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const busy = useChatSessionStore((session) => session.busy);
-  const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
-  const [agentRuns, setAgentRuns] = useState<AgentRun[]>([]);
-  const [agentRunsChatId, setAgentRunsChatId] = useState<string | null>(null);
-  const [agentRunsLoading, setAgentRunsLoading] = useState(false);
-  const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
-  const [stoppingSandboxRunKeys, setStoppingSandboxRunKeys] = useState<Set<string>>(
-    new Set(),
-  );
-  const [sandboxStopErrorKeys, setSandboxStopErrorKeys] = useState<Set<string>>(
-    new Set(),
-  );
-  const [folderAccessRequests, setFolderAccessRequests] = useState<
-    PendingFolderAccessRequest[]
-  >([]);
-  const [resolvingFolderCalls, setResolvingFolderCalls] = useState<Set<string>>(
-    new Set(),
-  );
-  const [folderAccessErrors, setFolderAccessErrors] = useState<
-    Record<string, string>
-  >({});
-  const [userQuestionRequests, setUserQuestionRequests] = useState<
-    PendingUserQuestions[]
-  >([]);
-  const [answeringQuestionCalls, setAnsweringQuestionCalls] = useState<
-    Set<string>
-  >(new Set());
-  const [userQuestionErrors, setUserQuestionErrors] = useState<
-    Record<string, string>
-  >({});
-  const [decidingApprovalCalls, setDecidingApprovalCalls] = useState<
-    Set<string>
-  >(new Set());
-  const [approvalErrors, setApprovalErrors] = useState<Record<string, string>>(
-    {},
-  );
   const [draft, setDraft] = useState("");
   const [addingSourceChatId, setAddingSourceChatId] = useState<string | null>(
     null,
@@ -145,15 +92,6 @@ export default function App() {
     chatId: string;
     message: string;
   } | null>(null);
-  const [cancelPendingTurnId, setCancelPendingTurnId] = useState<string | null>(
-    null,
-  );
-  const [cancelError, setCancelError] = useState<string | null>(null);
-  const [steerPendingTurnId, setSteerPendingTurnId] = useState<string | null>(
-    null,
-  );
-  const [steerError, setSteerError] = useState<string | null>(null);
-  const [steerStatus, setSteerStatus] = useState<string | null>(null);
   const skipRenameCommitRef = useRef(false);
   const [status, setStatus] = useState("starting…");
   // Owns the selected chat's event socket; chat switches dispose it eagerly
@@ -162,20 +100,19 @@ export default function App() {
   const handleEventRef = useRef<(event: SequencedEvent) => void>(() => {});
   const chatSelectionRef = useRef(0);
   const terminalHydrationGenerationRef = useRef(0);
-  const refreshFolderAccessRef = useRef<(() => void) | null>(null);
-  const refreshUserQuestionsRef = useRef<(() => void) | null>(null);
-  const refreshAgentRunsRef = useRef<(() => void) | null>(null);
-  const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
-  const answeringQuestionCallsRef = useRef<Set<string>>(new Set());
-  const seenQuestionCallIdsRef = useRef<Set<string>>(new Set());
-  const decidingApprovalCallsRef = useRef<Set<string>>(new Set());
-  const cancelRequestTurnRef = useRef<string | null>(null);
   const draftRef = useRef("");
   const selectedChatIdRef = useRef<string | null>(null);
-  const steerFenceRef = useRef(new ActiveTurnSteerFence());
-  const sandboxStopFenceRef = useRef(new SandboxAgentStopFence());
   const creationInFlightRef = useRef(false);
   const deletionInFlightRef = useRef(false);
+  // The selected conversation's in-flight requests. Mounted per chat, so the
+  // root drives it only where the root still owns the truth: the event socket
+  // reports what a turn is doing, and chat deletion ends everything at once.
+  const requestsRef = useRef<ConversationRequestsHandle | null>(null);
+  const chatSelection = useRef({
+    selection: chatSelectionRef,
+    chatId: selectedChatIdRef,
+    deleting: deletionInFlightRef,
+  }).current;
   const { confirm, dialog: confirmDialog } = useConfirm();
   const { mode: themeMode, cycle: cycleTheme, setMode: setThemeMode } = useTheme();
   const desktopUpdates = useDesktopUpdates();
@@ -196,8 +133,6 @@ export default function App() {
     return () => {
       cancelled = true;
       terminalHydrationGenerationRef.current += 1;
-      steerFenceRef.current.invalidate();
-      sandboxStopFenceRef.current.invalidate();
     };
   }, []);
 
@@ -286,51 +221,6 @@ export default function App() {
   }, [client, chat?.id]);
 
   useEffect(() => {
-    if (!client || !chat) return;
-    let cancelled = false;
-    let requestSeq = 0;
-
-    const refresh = async () => {
-      const seq = ++requestSeq;
-      try {
-        const requests = await client.listPendingUserQuestions(chat.id);
-        if (!cancelled && seq === requestSeq) {
-          const hasNewRequest = requests.some(
-            (request) => !seenQuestionCallIdsRef.current.has(request.callId),
-          );
-          seenQuestionCallIdsRef.current = new Set(
-            requests.map((request) => request.callId),
-          );
-          setUserQuestionRequests(requests);
-          if (hasNewRequest) {
-            void requestUserAttention().catch(() => {
-              // Attention is a best-effort hint. Durable polling is truth.
-            });
-          }
-        }
-      } catch (err) {
-        if (!cancelled && seq === requestSeq) {
-          console.error("failed to refresh pending user questions", err);
-        }
-      }
-    };
-
-    refreshUserQuestionsRef.current = () => void refresh();
-    void refresh();
-    const interval = window.setInterval(() => void refresh(), 10_000);
-    return () => {
-      cancelled = true;
-      requestSeq += 1;
-      window.clearInterval(interval);
-      if (refreshUserQuestionsRef.current) {
-        refreshUserQuestionsRef.current = null;
-      }
-      setUserQuestionRequests([]);
-      seenQuestionCallIdsRef.current = new Set();
-    };
-  }, [client, chat?.id]);
-
-  useEffect(() => {
     if (!client || !chat || hydratedChatId !== chat.id) return;
     const chatId = chat.id;
     const controller = new ChatSessionController({
@@ -350,152 +240,6 @@ export default function App() {
     };
   }, [client, chat?.id, hydratedChatId]);
 
-  useEffect(() => {
-    if (!client || !chat) return;
-    let cancelled = false;
-    let requestSeq = 0;
-
-    const refresh = async () => {
-      const seq = ++requestSeq;
-      try {
-        const runs = await client.listAgentRuns(chat.id);
-        if (!cancelled && seq === requestSeq) {
-          setAgentRuns(runs);
-          setAgentRunsError(null);
-        }
-      } catch (err) {
-        if (!cancelled && seq === requestSeq) {
-          setAgentRunsError(String(err));
-        }
-      } finally {
-        if (!cancelled && seq === requestSeq) {
-          setAgentRunsLoading(false);
-        }
-      }
-    };
-
-    setAgentRuns([]);
-    setAgentRunsChatId(chat.id);
-    setAgentRunsError(null);
-    setAgentRunsLoading(true);
-    refreshAgentRunsRef.current = () => void refresh();
-    void refresh();
-    return () => {
-      cancelled = true;
-      requestSeq += 1;
-      if (refreshAgentRunsRef.current) {
-        refreshAgentRunsRef.current = null;
-      }
-    };
-  }, [client, chat?.id]);
-
-  const visibleAgentRuns = agentRunsForChat(agentRunsChatId, chat?.id ?? null, agentRuns);
-  const visibleStoppingSandboxRunIds = new Set(
-    visibleAgentRuns
-      .filter((run) =>
-        stoppingSandboxRunKeys.has(sandboxAgentStopKey(chat?.id ?? "", run.id)),
-      )
-      .map((run) => run.id),
-  );
-  const visibleSandboxStopErrorRunIds = new Set(
-    visibleAgentRuns
-      .filter((run) =>
-        sandboxStopErrorKeys.has(sandboxAgentStopKey(chat?.id ?? "", run.id)),
-      )
-      .map((run) => run.id),
-  );
-  const hasActiveSandboxRun = visibleAgentRuns.some(
-    (run) =>
-      run.execution === "sandbox" &&
-      ["queued", "running", "cancelling", "waiting", "retry_wait"].includes(
-        run.status,
-      ),
-  );
-
-  useEffect(() => {
-    if (!hasActiveSandboxRun) return;
-    const interval = window.setInterval(
-      () => refreshAgentRunsRef.current?.(),
-      5_000,
-    );
-    return () => window.clearInterval(interval);
-  }, [hasActiveSandboxRun]);
-
-  async function onStopSandboxAgentRun(runId: string) {
-    if (!client || !chat || deletionInFlightRef.current) return;
-    const target = visibleAgentRuns.find((run) => run.id === runId);
-    if (!target || !canStopSandboxAgentRun(target)) return;
-
-    const chatId = chat.id;
-    const request = sandboxStopFenceRef.current.begin(chatId, runId);
-    if (!request) return;
-    const key = sandboxAgentStopKey(chatId, runId);
-    setStoppingSandboxRunKeys((current) => new Set(current).add(key));
-    setSandboxStopErrorKeys((current) => {
-      const next = new Set(current);
-      next.delete(key);
-      return next;
-    });
-
-    try {
-      const cancellation = await client.cancelAgentRun(chatId, runId);
-      if (!sandboxStopFenceRef.current.isCurrent(request, selectedChatIdRef.current)) {
-        return;
-      }
-      setAgentRuns((current) =>
-        reconcileSandboxAgentCancellation(current, cancellation),
-      );
-      refreshAgentRunsRef.current?.();
-    } catch {
-      if (!sandboxStopFenceRef.current.isCurrent(request, selectedChatIdRef.current)) {
-        return;
-      }
-      setSandboxStopErrorKeys((current) => new Set(current).add(key));
-    } finally {
-      if (sandboxStopFenceRef.current.finish(request, selectedChatIdRef.current)) {
-        setStoppingSandboxRunKeys((current) => {
-          const next = new Set(current);
-          next.delete(key);
-          return next;
-        });
-      }
-    }
-  }
-
-  useEffect(() => {
-    if (!client || !chat) return;
-    let cancelled = false;
-    let requestSeq = 0;
-
-    const refresh = async () => {
-      const seq = ++requestSeq;
-      try {
-        const requests = await client.listPendingFolderAccessRequests(chat.id);
-        if (!cancelled && seq === requestSeq) {
-          setFolderAccessRequests(requests);
-        }
-      } catch (err) {
-        if (!cancelled && seq === requestSeq) {
-          console.error("failed to refresh pending folder access", err);
-          setFolderAccessRequests([]);
-        }
-      }
-    };
-
-    refreshFolderAccessRef.current = () => void refresh();
-    void refresh();
-    const interval = window.setInterval(() => void refresh(), 10_000);
-    return () => {
-      cancelled = true;
-      requestSeq += 1;
-      window.clearInterval(interval);
-      if (refreshFolderAccessRef.current) {
-        refreshFolderAccessRef.current = null;
-      }
-      setFolderAccessRequests([]);
-    };
-  }, [client, chat?.id]);
-
   function updateSession(update: (state: ChatSessionState) => ChatSessionState) {
     useChatSessionStore.getState().update(update);
   }
@@ -511,25 +255,19 @@ export default function App() {
   function applySessionEffect(effect: ChatSessionEffect) {
     switch (effect.type) {
       case "refresh_agent_runs":
-        refreshAgentRunsRef.current?.();
+        requestsRef.current?.refreshAgentRuns();
         return;
       case "refresh_folder_access":
-        refreshFolderAccessRef.current?.();
+        requestsRef.current?.refreshFolderAccess();
         return;
       case "refresh_user_questions":
-        refreshUserQuestionsRef.current?.();
+        requestsRef.current?.refreshUserQuestions();
         return;
       case "turn_began":
-        setCancelPendingTurnId(null);
-        setCancelError(null);
-        cancelRequestTurnRef.current = null;
-        if (effect.startsDifferentTurn) clearSteerRequestState();
+        requestsRef.current?.turnBegan(effect.startsDifferentTurn);
         return;
       case "turn_resolved":
-        setCancelPendingTurnId(null);
-        setCancelError(null);
-        cancelRequestTurnRef.current = null;
-        clearSteerRequestState();
+        requestsRef.current?.turnResolved();
         return;
       case "invalidate_terminal_hydration":
         terminalHydrationGenerationRef.current += 1;
@@ -573,28 +311,12 @@ export default function App() {
       busy: false,
       activeTurnId: null,
     }));
-    setCancelPendingTurnId(null);
-    setCancelError(null);
-    cancelRequestTurnRef.current = null;
-    clearSteerRequestState();
+    requestsRef.current?.turnResolved();
   }
 
   function setComposerDraft(nextDraft: string) {
     draftRef.current = nextDraft;
     setDraft(nextDraft);
-  }
-
-  function clearSteerRequestState() {
-    steerFenceRef.current.invalidate();
-    setSteerPendingTurnId(null);
-    setSteerError(null);
-    setSteerStatus(null);
-  }
-
-  function onComposerDraftChange(nextDraft: string) {
-    setComposerDraft(nextDraft);
-    setSteerError(null);
-    setSteerStatus(null);
   }
 
   async function refreshCatalog() {
@@ -629,15 +351,14 @@ export default function App() {
         },
       ],
     }));
-    setCancelPendingTurnId(null);
-    setCancelError(null);
+    requestsRef.current?.turnSubmitted();
     try {
       await client.postMessage(chatId, turnId, content);
       if (chatSelectionRef.current !== selection) return;
       setRecentSource((current) =>
         current?.chatId === chatId ? null : current,
       );
-      refreshAgentRunsRef.current?.();
+      requestsRef.current?.refreshAgentRuns();
     } catch (err) {
       if (chatSelectionRef.current !== selection) return;
       resolveActiveTurn();
@@ -672,110 +393,6 @@ export default function App() {
     }
   }
 
-  async function onSteerActiveTurn() {
-    const admission = {
-      busy,
-      turnId: useChatSessionStore.getState().activeTurnId,
-      cancelRequestTurnId: cancelRequestTurnRef.current,
-      deletionInFlight: deletionInFlightRef.current,
-    };
-    if (
-      !client ||
-      !chat ||
-      !canBeginActiveTurnSteer(admission)
-    ) {
-      return;
-    }
-    const turnId = admission.turnId;
-
-    const request = steerFenceRef.current.begin(
-      {
-        chatId: chat.id,
-        turnId,
-        selection: chatSelectionRef.current,
-      },
-      draftRef.current,
-      () => crypto.randomUUID(),
-    );
-    if (!request) return;
-
-    setSteerPendingTurnId(turnId);
-    setSteerError(null);
-    setSteerStatus("Sending guidance…");
-    setCancelError(null);
-    try {
-      await client.steer(
-        request.chatId,
-        request.turnId,
-        request.steerId,
-        request.content,
-        true,
-      );
-      if (
-        !steerFenceRef.current.canApplyResponse(request, {
-          chatId: selectedChatIdRef.current ?? "",
-          turnId: useChatSessionStore.getState().activeTurnId ?? "",
-          selection: chatSelectionRef.current,
-        })
-      ) {
-        return;
-      }
-
-      steerFenceRef.current.finish(request);
-      setSteerPendingTurnId(null);
-      if (shouldClearAcceptedSteerDraft(request, draftRef.current)) {
-        setComposerDraft("");
-      }
-      setSteerStatus("Guidance sent");
-    } catch (err) {
-      if (
-        !steerFenceRef.current.canApplyResponse(request, {
-          chatId: selectedChatIdRef.current ?? "",
-          turnId: useChatSessionStore.getState().activeTurnId ?? "",
-          selection: chatSelectionRef.current,
-        })
-      ) {
-        return;
-      }
-
-      steerFenceRef.current.fail(request);
-      setSteerPendingTurnId(null);
-      setSteerStatus(null);
-      setSteerError(String(err));
-    }
-  }
-
-  async function onCancelActiveTurn() {
-    const turnId = activeTurnId;
-    if (
-      !client ||
-      !chat ||
-      !busy ||
-      !turnId ||
-      cancelRequestTurnRef.current === turnId
-    ) {
-      return;
-    }
-    const selection = chatSelectionRef.current;
-    const chatId = chat.id;
-
-    cancelRequestTurnRef.current = turnId;
-    setCancelPendingTurnId(turnId);
-    setCancelError(null);
-    try {
-      await client.cancel(chatId, turnId);
-    } catch (err) {
-      if (
-        chatSelectionRef.current === selection &&
-        cancelRequestTurnRef.current === turnId
-      ) {
-        cancelRequestTurnRef.current = null;
-        setCancelPendingTurnId(null);
-        setCancelError(String(err));
-      }
-    }
-  }
-
   async function onNewChat() {
     if (!client || creationInFlightRef.current || deletionInFlightRef.current) return;
     creationInFlightRef.current = true;
@@ -805,25 +422,9 @@ export default function App() {
     controllerRef.current?.dispose();
     controllerRef.current = null;
     useChatSessionStore.getState().reset();
-    setAgentRuns([]);
-    setAgentRunsError(null);
-    setFolderAccessRequests([]);
-    setFolderAccessErrors({});
-    setUserQuestionRequests([]);
-    seenQuestionCallIdsRef.current = new Set();
-    answeringQuestionCallsRef.current = new Set();
-    setAnsweringQuestionCalls(new Set());
-    setUserQuestionErrors({});
-    decidingApprovalCallsRef.current = new Set();
-    setDecidingApprovalCalls(new Set());
-    setApprovalErrors({});
     setComposerDraft("");
     setRecentSource(null);
     setSourceAttachmentError(null);
-    setCancelPendingTurnId(null);
-    setCancelError(null);
-    cancelRequestTurnRef.current = null;
-    clearSteerRequestState();
     activateChat(created);
     chatListActions.prependChat(created);
     chatListActions.setChatsError(null);
@@ -849,10 +450,7 @@ export default function App() {
       // This invalidates callbacks that captured the deleted selection. The
       // ref update also gates sends before the disabled composer renders.
       chatSelectionRef.current += 1;
-      clearSteerRequestState();
-      sandboxStopFenceRef.current.invalidate();
-      setStoppingSandboxRunKeys(new Set());
-      setSandboxStopErrorKeys(new Set());
+      requestsRef.current?.abandonForChatDeletion();
     }
     try {
       await client.deleteChat(target.id);
@@ -883,9 +481,6 @@ export default function App() {
     chatSelectionRef.current += 1;
     terminalHydrationGenerationRef.current += 1;
     selectedChatIdRef.current = next.id;
-    sandboxStopFenceRef.current.invalidate();
-    setStoppingSandboxRunKeys(new Set());
-    setSandboxStopErrorKeys(new Set());
     updateSession((session) => ({
       ...session,
       markerScrubber: new AssistantSourceMarkerStreamScrubber(),
@@ -907,25 +502,9 @@ export default function App() {
     controllerRef.current?.dispose();
     controllerRef.current = null;
     useChatSessionStore.getState().reset();
-    setAgentRuns([]);
-    setAgentRunsError(null);
-    setFolderAccessRequests([]);
-    setFolderAccessErrors({});
-    setUserQuestionRequests([]);
-    seenQuestionCallIdsRef.current = new Set();
-    answeringQuestionCallsRef.current = new Set();
-    setAnsweringQuestionCalls(new Set());
-    setUserQuestionErrors({});
-    decidingApprovalCallsRef.current = new Set();
-    setDecidingApprovalCalls(new Set());
-    setApprovalErrors({});
     setComposerDraft("");
     setRecentSource(null);
     setSourceAttachmentError(null);
-    setCancelPendingTurnId(null);
-    setCancelError(null);
-    cancelRequestTurnRef.current = null;
-    clearSteerRequestState();
     cancelChatRename();
     activateChat(next);
     setStatus(`chat ${next.id.slice(0, 8)}…`);
@@ -995,182 +574,6 @@ export default function App() {
     // after a selection change the ids differ, so this stays fence-safe.
     chatListActions.replaceChat(updated);
     void selection;
-  }
-
-  async function onApproval(
-    callId: string,
-    decision: "approve" | "reject",
-    remember = false,
-  ) {
-    if (!client || !chat) return;
-    if (decidingApprovalCallsRef.current.has(callId)) return;
-    decidingApprovalCallsRef.current.add(callId);
-    setDecidingApprovalCalls((calls) => new Set(calls).add(callId));
-    setApprovalErrors((errors) => {
-      const next = { ...errors };
-      delete next[callId];
-      return next;
-    });
-    try {
-      await client.decideApproval(chat.id, callId, decision, remember);
-      updateSession((session) => ({
-        ...session,
-        messages: session.messages.map((m) =>
-          m.role === "approval" && m.callId === callId
-            ? { ...m, resolved: true }
-            : m,
-        ),
-      }));
-    } catch (err) {
-      setApprovalErrors((errors) => ({
-        ...errors,
-        [callId]: `Could not send your decision: ${String(err)}`,
-      }));
-    } finally {
-      decidingApprovalCallsRef.current.delete(callId);
-      setDecidingApprovalCalls((calls) => {
-        const next = new Set(calls);
-        next.delete(callId);
-        return next;
-      });
-    }
-  }
-
-  async function onFolderAccessDecision(
-    callId: string,
-    decision: FolderAccessDecision,
-  ) {
-    if (!chat || !hasNativeHost()) return;
-    if (resolvingFolderCallsRef.current.size > 0) return;
-    resolvingFolderCallsRef.current.add(callId);
-    setResolvingFolderCalls((calls) => new Set(calls).add(callId));
-    setFolderAccessErrors((errors) => {
-      const next = { ...errors };
-      delete next[callId];
-      return next;
-    });
-    try {
-      await resolveFolderAccessRequest(chat.id, callId, decision);
-    } catch (err) {
-      setFolderAccessErrors((errors) => ({
-        ...errors,
-        [callId]: String(err),
-      }));
-    } finally {
-      resolvingFolderCallsRef.current.delete(callId);
-      setResolvingFolderCalls((calls) => {
-        const next = new Set(calls);
-        next.delete(callId);
-        return next;
-      });
-      refreshFolderAccessRef.current?.();
-    }
-  }
-
-  async function onFolderAccessCancel(callId: string, turnId: string) {
-    if (!client || !chat || resolvingFolderCallsRef.current.size > 0) return;
-    resolvingFolderCallsRef.current.add(callId);
-    setResolvingFolderCalls((calls) => new Set(calls).add(callId));
-    setFolderAccessErrors((errors) => {
-      const next = { ...errors };
-      delete next[callId];
-      return next;
-    });
-    try {
-      await client.cancel(chat.id, turnId);
-    } catch (err) {
-      setFolderAccessErrors((errors) => ({
-        ...errors,
-        [callId]: String(err),
-      }));
-    } finally {
-      resolvingFolderCallsRef.current.delete(callId);
-      setResolvingFolderCalls((calls) => {
-        const next = new Set(calls);
-        next.delete(callId);
-        return next;
-      });
-      refreshFolderAccessRef.current?.();
-    }
-  }
-
-  async function onAnswerUserQuestions(
-    callId: string,
-    answers: UserQuestionAnswer[],
-  ) {
-    if (!client || !chat || answeringQuestionCallsRef.current.has(callId)) {
-      return;
-    }
-    const chatId = chat.id;
-    const selection = chatSelectionRef.current;
-    answeringQuestionCallsRef.current.add(callId);
-    setAnsweringQuestionCalls((calls) => new Set(calls).add(callId));
-    setUserQuestionErrors((errors) => {
-      const next = { ...errors };
-      delete next[callId];
-      return next;
-    });
-    try {
-      await client.answerUserQuestions(chatId, callId, answers);
-    } catch (err) {
-      if (chatSelectionRef.current === selection) {
-        setUserQuestionErrors((errors) => ({
-          ...errors,
-          [callId]: `Could not send your answer: ${String(err)}`,
-        }));
-      }
-    } finally {
-      answeringQuestionCallsRef.current.delete(callId);
-      setAnsweringQuestionCalls((calls) => {
-        const next = new Set(calls);
-        next.delete(callId);
-        return next;
-      });
-      if (chatSelectionRef.current === selection) {
-        refreshUserQuestionsRef.current?.();
-      }
-    }
-  }
-
-  async function onUserQuestionsCancel(turnId: string) {
-    if (!client || !chat) return;
-    const request = userQuestionRequests.find(
-      (candidate) => candidate.turnId === turnId,
-    );
-    if (!request || answeringQuestionCallsRef.current.has(request.callId)) {
-      return;
-    }
-    const chatId = chat.id;
-    const selection = chatSelectionRef.current;
-    answeringQuestionCallsRef.current.add(request.callId);
-    setAnsweringQuestionCalls((calls) =>
-      new Set(calls).add(request.callId),
-    );
-    setUserQuestionErrors((errors) => {
-      const next = { ...errors };
-      delete next[request.callId];
-      return next;
-    });
-    try {
-      await client.cancel(chatId, turnId);
-    } catch (err) {
-      if (chatSelectionRef.current === selection) {
-        setUserQuestionErrors((errors) => ({
-          ...errors,
-          [request.callId]: `Could not cancel the turn: ${String(err)}`,
-        }));
-      }
-    } finally {
-      answeringQuestionCallsRef.current.delete(request.callId);
-      setAnsweringQuestionCalls((calls) => {
-        const next = new Set(calls);
-        next.delete(request.callId);
-        return next;
-      });
-      if (chatSelectionRef.current === selection) {
-        refreshUserQuestionsRef.current?.();
-      }
-    }
   }
 
   async function onRestartForUpdate() {
@@ -1258,108 +661,80 @@ export default function App() {
       />}
 
       <div className="main">
-        {surface.kind === "settings" ? (
-          <SettingsView
-            client={client}
-            models={models}
-            providers={providers}
-            onProvidersChanged={() => void refreshCatalog()}
-            onBack={() => uiActions.selectChatWorkspace(chat.id)}
-            themeMode={themeMode}
-            onThemeChange={setThemeMode}
-            updateState={desktopUpdates.state}
-            onCheckForUpdate={desktopUpdates.check}
-            onRestartForUpdate={onRestartForUpdate}
-          />
-        ) : (
-          <ChatWorkspace
-            chat={chat}
-            status={status}
-            nativeHost={hasNativeHost()}
-            transcript={
-              <ChatView
-                key={chat.id}
-                chat={chat}
-                hydrated={hydratedChatId === chat.id}
-                nativeHost={hasNativeHost()}
-                deletingChat={deletingChatId !== null}
-                agentRuns={visibleAgentRuns}
-                agentRunsLoading={
-                  agentRunsChatId === chat.id ? agentRunsLoading : true
-                }
-                agentRunsError={agentRunsChatId === chat.id ? agentRunsError : null}
-                stoppingRunIds={visibleStoppingSandboxRunIds}
-                stopErrorRunIds={visibleSandboxStopErrorRunIds}
-                onRetryAgentRuns={() => refreshAgentRunsRef.current?.()}
-                onStopSandboxRun={(runId) => void onStopSandboxAgentRun(runId)}
-                folderAccessRequests={folderAccessRequests}
-                userQuestionRequests={userQuestionRequests}
-                resolvingFolderCalls={resolvingFolderCalls}
-                folderAccessErrors={folderAccessErrors}
-                answeringQuestionCalls={answeringQuestionCalls}
-                userQuestionErrors={userQuestionErrors}
-                decidingApprovalCalls={decidingApprovalCalls}
-                approvalErrors={approvalErrors}
-                onApproval={(callId, decision, remember) =>
-                  void onApproval(callId, decision, remember)
-                }
-                onFolderAccessDecision={(callId, decision) =>
-                  void onFolderAccessDecision(callId, decision)
-                }
-                onFolderAccessCancel={(callId, turnId) =>
-                  void onFolderAccessCancel(callId, turnId)
-                }
-                onAnswerUserQuestions={(callId, answers) =>
-                  void onAnswerUserQuestions(callId, answers)
-                }
-                onUserQuestionsCancel={(turnId) =>
-                  void onUserQuestionsCancel(turnId)
-                }
-                draft={draft}
-                attachingSource={addingSourceChatId !== null}
-                attachedSourceName={
-                  recentSource && recentSource.chatId === chat.id
-                    ? recentSource.source.displayName
-                    : null
-                }
-                sourceAttachmentError={
-                  sourceAttachmentError && sourceAttachmentError.chatId === chat.id
-                    ? sourceAttachmentError.message
-                    : null
-                }
-                composerModelMenu={
-                  <>
-                    <ModelMenu
-                      models={models}
-                      value={chat.model}
-                      disabled={deletingChatId !== null}
-                      onChange={onModelChange}
-              />
-                    {modelForSelection(models, chat.model)?.supports_reasoning_effort && (
-                      <ReasoningEffortMenu
-                        value={chat.reasoning_effort}
+        <ConversationRequestsProvider
+          key={chat.id}
+          ref={requestsRef}
+          client={client}
+          chat={chat}
+          selection={chatSelection}
+          draftRef={draftRef}
+          onDraftAccepted={() => setComposerDraft("")}
+        >
+          {surface.kind === "settings" ? (
+            <SettingsView
+              client={client}
+              models={models}
+              providers={providers}
+              onProvidersChanged={() => void refreshCatalog()}
+              onBack={() => uiActions.selectChatWorkspace(chat.id)}
+              themeMode={themeMode}
+              onThemeChange={setThemeMode}
+              updateState={desktopUpdates.state}
+              onCheckForUpdate={desktopUpdates.check}
+              onRestartForUpdate={onRestartForUpdate}
+            />
+          ) : (
+            <ChatWorkspace
+              chat={chat}
+              status={status}
+              nativeHost={hasNativeHost()}
+              transcript={
+                <ChatView
+                  chat={chat}
+                  hydrated={hydratedChatId === chat.id}
+                  nativeHost={hasNativeHost()}
+                  deletingChat={deletingChatId !== null}
+                  draft={draft}
+                  attachingSource={addingSourceChatId !== null}
+                  attachedSourceName={
+                    recentSource && recentSource.chatId === chat.id
+                      ? recentSource.source.displayName
+                      : null
+                  }
+                  sourceAttachmentError={
+                    sourceAttachmentError &&
+                    sourceAttachmentError.chatId === chat.id
+                      ? sourceAttachmentError.message
+                      : null
+                  }
+                  composerModelMenu={
+                    <>
+                      <ModelMenu
+                        models={models}
+                        value={chat.model}
                         disabled={deletingChatId !== null}
-                        onChange={onReasoningEffortChange}
-              />
-                    )}
-                  </>
-                }
-                cancelError={cancelError}
-                cancelPendingTurnId={cancelPendingTurnId}
-                steerError={steerError}
-                steerStatus={steerStatus}
-                steerPendingTurnId={steerPendingTurnId}
-                onDraftChange={onComposerDraftChange}
-                onAddSource={onAddSource}
-                onDismissAttachedSource={() => setRecentSource(null)}
-                onSelectPrompt={setComposerDraft}
-                onSend={onSend}
-                onSteer={onSteerActiveTurn}
-                onStop={onCancelActiveTurn}
-              />
-            }
-          />
-        )}
+                        onChange={onModelChange}
+                      />
+                      {modelForSelection(models, chat.model)
+                        ?.supports_reasoning_effort && (
+                        <ReasoningEffortMenu
+                          value={chat.reasoning_effort}
+                          disabled={deletingChatId !== null}
+                          onChange={onReasoningEffortChange}
+                        />
+                      )}
+                    </>
+                  }
+                  onDraftChange={setComposerDraft}
+                  onAddSource={onAddSource}
+                  onDismissAttachedSource={() => setRecentSource(null)}
+                  onSelectPrompt={setComposerDraft}
+                  onSend={onSend}
+                />
+              }
+            />
+          )}
+        </ConversationRequestsProvider>
       </div>
       </div>
     </div>

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -4,55 +4,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Chat } from "./api";
 import { ChatView, type ChatViewProps } from "./ChatView";
 import { useChatSessionStore } from "./ChatSessionStore";
+import type { ConversationRequests } from "./ConversationRequests";
+import {
+  idleConversationRequests,
+  withConversationRequests,
+} from "./test/conversationRequests";
 
 const chat = { id: "chat-1", title: "Roadmap", project_id: null } as unknown as Chat;
 
-function renderChatView(overrides: Partial<ChatViewProps> = {}) {
+function renderChatView(
+  overrides: Partial<ChatViewProps> = {},
+  requests: ConversationRequests = idleConversationRequests(),
+) {
   const props: ChatViewProps = {
     chat,
     hydrated: true,
     nativeHost: false,
     deletingChat: false,
-    agentRuns: [],
-    agentRunsLoading: false,
-    agentRunsError: null,
-    stoppingRunIds: new Set(),
-    stopErrorRunIds: new Set(),
-    onRetryAgentRuns: vi.fn(),
-    onStopSandboxRun: vi.fn(),
-    folderAccessRequests: [],
-    userQuestionRequests: [],
-    resolvingFolderCalls: new Set(),
-    folderAccessErrors: {},
-    answeringQuestionCalls: new Set(),
-    userQuestionErrors: {},
-    decidingApprovalCalls: new Set(),
-    approvalErrors: {},
-    onApproval: vi.fn(),
-    onFolderAccessDecision: vi.fn(),
-    onFolderAccessCancel: vi.fn(),
-    onAnswerUserQuestions: vi.fn(),
-    onUserQuestionsCancel: vi.fn(),
     draft: "",
     composerModelMenu: null,
     attachingSource: false,
     attachedSourceName: null,
     sourceAttachmentError: null,
-    cancelError: null,
-    cancelPendingTurnId: null,
-    steerError: null,
-    steerStatus: null,
-    steerPendingTurnId: null,
     onDraftChange: vi.fn(),
     onAddSource: vi.fn(async () => {}),
     onDismissAttachedSource: vi.fn(),
     onSelectPrompt: vi.fn(),
     onSend: vi.fn(async () => {}),
-    onSteer: vi.fn(async () => {}),
-    onStop: vi.fn(async () => {}),
     ...overrides,
   };
-  render(<ChatView {...props} />);
+  render(withConversationRequests(<ChatView {...props} />, requests));
   return props;
 }
 

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -1,16 +1,10 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import type {
-  AgentRun,
-  Chat,
-  PendingFolderAccessRequest,
-  PendingUserQuestions,
-  UserQuestionAnswer,
-} from "./api";
+import type { Chat } from "./api";
 import { AgentActivityPanel } from "./AgentActivityPanel";
 import { followScrollBehavior, isNearBottom, scrollToLatest } from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
 import { Composer } from "./Composer";
-import type { FolderAccessDecision } from "./host";
+import { useConversationRequests } from "./ConversationRequests";
 import { MessageList } from "./MessageList";
 import { useTranscriptVisible } from "./TranscriptVisibility";
 import { ArrowDown } from "lucide-react";
@@ -20,104 +14,43 @@ export type ChatViewProps = {
   hydrated: boolean;
   nativeHost: boolean;
   deletingChat: boolean;
-  agentRuns: AgentRun[];
-  agentRunsLoading: boolean;
-  agentRunsError: string | null;
-  stoppingRunIds: Set<string>;
-  stopErrorRunIds: Set<string>;
-  onRetryAgentRuns: () => void;
-  onStopSandboxRun: (runId: string) => void;
-  folderAccessRequests: PendingFolderAccessRequest[];
-  userQuestionRequests: PendingUserQuestions[];
-  resolvingFolderCalls: Set<string>;
-  folderAccessErrors: Record<string, string>;
-  answeringQuestionCalls: Set<string>;
-  userQuestionErrors: Record<string, string>;
-  decidingApprovalCalls: Set<string>;
-  approvalErrors: Record<string, string>;
-  onApproval: (
-    callId: string,
-    decision: "approve" | "reject",
-    remember?: boolean,
-  ) => void;
-  onFolderAccessDecision: (
-    callId: string,
-    decision: FolderAccessDecision,
-  ) => void;
-  onFolderAccessCancel: (callId: string, turnId: string) => void;
-  onAnswerUserQuestions: (
-    callId: string,
-    answers: UserQuestionAnswer[],
-  ) => void;
-  onUserQuestionsCancel: (turnId: string) => void;
   draft: string;
   composerModelMenu: ReactNode;
   attachingSource: boolean;
   attachedSourceName: string | null;
   sourceAttachmentError: string | null;
-  cancelError: string | null;
-  cancelPendingTurnId: string | null;
-  steerError: string | null;
-  steerStatus: string | null;
-  steerPendingTurnId: string | null;
   onDraftChange: (value: string) => void;
   onAddSource: () => Promise<void>;
   onDismissAttachedSource: () => void;
   onSelectPrompt: (prompt: string) => void;
   onSend: () => Promise<void>;
-  onSteer: () => Promise<void>;
-  onStop: () => Promise<void>;
 };
 
 /**
  * The chat pane: agent activity, transcript, and composer, rendered as the
  * body of the chat workspace. Reads the live session (messages, busy, active
- * turn) straight from the session store.
- * Mount with `key={chat.id}` so scroll-follow state resets per conversation.
+ * turn) straight from the session store, and what the conversation is waiting
+ * on from its request context; the caller supplies only the composer's draft.
+ * The conversation-scoped provider above it carries `key={chat.id}`, which is
+ * what resets scroll-follow state per conversation.
  */
 export function ChatView({
   chat,
   hydrated,
   nativeHost,
   deletingChat,
-  agentRuns,
-  agentRunsLoading,
-  agentRunsError,
-  stoppingRunIds,
-  stopErrorRunIds,
-  onRetryAgentRuns,
-  onStopSandboxRun,
-  folderAccessRequests,
-  userQuestionRequests,
-  resolvingFolderCalls,
-  folderAccessErrors,
-  answeringQuestionCalls,
-  userQuestionErrors,
-  decidingApprovalCalls,
-  approvalErrors,
-  onApproval,
-  onFolderAccessDecision,
-  onFolderAccessCancel,
-  onAnswerUserQuestions,
-  onUserQuestionsCancel,
   draft,
   composerModelMenu,
   attachingSource,
   attachedSourceName,
   sourceAttachmentError,
-  cancelError,
-  cancelPendingTurnId,
-  steerError,
-  steerStatus,
-  steerPendingTurnId,
   onDraftChange,
   onAddSource,
   onDismissAttachedSource,
   onSelectPrompt,
   onSend,
-  onSteer,
-  onStop,
 }: ChatViewProps) {
+  const requests = useConversationRequests();
   const transcriptVisible = useTranscriptVisible();
   const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);
@@ -126,6 +59,7 @@ export function ChatView({
     (session) => session.reasoningActive,
   );
 
+  const { folderAccessRequests, userQuestionRequests } = requests;
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const followsLatestRef = useRef(true);
   const visibleContinuationCallIdsRef = useRef<Set<string>>(new Set());
@@ -165,13 +99,13 @@ export function ChatView({
   return (
     <section className="chat-pane">
       <AgentActivityPanel
-        runs={agentRuns}
-        loading={agentRunsLoading}
-        error={agentRunsError}
-        onRetry={onRetryAgentRuns}
-        stoppingRunIds={stoppingRunIds}
-        stopErrorRunIds={stopErrorRunIds}
-        onStop={onStopSandboxRun}
+        runs={requests.agentRuns}
+        loading={requests.agentRunsLoading}
+        error={requests.agentRunsError}
+        onRetry={requests.refreshAgentRuns}
+        stoppingRunIds={requests.stoppingRunIds}
+        stopErrorRunIds={requests.stopErrorRunIds}
+        onStop={requests.stopSandboxRun}
       />
 
       <div className="message-view">
@@ -180,13 +114,13 @@ export function ChatView({
           folderAccessRequests={folderAccessRequests}
           userQuestionRequests={userQuestionRequests}
           nativeHost={nativeHost}
-          nativeBusy={resolvingFolderCalls.size > 0}
-          resolvingFolderCalls={resolvingFolderCalls}
-          folderAccessErrors={folderAccessErrors}
-          answeringQuestionCalls={answeringQuestionCalls}
-          userQuestionErrors={userQuestionErrors}
-          decidingApprovalCalls={decidingApprovalCalls}
-          approvalErrors={approvalErrors}
+          nativeBusy={requests.resolvingFolderCalls.size > 0}
+          resolvingFolderCalls={requests.resolvingFolderCalls}
+          folderAccessErrors={requests.folderAccessErrors}
+          answeringQuestionCalls={requests.answeringQuestionCalls}
+          userQuestionErrors={requests.userQuestionErrors}
+          decidingApprovalCalls={requests.decidingApprovalCalls}
+          approvalErrors={requests.approvalErrors}
           busy={busy}
           reasoningActive={reasoningActive}
           scrollRef={scrollRef}
@@ -195,11 +129,11 @@ export function ChatView({
             followsLatestRef.current = followsLatest;
             if (followsLatest) setHasUnreadActivity(false);
           }}
-          onApproval={onApproval}
-          onFolderAccessDecision={onFolderAccessDecision}
-          onFolderAccessCancel={onFolderAccessCancel}
-          onAnswerUserQuestions={onAnswerUserQuestions}
-          onUserQuestionsCancel={onUserQuestionsCancel}
+          onApproval={requests.decideApproval}
+          onFolderAccessDecision={requests.decideFolderAccess}
+          onFolderAccessCancel={requests.cancelFolderAccess}
+          onAnswerUserQuestions={requests.answerUserQuestions}
+          onUserQuestionsCancel={requests.cancelUserQuestions}
           onSelectPrompt={onSelectPrompt}
           hydrated={hydrated}
         />
@@ -224,9 +158,9 @@ export function ChatView({
       <Composer
         activeTurnId={activeTurnId}
         busy={busy}
-        cancelError={cancelError}
+        cancelError={requests.cancelError}
         cancelPending={
-          activeTurnId !== null && cancelPendingTurnId === activeTurnId
+          activeTurnId !== null && requests.cancelPendingTurnId === activeTurnId
         }
         disabled={deletingChat}
         draft={draft}
@@ -237,16 +171,21 @@ export function ChatView({
         sourceAttachmentError={sourceAttachmentError}
         onAddSource={onAddSource}
         onDismissAttachedSource={onDismissAttachedSource}
-        onDraftChange={onDraftChange}
+        onDraftChange={(value) => {
+          // Typing supersedes whatever the last steer reported about a draft
+          // that no longer exists.
+          requests.clearSteerFeedback();
+          onDraftChange(value);
+        }}
         onSend={onSend}
-        onSteer={onSteer}
-        onStop={onStop}
+        onSteer={requests.steerActiveTurn}
+        onStop={requests.cancelActiveTurn}
         resetKey={chat.id}
-        steerError={steerError}
+        steerError={requests.steerError}
         steerPending={
-          activeTurnId !== null && steerPendingTurnId === activeTurnId
+          activeTurnId !== null && requests.steerPendingTurnId === activeTurnId
         }
-        steerStatus={steerStatus}
+        steerStatus={requests.steerStatus}
       />
     </section>
   );

--- a/crates/openwave-desktop/ui/src/ConversationRequests.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ConversationRequests.dom.test.tsx
@@ -1,0 +1,296 @@
+// @vitest-environment jsdom
+import { createRef } from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentRun, ApiClient, Chat, PendingUserQuestions } from "./api";
+import { useChatSessionStore } from "./ChatSessionStore";
+import {
+  ConversationRequestsProvider,
+  useConversationRequests,
+  type ChatSelectionFence,
+  type ConversationRequests,
+  type ConversationRequestsHandle,
+} from "./ConversationRequests";
+
+const chat = { id: "chat-1", title: "Roadmap" } as unknown as Chat;
+
+const question: PendingUserQuestions = {
+  callId: "call-1",
+  turnId: "turn-1",
+  questions: [{ id: "q1", question: "Which environment?", options: [] }],
+} as unknown as PendingUserQuestions;
+
+const sandboxRun: AgentRun = {
+  id: "run-1",
+  execution: "sandbox",
+  status: "running",
+  activity: null,
+} as unknown as AgentRun;
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  // Nothing observes the rejection until the component's catch runs.
+  promise.catch(() => {});
+  return { promise, resolve, reject };
+}
+
+function fakeClient(overrides: Partial<ApiClient> = {}): ApiClient {
+  return {
+    listAgentRuns: vi.fn(async () => []),
+    listPendingFolderAccessRequests: vi.fn(async () => []),
+    listPendingUserQuestions: vi.fn(async () => []),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+type Seen = { current: ConversationRequests | null };
+
+/** Renders the published values so assertions read the context, not internals. */
+function RequestsProbe({ seen }: { seen: Seen }) {
+  const requests = useConversationRequests();
+  seen.current = requests;
+  return (
+    <dl>
+      <dd data-testid="questions">
+        {requests.userQuestionRequests.map((r) => r.callId).join(",")}
+      </dd>
+      <dd data-testid="question-errors">
+        {Object.values(requests.userQuestionErrors).join(",")}
+      </dd>
+      <dd data-testid="approval-errors">
+        {Object.values(requests.approvalErrors).join(",")}
+      </dd>
+      <dd data-testid="runs">
+        {requests.agentRuns.map((run) => run.id).join(",")}
+      </dd>
+      <dd data-testid="stop-errors">
+        {[...requests.stopErrorRunIds].join(",")}
+      </dd>
+      <dd data-testid="steer-status">{requests.steerStatus ?? ""}</dd>
+      <dd data-testid="cancel-pending">{requests.cancelPendingTurnId ?? ""}</dd>
+      <button
+        type="button"
+        onClick={() => requests.answerUserQuestions("call-1", [])}
+      >
+        answer
+      </button>
+      <button type="button" onClick={() => requests.stopSandboxRun("run-1")}>
+        stop run
+      </button>
+      <button
+        type="button"
+        onClick={() => requests.decideApproval("call-1", "approve")}
+      >
+        approve
+      </button>
+      <button type="button" onClick={() => void requests.steerActiveTurn()}>
+        steer
+      </button>
+      <button type="button" onClick={() => void requests.cancelActiveTurn()}>
+        stop turn
+      </button>
+    </dl>
+  );
+}
+
+function renderRequests(client: ApiClient, draft = "") {
+  const selection: ChatSelectionFence = {
+    selection: { current: 1 },
+    chatId: { current: chat.id },
+    deleting: { current: false },
+  };
+  const handle = createRef<ConversationRequestsHandle>();
+  const seen: Seen = { current: null };
+  const tree = (open: Chat) => (
+    // Keyed by chat: the conversation's requests belong to the conversation,
+    // so selecting another one replaces them rather than resetting them.
+    <ConversationRequestsProvider
+      key={open.id}
+      client={client}
+      chat={open}
+      selection={selection}
+      draftRef={{ current: draft }}
+      onDraftAccepted={vi.fn()}
+      ref={handle}
+    >
+      <RequestsProbe seen={seen} />
+    </ConversationRequestsProvider>
+  );
+  const { rerender } = render(tree(chat));
+  const selectChat = (next: Chat) => {
+    selection.selection.current += 1;
+    selection.chatId.current = next.id;
+    rerender(tree(next));
+  };
+  return { selection, handle, seen, selectChat };
+}
+
+function beginTurn(turnId: string) {
+  act(() => {
+    useChatSessionStore.getState().update((session) => ({
+      ...session,
+      busy: true,
+      activeTurnId: turnId,
+    }));
+  });
+}
+
+/** Lets the mount-time polls settle so assertions see their first result. */
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  useChatSessionStore.getState().reset();
+});
+afterEach(cleanup);
+
+describe("ConversationRequestsProvider", () => {
+  it("publishes what the conversation is waiting on", async () => {
+    renderRequests(
+      fakeClient({
+        listPendingUserQuestions: vi.fn(async () => [question]),
+        listAgentRuns: vi.fn(async () => [sandboxRun]),
+      }),
+    );
+    await settle();
+
+    expect(screen.getByTestId("questions")).toHaveTextContent("call-1");
+    expect(screen.getByTestId("runs")).toHaveTextContent("run-1");
+  });
+
+  it("discards a failed answer once the selection has moved on", async () => {
+    const answer = deferred<void>();
+    const { selection } = renderRequests(
+      fakeClient({
+        listPendingUserQuestions: vi.fn(async () => [question]),
+        answerUserQuestions: vi.fn(() => answer.promise),
+      }),
+    );
+    await settle();
+
+    act(() => screen.getByText("answer").click());
+    // The user selects another chat while the answer is still in flight.
+    selection.selection.current += 1;
+    await act(async () => {
+      answer.reject(new Error("gone"));
+      await answer.promise.catch(() => {});
+    });
+
+    expect(screen.getByTestId("question-errors")).toHaveTextContent("");
+  });
+
+  it("drops an in-flight sandbox stop when the chat is being deleted", async () => {
+    const stop = deferred<never>();
+    const { handle } = renderRequests(
+      fakeClient({
+        listAgentRuns: vi.fn(async () => [sandboxRun]),
+        cancelAgentRun: vi.fn(() => stop.promise),
+      }),
+    );
+    await settle();
+
+    act(() => screen.getByText("stop run").click());
+    act(() => handle.current?.abandonForChatDeletion());
+    await act(async () => {
+      stop.reject(new Error("gone"));
+      await stop.promise.catch(() => {});
+    });
+
+    expect(screen.getByTestId("stop-errors")).toHaveTextContent("");
+  });
+
+  it("clears steer and cancel state once the turn resolves", async () => {
+    const steer = deferred<void>();
+    const { handle } = renderRequests(
+      fakeClient({
+        steer: vi.fn(() => steer.promise),
+        cancel: vi.fn(async () => {}),
+      }),
+      "try the other branch",
+    );
+    await settle();
+    beginTurn("turn-1");
+
+    act(() => screen.getByText("steer").click());
+    await act(async () => {
+      steer.resolve();
+      await steer.promise;
+    });
+    act(() => screen.getByText("stop turn").click());
+
+    expect(screen.getByTestId("steer-status")).toHaveTextContent(
+      "Guidance sent",
+    );
+    expect(screen.getByTestId("cancel-pending")).toHaveTextContent("turn-1");
+
+    act(() => handle.current?.turnResolved());
+
+    expect(screen.getByTestId("steer-status")).toHaveTextContent("");
+    expect(screen.getByTestId("cancel-pending")).toHaveTextContent("");
+  });
+
+  it("discards a decision that lands after another chat is selected", async () => {
+    const decision = deferred<void>();
+    const { selectChat } = renderRequests(
+      fakeClient({ decideApproval: vi.fn(() => decision.promise) }),
+    );
+    await settle();
+
+    act(() => screen.getByText("approve").click());
+    act(() => selectChat({ ...chat, id: "chat-2" } as Chat));
+    await act(async () => {
+      decision.reject(new Error("gone"));
+      await decision.promise.catch(() => {});
+    });
+    await settle();
+
+    expect(screen.getByTestId("approval-errors")).toHaveTextContent("");
+  });
+
+  it("settles a steer only once the guidance has been accepted", async () => {
+    // The composer awaits this to decide where focus belongs afterwards, so
+    // resolving on submit would restore focus while the request is still open.
+    const steer = deferred<void>();
+    const { seen } = renderRequests(
+      fakeClient({ steer: vi.fn(() => steer.promise) }),
+      "try the other branch",
+    );
+    await settle();
+    beginTurn("turn-1");
+
+    let settled = false;
+    let sending!: Promise<void>;
+    act(() => {
+      sending = seen.current!.steerActiveTurn().then(() => {
+        settled = true;
+      });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(settled).toBe(false);
+
+    await act(async () => {
+      steer.resolve();
+      await sending;
+    });
+
+    expect(settled).toBe(true);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ConversationRequests.tsx
+++ b/crates/openwave-desktop/ui/src/ConversationRequests.tsx
@@ -1,0 +1,771 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type ReactNode,
+  type Ref,
+  type RefObject,
+} from "react";
+import type {
+  AgentRun,
+  ApiClient,
+  Chat,
+  PendingFolderAccessRequest,
+  PendingUserQuestions,
+  UserQuestionAnswer,
+} from "./api";
+import {
+  ActiveTurnSteerFence,
+  canBeginActiveTurnSteer,
+  shouldClearAcceptedSteerDraft,
+} from "./ActiveTurnSteer";
+import { agentRunsForChat } from "./AgentActivityPanel";
+import { useChatSessionStore } from "./ChatSessionStore";
+import {
+  SandboxAgentStopFence,
+  canStopSandboxAgentRun,
+  reconcileSandboxAgentCancellation,
+  sandboxAgentStopKey,
+} from "./SandboxAgentStop";
+import {
+  hasNativeHost,
+  requestUserAttention,
+  resolveFolderAccessRequest,
+  type FolderAccessDecision,
+} from "./host";
+
+/**
+ * What the root knows about chat selection, read by requests that are already
+ * in flight to decide whether their response still applies. The provider is
+ * mounted per conversation, so a response that outlives its chat usually lands
+ * on an unmounted instance — but a chat is deleted while its own conversation
+ * is still on screen, and that case needs the counters.
+ */
+export type ChatSelectionFence = {
+  /** Bumped whenever the selected chat changes, including on deletion. */
+  selection: RefObject<number>;
+  chatId: RefObject<string | null>;
+  deleting: RefObject<boolean>;
+};
+
+/** Everything one conversation is currently waiting on, and how to answer it. */
+export type ConversationRequests = {
+  agentRuns: AgentRun[];
+  agentRunsLoading: boolean;
+  agentRunsError: string | null;
+  stoppingRunIds: Set<string>;
+  stopErrorRunIds: Set<string>;
+  refreshAgentRuns: () => void;
+  stopSandboxRun: (runId: string) => void;
+
+  folderAccessRequests: PendingFolderAccessRequest[];
+  resolvingFolderCalls: Set<string>;
+  folderAccessErrors: Record<string, string>;
+  decideFolderAccess: (callId: string, decision: FolderAccessDecision) => void;
+  cancelFolderAccess: (callId: string, turnId: string) => void;
+
+  userQuestionRequests: PendingUserQuestions[];
+  answeringQuestionCalls: Set<string>;
+  userQuestionErrors: Record<string, string>;
+  answerUserQuestions: (callId: string, answers: UserQuestionAnswer[]) => void;
+  cancelUserQuestions: (turnId: string) => void;
+
+  decidingApprovalCalls: Set<string>;
+  approvalErrors: Record<string, string>;
+  decideApproval: (
+    callId: string,
+    decision: "approve" | "reject",
+    remember?: boolean,
+  ) => void;
+
+  cancelPendingTurnId: string | null;
+  cancelError: string | null;
+  cancelActiveTurn: () => Promise<void>;
+
+  steerPendingTurnId: string | null;
+  steerError: string | null;
+  steerStatus: string | null;
+  /** Settles when the guidance has been accepted or rejected, not on submit;
+   *  the composer waits on it to decide where focus belongs afterwards. */
+  steerActiveTurn: () => Promise<void>;
+  /** Typing withdraws the last steer's outcome; the draft it described is gone. */
+  clearSteerFeedback: () => void;
+};
+
+/**
+ * How the root drives this state from the parts of the chat it still owns: the
+ * event socket, which reports what the turn is doing, and chat deletion.
+ */
+export type ConversationRequestsHandle = {
+  refreshAgentRuns: () => void;
+  refreshFolderAccess: () => void;
+  refreshUserQuestions: () => void;
+  /** A turn started. A steer aimed at a turn that has been replaced is stale. */
+  turnBegan: (startsDifferentTurn: boolean) => void;
+  /** A turn ended, here or on the server. Nothing about it is still pending. */
+  turnResolved: () => void;
+  /** A turn was just submitted from this client; only cancel feedback is stale. */
+  turnSubmitted: () => void;
+  /** This conversation's chat is going away. Nothing in flight may land. */
+  abandonForChatDeletion: () => void;
+};
+
+export type ConversationRequestsProviderProps = {
+  client: ApiClient;
+  chat: Chat;
+  selection: ChatSelectionFence;
+  /** The live composer draft, which is what a steer sends. */
+  draftRef: RefObject<string>;
+  /** Called when an accepted steer consumed the draft it was sent from. */
+  onDraftAccepted: () => void;
+  ref?: Ref<ConversationRequestsHandle>;
+  children: ReactNode;
+};
+
+const ConversationRequestsContext = createContext<ConversationRequests | null>(
+  null,
+);
+
+/**
+ * Publishes a conversation's requests to the surfaces that render them, for a
+ * caller that already holds the value. `ConversationRequestsProvider` is what
+ * produces one from a live chat.
+ */
+export const ConversationRequestsScope = ConversationRequestsContext.Provider;
+
+export function useConversationRequests(): ConversationRequests {
+  const requests = useContext(ConversationRequestsContext);
+  if (!requests) {
+    throw new Error(
+      "useConversationRequests must be used inside a ConversationRequestsProvider",
+    );
+  }
+  return requests;
+}
+
+/**
+ * Owns what one conversation has in flight: its agent runs, the approvals and
+ * folder-access and question prompts it is parked on, and the steer and cancel
+ * controls for its active turn.
+ *
+ * Mount with `key={chat.id}`. The state here is the conversation's, so a new
+ * conversation gets a new instance rather than a reset — which is also what
+ * makes a response that arrives after the switch land on nothing.
+ */
+export function ConversationRequestsProvider({
+  client,
+  chat,
+  selection,
+  draftRef,
+  onDraftAccepted,
+  ref,
+  children,
+}: ConversationRequestsProviderProps) {
+  const busy = useChatSessionStore((session) => session.busy);
+  const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
+
+  const [agentRuns, setAgentRuns] = useState<AgentRun[]>([]);
+  const [agentRunsChatId, setAgentRunsChatId] = useState<string | null>(null);
+  const [agentRunsLoading, setAgentRunsLoading] = useState(false);
+  const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
+  const [stoppingSandboxRunKeys, setStoppingSandboxRunKeys] = useState<
+    Set<string>
+  >(new Set());
+  const [sandboxStopErrorKeys, setSandboxStopErrorKeys] = useState<Set<string>>(
+    new Set(),
+  );
+  const [folderAccessRequests, setFolderAccessRequests] = useState<
+    PendingFolderAccessRequest[]
+  >([]);
+  const [resolvingFolderCalls, setResolvingFolderCalls] = useState<Set<string>>(
+    new Set(),
+  );
+  const [folderAccessErrors, setFolderAccessErrors] = useState<
+    Record<string, string>
+  >({});
+  const [userQuestionRequests, setUserQuestionRequests] = useState<
+    PendingUserQuestions[]
+  >([]);
+  const [answeringQuestionCalls, setAnsweringQuestionCalls] = useState<
+    Set<string>
+  >(new Set());
+  const [userQuestionErrors, setUserQuestionErrors] = useState<
+    Record<string, string>
+  >({});
+  const [decidingApprovalCalls, setDecidingApprovalCalls] = useState<
+    Set<string>
+  >(new Set());
+  const [approvalErrors, setApprovalErrors] = useState<Record<string, string>>(
+    {},
+  );
+  const [cancelPendingTurnId, setCancelPendingTurnId] = useState<string | null>(
+    null,
+  );
+  const [cancelError, setCancelError] = useState<string | null>(null);
+  const [steerPendingTurnId, setSteerPendingTurnId] = useState<string | null>(
+    null,
+  );
+  const [steerError, setSteerError] = useState<string | null>(null);
+  const [steerStatus, setSteerStatus] = useState<string | null>(null);
+
+  const refreshFolderAccessRef = useRef<(() => void) | null>(null);
+  const refreshUserQuestionsRef = useRef<(() => void) | null>(null);
+  const refreshAgentRunsRef = useRef<(() => void) | null>(null);
+  const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
+  const answeringQuestionCallsRef = useRef<Set<string>>(new Set());
+  const seenQuestionCallIdsRef = useRef<Set<string>>(new Set());
+  const decidingApprovalCallsRef = useRef<Set<string>>(new Set());
+  const cancelRequestTurnRef = useRef<string | null>(null);
+  const steerFenceRef = useRef(new ActiveTurnSteerFence());
+  const sandboxStopFenceRef = useRef(new SandboxAgentStopFence());
+
+  useEffect(() => {
+    const steerFence = steerFenceRef.current;
+    const sandboxStopFence = sandboxStopFenceRef.current;
+    return () => {
+      steerFence.invalidate();
+      sandboxStopFence.invalidate();
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let requestSeq = 0;
+
+    const refresh = async () => {
+      const seq = ++requestSeq;
+      try {
+        const requests = await client.listPendingUserQuestions(chat.id);
+        if (!cancelled && seq === requestSeq) {
+          const hasNewRequest = requests.some(
+            (request) => !seenQuestionCallIdsRef.current.has(request.callId),
+          );
+          seenQuestionCallIdsRef.current = new Set(
+            requests.map((request) => request.callId),
+          );
+          setUserQuestionRequests(requests);
+          if (hasNewRequest) {
+            void requestUserAttention().catch(() => {
+              // Attention is a best-effort hint. Durable polling is truth.
+            });
+          }
+        }
+      } catch (err) {
+        if (!cancelled && seq === requestSeq) {
+          console.error("failed to refresh pending user questions", err);
+        }
+      }
+    };
+
+    refreshUserQuestionsRef.current = () => void refresh();
+    void refresh();
+    const interval = window.setInterval(() => void refresh(), 10_000);
+    return () => {
+      cancelled = true;
+      requestSeq += 1;
+      window.clearInterval(interval);
+      if (refreshUserQuestionsRef.current) {
+        refreshUserQuestionsRef.current = null;
+      }
+      setUserQuestionRequests([]);
+      seenQuestionCallIdsRef.current = new Set();
+    };
+  }, [client, chat.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let requestSeq = 0;
+
+    const refresh = async () => {
+      const seq = ++requestSeq;
+      try {
+        const runs = await client.listAgentRuns(chat.id);
+        if (!cancelled && seq === requestSeq) {
+          setAgentRuns(runs);
+          setAgentRunsError(null);
+        }
+      } catch (err) {
+        if (!cancelled && seq === requestSeq) {
+          setAgentRunsError(String(err));
+        }
+      } finally {
+        if (!cancelled && seq === requestSeq) {
+          setAgentRunsLoading(false);
+        }
+      }
+    };
+
+    setAgentRuns([]);
+    setAgentRunsChatId(chat.id);
+    setAgentRunsError(null);
+    setAgentRunsLoading(true);
+    refreshAgentRunsRef.current = () => void refresh();
+    void refresh();
+    return () => {
+      cancelled = true;
+      requestSeq += 1;
+      if (refreshAgentRunsRef.current) {
+        refreshAgentRunsRef.current = null;
+      }
+    };
+  }, [client, chat.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let requestSeq = 0;
+
+    const refresh = async () => {
+      const seq = ++requestSeq;
+      try {
+        const requests = await client.listPendingFolderAccessRequests(chat.id);
+        if (!cancelled && seq === requestSeq) {
+          setFolderAccessRequests(requests);
+        }
+      } catch (err) {
+        if (!cancelled && seq === requestSeq) {
+          console.error("failed to refresh pending folder access", err);
+          setFolderAccessRequests([]);
+        }
+      }
+    };
+
+    refreshFolderAccessRef.current = () => void refresh();
+    void refresh();
+    const interval = window.setInterval(() => void refresh(), 10_000);
+    return () => {
+      cancelled = true;
+      requestSeq += 1;
+      window.clearInterval(interval);
+      if (refreshFolderAccessRef.current) {
+        refreshFolderAccessRef.current = null;
+      }
+      setFolderAccessRequests([]);
+    };
+  }, [client, chat.id]);
+
+  const visibleAgentRuns = agentRunsForChat(
+    agentRunsChatId,
+    chat.id,
+    agentRuns,
+  );
+  const stoppingRunIds = new Set(
+    visibleAgentRuns
+      .filter((run) =>
+        stoppingSandboxRunKeys.has(sandboxAgentStopKey(chat.id, run.id)),
+      )
+      .map((run) => run.id),
+  );
+  const stopErrorRunIds = new Set(
+    visibleAgentRuns
+      .filter((run) =>
+        sandboxStopErrorKeys.has(sandboxAgentStopKey(chat.id, run.id)),
+      )
+      .map((run) => run.id),
+  );
+  const hasActiveSandboxRun = visibleAgentRuns.some(
+    (run) =>
+      run.execution === "sandbox" &&
+      ["queued", "running", "cancelling", "waiting", "retry_wait"].includes(
+        run.status,
+      ),
+  );
+
+  useEffect(() => {
+    if (!hasActiveSandboxRun) return;
+    const interval = window.setInterval(
+      () => refreshAgentRunsRef.current?.(),
+      5_000,
+    );
+    return () => window.clearInterval(interval);
+  }, [hasActiveSandboxRun]);
+
+  function clearSteerRequestState() {
+    steerFenceRef.current.invalidate();
+    setSteerPendingTurnId(null);
+    setSteerError(null);
+    setSteerStatus(null);
+  }
+
+  function clearCancelRequestState() {
+    setCancelPendingTurnId(null);
+    setCancelError(null);
+    cancelRequestTurnRef.current = null;
+  }
+
+  async function stopSandboxRun(runId: string) {
+    if (selection.deleting.current) return;
+    const target = visibleAgentRuns.find((run) => run.id === runId);
+    if (!target || !canStopSandboxAgentRun(target)) return;
+
+    const chatId = chat.id;
+    const request = sandboxStopFenceRef.current.begin(chatId, runId);
+    if (!request) return;
+    const key = sandboxAgentStopKey(chatId, runId);
+    setStoppingSandboxRunKeys((current) => new Set(current).add(key));
+    setSandboxStopErrorKeys((current) => {
+      const next = new Set(current);
+      next.delete(key);
+      return next;
+    });
+
+    try {
+      const cancellation = await client.cancelAgentRun(chatId, runId);
+      if (!sandboxStopFenceRef.current.isCurrent(request, selection.chatId.current)) {
+        return;
+      }
+      setAgentRuns((current) =>
+        reconcileSandboxAgentCancellation(current, cancellation),
+      );
+      refreshAgentRunsRef.current?.();
+    } catch {
+      if (!sandboxStopFenceRef.current.isCurrent(request, selection.chatId.current)) {
+        return;
+      }
+      setSandboxStopErrorKeys((current) => new Set(current).add(key));
+    } finally {
+      if (sandboxStopFenceRef.current.finish(request, selection.chatId.current)) {
+        setStoppingSandboxRunKeys((current) => {
+          const next = new Set(current);
+          next.delete(key);
+          return next;
+        });
+      }
+    }
+  }
+
+  async function decideApproval(
+    callId: string,
+    decision: "approve" | "reject",
+    remember = false,
+  ) {
+    if (decidingApprovalCallsRef.current.has(callId)) return;
+    decidingApprovalCallsRef.current.add(callId);
+    setDecidingApprovalCalls((calls) => new Set(calls).add(callId));
+    setApprovalErrors((errors) => {
+      const next = { ...errors };
+      delete next[callId];
+      return next;
+    });
+    try {
+      await client.decideApproval(chat.id, callId, decision, remember);
+      useChatSessionStore.getState().update((session) => ({
+        ...session,
+        messages: session.messages.map((m) =>
+          m.role === "approval" && m.callId === callId
+            ? { ...m, resolved: true }
+            : m,
+        ),
+      }));
+    } catch (err) {
+      setApprovalErrors((errors) => ({
+        ...errors,
+        [callId]: `Could not send your decision: ${String(err)}`,
+      }));
+    } finally {
+      decidingApprovalCallsRef.current.delete(callId);
+      setDecidingApprovalCalls((calls) => {
+        const next = new Set(calls);
+        next.delete(callId);
+        return next;
+      });
+    }
+  }
+
+  async function decideFolderAccess(
+    callId: string,
+    decision: FolderAccessDecision,
+  ) {
+    if (!hasNativeHost()) return;
+    if (resolvingFolderCallsRef.current.size > 0) return;
+    resolvingFolderCallsRef.current.add(callId);
+    setResolvingFolderCalls((calls) => new Set(calls).add(callId));
+    setFolderAccessErrors((errors) => {
+      const next = { ...errors };
+      delete next[callId];
+      return next;
+    });
+    try {
+      await resolveFolderAccessRequest(chat.id, callId, decision);
+    } catch (err) {
+      setFolderAccessErrors((errors) => ({
+        ...errors,
+        [callId]: String(err),
+      }));
+    } finally {
+      resolvingFolderCallsRef.current.delete(callId);
+      setResolvingFolderCalls((calls) => {
+        const next = new Set(calls);
+        next.delete(callId);
+        return next;
+      });
+      refreshFolderAccessRef.current?.();
+    }
+  }
+
+  async function cancelFolderAccess(callId: string, turnId: string) {
+    if (resolvingFolderCallsRef.current.size > 0) return;
+    resolvingFolderCallsRef.current.add(callId);
+    setResolvingFolderCalls((calls) => new Set(calls).add(callId));
+    setFolderAccessErrors((errors) => {
+      const next = { ...errors };
+      delete next[callId];
+      return next;
+    });
+    try {
+      await client.cancel(chat.id, turnId);
+    } catch (err) {
+      setFolderAccessErrors((errors) => ({
+        ...errors,
+        [callId]: String(err),
+      }));
+    } finally {
+      resolvingFolderCallsRef.current.delete(callId);
+      setResolvingFolderCalls((calls) => {
+        const next = new Set(calls);
+        next.delete(callId);
+        return next;
+      });
+      refreshFolderAccessRef.current?.();
+    }
+  }
+
+  async function answerUserQuestions(
+    callId: string,
+    answers: UserQuestionAnswer[],
+  ) {
+    if (answeringQuestionCallsRef.current.has(callId)) return;
+    const chatId = chat.id;
+    const selected = selection.selection.current;
+    answeringQuestionCallsRef.current.add(callId);
+    setAnsweringQuestionCalls((calls) => new Set(calls).add(callId));
+    setUserQuestionErrors((errors) => {
+      const next = { ...errors };
+      delete next[callId];
+      return next;
+    });
+    try {
+      await client.answerUserQuestions(chatId, callId, answers);
+    } catch (err) {
+      if (selection.selection.current === selected) {
+        setUserQuestionErrors((errors) => ({
+          ...errors,
+          [callId]: `Could not send your answer: ${String(err)}`,
+        }));
+      }
+    } finally {
+      answeringQuestionCallsRef.current.delete(callId);
+      setAnsweringQuestionCalls((calls) => {
+        const next = new Set(calls);
+        next.delete(callId);
+        return next;
+      });
+      if (selection.selection.current === selected) {
+        refreshUserQuestionsRef.current?.();
+      }
+    }
+  }
+
+  async function cancelUserQuestions(turnId: string) {
+    const request = userQuestionRequests.find(
+      (candidate) => candidate.turnId === turnId,
+    );
+    if (!request || answeringQuestionCallsRef.current.has(request.callId)) {
+      return;
+    }
+    const chatId = chat.id;
+    const selected = selection.selection.current;
+    answeringQuestionCallsRef.current.add(request.callId);
+    setAnsweringQuestionCalls((calls) => new Set(calls).add(request.callId));
+    setUserQuestionErrors((errors) => {
+      const next = { ...errors };
+      delete next[request.callId];
+      return next;
+    });
+    try {
+      await client.cancel(chatId, turnId);
+    } catch (err) {
+      if (selection.selection.current === selected) {
+        setUserQuestionErrors((errors) => ({
+          ...errors,
+          [request.callId]: `Could not cancel the turn: ${String(err)}`,
+        }));
+      }
+    } finally {
+      answeringQuestionCallsRef.current.delete(request.callId);
+      setAnsweringQuestionCalls((calls) => {
+        const next = new Set(calls);
+        next.delete(request.callId);
+        return next;
+      });
+      if (selection.selection.current === selected) {
+        refreshUserQuestionsRef.current?.();
+      }
+    }
+  }
+
+  async function steerActiveTurn() {
+    const admission = {
+      busy,
+      turnId: useChatSessionStore.getState().activeTurnId,
+      cancelRequestTurnId: cancelRequestTurnRef.current,
+      deletionInFlight: selection.deleting.current,
+    };
+    if (!canBeginActiveTurnSteer(admission)) return;
+    const turnId = admission.turnId;
+
+    const request = steerFenceRef.current.begin(
+      {
+        chatId: chat.id,
+        turnId,
+        selection: selection.selection.current,
+      },
+      draftRef.current,
+      () => crypto.randomUUID(),
+    );
+    if (!request) return;
+
+    setSteerPendingTurnId(turnId);
+    setSteerError(null);
+    setSteerStatus("Sending guidance…");
+    setCancelError(null);
+    try {
+      await client.steer(
+        request.chatId,
+        request.turnId,
+        request.steerId,
+        request.content,
+        true,
+      );
+      if (!steerFenceRef.current.canApplyResponse(request, currentSteerTarget())) {
+        return;
+      }
+
+      steerFenceRef.current.finish(request);
+      setSteerPendingTurnId(null);
+      if (shouldClearAcceptedSteerDraft(request, draftRef.current)) {
+        onDraftAccepted();
+      }
+      setSteerStatus("Guidance sent");
+    } catch (err) {
+      if (!steerFenceRef.current.canApplyResponse(request, currentSteerTarget())) {
+        return;
+      }
+
+      steerFenceRef.current.fail(request);
+      setSteerPendingTurnId(null);
+      setSteerStatus(null);
+      setSteerError(String(err));
+    }
+  }
+
+  function currentSteerTarget() {
+    return {
+      chatId: selection.chatId.current ?? "",
+      turnId: useChatSessionStore.getState().activeTurnId ?? "",
+      selection: selection.selection.current,
+    };
+  }
+
+  async function cancelActiveTurn() {
+    const turnId = activeTurnId;
+    if (!busy || !turnId || cancelRequestTurnRef.current === turnId) return;
+    const selected = selection.selection.current;
+    const chatId = chat.id;
+
+    cancelRequestTurnRef.current = turnId;
+    setCancelPendingTurnId(turnId);
+    setCancelError(null);
+    try {
+      await client.cancel(chatId, turnId);
+    } catch (err) {
+      if (
+        selection.selection.current === selected &&
+        cancelRequestTurnRef.current === turnId
+      ) {
+        cancelRequestTurnRef.current = null;
+        setCancelPendingTurnId(null);
+        setCancelError(String(err));
+      }
+    }
+  }
+
+  useImperativeHandle(
+    ref,
+    (): ConversationRequestsHandle => ({
+      refreshAgentRuns: () => refreshAgentRunsRef.current?.(),
+      refreshFolderAccess: () => refreshFolderAccessRef.current?.(),
+      refreshUserQuestions: () => refreshUserQuestionsRef.current?.(),
+      turnBegan: (startsDifferentTurn) => {
+        clearCancelRequestState();
+        if (startsDifferentTurn) clearSteerRequestState();
+      },
+      turnResolved: () => {
+        clearCancelRequestState();
+        clearSteerRequestState();
+      },
+      turnSubmitted: () => {
+        setCancelPendingTurnId(null);
+        setCancelError(null);
+      },
+      abandonForChatDeletion: () => {
+        clearSteerRequestState();
+        sandboxStopFenceRef.current.invalidate();
+        setStoppingSandboxRunKeys(new Set());
+        setSandboxStopErrorKeys(new Set());
+      },
+    }),
+    [],
+  );
+
+  const requests: ConversationRequests = {
+    agentRuns: visibleAgentRuns,
+    agentRunsLoading: agentRunsChatId === chat.id ? agentRunsLoading : true,
+    agentRunsError: agentRunsChatId === chat.id ? agentRunsError : null,
+    stoppingRunIds,
+    stopErrorRunIds,
+    refreshAgentRuns: () => refreshAgentRunsRef.current?.(),
+    stopSandboxRun: (runId) => void stopSandboxRun(runId),
+
+    folderAccessRequests,
+    resolvingFolderCalls,
+    folderAccessErrors,
+    decideFolderAccess: (callId, decision) =>
+      void decideFolderAccess(callId, decision),
+    cancelFolderAccess: (callId, turnId) =>
+      void cancelFolderAccess(callId, turnId),
+
+    userQuestionRequests,
+    answeringQuestionCalls,
+    userQuestionErrors,
+    answerUserQuestions: (callId, answers) =>
+      void answerUserQuestions(callId, answers),
+    cancelUserQuestions: (turnId) => void cancelUserQuestions(turnId),
+
+    decidingApprovalCalls,
+    approvalErrors,
+    decideApproval: (callId, decision, remember) =>
+      void decideApproval(callId, decision, remember),
+
+    cancelPendingTurnId,
+    cancelError,
+    cancelActiveTurn,
+
+    steerPendingTurnId,
+    steerError,
+    steerStatus,
+    steerActiveTurn,
+    clearSteerFeedback: () => {
+      setSteerError(null);
+      setSteerStatus(null);
+    },
+  };
+
+  return (
+    <ConversationRequestsContext.Provider value={requests}>
+      {children}
+    </ConversationRequestsContext.Provider>
+  );
+}

--- a/crates/openwave-desktop/ui/src/test/conversationRequests.tsx
+++ b/crates/openwave-desktop/ui/src/test/conversationRequests.tsx
@@ -1,0 +1,59 @@
+import { vi } from "vitest";
+import type { ReactNode } from "react";
+import {
+  ConversationRequestsScope,
+  type ConversationRequests,
+} from "../ConversationRequests";
+
+/** A conversation with nothing in flight, for surfaces under test. */
+export function idleConversationRequests(
+  overrides: Partial<ConversationRequests> = {},
+): ConversationRequests {
+  return {
+    agentRuns: [],
+    agentRunsLoading: false,
+    agentRunsError: null,
+    stoppingRunIds: new Set(),
+    stopErrorRunIds: new Set(),
+    refreshAgentRuns: vi.fn(),
+    stopSandboxRun: vi.fn(),
+
+    folderAccessRequests: [],
+    resolvingFolderCalls: new Set(),
+    folderAccessErrors: {},
+    decideFolderAccess: vi.fn(),
+    cancelFolderAccess: vi.fn(),
+
+    userQuestionRequests: [],
+    answeringQuestionCalls: new Set(),
+    userQuestionErrors: {},
+    answerUserQuestions: vi.fn(),
+    cancelUserQuestions: vi.fn(),
+
+    decidingApprovalCalls: new Set(),
+    approvalErrors: {},
+    decideApproval: vi.fn(),
+
+    cancelPendingTurnId: null,
+    cancelError: null,
+    cancelActiveTurn: vi.fn(async () => {}),
+
+    steerPendingTurnId: null,
+    steerError: null,
+    steerStatus: null,
+    steerActiveTurn: vi.fn(async () => {}),
+    clearSteerFeedback: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function withConversationRequests(
+  children: ReactNode,
+  requests: ConversationRequests = idleConversationRequests(),
+) {
+  return (
+    <ConversationRequestsScope value={requests}>
+      {children}
+    </ConversationRequestsScope>
+  );
+}


### PR DESCRIPTION
Selecting Sources or Outputs, cancelling a turn, and answering an approval all
read the same conversation state, and all of it lived in the root component.
`App.tsx` owned the polling for agent runs, folder access, and user questions,
the fences that keep a stale response off a newly selected chat, and the steer
and cancel controls — then handed roughly thirty props down to the chat surface,
most of which it only forwarded.

That is why every chat-scoped surface has had to be wired through the top of the
tree, and why two surfaces reading the same conversation both had to receive it
from the root.

## What changed

A `ConversationRequestsProvider` now owns what one conversation has in flight,
and the surfaces that render it read the context directly. It is mounted with
`key={chat.id}`: the state belongs to the conversation, so selecting another one
replaces it rather than resetting it field by field — which is also what makes a
response that arrives after the switch land on nothing.

The root keeps what it genuinely owns — boot, the client, the event socket, and
chat selection — and drives the rest through a small handle: the three refreshes
a stream event can ask for, what a turn beginning or resolving means for the
cancel and steer controls, and the one case where a chat is deleted while its own
conversation is still on screen and the fences have to be invalidated in place.

The fences move with the state they guard rather than changing. `ChatView` drops
from forty props to fourteen; `App.tsx` from 1376 lines to 751. `MessageList`
stays prop-driven — it is a leaf renderer, and keeping it that way is what its
suites test.

## Worth knowing

- The steer control now returns a promise that settles when the guidance is
  accepted or rejected, not when it is submitted. The composer awaits it to
  decide where focus belongs afterwards, so a fire-and-forget wrapper would have
  restored focus while the request was still open. There is a test for it.
- The per-chat key sits above the workspace rather than on the transcript, so the
  scoped surfaces remount on a chat switch too. They already refetched on a
  `chatId` change; the one thing that behaves differently is the Sources search
  box, which used to carry a query over from the previous conversation.
- The provider wraps both the workspace and Settings, so polling and the
  new-question attention hint still run while Settings is open, as before.

## Verification

`tsc`, 345 vitest tests, and a production build. The four new fence tests were
checked by mutation — removing each guard (the selection check on a failed
answer, the sandbox stop fence, the per-chat key) fails the corresponding test.

Closes #450