### PR TITLE
fix(desktop): hold the folder picker's latch across a chat switch

### DIFF
--- a/crates/openwave-desktop/ui/src/FolderDecisionLatch.ts
+++ b/crates/openwave-desktop/ui/src/FolderDecisionLatch.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+
+/**
+ * The one folder request whose decision is currently being resolved.
+ *
+ * Resolving a decision opens the host's native folder picker, and the host
+ * serialises those — a second call while one is open is rejected outright.
+ * The picker is a single shared resource, so the latch that keeps a reader
+ * from starting a second decision cannot live with the conversation: leaving
+ * a chat while its picker is still open would otherwise hand out a fresh
+ * claim, and the next decision would fail in the host instead of being
+ * offered as unavailable.
+ *
+ * Held app-wide and keyed by call id, so the card that owns the open decision
+ * can still show its own progress while every other card reads as blocked.
+ */
+export type FolderDecisionLatchStore = {
+  resolving: Set<string>;
+  /** Take the latch for this call, or report that another decision holds it. */
+  claim: (callId: string) => boolean;
+  release: (callId: string) => void;
+};
+
+export function createFolderDecisionLatchStore() {
+  return create<FolderDecisionLatchStore>()((set, get) => ({
+    resolving: new Set(),
+    claim: (callId) => {
+      if (get().resolving.size > 0) return false;
+      set({ resolving: new Set([callId]) });
+      return true;
+    },
+    release: (callId) =>
+      set((state) => {
+        const next = new Set(state.resolving);
+        next.delete(callId);
+        return { resolving: next };
+      }),
+  }));
+}
+
+export const useFolderDecisionLatch = createFolderDecisionLatchStore();

--- a/crates/openwave-desktop/ui/src/useFolderAccessRequests.test.ts
+++ b/crates/openwave-desktop/ui/src/useFolderAccessRequests.test.ts
@@ -3,6 +3,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient } from "./api";
 import { useFolderAccessRequests } from "./useFolderAccessRequests";
+import { useFolderDecisionLatch } from "./FolderDecisionLatch";
 import { useRefreshSignals } from "./RefreshSignals";
 import * as host from "./host";
 
@@ -26,6 +27,9 @@ function stubClient(overrides: Partial<Record<string, unknown>> = {}) {
 beforeEach(() => {
   vi.mocked(host.hasNativeHost).mockReturnValue(true);
   vi.mocked(host.resolveFolderAccessRequest).mockReset();
+  // The latch is app-wide, so a decision left open by one case would block
+  // the next one.
+  useFolderDecisionLatch.setState({ resolving: new Set() });
 });
 
 afterEach(cleanup);
@@ -133,5 +137,48 @@ describe("useFolderAccessRequests", () => {
     expect(client.listPendingFolderAccessRequests).toHaveBeenLastCalledWith(
       "chat-2",
     );
+  });
+
+  it("keeps the native picker latched across a conversation switch", async () => {
+    // The picker is one shared host resource. Leaving the chat that opened it
+    // must not hand a second decision a fresh claim, or the host rejects it and
+    // the reader sees an error where the control should have read as blocked.
+    let openPicker!: () => void;
+    vi.mocked(host.resolveFolderAccessRequest).mockReturnValue(
+      new Promise<void>((resolve) => {
+        openPicker = resolve;
+      }),
+    );
+
+    const firstClient = stubClient();
+    const first = renderHook(() =>
+      useFolderAccessRequests(firstClient, "chat-1"),
+    );
+    act(() => first.result.current.decide("call-1", "allow"));
+    await waitFor(() =>
+      expect(first.result.current.resolving.has("call-1")).toBe(true),
+    );
+
+    // The reader switches conversations while the picker is still open.
+    first.unmount();
+    const secondClient = stubClient();
+    const second = renderHook(() =>
+      useFolderAccessRequests(secondClient, "chat-2"),
+    );
+
+    expect(second.result.current.resolving.size).toBe(1);
+    act(() => second.result.current.decide("call-2", "allow"));
+
+    expect(host.resolveFolderAccessRequest).toHaveBeenCalledTimes(1);
+    expect(host.resolveFolderAccessRequest).not.toHaveBeenCalledWith(
+      "chat-2",
+      "call-2",
+      "allow",
+    );
+
+    await act(async () => {
+      openPicker();
+    });
+    expect(second.result.current.resolving.size).toBe(0);
   });
 });

--- a/crates/openwave-desktop/ui/src/useFolderAccessRequests.ts
+++ b/crates/openwave-desktop/ui/src/useFolderAccessRequests.ts
@@ -5,6 +5,7 @@ import {
   resolveFolderAccessRequest,
   type FolderAccessDecision,
 } from "./host";
