### PR TITLE
fix(desktop): fence a conversation's requests against its own deletion

### DIFF
--- a/crates/openwave-desktop/ui/src/OpenConversation.ts
+++ b/crates/openwave-desktop/ui/src/OpenConversation.ts
@@ -1,0 +1,30 @@
+import { useRef } from "react";
+import { useChatListStore } from "./ChatListStore";
+
+/**
+ * Whether a response that started under `startedChatId` may still be applied.
+ *
+ * The surfaces that own a conversation's requests are keyed on the chat, so a
+ * response that outlives a chat *switch* lands on an unmounted hook and is
+ * discarded for free. Deletion is the case that keying misses: the root marks
+ * the chat as deleting and only selects a replacement once the delete request
+ * and the chat-list reload have both come back, so the doomed conversation
+ * stays mounted — with a matching id — for the whole round trip.
+ *
+ * Returns a stable predicate that reads current truth when it is called, so a
+ * handler can capture it before an await and still ask an up-to-date question
+ * afterwards.
+ */
+export function useOpenConversation(
+  chatId: string | null,
+): (startedChatId: string) => boolean {
+  const deletingChatId = useChatListStore((state) => state.deletingChatId);
+  const current = useRef({ chatId, deletingChatId });
+  current.current = { chatId, deletingChatId };
+
+  return useRef(
+    (startedChatId: string) =>
+      current.current.chatId === startedChatId &&
+      current.current.deletingChatId !== startedChatId,
+  ).current;
+}

--- a/crates/openwave-desktop/ui/src/useFolderAccessRequests.ts
+++ b/crates/openwave-desktop/ui/src/useFolderAccessRequests.ts
@@ -6,6 +6,7 @@ import {
   type FolderAccessDecision,
 } from "./host";
 import { useFolderDecisionLatch } from "./FolderDecisionLatch";
+import { useOpenConversation } from "./OpenConversation";
 import { useRefreshSignals } from "./RefreshSignals";
 
 const POLL_INTERVAL_MS = 10_000;
