### PR TITLE
fix(agent): stop discarding recoverable turns

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1102,6 +1102,7 @@ impl Agent {
                 Done,
                 Cancelled,
                 Steered,
+                Failed(String),
             }
             let mut streamed_events = AssistantStreamEventFilter::new(events);
             let stream_end = loop {
@@ -1154,15 +1155,25 @@ impl Agent {
                         progress.usage = total_usage;
                     }
                     ProviderEvent::Stop { reason } => stop_reason = reason,
+                    ProviderEvent::Failed { message } => break StreamEnd::Failed(message),
                 }
             };
-            if matches!(stream_end, StreamEnd::Steered) {
+            if matches!(stream_end, StreamEnd::Steered | StreamEnd::Failed(_)) {
                 streamed_events.discard();
             } else {
                 // Normal completion and cancellation retain malformed or
-                // incomplete marker-like prose exactly. Only a steer discards
-                // the entire candidate under StreamInterrupted semantics.
+                // incomplete marker-like prose exactly. Only a steer or a
+                // broken stream discards the entire candidate under
+                // StreamInterrupted semantics.
                 streamed_events.finish();
+            }
+            // A stream that broke mid-flight left this step's tool-call
+            // arguments possibly truncated mid-JSON. Nothing here is safe to
+            // act on, and nothing was persisted, so fail the turn under a
+            // retryable provider code rather than executing the fragment.
+            if let StreamEnd::Failed(message) = stream_end {
+                events.send(AgentEvent::StreamInterrupted);
+                return Err(AgentError::Provider(message));
             }
             // Prefer cancel when both cancel and interrupt are ready (cancel is
             // the left arm of the nested select). Also catch a cancel that raced
@@ -1203,12 +1214,17 @@ impl Agent {
                 .filter(|call| self.tools.execution(&call.name) == Some(ToolCallExecution::Client))
                 .collect::<Vec<_>>();
             if !client_calls.is_empty() {
-                if calls.len() != 1 || client_calls.len() != 1 || !text.is_empty() {
+                // Prose is kept, exactly as for a sensitive call (#372): the
+                // model narrates before it acts, and rejecting the step for
+                // that alone burned the step budget on a correction it was
+                // never going to satisfy. Only sibling calls stay forbidden —
+                // the checkpoint can carry one call across the resume.
+                if calls.len() != 1 || client_calls.len() != 1 {
                     events.send(AgentEvent::StreamInterrupted);
                     transcript.push(ChatMessage {
                         role: Role::User,
                         content: vec![ContentBlock::Text {
-                            text: "A client-executed tool must be requested alone, without assistant text or sibling tool calls. Retry the request in that form.".into(),
+                            text: "A client-executed tool must be requested alone, without sibling tool calls. Retry the request in that form.".into(),
                         }],
                     });
                     continue;
@@ -1249,6 +1265,14 @@ impl Agent {
                 let steer_revision = generation_steer_revision.ok_or_else(|| {
                     AgentError::Store("client-executed tools require a durably claimed turn".into())
                 })?;
+                // The checkpoint returns from the loop and the resumed attempt
+                // rebuilds its transcript from the store, so an unpersisted
+                // preamble would be lost. Fence on the lease first: the stream
+                // just consumed may have outlasted it.
+                if !text.is_empty() {
+                    self.ensure_durable_lease_current(turn_id).await?;
+                    self.persist_assistant(chat.id, turn_id, &candidate).await?;
+                }
                 return Ok(AgentTurnOutcome::ClientToolCall {
                     request,
                     usage: total_usage,
@@ -1265,12 +1289,12 @@ impl Agent {
                 })
                 .collect::<Vec<_>>();
             if !sandbox_spawns.is_empty() {
-                if calls.len() != 1 || sandbox_spawns.len() != 1 || !text.is_empty() {
+                if calls.len() != 1 || sandbox_spawns.len() != 1 {
                     events.send(AgentEvent::StreamInterrupted);
                     transcript.push(ChatMessage {
                         role: Role::User,
                         content: vec![ContentBlock::Text {
-                            text: "A sandbox delegation must be requested alone, without assistant text or sibling tool calls. Retry the request in that form.".into(),
+                            text: "A sandbox delegation must be requested alone, without sibling tool calls. Retry the request in that form.".into(),
                         }],
                     });
                     continue;
@@ -1306,6 +1330,10 @@ impl Agent {
                     });
                     continue;
                 };
+                if !text.is_empty() {
+                    self.ensure_durable_lease_current(turn_id).await?;
+                    self.persist_assistant(chat.id, turn_id, &candidate).await?;
+                }
                 return Ok(AgentTurnOutcome::SandboxAgentSpawn {
                     request: SandboxAgentSpawnRequest {
                         call_id: call.call_id,
@@ -1328,11 +1356,11 @@ impl Agent {
                 })
                 .collect::<Vec<_>>();
             if !agent_waits.is_empty() {
-                if calls.len() != 1 || agent_waits.len() != 1 || !text.is_empty() {
+                if calls.len() != 1 || agent_waits.len() != 1 {
                     events.send(AgentEvent::StreamInterrupted);
                     transcript.push(ChatMessage::text(
                         Role::User,
-                        "wait_for_agents must be requested alone, without assistant text or sibling tool calls. Retry the request in that form.",
+                        "wait_for_agents must be requested alone, without sibling tool calls. Retry the request in that form.",
                     ));
                     continue;
                 }
@@ -1362,6 +1390,10 @@ impl Agent {
                     ));
                     continue;
                 };
+                if !text.is_empty() {
+                    self.ensure_durable_lease_current(turn_id).await?;
+                    self.persist_assistant(chat.id, turn_id, &candidate).await?;
+                }
                 return Ok(AgentTurnOutcome::WaitForAgents {
                     request: ForegroundAgentWaitRequest {
                         call_id: call.call_id,
@@ -2833,6 +2865,9 @@ mod tests {
 
     struct ClientToolProvider {
         assistant_text: bool,
+        /// Emit a second, server-executed call beside the client one — the
+        /// shape the loop still refuses, since a checkpoint carries one call.
+        sibling_call: bool,
         name: &'static str,
         arguments: &'static str,
     }
@@ -3106,6 +3141,22 @@ mod tests {
                     reason: StopReason::ToolUse,
                 },
             ];
+            if self.sibling_call {
+                events.splice(
+                    1..1,
+                    [
+                        ProviderEvent::ToolCallStarted {
+                            index: 1,
+                            id: "native_2".into(),
+                            name: "read_file".into(),
+                        },
+                        ProviderEvent::ToolCallArgsDelta {
+                            index: 1,
+                            fragment: r#"{"path":"a.txt"}"#.into(),
+                        },
+                    ],
+                );
+            }
             if self.assistant_text {
                 events.insert(
                     0,
@@ -3211,6 +3262,7 @@ mod tests {
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
                 assistant_text: false,
+                sibling_call: false,
                 name: "connect_folder",
                 arguments: r#"{"hint":"Documents"}"#,
             }),
@@ -3261,6 +3313,7 @@ mod tests {
         let invalid_agent = Agent::new(
             Arc::new(ClientToolProvider {
                 assistant_text: false,
+                sibling_call: false,
                 name: crate::REQUEST_FOLDER_ACCESS_TOOL,
                 arguments: r#"{"reason":"Read reports","requested_capabilities":["write_files"],"path":"/Users/example/Documents"}"#,
             }),
@@ -3354,6 +3407,7 @@ mod tests {
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
                 assistant_text: false,
+                sibling_call: false,
                 name: crate::ASK_USER_QUESTIONS_TOOL,
                 arguments: r#"{"questions":[{"id":"target","header":"Target","question":"Where should I deploy?","options":[{"id":"staging","label":"Staging","description":"Deploy for verification."}]}]}"#,
             }),
@@ -3434,6 +3488,7 @@ mod tests {
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
                 assistant_text: false,
+                sibling_call: false,
                 name: crate::SPAWN_SANDBOX_AGENT_TOOL,
                 arguments: r#"{"task":"Research the error handling options."}"#,
             }),
@@ -3566,6 +3621,7 @@ mod tests {
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
                 assistant_text: false,
+                sibling_call: false,
                 name: crate::WAIT_FOR_AGENTS_TOOL,
                 arguments,
             }),
@@ -3611,7 +3667,91 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn claimed_agent_retries_a_mixed_client_call_then_preserves_exhausted_usage() {
+    async fn claimed_agent_retries_a_client_call_with_siblings_then_preserves_exhausted_usage() {
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "fake", "connect documents")
+            .await
+            .unwrap();
+        let lease_token = uuid::Uuid::new_v4();
+        let claimed_at = Utc::now();
+        store
+            .claim_turn_run(
+                lease_token,
+                claimed_at,
+                claimed_at + chrono::Duration::minutes(1),
+            )
+            .await
+            .unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.register_client(ToolSpec {
+            name: "connect_folder".into(),
+            description: "Ask the desktop to connect a folder".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        });
+        let agent = Agent::new(
+            Arc::new(ClientToolProvider {
+                assistant_text: false,
+                sibling_call: true,
+                name: "connect_folder",
+                arguments: r#"{"hint":"Documents"}"#,
+            }),
+            Arc::new(registry),
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                max_steps: 2,
+                ..AgentConfig::default()
+            },
+        )
+        .with_durable_steer(lease_token);
+        let (tx, _rx) = unbounded();
+        let outcome = agent
+            .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
+            .await
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            AgentTurnOutcome::Failed {
+                error,
+                usage: Usage {
+                    input_tokens: 10,
+                    output_tokens: 4,
+                    ..
+                },
+                model_steps: 2,
+            } if error.kind == "max_steps_exceeded"
+        ));
+        assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
+    }
+
+    /// The model narrates before it acts. Rejecting a client call for carrying
+    /// a preamble spent the whole step budget on a correction the model never
+    /// satisfied — the same failure #372 fixed for sensitive calls. The step
+    /// must check point instead, keeping the preamble durable across the
+    /// resume.
+    #[tokio::test]
+    async fn client_call_with_prose_checkpoints_and_keeps_the_preamble() {
         let db = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -3656,6 +3796,7 @@ mod tests {
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
                 assistant_text: true,
+                sibling_call: false,
                 name: "connect_folder",
                 arguments: r#"{"hint":"Documents"}"#,
             }),
@@ -3673,19 +3814,28 @@ mod tests {
             .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
             .await
             .unwrap();
-        assert!(matches!(
-            outcome,
-            AgentTurnOutcome::Failed {
-                error,
-                usage: Usage {
-                    input_tokens: 10,
-                    output_tokens: 4,
-                    ..
-                },
-                model_steps: 2,
-            } if error.kind == "max_steps_exceeded"
-        ));
-        assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
+
+        // One step, not an exhausted budget: the call reached its checkpoint.
+        let AgentTurnOutcome::ClientToolCall {
+            request,
+            model_steps,
+            ..
+        } = outcome
+        else {
+            panic!("expected a client tool checkpoint, got {outcome:?}");
+        };
+        assert_eq!(request.name, "connect_folder");
+        assert_eq!(model_steps, 1);
+
+        // The preamble is durable, so the resumed attempt rebuilds it.
+        let messages = store.list_messages(chat.id).await.unwrap();
+        assert!(
+            messages
+                .iter()
+                .any(|message| message.role == Role::Assistant
+                    && message.content.contains("I will connect it")),
+            "the assistant preamble should survive the checkpoint: {messages:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/context.rs
+++ b/crates/openwave-core/src/context.rs
@@ -78,7 +78,20 @@ pub fn fit_to_budget(
     content_floor: usize,
 ) -> (Vec<ChatMessage>, bool) {
     if messages.is_empty() || estimate_transcript_tokens(messages) <= budget {
-        return (messages.to_vec(), false);
+        // Fitting is not the only thing a transcript needs. A turn that died
+        // with tool calls still pending leaves a ToolUse with no ToolResult,
+        // which providers reject outright — and because that transcript is
+        // usually well under budget, the reduction path below never runs and
+        // never repairs it. Repair here too, so one interrupted turn cannot
+        // wedge every later turn in the chat. This is a structural fix rather
+        // than a reduction, so it does not report `was_reduced`.
+        let mut fitted = messages.to_vec();
+        if has_orphaned_tool_blocks(&fitted) {
+            strip_orphaned_tool_blocks(&mut fitted);
+            merge_adjacent_roles(&mut fitted);
+            ensure_starts_with_user(&mut fitted);
+        }
+        return (fitted, false);
     }
 
     let mut entries: Vec<Entry> = messages
@@ -395,6 +408,29 @@ fn truncate_str(s: &str, target_tokens: usize) -> String {
 }
 
 // ── Cleanup ────────────────────────────────────────────────────────
+
+/// Report whether any ToolUse lacks a matching ToolResult, or vice versa.
+#[must_use]
+pub fn has_orphaned_tool_blocks(messages: &[ChatMessage]) -> bool {
+    let mut use_ids: HashSet<&str> = HashSet::new();
+    let mut result_ids: HashSet<&str> = HashSet::new();
+
+    for msg in messages {
+        for block in &msg.content {
+            match block {
+                ContentBlock::ToolUse { id, .. } => {
+                    use_ids.insert(id.as_str());
+                }
+                ContentBlock::ToolResult { tool_use_id, .. } => {
+                    result_ids.insert(tool_use_id.as_str());
+                }
+                _ => {}
+            }
+        }
+    }
+
+    use_ids.symmetric_difference(&result_ids).next().is_some()
+}
 
 /// Remove ToolUse blocks with no matching ToolResult and vice versa.
 pub fn strip_orphaned_tool_blocks(messages: &mut Vec<ChatMessage>) {
@@ -743,6 +779,44 @@ mod tests {
             .content
             .iter()
             .any(|b| matches!(b, ContentBlock::ToolUse { .. }))));
+    }
+
+    /// A turn that died with a tool call unresolved leaves a ToolUse with no
+    /// ToolResult. That transcript is usually well under budget, so the
+    /// reduction path never runs — yet providers reject it outright, which
+    /// wedged every later turn in the chat. Repair it even when it fits.
+    #[test]
+    fn repairs_orphaned_tool_use_even_when_the_transcript_already_fits() {
+        let msgs = vec![
+            user_msg("go"),
+            tool_use_msg("tu_1", "read_file", "a"),
+            // The turn died here: no matching ToolResult was ever committed.
+            user_msg("next"),
+        ];
+        let (fitted, was_reduced) = fit_to_budget(&msgs, 100_000, 500);
+        assert!(
+            !fitted.iter().any(|m| m
+                .content
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolUse { .. }))),
+            "the orphaned tool use should be stripped: {fitted:?}"
+        );
+        // Structural repair is not a context reduction — reporting one here
+        // would tell the client its context had been truncated.
+        assert!(!was_reduced);
+    }
+
+    #[test]
+    fn under_budget_transcripts_are_otherwise_untouched() {
+        let msgs = vec![
+            user_msg("go"),
+            tool_use_msg("tu_1", "read_file", "a"),
+            tool_result_msg("tu_1", "data"),
+            assistant_msg("done"),
+        ];
+        let (fitted, was_reduced) = fit_to_budget(&msgs, 100_000, 500);
+        assert_eq!(fitted, msgs);
+        assert!(!was_reduced);
     }
 
     #[test]

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -215,6 +215,17 @@ pub enum ProviderEvent {
         /// Why it stopped.
         reason: StopReason,
     },
+    /// The stream ended abnormally — a transport error cut it off mid-flight.
+    ///
+    /// Distinct from [`ProviderEvent::Stop`]: whatever text and tool calls have
+    /// accumulated so far are incomplete, and a tool call's JSON arguments in
+    /// particular may be truncated mid-value. Consumers must discard the
+    /// partial step and treat the completion as failed rather than acting on
+    /// it.
+    Failed {
+        /// Why the stream broke, for the turn's failure detail.
+        message: String,
+    },
 }
 
 /// An LLM backend the agent streams completions from. Held as a trait object,

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -93,7 +93,18 @@ impl ModelProvider for AnthropicProvider {
             let mut buffer: Vec<u8> = Vec::new();
             let mut state = StreamState::default();
             while let Some(chunk) = bytes.next().await {
-                let Ok(chunk) = chunk else { break }; // mid-stream transport error: end
+                // A mid-stream transport error must not read as a clean end:
+                // the accumulated tool-call arguments may be truncated
+                // mid-JSON, and acting on them silently corrupts the step.
+                let chunk = match chunk {
+                    Ok(chunk) => chunk,
+                    Err(error) => {
+                        yield ProviderEvent::Failed {
+                            message: format!("anthropic stream ended early: {error}"),
+                        };
+                        return;
+                    }
+                };
                 buffer.extend_from_slice(&chunk);
                 for frame in drain_frames(&mut buffer) {
                     if let Some(data) = frame_data(&frame) {

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -117,7 +117,18 @@ impl ModelProvider for OpenAiCompatProvider {
             let mut buffer: Vec<u8> = Vec::new();
             let mut state = StreamState::default();
             while let Some(chunk) = bytes.next().await {
-                let Ok(chunk) = chunk else { break };
+                // A mid-stream transport error must not read as a clean end:
+                // the accumulated tool-call arguments may be truncated
+                // mid-JSON, and acting on them silently corrupts the step.
+                let chunk = match chunk {
+                    Ok(chunk) => chunk,
+                    Err(error) => {
+                        yield ProviderEvent::Failed {
+                            message: format!("stream ended early: {error}"),
+                        };
+                        return;
+                    }
+                };
                 buffer.extend_from_slice(&chunk);
                 for frame in drain_frames(&mut buffer) {
                     if let Some(data) = frame_data(&frame) {

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -1121,6 +1121,10 @@ async fn complete_sandbox_task(
                 return Ok(SandboxCompletion::Final(text));
             }
             ProviderEvent::ReasoningDelta { .. } | ProviderEvent::Usage(_) => {}
+            // The stream broke mid-flight, so `text` and `arguments` are both
+            // possibly truncated. Fail under the retryable provider code
+            // instead of treating the fragment as a result.
+            ProviderEvent::Failed { message } => return Err(AgentError::Provider(message)),
             _ => {
                 return Err(AgentError::msg(
                     "sandbox agent provider emitted an unsupported event",


### PR DESCRIPTION
Closes #473.

A turn that hit a recoverable condition threw away the step it had just produced, injected a corrective user message, and re-prompted. Nothing counted repeats, so the model reproduced the same shape and the turn looped until `max_steps_exceeded`. In the desktop UI that reads as the assistant answering, greying out, and starting over.

Three separate defects, all on that path.

### Prose no longer discards the step

`agent.rs` rejected a client-executed call, a sandbox delegation, or `wait_for_agents` if the model had written anything before the call. Narrating before acting is the model's default behaviour, so this triggered constantly.

#372 already removed this exact rejection from the sensitive-call path, with a comment recording that it "burned the whole step budget on corrective retries the model never satisfied". That fix was never carried across. It is now: all three branches keep the preamble and reject only genuine sibling calls, which a single-call checkpoint still cannot carry.

Each branch persists the preamble before returning its checkpoint, fenced on the lease, since the resumed attempt rebuilds its transcript from the store and would otherwise lose the text.

### Broken streams are no longer mistaken for clean endings

Both provider adapters ended the stream silently on a mid-stream transport error, so the loop saw `StopReason::EndTurn` and executed whatever had accumulated — including tool calls whose JSON arguments were truncated mid-value, which `parse_args` then quietly degrades to `{}`.

Adds `ProviderEvent::Failed`. The agent discards the partial candidate and fails the turn under the retryable `provider` code, so the turn retries rather than acting on a fragment.

### Orphaned tool blocks are repaired even under budget

`fit_to_budget` returned early whenever a transcript already fit, skipping `strip_orphaned_tool_blocks`. A turn that died with a call still pending leaves a `tool_use` with no `tool_result` — a shape providers reject as `invalid_request`, which is not retryable. Since that transcript is normally well under budget, the repair never ran and every later turn in the chat failed permanently.

Repair now runs on the fitting path too. It does not report `was_reduced`, so a structural fix is not mistaken for a context truncation.

### Tests

`claimed_agent_retries_a_mixed_client_call_then_preserves_exhausted_usage` asserted the bug: it drove step exhaustion with prose plus a client call. It now uses a sibling-call shape, which is still legitimately refused, and keeps its original usage-accounting assertions.

New coverage for the checkpoint keeping its preamble, for the orphan repair on the under-budget path, and for under-budget transcripts being otherwise untouched.

### Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, and `cargo check --workspace --locked` all clean, with no lockfile change.

### Not addressed here

The loop still refuses batch shapes the model cannot reliably be prompted into avoiding — providers parallelise tool calls by design — rather than sequencing a mixed batch itself. That is a change to durable resume semantics and wants its own issue.