### PR TITLE
refactor(desktop): move agent runs and the turn controls out of the root

### DIFF
--- a/crates/openwave-desktop/ui/src/ActiveTurnSteer.test.ts
+++ b/crates/openwave-desktop/ui/src/ActiveTurnSteer.test.ts
@@ -6,7 +6,7 @@ import {
   shouldClearAcceptedSteerDraft,
 } from "./ActiveTurnSteer";
 
-const target = { chatId: "chat-1", turnId: "turn-1", selection: 4 };
+const target = { chatId: "chat-1", turnId: "turn-1" };
 
 describe("ActiveTurnSteerFence", () => {
   it("rejects steer admission synchronously once cancellation starts", () => {
@@ -83,10 +83,6 @@ describe("ActiveTurnSteerFence", () => {
     expect(
       fence.canApplyResponse(request, { ...target, turnId: "turn-2" }),
     ).toBe(false);
-    expect(
-      fence.canApplyResponse(request, { ...target, selection: 5 }),
-    ).toBe(false);
-
   });
 
   it.each(["terminal event", "chat switch", "unmount"])(

--- a/crates/openwave-desktop/ui/src/ActiveTurnSteer.ts
+++ b/crates/openwave-desktop/ui/src/ActiveTurnSteer.ts
@@ -1,9 +1,21 @@
 export const MAX_STEER_CHARACTERS = 65_536;
 
+/**
+ * The conversation and turn a piece of guidance was aimed at.
+ *
+ * This used to carry the root's conversation-selection counter as a third
+ * discriminator, from when one fence spanned every chat. The fence now belongs
+ * to the hook that owns a single conversation's turn controls, and the counter
+ * no longer distinguishes anything the chat id does not: a chat *switch* is
+ * either an unmount, which takes the fence with it, or a new `chatId`, which
+ * the id comparison below already rejects; a chat *deletion* leaves the doomed
+ * conversation mounted under its own id, and is handled by invalidating the
+ * fence and by refusing to name a chat that is on its way out as the current
+ * target. See [useTurnControls].
+ */
 export type ActiveTurnTarget = {
   chatId: string;
   turnId: string;
-  selection: number;
 };
 
 export type ActiveTurnSteerRequest = ActiveTurnTarget & {
@@ -30,11 +42,7 @@ function sameTarget(
   left: ActiveTurnTarget,
   right: ActiveTurnTarget,
 ): boolean {
-  return (
-    left.chatId === right.chatId &&
-    left.turnId === right.turnId &&
-    left.selection === right.selection
-  );
+  return left.chatId === right.chatId && left.turnId === right.turnId;
 }
 
 export class ActiveTurnSteerFence {

--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentRun } from "./api";
-import { AgentActivityPanel, agentRunsForChat } from "./AgentActivityPanel";
+import { AgentActivityPanel } from "./AgentActivityPanel";
 
 function run(overrides: Partial<AgentRun>): AgentRun {
   return {
@@ -26,14 +26,6 @@ const noStops = {
 };
 
 describe("AgentActivityPanel", () => {
-  it("shows snapshots only for the conversation that owns them", () => {
-    const runs = [run({ id: "chat-a-run" })];
-
-    expect(agentRunsForChat("chat-a", "chat-a", runs)).toBe(runs);
-    expect(agentRunsForChat("chat-a", "chat-b", runs)).toEqual([]);
-    expect(agentRunsForChat(null, "chat-a", runs)).toEqual([]);
-  });
-
   it("groups live and recent background work with a focused live region", () => {
     const markup = renderToStaticMarkup(
       <AgentActivityPanel

--- a/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityPanel.tsx
@@ -4,14 +4,6 @@ import { canStopSandboxAgentRun } from "./SandboxAgentStop";
 
 const MAX_RECENT_TERMINAL_SANDBOX_RUNS = 2;
 
-export function agentRunsForChat(
-  ownerChatId: string | null,
-  selectedChatId: string | null,
-  runs: AgentRun[],
-): AgentRun[] {
-  return ownerChatId !== null && ownerChatId === selectedChatId ? runs : [];
-}
-
 export function AgentActivityPanel({
   runs,
   loading,

--- a/crates/openwave-desktop/ui/src/App.tsx
+++ b/crates/openwave-desktop/ui/src/App.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import {
   ApiClient,
-  type AgentRun,
   type Chat,
   type ModelInfo,
   type ModelSelectionKey,
@@ -20,6 +19,7 @@ import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
 import { ChatSessionController } from "./ChatSessionController";
 import { useChatSessionStore } from "./ChatSessionStore";
 import { useRefreshSignals } from "./RefreshSignals";
+import { useTurnLifecycle } from "./TurnLifecycleSignals";
 import { useChatListStore } from "./ChatListStore";
 import { useUiStore } from "./UiStore";
 import {
@@ -35,21 +35,9 @@ import {
   type ChatSessionState,
 } from "./ChatSessionReducer";
 import {
-  ActiveTurnSteerFence,
-  canBeginActiveTurnSteer,
-  shouldClearAcceptedSteerDraft,
-} from "./ActiveTurnSteer";
-import {
   loadCurrentTerminalTranscript,
   presentChatTranscript,
 } from "./ChatTranscriptPresentation";
-import { agentRunsForChat } from "./AgentActivityPanel";
-import {
-  SandboxAgentStopFence,
-  canStopSandboxAgentRun,
-  reconcileSandboxAgentCancellation,
-  sandboxAgentStopKey,
-} from "./SandboxAgentStop";
 import { prependReplacementChat } from "./ChatDeletion";
 import { useConfirm } from "./components/ConfirmDialog";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
@@ -75,6 +63,7 @@ const sessionDeps = {
 const chatListActions = useChatListStore.getState();
 const uiActions = useUiStore.getState();
 const { signal: signalRefresh } = useRefreshSignals.getState();
+const { signal: signalTurnLifecycle } = useTurnLifecycle.getState();
 
 export default function App() {
   const [bootError, setBootError] = useState<string | null>(null);
@@ -91,17 +80,6 @@ export default function App() {
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const busy = useChatSessionStore((session) => session.busy);
-  const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
-  const [agentRuns, setAgentRuns] = useState<AgentRun[]>([]);
-  const [agentRunsChatId, setAgentRunsChatId] = useState<string | null>(null);
-  const [agentRunsLoading, setAgentRunsLoading] = useState(false);
-  const [agentRunsError, setAgentRunsError] = useState<string | null>(null);
-  const [stoppingSandboxRunKeys, setStoppingSandboxRunKeys] = useState<Set<string>>(
-    new Set(),
-  );
-  const [sandboxStopErrorKeys, setSandboxStopErrorKeys] = useState<Set<string>>(
-    new Set(),
-  );
   const [draft, setDraft] = useState("");
   const [addingSourceChatId, setAddingSourceChatId] = useState<string | null>(
     null,
@@ -114,15 +92,6 @@ export default function App() {
     chatId: string;
     message: string;
   } | null>(null);
-  const [cancelPendingTurnId, setCancelPendingTurnId] = useState<string | null>(
-    null,
-  );
-  const [cancelError, setCancelError] = useState<string | null>(null);
-  const [steerPendingTurnId, setSteerPendingTurnId] = useState<string | null>(
-    null,
-  );
-  const [steerError, setSteerError] = useState<string | null>(null);
-  const [steerStatus, setSteerStatus] = useState<string | null>(null);
   const skipRenameCommitRef = useRef(false);
   const [status, setStatus] = useState("starting…");
   // Owns the selected chat's event socket; chat switches dispose it eagerly
@@ -131,12 +100,8 @@ export default function App() {
   const handleEventRef = useRef<(event: SequencedEvent) => void>(() => {});
   const chatSelectionRef = useRef(0);
   const terminalHydrationGenerationRef = useRef(0);
-  const refreshAgentRunsRef = useRef<(() => void) | null>(null);
-  const cancelRequestTurnRef = useRef<string | null>(null);
   const draftRef = useRef("");
   const selectedChatIdRef = useRef<string | null>(null);
-  const steerFenceRef = useRef(new ActiveTurnSteerFence());
-  const sandboxStopFenceRef = useRef(new SandboxAgentStopFence());
   const creationInFlightRef = useRef(false);
   const deletionInFlightRef = useRef(false);
   const { confirm, dialog: confirmDialog } = useConfirm();
@@ -159,8 +124,6 @@ export default function App() {
     return () => {
       cancelled = true;
       terminalHydrationGenerationRef.current += 1;
-      steerFenceRef.current.invalidate();
-      sandboxStopFenceRef.current.invalidate();
     };
   }, []);
 
@@ -268,118 +231,6 @@ export default function App() {
     };
   }, [client, chat?.id, hydratedChatId]);
 
-  useEffect(() => {
-    if (!client || !chat) return;
-    let cancelled = false;
-    let requestSeq = 0;
-
-    const refresh = async () => {
-      const seq = ++requestSeq;
-      try {
-        const runs = await client.listAgentRuns(chat.id);
-        if (!cancelled && seq === requestSeq) {
-          setAgentRuns(runs);
-          setAgentRunsError(null);
-        }
-      } catch (err) {
-        if (!cancelled && seq === requestSeq) {
-          setAgentRunsError(String(err));
-        }
-      } finally {
-        if (!cancelled && seq === requestSeq) {
-          setAgentRunsLoading(false);
-        }
-      }
-    };
-
-    setAgentRuns([]);
-    setAgentRunsChatId(chat.id);
-    setAgentRunsError(null);
-    setAgentRunsLoading(true);
-    refreshAgentRunsRef.current = () => void refresh();
-    void refresh();
-    return () => {
-      cancelled = true;
-      requestSeq += 1;
-      if (refreshAgentRunsRef.current) {
-        refreshAgentRunsRef.current = null;
-      }
-    };
-  }, [client, chat?.id]);
-
-  const visibleAgentRuns = agentRunsForChat(agentRunsChatId, chat?.id ?? null, agentRuns);
-  const visibleStoppingSandboxRunIds = new Set(
-    visibleAgentRuns
-      .filter((run) =>
-        stoppingSandboxRunKeys.has(sandboxAgentStopKey(chat?.id ?? "", run.id)),
-      )
-      .map((run) => run.id),
-  );
-  const visibleSandboxStopErrorRunIds = new Set(
-    visibleAgentRuns
-      .filter((run) =>
-        sandboxStopErrorKeys.has(sandboxAgentStopKey(chat?.id ?? "", run.id)),
-      )
-      .map((run) => run.id),
-  );
-  const hasActiveSandboxRun = visibleAgentRuns.some(
-    (run) =>
-      run.execution === "sandbox" &&
-      ["queued", "running", "cancelling", "waiting", "retry_wait"].includes(
-        run.status,
-      ),
-  );
-
-  useEffect(() => {
-    if (!hasActiveSandboxRun) return;
-    const interval = window.setInterval(
-      () => refreshAgentRunsRef.current?.(),
-      5_000,
-    );
-    return () => window.clearInterval(interval);
-  }, [hasActiveSandboxRun]);
-
-  async function onStopSandboxAgentRun(runId: string) {
-    if (!client || !chat || deletionInFlightRef.current) return;
-    const target = visibleAgentRuns.find((run) => run.id === runId);
-    if (!target || !canStopSandboxAgentRun(target)) return;
-
-    const chatId = chat.id;
-    const request = sandboxStopFenceRef.current.begin(chatId, runId);
-    if (!request) return;
-    const key = sandboxAgentStopKey(chatId, runId);
-    setStoppingSandboxRunKeys((current) => new Set(current).add(key));
-    setSandboxStopErrorKeys((current) => {
-      const next = new Set(current);
-      next.delete(key);
-      return next;
-    });
-
-    try {
-      const cancellation = await client.cancelAgentRun(chatId, runId);
-      if (!sandboxStopFenceRef.current.isCurrent(request, selectedChatIdRef.current)) {
-        return;
-      }
-      setAgentRuns((current) =>
-        reconcileSandboxAgentCancellation(current, cancellation),
-      );
-      refreshAgentRunsRef.current?.();
-    } catch {
-      if (!sandboxStopFenceRef.current.isCurrent(request, selectedChatIdRef.current)) {
-        return;
-      }
-      setSandboxStopErrorKeys((current) => new Set(current).add(key));
-    } finally {
-      if (sandboxStopFenceRef.current.finish(request, selectedChatIdRef.current)) {
-        setStoppingSandboxRunKeys((current) => {
-          const next = new Set(current);
-          next.delete(key);
-          return next;
-        });
-      }
-    }
-  }
-
   function updateSession(update: (state: ChatSessionState) => ChatSessionState) {
     useChatSessionStore.getState().update(update);
   }
@@ -395,7 +246,7 @@ export default function App() {
   function applySessionEffect(effect: ChatSessionEffect) {
     switch (effect.type) {
       case "refresh_agent_runs":
-        refreshAgentRunsRef.current?.();
+        signalRefresh("agentRuns");
         return;
       case "refresh_folder_access":
         signalRefresh("folderAccess");
@@ -404,16 +255,12 @@ export default function App() {
         signalRefresh("userQuestions");
         return;
       case "turn_began":
-        setCancelPendingTurnId(null);
-        setCancelError(null);
-        cancelRequestTurnRef.current = null;
-        if (effect.startsDifferentTurn) clearSteerRequestState();
+        signalTurnLifecycle(
+          effect.startsDifferentTurn ? "began" : "began_same_turn",
+        );
         return;
       case "turn_resolved":
-        setCancelPendingTurnId(null);
-        setCancelError(null);
-        cancelRequestTurnRef.current = null;
-        clearSteerRequestState();
+        signalTurnLifecycle("resolved");
         return;
       case "invalidate_terminal_hydration":
         terminalHydrationGenerationRef.current += 1;
@@ -457,28 +304,12 @@ export default function App() {
       busy: false,
       activeTurnId: null,
     }));
-    setCancelPendingTurnId(null);
-    setCancelError(null);
-    cancelRequestTurnRef.current = null;
-    clearSteerRequestState();
+    signalTurnLifecycle("resolved");
   }
 
   function setComposerDraft(nextDraft: string) {
     draftRef.current = nextDraft;
     setDraft(nextDraft);
-  }
-
-  function clearSteerRequestState() {
-    steerFenceRef.current.invalidate();
-    setSteerPendingTurnId(null);
-    setSteerError(null);
-    setSteerStatus(null);
-  }
-
-  function onComposerDraftChange(nextDraft: string) {
-    setComposerDraft(nextDraft);
-    setSteerError(null);
-    setSteerStatus(null);
   }
 
   async function refreshCatalog() {
@@ -513,15 +344,14 @@ export default function App() {
         },
       ],
     }));
-    setCancelPendingTurnId(null);
-    setCancelError(null);
+    signalTurnLifecycle("submitted");
     try {
       await client.postMessage(chatId, turnId, content);
       if (chatSelectionRef.current !== selection) return;
       setRecentSource((current) =>
         current?.chatId === chatId ? null : current,
       );
-      refreshAgentRunsRef.current?.();
+      signalRefresh("agentRuns");
     } catch (err) {
       if (chatSelectionRef.current !== selection) return;
       resolveActiveTurn();
@@ -556,110 +386,6 @@ export default function App() {
     }
   }
 
-  async function onSteerActiveTurn() {
-    const admission = {
-      busy,
-      turnId: useChatSessionStore.getState().activeTurnId,
-      cancelRequestTurnId: cancelRequestTurnRef.current,
-      deletionInFlight: deletionInFlightRef.current,
-    };
-    if (
-      !client ||
-      !chat ||
-      !canBeginActiveTurnSteer(admission)
-    ) {
-      return;
-    }
-    const turnId = admission.turnId;
-
-    const request = steerFenceRef.current.begin(
-      {
-        chatId: chat.id,
-        turnId,
-        selection: chatSelectionRef.current,
-      },
-      draftRef.current,
-      () => crypto.randomUUID(),
-    );
-    if (!request) return;
-
-    setSteerPendingTurnId(turnId);
-    setSteerError(null);
-    setSteerStatus("Sending guidance…");
-    setCancelError(null);
-    try {
-      await client.steer(
-        request.chatId,
-        request.turnId,
-        request.steerId,
-        request.content,
-        true,
-      );
-      if (
-        !steerFenceRef.current.canApplyResponse(request, {
-          chatId: selectedChatIdRef.current ?? "",
-          turnId: useChatSessionStore.getState().activeTurnId ?? "",
-          selection: chatSelectionRef.current,
-        })
-      ) {
-        return;
-      }
-
-      steerFenceRef.current.finish(request);
-      setSteerPendingTurnId(null);
-      if (shouldClearAcceptedSteerDraft(request, draftRef.current)) {
-        setComposerDraft("");
-      }
-      setSteerStatus("Guidance sent");
-    } catch (err) {
-      if (
-        !steerFenceRef.current.canApplyResponse(request, {
-          chatId: selectedChatIdRef.current ?? "",
-          turnId: useChatSessionStore.getState().activeTurnId ?? "",
-          selection: chatSelectionRef.current,
-        })
-      ) {
-        return;
-      }
-
-      steerFenceRef.current.fail(request);
-      setSteerPendingTurnId(null);
-      setSteerStatus(null);
-      setSteerError(String(err));
-    }
-  }
-
-  async function onCancelActiveTurn() {
-    const turnId = activeTurnId;
-    if (
-      !client ||
-      !chat ||
-      !busy ||
-      !turnId ||
-      cancelRequestTurnRef.current === turnId
-    ) {
-      return;
-    }
-    const selection = chatSelectionRef.current;
-    const chatId = chat.id;
-
-    cancelRequestTurnRef.current = turnId;
-    setCancelPendingTurnId(turnId);
-    setCancelError(null);
-    try {
-      await client.cancel(chatId, turnId);
-    } catch (err) {
-      if (
-        chatSelectionRef.current === selection &&
-        cancelRequestTurnRef.current === turnId
-      ) {
-        cancelRequestTurnRef.current = null;
-        setCancelPendingTurnId(null);
-        setCancelError(String(err));
-      }
-    }
-  }
-
   async function onNewChat() {
     if (!client || creationInFlightRef.current || deletionInFlightRef.current) return;
     creationInFlightRef.current = true;
@@ -689,15 +415,9 @@ export default function App() {
     controllerRef.current?.dispose();
     controllerRef.current = null;
     useChatSessionStore.getState().reset();
-    setAgentRuns([]);
-    setAgentRunsError(null);
     setComposerDraft("");
     setRecentSource(null);
     setSourceAttachmentError(null);
-    setCancelPendingTurnId(null);
-    setCancelError(null);
-    cancelRequestTurnRef.current = null;
-    clearSteerRequestState();
     activateChat(created);
     chatListActions.prependChat(created);
     chatListActions.setChatsError(null);
@@ -721,12 +441,9 @@ export default function App() {
     const deletingSelectedChat = chat?.id === target.id;
     if (deletingSelectedChat) {
       // This invalidates callbacks that captured the deleted selection. The
-      // ref update also gates sends before the disabled composer renders.
+      // ref update also gates sends before the disabled composer renders. The
+      // chat pane retires its own in-flight work off the deleting chat id.
       chatSelectionRef.current += 1;
-      clearSteerRequestState();
-      sandboxStopFenceRef.current.invalidate();
-      setStoppingSandboxRunKeys(new Set());
-      setSandboxStopErrorKeys(new Set());
     }
     try {
       await client.deleteChat(target.id);
@@ -752,14 +469,17 @@ export default function App() {
     }
   }
 
+  /**
+   * Opens `next` as the selected conversation. Everything scoped to a single
+   * conversation — its agent runs, its pending requests, its turn controls —
+   * lives in the chat pane, which is keyed on the chat id, so this remounts it
+   * with nothing carried over from the chat being left behind.
+   */
   function activateChat(next: Chat) {
     uiActions.selectChatWorkspace(next.id);
     chatSelectionRef.current += 1;
     terminalHydrationGenerationRef.current += 1;
     selectedChatIdRef.current = next.id;
-    sandboxStopFenceRef.current.invalidate();
-    setStoppingSandboxRunKeys(new Set());
-    setSandboxStopErrorKeys(new Set());
     updateSession((session) => ({
       ...session,
       markerScrubber: new AssistantSourceMarkerStreamScrubber(),
@@ -781,15 +501,9 @@ export default function App() {
     controllerRef.current?.dispose();
     controllerRef.current = null;
     useChatSessionStore.getState().reset();
-    setAgentRuns([]);
-    setAgentRunsError(null);
     setComposerDraft("");
     setRecentSource(null);
     setSourceAttachmentError(null);
-    setCancelPendingTurnId(null);
-    setCancelError(null);
-    cancelRequestTurnRef.current = null;
-    clearSteerRequestState();
     cancelChatRename();
     activateChat(next);
     setStatus(`chat ${next.id.slice(0, 8)}…`);
@@ -979,16 +693,8 @@ export default function App() {
               hydrated={hydratedChatId === chat.id}
               nativeHost={hasNativeHost()}
               deletingChat={deletingChatId !== null}
-              agentRuns={visibleAgentRuns}
-              agentRunsLoading={
-                agentRunsChatId === chat.id ? agentRunsLoading : true
-              }
-              agentRunsError={agentRunsChatId === chat.id ? agentRunsError : null}
-              stoppingRunIds={visibleStoppingSandboxRunIds}
-              stopErrorRunIds={visibleSandboxStopErrorRunIds}
-              onRetryAgentRuns={() => refreshAgentRunsRef.current?.()}
-              onStopSandboxRun={(runId) => void onStopSandboxAgentRun(runId)}
               draft={draft}
+              draftRef={draftRef}
               attachingSource={addingSourceChatId !== null}
               attachedSourceName={
                 recentSource && recentSource.chatId === chat.id
@@ -1017,18 +723,11 @@ export default function App() {
                   )}
                 </>
               }
-              cancelError={cancelError}
-              cancelPendingTurnId={cancelPendingTurnId}
-              steerError={steerError}
-              steerStatus={steerStatus}
-              steerPendingTurnId={steerPendingTurnId}
-              onDraftChange={onComposerDraftChange}
+              onDraftChange={setComposerDraft}
               onAddSource={onAddSource}
               onDismissAttachedSource={() => setRecentSource(null)}
               onSelectPrompt={setComposerDraft}
               onSend={onSend}
-              onSteer={onSteerActiveTurn}
-              onStop={onCancelActiveTurn}
           />
           }
         />

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useRef, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, Chat } from "./api";
 import { ChatView, type ChatViewProps } from "./ChatView";
@@ -19,10 +20,45 @@ const chat = { id: "chat-1", title: "Roadmap", project_id: null } as unknown as 
 const client = {
   listPendingFolderAccessRequests: vi.fn().mockResolvedValue([]),
   listPendingUserQuestions: vi.fn().mockResolvedValue([]),
+  listAgentRuns: vi.fn().mockResolvedValue([]),
   decideApproval: vi.fn().mockResolvedValue(undefined),
   cancel: vi.fn().mockResolvedValue(undefined),
+  steer: vi.fn().mockResolvedValue(undefined),
   answerUserQuestions: vi.fn().mockResolvedValue(undefined),
 } as unknown as ApiClient;
+
+/**
+ * The pane with the draft wired up the way the root wires it: state for
+ * rendering, a ref for reading it at the moment guidance is sent.
+ */
+function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
+  const [draft, setDraft] = useState("");
+  const draftRef = useRef("");
+  return (
+    <ChatView
+      client={client}
+      chat={chat}
+      hydrated
+      nativeHost={false}
+      deletingChat={false}
+      draft={draft}
+      draftRef={draftRef}
+      composerModelMenu={null}
+      attachingSource={false}
+      attachedSourceName={null}
+      sourceAttachmentError={null}
+      onDraftChange={(value) => {
+        draftRef.current = value;
+        setDraft(value);
+      }}
+      onAddSource={vi.fn(async () => {})}
+      onDismissAttachedSource={vi.fn()}
+      onSelectPrompt={vi.fn()}
+      onSend={vi.fn(async () => {})}
+      {...overrides}
+    />
+  );
+}
 
 function renderChatView(overrides: Partial<ChatViewProps> = {}) {
   const props: ChatViewProps = {
@@ -31,30 +67,17 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
     hydrated: true,
     nativeHost: false,
     deletingChat: false,
-    agentRuns: [],
-    agentRunsLoading: false,
-    agentRunsError: null,
-    stoppingRunIds: new Set(),
-    stopErrorRunIds: new Set(),
-    onRetryAgentRuns: vi.fn(),
-    onStopSandboxRun: vi.fn(),
     draft: "",
+    draftRef: { current: "" },
     composerModelMenu: null,
     attachingSource: false,
     attachedSourceName: null,
     sourceAttachmentError: null,
-    cancelError: null,
-    cancelPendingTurnId: null,
-    steerError: null,
-    steerStatus: null,
-    steerPendingTurnId: null,
     onDraftChange: vi.fn(),
     onAddSource: vi.fn(async () => {}),
     onDismissAttachedSource: vi.fn(),
     onSelectPrompt: vi.fn(),
     onSend: vi.fn(async () => {}),
-    onSteer: vi.fn(async () => {}),
-    onStop: vi.fn(async () => {}),
     ...overrides,
   };
   render(<ChatView {...props} />);
@@ -152,5 +175,54 @@ describe("ChatView", () => {
         );
     });
     expect(screen.getByText("streamed answer")).toBeInTheDocument();
+  });
+
+  it("leaves the sent-guidance notice standing when it clears the draft", async () => {
+    useChatSessionStore.getState().update((session) => ({
+      ...session,
+      busy: true,
+      activeTurnId: "turn-1",
+    }));
+    render(<DraftingChatView />);
+
+    const message = screen.getByLabelText("Message");
+    await userEvent.type(message, "go left");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Redirect active response" }),
+    );
+
+    // Accepting guidance empties the composer. That clearing must not read as
+    // the reader retyping, or the notice they were just given disappears.
+    expect(await screen.findByText("Guidance sent")).toBeInTheDocument();
+    expect(message).toHaveValue("");
+
+    await userEvent.type(message, "n");
+
+    await waitFor(() =>
+      expect(screen.queryByText("Guidance sent")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("retires the redirect failure the reader is answering by retyping", async () => {
+    vi.mocked(client.steer).mockRejectedValueOnce(new Error("steer rejected"));
+    useChatSessionStore.getState().update((session) => ({
+      ...session,
+      busy: true,
+      activeTurnId: "turn-1",
+    }));
+    render(<DraftingChatView />);
+
+    const message = screen.getByLabelText("Message");
+    await userEvent.type(message, "go left");
+    await userEvent.click(
+      screen.getByRole("button", { name: "Redirect active response" }),
+    );
+    expect(await screen.findByText(/steer rejected/)).toBeInTheDocument();
+
+    await userEvent.type(message, " now");
+
+    await waitFor(() =>
+      expect(screen.queryByText(/steer rejected/)).not.toBeInTheDocument(),
+    );
   });
 });

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -1,13 +1,21 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
-import type { AgentRun, ApiClient, Chat } from "./api";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import type { ApiClient, Chat } from "./api";
 import { AgentActivityPanel } from "./AgentActivityPanel";
 import { followScrollBehavior, isNearBottom, scrollToLatest } from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
 import { Composer } from "./Composer";
 import { MessageList } from "./MessageList";
 import { useTranscriptVisible } from "./TranscriptVisibility";
+import { useAgentRuns } from "./useAgentRuns";
 import { useFolderAccessRequests } from "./useFolderAccessRequests";
 import { useToolApprovals } from "./useToolApprovals";
+import { useTurnControls } from "./useTurnControls";
 import { useUserQuestions } from "./useUserQuestions";
 import { ArrowDown } from "lucide-react";
 
@@ -17,36 +25,25 @@ export type ChatViewProps = {
   hydrated: boolean;
   nativeHost: boolean;
   deletingChat: boolean;
-  agentRuns: AgentRun[];
-  agentRunsLoading: boolean;
-  agentRunsError: string | null;
-  stoppingRunIds: Set<string>;
-  stopErrorRunIds: Set<string>;
-  onRetryAgentRuns: () => void;
-  onStopSandboxRun: (runId: string) => void;
   draft: string;
+  /** The same draft, readable synchronously — see [useTurnControls]. */
+  draftRef: RefObject<string>;
   composerModelMenu: ReactNode;
   attachingSource: boolean;
   attachedSourceName: string | null;
   sourceAttachmentError: string | null;
-  cancelError: string | null;
-  cancelPendingTurnId: string | null;
-  steerError: string | null;
-  steerStatus: string | null;
-  steerPendingTurnId: string | null;
   onDraftChange: (value: string) => void;
   onAddSource: () => Promise<void>;
   onDismissAttachedSource: () => void;
   onSelectPrompt: (prompt: string) => void;
   onSend: () => Promise<void>;
-  onSteer: () => Promise<void>;
-  onStop: () => Promise<void>;
 };
 
 /**
  * The chat pane: agent activity, transcript, and composer, rendered as the
  * body of the chat workspace. Reads the live session (messages, busy, active
- * turn) straight from the session store.
+ * turn) straight from the session store, and owns this conversation's pending
+ * requests, agent runs, and turn controls.
  * Mount with `key={chat.id}` so scroll-follow state resets per conversation.
  */
 export function ChatView({
@@ -55,35 +52,26 @@ export function ChatView({
   hydrated,
   nativeHost,
   deletingChat,
-  agentRuns,
-  agentRunsLoading,
-  agentRunsError,
-  stoppingRunIds,
-  stopErrorRunIds,
-  onRetryAgentRuns,
-  onStopSandboxRun,
   draft,
+  draftRef,
   composerModelMenu,
   attachingSource,
   attachedSourceName,
   sourceAttachmentError,
-  cancelError,
-  cancelPendingTurnId,
-  steerError,
-  steerStatus,
-  steerPendingTurnId,
   onDraftChange,
   onAddSource,
   onDismissAttachedSource,
   onSelectPrompt,
   onSend,
-  onSteer,
-  onStop,
 }: ChatViewProps) {
   const transcriptVisible = useTranscriptVisible();
   const folderAccess = useFolderAccessRequests(client, chat.id);
   const userQuestions = useUserQuestions(client, chat.id);
   const approvals = useToolApprovals(client, chat.id);
+  const agentRuns = useAgentRuns(client, chat.id);
+  const turnControls = useTurnControls(client, chat.id, draftRef, () =>
+    onDraftChange(""),
+  );
   const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);
   const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
@@ -130,13 +118,13 @@ export function ChatView({
   return (
     <section className="chat-pane">
       <AgentActivityPanel
-        runs={agentRuns}
-        loading={agentRunsLoading}
-        error={agentRunsError}
-        onRetry={onRetryAgentRuns}
-        stoppingRunIds={stoppingRunIds}
-        stopErrorRunIds={stopErrorRunIds}
-        onStop={onStopSandboxRun}
+        runs={agentRuns.runs}
+        loading={agentRuns.loading}
+        error={agentRuns.error}
+        onRetry={agentRuns.refresh}
+        stoppingRunIds={agentRuns.stoppingRunIds}
+        stopErrorRunIds={agentRuns.stopErrorRunIds}
+        onStop={agentRuns.stop}
       />
 
       <div className="message-view">
@@ -189,9 +177,10 @@ export function ChatView({
       <Composer
         activeTurnId={activeTurnId}
         busy={busy}
-        cancelError={cancelError}
+        cancelError={turnControls.cancelError}
         cancelPending={
-          activeTurnId !== null && cancelPendingTurnId === activeTurnId
+          activeTurnId !== null &&
+          turnControls.cancelPendingTurnId === activeTurnId
         }
         disabled={deletingChat}
         draft={draft}
@@ -202,16 +191,23 @@ export function ChatView({
         sourceAttachmentError={sourceAttachmentError}
         onAddSource={onAddSource}
         onDismissAttachedSource={onDismissAttachedSource}
-        onDraftChange={onDraftChange}
+        // Typing retires the verdict on the last piece of guidance. Accepted
+        // guidance clears the draft through the raw callback instead, so
+        // "Guidance sent" survives the clearing it caused.
+        onDraftChange={(value) => {
+          turnControls.clearSteerFeedback();
+          onDraftChange(value);
+        }}
         onSend={onSend}
-        onSteer={onSteer}
-        onStop={onStop}
+        onSteer={turnControls.steer}
+        onStop={turnControls.cancel}
         resetKey={chat.id}
-        steerError={steerError}
+        steerError={turnControls.steerError}
         steerPending={
-          activeTurnId !== null && steerPendingTurnId === activeTurnId
+          activeTurnId !== null &&
+          turnControls.steerPendingTurnId === activeTurnId
         }
-        steerStatus={steerStatus}
+        steerStatus={turnControls.steerStatus}
       />
     </section>
   );

--- a/crates/openwave-desktop/ui/src/RefreshSignals.ts
+++ b/crates/openwave-desktop/ui/src/RefreshSignals.ts
@@ -3,7 +3,7 @@ import { create } from "zustand";
 /**
  * Server-side state the event stream can report as moved on.
  */
-export type RefreshTarget = "folderAccess" | "userQuestions";
+export type RefreshTarget = "agentRuns" | "folderAccess" | "userQuestions";
 
 /**
  * A revision counter per pollable target.
@@ -16,6 +16,7 @@ export type RefreshTarget = "folderAccess" | "userQuestions";
  * refreshes, not one.
  */
 export type RefreshSignalStore = {
+  agentRuns: number;
   folderAccess: number;
   userQuestions: number;
   signal: (target: RefreshTarget) => void;
@@ -23,6 +24,7 @@ export type RefreshSignalStore = {
 
 export function createRefreshSignalStore() {
   return create<RefreshSignalStore>()((set) => ({
+    agentRuns: 0,
     folderAccess: 0,
     userQuestions: 0,
     signal: (target) =>

--- a/crates/openwave-desktop/ui/src/TurnLifecycleSignals.ts
+++ b/crates/openwave-desktop/ui/src/TurnLifecycleSignals.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+
+/**
+ * What just happened to a conversation's active turn.
+ *
+ * `began` and `began_same_turn` are the same server event told apart by whether
+ * it opened a *different* turn than the one already running. Guidance sent to a
+ * turn that is still going is still standing, so only a different turn retires
+ * it; a cancel request is retired either way.
+ *
+ * `submitted` is the local half: the composer has posted a message and the turn
+ * it opened has not been confirmed yet.
+ */
+export type TurnLifecycleEvent =
+  | "began"
+  | "began_same_turn"
+  | "resolved"
+  | "submitted";
+
+/**
+ * The last thing that happened to the active turn, behind a revision counter.
+ *
+ * Same shape and the same reason as [RefreshSignals]: the event socket is owned
+ * by the component that holds the chat session, but the turn controls live with
+ * the composer that renders them. A counter rather than a flag so two events in
+ * a row are two reactions, not one — and the event rides alongside it because,
+ * unlike "go and poll again", what the controls should do differs per event and
+ * a bare counter cannot carry that.
+ */
+export type TurnLifecycleStore = {
+  revision: number;
+  last: TurnLifecycleEvent;
+  signal: (event: TurnLifecycleEvent) => void;
+};
+
+export function createTurnLifecycleStore() {
+  return create<TurnLifecycleStore>()((set) => ({
+    revision: 0,
+    last: "resolved",
+    signal: (event) =>
+      set((state) => ({ revision: state.revision + 1, last: event })),
+  }));
+}
+
+export const useTurnLifecycle = createTurnLifecycleStore();

--- a/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
@@ -1,0 +1,330 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentRun, ApiClient } from "./api";
+import { useAgentRuns } from "./useAgentRuns";
+import { useChatListStore } from "./ChatListStore";
+import { useRefreshSignals } from "./RefreshSignals";
+
+function run(overrides: Partial<AgentRun> = {}): AgentRun {
+  return {
+    id: "run-1",
+    parent_id: null,
+    execution: "sandbox",
+    status: "running",
+    started_at: "2026-07-24T12:00:00Z",
+    finished_at: null,
+    last_error_code: null,
+    activity: null,
+    created_at: "2026-07-24T12:00:00Z",
+    updated_at: "2026-07-24T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  promise.catch(() => {});
+  return { promise, resolve, reject };
+}
+
+function stubClient(overrides: Record<string, unknown> = {}) {
+  return {
+    listAgentRuns: vi.fn().mockResolvedValue([]),
+    cancelAgentRun: vi
+      .fn()
+      .mockResolvedValue({ id: "run-1", status: "cancelling" }),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+afterEach(() => {
+  cleanup();
+  useChatListStore.getState().setDeletingChatId(null);
+});
+
+describe("useAgentRuns", () => {
+  it("reads as loading until the first listing comes back", async () => {
+    const listing = deferred<AgentRun[]>();
+    const client = stubClient({ listAgentRuns: vi.fn(() => listing.promise) });
+    const seen: boolean[] = [];
+    const { result } = renderHook(() => {
+      const agentRuns = useAgentRuns(client, "chat-1");
+      seen.push(agentRuns.loading);
+      return agentRuns;
+    });
+
+    // From the very first paint, before the effect that asks has even run:
+    // "we have not asked yet" must not render as "there is no background work".
+    expect(seen[0]).toBe(true);
+    expect(result.current.loading).toBe(true);
+    expect(result.current.runs).toEqual([]);
+
+    await act(async () => {
+      listing.resolve([run()]);
+      await listing.promise;
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.runs).toHaveLength(1);
+    expect(client.listAgentRuns).toHaveBeenCalledWith("chat-1");
+  });
+
+  it("reports a failed listing and clears it on the next success", async () => {
+    const client = stubClient({
+      listAgentRuns: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("activity unavailable"))
+        .mockResolvedValue([]),
+    });
+    const { result } = renderHook(() => useAgentRuns(client, "chat-1"));
+
+    await waitFor(() =>
+      expect(result.current.error).toContain("activity unavailable"),
+    );
+
+    act(() => result.current.refresh());
+
+    await waitFor(() => expect(result.current.error).toBeNull());
+  });
+
+  it("refreshes when the event stream signals", async () => {
+    const client = stubClient();
+    renderHook(() => useAgentRuns(client, "chat-1"));
+    await waitFor(() => expect(client.listAgentRuns).toHaveBeenCalledTimes(1));
+
+    act(() => useRefreshSignals.getState().signal("agentRuns"));
+
+    await waitFor(() => expect(client.listAgentRuns).toHaveBeenCalledTimes(2));
+  });
+
+  it("ignores a signal raised for another pollable target", async () => {
+    const client = stubClient();
+    renderHook(() => useAgentRuns(client, "chat-1"));
+    await waitFor(() => expect(client.listAgentRuns).toHaveBeenCalledTimes(1));
+
+    act(() => useRefreshSignals.getState().signal("userQuestions"));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(client.listAgentRuns).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls only while a sandbox run is live", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = stubClient({
+        listAgentRuns: vi
+          .fn()
+          .mockResolvedValueOnce([run({ status: "running" })])
+          .mockResolvedValue([run({ status: "completed" })]),
+      });
+      const { result } = renderHook(() => useAgentRuns(client, "chat-1"));
+      await act(async () => {});
+      expect(result.current.runs[0]?.status).toBe("running");
+
+      await act(async () => {
+        vi.advanceTimersByTime(5_000);
+      });
+      expect(client.listAgentRuns).toHaveBeenCalledTimes(2);
+
+      // The run has finished, so the interval must not stand.
+      await act(async () => {
+        vi.advanceTimersByTime(15_000);
+      });
+      expect(client.listAgentRuns).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves a foreground run unpolled", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = stubClient({
+        listAgentRuns: vi
+          .fn()
+          .mockResolvedValue([run({ execution: "foreground", status: "running" })]),
+      });
+      renderHook(() => useAgentRuns(client, "chat-1"));
+      await act(async () => {});
+
+      await act(async () => {
+        vi.advanceTimersByTime(15_000);
+      });
+
+      expect(client.listAgentRuns).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fences a second stop for a run already stopping", async () => {
+    const stop = deferred<{ id: string; status: string }>();
+    const client = stubClient({
+      listAgentRuns: vi.fn().mockResolvedValue([run()]),
+      cancelAgentRun: vi.fn(() => stop.promise),
+    });
+    const { result } = renderHook(() => useAgentRuns(client, "chat-1"));
+    await waitFor(() => expect(result.current.runs).toHaveLength(1));
+
+    act(() => result.current.stop("run-1"));
+    await waitFor(() => expect(result.current.stoppingRunIds.size).toBe(1));
+    act(() => result.current.stop("run-1"));
+
+    expect(client.cancelAgentRun).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      stop.resolve({ id: "run-1", status: "cancelling" });
+      await stop.promise;
+    });
+    expect(result.current.stoppingRunIds.size).toBe(0);
+  });
+
+  it("refuses to stop a run that is not a live sandbox run", async () => {
+    const client = stubClient({
+      listAgentRuns: vi
+        .fn()
+        .mockResolvedValue([run({ status: "completed" }), run({ id: "fg", execution: "foreground" })]),
+    });
+    const { result } = renderHook(() => useAgentRuns(client, "chat-1"));
+    await waitFor(() => expect(result.current.runs).toHaveLength(2));
+
+    act(() => result.current.stop("run-1"));
+    act(() => result.current.stop("fg"));
+
+    expect(client.cancelAgentRun).not.toHaveBeenCalled();
+  });
+
+  it("marks the run when its stop fails", async () => {
+    const client = stubClient({
+      listAgentRuns: vi.fn().mockResolvedValue([run()]),
+      cancelAgentRun: vi.fn().mockRejectedValue(new Error("sandbox is gone")),
+    });
+    const { result } = renderHook(() => useAgentRuns(client, "chat-1"));
+    await waitFor(() => expect(result.current.runs).toHaveLength(1));
+
+    await act(async () => result.current.stop("run-1"));
+
+    await waitFor(() =>
+      expect(result.current.stopErrorRunIds.has("run-1")).toBe(true),
+    );
+    expect(result.current.stoppingRunIds.has("run-1")).toBe(false);
+  });
+
+  it("does not start a stop while a deletion is in flight", async () => {
+    const client = stubClient({
+      listAgentRuns: vi.fn().mockResolvedValue([run()]),
+    });
+    const { result } = renderHook(() => useAgentRuns(client, "chat-1"));
+    await waitFor(() => expect(result.current.runs).toHaveLength(1));
+
+    // Any deletion, not only this chat's: the request would race a chat list
+    // that is already being rebuilt.
+    act(() => useChatListStore.getState().setDeletingChatId("chat-other"));
+    act(() => result.current.stop("run-1"));
+
+    expect(client.cancelAgentRun).not.toHaveBeenCalled();
+  });
+
+  it("drops a failed stop once its chat is being deleted", async () => {
+    const stop = deferred<{ id: string; status: string }>();
+    const client = stubClient({
+      listAgentRuns: vi.fn().mockResolvedValue([run()]),
+      cancelAgentRun: vi.fn(() => stop.promise),
+    });
+    const { result } = renderHook(() => useAgentRuns(client, "chat-1"));
+    await waitFor(() => expect(result.current.runs).toHaveLength(1));
+
+    act(() => result.current.stop("run-1"));
+    await waitFor(() => expect(result.current.stoppingRunIds.size).toBe(1));
+
+    // The reader deletes the chat before the stop settles. Its id still matches
+    // the pane, which is why a plain id comparison misses this.
+    act(() => useChatListStore.getState().setDeletingChatId("chat-1"));
+    await act(async () => {
+      stop.reject(new Error("gone"));
+      await stop.promise.catch(() => {});
+    });
+
+    expect(result.current.stopErrorRunIds.size).toBe(0);
+    // The deleting chat also drops the markers, so its replacement does not
+    // inherit a button stuck on "Stopping…".
+    expect(result.current.stoppingRunIds.size).toBe(0);
+  });
+
+  it("lets the reader stop the run again once a failed deletion releases it", async () => {
+    const first = deferred<{ id: string; status: string }>();
+    const client = stubClient({
+      listAgentRuns: vi.fn().mockResolvedValue([run()]),
+      cancelAgentRun: vi.fn(() => first.promise),
+    });
+    const { result } = renderHook(() => useAgentRuns(client, "chat-1"));
+    await waitFor(() => expect(result.current.runs).toHaveLength(1));
+
+    act(() => result.current.stop("run-1"));
+    act(() => useChatListStore.getState().setDeletingChatId("chat-1"));
+    await act(async () => {
+      first.resolve({ id: "run-1", status: "cancelling" });
+      await first.promise;
+    });
+    // The delete failed, so the conversation the reader was in is still here.
+    act(() => useChatListStore.getState().setDeletingChatId(null));
+
+    act(() => result.current.stop("run-1"));
+
+    // A stop the fence never released would leave the button dead for good.
+    expect(client.cancelAgentRun).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not apply a cancellation onto the conversation that replaced it", async () => {
+    const stop = deferred<{ id: string; status: string }>();
+    const client = stubClient({
+      listAgentRuns: vi.fn().mockResolvedValue([run()]),
+      cancelAgentRun: vi.fn(() => stop.promise),
+    });
+    const { result, rerender } = renderHook(
+      ({ chatId }) => useAgentRuns(client, chatId),
+      { initialProps: { chatId: "chat-1" } },
+    );
+    await waitFor(() => expect(result.current.runs).toHaveLength(1));
+
+    act(() => result.current.stop("run-1"));
+    await waitFor(() => expect(result.current.stoppingRunIds.size).toBe(1));
+
+    rerender({ chatId: "chat-2" });
+    await waitFor(() =>
+      expect(client.listAgentRuns).toHaveBeenLastCalledWith("chat-2"),
+    );
+    expect(client.listAgentRuns).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      stop.resolve({ id: "run-1", status: "cancelling" });
+      await stop.promise;
+    });
+
+    expect(
+      result.current.runs.some((item) => item.status === "cancelling"),
+    ).toBe(false);
+    // Nor may it reach for a fresh listing of the conversation now open.
+    expect(client.listAgentRuns).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops the previous chat's runs when the conversation changes", async () => {
+    const client = stubClient({
+      listAgentRuns: vi.fn().mockResolvedValueOnce([run()]).mockResolvedValue([]),
+    });
+    const { result, rerender } = renderHook(
+      ({ chatId }) => useAgentRuns(client, chatId),
+      { initialProps: { chatId: "chat-1" } },
+    );
+    await waitFor(() => expect(result.current.runs).toHaveLength(1));
+
+    rerender({ chatId: "chat-2" });
+
+    await waitFor(() => expect(result.current.runs).toHaveLength(0));
+    expect(client.listAgentRuns).toHaveBeenLastCalledWith("chat-2");
+  });
+});

--- a/crates/openwave-desktop/ui/src/useAgentRuns.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.ts
@@ -1,0 +1,193 @@
+import { useEffect, useRef, useState } from "react";
+import type { AgentRun, ApiClient } from "./api";
+import { useChatListStore } from "./ChatListStore";
+import { useOpenConversation } from "./OpenConversation";
+import { useRefreshSignals } from "./RefreshSignals";
+import {
+  SandboxAgentStopFence,
+  canStopSandboxAgentRun,
+  reconcileSandboxAgentCancellation,
+} from "./SandboxAgentStop";
+
+/**
+ * How often a live sandbox run is re-read. Sandbox progress arrives as durable
+ * state rather than on the conversation's event stream, so the panel has to ask.
+ */
+const LIVE_POLL_INTERVAL_MS = 5_000;
+
+const LIVE_SANDBOX_STATUSES = [
+  "queued",
+  "running",
+  "cancelling",
+  "waiting",
+  "retry_wait",
+];
+
+export type AgentRuns = {
+  runs: AgentRun[];
+  loading: boolean;
+  error: string | null;
+  stoppingRunIds: Set<string>;
+  stopErrorRunIds: Set<string>;
+  refresh: () => void;
+  stop: (runId: string) => void;
+};
+
+/**
+ * The agent runs behind one conversation, and the stops that end them.
+ *
+ * Unlike the other pollers here there is no standing interval: the event stream
+ * says when a run has moved, and only a *live sandbox* run — which reports
+ * progress outside that stream — is polled, for as long as it stays live.
+ *
+ * A stop is fenced per run so a second click while one is in flight is ignored,
+ * and every completion is measured against the conversation it started under:
+ * see [SandboxAgentStopFence].
+ */
+export function useAgentRuns(
+  client: ApiClient | null,
+  chatId: string | null,
+): AgentRuns {
+  const [runs, setRuns] = useState<AgentRun[]>([]);
+  // True until the first listing comes back. "We have not asked yet" must not
+  // render as "we asked and this conversation has no background work".
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [stoppingRunIds, setStoppingRunIds] = useState<Set<string>>(new Set());
+  const [stopErrorRunIds, setStopErrorRunIds] = useState<Set<string>>(new Set());
+  const refreshRef = useRef<(() => void) | null>(null);
+  const stopFenceRef = useRef(new SandboxAgentStopFence());
+  const stillOpen = useOpenConversation(chatId);
+  const deletingChatId = useChatListStore((state) => state.deletingChatId);
+  const signal = useRefreshSignals((state) => state.agentRuns);
+
+  useEffect(() => {
+    if (!client || !chatId) return;
+    let cancelled = false;
+    let requestSeq = 0;
+
+    const refresh = async () => {
+      const seq = ++requestSeq;
+      try {
+        const listed = await client.listAgentRuns(chatId);
+        if (!cancelled && seq === requestSeq) {
+          setRuns(listed);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled && seq === requestSeq) setError(String(err));
+      } finally {
+        if (!cancelled && seq === requestSeq) setLoading(false);
+      }
+    };
+
+    setRuns([]);
+    setError(null);
+    setLoading(true);
+    refreshRef.current = () => void refresh();
+    void refresh();
+    return () => {
+      cancelled = true;
+      requestSeq += 1;
+      refreshRef.current = null;
+    };
+  }, [client, chatId]);
+
+  // Only a signal raised after this hook mounted means anything to it; the
+  // counter is app-wide and may already be well past zero on arrival.
+  const lastSignalRef = useRef(signal);
+  useEffect(() => {
+    if (lastSignalRef.current === signal) return;
+    lastSignalRef.current = signal;
+    refreshRef.current?.();
+  }, [signal]);
+
+  const hasLiveSandboxRun = runs.some(
+    (run) =>
+      run.execution === "sandbox" && LIVE_SANDBOX_STATUSES.includes(run.status),
+  );
+  useEffect(() => {
+    if (!hasLiveSandboxRun) return;
+    const interval = window.setInterval(
+      () => refreshRef.current?.(),
+      LIVE_POLL_INTERVAL_MS,
+    );
+    return () => window.clearInterval(interval);
+  }, [hasLiveSandboxRun]);
+
+  // Deleting this conversation takes its runs with it. Invalidating the fence
+  // makes every stop still in flight stale, and the markers go with it so the
+  // replacement conversation does not inherit a "Stopping…" button.
+  useEffect(() => {
+    if (!chatId || deletingChatId !== chatId) return;
+    stopFenceRef.current.invalidate();
+    setStoppingRunIds(new Set());
+    setStopErrorRunIds(new Set());
+  }, [chatId, deletingChatId]);
+
+  /**
+   * The chat a stop completion should be measured against: this conversation
+   * while it is still open, and nothing once it is not. Naming no chat makes
+   * every token stale, which is what a stop that fails against a chat on its
+   * way out deserves — the error would have nowhere to be read.
+   */
+  function fencedChatId(startedChatId: string): string | null {
+    return stillOpen(startedChatId) ? startedChatId : null;
+  }
+
+  async function stop(runId: string) {
+    // Any deletion in flight blocks a stop, not just this chat's: the request
+    // would race a chat list that is already being rebuilt.
+    if (!client || !chatId || deletingChatId !== null) return;
+    const target = runs.find((run) => run.id === runId);
+    if (!target || !canStopSandboxAgentRun(target)) return;
+
+    const startedChatId = chatId;
+    const request = stopFenceRef.current.begin(startedChatId, runId);
+    if (!request) return;
+    setStoppingRunIds((current) => new Set(current).add(runId));
+    setStopErrorRunIds((current) => {
+      const next = new Set(current);
+      next.delete(runId);
+      return next;
+    });
+
+    try {
+      const cancellation = await client.cancelAgentRun(startedChatId, runId);
+      if (
+        !stopFenceRef.current.isCurrent(request, fencedChatId(startedChatId))
+      ) {
+        return;
+      }
+      setRuns((current) =>
+        reconcileSandboxAgentCancellation(current, cancellation),
+      );
+      refreshRef.current?.();
+    } catch {
+      if (
+        !stopFenceRef.current.isCurrent(request, fencedChatId(startedChatId))
+      ) {
+        return;
+      }
+      setStopErrorRunIds((current) => new Set(current).add(runId));
+    } finally {
+      if (stopFenceRef.current.finish(request, fencedChatId(startedChatId))) {
+        setStoppingRunIds((current) => {
+          const next = new Set(current);
+          next.delete(runId);
+          return next;
+        });
+      }
+    }
+  }
+
+  return {
+    runs,
+    loading,
+    error,
+    stoppingRunIds,
+    stopErrorRunIds,
+    refresh: () => refreshRef.current?.(),
+    stop: (runId) => void stop(runId),
+  };
+}

--- a/crates/openwave-desktop/ui/src/useTurnControls.test.ts
+++ b/crates/openwave-desktop/ui/src/useTurnControls.test.ts
@@ -1,0 +1,416 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient } from "./api";
+import { useChatListStore } from "./ChatListStore";
+import { useChatSessionStore } from "./ChatSessionStore";
+import { useTurnControls } from "./useTurnControls";
+import { useTurnLifecycle } from "./TurnLifecycleSignals";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  promise.catch(() => {});
+  return { promise, resolve, reject };
+}
+
+function stubClient(overrides: Record<string, unknown> = {}) {
+  return {
+    cancel: vi.fn().mockResolvedValue(undefined),
+    steer: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+/** Puts the session store where a turn is running, as the composer sees it. */
+function runTurn(turnId = "turn-1") {
+  useChatSessionStore
+    .getState()
+    .update((session) => ({ ...session, busy: true, activeTurnId: turnId }));
+}
+
+function mount(client: ApiClient, draft = "change course", chatId = "chat-1") {
+  const draftRef = { current: draft };
+  const onDraftAccepted = vi.fn(() => {
+    draftRef.current = "";
+  });
+  const view = renderHook(
+    ({ id }) => useTurnControls(client, id, draftRef, onDraftAccepted),
+    { initialProps: { id: chatId } },
+  );
+  return { ...view, draftRef, onDraftAccepted };
+}
+
+beforeEach(() => {
+  useChatSessionStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+  useChatListStore.getState().setDeletingChatId(null);
+});
+
+describe("useTurnControls", () => {
+  it("settles the steer promise when the request settles, not when it is sent", async () => {
+    // The composer awaits this to time restoring focus. Resolving on submit
+    // would hand focus back while the request is still open, and would make the
+    // composer's own stale-submission guard unreachable.
+    const request = deferred<void>();
+    const client = stubClient({ steer: vi.fn(() => request.promise) });
+    const { result } = mount(client);
+    act(() => runTurn());
+
+    let settled = false;
+    let steering!: Promise<void>;
+    act(() => {
+      steering = result.current.steer().then(() => {
+        settled = true;
+      });
+    });
+    await waitFor(() =>
+      expect(result.current.steerPendingTurnId).toBe("turn-1"),
+    );
+    expect(settled).toBe(false);
+
+    await act(async () => {
+      request.resolve();
+      await steering;
+    });
+
+    expect(settled).toBe(true);
+    expect(result.current.steerStatus).toBe("Guidance sent");
+  });
+
+  it("sends the live draft and clears it once the guidance is accepted", async () => {
+    const client = stubClient();
+    const { result, draftRef, onDraftAccepted } = mount(client, "  go left  ");
+    act(() => runTurn());
+
+    await act(async () => result.current.steer());
+
+    expect(client.steer).toHaveBeenCalledWith(
+      "chat-1",
+      "turn-1",
+      expect.any(String),
+      "go left",
+      true,
+    );
+    expect(onDraftAccepted).toHaveBeenCalledTimes(1);
+    expect(draftRef.current).toBe("");
+    expect(result.current.steerPendingTurnId).toBeNull();
+  });
+
+  it("keeps a draft the reader has since changed", async () => {
+    const request = deferred<void>();
+    const client = stubClient({ steer: vi.fn(() => request.promise) });
+    const { result, draftRef, onDraftAccepted } = mount(client, "go left");
+    act(() => runTurn());
+
+    const steering = result.current.steer();
+    draftRef.current = "go left, then right";
+    await act(async () => {
+      request.resolve();
+      await steering;
+    });
+
+    expect(onDraftAccepted).not.toHaveBeenCalled();
+    expect(result.current.steerStatus).toBe("Guidance sent");
+  });
+
+  it("reports a failed steer and lets the reader retry it", async () => {
+    const client = stubClient({
+      steer: vi.fn().mockRejectedValue(new Error("steer rejected")),
+    });
+    const { result } = mount(client);
+    act(() => runTurn());
+
+    await act(async () => result.current.steer());
+
+    expect(result.current.steerError).toContain("steer rejected");
+    expect(result.current.steerStatus).toBeNull();
+    expect(result.current.steerPendingTurnId).toBeNull();
+
+    await act(async () => result.current.steer());
+    expect(client.steer).toHaveBeenCalledTimes(2);
+    // Unchanged guidance keeps its identity, so a retry cannot be applied twice.
+    expect(vi.mocked(client.steer).mock.calls[1]?.[2]).toBe(
+      vi.mocked(client.steer).mock.calls[0]?.[2],
+    );
+  });
+
+  it("clears the steer verdict without disturbing a request in flight", async () => {
+    const request = deferred<void>();
+    const client = stubClient({ steer: vi.fn(() => request.promise) });
+    const { result } = mount(client);
+    act(() => runTurn());
+
+    act(() => void result.current.steer());
+    await waitFor(() =>
+      expect(result.current.steerStatus).toBe("Sending guidance…"),
+    );
+
+    act(() => result.current.clearSteerFeedback());
+
+    expect(result.current.steerStatus).toBeNull();
+    expect(result.current.steerError).toBeNull();
+    expect(result.current.steerPendingTurnId).toBe("turn-1");
+    await act(async () => {
+      request.resolve();
+      await request.promise;
+    });
+  });
+
+  it("drops a failed steer once its chat is being deleted", async () => {
+    const request = deferred<void>();
+    const client = stubClient({ steer: vi.fn(() => request.promise) });
+    const { result } = mount(client);
+    act(() => runTurn());
+
+    act(() => void result.current.steer());
+    await waitFor(() =>
+      expect(result.current.steerPendingTurnId).toBe("turn-1"),
+    );
+
+    // The chat keeps its id for the whole delete round trip, which is why a
+    // plain id comparison misses this.
+    act(() => useChatListStore.getState().setDeletingChatId("chat-1"));
+    await act(async () => {
+      request.reject(new Error("gone"));
+      await request.promise.catch(() => {});
+    });
+
+    expect(result.current.steerError).toBeNull();
+    expect(result.current.steerStatus).toBeNull();
+    expect(result.current.steerPendingTurnId).toBeNull();
+  });
+
+  it("does not report a steer onto the conversation that replaced it", async () => {
+    // The chat pane is keyed on the chat, so in the app this reply lands on an
+    // unmounted hook. The chat id in the request's identity is what makes that
+    // safe rather than incidental.
+    const request = deferred<void>();
+    const client = stubClient({ steer: vi.fn(() => request.promise) });
+    const { result, rerender, onDraftAccepted } = mount(client);
+    act(() => runTurn());
+
+    act(() => void result.current.steer());
+    await waitFor(() =>
+      expect(result.current.steerPendingTurnId).toBe("turn-1"),
+    );
+
+    rerender({ id: "chat-2" });
+    await act(async () => {
+      request.resolve();
+      await request.promise;
+    });
+
+    expect(result.current.steerStatus).not.toBe("Guidance sent");
+    expect(onDraftAccepted).not.toHaveBeenCalled();
+  });
+
+  it("refuses guidance while a cancel for the turn is outstanding", async () => {
+    const cancelling = deferred<void>();
+    const client = stubClient({ cancel: vi.fn(() => cancelling.promise) });
+    const { result } = mount(client);
+    act(() => runTurn());
+
+    act(() => void result.current.cancel());
+    await waitFor(() =>
+      expect(result.current.cancelPendingTurnId).toBe("turn-1"),
+    );
+    await act(async () => result.current.steer());
+
+    expect(client.steer).not.toHaveBeenCalled();
+    await act(async () => {
+      cancelling.resolve();
+      await cancelling.promise;
+    });
+  });
+
+  it("refuses a second cancel for the turn it already asked to stop", async () => {
+    const cancelling = deferred<void>();
+    const client = stubClient({ cancel: vi.fn(() => cancelling.promise) });
+    const { result } = mount(client);
+    act(() => runTurn());
+
+    act(() => void result.current.cancel());
+    await waitFor(() =>
+      expect(result.current.cancelPendingTurnId).toBe("turn-1"),
+    );
+    await act(async () => result.current.cancel());
+
+    expect(client.cancel).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      cancelling.resolve();
+      await cancelling.promise;
+    });
+  });
+
+  it("reports a failed cancel and reopens the control", async () => {
+    const client = stubClient({
+      cancel: vi.fn().mockRejectedValue(new Error("already finished")),
+    });
+    const { result } = mount(client);
+    act(() => runTurn());
+
+    await act(async () => result.current.cancel());
+
+    expect(result.current.cancelError).toContain("already finished");
+    expect(result.current.cancelPendingTurnId).toBeNull();
+
+    await act(async () => result.current.cancel());
+    expect(client.cancel).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops a failed cancel once its chat is being deleted", async () => {
+    const cancelling = deferred<void>();
+    const client = stubClient({ cancel: vi.fn(() => cancelling.promise) });
+    const { result } = mount(client);
+    act(() => runTurn());
+
+    act(() => void result.current.cancel());
+    await waitFor(() =>
+      expect(result.current.cancelPendingTurnId).toBe("turn-1"),
+    );
+
+    act(() => useChatListStore.getState().setDeletingChatId("chat-1"));
+    await act(async () => {
+      cancelling.reject(new Error("gone"));
+      await cancelling.promise.catch(() => {});
+    });
+
+    expect(result.current.cancelError).toBeNull();
+  });
+
+  it("does not steer a conversation that is being deleted", async () => {
+    const client = stubClient();
+    const { result } = mount(client);
+    act(() => runTurn());
+
+    act(() => useChatListStore.getState().setDeletingChatId("chat-2"));
+    await act(async () => result.current.steer());
+
+    expect(client.steer).not.toHaveBeenCalled();
+  });
+
+  it("retires guidance aimed at a conversation being deleted", async () => {
+    const client = stubClient();
+    const { result } = mount(client);
+    act(() => runTurn());
+    await act(async () => result.current.steer());
+    expect(result.current.steerStatus).toBe("Guidance sent");
+
+    act(() => useChatListStore.getState().setDeletingChatId("chat-1"));
+
+    await waitFor(() => expect(result.current.steerStatus).toBeNull());
+  });
+
+  it("lets the reader steer again once a failed deletion releases the turn", async () => {
+    const request = deferred<void>();
+    const client = stubClient({ steer: vi.fn(() => request.promise) });
+    const { result } = mount(client);
+    act(() => runTurn());
+
+    act(() => void result.current.steer());
+    act(() => useChatListStore.getState().setDeletingChatId("chat-1"));
+    await act(async () => {
+      request.resolve();
+      await request.promise;
+    });
+    // The delete failed, so the conversation the reader was guiding is still
+    // here — and guidance the fence never released could never be sent again.
+    act(() => useChatListStore.getState().setDeletingChatId(null));
+
+    await act(async () => result.current.steer());
+
+    expect(client.steer).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("useTurnControls turn lifecycle", () => {
+  /** Sends guidance and asks to stop, so both controls have state to retire. */
+  async function armBothControls(client: ApiClient) {
+    const view = mount(client);
+    act(() => runTurn());
+    await act(async () => view.result.current.steer());
+    await act(async () => view.result.current.cancel());
+    expect(view.result.current.steerStatus).toBe("Guidance sent");
+    return view;
+  }
+
+  it("retires the cancel and the guidance when a different turn begins", async () => {
+    const client = stubClient();
+    const { result } = await armBothControls(client);
+
+    act(() => useTurnLifecycle.getState().signal("began"));
+
+    expect(result.current.cancelPendingTurnId).toBeNull();
+    expect(result.current.cancelError).toBeNull();
+    expect(result.current.steerStatus).toBeNull();
+    expect(result.current.steerPendingTurnId).toBeNull();
+
+    // The cancel-request turn went with it, so the control is live again.
+    await act(async () => result.current.cancel());
+    expect(client.cancel).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps standing guidance when the same turn is re-announced", async () => {
+    const client = stubClient();
+    const { result } = await armBothControls(client);
+
+    act(() => useTurnLifecycle.getState().signal("began_same_turn"));
+
+    // The turn the reader guided is still running, so the notice stands.
+    expect(result.current.steerStatus).toBe("Guidance sent");
+    expect(result.current.cancelPendingTurnId).toBeNull();
+    await act(async () => result.current.cancel());
+    expect(client.cancel).toHaveBeenCalledTimes(2);
+  });
+
+  it("retires both controls when the turn resolves", async () => {
+    const client = stubClient();
+    const { result } = await armBothControls(client);
+
+    act(() => useTurnLifecycle.getState().signal("resolved"));
+
+    expect(result.current.cancelPendingTurnId).toBeNull();
+    expect(result.current.steerStatus).toBeNull();
+    await act(async () => result.current.cancel());
+    expect(client.cancel).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the cancel-request turn standing after a local submission", async () => {
+    const client = stubClient();
+    const { result } = await armBothControls(client);
+
+    act(() => useTurnLifecycle.getState().signal("submitted"));
+
+    // What the reader can see is cleared, but the turn already asked to stop is
+    // still fenced: only the server confirming a turn retires that.
+    expect(result.current.cancelPendingTurnId).toBeNull();
+    expect(result.current.cancelError).toBeNull();
+    expect(result.current.steerStatus).toBe("Guidance sent");
+    await act(async () => result.current.cancel());
+    expect(client.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("reacts once per signal, so a repeated event is a repeated reaction", async () => {
+    const client = stubClient();
+    const { result, draftRef } = mount(client);
+    act(() => runTurn());
+
+    for (const _attempt of [1, 2]) {
+      // Accepting the first attempt emptied the composer; the reader types the
+      // next piece of guidance before sending it.
+      draftRef.current = "change course";
+      await act(async () => result.current.steer());
+      expect(result.current.steerStatus).toBe("Guidance sent");
+      act(() => useTurnLifecycle.getState().signal("resolved"));
+      expect(result.current.steerStatus).toBeNull();
+    }
+  });
+});

--- a/crates/openwave-desktop/ui/src/useTurnControls.ts
+++ b/crates/openwave-desktop/ui/src/useTurnControls.ts
@@ -1,0 +1,227 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+import {
+  ActiveTurnSteerFence,
+  canBeginActiveTurnSteer,
+  shouldClearAcceptedSteerDraft,
+  type ActiveTurnSteerRequest,
+} from "./ActiveTurnSteer";
+import type { ApiClient } from "./api";
+import { useChatListStore } from "./ChatListStore";
+import { useChatSessionStore } from "./ChatSessionStore";
+import { useOpenConversation } from "./OpenConversation";
+import { useTurnLifecycle } from "./TurnLifecycleSignals";
+
+export type TurnControls = {
+  cancelPendingTurnId: string | null;
+  cancelError: string | null;
+  cancel: () => Promise<void>;
+  steerPendingTurnId: string | null;
+  steerError: string | null;
+  steerStatus: string | null;
+  steer: () => Promise<void>;
+  clearSteerFeedback: () => void;
+};
+
+/**
+ * Stopping and redirecting one conversation's active turn.
+ *
+ * Both controls are guarded against being pressed twice: a cancel remembers the
+ * turn it was issued for, and guidance is fenced by [ActiveTurnSteerFence] so a
+ * retry of unchanged text reuses its identity rather than sending twice. The
+ * turn itself moves on the event stream, which arrives here as a
+ * [TurnLifecycleEvent] — what to retire differs per event, which is why this
+ * reads a named event and not just a revision counter.
+ *
+ * @param draftRef the live composer draft, read at the moment guidance is sent
+ *   rather than at render, so a keystroke that has not painted yet still counts.
+ * @param onDraftAccepted called when accepted guidance was the draft still in
+ *   the composer, so the composer can clear it.
+ */
+export function useTurnControls(
+  client: ApiClient | null,
+  chatId: string | null,
+  draftRef: RefObject<string>,
+  onDraftAccepted: () => void,
+): TurnControls {
+  const [cancelPendingTurnId, setCancelPendingTurnId] = useState<string | null>(
+    null,
+  );
+  const [cancelError, setCancelError] = useState<string | null>(null);
+  const [steerPendingTurnId, setSteerPendingTurnId] = useState<string | null>(
+    null,
+  );
+  const [steerError, setSteerError] = useState<string | null>(null);
+  const [steerStatus, setSteerStatus] = useState<string | null>(null);
+  const cancelRequestTurnRef = useRef<string | null>(null);
+  const steerFenceRef = useRef(new ActiveTurnSteerFence());
+  const busy = useChatSessionStore((session) => session.busy);
+  const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
+  const stillOpen = useOpenConversation(chatId);
+  const deletingChatId = useChatListStore((state) => state.deletingChatId);
+  const revision = useTurnLifecycle((state) => state.revision);
+  const lifecycleEvent = useTurnLifecycle((state) => state.last);
+
+  function clearCancelRequestState() {
+    cancelRequestTurnRef.current = null;
+    setCancelPendingTurnId(null);
+    setCancelError(null);
+  }
+
+  function clearSteerRequestState() {
+    steerFenceRef.current.invalidate();
+    setSteerPendingTurnId(null);
+    setSteerError(null);
+    setSteerStatus(null);
+  }
+
+  // Only a signal raised after this hook mounted means anything to it; the
+  // counter is app-wide and may already be well past zero on arrival.
+  const lastRevisionRef = useRef(revision);
+  useEffect(() => {
+    if (lastRevisionRef.current === revision) return;
+    lastRevisionRef.current = revision;
+    switch (lifecycleEvent) {
+      case "began":
+        clearCancelRequestState();
+        clearSteerRequestState();
+        return;
+      case "began_same_turn":
+        // The turn the reader is guiding is still the one running, so their
+        // guidance — and the notice that it was sent — still stands.
+        clearCancelRequestState();
+        return;
+      case "resolved":
+        clearCancelRequestState();
+        clearSteerRequestState();
+        return;
+      case "submitted":
+        // A local submission clears only what the reader can see. The
+        // cancel-request turn is deliberately left standing: it fences a second
+        // stop for the turn it named, and the `began` that confirms the new
+        // turn is what retires it.
+        setCancelPendingTurnId(null);
+        setCancelError(null);
+        return;
+    }
+  }, [revision, lifecycleEvent]);
+
+  // Deleting this conversation retires the guidance aimed at it: the fence goes
+  // stale so a reply still in flight cannot land, and the notice goes with the
+  // conversation rather than following the reader to its replacement.
+  useEffect(() => {
+    if (!chatId || deletingChatId !== chatId) return;
+    clearSteerRequestState();
+  }, [chatId, deletingChatId]);
+
+  /**
+   * Whether a steer reply may still be applied. The current chat is named only
+   * while this conversation is genuinely open — a chat being deleted keeps its
+   * id for the whole round trip, so naming it here would let a reply paint onto
+   * a conversation on its way out.
+   */
+  function canApplySteerResponse(request: ActiveTurnSteerRequest): boolean {
+    return steerFenceRef.current.canApplyResponse(request, {
+      chatId: stillOpen(request.chatId) ? request.chatId : "",
+      turnId: useChatSessionStore.getState().activeTurnId ?? "",
+    });
+  }
+
+  async function cancel(): Promise<void> {
+    const turnId = activeTurnId;
+    if (
+      !client ||
+      !chatId ||
+      !busy ||
+      !turnId ||
+      cancelRequestTurnRef.current === turnId
+    ) {
+      return;
+    }
+    const startedChatId = chatId;
+
+    cancelRequestTurnRef.current = turnId;
+    setCancelPendingTurnId(turnId);
+    setCancelError(null);
+    try {
+      await client.cancel(startedChatId, turnId);
+    } catch (err) {
+      if (
+        stillOpen(startedChatId) &&
+        cancelRequestTurnRef.current === turnId
+      ) {
+        cancelRequestTurnRef.current = null;
+        setCancelPendingTurnId(null);
+        setCancelError(String(err));
+      }
+    }
+  }
+
+  /**
+   * Sends the composer draft as guidance. The returned promise settles when the
+   * request does, not when it is submitted: the composer awaits this to time
+   * restoring focus, and resolving early would hand focus back while the request
+   * is still open and put the caret in a field the reader may retype into.
+   */
+  async function steer(): Promise<void> {
+    const admission = {
+      busy,
+      turnId: useChatSessionStore.getState().activeTurnId,
+      cancelRequestTurnId: cancelRequestTurnRef.current,
+      deletionInFlight: deletingChatId !== null,
+    };
+    if (!client || !chatId || !canBeginActiveTurnSteer(admission)) return;
+    const turnId = admission.turnId;
+
+    const request = steerFenceRef.current.begin(
+      { chatId, turnId },
+      draftRef.current,
+      () => crypto.randomUUID(),
+    );
+    if (!request) return;
+
+    setSteerPendingTurnId(turnId);
+    setSteerError(null);
+    setSteerStatus("Sending guidance…");
+    setCancelError(null);
+    try {
+      await client.steer(
+        request.chatId,
+        request.turnId,
+        request.steerId,
+        request.content,
+        true,
+      );
+      if (!canApplySteerResponse(request)) return;
+
+      steerFenceRef.current.finish(request);
+      setSteerPendingTurnId(null);
+      if (shouldClearAcceptedSteerDraft(request, draftRef.current)) {
+        onDraftAccepted();
+      }
+      setSteerStatus("Guidance sent");
+    } catch (err) {
+      if (!canApplySteerResponse(request)) return;
+
+      steerFenceRef.current.fail(request);
+      setSteerPendingTurnId(null);
+      setSteerStatus(null);
+      setSteerError(String(err));
+    }
+  }
+
+  return {
+    cancelPendingTurnId,
+    cancelError,
+    cancel,
+    steerPendingTurnId,
+    steerError,
+    steerStatus,
+    steer,
+    // Typing is the reader answering the last attempt; the verdict on it goes
+    // stale as soon as the text it was about changes.
+    clearSteerFeedback: () => {
+      setSteerError(null);
+      setSteerStatus(null);
+    },
+  };
+}


### PR DESCRIPTION
Finishes the scope #450 named. #472 moved approvals, folder access and questions out of the root; agent runs, steering and cancellation stayed, still threaded into the chat pane as props it only forwarded.

## The change

Same shape as the hooks already there:

- **`useAgentRuns`** — polling, the faster poll while a sandbox run is live, and the stop, with its fence.
- **`useTurnControls`** — steering and cancellation together, because they are one concern: guidance is inadmissible while a stop is pending, and the same turn boundaries retire both.

The event stream reaches them through `RefreshSignals`, as with the other pollers. Turn lifecycle needed slightly more than a revision counter can carry — whether a turn *replaced* a different one changes what should be withdrawn — so it gets a counter alongside the event that raised it. The four transitions keep their existing asymmetries:

| signal | cancel pending/error | `cancelRequestTurnRef` | steer state |
|---|---|---|---|
| `began` (different turn) | cleared | cleared | cleared |
| `began` (same turn re-announced) | cleared | cleared | **kept** — the turn being guided is still running |
| `resolved` | cleared | cleared | cleared |
| local submit | cleared | **kept** — it fences a second stop until `began` retires it | kept |

## Scaffolding removed

- `agentRunsForChat` guarded against another conversation's runs landing in this one. A hook scoped to a single chat cannot see them. Initialising the hook as loading preserves the one thing the guard still bought: "not asked yet" must not render as "asked and got nothing".
- `ActiveTurnTarget` drops the root's selection counter. Inside a per-conversation hook it no longer discriminates anything the chat id does not — a switch is either an unmount, which takes the fence with it, or a new chat id the comparison already rejects; a deletion leaves the conversation mounted under its own id and is handled by invalidating the fence and by refusing to name a deleting chat as the current target.

## Worth knowing

`steer` returns a promise that settles when the guidance is **accepted or rejected**, not when it is sent. `Composer` awaits it to decide where the caret belongs, so resolving early would restore focus into a field the reader may still be retyping and would make its stale-submission guard unreachable. There is a test that fails if this regresses.

The delete-window fence from #489 is extended to cancellation and to the sandbox stop, which had the same shape.

`App.tsx` 1042 → 747 lines; the chat pane 27 → 16 props. `MessageList` is untouched and stays prop-driven.

## Verification

`tsc`, 404 vitest tests (from 370), production build. The new suites cover polling and signal refresh, both fences, the delete window, the late-settling steer promise, the draft-clearing rules, and each lifecycle transition — each mutation-checked by breaking the guard it covers and confirming the test fails.

Closes #484