### PR TITLE
feat: show what a command produced, not just that it ran

### DIFF
--- a/crates/openwave-code-execution/src/tool.rs
+++ b/crates/openwave-code-execution/src/tool.rs
@@ -140,12 +140,17 @@ impl Tool for ExecTool {
             content.push_str(&response.stderr);
         }
         let failed = response.timed_out || response.exit_code != Some(0);
+        // `stdout`/`stderr` ride here as well as in the model-facing content
+        // so the renderer's closed result projection can read them field by
+        // field rather than parsing them back out of prose.
         let mut output = ToolOutput::text(content).with_data(json!({
             "provider": response.provider,
             "exit_code": response.exit_code,
             "timed_out": response.timed_out,
             "output_truncated": response.output_truncated,
             "duration_ms": response.duration_ms,
+            "stdout": response.stdout,
+            "stderr": response.stderr,
         }));
         output.is_error = failed;
         Ok(output)

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -33,7 +33,7 @@ use crate::agent_tools::{
 };
 use crate::approval::{
     ApprovalDecision, ApprovalGate, ApprovalJournalIdentity, ApprovalRequest,
-    ApprovalRequiredPublication, RefuseGate, StandingGrants, ToolApprovalKind, ToolApprovalPreview,
+    ApprovalRequiredPublication, RefuseGate, StandingGrants, ToolApprovalKind,
 };
 use crate::cancel::CancelToken;
 use crate::citation::{
@@ -48,6 +48,7 @@ use crate::model::{
     Chat, Message, Role, ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus,
     TurnRunStatus,
 };
+use crate::preview::{ToolActionPreview, ToolResultPreview};
 use crate::provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, StopReason, Usage,
 };
