### PR TITLE
refactor(desktop): move per-conversation request state out of the root

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -5,29 +5,21 @@ import {
   type Chat,
   type ModelInfo,
   type ModelSelectionKey,
-  type PendingFolderAccessRequest,
-  type PendingUserQuestions,
   type ProviderInfo,
   type ReasoningEffort,
   type SequencedEvent,
   type ServerInfo,
-  type UserQuestionAnswer,
 } from "./api";
 import { modelForSelection } from "./ModelSelection";
 import { resolveServerInfo } from "./boot";
-import {
-  hasMacOverlayTitlebar,
-  hasNativeHost,
-  requestUserAttention,
-  resolveFolderAccessRequest,
-  type FolderAccessDecision,
-} from "./host";
+import { hasMacOverlayTitlebar, hasNativeHost } from "./host";
 import { Logomark } from "./Logomark";
 import { useTheme } from "./theme";
 import { SettingsView } from "./SettingsView";
 import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
 import { ChatSessionController } from "./ChatSessionController";
 import { useChatSessionStore } from "./ChatSessionStore";
+import { useRefreshSignals } from "./RefreshSignals";
 import { useChatListStore } from "./ChatListStore";
 import { useUiStore } from "./UiStore";
 import {
@@ -82,6 +74,7 @@ const sessionDeps = {
 // calling actions only — never read state fields from them.
 const chatListActions = useChatListStore.getState();
 const uiActions = useUiStore.getState();
+const { signal: signalRefresh } = useRefreshSignals.getState();
 
 export default function App() {
   const [bootError, setBootError] = useState<string | null>(null);
@@ -108,30 +101,6 @@ export default function App() {
   );
   const [sandboxStopErrorKeys, setSandboxStopErrorKeys] = useState<Set<string>>(
     new Set(),
-  );
-  const [folderAccessRequests, setFolderAccessRequests] = useState<
-    PendingFolderAccessRequest[]
-  >([]);
-  const [resolvingFolderCalls, setResolvingFolderCalls] = useState<Set<string>>(
-    new Set(),
-  );
-  const [folderAccessErrors, setFolderAccessErrors] = useState<
-    Record<string, string>
-  >({});
-  const [userQuestionRequests, setUserQuestionRequests] = useState<
-    PendingUserQuestions[]
-  >([]);
-  const [answeringQuestionCalls, setAnsweringQuestionCalls] = useState<
-    Set<string>
-  >(new Set());
-  const [userQuestionErrors, setUserQuestionErrors] = useState<
-    Record<string, string>
-  >({});
-  const [decidingApprovalCalls, setDecidingApprovalCalls] = useState<
-    Set<string>
-  >(new Set());
-  const [approvalErrors, setApprovalErrors] = useState<Record<string, string>>(
-    {},
   );
   const [draft, setDraft] = useState("");
   const [addingSourceChatId, setAddingSourceChatId] = useState<string | null>(
@@ -162,13 +131,7 @@ export default function App() {
   const handleEventRef = useRef<(event: SequencedEvent) => void>(() => {});
   const chatSelectionRef = useRef(0);
   const terminalHydrationGenerationRef = useRef(0);
-  const refreshFolderAccessRef = useRef<(() => void) | null>(null);
-  const refreshUserQuestionsRef = useRef<(() => void) | null>(null);
   const refreshAgentRunsRef = useRef<(() => void) | null>(null);
-  const resolvingFolderCallsRef = useRef<Set<string>>(new Set());
-  const answeringQuestionCallsRef = useRef<Set<string>>(new Set());
-  const seenQuestionCallIdsRef = useRef<Set<string>>(new Set());
-  const decidingApprovalCallsRef = useRef<Set<string>>(new Set());
   const cancelRequestTurnRef = useRef<string | null>(null);
   const draftRef = useRef("");
   const selectedChatIdRef = useRef<string | null>(null);
@@ -282,51 +245,6 @@ export default function App() {
     })();
     return () => {
       cancelled = true;
-    };
-  }, [client, chat?.id]);
-
-  useEffect(() => {
-    if (!client || !chat) return;
-    let cancelled = false;
-    let requestSeq = 0;
-
-    const refresh = async () => {
-      const seq = ++requestSeq;
-      try {
-        const requests = await client.listPendingUserQuestions(chat.id);
-        if (!cancelled && seq === requestSeq) {
-          const hasNewRequest = requests.some(
-            (request) => !seenQuestionCallIdsRef.current.has(request.callId),
-          );
-          seenQuestionCallIdsRef.current = new Set(
-            requests.map((request) => request.callId),
-          );
-          setUserQuestionRequests(requests);
-          if (hasNewRequest) {
-            void requestUserAttention().catch(() => {
-              // Attention is a best-effort hint. Durable polling is truth.
-            });
-          }
-        }
-      } catch (err) {
-        if (!cancelled && seq === requestSeq) {
-          console.error("failed to refresh pending user questions", err);
-        }
-      }
-    };
-
-    refreshUserQuestionsRef.current = () => void refresh();
-    void refresh();
-    const interval = window.setInterval(() => void refresh(), 10_000);
-    return () => {
-      cancelled = true;
-      requestSeq += 1;
-      window.clearInterval(interval);
-      if (refreshUserQuestionsRef.current) {
-        refreshUserQuestionsRef.current = null;
-      }
-      setUserQuestionRequests([]);
-      seenQuestionCallIdsRef.current = new Set();
     };
   }, [client, chat?.id]);
 
@@ -462,40 +380,6 @@ export default function App() {
     }
   }
 
-  useEffect(() => {
-    if (!client || !chat) return;
-    let cancelled = false;
-    let requestSeq = 0;
-
-    const refresh = async () => {
-      const seq = ++requestSeq;
-      try {
-        const requests = await client.listPendingFolderAccessRequests(chat.id);
-        if (!cancelled && seq === requestSeq) {
-          setFolderAccessRequests(requests);
-        }
-      } catch (err) {
-        if (!cancelled && seq === requestSeq) {
-          console.error("failed to refresh pending folder access", err);
-          setFolderAccessRequests([]);
-        }
-      }
-    };
-
-    refreshFolderAccessRef.current = () => void refresh();
-    void refresh();
-    const interval = window.setInterval(() => void refresh(), 10_000);
-    return () => {
-      cancelled = true;
-      requestSeq += 1;
-      window.clearInterval(interval);
-      if (refreshFolderAccessRef.current) {
-        refreshFolderAccessRef.current = null;
-      }
-      setFolderAccessRequests([]);
-    };
-  }, [client, chat?.id]);
-
   function updateSession(update: (state: ChatSessionState) => ChatSessionState) {
     useChatSessionStore.getState().update(update);
   }
@@ -514,10 +398,10 @@ export default function App() {
         refreshAgentRunsRef.current?.();
         return;
       case "refresh_folder_access":
-        refreshFolderAccessRef.current?.();
+        signalRefresh("folderAccess");
         return;
       case "refresh_user_questions":
-        refreshUserQuestionsRef.current?.();
+        signalRefresh("userQuestions");
         return;
       case "turn_began":
         setCancelPendingTurnId(null);
@@ -807,16 +691,6 @@ export default function App() {
     useChatSessionStore.getState().reset();
     setAgentRuns([]);
     setAgentRunsError(null);
-    setFolderAccessRequests([]);
-    setFolderAccessErrors({});
-    setUserQuestionRequests([]);
-    seenQuestionCallIdsRef.current = new Set();
-    answeringQuestionCallsRef.current = new Set();
-    setAnsweringQuestionCalls(new Set());
-    setUserQuestionErrors({});
-    decidingApprovalCallsRef.current = new Set();
-    setDecidingApprovalCalls(new Set());
-    setApprovalErrors({});
     setComposerDraft("");
     setRecentSource(null);
     setSourceAttachmentError(null);
@@ -909,16 +783,6 @@ export default function App() {
     useChatSessionStore.getState().reset();
     setAgentRuns([]);
     setAgentRunsError(null);
-    setFolderAccessRequests([]);
-    setFolderAccessErrors({});
-    setUserQuestionRequests([]);
-    seenQuestionCallIdsRef.current = new Set();
-    answeringQuestionCallsRef.current = new Set();
-    setAnsweringQuestionCalls(new Set());
-    setUserQuestionErrors({});
-    decidingApprovalCallsRef.current = new Set();
-    setDecidingApprovalCalls(new Set());
-    setApprovalErrors({});
     setComposerDraft("");
     setRecentSource(null);
     setSourceAttachmentError(null);
@@ -995,182 +859,6 @@ export default function App() {
     // after a selection change the ids differ, so this stays fence-safe.
     chatListActions.replaceChat(updated);
     void selection;
-  }
-
-  async function onApproval(
-    callId: string,
-    decision: "approve" | "reject",
-    remember = false,
-  ) {
-    if (!client || !chat) return;
-    if (decidingApprovalCallsRef.current.has(callId)) return;
-    decidingApprovalCallsRef.current.add(callId);
-    setDecidingApprovalCalls((calls) => new Set(calls).add(callId));
-    setApprovalErrors((errors) => {
-      const next = { ...errors };
-      delete next[callId];
-      return next;
-    });
-    try {
-      await client.decideApproval(chat.id, callId, decision, remember);
-      updateSession((session) => ({
-        ...session,
-        messages: session.messages.map((m) =>
-          m.role === "approval" && m.callId === callId
-            ? { ...m, resolved: true }
-            : m,
-        ),
-      }));
-    } catch (err) {
-      setApprovalErrors((errors) => ({
-        ...errors,
-        [callId]: `Could not send your decision: ${String(err)}`,
-      }));
-    } finally {
-      decidingApprovalCallsRef.current.delete(callId);
-      setDecidingApprovalCalls((calls) => {
-        const next = new Set(calls);
-        next.delete(callId);
-        return next;
-      });
-    }
-  }
-
-  async function onFolderAccessDecision(
-    callId: string,
-    decision: FolderAccessDecision,
-  ) {
-    if (!chat || !hasNativeHost()) return;
-    if (resolvingFolderCallsRef.current.size > 0) return;
-    resolvingFolderCallsRef.current.add(callId);
-    setResolvingFolderCalls((calls) => new Set(calls).add(callId));
-    setFolderAccessErrors((errors) => {
-      const next = { ...errors };
-      delete next[callId];
-      return next;
-    });
-    try {
-      await resolveFolderAccessRequest(chat.id, callId, decision);
-    } catch (err) {
-      setFolderAccessErrors((errors) => ({
-        ...errors,
-        [callId]: String(err),
-      }));
-    } finally {
-      resolvingFolderCallsRef.current.delete(callId);
-      setResolvingFolderCalls((calls) => {
-        const next = new Set(calls);
-        next.delete(callId);
-        return next;
-      });
-      refreshFolderAccessRef.current?.();
-    }
-  }
-
-  async function onFolderAccessCancel(callId: string, turnId: string) {
-    if (!client || !chat || resolvingFolderCallsRef.current.size > 0) return;
-    resolvingFolderCallsRef.current.add(callId);
-    setResolvingFolderCalls((calls) => new Set(calls).add(callId));
-    setFolderAccessErrors((errors) => {
-      const next = { ...errors };
-      delete next[callId];
-      return next;
-    });
-    try {
-      await client.cancel(chat.id, turnId);
-    } catch (err) {
-      setFolderAccessErrors((errors) => ({
-        ...errors,
-        [callId]: String(err),
-      }));
-    } finally {
-      resolvingFolderCallsRef.current.delete(callId);
-      setResolvingFolderCalls((calls) => {
-        const next = new Set(calls);
-        next.delete(callId);
-        return next;
-      });
-      refreshFolderAccessRef.current?.();
-    }
-  }
-
-  async function onAnswerUserQuestions(
-    callId: string,
-    answers: UserQuestionAnswer[],
-  ) {
-    if (!client || !chat || answeringQuestionCallsRef.current.has(callId)) {
-      return;
-    }
-    const chatId = chat.id;
-    const selection = chatSelectionRef.current;
-    answeringQuestionCallsRef.current.add(callId);
-    setAnsweringQuestionCalls((calls) => new Set(calls).add(callId));
-    setUserQuestionErrors((errors) => {
-      const next = { ...errors };
-      delete next[callId];
-      return next;
-    });
-    try {
-      await client.answerUserQuestions(chatId, callId, answers);
-    } catch (err) {
-      if (chatSelectionRef.current === selection) {
-        setUserQuestionErrors((errors) => ({
-          ...errors,
-          [callId]: `Could not send your answer: ${String(err)}`,
-        }));
-      }
-    } finally {
-      answeringQuestionCallsRef.current.delete(callId);
-      setAnsweringQuestionCalls((calls) => {
-        const next = new Set(calls);
-        next.delete(callId);
-        return next;
-      });
-      if (chatSelectionRef.current === selection) {
-        refreshUserQuestionsRef.current?.();
-      }
-    }
-  }
-
-  async function onUserQuestionsCancel(turnId: string) {
-    if (!client || !chat) return;
-    const request = userQuestionRequests.find(
-      (candidate) => candidate.turnId === turnId,
-    );
-    if (!request || answeringQuestionCallsRef.current.has(request.callId)) {
-      return;
-    }
-    const chatId = chat.id;
-    const selection = chatSelectionRef.current;
-    answeringQuestionCallsRef.current.add(request.callId);
-    setAnsweringQuestionCalls((calls) =>
-      new Set(calls).add(request.callId),
-    );
-    setUserQuestionErrors((errors) => {
-      const next = { ...errors };
-      delete next[request.callId];
-      return next;
-    });
-    try {
-      await client.cancel(chatId, turnId);
-    } catch (err) {
-      if (chatSelectionRef.current === selection) {
-        setUserQuestionErrors((errors) => ({
-          ...errors,
-          [request.callId]: `Could not cancel the turn: ${String(err)}`,
-        }));
-      }
-    } finally {
-      answeringQuestionCallsRef.current.delete(request.callId);
-      setAnsweringQuestionCalls((calls) => {
-        const next = new Set(calls);
-        next.delete(request.callId);
-        return next;
-      });
-      if (chatSelectionRef.current === selection) {
-        refreshUserQuestionsRef.current?.();
-      }
-    }
   }
 
   async function onRestartForUpdate() {
@@ -1279,6 +967,7 @@ export default function App() {
             transcript={
               <ChatView
                 key={chat.id}
+                client={client}
                 chat={chat}
                 hydrated={hydratedChatId === chat.id}
                 nativeHost={hasNativeHost()}
@@ -1292,29 +981,6 @@ export default function App() {
                 stopErrorRunIds={visibleSandboxStopErrorRunIds}
                 onRetryAgentRuns={() => refreshAgentRunsRef.current?.()}
                 onStopSandboxRun={(runId) => void onStopSandboxAgentRun(runId)}
-                folderAccessRequests={folderAccessRequests}
-                userQuestionRequests={userQuestionRequests}
-                resolvingFolderCalls={resolvingFolderCalls}
-                folderAccessErrors={folderAccessErrors}
-                answeringQuestionCalls={answeringQuestionCalls}
-                userQuestionErrors={userQuestionErrors}
-                decidingApprovalCalls={decidingApprovalCalls}
-                approvalErrors={approvalErrors}
-                onApproval={(callId, decision, remember) =>
-                  void onApproval(callId, decision, remember)
-                }
-                onFolderAccessDecision={(callId, decision) =>
-                  void onFolderAccessDecision(callId, decision)
-                }
-                onFolderAccessCancel={(callId, turnId) =>
-                  void onFolderAccessCancel(callId, turnId)
-                }
-                onAnswerUserQuestions={(callId, answers) =>
-                  void onAnswerUserQuestions(callId, answers)
-                }
-                onUserQuestionsCancel={(turnId) =>
-                  void onUserQuestionsCancel(turnId)
-                }
                 draft={draft}
                 attachingSource={addingSourceChatId !== null}
                 attachedSourceName={

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -1,14 +1,32 @@
 // @vitest-environment jsdom
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Chat } from "./api";
+import type { ApiClient, Chat } from "./api";
 import { ChatView, type ChatViewProps } from "./ChatView";
 import { useChatSessionStore } from "./ChatSessionStore";
 
+vi.mock("./host", () => ({
+  hasNativeHost: () => false,
+  requestUserAttention: vi.fn().mockResolvedValue(undefined),
+  resolveFolderAccessRequest: vi.fn(),
+}));
+
 const chat = { id: "chat-1", title: "Roadmap", project_id: null } as unknown as Chat;
+
+// The chat pane owns its conversation's request state, so it polls through the
+// client rather than being handed the results.
+const client = {
+  listPendingFolderAccessRequests: vi.fn().mockResolvedValue([]),
+  listPendingUserQuestions: vi.fn().mockResolvedValue([]),
+  decideApproval: vi.fn().mockResolvedValue(undefined),
+  cancel: vi.fn().mockResolvedValue(undefined),
+  answerUserQuestions: vi.fn().mockResolvedValue(undefined),
+} as unknown as ApiClient;
 
 function renderChatView(overrides: Partial<ChatViewProps> = {}) {
   const props: ChatViewProps = {
+    client,
     chat,
     hydrated: true,
     nativeHost: false,
@@ -20,19 +38,6 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
     stopErrorRunIds: new Set(),
     onRetryAgentRuns: vi.fn(),
     onStopSandboxRun: vi.fn(),
-    folderAccessRequests: [],
-    userQuestionRequests: [],
-    resolvingFolderCalls: new Set(),
-    folderAccessErrors: {},
-    answeringQuestionCalls: new Set(),
-    userQuestionErrors: {},
-    decidingApprovalCalls: new Set(),
-    approvalErrors: {},
-    onApproval: vi.fn(),
-    onFolderAccessDecision: vi.fn(),
-    onFolderAccessCancel: vi.fn(),
-    onAnswerUserQuestions: vi.fn(),
-    onUserQuestionsCancel: vi.fn(),
     draft: "",
     composerModelMenu: null,
     attachingSource: false,
@@ -73,6 +78,61 @@ describe("ChatView", () => {
     renderChatView();
     expect(screen.getByText("hello there")).toBeInTheDocument();
     expect(screen.getByText("hi!")).toBeInTheDocument();
+  });
+
+  it("polls for its own conversation's pending approvals and questions", async () => {
+    vi.mocked(client.listPendingUserQuestions).mockResolvedValueOnce([
+      {
+        callId: "call-q",
+        turnId: "turn-1",
+        askedAt: "2026-07-24T00:00:00.000Z",
+        questions: [
+          {
+            id: "q1",
+            header: "Scope",
+            question: "Which quarter?",
+            options: [],
+            allowFreeForm: true,
+          },
+        ],
+      },
+    ]);
+
+    renderChatView();
+
+    expect(await screen.findByText("Which quarter?")).toBeInTheDocument();
+    expect(client.listPendingUserQuestions).toHaveBeenCalledWith("chat-1");
+    expect(client.listPendingFolderAccessRequests).toHaveBeenCalledWith(
+      "chat-1",
+    );
+  });
+
+  it("sends an approval decision through its own client", async () => {
+    useChatSessionStore.getState().update((session) => ({
+      ...session,
+      messages: [
+        {
+          id: "m1",
+          role: "approval",
+          callId: "call-a",
+          summary: "Run a command",
+          canApprove: true,
+          canRemember: false,
+        },
+      ],
+    }));
+    renderChatView();
+
+    await userEvent.click(screen.getAllByRole("option")[0]!);
+
+    await waitFor(() =>
+      expect(client.decideApproval).toHaveBeenCalledWith(
+        "chat-1",
+        "call-a",
+        "approve",
+        false,
+      ),
+    );
   });
 
   it("re-renders as stream events land in the store", () => {

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -1,21 +1,18 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import type {
-  AgentRun,
-  Chat,
-  PendingFolderAccessRequest,
-  PendingUserQuestions,
-  UserQuestionAnswer,
-} from "./api";
+import type { AgentRun, ApiClient, Chat } from "./api";
 import { AgentActivityPanel } from "./AgentActivityPanel";
 import { followScrollBehavior, isNearBottom, scrollToLatest } from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
 import { Composer } from "./Composer";
-import type { FolderAccessDecision } from "./host";
 import { MessageList } from "./MessageList";
 import { useTranscriptVisible } from "./TranscriptVisibility";
+import { useFolderAccessRequests } from "./useFolderAccessRequests";
+import { useToolApprovals } from "./useToolApprovals";
+import { useUserQuestions } from "./useUserQuestions";
 import { ArrowDown } from "lucide-react";
 
 export type ChatViewProps = {
+  client: ApiClient;
   chat: Chat;
   hydrated: boolean;
   nativeHost: boolean;
@@ -27,29 +24,6 @@ export type ChatViewProps = {
   stopErrorRunIds: Set<string>;
   onRetryAgentRuns: () => void;
   onStopSandboxRun: (runId: string) => void;
-  folderAccessRequests: PendingFolderAccessRequest[];
-  userQuestionRequests: PendingUserQuestions[];
-  resolvingFolderCalls: Set<string>;
-  folderAccessErrors: Record<string, string>;
-  answeringQuestionCalls: Set<string>;
-  userQuestionErrors: Record<string, string>;
-  decidingApprovalCalls: Set<string>;
-  approvalErrors: Record<string, string>;
-  onApproval: (
-    callId: string,
-    decision: "approve" | "reject",
-    remember?: boolean,
-  ) => void;
-  onFolderAccessDecision: (
-    callId: string,
-    decision: FolderAccessDecision,
-  ) => void;
-  onFolderAccessCancel: (callId: string, turnId: string) => void;
-  onAnswerUserQuestions: (
-    callId: string,
-    answers: UserQuestionAnswer[],
-  ) => void;
-  onUserQuestionsCancel: (turnId: string) => void;
   draft: string;
   composerModelMenu: ReactNode;
   attachingSource: boolean;
@@ -76,6 +50,7 @@ export type ChatViewProps = {
  * Mount with `key={chat.id}` so scroll-follow state resets per conversation.
  */
 export function ChatView({
+  client,
   chat,
   hydrated,
   nativeHost,
@@ -87,19 +62,6 @@ export function ChatView({
   stopErrorRunIds,
   onRetryAgentRuns,
   onStopSandboxRun,
-  folderAccessRequests,
-  userQuestionRequests,
-  resolvingFolderCalls,
-  folderAccessErrors,
-  answeringQuestionCalls,
-  userQuestionErrors,
-  decidingApprovalCalls,
-  approvalErrors,
-  onApproval,
-  onFolderAccessDecision,
-  onFolderAccessCancel,
-  onAnswerUserQuestions,
-  onUserQuestionsCancel,
   draft,
   composerModelMenu,
   attachingSource,
@@ -119,6 +81,9 @@ export function ChatView({
   onStop,
 }: ChatViewProps) {
   const transcriptVisible = useTranscriptVisible();
+  const folderAccess = useFolderAccessRequests(client, chat.id);
+  const userQuestions = useUserQuestions(client, chat.id);
+  const approvals = useToolApprovals(client, chat.id);
   const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);
   const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
@@ -145,8 +110,8 @@ export function ChatView({
 
   useEffect(() => {
     const next = new Set([
-      ...folderAccessRequests.map((request) => request.callId),
-      ...userQuestionRequests.map((request) => request.callId),
+      ...folderAccess.requests.map((request) => request.callId),
+      ...userQuestions.requests.map((request) => request.callId),
     ]);
     const gainedRequest = [...next].some(
       (callId) => !visibleContinuationCallIdsRef.current.has(callId),
@@ -160,7 +125,7 @@ export function ChatView({
     } else {
       setHasUnreadActivity(true);
     }
-  }, [folderAccessRequests, userQuestionRequests]);
+  }, [folderAccess.requests, userQuestions.requests]);
 
   return (
     <section className="chat-pane">
@@ -177,16 +142,16 @@ export function ChatView({
       <div className="message-view">
         <MessageList
           messages={messages}
-          folderAccessRequests={folderAccessRequests}
-          userQuestionRequests={userQuestionRequests}
+          folderAccessRequests={folderAccess.requests}
+          userQuestionRequests={userQuestions.requests}
           nativeHost={nativeHost}
-          nativeBusy={resolvingFolderCalls.size > 0}
-          resolvingFolderCalls={resolvingFolderCalls}
-          folderAccessErrors={folderAccessErrors}
-          answeringQuestionCalls={answeringQuestionCalls}
-          userQuestionErrors={userQuestionErrors}
-          decidingApprovalCalls={decidingApprovalCalls}
-          approvalErrors={approvalErrors}
+          nativeBusy={folderAccess.resolving.size > 0}
+          resolvingFolderCalls={folderAccess.resolving}
+          folderAccessErrors={folderAccess.errors}
+          answeringQuestionCalls={userQuestions.answering}
+          userQuestionErrors={userQuestions.errors}
+          decidingApprovalCalls={approvals.deciding}
+          approvalErrors={approvals.errors}
           busy={busy}
           reasoningActive={reasoningActive}
           scrollRef={scrollRef}
@@ -195,11 +160,11 @@ export function ChatView({
             followsLatestRef.current = followsLatest;
             if (followsLatest) setHasUnreadActivity(false);
           }}
-          onApproval={onApproval}
-          onFolderAccessDecision={onFolderAccessDecision}
-          onFolderAccessCancel={onFolderAccessCancel}
-          onAnswerUserQuestions={onAnswerUserQuestions}
-          onUserQuestionsCancel={onUserQuestionsCancel}
+          onApproval={approvals.decide}
+          onFolderAccessDecision={folderAccess.decide}
+          onFolderAccessCancel={folderAccess.cancel}
+          onAnswerUserQuestions={userQuestions.answer}
+          onUserQuestionsCancel={userQuestions.cancel}
           onSelectPrompt={onSelectPrompt}
           hydrated={hydrated}
         />

--- a/crates/openwave-desktop/ui/src/RefreshSignals.ts
+++ b/crates/openwave-desktop/ui/src/RefreshSignals.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+
+/**
+ * Server-side state the event stream can report as moved on.
+ */
+export type RefreshTarget = "folderAccess" | "userQuestions";
+
+/**
+ * A revision counter per pollable target.
+ *
+ * The event socket is owned by the component that holds the chat session, but
+ * the pollers that own this state live with the surfaces that render it.
+ * Bumping a revision lets the stream say "this has changed" without the root
+ * holding a callback ref for every poller, and without a poller reaching back
+ * into the stream. A counter rather than a flag so two signals in a row are two
+ * refreshes, not one.
+ */
+export type RefreshSignalStore = {
+  folderAccess: number;
+  userQuestions: number;
+  signal: (target: RefreshTarget) => void;
+};
+
+export function createRefreshSignalStore() {
+  return create<RefreshSignalStore>()((set) => ({
+    folderAccess: 0,
+    userQuestions: 0,
+    signal: (target) =>
+      set((state) => ({ [target]: state[target] + 1 }) as Partial<RefreshSignalStore>),
+  }));
+}
+
+export const useRefreshSignals = createRefreshSignalStore();

--- a/crates/openwave-desktop/ui/src/useFolderAccessRequests.test.ts
+++ b/crates/openwave-desktop/ui/src/useFolderAccessRequests.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "./api";
+import { useFolderAccessRequests } from "./useFolderAccessRequests";
+import { useRefreshSignals } from "./RefreshSignals";
+import * as host from "./host";
+
+vi.mock("./host", () => ({
+  hasNativeHost: vi.fn(() => true),
+  resolveFolderAccessRequest: vi.fn(),
+}));
+
+function request(callId: string) {
+  return { callId, turnId: "turn-1", displayPath: "~/Notes" };
+}
+
+function stubClient(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    listPendingFolderAccessRequests: vi.fn().mockResolvedValue([]),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+beforeEach(() => {
+  vi.mocked(host.hasNativeHost).mockReturnValue(true);
+  vi.mocked(host.resolveFolderAccessRequest).mockReset();
+});
+
+afterEach(cleanup);
+
+describe("useFolderAccessRequests", () => {
+  it("loads the conversation's pending requests", async () => {
+    const client = stubClient({
+      listPendingFolderAccessRequests: vi.fn().mockResolvedValue([
+        request("call-1"),
+      ]),
+    });
+    const { result } = renderHook(() =>
+      useFolderAccessRequests(client, "chat-1"),
+    );
+
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+    expect(client.listPendingFolderAccessRequests).toHaveBeenCalledWith(
+      "chat-1",
+    );
+  });
+
+  it("refreshes when the event stream signals", async () => {
+    const client = stubClient();
+    renderHook(() => useFolderAccessRequests(client, "chat-1"));
+    await waitFor(() =>
+      expect(client.listPendingFolderAccessRequests).toHaveBeenCalledTimes(1),
+    );
+
+    act(() => useRefreshSignals.getState().signal("folderAccess"));
+
+    await waitFor(() =>
+      expect(client.listPendingFolderAccessRequests).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("allows only one decision at a time, since each opens a native dialog", async () => {
+    let release: (() => void) | undefined;
+    vi.mocked(host.resolveFolderAccessRequest).mockImplementation(
+      () => new Promise<void>((resolve) => (release = resolve)),
+    );
+    const client = stubClient();
+    const { result } = renderHook(() =>
+      useFolderAccessRequests(client, "chat-1"),
+    );
+
+    act(() => result.current.decide("call-1", "allow"));
+    await waitFor(() => expect(result.current.resolving.size).toBe(1));
+
+    act(() => result.current.decide("call-2", "allow"));
+    expect(host.resolveFolderAccessRequest).toHaveBeenCalledTimes(1);
+    expect(result.current.resolving.has("call-2")).toBe(false);
+
+    await act(async () => {
+      release?.();
+    });
+    await waitFor(() => expect(result.current.resolving.size).toBe(0));
+  });
+
+  it("does not decide without a native host to ask", async () => {
+    vi.mocked(host.hasNativeHost).mockReturnValue(false);
+    const client = stubClient();
+    const { result } = renderHook(() =>
+      useFolderAccessRequests(client, "chat-1"),
+    );
+
+    act(() => result.current.decide("call-1", "allow"));
+
+    expect(host.resolveFolderAccessRequest).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed decision against its own request", async () => {
+    vi.mocked(host.resolveFolderAccessRequest).mockRejectedValue(
+      new Error("Folder is unavailable"),
+    );
+    const client = stubClient();
+    const { result } = renderHook(() =>
+      useFolderAccessRequests(client, "chat-1"),
+    );
+
+    await act(async () => result.current.decide("call-1", "allow"));
+
+    await waitFor(() =>
+      expect(result.current.errors["call-1"]).toContain(
+        "Folder is unavailable",
+      ),
+    );
+  });
+
+  it("drops the previous chat's requests when the conversation changes", async () => {
+    const client = stubClient({
+      listPendingFolderAccessRequests: vi
+        .fn()
+        .mockResolvedValueOnce([request("call-1")])
+        .mockResolvedValue([]),
+    });
+    const { result, rerender } = renderHook(
+      ({ chatId }) => useFolderAccessRequests(client, chatId),
+      { initialProps: { chatId: "chat-1" } },
+    );
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+
+    rerender({ chatId: "chat-2" });
+
+    await waitFor(() => expect(result.current.requests).toHaveLength(0));
+    expect(client.listPendingFolderAccessRequests).toHaveBeenLastCalledWith(
+      "chat-2",
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/useFolderAccessRequests.ts
+++ b/crates/openwave-desktop/ui/src/useFolderAccessRequests.ts
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState } from "react";
+import type { ApiClient, PendingFolderAccessRequest } from "./api";
+import {
+  hasNativeHost,
+  resolveFolderAccessRequest,
+  type FolderAccessDecision,
+} from "./host";
+import { useRefreshSignals } from "./RefreshSignals";
+
+const POLL_INTERVAL_MS = 10_000;
+
+export type FolderAccessRequests = {
+  requests: PendingFolderAccessRequest[];
+  resolving: Set<string>;
+  errors: Record<string, string>;
+  decide: (callId: string, decision: FolderAccessDecision) => void;
+  cancel: (callId: string, turnId: string) => void;
+};
+
+/**
+ * Pending folder-access requests for one conversation, and the decisions that
+ * resolve them.
+ *
+ * Polling is the durable truth; the event stream only says when to look again.
+ * A decision opens a native dialog, so at most one is in flight at a time —
+ * a second prompt while the first is open would be answering a question the
+ * reader cannot see.
+ */
+export function useFolderAccessRequests(
+  client: ApiClient | null,
+  chatId: string | null,
+): FolderAccessRequests {
+  const [requests, setRequests] = useState<PendingFolderAccessRequest[]>([]);
+  const [resolving, setResolving] = useState<Set<string>>(new Set());
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const resolvingRef = useRef<Set<string>>(new Set());
+  const refreshRef = useRef<(() => void) | null>(null);
+  const signal = useRefreshSignals((state) => state.folderAccess);
+
+  useEffect(() => {
+    if (!client || !chatId) return;
+    let cancelled = false;
+    let requestSeq = 0;
+
+    const refresh = async () => {
+      const seq = ++requestSeq;
+      try {
+        const pending = await client.listPendingFolderAccessRequests(chatId);
+        if (!cancelled && seq === requestSeq) setRequests(pending);
+      } catch (err) {
+        if (!cancelled && seq === requestSeq) {
+          console.error("failed to refresh pending folder access", err);
+          setRequests([]);
+        }
+      }
+    };
+
+    refreshRef.current = () => void refresh();
+    void refresh();
+    const interval = window.setInterval(() => void refresh(), POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      requestSeq += 1;
+      window.clearInterval(interval);
+      refreshRef.current = null;
+      setRequests([]);
+    };
+  }, [client, chatId]);
+
+  // Only a signal raised after this hook mounted means anything to it; the
+  // counter is app-wide and may already be well past zero on arrival.
+  const lastSignalRef = useRef(signal);
+  useEffect(() => {
+    if (lastSignalRef.current === signal) return;
+    lastSignalRef.current = signal;
+    refreshRef.current?.();
+  }, [signal]);
+
+  function beginResolving(callId: string) {
+    resolvingRef.current.add(callId);
+    setResolving((calls) => new Set(calls).add(callId));
+    setErrors((current) => {
+      const next = { ...current };
+      delete next[callId];
+      return next;
+    });
+  }
+
+  function finishResolving(callId: string) {
+    resolvingRef.current.delete(callId);
+    setResolving((calls) => {
+      const next = new Set(calls);
+      next.delete(callId);
+      return next;
+    });
+    refreshRef.current?.();
+  }
+
+  async function decide(callId: string, decision: FolderAccessDecision) {
+    if (!chatId || !hasNativeHost()) return;
+    if (resolvingRef.current.size > 0) return;
+    beginResolving(callId);
+    try {
+      await resolveFolderAccessRequest(chatId, callId, decision);
+    } catch (err) {
+      setErrors((current) => ({ ...current, [callId]: String(err) }));
+    } finally {
+      finishResolving(callId);
+    }
+  }
+
+  async function cancel(callId: string, turnId: string) {
+    if (!client || !chatId || resolvingRef.current.size > 0) return;
+    beginResolving(callId);
+    try {
+      await client.cancel(chatId, turnId);
+    } catch (err) {
+      setErrors((current) => ({ ...current, [callId]: String(err) }));
+    } finally {
+      finishResolving(callId);
+    }
+  }
+
+  return {
+    requests,
+    resolving,
+    errors,
+    decide: (callId, decision) => void decide(callId, decision),
+    cancel: (callId, turnId) => void cancel(callId, turnId),
+  };
+}

--- a/crates/openwave-desktop/ui/src/useToolApprovals.test.ts
+++ b/crates/openwave-desktop/ui/src/useToolApprovals.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "./api";
+import { useChatSessionStore } from "./ChatSessionStore";
+import { useToolApprovals } from "./useToolApprovals";
+
+function stubClient(overrides: Record<string, unknown> = {}) {
+  return {
+    decideApproval: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+function seedApprovalCard(callId: string) {
+  useChatSessionStore.getState().update((session) => ({
+    ...session,
+    messages: [
+      {
+        id: "m1",
+        role: "approval" as const,
+        callId,
+        summary: "Run a command",
+        canApprove: true,
+        canRemember: true,
+      },
+    ],
+  }));
+}
+
+beforeEach(() => {
+  useChatSessionStore.getState().reset();
+});
+
+afterEach(cleanup);
+
+describe("useToolApprovals", () => {
+  it("sends a decision and marks its card resolved", async () => {
+    seedApprovalCard("call-1");
+    const client = stubClient();
+    const { result } = renderHook(() => useToolApprovals(client, "chat-1"));
+
+    await act(async () => result.current.decide("call-1", "approve", true));
+
+    expect(client.decideApproval).toHaveBeenCalledWith(
+      "chat-1",
+      "call-1",
+      "approve",
+      true,
+    );
+    const [message] = useChatSessionStore.getState().messages;
+    expect(message.role === "approval" && message.resolved).toBe(true);
+  });
+
+  it("defaults to not remembering the decision", async () => {
+    const client = stubClient();
+    const { result } = renderHook(() => useToolApprovals(client, "chat-1"));
+
+    await act(async () => result.current.decide("call-1", "reject"));
+
+    expect(client.decideApproval).toHaveBeenCalledWith(
+      "chat-1",
+      "call-1",
+      "reject",
+      false,
+    );
+  });
+
+  it("ignores a second click while a decision is in flight", async () => {
+    let release: (() => void) | undefined;
+    const client = stubClient({
+      decideApproval: vi
+        .fn()
+        .mockImplementation(
+          () => new Promise<void>((resolve) => (release = resolve)),
+        ),
+    });
+    const { result } = renderHook(() => useToolApprovals(client, "chat-1"));
+
+    act(() => result.current.decide("call-1", "approve"));
+    await waitFor(() => expect(result.current.deciding.has("call-1")).toBe(true));
+    act(() => result.current.decide("call-1", "reject"));
+
+    expect(client.decideApproval).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      release?.();
+    });
+    await waitFor(() => expect(result.current.deciding.size).toBe(0));
+  });
+
+  it("decides two different calls at once", async () => {
+    const client = stubClient({
+      decideApproval: vi.fn().mockImplementation(() => new Promise(() => {})),
+    });
+    const { result } = renderHook(() => useToolApprovals(client, "chat-1"));
+
+    act(() => result.current.decide("call-1", "approve"));
+    act(() => result.current.decide("call-2", "approve"));
+
+    await waitFor(() => expect(result.current.deciding.size).toBe(2));
+    expect(client.decideApproval).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a failed decision and leaves the card unresolved", async () => {
+    seedApprovalCard("call-1");
+    const client = stubClient({
+      decideApproval: vi.fn().mockRejectedValue(new Error("server said no")),
+    });
+    const { result } = renderHook(() => useToolApprovals(client, "chat-1"));
+
+    await act(async () => result.current.decide("call-1", "approve"));
+
+    await waitFor(() =>
+      expect(result.current.errors["call-1"]).toContain("server said no"),
+    );
+    const [message] = useChatSessionStore.getState().messages;
+    expect(message.role === "approval" && message.resolved).toBeFalsy();
+  });
+});

--- a/crates/openwave-desktop/ui/src/useToolApprovals.ts
+++ b/crates/openwave-desktop/ui/src/useToolApprovals.ts
@@ -1,0 +1,75 @@
+import { useRef, useState } from "react";
+import type { ApiClient } from "./api";
+import { useChatSessionStore } from "./ChatSessionStore";
+
+export type ToolApprovals = {
+  deciding: Set<string>;
+  errors: Record<string, string>;
+  decide: (
+    callId: string,
+    decision: "approve" | "reject",
+    remember?: boolean,
+  ) => void;
+};
+
+/**
+ * Decisions on the tool approvals waiting in one conversation.
+ *
+ * Unlike folder access, several approvals can be resolved at once — the guard
+ * is per call, so a second click on the same card is ignored while its decision
+ * is in flight. There is nothing to poll: approvals arrive on the event stream
+ * as transcript messages, and a decision marks its own card resolved.
+ */
+export function useToolApprovals(
+  client: ApiClient | null,
+  chatId: string | null,
+): ToolApprovals {
+  const [deciding, setDeciding] = useState<Set<string>>(new Set());
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const decidingRef = useRef<Set<string>>(new Set());
+
+  async function send(
+    callId: string,
+    decision: "approve" | "reject",
+    remember: boolean,
+  ) {
+    if (!client || !chatId || decidingRef.current.has(callId)) return;
+    decidingRef.current.add(callId);
+    setDeciding((calls) => new Set(calls).add(callId));
+    setErrors((current) => {
+      const next = { ...current };
+      delete next[callId];
+      return next;
+    });
+    try {
+      await client.decideApproval(chatId, callId, decision, remember);
+      useChatSessionStore.getState().update((session) => ({
+        ...session,
+        messages: session.messages.map((message) =>
+          message.role === "approval" && message.callId === callId
+            ? { ...message, resolved: true }
+            : message,
+        ),
+      }));
+    } catch (err) {
+      setErrors((current) => ({
+        ...current,
+        [callId]: `Could not send your decision: ${String(err)}`,
+      }));
+    } finally {
+      decidingRef.current.delete(callId);
+      setDeciding((calls) => {
+        const next = new Set(calls);
+        next.delete(callId);
+        return next;
+      });
+    }
+  }
+
+  return {
+    deciding,
+    errors,
+    decide: (callId, decision, remember = false) =>
+      void send(callId, decision, remember),
+  };
+}

--- a/crates/openwave-desktop/ui/src/useUserQuestions.test.ts
+++ b/crates/openwave-desktop/ui/src/useUserQuestions.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "./api";
+import { useUserQuestions } from "./useUserQuestions";
+import { useRefreshSignals } from "./RefreshSignals";
+import * as host from "./host";
+
+vi.mock("./host", () => ({
+  requestUserAttention: vi.fn().mockResolvedValue(undefined),
+}));
+
+function pending(callId: string, turnId = "turn-1") {
+  return { callId, turnId, questions: [] };
+}
+
+function stubClient(overrides: Record<string, unknown> = {}) {
+  return {
+    listPendingUserQuestions: vi.fn().mockResolvedValue([]),
+    answerUserQuestions: vi.fn().mockResolvedValue(undefined),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+afterEach(cleanup);
+
+describe("useUserQuestions", () => {
+  it("asks for attention only when a request is new", async () => {
+    const client = stubClient({
+      listPendingUserQuestions: vi.fn().mockResolvedValue([pending("call-1")]),
+    });
+    renderHook(() => useUserQuestions(client, "chat-1"));
+
+    await waitFor(() =>
+      expect(host.requestUserAttention).toHaveBeenCalledTimes(1),
+    );
+
+    act(() => useRefreshSignals.getState().signal("userQuestions"));
+    await waitFor(() =>
+      expect(client.listPendingUserQuestions).toHaveBeenCalledTimes(2),
+    );
+    expect(host.requestUserAttention).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a second answer for a call already in flight", async () => {
+    let release: (() => void) | undefined;
+    const client = stubClient({
+      listPendingUserQuestions: vi.fn().mockResolvedValue([pending("call-1")]),
+      answerUserQuestions: vi
+        .fn()
+        .mockImplementation(
+          () => new Promise<void>((resolve) => (release = resolve)),
+        ),
+    });
+    const { result } = renderHook(() => useUserQuestions(client, "chat-1"));
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+
+    act(() => result.current.answer("call-1", []));
+    await waitFor(() => expect(result.current.answering.size).toBe(1));
+    act(() => result.current.answer("call-1", []));
+
+    expect(client.answerUserQuestions).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      release?.();
+    });
+  });
+
+  it("cancels the turn that owns a request", async () => {
+    const client = stubClient({
+      listPendingUserQuestions: vi
+        .fn()
+        .mockResolvedValue([pending("call-9", "turn-9")]),
+    });
+    const { result } = renderHook(() => useUserQuestions(client, "chat-1"));
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+
+    await act(async () => result.current.cancel("turn-9"));
+
+    expect(client.cancel).toHaveBeenCalledWith("chat-1", "turn-9");
+  });
+
+  it("ignores a cancel for a turn it has no request for", async () => {
+    const client = stubClient();
+    const { result } = renderHook(() => useUserQuestions(client, "chat-1"));
+
+    await act(async () => result.current.cancel("turn-unknown"));
+
+    expect(client.cancel).not.toHaveBeenCalled();
+  });
+
+  it("does not report a failure onto the conversation that replaced it", async () => {
+    let reject: ((err: Error) => void) | undefined;
+    const client = stubClient({
+      listPendingUserQuestions: vi.fn().mockResolvedValue([pending("call-1")]),
+      answerUserQuestions: vi
+        .fn()
+        .mockImplementation(
+          () => new Promise<void>((_resolve, no) => (reject = no)),
+        ),
+    });
+    const { result, rerender } = renderHook(
+      ({ chatId }) => useUserQuestions(client, chatId),
+      { initialProps: { chatId: "chat-1" } },
+    );
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+
+    act(() => result.current.answer("call-1", []));
+    await waitFor(() => expect(result.current.answering.size).toBe(1));
+
+    rerender({ chatId: "chat-2" });
+    await act(async () => {
+      reject?.(new Error("network went away"));
+    });
+
+    expect(result.current.errors).toEqual({});
+  });
+});

--- a/crates/openwave-desktop/ui/src/useUserQuestions.ts
+++ b/crates/openwave-desktop/ui/src/useUserQuestions.ts
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState } from "react";
+import type { ApiClient, PendingUserQuestions, UserQuestionAnswer } from "./api";
+import { requestUserAttention } from "./host";
+import { useRefreshSignals } from "./RefreshSignals";
+
+const POLL_INTERVAL_MS = 10_000;
+
+export type UserQuestions = {
+  requests: PendingUserQuestions[];
+  answering: Set<string>;
+  errors: Record<string, string>;
+  answer: (callId: string, answers: UserQuestionAnswer[]) => void;
+  cancel: (turnId: string) => void;
+};
+
+/**
+ * Questions the agent is waiting on for one conversation, and the answers that
+ * release it.
+ *
+ * A reply that lands after the conversation has moved on must not write an
+ * error onto, or trigger a refresh for, whatever chat is open now — so every
+ * request records the chat it started under and checks it before touching
+ * state.
+ */
+export function useUserQuestions(
+  client: ApiClient | null,
+  chatId: string | null,
+): UserQuestions {
+  const [requests, setRequests] = useState<PendingUserQuestions[]>([]);
+  const [answering, setAnswering] = useState<Set<string>>(new Set());
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const answeringRef = useRef<Set<string>>(new Set());
+  const seenCallIdsRef = useRef<Set<string>>(new Set());
+  const refreshRef = useRef<(() => void) | null>(null);
+  const currentChatIdRef = useRef(chatId);
+  currentChatIdRef.current = chatId;
+  const signal = useRefreshSignals((state) => state.userQuestions);
+
+  useEffect(() => {
+    if (!client || !chatId) return;
+    let cancelled = false;
+    let requestSeq = 0;
+
+    const refresh = async () => {
+      const seq = ++requestSeq;
+      try {
+        const pending = await client.listPendingUserQuestions(chatId);
+        if (cancelled || seq !== requestSeq) return;
+        const hasNewRequest = pending.some(
+          (request) => !seenCallIdsRef.current.has(request.callId),
+        );
+        seenCallIdsRef.current = new Set(
+          pending.map((request) => request.callId),
+        );
+        setRequests(pending);
+        if (hasNewRequest) {
+          void requestUserAttention().catch(() => {
+            // Attention is a best-effort hint. Durable polling is truth.
+          });
+        }
+      } catch (err) {
+        if (!cancelled && seq === requestSeq) {
+          console.error("failed to refresh pending user questions", err);
+        }
+      }
+    };
+
+    refreshRef.current = () => void refresh();
+    void refresh();
+    const interval = window.setInterval(() => void refresh(), POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      requestSeq += 1;
+      window.clearInterval(interval);
+      refreshRef.current = null;
+      setRequests([]);
+      seenCallIdsRef.current = new Set();
+    };
+  }, [client, chatId]);
+
+  // Only a signal raised after this hook mounted means anything to it; the
+  // counter is app-wide and may already be well past zero on arrival.
+  const lastSignalRef = useRef(signal);
+  useEffect(() => {
+    if (lastSignalRef.current === signal) return;
+    lastSignalRef.current = signal;
+    refreshRef.current?.();
+  }, [signal]);
+
+  async function send(
+    callId: string,
+    startedChatId: string,
+    request: () => Promise<unknown>,
+    failure: (err: unknown) => string,
+  ) {
+    answeringRef.current.add(callId);
+    setAnswering((calls) => new Set(calls).add(callId));
+    setErrors((current) => {
+      const next = { ...current };
+      delete next[callId];
+      return next;
+    });
+    try {
+      await request();
+    } catch (err) {
+      if (currentChatIdRef.current === startedChatId) {
+        setErrors((current) => ({ ...current, [callId]: failure(err) }));
+      }
+    } finally {
+      answeringRef.current.delete(callId);
+      setAnswering((calls) => {
+        const next = new Set(calls);
+        next.delete(callId);
+        return next;
+      });
+      if (currentChatIdRef.current === startedChatId) refreshRef.current?.();
+    }
+  }
+
+  function answer(callId: string, answers: UserQuestionAnswer[]) {
+    if (!client || !chatId || answeringRef.current.has(callId)) return;
+    const startedChatId = chatId;
+    void send(
+      callId,
+      startedChatId,
+      () => client.answerUserQuestions(startedChatId, callId, answers),
+      (err) => `Could not send your answer: ${String(err)}`,
+    );
+  }
+
+  function cancel(turnId: string) {
+    if (!client || !chatId) return;
+    const request = requests.find((candidate) => candidate.turnId === turnId);
+    if (!request || answeringRef.current.has(request.callId)) return;
+    const startedChatId = chatId;
+    void send(
+      request.callId,
+      startedChatId,
+      () => client.cancel(startedChatId, turnId),
+      (err) => `Could not cancel the turn: ${String(err)}`,
+    );
+  }
+
+  return { requests, answering, errors, answer, cancel };
+}


### PR DESCRIPTION
`App.tsx` owned approvals, folder access, and user questions for the selected chat — their state, their pollers, their in-flight guards, and the handlers that resolve them — then threaded all of it back down as fourteen props that `ChatView` only forwarded to `MessageList`.

Each concern now lives in its own hook, held by the pane that renders it. Since the pane is keyed on the conversation, switching chats disposes the pollers and their state instead of relying on the root to reset every field by hand.

Every guard is carried over deliberately, because they are not the same:

- Folder access allows **one decision at a time app-wide** (a `size > 0` mutex), since each one opens a native dialog and a second prompt would be asking about something the reader cannot see.
- Approvals guard **per call**, so unrelated cards resolve independently.
- A user-question reply records the chat it started under and re-checks it before writing an error or triggering a refresh, so a late failure cannot land on the conversation that replaced it.

The event stream reaches the pollers through a revision counter rather than the root holding a callback ref for each one. Writing the tests turned up a flaw in that: a hook mounting while the counter was already non-zero fired a redundant refresh, which raced its own first load. Hooks now only react to signals raised after they mount.

`App.tsx` goes from 1376 to 1042 lines; `ChatView`'s props drop from forty to twenty-seven. `MessageList` is untouched and stays purely presentational — I deliberately did not put this behind a context, which would have traded a clean prop-tested component for app wiring.

These fences had no test coverage at all before this. Each hook now has its own suite (16 cases), plus two `ChatView` cases proving the pane polls and decides through its own client. Verified with `tsc`, the full vitest suite (357 passing), and a production build.

Closes #450