@@ -36,6 +37,7 @@ export function useFolderAccessRequests(
   const [errors, setErrors] = useState<Record<string, string>>({});
   const resolving = useFolderDecisionLatch((state) => state.resolving);
   const refreshRef = useRef<(() => void) | null>(null);
+  const stillOpen = useOpenConversation(chatId);
   const signal = useRefreshSignals((state) => state.folderAccess);
 
   useEffect(() => {
@@ -88,32 +90,39 @@ export function useFolderAccessRequests(
     return true;
   }
 
-  function finishResolving(callId: string) {
+  /** The latch is released unconditionally — it is the host's, not the chat's. */
+  function finishResolving(callId: string, startedChatId: string) {
     useFolderDecisionLatch.getState().release(callId);
-    refreshRef.current?.();
+    if (stillOpen(startedChatId)) refreshRef.current?.();
   }
 
   async function decide(callId: string, decision: FolderAccessDecision) {
     if (!chatId || !hasNativeHost()) return;
+    const startedChatId = chatId;
     if (!beginResolving(callId)) return;
     try {
-      await resolveFolderAccessRequest(chatId, callId, decision);
+      await resolveFolderAccessRequest(startedChatId, callId, decision);
     } catch (err) {
-      setErrors((current) => ({ ...current, [callId]: String(err) }));
+      if (stillOpen(startedChatId)) {
+        setErrors((current) => ({ ...current, [callId]: String(err) }));
+      }
     } finally {
-      finishResolving(callId);
+      finishResolving(callId, startedChatId);
     }
   }
 
   async function cancel(callId: string, turnId: string) {
     if (!client || !chatId) return;
+    const startedChatId = chatId;
     if (!beginResolving(callId)) return;
     try {
-      await client.cancel(chatId, turnId);
+      await client.cancel(startedChatId, turnId);
     } catch (err) {
-      setErrors((current) => ({ ...current, [callId]: String(err) }));
+      if (stillOpen(startedChatId)) {
+        setErrors((current) => ({ ...current, [callId]: String(err) }));
+      }
     } finally {
-      finishResolving(callId);
+      finishResolving(callId, startedChatId);
     }
   }
 

--- a/crates/openwave-desktop/ui/src/useToolApprovals.test.ts
+++ b/crates/openwave-desktop/ui/src/useToolApprovals.test.ts
@@ -3,7 +3,20 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient } from "./api";
 import { useChatSessionStore } from "./ChatSessionStore";
+import { useChatListStore } from "./ChatListStore";
 import { useToolApprovals } from "./useToolApprovals";
+
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  promise.catch(() => {});
+  return { promise, resolve, reject };
+}
 
 function stubClient(overrides: Record<string, unknown> = {}) {
   return {
@@ -32,7 +45,10 @@ beforeEach(() => {
   useChatSessionStore.getState().reset();
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  useChatListStore.getState().setDeletingChatId(null);
+});
 
 describe("useToolApprovals", () => {
   it("sends a decision and marks its card resolved", async () => {
@@ -115,5 +131,26 @@ describe("useToolApprovals", () => {
     );
     const [message] = useChatSessionStore.getState().messages;
     expect(message.role === "approval" && message.resolved).toBeFalsy();
+  });
+
+  it("drops a failed decision once its chat is being deleted", async () => {
+    // The pane stays mounted on the doomed chat for the whole delete round
+    // trip, so its id still matches — the deletion is the only signal that the
+    // conversation this error would land on is on its way out.
+    const decision = deferred<void>();
+    const client = stubClient({
+      decideApproval: vi.fn(() => decision.promise),
+    });
+    seedApprovalCard("call-1");
+    const { result } = renderHook(() => useToolApprovals(client, "chat-1"));
+
+    act(() => result.current.decide("call-1", "approve"));
+    act(() => useChatListStore.getState().setDeletingChatId("chat-1"));
+    await act(async () => {
+      decision.reject(new Error("gone"));
+      await decision.promise.catch(() => {});
+    });
+
+    expect(result.current.errors).toEqual({});
   });
 });

--- a/crates/openwave-desktop/ui/src/useToolApprovals.ts
+++ b/crates/openwave-desktop/ui/src/useToolApprovals.ts
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import type { ApiClient } from "./api";
 import { useChatSessionStore } from "./ChatSessionStore";
+import { useOpenConversation } from "./OpenConversation";
 
 export type ToolApprovals = {
   deciding: Set<string>;
@@ -27,6 +28,7 @@ export function useToolApprovals(
   const [deciding, setDeciding] = useState<Set<string>>(new Set());
   const [errors, setErrors] = useState<Record<string, string>>({});
   const decidingRef = useRef<Set<string>>(new Set());
+  const stillOpen = useOpenConversation(chatId);
 
   async function send(
     callId: string,
@@ -34,6 +36,7 @@ export function useToolApprovals(
     remember: boolean,
   ) {
     if (!client || !chatId || decidingRef.current.has(callId)) return;
+    const startedChatId = chatId;
     decidingRef.current.add(callId);
     setDeciding((calls) => new Set(calls).add(callId));
     setErrors((current) => {
@@ -42,7 +45,7 @@ export function useToolApprovals(
       return next;
     });
     try {
-      await client.decideApproval(chatId, callId, decision, remember);
+      await client.decideApproval(startedChatId, callId, decision, remember);
       useChatSessionStore.getState().update((session) => ({
         ...session,
         messages: session.messages.map((message) =>
@@ -52,10 +55,14 @@ export function useToolApprovals(
         ),
       }));
     } catch (err) {
-      setErrors((current) => ({
-        ...current,
-        [callId]: `Could not send your decision: ${String(err)}`,
-      }));
+      // A decision that fails against a chat on its way out has nowhere to be
+      // read; the conversation it belonged to is going with it.
+      if (stillOpen(startedChatId)) {
+        setErrors((current) => ({
+          ...current,
+          [callId]: `Could not send your decision: ${String(err)}`,
+        }));
+      }
     } finally {
       decidingRef.current.delete(callId);
       setDeciding((calls) => {

--- a/crates/openwave-desktop/ui/src/useUserQuestions.test.ts
+++ b/crates/openwave-desktop/ui/src/useUserQuestions.test.ts
@@ -2,6 +2,7 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient } from "./api";
+import { useChatListStore } from "./ChatListStore";
 import { useUserQuestions } from "./useUserQuestions";
 import { useRefreshSignals } from "./RefreshSignals";
 import * as host from "./host";
@@ -14,6 +15,18 @@ function pending(callId: string, turnId = "turn-1") {
   return { callId, turnId, questions: [] };
 }
 
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  promise.catch(() => {});
+  return { promise, resolve, reject };
+}
+
 function stubClient(overrides: Record<string, unknown> = {}) {
   return {
     listPendingUserQuestions: vi.fn().mockResolvedValue([]),
@@ -23,7 +36,10 @@ function stubClient(overrides: Record<string, unknown> = {}) {
   } as unknown as ApiClient;
 }
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  useChatListStore.getState().setDeletingChatId(null);
+});
 
 describe("useUserQuestions", () => {
   it("asks for attention only when a request is new", async () => {
@@ -111,6 +127,27 @@ describe("useUserQuestions", () => {
     rerender({ chatId: "chat-2" });
     await act(async () => {
       reject?.(new Error("network went away"));
+    });
+
+    expect(result.current.errors).toEqual({});
+  });
+
+  it("drops a failed answer once its chat is being deleted", async () => {
+    const answer = deferred<void>();
+    const client = stubClient({
+      listPendingUserQuestions: vi.fn().mockResolvedValue([pending("call-1")]),
+      answerUserQuestions: vi.fn(() => answer.promise),
+    });
+    const { result } = renderHook(() => useUserQuestions(client, "chat-1"));
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+
+    act(() => result.current.answer("call-1", []));
+    // The reader deletes the chat before the answer settles. Its id still
+    // matches the pane, which is why a plain id comparison misses this.
+    act(() => useChatListStore.getState().setDeletingChatId("chat-1"));
+    await act(async () => {
+      answer.reject(new Error("gone"));
+      await answer.promise.catch(() => {});
     });
 
     expect(result.current.errors).toEqual({});

--- a/crates/openwave-desktop/ui/src/useUserQuestions.ts
+++ b/crates/openwave-desktop/ui/src/useUserQuestions.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { ApiClient, PendingUserQuestions, UserQuestionAnswer } from "./api";
 import { requestUserAttention } from "./host";
+import { useOpenConversation } from "./OpenConversation";
 import { useRefreshSignals } from "./RefreshSignals";
 
 const POLL_INTERVAL_MS = 10_000;
@@ -32,8 +33,7 @@ export function useUserQuestions(
   const answeringRef = useRef<Set<string>>(new Set());
   const seenCallIdsRef = useRef<Set<string>>(new Set());
   const refreshRef = useRef<(() => void) | null>(null);
-  const currentChatIdRef = useRef(chatId);
-  currentChatIdRef.current = chatId;
+  const stillOpen = useOpenConversation(chatId);
   const signal = useRefreshSignals((state) => state.userQuestions);
 
   useEffect(() => {
@@ -103,7 +103,7 @@ export function useUserQuestions(
     try {
       await request();
     } catch (err) {
-      if (currentChatIdRef.current === startedChatId) {
+      if (stillOpen(startedChatId)) {
         setErrors((current) => ({ ...current, [callId]: failure(err) }));
       }
     } finally {
@@ -113,7 +113,7 @@ export function useUserQuestions(
         next.delete(callId);
         return next;
       });
-      if (currentChatIdRef.current === startedChatId) refreshRef.current?.();
+      if (stillOpen(startedChatId)) refreshRef.current?.();
     }
   }
 


### PR DESCRIPTION
`useUserQuestions` guards a late response by comparing the chat id it started under against the current one. That reads as equivalent to the monotonic selection counter it replaced, and it isn't.

`onDeleteChat` marks the chat as deleting immediately, then awaits `deleteChat` and `listChats` (and sometimes `createChat`) before `selectChat(next, true)` swaps the pane. For that whole round trip the doomed conversation is still mounted and its id still matches, so the fence passes. The old counter was bumped at the *start* of deletion, which is exactly what made it catch this.

## Effect

Answer a question card, then delete that chat before the request settles — nothing disables the cards during deletion:

- "Could not send your answer: …" is painted onto a conversation that is being deleted, and
- one more `listPendingUserQuestions` fires against the deleted chat, logging a failed refresh.

Transient, since the replacement chat remounts the pane — a brief error flash and a wasted request rather than stuck state. The plain A→B→A switch case was already safe; the hook is unmounted, so the late write is a no-op.

## The change

One shared `useOpenConversation(chatId)` predicate, read at call time so a handler can capture it before an await and still ask an up-to-date question afterwards. It answers no when the chat has changed *or* when this conversation's own chat is being deleted.

Applied to all three hooks. Approvals and folder access had no chat fence at all, so they gain one — same shape, same window.

One thing deliberately left unfenced: the folder picker's latch is released whether or not the conversation survived. It belongs to the host rather than the chat, and leaking it would block every later decision app-wide.

## Verification

`tsc`, 360 vitest tests, production build. Both new cases fail when the predicate is reduced to a chat-id comparison. The suites reset the deleting flag between cases, since it is app-wide state.

Closes #486