### PR TITLE
fix(desktop): keep the conversation mounted behind Settings

### DIFF
--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -946,7 +946,7 @@ export default function App() {
       />}
 
       <div className="main">
-        {surface.kind === "settings" ? (
+        {surface.kind === "settings" && (
           <SettingsView
             client={client}
             models={models}
@@ -959,73 +959,79 @@ export default function App() {
             onCheckForUpdate={desktopUpdates.check}
             onRestartForUpdate={onRestartForUpdate}
           />
-        ) : (
-          <ChatWorkspace
-            chat={chat}
-            status={status}
-            nativeHost={hasNativeHost()}
-            transcript={
-              <ChatView
-                key={chat.id}
-                client={client}
-                chat={chat}
-                hydrated={hydratedChatId === chat.id}
-                nativeHost={hasNativeHost()}
-                deletingChat={deletingChatId !== null}
-                agentRuns={visibleAgentRuns}
-                agentRunsLoading={
-                  agentRunsChatId === chat.id ? agentRunsLoading : true
-                }
-                agentRunsError={agentRunsChatId === chat.id ? agentRunsError : null}
-                stoppingRunIds={visibleStoppingSandboxRunIds}
-                stopErrorRunIds={visibleSandboxStopErrorRunIds}
-                onRetryAgentRuns={() => refreshAgentRunsRef.current?.()}
-                onStopSandboxRun={(runId) => void onStopSandboxAgentRun(runId)}
-                draft={draft}
-                attachingSource={addingSourceChatId !== null}
-                attachedSourceName={
-                  recentSource && recentSource.chatId === chat.id
-                    ? recentSource.source.displayName
-                    : null
-                }
-                sourceAttachmentError={
-                  sourceAttachmentError && sourceAttachmentError.chatId === chat.id
-                    ? sourceAttachmentError.message
-                    : null
-                }
-                composerModelMenu={
-                  <>
-                    <ModelMenu
-                      models={models}
-                      value={chat.model}
-                      disabled={deletingChatId !== null}
-                      onChange={onModelChange}
-              />
-                    {modelForSelection(models, chat.model)?.supports_reasoning_effort && (
-                      <ReasoningEffortMenu
-                        value={chat.reasoning_effort}
-                        disabled={deletingChatId !== null}
-                        onChange={onReasoningEffortChange}
-              />
-                    )}
-                  </>
-                }
-                cancelError={cancelError}
-                cancelPendingTurnId={cancelPendingTurnId}
-                steerError={steerError}
-                steerStatus={steerStatus}
-                steerPendingTurnId={steerPendingTurnId}
-                onDraftChange={onComposerDraftChange}
-                onAddSource={onAddSource}
-                onDismissAttachedSource={() => setRecentSource(null)}
-                onSelectPrompt={setComposerDraft}
-                onSend={onSend}
-                onSteer={onSteerActiveTurn}
-                onStop={onCancelActiveTurn}
-              />
-            }
-          />
         )}
+        {/*
+          Kept mounted behind Settings, not swapped out for it. The pollers for
+          this conversation's pending prompts live in the pane, and a reader who
+          steps into Settings should still be told when the agent asks them
+          something.
+        */}
+        <ChatWorkspace
+          chat={chat}
+          status={status}
+          nativeHost={hasNativeHost()}
+          hidden={surface.kind === "settings"}
+          transcript={
+            <ChatView
+              key={chat.id}
+              client={client}
+              chat={chat}
+              hydrated={hydratedChatId === chat.id}
+              nativeHost={hasNativeHost()}
+              deletingChat={deletingChatId !== null}
+              agentRuns={visibleAgentRuns}
+              agentRunsLoading={
+                agentRunsChatId === chat.id ? agentRunsLoading : true
+              }
+              agentRunsError={agentRunsChatId === chat.id ? agentRunsError : null}
+              stoppingRunIds={visibleStoppingSandboxRunIds}
+              stopErrorRunIds={visibleSandboxStopErrorRunIds}
+              onRetryAgentRuns={() => refreshAgentRunsRef.current?.()}
+              onStopSandboxRun={(runId) => void onStopSandboxAgentRun(runId)}
+              draft={draft}
+              attachingSource={addingSourceChatId !== null}
+              attachedSourceName={
+                recentSource && recentSource.chatId === chat.id
+                  ? recentSource.source.displayName
+                  : null
+              }
+              sourceAttachmentError={
+                sourceAttachmentError && sourceAttachmentError.chatId === chat.id
+                  ? sourceAttachmentError.message
+                  : null
+              }
+              composerModelMenu={
+                <>
+                  <ModelMenu
+                    models={models}
+                    value={chat.model}
+                    disabled={deletingChatId !== null}
+                    onChange={onModelChange}
+            />
+                  {modelForSelection(models, chat.model)?.supports_reasoning_effort && (
+                    <ReasoningEffortMenu
+                      value={chat.reasoning_effort}
+                      disabled={deletingChatId !== null}
+                      onChange={onReasoningEffortChange}
+            />
+                  )}
+                </>
+              }
+              cancelError={cancelError}
+              cancelPendingTurnId={cancelPendingTurnId}
+              steerError={steerError}
+              steerStatus={steerStatus}
+              steerPendingTurnId={steerPendingTurnId}
+              onDraftChange={onComposerDraftChange}
+              onAddSource={onAddSource}
+              onDismissAttachedSource={() => setRecentSource(null)}
+              onSelectPrompt={setComposerDraft}
+              onSend={onSend}
+              onSteer={onSteerActiveTurn}
+              onStop={onCancelActiveTurn}
+          />
+          }
+        />
       </div>
       </div>
     </div>

--- a/crates/openwave-desktop/ui/src/ChatWorkspace.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatWorkspace.dom.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Chat } from "./api";
 import { ChatWorkspace } from "./ChatWorkspace";
+import { useTranscriptVisible } from "./TranscriptVisibility";
 import { useUiStore } from "./UiStore";
 
 vi.mock("./documents", () => ({
@@ -39,13 +40,20 @@ const chat = {
   project_id: null,
 } as unknown as Chat;
 
-function renderWorkspace(nativeHost = true) {
+function TranscriptProbe() {
+  return (
+    <div data-testid="transcript" data-visible={String(useTranscriptVisible())} />
+  );
+}
+
+function renderWorkspace(nativeHost = true, hidden = false) {
   return render(
     <ChatWorkspace
       chat={chat}
       status="chat chat-1 · live"
       nativeHost={nativeHost}
-      transcript={<div data-testid="transcript" />}
+      hidden={hidden}
+      transcript={<TranscriptProbe />}
     />,
   );
 }
@@ -170,5 +178,26 @@ describe("ChatWorkspace", () => {
     expect(
       screen.queryByRole("heading", { name: "Sources" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("stays mounted but off screen behind a global surface", () => {
+    // Settings replaces the pane. Unmounting the conversation with it would
+    // take its pollers along, so a question asked while the reader is in
+    // Settings would go unannounced until they navigated back.
+    const { container } = renderWorkspace(true, true);
+
+    expect(screen.getByTestId("transcript")).toBeInTheDocument();
+    expect(container.querySelector(".chat-workspace")).toHaveAttribute("hidden");
+  });
+
+  it("tells a hidden transcript it is off screen", () => {
+    // Scrolling an element with no layout does nothing, so a transcript that
+    // believes it is visible would leave a following reader mid-history.
+    renderWorkspace(true, true);
+
+    expect(screen.getByTestId("transcript")).toHaveAttribute(
+      "data-visible",
+      "false",
+    );
   });
 });

--- a/crates/openwave-desktop/ui/src/ChatWorkspace.tsx
+++ b/crates/openwave-desktop/ui/src/ChatWorkspace.tsx
@@ -20,6 +20,12 @@ export type ChatWorkspaceProps = {
   nativeHost: boolean;
   /** The transcript surface, supplied by the owner that holds session state. */
   transcript: ReactNode;
+  /**
+   * Off screen behind a global surface like Settings. The conversation stays
+   * mounted so it keeps streaming and polling, and so returning to it costs
+   * neither its scroll position nor a pending prompt.
+   */
+  hidden?: boolean;
 };
 
 /**
@@ -30,13 +36,15 @@ export type ChatWorkspaceProps = {
  * The transcript stays mounted while a surface is open. That is the point of
  * the arrangement — a conversation's own sources should be readable without
  * leaving the conversation, and detail can only move out of the transcript if
- * there is somewhere beside it to put it.
+ * there is somewhere beside it to put it. The same holds one level up: the
+ * whole workspace stays mounted behind a global surface rather than unmounting.
  */
 export function ChatWorkspace({
   chat,
   status,
   nativeHost,
   transcript,
+  hidden = false,
 }: ChatWorkspaceProps) {
   const selected = useUiStore((state) => state.surface);
   const expanded = useUiStore((state) => state.expanded);
@@ -55,7 +63,7 @@ export function ChatWorkspace({
   const panelOpen = opensBesideTranscript(surface.kind);
 
   return (
-    <div className="chat-workspace">
+    <div className="chat-workspace" hidden={hidden}>
       <header className="conversation-header">
         <div className="conversation-title-row">
           <h1>{chat.title?.trim() || "New chat"}</h1>
@@ -117,7 +125,7 @@ export function ChatWorkspace({
               : undefined
           }
         >
-          <TranscriptVisibilityProvider value={slots.showTranscript}>
+          <TranscriptVisibilityProvider value={!hidden && slots.showTranscript}>
             {transcript}
           </TranscriptVisibilityProvider>
         </div>

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -586,6 +586,10 @@ body {
   overflow: hidden;
 }
 
+.chat-workspace[hidden] {
+  display: none;
+}
+
 /* Each surface scrolls inside its own slot; the header above stays put. */
 .workspace-body {
   display: flex;


### PR DESCRIPTION
Settings is a global surface that replaced the pane, so opening it unmounted `ChatWorkspace` — and with it `useUserQuestions` and `useFolderAccessRequests`, which are held by the pane. Before those hooks existed, both pollers were root-level effects keyed on `[client, chat?.id]`, declared above the boot early-return, and ran whichever surface was showing.

`requestUserAttention()` — the dock bounce — fires only when the questions poller sees a call id it hasn't seen before, and that poller is now its only caller. So:

1. The reader opens Settings to add a provider key, then switches to another app.
2. The agent calls `ask_user_question`.
3. Nothing polls, the dock never bounces, and the agent stays blocked until the reader happens to navigate back.

## The change

`ChatWorkspace` takes a `hidden` prop and stays mounted behind the global surface instead of being swapped out for it — the same arrangement it already uses for the transcript behind an expanded panel, and for the same reason: leaving the conversation shouldn't cost it anything it was in the middle of.

Two details:

- A hidden workspace reports its transcript as off screen via `TranscriptVisibilityProvider`. Scrolling an element with no layout is a no-op, so a transcript that believed it was visible would run scroll-follow against nothing and leave a following reader mid-history on the way back. This is the same hazard the panel case already handles.
- `.chat-workspace` is `display: grid`, which beats the `hidden` attribute, so it needs the explicit `[hidden] { display: none }` override — matching what `.workspace-slot` already does.

Two side effects worth naming, both improvements: a Settings round-trip no longer discards the transcript's scroll position, and it no longer rebuilds `seenCallIdsRef` empty, which was firing a second attention hint for a question the reader had already been shown.

## Verification

`tsc`, 360 vitest tests, production build. Both new cases fail against the unfixed component — one when the `hidden` attribute is dropped, one when transcript visibility stops accounting for it.

Closes #485