### PR TITLE
fix(desktop): keep historical citations when reopening a chat

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -15,7 +15,6 @@ const transcript: ChatTranscript = {
       citations: [
         {
           id: "citation-private-id",
-          message_id: "assistant-durable",
           ordinal: 1,
           excerpt: "Bounded source excerpt",
           heading: null,
@@ -122,17 +121,25 @@ describe("terminal transcript presentation", () => {
     expect(wait).toHaveBeenCalledTimes(1);
   });
 
-  it("does not carry nested citations across message ownership", () => {
+  // Citation ownership is settled server-side: `get_chat_transcript` groups by
+  // message id and nests the result, so the wire carries no `message_id` for
+  // the renderer to re-check. The renderer's job is to carry through exactly
+  // what it was given — an earlier client-side ownership filter compared
+  // against a field that is never serialized and dropped every citation.
+  it("presents every citation the server nested under the message", () => {
     const presented = presentChatTranscript({
       ...transcript,
       messages: [
         {
           ...transcript.messages[0],
           citations: [
+            transcript.messages[0].citations![0],
             {
-              ...transcript.messages[0].citations![0],
-              message_id: "a-different-message",
-              excerpt: "cross-message private excerpt",
+              id: "citation-second",
+              ordinal: 2,
+              excerpt: "Second bounded excerpt",
+              heading: "Heading",
+              pages: [4],
             },
           ],
         },
@@ -145,11 +152,23 @@ describe("terminal transcript presentation", () => {
         role: "assistant",
         text: "Clean durable answer",
         createdAt: "2026-07-19T10:00:00Z",
-        sources: [],
+        sources: [
+          {
+            id: "citation-private-id",
+            ordinal: 1,
+            excerpt: "Bounded source excerpt",
+            heading: null,
+            pages: [],
+          },
+          {
+            id: "citation-second",
+            ordinal: 2,
+            excerpt: "Second bounded excerpt",
+            heading: "Heading",
+            pages: [4],
+          },
+        ],
       },
     ]);
-    expect(JSON.stringify(presented?.messages)).not.toContain(
-      "cross-message private excerpt",
-    );
   });
 });

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
@@ -140,7 +140,11 @@ describe("hydrateTranscriptHistory", () => {
     ]);
   });
 
-  it("attaches sources only to their exact owning assistant message", () => {
+  // The payload here matches the wire exactly: the server groups citations by
+  // message and nests them, so `message_id` is skipped during serialization.
+  // The previous fixture invented that field, which made this suite pass while
+  // production dropped every historical citation.
+  it("keeps the sources the server nested under each assistant message", () => {
     const entries = hydrateTranscriptHistory(
       [
         {
@@ -151,19 +155,10 @@ describe("hydrateTranscriptHistory", () => {
           citations: [
             {
               id: "citation-1",
-              message_id: "assistant-1",
               ordinal: 1,
               excerpt: "safe excerpt",
               heading: "Safe heading",
               pages: [2],
-            },
-            {
-              id: "citation-crossed",
-              message_id: "assistant-2",
-              ordinal: 2,
-              excerpt: "must not cross messages",
-              heading: null,
-              pages: [],
             },
           ],
         },
@@ -183,7 +178,6 @@ describe("hydrateTranscriptHistory", () => {
       sources: [{ id: "citation-1", excerpt: "safe excerpt" }],
     });
     expect(entries[1]).toMatchObject({ id: "assistant-2", sources: [] });
-    expect(JSON.stringify(entries)).not.toContain("must not cross messages");
   });
 
   it("treats citations omitted from a partial response as an empty source list", () => {

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -52,17 +52,21 @@ export function hydrateTranscriptHistory(
       kind: "message" as const,
       role: message.role,
       text: message.content,
+      // Ownership is already established by the server, which groups citations
+      // by message before nesting them in each snapshot — which is why the
+      // wire shape carries no `message_id`. Re-filtering on one here compared
+      // against `undefined` and silently dropped every historical citation.
       sources:
         message.role === "assistant"
-          ? (message.citations ?? [])
-              .filter((citation) => citation.message_id === message.id)
-              .map(({ id, ordinal, excerpt, heading, pages }) => ({
+          ? (message.citations ?? []).map(
+              ({ id, ordinal, excerpt, heading, pages }) => ({
                 id,
                 ordinal,
                 excerpt,
                 heading,
                 pages,
-              }))
+              }),
+            )
           : [],
       createdAt: message.created_at,
     })),

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -15,7 +15,8 @@ export type ProviderInfo = {
   kind: ProviderKind;
   enabled: boolean;
   has_credential: boolean;
-  base_url: string | null;
+  /** Absent, not null, when unset — the server skips serializing `None`. */
+  base_url?: string;
   models: CustomModelConfig[];
 };
 
@@ -146,10 +147,14 @@ export type ChatMessage = {
   citations?: ChatMessageCitation[];
 };
 
-/** A bounded, renderer-safe evidence snapshot owned by one assistant message. */
+/**
+ * A bounded, renderer-safe evidence snapshot owned by one assistant message.
+ *
+ * Ownership is positional: the server nests each citation under its message and
+ * deliberately skips `message_id` on the wire. Do not reintroduce it.
+ */
 export type ChatMessageCitation = {
   id: string;
-  message_id: string;
   ordinal: number;
   excerpt: string;
   heading: string | null;

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -72,10 +72,10 @@ describe("ProvidersPanel", () => {
       <ProvidersPanel
         providers={[
           {
+            // `base_url` is omitted, not null, exactly as the server sends it.
             kind: "anthropic",
             enabled: false,
             has_credential: false,
-            base_url: null,
             models: [],
           },
         ]}


### PR DESCRIPTION
Closes #475.

Reopening a chat rendered every assistant message with no sources, however many citations the turn had produced. Live citations during a turn were fine; only the durable transcript was affected.

`AssistantCitationSnapshot.message_id` is `#[serde(skip)]`, and deliberately so — `get_chat_transcript` groups citations by message and nests them under their owning `ChatMessageSnapshot`, making ownership positional and the field redundant on the wire. A server test pins the emitted key set to exactly `["excerpt","heading","id","ordinal","pages"]`.

The renderer nonetheless declared `message_id` as required and re-filtered on it:

```ts
.filter((citation) => citation.message_id === message.id)
```

which compares `undefined` against the message id, matches nothing, and drops every citation.

Removes the phantom field and the redundant filter. Ownership is the server's job and is already settled before the payload is serialized.

### Why the tests passed

The vitest fixtures hand-authored `message_id` into a payload the server has never sent, so the suite validated a shape that does not exist. One test asserted a cross-message ownership guarantee that cannot hold client-side, because the field it checked is not transmitted; it now covers what this boundary is actually responsible for — carrying through exactly the citations it was given.

Deleting the field from the type immediately surfaced two further fixtures inventing it, which is the useful part: the type was the only thing that could have caught this, and it was wrong.

### Also fixed

`ProviderInfo.base_url` is `skip_serializing_if = "Option::is_none"`, so the key is absent rather than null. It was typed required-and-nullable, masked today by a `?? ""` but broken for any presence or null check. Corrected to optional, which surfaced a fixture sending `base_url: null` — again a shape the server never emits.

### Verification

`tsc`, the vitest suite (357 tests), and a production build all clean.

### Follow-up

Both defects are optionality mismatches — `serde(skip)` and `skip_serializing_if` — invisible to every test on either side. Worth generating the renderer's wire types from the Rust definitions so the class cannot recur; I'll open that separately.