+import { useFolderDecisionLatch } from "./FolderDecisionLatch";
 import { useRefreshSignals } from "./RefreshSignals";
 
 const POLL_INTERVAL_MS = 10_000;
@@ -24,16 +25,16 @@ export type FolderAccessRequests = {
  * Polling is the durable truth; the event stream only says when to look again.
  * A decision opens a native dialog, so at most one is in flight at a time —
  * a second prompt while the first is open would be answering a question the
- * reader cannot see.
+ * reader cannot see. That latch is held app-wide rather than here, because the
+ * picker outlives this conversation: see [FolderDecisionLatch].
  */
 export function useFolderAccessRequests(
   client: ApiClient | null,
   chatId: string | null,
 ): FolderAccessRequests {
   const [requests, setRequests] = useState<PendingFolderAccessRequest[]>([]);
-  const [resolving, setResolving] = useState<Set<string>>(new Set());
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const resolvingRef = useRef<Set<string>>(new Set());
+  const resolving = useFolderDecisionLatch((state) => state.resolving);
   const refreshRef = useRef<(() => void) | null>(null);
   const signal = useRefreshSignals((state) => state.folderAccess);
 
@@ -76,30 +77,25 @@ export function useFolderAccessRequests(
     refreshRef.current?.();
   }, [signal]);
 
-  function beginResolving(callId: string) {
-    resolvingRef.current.add(callId);
-    setResolving((calls) => new Set(calls).add(callId));
+  /** Takes the app-wide latch, or reports that another decision holds it. */
+  function beginResolving(callId: string): boolean {
+    if (!useFolderDecisionLatch.getState().claim(callId)) return false;
     setErrors((current) => {
       const next = { ...current };
       delete next[callId];
       return next;
     });
+    return true;
   }
 
   function finishResolving(callId: string) {
-    resolvingRef.current.delete(callId);
-    setResolving((calls) => {
-      const next = new Set(calls);
-      next.delete(callId);
-      return next;
-    });
+    useFolderDecisionLatch.getState().release(callId);
     refreshRef.current?.();
   }
 
   async function decide(callId: string, decision: FolderAccessDecision) {
     if (!chatId || !hasNativeHost()) return;
-    if (resolvingRef.current.size > 0) return;
-    beginResolving(callId);
+    if (!beginResolving(callId)) return;
     try {
       await resolveFolderAccessRequest(chatId, callId, decision);
     } catch (err) {
@@ -110,8 +106,8 @@ export function useFolderAccessRequests(
   }
 
   async function cancel(callId: string, turnId: string) {
-    if (!client || !chatId || resolvingRef.current.size > 0) return;
-    beginResolving(callId);
+    if (!client || !chatId) return;
+    if (!beginResolving(callId)) return;
     try {
       await client.cancel(chatId, turnId);
     } catch (err) {


### PR DESCRIPTION
Resolving a folder-access request opens the host's native folder picker, and the host serialises those — `client_execution.rs:76-78` takes `state.picker.try_lock()` and rejects a second call outright.

The UI used to make that unreachable. `resolvingFolderCallsRef` lived on the root component and was deliberately left out of both chat-switch reset blocks, so an open decision kept every other folder card reading as blocked whichever conversation you navigated to. Moving the concern into `useFolderAccessRequests` put the latch inside a hook held by `ChatView`, which is keyed on the conversation — so it now resets on every chat switch.

That gap is reachable. The Tauri command holds the picker lock for its whole body, including the receipt work after the picker closes, and the webview is interactive again during that tail:

1. Chat A has a pending folder request; the reader clicks Allow.
2. The reader switches to chat B, which also has one, and clicks Allow.
3. The second call reaches the host and is rejected, and the raw string `another native folder request is already active` lands in the card's error slot — where the buttons used to be replaced with "Finish the current folder request first."

Nothing is corrupted, since the host lock holds. It's the error that shouldn't be reachable.

## The change

The latch moves to its own store, held app-wide because the picker is a single shared resource that outlives any one conversation. It stays keyed by call id, so the card that owns the open decision still shows its own progress while the others read as blocked — the same split the root-held version had.

`errors` stays with the conversation, which is where a card's failure belongs.

## Verification

`tsc`, 358 vitest tests, production build. The new case fails against the current hook and passes with the latch hoisted; the six existing cases are unchanged. The suite resets the latch per test, since an app-wide one would otherwise leak between them.

Closes #481