@@ -785,6 +786,14 @@ struct PendingCall {
     provider_id: String,
     name: String,
     args: String,
+}
+
+/// The closed action projection for a pending call, parsed from the arguments
+/// it will run with. Arguments that never parsed cannot describe an action.
+fn call_action_preview(call: &PendingCall) -> Option<ToolActionPreview> {
+    serde_json::from_str(&call.args)
+        .ok()
+        .and_then(|args| ToolActionPreview::build(&call.name, &args))
 }
 
 struct AssistantCandidate {
@@ -1595,6 +1604,8 @@ impl Agent {
                 events.send(AgentEvent::ToolCallCompleted {
                     call_id: call.call_id,
                     output: output.clone(),
+                    action: call_action_preview(call),
+                    result: ToolResultPreview::build(&call.name, output.data.as_ref()),
                 });
                 if needs_resolution {
                     let resolution = if output.is_error {
@@ -2077,9 +2088,7 @@ impl Agent {
             // asked about before the restart.
             let preview = match durable_approval {
                 Some(approval) => approval.preview.clone(),
-                None => serde_json::from_str(&call.args)
-                    .ok()
-                    .and_then(|args| ToolApprovalPreview::build(&call.name, &args)),
+                None => call_action_preview(call),
             };
             if self.durable_steer_lease.is_some() && events.flush().await.is_err() {
                 return ToolOutput::error("approval event journal is unavailable");
@@ -2315,6 +2324,8 @@ impl Agent {
                 events.send(AgentEvent::ToolCallCompleted {
                     call_id: call.call_id,
                     output: output.clone(),
+                    action: call_action_preview(&call),
+                    result: ToolResultPreview::build(&call.name, output.data.as_ref()),
                 });
                 transcript.push(ChatMessage {
                     role: Role::User,
@@ -2381,6 +2392,8 @@ impl Agent {
             events.send(AgentEvent::ToolCallCompleted {
                 call_id: call.call_id,
                 output: output.clone(),
+                action: call_action_preview(&call),
+                result: ToolResultPreview::build(&call.name, output.data.as_ref()),
             });
             transcript.push(ChatMessage {
                 role: Role::User,

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -15,6 +15,7 @@ use std::sync::RwLock;
 
 use crate::event::SequencedEvent;
 use crate::id::{CallId, ChatId, TurnId};
+use crate::preview::ToolActionPreview;
 use crate::tool::ApprovalClass;
 use chrono::{DateTime, Utc};
 
@@ -140,83 +141,6 @@ impl ToolApprovalKind {
     }
 }
 
-/// The exact action a parked call will take, in a form a human can inspect.
-///
-/// [`ToolApprovalKind`] names the *class* of egress being consented to; it
-/// cannot say which command is about to run. Consent that cannot be inspected
-/// is not consent, so a tool may additionally project a preview.
-///
-/// This is not an arguments passthrough. Each variant enumerates exactly the
-/// fields a decision needs, a tool without a variant projects nothing, and
-/// values are clamped so a model cannot use the card as an unbounded canvas.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "tool", rename_all = "snake_case")]
-pub enum ToolApprovalPreview {
-    /// A command execution, as the argument vector it will actually run. There
-    /// is no shell string to show because no shell parses it.
-    Exec {
-        /// Executable name or path the model chose.
-        command: String,
-        /// Arguments passed directly to the executable.
-        args: Vec<String>,
-        /// Working directory relative to the chat's private scratch, never a
-        /// host path.
-        cwd: String,
-    },
-}
-
-impl ToolApprovalPreview {
-    /// Longest command, argument, or directory string a preview carries.
-    pub const MAX_FIELD_CHARS: usize = 512;
-
-    /// Most arguments a preview carries before it elides the tail.
-    pub const MAX_ARGS: usize = 32;
-
-    /// Project the preview for a call, or `None` when the tool has none.
-    ///
-    /// `arguments` are the canonical model-authored arguments. Only the fields
-    /// named by a variant are read; malformed arguments simply yield `None`
-    /// rather than degrading the card into a raw JSON dump.
-    #[must_use]
-    pub fn build(tool_name: &str, arguments: &serde_json::Value) -> Option<Self> {
-        match tool_name {
-            // Kept beside `ToolApprovalKind::for_tool_name`, which already owns
-            // the closed mapping from tool name to consent semantics.
-            "exec" => {
-                let command = clamp(arguments.get("command")?.as_str()?)?;
-                let args = arguments
-                    .get("args")
-                    .and_then(serde_json::Value::as_array)
-                    .map(|args| {
-                        args.iter()
-                            .take(Self::MAX_ARGS)
-                            .filter_map(|arg| arg.as_str().and_then(clamp))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let cwd = arguments
-                    .get("cwd")
-                    .and_then(serde_json::Value::as_str)
-                    .and_then(clamp)
-                    .unwrap_or_else(|| ".".into());
-                Some(Self::Exec { command, args, cwd })
-            }
-            _ => None,
-        }
-    }
-}
-
-/// Bound one preview field, dropping control characters that could forge card
-/// structure. An empty or all-control field is not presentable.
-fn clamp(value: &str) -> Option<String> {
-    let cleaned: String = value
-        .chars()
-        .filter(|character| !character.is_control())
-        .take(ToolApprovalPreview::MAX_FIELD_CHARS)
-        .collect();
-    (!cleaned.is_empty()).then_some(cleaned)
-}
-
 impl ToolApprovalStatus {
     /// Stable database representation.
     #[must_use]
@@ -231,7 +155,7 @@ impl ToolApprovalStatus {
 
 /// Private durable approval state. Canonical tool arguments and model summaries
 /// deliberately remain outside this read model; only the closed
-/// [`ToolApprovalPreview`] projection of those arguments is presentable.
+/// [`ToolActionPreview`] projection of those arguments is presentable.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolApproval {
     pub call_id: CallId,
@@ -241,7 +165,7 @@ pub struct ToolApproval {
     pub class: ApprovalClass,
     pub kind: ToolApprovalKind,
     /// What the call will do, when the tool projects it.
-    pub preview: Option<ToolApprovalPreview>,
+    pub preview: Option<ToolActionPreview>,
     pub status: ToolApprovalStatus,
     pub reason: Option<String>,
     pub requested_at: DateTime<Utc>,
@@ -438,7 +362,7 @@ pub struct ApprovalRequest {
     pub kind: ToolApprovalKind,
     /// Closed projection of the arguments this call will run with, when the
     /// tool has one. Registration ignores it; it exists to be presented.
-    pub preview: Option<ToolApprovalPreview>,
+    pub preview: Option<ToolActionPreview>,
     /// Short human-readable summary of what will happen.
     pub summary: String,
 }
@@ -660,73 +584,5 @@ mod standing_grant_tests {
 
         grants.clear();
         assert!(!grants.covers(chat, "search", kind));
-    }
-
-    #[test]
-    fn exec_preview_carries_the_argument_vector_and_defaults_its_directory() {
-        let preview = ToolApprovalPreview::build(
-            "exec",
-            &serde_json::json!({ "command": "python3", "args": ["-c", "print(1)"] }),
-        );
-        assert_eq!(
-            preview,
-            Some(ToolApprovalPreview::Exec {
-                command: "python3".into(),
-                args: vec!["-c".into(), "print(1)".into()],
-                cwd: ".".into(),
-            })
-        );
-    }
-
-    #[test]
-    fn only_tools_with_a_variant_project_a_preview() {
-        for (tool, arguments) in [
-            ("search", serde_json::json!({ "query": "private" })),
-            ("web_search", serde_json::json!({ "query": "private" })),
-            (
-                "write_file",
-                serde_json::json!({ "path": "/Users/private" }),
-            ),
-            ("mcp__server__tool", serde_json::json!({ "any": "thing" })),
-        ] {
-            assert_eq!(ToolApprovalPreview::build(tool, &arguments), None);
-        }
-    }
-
-    #[test]
-    fn malformed_exec_arguments_yield_no_preview_rather_than_a_raw_dump() {
-        for arguments in [
-            serde_json::json!({}),
-            serde_json::json!({ "command": "" }),
-            serde_json::json!({ "command": 7 }),
-            serde_json::json!("not an object"),
-        ] {
-            assert_eq!(ToolApprovalPreview::build("exec", &arguments), None);
-        }
-    }
-
-    #[test]
-    fn exec_preview_bounds_the_card_a_model_can_paint() {
-        let long = "a".repeat(ToolApprovalPreview::MAX_FIELD_CHARS * 2);
-        let many: Vec<_> = (0..ToolApprovalPreview::MAX_ARGS * 2)
-            .map(|index| index.to_string())
-            .collect();
-        let Some(ToolApprovalPreview::Exec { command, args, cwd }) = ToolApprovalPreview::build(
-            "exec",
-            &serde_json::json!({
-                "command": long,
-                "args": many,
-                // Control characters could otherwise forge card structure.
-                "cwd": "scratch\n\u{1b}[31mapproved",
-            }),
-        ) else {
-            panic!("exec projects a preview");
-        };
-        assert_eq!(
-            command.chars().count(),
-            ToolApprovalPreview::MAX_FIELD_CHARS
-        );
-        assert_eq!(args.len(), ToolApprovalPreview::MAX_ARGS);
-        assert_eq!(cwd, "scratch[31mapproved");
     }
 }

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -5,13 +5,13 @@ use sea_orm::{
 };
 
 use crate::approval::{
-    ApprovalDecision, ApprovalRequest, ToolApproval, ToolApprovalKind, ToolApprovalPreview,
-    ToolApprovalStatus,
+    ApprovalDecision, ApprovalRequest, ToolApproval, ToolApprovalKind, ToolApprovalStatus,
 };
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{CallId, ChatId, TurnId};
 use crate::model::{ToolCallExecution, ToolCallStatus, TurnRunStatus};
+use crate::preview::ToolActionPreview;
 use crate::storage::{
     DecideToolApprovalOutcome, JournaledToolApprovalOutcome, RequestToolApprovalOutcome,
 };
@@ -488,7 +488,7 @@ fn approval_from_model(model: &entities::tool_call::Model) -> Result<ToolApprova
         // Rebuilt from the arguments the call is durably parked on rather than
         // stored separately, so a recovered card can never describe a different
         // action from the one that will run.
-        preview: ToolApprovalPreview::build(&model.name, &model.arguments),
+        preview: ToolActionPreview::build(&model.name, &model.arguments),
         status,
         reason: model.approval_reason.clone(),
         requested_at: model

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -692,6 +692,7 @@ fn tool_activity_from_call(call: ToolCallRecord) -> ChatToolActivitySnapshot {
     };
     ChatToolActivitySnapshot {
         title: historical_tool_title(&call.name),
+        action: crate::preview::ToolActionPreview::build(&call.name, &call.arguments),
         status,
         started_at: call.created_at,
         finished_at: call.resolved_at,

--- a/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait.rs
@@ -622,6 +622,8 @@ pub(in crate::db) async fn resume_turn_for_agent_run_wait_set(
         let expected_event = AgentEvent::ToolCallCompleted {
             call_id: wait_id,
             output: crate::ToolOutput::text(result),
+            action: None,
+            result: None,
         };
         let stored_event: AgentEvent = serde_json::from_value(event_model.payload)?;
         if event_model.turn_id != Some(stored.turn_id)
@@ -774,6 +776,8 @@ pub(in crate::db) async fn resume_turn_for_agent_run_wait_set(
     let payload = AgentEvent::ToolCallCompleted {
         call_id: wait_id,
         output: crate::ToolOutput::text(canonical_result),
+        action: None,
+        result: None,
     };
     let event_seq = append_event_on(
         &transaction,
@@ -1017,6 +1021,8 @@ where
     let payload = AgentEvent::ToolCallCompleted {
         call_id: CallId(wait.id),
         output: crate::ToolOutput::error(result),
+        action: None,
+        result: None,
     };
     let event_seq = append_event_on(
         conn,

--- a/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait/tool_receipt.rs
+++ b/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait/tool_receipt.rs
@@ -107,6 +107,8 @@ where
         } else {
             crate::ToolOutput::text(result)
         },
+        action: None,
+        result: None,
     };
     Ok(event.turn_id == Some(wait.turn_id)
         && event.lease_token == Some(wait.park_lease_token)

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -247,6 +247,8 @@ where
     let payload = AgentEvent::ToolCallCompleted {
         call_id: request.call_id,
         output: ToolOutput::text(request.result.clone()),
+        action: None,
+        result: None,
     };
     let event_seq = append_event_on(
         conn,
@@ -407,6 +409,8 @@ where
     let expected_event = AgentEvent::ToolCallCompleted {
         call_id: checkpoint.call_id,
         output: ToolOutput::text(checkpoint.result.clone()),
+        action: None,
+        result: None,
     };
     let stored_event: AgentEvent = serde_json::from_value(event.payload)?;
     let arguments = canonical_arguments(request)?;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -11458,7 +11458,7 @@ async fn recovered_exec_approval_still_names_the_command_it_will_run() {
         .unwrap();
     assert_eq!(
         recovered.preview,
-        Some(crate::ToolApprovalPreview::Exec {
+        Some(crate::ToolActionPreview::Exec {
             command: "cargo".into(),
             args: vec!["build".into()],
             cwd: "checkout".into(),

--- a/crates/openwave-core/src/db/tests/multi_agent_wait.rs
+++ b/crates/openwave-core/src/db/tests/multi_agent_wait.rs
@@ -110,6 +110,8 @@ async fn assert_cancelled_wait_shape(
         AgentEvent::ToolCallCompleted {
             call_id: wait_id,
             output: crate::ToolOutput::error(expected_result),
+            action: None,
+            result: None,
         }
     );
 }
@@ -756,7 +758,10 @@ async fn ordered_all_wait_consumes_once_and_exactly_recovers_after_reclaim() {
     }));
     assert_eq!(completed_call.status, ToolCallStatus::Completed);
     assert_eq!(completed_call.execution, ToolCallExecution::Orchestration);
-    let AgentEvent::ToolCallCompleted { call_id, output } = completed_event.event else {
+    let AgentEvent::ToolCallCompleted {
+        call_id, output, ..
+    } = completed_event.event
+    else {
         panic!("wait completion emitted the wrong event")
     };
     assert_eq!(call_id, wait_id);

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -81,7 +81,7 @@ pub enum AgentEvent {
         /// Closed projection of what the call will do, when its tool has one.
         /// Absent on journal rows written before previews existed.
         #[serde(default)]
-        preview: Option<crate::approval::ToolApprovalPreview>,
+        preview: Option<crate::preview::ToolActionPreview>,
         /// A short, human-readable summary of what will happen.
         summary: String,
     },
@@ -98,6 +98,13 @@ pub enum AgentEvent {
         call_id: CallId,
         /// The tool's output.
         output: ToolOutput,
+        /// Closed projection of what the call did, when its tool has one.
+        /// Absent on journal rows written before previews existed.
+        #[serde(default)]
+        action: Option<crate::preview::ToolActionPreview>,
+        /// Closed projection of what the call produced, when its tool has one.
+        #[serde(default)]
+        result: Option<crate::preview::ToolResultPreview>,
     },
     /// The turn finished successfully.
     TurnCompleted {
@@ -181,6 +188,8 @@ mod tests {
         let ev = AgentEvent::ToolCallCompleted {
             call_id: CallId::new(),
             output: ToolOutput::text("done"),
+            action: None,
+            result: None,
         };
         let json = serde_json::to_string(&ev).unwrap();
         assert_eq!(serde_json::from_str::<AgentEvent>(&json).unwrap(), ev);

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod id;
 #[cfg(feature = "keychain")]
 pub mod keychain;
 pub mod model;
+pub mod preview;
 pub mod provider;
 pub mod steer;
 pub mod storage;
@@ -67,8 +68,7 @@ pub use agent_tools::{
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
     ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, AutoApproveGate,
-    RefuseGate, StandingGrant, StandingGrants, ToolApproval, ToolApprovalKind, ToolApprovalPreview,
-    ToolApprovalStatus,
+    RefuseGate, StandingGrant, StandingGrants, ToolApproval, ToolApprovalKind, ToolApprovalStatus,
 };
 #[cfg(feature = "blob-fs")]
 pub use blob::FsBlobStore;
@@ -124,6 +124,7 @@ pub use model::{
     TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus,
     MAX_ATTACHMENT_REVISION, MAX_ROOT_ATTACHMENTS,
 };
+pub use preview::{ToolActionPreview, ToolResultPreview};
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
     Usage,

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -1,0 +1,297 @@
+//! Closed renderer projections of what a tool will do, and what it did.
+//!
+//! The renderer boundary carries no tool arguments and no tool output. These
+//! types are the deliberate exceptions: a tool may opt in to showing a human
+//! the action under review and the result it produced, field by field.
+//!
+//! They are not passthroughs. Each variant enumerates exactly what a person
+//! needs in order to consent to an action or to understand its outcome, values
+//! are clamped, and a tool without a variant projects nothing.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Longest command, argument, or directory string an action preview carries.
+pub const MAX_ACTION_FIELD_CHARS: usize = 512;
+
+/// Most arguments an action preview carries before it elides the tail.
+pub const MAX_ACTION_ARGS: usize = 32;
+
+/// Longest captured stream a result preview carries. The execution provider
+/// already bounds what it captures; this bounds what crosses the boundary.
+pub const MAX_RESULT_STREAM_CHARS: usize = 40_000;
+
+/// The action a call will take, in a form a human can inspect.
+///
+/// Approval cards need this because consent to an action you cannot see is not
+/// consent. Result cards reuse it so the same action is described the same way
+/// before and after it runs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "tool", rename_all = "snake_case")]
+pub enum ToolActionPreview {
+    /// A command execution, as the argument vector it will actually run. There
+    /// is no shell string to show because no shell parses it.
+    Exec {
+        /// Executable name or path the model chose.
+        command: String,
+        /// Arguments passed directly to the executable.
+        args: Vec<String>,
+        /// Working directory relative to the chat's private scratch, never a
+        /// host path.
+        cwd: String,
+    },
+}
+
+impl ToolActionPreview {
+    /// Project the action for a call, or `None` when the tool has none.
+    ///
+    /// `arguments` are the canonical model-authored arguments. Only the fields
+    /// named by a variant are read; malformed arguments yield `None` rather
+    /// than degrading the card into a raw JSON dump.
+    #[must_use]
+    pub fn build(tool_name: &str, arguments: &Value) -> Option<Self> {
+        match tool_name {
+            // Kept beside `ToolApprovalKind::for_tool_name`, which already owns
+            // the closed mapping from tool name to consent semantics.
+            "exec" => {
+                let command = clamp(arguments.get("command")?.as_str()?, MAX_ACTION_FIELD_CHARS)?;
+                let args = arguments
+                    .get("args")
+                    .and_then(Value::as_array)
+                    .map(|args| {
+                        args.iter()
+                            .take(MAX_ACTION_ARGS)
+                            .filter_map(|arg| {
+                                arg.as_str()
+                                    .and_then(|arg| clamp(arg, MAX_ACTION_FIELD_CHARS))
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let cwd = arguments
+                    .get("cwd")
+                    .and_then(Value::as_str)
+                    .and_then(|cwd| clamp(cwd, MAX_ACTION_FIELD_CHARS))
+                    .unwrap_or_else(|| ".".into());
+                Some(Self::Exec { command, args, cwd })
+            }
+            _ => None,
+        }
+    }
+}
+
+/// What a call produced, in a form a human can read.
+///
+/// A command's output is the whole reason to run it. Withholding it leaves the
+/// transcript asserting that something happened without ever showing what.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "tool", rename_all = "snake_case")]
+pub enum ToolResultPreview {
+    Exec {
+        /// Process exit status, or `None` when it was killed by a signal.
+        exit_code: Option<i32>,
+        /// Whether the provider stopped the command at its time limit.
+        timed_out: bool,
+        /// Whether the provider dropped output past its capture limit.
+        output_truncated: bool,
+        stdout: String,
+        stderr: String,
+    },
+}
+
+impl ToolResultPreview {
+    /// Project the result of a call from the tool's own structured output.
+    ///
+    /// `data` is [`crate::ToolOutput::data`], which is otherwise private. A
+    /// tool opts in by putting the enumerated fields there; everything else it
+    /// carries stays behind the boundary.
+    #[must_use]
+    pub fn build(tool_name: &str, data: Option<&Value>) -> Option<Self> {
+        match tool_name {
+            "exec" => {
+                let data = data?;
+                Some(Self::Exec {
+                    exit_code: data
+                        .get("exit_code")
+                        .and_then(Value::as_i64)
+                        .and_then(|code| i32::try_from(code).ok()),
+                    timed_out: data
+                        .get("timed_out")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                    output_truncated: data
+                        .get("output_truncated")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                    stdout: stream(data.get("stdout")),
+                    stderr: stream(data.get("stderr")),
+                })
+            }
+            _ => None,
+        }
+    }
+
+    /// Whether this result has any captured output to show.
+    #[must_use]
+    pub fn has_output(&self) -> bool {
+        match self {
+            Self::Exec { stdout, stderr, .. } => !stdout.is_empty() || !stderr.is_empty(),
+        }
+    }
+}
+
+/// Bound a captured stream, keeping its newlines: output without line breaks
+/// is not output anyone can read.
+fn stream(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_str)
+        .map(|text| {
+            text.chars()
+                .filter(|character| {
+                    !character.is_control() || *character == '\n' || *character == '\t'
+                })
+                .take(MAX_RESULT_STREAM_CHARS)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Bound one single-line preview field, dropping control characters that could
+/// forge card structure. An empty or all-control field is not presentable.
+fn clamp(value: &str, max_chars: usize) -> Option<String> {
+    let cleaned: String = value
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(max_chars)
+        .collect();
+    (!cleaned.is_empty()).then_some(cleaned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exec_action_carries_the_argument_vector_and_defaults_its_directory() {
+        assert_eq!(
+            ToolActionPreview::build(
+                "exec",
+                &serde_json::json!({ "command": "python3", "args": ["-c", "print(1)"] }),
+            ),
+            Some(ToolActionPreview::Exec {
+                command: "python3".into(),
+                args: vec!["-c".into(), "print(1)".into()],
+                cwd: ".".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn only_tools_with_a_variant_project_anything() {
+        for (tool, arguments) in [
+            ("search", serde_json::json!({ "query": "private" })),
+            ("web_search", serde_json::json!({ "query": "private" })),
+            (
+                "write_file",
+                serde_json::json!({ "path": "/Users/private" }),
+            ),
+            ("mcp__server__tool", serde_json::json!({ "any": "thing" })),
+        ] {
+            assert_eq!(ToolActionPreview::build(tool, &arguments), None);
+            assert_eq!(ToolResultPreview::build(tool, Some(&arguments)), None);
+        }
+    }
+
+    #[test]
+    fn malformed_exec_arguments_yield_no_preview_rather_than_a_raw_dump() {
+        for arguments in [
+            serde_json::json!({}),
+            serde_json::json!({ "command": "" }),
+            serde_json::json!({ "command": 7 }),
+            serde_json::json!("not an object"),
+        ] {
+            assert_eq!(ToolActionPreview::build("exec", &arguments), None);
+        }
+    }
+
+    #[test]
+    fn exec_action_bounds_the_card_a_model_can_paint() {
+        let long = "a".repeat(MAX_ACTION_FIELD_CHARS * 2);
+        let many: Vec<_> = (0..MAX_ACTION_ARGS * 2).map(|i| i.to_string()).collect();
+        let Some(ToolActionPreview::Exec { command, args, cwd }) = ToolActionPreview::build(
+            "exec",
+            &serde_json::json!({
+                "command": long,
+                "args": many,
+                // Control characters could otherwise forge card structure.
+                "cwd": "scratch\n\u{1b}[31mapproved",
+            }),
+        ) else {
+            panic!("exec projects an action");
+        };
+        assert_eq!(command.chars().count(), MAX_ACTION_FIELD_CHARS);
+        assert_eq!(args.len(), MAX_ACTION_ARGS);
+        assert_eq!(cwd, "scratch[31mapproved");
+    }
+
+    #[test]
+    fn exec_result_carries_the_streams_and_the_exit_status() {
+        let result = ToolResultPreview::build(
+            "exec",
+            Some(&serde_json::json!({
+                "exit_code": 1,
+                "timed_out": false,
+                "output_truncated": true,
+                "stdout": "line one\nline two\n",
+                "stderr": "boom\n",
+            })),
+        );
+        assert_eq!(
+            result,
+            Some(ToolResultPreview::Exec {
+                exit_code: Some(1),
+                timed_out: false,
+                output_truncated: true,
+                stdout: "line one\nline two\n".into(),
+                stderr: "boom\n".into(),
+            })
+        );
+        assert!(result.unwrap().has_output());
+    }
+
+    #[test]
+    fn a_signal_kill_has_no_exit_code_and_a_silent_run_has_no_output() {
+        let Some(result) = ToolResultPreview::build(
+            "exec",
+            Some(&serde_json::json!({ "exit_code": null, "timed_out": true })),
+        ) else {
+            panic!("exec projects a result");
+        };
+        assert_eq!(
+            result,
+            ToolResultPreview::Exec {
+                exit_code: None,
+                timed_out: true,
+                output_truncated: false,
+                stdout: String::new(),
+                stderr: String::new(),
+            }
+        );
+        assert!(!result.has_output());
+    }
+
+    #[test]
+    fn captured_streams_keep_their_line_breaks_but_stay_bounded() {
+        let Some(ToolResultPreview::Exec { stdout, stderr, .. }) = ToolResultPreview::build(
+            "exec",
+            Some(&serde_json::json!({
+                "stdout": "a".repeat(MAX_RESULT_STREAM_CHARS * 2),
+                "stderr": "kept\nlines\n\u{1b}[31mbut not escapes",
+            })),
+        ) else {
+            panic!("exec projects a result");
+        };
+        assert_eq!(stdout.chars().count(), MAX_RESULT_STREAM_CHARS);
+        assert_eq!(stderr, "kept\nlines\n[31mbut not escapes");
+    }
+}

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -102,12 +102,18 @@ pub enum ChatToolActivityStatus {
     Cancelled,
 }
 
-/// A completed tool invocation with no arguments, results, tool identity,
-/// provider metadata, executor identity, lease, or diagnostic detail.
+/// A completed tool invocation with no results, tool identity, provider
+/// metadata, executor identity, lease, or diagnostic detail. The only arguments
+/// it can carry are the ones a tool explicitly projects for display.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ChatToolActivitySnapshot {
     /// Fixed allowlisted presentation title, never a provider-supplied name.
     pub title: &'static str,
+    /// Closed projection of what the call did, when its tool has one. Rebuilt
+    /// from the arguments it ran with, so history describes the same action
+    /// the live stream did.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<crate::preview::ToolActionPreview>,
     pub status: ChatToolActivityStatus,
     pub started_at: chrono::DateTime<chrono::Utc>,
     pub finished_at: Option<chrono::DateTime<chrono::Utc>>,

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
-import type { ToolApprovalPreview } from "./api";
+import type { ToolActionPreview } from "./api";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ScrollableContainer } from "./ScrollableContainer";
@@ -20,7 +20,7 @@ type ApprovalCardProps = {
   /** Fixed copy naming the class of action under review. */
   summary: string;
   /** The tool's own view of the concrete action, when it projects one. */
-  preview: ToolApprovalPreview | null;
+  preview: ToolActionPreview | null;
   canApprove: boolean;
   canRemember: boolean;
   deciding: boolean;
@@ -196,7 +196,7 @@ export function ApprovalCard({
  * tool with nothing to show has only that sentence, so it stays the question.
  */
 export function approvalAsk(
-  preview: ToolApprovalPreview | null,
+  preview: ToolActionPreview | null,
   summary: string,
 ): { title: string; summaryLine: string | null } {
   if (preview?.tool === "exec") {
@@ -212,7 +212,7 @@ export function approvalAsk(
  * so an unpresentable action can never be waved through from here.
  */
 export function approvalOptions(
-  preview: ToolApprovalPreview | null,
+  preview: ToolActionPreview | null,
   canApprove: boolean,
   canRemember: boolean,
 ): ApprovalOption[] {

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -1,5 +1,5 @@
 import type { SequencedEvent } from "./api";
-import { parseToolApprovalPreview } from "./api";
+import { parseToolActionPreview, parseToolResultPreview } from "./api";
 import { shouldRefreshAgentRunsAfterToolEvent } from "./AgentRunRefresh";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
 import type { ChatMessage } from "./MessageList";
@@ -245,7 +245,7 @@ export function reduceChatSessionEvent(
             // Validated here rather than trusted: the socket frame is the one
             // place a preview arrives without having gone through the HTTP
             // recovery parser.
-            preview: parseToolApprovalPreview(event.preview),
+            preview: parseToolActionPreview(event.preview),
             canApprove: approval.canApprove,
             canRemember: approval.canRemember,
           }),
@@ -283,6 +283,12 @@ export function reduceChatSessionEvent(
                 : event.status === "failed"
                   ? "failed"
                   : "completed",
+            // Validated here rather than trusted: the socket frame is the one
+            // place a projection arrives without going through the HTTP parser.
+            // A call approved by a standing grant never had an approval card,
+            // so completion is the first time the action itself arrives.
+            preview: parseToolActionPreview(event.action) ?? tool.preview,
+            result: parseToolResultPreview(event.result),
           })),
         },
         effects,

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -37,6 +37,7 @@ export function presentChatTranscript(
           callId: entry.id,
           name: entry.name,
           status: entry.status,
+          preview: entry.preview,
         }
       : entry.role === "assistant"
         ? {

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -320,3 +320,71 @@ describe("card order", () => {
     ]);
   });
 });
+
+describe("command output", () => {
+  const preview = {
+    tool: "exec" as const,
+    command: "cargo",
+    args: ["build"],
+    cwd: ".",
+  };
+  const ran = {
+    tool: "exec" as const,
+    exitCode: 0,
+    timedOut: false,
+    outputTruncated: false,
+    stdout: "",
+    stderr: "",
+  };
+
+  function list(result: typeof ran | null) {
+    return render(
+      <MessageList
+        messages={[
+          {
+            id: "t1",
+            role: "tool",
+            callId: "c1",
+            name: "exec",
+            status: "completed",
+            preview,
+            result,
+          },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+  }
+
+  it("opens onto the output, with the command one tab away", async () => {
+    const user = userEvent.setup();
+    list({ ...ran, stdout: "two tests passed\n" });
+
+    await user.click(screen.getByRole("button", { name: /cargo build/ }));
+    expect(screen.getByText(/two tests passed/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "command" }));
+    expect(screen.getByText(/cargo build/, { selector: "pre" })).toBeInTheDocument();
+  });
+
+  it("drops the tab pair for a command that finished silently", async () => {
+    const user = userEvent.setup();
+    list(ran);
+
+    await user.click(screen.getByRole("button", { name: /cargo build/ }));
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+    expect(screen.getByText(/cargo build/, { selector: "pre" })).toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -3,7 +3,8 @@ import type { ReactNode, RefObject, UIEvent } from "react";
 import type {
   PendingFolderAccessRequest,
   PendingUserQuestions,
-  ToolApprovalPreview,
+  ToolActionPreview,
+  ToolResultPreview,
   UserQuestionAnswer,
 } from "./api";
 import { ApprovalCard } from "./ApprovalCard";
@@ -38,14 +39,16 @@ export type ChatMessage =
       name: string;
       status: ToolCallStatus;
       /** The tool's own closed view of what it is doing, when it has one. */
-      preview?: ToolApprovalPreview | null;
+      preview?: ToolActionPreview | null;
+      /** What the call produced, once it has produced anything. */
+      result?: ToolResultPreview | null;
     }
   | {
       id: string;
       role: "approval";
       callId: string;
       summary: string;
-      preview?: ToolApprovalPreview | null;
+      preview?: ToolActionPreview | null;
       canApprove: boolean;
       canRemember: boolean;
       resolved?: boolean;
@@ -326,6 +329,7 @@ function surfacedCards(
         name={entry.name}
         status={entry.status}
         preview={entry.preview}
+        result={entry.result ?? null}
       />,
     );
   }

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -1,7 +1,10 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import type { ToolResultPreview } from "./api";
+import { toolPreviewPresentation } from "./ToolPreview";
 import {
   ToolCommandCard,
+  commandOutput,
   toolCallPresentation,
   toolApprovalPresentation,
 } from "./ToolCallCard";
@@ -84,7 +87,7 @@ describe("toolCallPresentation", () => {
 describe("ToolCommandCard", () => {
   it("titles itself with the command instead of a generic phrase", () => {
     const markup = renderToStaticMarkup(
-      <ToolCommandCard name="exec" status="completed" preview={preview} />,
+      <ToolCommandCard name="exec" status="completed" preview={preview} result={null} />,
     );
 
     expect(visibleText(markup)).toContain("cargo test --workspace");
@@ -95,14 +98,13 @@ describe("ToolCommandCard", () => {
 
   it("opens while the command is running and closes once it has settled", () => {
     const running = renderToStaticMarkup(
-      <ToolCommandCard name="exec" status="running" preview={preview} />,
+      <ToolCommandCard name="exec" status="running" preview={preview} result={null} />,
     );
     const done = renderToStaticMarkup(
-      <ToolCommandCard name="exec" status="completed" preview={preview} />,
+      <ToolCommandCard name="exec" status="completed" preview={preview} result={null} />,
     );
 
     expect(running).toContain('aria-expanded="true"');
-    expect(visibleText(running)).toContain("# working directory: checkout");
     expect(done).toContain('aria-expanded="false"');
   });
 
@@ -115,7 +117,7 @@ describe("ToolCommandCard", () => {
       ["cancelled", "Not run"],
     ] as const) {
       const markup = renderToStaticMarkup(
-        <ToolCommandCard name="exec" status={status} preview={preview} />,
+        <ToolCommandCard name="exec" status={status} preview={preview} result={null} />,
       );
       expect(visibleText(markup)).toContain(badge);
     }
@@ -155,5 +157,102 @@ describe("toolApprovalPresentation", () => {
       canApprove: false,
       canRemember: false,
     });
+  });
+});
+
+describe("command output", () => {
+  const ran = {
+    tool: "exec" as const,
+    exitCode: 0,
+    timedOut: false,
+    outputTruncated: false,
+    stdout: "",
+    stderr: "",
+  };
+
+  it("labels each captured stream and keeps them in order", () => {
+    // Each stream's own trailing newline is trimmed, so the two sections are
+    // separated by exactly one blank line rather than three.
+    expect(
+      commandOutput({ ...ran, stdout: "one\n", stderr: "boom\n" }),
+    ).toBe("$ stdout\none\n\n$ stderr\nboom");
+  });
+
+  it("says nothing at all when nothing was captured", () => {
+    expect(commandOutput(ran)).toBeNull();
+    expect(commandOutput(null)).toBeNull();
+  });
+
+  it("says so when the provider stopped capturing", () => {
+    expect(
+      commandOutput({ ...ran, stdout: "one\n", outputTruncated: true }),
+    ).toContain("# output was truncated at the capture limit");
+  });
+
+  it("states the outcome alongside the command", () => {
+    const detail = (result: Parameters<typeof commandOutput>[0]) =>
+      toolPreviewPresentation(preview, result).detail;
+
+    expect(detail({ ...ran, exitCode: 2 })).toContain("# exit code: 2");
+    expect(detail({ ...ran, exitCode: null, timedOut: true })).toContain(
+      "# stopped at the time limit",
+    );
+    expect(detail({ ...ran, exitCode: null })).toContain(
+      "# killed by a signal",
+    );
+    // Before it has run there is no outcome to state.
+    expect(detail(null)).toBe(
+      "cargo test --workspace\n# working directory: checkout",
+    );
+  });
+
+  it("says it is waiting rather than showing an empty pane mid-run", () => {
+    const markup = renderToStaticMarkup(
+      <ToolCommandCard
+        name="exec"
+        status="running"
+        preview={preview}
+        result={null}
+      />,
+    );
+
+    expect(markup).toContain('role="tab"');
+    expect(visibleText(markup)).toContain("Waiting for output…");
+  });
+});
+
+describe("outcome badges", () => {
+  const ran: ToolResultPreview = {
+    tool: "exec",
+    exitCode: 0,
+    timedOut: false,
+    outputTruncated: false,
+    stdout: "",
+    stderr: "",
+  };
+
+  it("prefers the most specific thing it can say about a failure", () => {
+    const badge = (
+      result: ToolResultPreview | null,
+      status: "completed" | "failed",
+    ) =>
+      visibleText(
+        renderToStaticMarkup(
+          <ToolCommandCard
+            name="exec"
+            status={status}
+            preview={preview}
+            result={result}
+          />,
+        ),
+      );
+
+    expect(badge({ ...ran, exitCode: 101 }, "failed")).toContain("Exit 101");
+    expect(badge({ ...ran, exitCode: null, timedOut: true }, "failed")).toContain(
+      "Timed out",
+    );
+    expect(badge(ran, "completed")).toContain("Done");
+    // No result to be specific about yet.
+    expect(badge(null, "failed")).toContain("Failed");
   });
 });

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,6 +1,6 @@
 import { useId, useState } from "react";
 import { Check, ChevronDown, Clock, Loader2, Terminal, X } from "lucide-react";
-import type { ToolApprovalPreview } from "./api";
+import type { ToolActionPreview, ToolResultPreview } from "./api";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { ToolTone } from "./ToolStatusIcon";
@@ -18,7 +18,9 @@ type ToolCommandCardProps = {
   name: string;
   status: ToolCallStatus;
   /** The tool's own view of the command, which is what the card is for. */
-  preview: ToolApprovalPreview;
+  preview: ToolActionPreview;
+  /** What the command produced, once it has produced anything. */
+  result: ToolResultPreview | null;
 };
 
 type ToolPresentation = {
@@ -175,12 +177,22 @@ const FALLBACK_TOOL: ToolPresentation = {
  * Only tools that project a preview get a card. Everything else lives in the
  * activity rail, where a line of text is the whole story the renderer has.
  */
-export function ToolCommandCard({ name, status, preview }: ToolCommandCardProps) {
+export function ToolCommandCard({
+  name,
+  status,
+  preview,
+  result,
+}: ToolCommandCardProps) {
   const presentation = toolCallPresentation(name, status);
-  const command = toolPreviewPresentation(preview);
+  const command = toolPreviewPresentation(preview, result);
   const running = presentation.tone === "running";
   const [expanded, setExpanded] = useState(running);
+  const [tab, setTab] = useState<"command" | "output">("output");
   const bodyId = useId();
+  const output = commandOutput(result);
+  // A command that finished silently has nothing to tab between, and a
+  // "Command / Output → no output" pair reads as confusing noise.
+  const tabbed = running || output !== null;
 
   return (
     <section
@@ -208,29 +220,107 @@ export function ToolCommandCard({ name, status, preview }: ToolCommandCardProps)
           <Terminal className="size-3.5 shrink-0" aria-hidden="true" />
           <span className="truncate font-mono">{command.headline}</span>
         </span>
-        <ToolStatusBadge presentation={presentation} />
+        <ToolStatusBadge presentation={presentation} result={result} />
       </button>
       {expanded && (
-        <div id={bodyId} className="border-t p-1">
-          <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
-            {command.detail}
-          </ScrollableContainer>
+        <div id={bodyId} className="border-t">
+          {tabbed && (
+            <div
+              role="tablist"
+              aria-label="Command detail"
+              className="flex w-full items-center justify-start gap-1 border-b px-1"
+            >
+              {(["command", "output"] as const).map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  role="tab"
+                  aria-selected={tab === value}
+                  onClick={() => setTab(value)}
+                  className={cn(
+                    "cursor-pointer rounded-md px-2.5 py-1 text-xs font-medium capitalize transition-colors",
+                    tab === value
+                      ? "text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {value}
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="p-1">
+            {!tabbed || tab === "command" ? (
+              <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
+                {command.detail}
+              </ScrollableContainer>
+            ) : output === null ? (
+              <p className="text-muted-foreground flex items-center gap-1.5 p-2 text-xs">
+                <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+                Waiting for output…
+              </p>
+            ) : (
+              <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
+                {output}
+              </ScrollableContainer>
+            )}
+          </div>
         </div>
       )}
     </section>
   );
 }
 
+/**
+ * The captured streams, labelled and in the order they matter.
+ *
+ * `null` means nothing was captured — which for a finished command is a fact
+ * worth stating by omission rather than by an empty pane.
+ */
+export function commandOutput(result: ToolResultPreview | null): string | null {
+  if (!result) return null;
+  // Streams almost always end in a newline of their own; joining those with a
+  // blank line would open a three-line gap between the two sections.
+  const sections = [
+    result.stdout && `$ stdout\n${result.stdout.replace(/\s+$/, "")}`,
+    result.stderr && `$ stderr\n${result.stderr.replace(/\s+$/, "")}`,
+  ].filter((section): section is string => Boolean(section));
+  if (sections.length === 0) return null;
+  const body = sections.join("\n\n");
+  return result.outputTruncated
+    ? `${body}\n\n# output was truncated at the capture limit`
+    : body;
+}
+
 function ToolStatusBadge({
   presentation,
+  result,
 }: {
   presentation: ToolCallPresentation;
+  result: ToolResultPreview | null;
 }) {
   if (presentation.tone === "running") {
     return (
       <Badge variant="outline" className="shrink-0 gap-1">
         <Loader2 className="size-3 animate-spin" aria-hidden="true" />
         Running…
+      </Badge>
+    );
+  }
+  if (result?.timedOut) {
+    return (
+      <Badge variant="warning" className="shrink-0">
+        Timed out
+      </Badge>
+    );
+  }
+  // A non-zero exit is the most specific thing anyone can be told about a
+  // failed command, so it outranks the generic outcome word.
+  if (typeof result?.exitCode === "number" && result.exitCode !== 0) {
+    return (
+      <Badge variant="outline" className="text-destructive shrink-0 gap-1">
+        <X className="size-3" aria-hidden="true" />
+        Exit {result.exitCode}
       </Badge>
     );
   }

--- a/crates/openwave-desktop/ui/src/ToolPreview.tsx
+++ b/crates/openwave-desktop/ui/src/ToolPreview.tsx
@@ -1,4 +1,4 @@
-import type { ToolApprovalPreview } from "./api";
+import type { ToolActionPreview, ToolResultPreview } from "./api";
 
 /**
  * Presentation of a tool's own preview of the action it is about to take.
@@ -15,18 +15,26 @@ export type ToolPreviewPresentation = {
 };
 
 export function toolPreviewPresentation(
-  preview: ToolApprovalPreview,
+  preview: ToolActionPreview,
+  result: ToolResultPreview | null = null,
 ): ToolPreviewPresentation {
   const headline = [preview.command, ...preview.args]
     .map(quoteArgument)
     .join(" ");
-  // The working directory is a fact about the command, not part of it, so it
-  // reads as a comment rather than as something the shell would run. There is
-  // no shell here at all — this is an argument vector.
-  const detail =
-    preview.cwd === "."
-      ? headline
-      : `${headline}\n# working directory: ${preview.cwd}`;
+  // Everything below the command is a fact *about* it, so it reads as a
+  // comment rather than as something a shell would run. There is no shell here
+  // at all — this is an argument vector.
+  const detail = [
+    headline,
+    preview.cwd !== "." && `# working directory: ${preview.cwd}`,
+    result?.timedOut && "# stopped at the time limit",
+    result && !result.timedOut && result.exitCode === null && "# killed by a signal",
+    result?.exitCode !== null &&
+      result?.exitCode !== undefined &&
+      `# exit code: ${result.exitCode}`,
+  ]
+    .filter((line): line is string => typeof line === "string")
+    .join("\n");
   return { headline, detail };
 }
 

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -1,4 +1,5 @@
-import type { ChatMessage, ChatToolActivity } from "./api";
+import { parseToolActionPreview } from "./api";
+import type { ChatMessage, ChatToolActivity, ToolActionPreview } from "./api";
 import type { AssistantSource } from "./AssistantSources";
 import type { ToolCallStatus } from "./ToolCallCard";
 
@@ -15,6 +16,7 @@ export type HydratedTranscriptEntry =
       id: string;
       kind: "tool";
       name: string;
+      preview: ToolActionPreview | null;
       status: ToolCallStatus;
       createdAt: string;
     };
@@ -74,6 +76,9 @@ export function hydrateTranscriptHistory(
       kind: "tool" as const,
       name: HISTORY_TOOL_NAMES[activity.title],
       status: activity.status,
+      // History carries what the call did but not what it produced: results
+      // are not persisted, so a reloaded command card shows its command alone.
+      preview: parseToolActionPreview(activity.action),
       createdAt: activity.started_at,
     })),
   ];

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -158,6 +158,8 @@ export type ChatMessageCitation = {
 
 /** A fixed, terminal tool-card projection with no canonical tool data. */
 export type ChatToolActivity = {
+  /** What the call did, when its tool projects it. */
+  action?: ToolActionPreview;
   title:
     | "Search sources"
     | "Check sources"
@@ -250,13 +252,15 @@ export type AgentEvent =
       action: RendererToolName;
       approval: RendererApprovalKind;
       class: "read_only" | "workspace" | "sensitive";
-      preview?: ToolApprovalPreview;
+      preview?: ToolActionPreview;
     }
   | { type: "approval_decided"; call_id: string; approved: boolean }
   | {
       type: "tool_call_completed";
       call_id: string;
       status: "completed" | "failed";
+      action?: ToolActionPreview;
+      result?: ToolResultPreview;
     }
   | { type: "turn_completed" }
   | { type: "turn_failed" }
@@ -287,18 +291,34 @@ export type RendererToolName =
   | "other";
 
 /**
- * The action a parked call will take, in a form a human can inspect.
+ * The action a call will take, in a form a human can inspect.
  *
- * The renderer boundary otherwise carries no tool arguments. This is the one
- * exception: a tool may project a closed, field-by-field view of what it is
- * about to do, because consent to an action you cannot see is not consent.
- * Tools without a variant send nothing.
+ * The renderer boundary otherwise carries no tool arguments. This is one of two
+ * exceptions: a tool may project a closed, field-by-field view of what it is
+ * about to do, because consent to an action you cannot see is not consent, and
+ * because a result is unreadable without knowing what produced it.
  */
-export type ToolApprovalPreview = {
+export type ToolActionPreview = {
   tool: "exec";
   command: string;
   args: string[];
   cwd: string;
+};
+
+/**
+ * What a call produced.
+ *
+ * The other exception. A command's output is the whole reason to run it;
+ * withholding it leaves the transcript asserting that something happened
+ * without ever showing what.
+ */
+export type ToolResultPreview = {
+  tool: "exec";
+  exitCode: number | null;
+  timedOut: boolean;
+  outputTruncated: boolean;
+  stdout: string;
+  stderr: string;
 };
 
 export type RendererApprovalKind =
@@ -331,7 +351,7 @@ export type PendingToolApproval = {
   approval: RendererApprovalKind;
   class: "read_only" | "workspace" | "sensitive";
   /** What the parked call will do, when its tool projects a preview. */
-  preview: ToolApprovalPreview | null;
+  preview: ToolActionPreview | null;
   canApprove: boolean;
   canRemember: boolean;
 };
@@ -992,7 +1012,7 @@ export function parsePendingToolApproval(
     action: value.action,
     approval: value.approval,
     class: value.class,
-    preview: parseToolApprovalPreview(value.preview),
+    preview: parseToolActionPreview(value.preview),
     canApprove: value.can_approve,
     canRemember: value.can_remember,
   };
@@ -1003,9 +1023,9 @@ export function parsePendingToolApproval(
  * dropped rather than partially rendered: an approval card that describes the
  * wrong action is worse than one that describes no action.
  */
-export function parseToolApprovalPreview(
+export function parseToolActionPreview(
   value: unknown,
-): ToolApprovalPreview | null {
+): ToolActionPreview | null {
   if (value === undefined || value === null) return null;
   if (!isRecord(value) || value.tool !== "exec") return null;
   const { command, args, cwd } = value;
@@ -1020,6 +1040,35 @@ export function parseToolApprovalPreview(
     return null;
   }
   return { tool: "exec", command, args, cwd };
+}
+
+/**
+ * Validate a result field by field, on the same terms as an action: anything
+ * that cannot be fully verified is dropped rather than half-rendered.
+ */
+export function parseToolResultPreview(
+  value: unknown,
+): ToolResultPreview | null {
+  if (value === undefined || value === null) return null;
+  if (!isRecord(value) || value.tool !== "exec") return null;
+  const { exit_code, timed_out, output_truncated, stdout, stderr } = value;
+  if (
+    (exit_code !== null && typeof exit_code !== "number") ||
+    typeof timed_out !== "boolean" ||
+    typeof output_truncated !== "boolean" ||
+    typeof stdout !== "string" ||
+    typeof stderr !== "string"
+  ) {
+    return null;
+  }
+  return {
+    tool: "exec",
+    exitCode: exit_code,
+    timedOut: timed_out,
+    outputTruncated: output_truncated,
+    stdout,
+    stderr,
+  };
 }
 
 function isRendererToolName(value: unknown): value is RendererToolName {

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -18,7 +18,7 @@ use std::sync::{
 
 use openwave_core::{
     ApprovalClass, ApprovalDecision, ApprovalGate, ApprovalRequest, CallId, ChatId, StandingGrants,
-    ToolApprovalKind, ToolApprovalPreview, ToolCtx, ToolOutput, ToolRegistry, TurnId, VERSION,
+    ToolActionPreview, ToolApprovalKind, ToolCtx, ToolOutput, ToolRegistry, TurnId, VERSION,
 };
 use serde_json::Value;
 
@@ -79,7 +79,7 @@ impl ApprovalBridge {
             tool_name: tool_name.to_string(),
             class,
             kind,
-            preview: ToolApprovalPreview::build(tool_name, arguments),
+            preview: ToolActionPreview::build(tool_name, arguments),
             summary: format!("{tool_name} requires approval"),
         };
         // MCP has no durable steer journal, so register without a journal identity.

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -6,8 +6,8 @@
 //! projection instead.
 
 use openwave_core::{
-    AgentEvent, ApprovalClass, CallId, MessageId, SequencedEvent, ToolApprovalKind,
-    ToolApprovalPreview, TurnId,
+    AgentEvent, ApprovalClass, CallId, MessageId, SequencedEvent, ToolActionPreview,
+    ToolApprovalKind, ToolResultPreview, TurnId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -51,7 +51,7 @@ pub(crate) enum RendererAgentEvent {
         /// field-by-field view of the action under review. Tools without one
         /// send nothing, as every tool did before.
         #[serde(skip_serializing_if = "Option::is_none")]
-        preview: Option<ToolApprovalPreview>,
+        preview: Option<ToolActionPreview>,
     },
     ApprovalDecided {
         call_id: CallId,
@@ -60,6 +60,15 @@ pub(crate) enum RendererAgentEvent {
     ToolCallCompleted {
         call_id: CallId,
         status: RendererToolStatus,
+        /// What the call did, when its tool projects it. Approval is not the
+        /// only moment a person needs to see the action.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        action: Option<ToolActionPreview>,
+        /// What the call produced. A command's output is the reason it ran;
+        /// withholding it leaves the transcript asserting that something
+        /// happened without ever showing what.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        result: Option<ToolResultPreview>,
     },
     TurnCompleted,
     TurnFailed,
@@ -177,16 +186,21 @@ impl From<&SequencedEvent> for RendererSequencedEvent {
                     approved: *approved,
                 }
             }
-            AgentEvent::ToolCallCompleted { call_id, output } => {
-                RendererAgentEvent::ToolCallCompleted {
-                    call_id: *call_id,
-                    status: if output.is_error {
-                        RendererToolStatus::Failed
-                    } else {
-                        RendererToolStatus::Completed
-                    },
-                }
-            }
+            AgentEvent::ToolCallCompleted {
+                call_id,
+                output,
+                action,
+                result,
+            } => RendererAgentEvent::ToolCallCompleted {
+                call_id: *call_id,
+                status: if output.is_error {
+                    RendererToolStatus::Failed
+                } else {
+                    RendererToolStatus::Completed
+                },
+                action: action.clone(),
+                result: result.clone(),
+            },
             AgentEvent::TurnCompleted { .. } => RendererAgentEvent::TurnCompleted,
             AgentEvent::TurnFailed { .. } => RendererAgentEvent::TurnFailed,
             AgentEvent::TurnCancelled { .. } => RendererAgentEvent::TurnCancelled,
@@ -242,6 +256,8 @@ mod tests {
                 output: ToolOutput::error("secret output").with_data(serde_json::json!({
                     "path": "/Users/private/document.txt",
                 })),
+                action: None,
+                result: None,
             },
             AgentEvent::TurnFailed {
                 error: (&AgentError::config("provider diagnostic")).into(),
@@ -313,7 +329,7 @@ mod tests {
                 tool_name: "exec".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::ExecMayRunNetworkedCommand,
-                preview: ToolApprovalPreview::build(
+                preview: ToolActionPreview::build(
                     "exec",
                     &serde_json::json!({
                         "command": "cargo",
@@ -335,6 +351,73 @@ mod tests {
     }
 
     #[test]
+    fn exec_completion_projects_what_ran_and_what_it_produced() {
+        let projected = RendererSequencedEvent::from(&SequencedEvent {
+            seq: 12,
+            event: AgentEvent::ToolCallCompleted {
+                call_id: CallId::new(),
+                output: ToolOutput::text("provider: local\nexit: 0").with_data(serde_json::json!({
+                    "provider": "local",
+                    "exit_code": 0,
+                    "timed_out": false,
+                    "output_truncated": false,
+                    "duration_ms": 12,
+                    "stdout": "two tests passed\n",
+                    "stderr": "",
+                })),
+                action: ToolActionPreview::build(
+                    "exec",
+                    &serde_json::json!({ "command": "cargo", "args": ["test"] }),
+                ),
+                result: ToolResultPreview::build(
+                    "exec",
+                    Some(&serde_json::json!({
+                        "provider": "local",
+                        "exit_code": 0,
+                        "duration_ms": 12,
+                        "stdout": "two tests passed\n",
+                        "stderr": "",
+                    })),
+                ),
+            },
+        });
+        let json = serde_json::to_string(&projected).unwrap();
+        assert!(json.contains(r#""command":"cargo""#));
+        assert!(json.contains(r#""stdout":"two tests passed\n""#));
+        assert!(json.contains(r#""exit_code":0"#));
+        // Only the enumerated fields cross. The provider identity and the
+        // model-facing content stay behind the boundary.
+        assert!(!json.contains("provider"));
+        assert!(!json.contains("duration_ms"));
+        assert!(!json.contains("exit: 0"));
+    }
+
+    #[test]
+    fn completions_without_a_projection_stay_closed() {
+        let projected = RendererSequencedEvent::from(&SequencedEvent {
+            seq: 13,
+            event: AgentEvent::ToolCallCompleted {
+                call_id: CallId::new(),
+                output: ToolOutput::text("private result").with_data(serde_json::json!({
+                    "stdout": "private stream",
+                })),
+                action: ToolActionPreview::build(
+                    "web_search",
+                    &serde_json::json!({ "query": "private query" }),
+                ),
+                result: ToolResultPreview::build(
+                    "web_search",
+                    Some(&serde_json::json!({ "stdout": "private stream" })),
+                ),
+            },
+        });
+        let json = serde_json::to_string(&projected).unwrap();
+        assert!(!json.contains("action"));
+        assert!(!json.contains("result"));
+        assert!(!json.contains("private"));
+    }
+
+    #[test]
     fn approvals_without_a_preview_stay_closed() {
         let projected = RendererSequencedEvent::from(&SequencedEvent {
             seq: 11,
@@ -343,7 +426,7 @@ mod tests {
                 tool_name: "web_search".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::WebSearchMayShareQuery,
-                preview: ToolApprovalPreview::build(
+                preview: ToolActionPreview::build(
                     "web_search",
                     &serde_json::json!({ "query": "private query" }),
                 ),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1583,7 +1583,7 @@ pub(crate) struct PendingApprovalSnapshot {
     pub approval: openwave_core::ToolApprovalKind,
     pub class: openwave_core::ApprovalClass,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub preview: Option<openwave_core::ToolApprovalPreview>,
+    pub preview: Option<openwave_core::ToolActionPreview>,
     pub can_approve: bool,
     pub can_remember: bool,
 }

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -199,7 +199,9 @@ enum LiveTurnState {
 
 enum ResolutionState {
     Retry,
-    Resolved(SequencedEvent),
+    /// Boxed: an event carrying a tool's projected command output dwarfs the
+    /// other variants, and this enum is returned on every resolution poll.
+    Resolved(Box<SequencedEvent>),
     Cancelling,
     Lost,
 }
@@ -863,7 +865,7 @@ impl TurnWorker {
                                 {
                                     ResolutionState::Retry => {}
                                     ResolutionState::Resolved(event) => {
-                                        self.publish(turn.chat_id, event);
+                                        self.publish(turn.chat_id, *event);
                                         return Ok(TurnWorkerOutcome::Completed(turn.id));
                                     }
                                     ResolutionState::Cancelling => break false,
@@ -1890,7 +1892,7 @@ impl TurnWorker {
                             }
                         };
                         return match recovered {
-                            Ok(Some(event)) => ResolutionState::Resolved(event),
+                            Ok(Some(event)) => ResolutionState::Resolved(Box::new(event)),
                             Ok(None) => ResolutionState::Lost,
                             Err(error) => {
                                 self.retry_after("terminal recovery", turn.id, &error).await;
@@ -1954,7 +1956,7 @@ impl TurnWorker {
                     {
                         ResolutionState::Retry | ResolutionState::Cancelling => {}
                         ResolutionState::Resolved(event) => {
-                            self.publish(turn.chat_id, event);
+                            self.publish(turn.chat_id, *event);
                             return Ok(TurnWorkerOutcome::Cancelled(turn.id));
                         }
                         ResolutionState::Lost => {
@@ -2097,7 +2099,7 @@ impl TurnWorker {
                     {
                         ResolutionState::Retry => {}
                         ResolutionState::Resolved(event) => {
-                            self.publish(turn.chat_id, event);
+                            self.publish(turn.chat_id, *event);
                             return Ok(TurnWorkerOutcome::Failed(turn.id));
                         }
                         ResolutionState::Cancelling => {


### PR DESCRIPTION
Closes #480

A command card showed the command and an outcome word. The output — the whole reason the command was run — never crossed the renderer boundary, so the transcript asserted that something happened without ever showing what.

## The projection

This extends the closed-projection idea that already carries the command, rather than opening the boundary further.

- `ToolApprovalPreview` becomes **`ToolActionPreview`**: a result card wants the same description of what ran as the approval card did, so the name should not be about approval.
- New **`ToolResultPreview`** describes what came back: exit code, timed-out and truncated flags, stdout, stderr. Built from the tool's own structured output (`ToolOutput::data`, otherwise private), clamped to 40k characters per stream, control characters stripped except tabs and newlines — output without line breaks is not output anyone can read.
- Tools without a variant still project nothing. Search, web search, and MCP carry no more than they did.

Both ride on `ToolCallCompleted`. That also fixes a gap from #451: a call approved by a **standing grant** never had an approval card, so nothing ever told the renderer what it was about to run. Now it gets a card.

History carries the action too, rebuilt from the arguments the call ran with, so a reloaded transcript describes the same action the live stream did.

## The card

- **Command/Output tabs**, opening on Output — that's what someone came to read.
- **"Waiting for output…"** while it runs, rather than an empty pane.
- A command that finished silently **drops the tab pair entirely**. A "Command / Output → no output" pair is confusing noise; the badge already carries the outcome.
- The command pane states the outcome as a comment beneath the command: `# exit code: 101`, `# stopped at the time limit`, `# killed by a signal`.
- The badge says the most specific thing available: `Exit 101` beats `Failed`; `Timed out` beats both.
- Each stream's trailing newline is trimmed before joining, so `$ stdout` and `$ stderr` are one blank line apart rather than three.

## Known gap

Results are not persisted, so a reloaded card shows its command without its output. Closing that means threading a preview through `ToolCallResolution` at ~56 construction sites plus a migration — deliberately its own slice.

## Incidental

`ResolutionState::Resolved` now boxes its `SequencedEvent`. The event grew past clippy's `large_enum_variant` threshold, and that enum is returned on every resolution poll.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, `cargo check --locked`; `tsc`, 347 vitest tests, production build. Rendered a running command, a failing one with real test output, and a silent one in both themes; screenshot at `.context/screenshots/command-output.png`.
