### PR TITLE
feat: let consent be about the command, not about commands in general

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -2101,6 +2101,11 @@ impl Agent {
         let approval_class = durable_approval
             .map(|approval| approval.class)
             .unwrap_or_else(|| tool.approval_class());
+        // The action a standing grant is matched against, and the one the card
+        // shows if this call ends up parking. Built once so a grant can never
+        // be tested against a different reading of the arguments than the
+        // human was shown.
+        let action = call_action_preview(call);
         // Standing grant: a brand-new Sensitive call the user already approved
         // for this chat runs without re-parking on the gate. A recovered call
         // (`durable_approval` present) keeps its durable park-and-resume
@@ -2113,6 +2118,7 @@ impl Agent {
                 chat.id,
                 &call.name,
                 ToolApprovalKind::for_tool_name(&call.name),
+                action.as_ref(),
             );
         if matches!(approval_class, ApprovalClass::Sensitive) && !bypass_by_standing_grant {
             let summary = format!("{} requires approval", call.name);
@@ -2124,7 +2130,7 @@ impl Agent {
             // asked about before the restart.
             let preview = match durable_approval {
                 Some(approval) => approval.preview.clone(),
-                None => call_action_preview(call),
+                None => action.clone(),
             };
             if self.durable_steer_lease.is_some() && events.flush().await.is_err() {
                 return ToolOutput::error("approval event journal is unavailable");

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -217,7 +217,79 @@ pub struct StandingGrant {
     chat_id: ChatId,
     tool_name: String,
     kind: ToolApprovalKind,
+    scope: GrantScope,
     granted_at: DateTime<Utc>,
+}
+
+/// How much a standing grant covers.
+///
+/// A grant is easy to widen by accident and hard to notice afterwards, so the
+/// scope is stated in the grant itself rather than inferred from the tool. The
+/// narrower variants exist because "don't ask me about commands again" is a
+/// much larger thing to agree to than "don't ask me about `cargo` again".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GrantScope {
+    /// Exactly this argument vector, and nothing else.
+    ExactCommand { command: String, args: Vec<String> },
+    /// This executable, with any arguments.
+    AnyArgsFor { command: String },
+    /// Every call to the tool.
+    WholeTool,
+}
+
+impl GrantScope {
+    /// Whether this scope covers the action a call is about to take.
+    ///
+    /// An action the renderer could not describe is never covered by a narrow
+    /// scope: matching it would mean guessing at what the call will do.
+    #[must_use]
+    pub fn covers_action(&self, action: Option<&crate::preview::ToolActionPreview>) -> bool {
+        use crate::preview::ToolActionPreview;
+        match self {
+            Self::WholeTool => true,
+            Self::ExactCommand { command, args } => matches!(
+                action,
+                Some(ToolActionPreview::Exec {
+                    command: call_command,
+                    args: call_args,
+                    ..
+                }) if call_command == command && call_args == args
+            ),
+            Self::AnyArgsFor { command } => matches!(
+                action,
+                Some(ToolActionPreview::Exec {
+                    command: call_command,
+                    ..
+                }) if call_command == command
+            ),
+        }
+    }
+
+    /// The scopes offered for an action, narrowest first.
+    ///
+    /// A tool with nothing to describe can only be granted wholesale, because
+    /// there is no narrower thing to name.
+    #[must_use]
+    pub fn ladder_for(action: Option<&crate::preview::ToolActionPreview>) -> Vec<Self> {
+        match action {
+            Some(crate::preview::ToolActionPreview::Exec { command, args, .. }) => {
+                let mut ladder = vec![Self::ExactCommand {
+                    command: command.clone(),
+                    args: args.clone(),
+                }];
+                // With no arguments, "exactly this" and "this executable with
+                // any arguments" would read as two names for one grant.
+                if !args.is_empty() {
+                    ladder.push(Self::AnyArgsFor {
+                        command: command.clone(),
+                    });
+                }
+                ladder.push(Self::WholeTool);
+                ladder
+            }
+            _ => vec![Self::WholeTool],
+        }
+    }
 }
 
 impl StandingGrant {
@@ -234,6 +306,20 @@ impl StandingGrant {
         kind: ToolApprovalKind,
         granted_at: DateTime<Utc>,
     ) -> Option<Self> {
+        Self::scoped(chat_id, tool_name, kind, GrantScope::WholeTool, granted_at)
+    }
+
+    /// Record consent limited to `scope`.
+    ///
+    /// Returns `None` on the same terms as [`StandingGrant::new`].
+    #[must_use]
+    pub fn scoped(
+        chat_id: ChatId,
+        tool_name: impl Into<String>,
+        kind: ToolApprovalKind,
+        scope: GrantScope,
+        granted_at: DateTime<Utc>,
+    ) -> Option<Self> {
         if !kind.is_standing_grantable() {
             return None;
         }
@@ -241,8 +327,15 @@ impl StandingGrant {
             chat_id,
             tool_name: tool_name.into(),
             kind,
+            scope,
             granted_at,
         })
+    }
+
+    /// How much this grant covers.
+    #[must_use]
+    pub const fn scope(&self) -> &GrantScope {
+        &self.scope
     }
 
     /// Chat the standing consent belongs to.
@@ -271,11 +364,18 @@ impl StandingGrant {
 
     /// Whether this grant covers an exact Sensitive action.
     #[must_use]
-    fn covers(&self, chat_id: ChatId, tool_name: &str, kind: ToolApprovalKind) -> bool {
+    fn covers(
+        &self,
+        chat_id: ChatId,
+        tool_name: &str,
+        kind: ToolApprovalKind,
+        action: Option<&crate::preview::ToolActionPreview>,
+    ) -> bool {
         self.chat_id == chat_id
             && self.tool_name == tool_name
             && self.kind == kind
             && kind.is_approvable()
+            && self.scope.covers_action(action)
     }
 }
 
@@ -314,6 +414,7 @@ impl StandingGrants {
             existing.chat_id == grant.chat_id
                 && existing.tool_name == grant.tool_name
                 && existing.kind == grant.kind
+                && existing.scope == grant.scope
         }) {
             grants.push(grant);
         }
@@ -321,10 +422,16 @@ impl StandingGrants {
 
     /// Whether a live grant covers this exact Sensitive action.
     #[must_use]
-    pub fn covers(&self, chat_id: ChatId, tool_name: &str, kind: ToolApprovalKind) -> bool {
+    pub fn covers(
+        &self,
+        chat_id: ChatId,
+        tool_name: &str,
+        kind: ToolApprovalKind,
+        action: Option<&crate::preview::ToolActionPreview>,
+    ) -> bool {
         self.read()
             .iter()
-            .any(|grant| grant.covers(chat_id, tool_name, kind))
+            .any(|grant| grant.covers(chat_id, tool_name, kind, action))
     }
 
     /// Drop every grant, e.g. on explicit revocation.
@@ -521,9 +628,9 @@ mod standing_grant_tests {
         let chat = ChatId::new();
         let grants = StandingGrants::from_grants(vec![grant(chat, "exec")]);
         let kind = ToolApprovalKind::for_tool_name("exec");
-        assert!(grants.covers(chat, "exec", kind));
+        assert!(grants.covers(chat, "exec", kind, None));
         // Deny-by-default still holds for a different chat.
-        assert!(!grants.covers(ChatId::new(), "exec", kind));
+        assert!(!grants.covers(ChatId::new(), "exec", kind, None));
     }
 
     #[test]
@@ -553,7 +660,12 @@ mod standing_grant_tests {
     fn empty_set_covers_nothing() {
         let chat = ChatId::new();
         let grants = StandingGrants::new();
-        assert!(!grants.covers(chat, "search", ToolApprovalKind::for_tool_name("search")));
+        assert!(!grants.covers(
+            chat,
+            "search",
+            ToolApprovalKind::for_tool_name("search"),
+            None
+        ));
     }
 
     #[test]
@@ -563,13 +675,147 @@ mod standing_grant_tests {
         let grants = StandingGrants::from_grants(vec![grant(chat, "search")]);
         let kind = ToolApprovalKind::for_tool_name("search");
 
-        assert!(grants.covers(chat, "search", kind));
-        assert!(!grants.covers(other_chat, "search", kind));
+        assert!(grants.covers(chat, "search", kind, None));
+        assert!(!grants.covers(other_chat, "search", kind, None));
         assert!(!grants.covers(
             chat,
             "third_party_sensitive",
             ToolApprovalKind::for_tool_name("third_party_sensitive"),
+            None,
         ));
+    }
+
+    fn exec_action(command: &str, args: &[&str]) -> crate::preview::ToolActionPreview {
+        crate::preview::ToolActionPreview::Exec {
+            command: command.into(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            cwd: ".".into(),
+        }
+    }
+
+    #[test]
+    fn an_exact_grant_covers_only_the_vector_it_named() {
+        let chat = ChatId::new();
+        let kind = ToolApprovalKind::for_tool_name("exec");
+        let grants = StandingGrants::new();
+        grants.record(
+            StandingGrant::scoped(
+                chat,
+                "exec",
+                kind,
+                GrantScope::ExactCommand {
+                    command: "cargo".into(),
+                    args: vec!["test".into()],
+                },
+                Utc::now(),
+            )
+            .unwrap(),
+        );
+
+        assert!(grants.covers(chat, "exec", kind, Some(&exec_action("cargo", &["test"]))));
+        assert!(!grants.covers(
+            chat,
+            "exec",
+            kind,
+            Some(&exec_action("cargo", &["publish"]))
+        ));
+        assert!(!grants.covers(chat, "exec", kind, Some(&exec_action("rm", &["test"]))));
+        // An action the renderer could not describe was never the one granted.
+        assert!(!grants.covers(chat, "exec", kind, None));
+    }
+
+    #[test]
+    fn an_executable_grant_covers_any_arguments_to_it() {
+        let chat = ChatId::new();
+        let kind = ToolApprovalKind::for_tool_name("exec");
+        let grants = StandingGrants::new();
+        grants.record(
+            StandingGrant::scoped(
+                chat,
+                "exec",
+                kind,
+                GrantScope::AnyArgsFor {
+                    command: "cargo".into(),
+                },
+                Utc::now(),
+            )
+            .unwrap(),
+        );
+
+        assert!(grants.covers(chat, "exec", kind, Some(&exec_action("cargo", &["test"]))));
+        assert!(grants.covers(
+            chat,
+            "exec",
+            kind,
+            Some(&exec_action("cargo", &["publish"]))
+        ));
+        assert!(!grants.covers(chat, "exec", kind, Some(&exec_action("rm", &["-rf"]))));
+    }
+
+    #[test]
+    fn a_whole_tool_grant_covers_an_action_it_cannot_read() {
+        let chat = ChatId::new();
+        let kind = ToolApprovalKind::for_tool_name("exec");
+        let grants = StandingGrants::new();
+        grants.record(grant(chat, "exec"));
+
+        assert!(grants.covers(chat, "exec", kind, Some(&exec_action("rm", &["-rf"]))));
+        assert!(grants.covers(chat, "exec", kind, None));
+    }
+
+    #[test]
+    fn the_ladder_runs_narrowest_first_and_never_names_one_grant_twice() {
+        assert_eq!(
+            GrantScope::ladder_for(Some(&exec_action("cargo", &["test"]))),
+            vec![
+                GrantScope::ExactCommand {
+                    command: "cargo".into(),
+                    args: vec!["test".into()],
+                },
+                GrantScope::AnyArgsFor {
+                    command: "cargo".into(),
+                },
+                GrantScope::WholeTool,
+            ]
+        );
+        // With no arguments, "exactly this" and "any arguments to this" would
+        // be two names for the same grant.
+        assert_eq!(
+            GrantScope::ladder_for(Some(&exec_action("true", &[]))),
+            vec![
+                GrantScope::ExactCommand {
+                    command: "true".into(),
+                    args: vec![],
+                },
+                GrantScope::WholeTool,
+            ]
+        );
+        // Nothing to describe means nothing narrower to offer.
+        assert_eq!(GrantScope::ladder_for(None), vec![GrantScope::WholeTool]);
+    }
+
+    #[test]
+    fn narrow_grants_for_the_same_tool_accumulate_rather_than_collapse() {
+        let chat = ChatId::new();
+        let kind = ToolApprovalKind::for_tool_name("exec");
+        let grants = StandingGrants::new();
+        for command in ["cargo", "git"] {
+            grants.record(
+                StandingGrant::scoped(
+                    chat,
+                    "exec",
+                    kind,
+                    GrantScope::AnyArgsFor {
+                        command: command.into(),
+                    },
+                    Utc::now(),
+                )
+                .unwrap(),
+            );
+        }
+        assert_eq!(grants.read().len(), 2);
+        assert!(grants.covers(chat, "exec", kind, Some(&exec_action("git", &["log"]))));
+        assert!(!grants.covers(chat, "exec", kind, Some(&exec_action("npm", &["i"]))));
     }
 
     #[test]
@@ -580,9 +826,9 @@ mod standing_grant_tests {
         grants.record(grant(chat, "search"));
         grants.record(grant(chat, "search"));
         assert_eq!(grants.read().len(), 1);
-        assert!(grants.covers(chat, "search", kind));
+        assert!(grants.covers(chat, "search", kind, None));
 
         grants.clear();
-        assert!(!grants.covers(chat, "search", kind));
+        assert!(!grants.covers(chat, "search", kind, None));
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -69,7 +69,8 @@ pub use agent_tools::{
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
     ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, AutoApproveGate,
-    RefuseGate, StandingGrant, StandingGrants, ToolApproval, ToolApprovalKind, ToolApprovalStatus,
+    GrantScope, RefuseGate, StandingGrant, StandingGrants, ToolApproval, ToolApprovalKind,
+    ToolApprovalStatus,
 };
 #[cfg(feature = "blob-fs")]
 pub use blob::FsBlobStore;

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
-import type { ToolActionPreview } from "./api";
+import type { ApprovalGrantRung, ToolActionPreview } from "./api";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ScrollableContainer } from "./ScrollableContainer";
@@ -8,12 +8,15 @@ import { toolPreviewPresentation } from "./ToolPreview";
 
 export type ApprovalDecision = "approve" | "reject";
 
-export type ApprovalOption = {
-  key: string;
-  label: string;
-  decision: ApprovalDecision;
-  remember: boolean;
-};
+export type ApprovalOption =
+  | {
+      kind: "decide";
+      key: string;
+      label: string;
+      decision: ApprovalDecision;
+      grant: ApprovalGrantRung | null;
+    }
+  | { kind: "more"; key: string; label: string };
 
 type ApprovalCardProps = {
   callId: string;
@@ -28,7 +31,7 @@ type ApprovalCardProps = {
   onDecide: (
     callId: string,
     decision: ApprovalDecision,
-    remember: boolean,
+    grant: ApprovalGrantRung | null,
   ) => void;
 };
 
@@ -54,7 +57,8 @@ export function ApprovalCard({
   error,
   onDecide,
 }: ApprovalCardProps) {
-  const options = approvalOptions(preview, canApprove, canRemember);
+  const [expanded, setExpanded] = useState(false);
+  const options = approvalOptions(preview, canApprove, canRemember, expanded);
   const [highlight, setHighlight] = useState(0);
   const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
   const hasAutoFocused = useRef(false);
@@ -84,7 +88,16 @@ export function ApprovalCard({
   const commit = (index: number) => {
     const option = options[index];
     if (!option || deciding) return;
-    onDecide(callId, option.decision, option.remember);
+    if (option.kind === "more") {
+      setExpanded(true);
+      // The revealed grants take the indices "More options" occupied, so
+      // leaving the highlight here would park it on a broader grant and let
+      // the next Enter commit it — the one thing this list exists to prevent.
+      setHighlight(0);
+      rowRefs.current[0]?.focus();
+      return;
+    }
+    onDecide(callId, option.decision, option.grant);
   };
 
   const focusRow = (to: number) => {
@@ -159,7 +172,10 @@ export function ApprovalCard({
             <span
               className={cn(
                 "flex-1",
-                option.decision === "reject" && "text-muted-foreground",
+                option.kind === "decide" &&
+                  option.decision === "reject" &&
+                  "text-muted-foreground",
+                option.kind === "more" && "text-muted-foreground",
               )}
             >
               {option.label}
@@ -205,8 +221,16 @@ export function approvalAsk(
   return { title: summary, summaryLine: null };
 }
 
+/** How many grants show before the rest move behind "More options". */
+const INLINE_GRANTS = 1;
+
 /**
  * Narrowest grant first, decline last.
+ *
+ * The broader rungs start hidden. Every option on screen is one keystroke
+ * away, so a list that shows "don't ask again" beside "just this once" makes
+ * the widest grant as cheap as the narrowest — and scope is easy to widen by
+ * accident and hard to notice afterwards.
  *
  * A kind the server will not let the renderer approve offers only the decline,
  * so an unpresentable action can never be waved through from here.
@@ -215,32 +239,84 @@ export function approvalOptions(
   preview: ToolActionPreview | null,
   canApprove: boolean,
   canRemember: boolean,
+  expanded = false,
 ): ApprovalOption[] {
-  const options: ApprovalOption[] = [];
-  if (canApprove) {
-    options.push({
+  if (!canApprove) return [declineOption()];
+
+  const options: ApprovalOption[] = [
+    {
+      kind: "decide",
       key: "once",
       // Named for the act, not the abstraction: "run it once" is what the
       // person is about to do.
       label:
         preview?.tool === "exec" ? "Yes, run it once" : "Yes, allow it once",
       decision: "approve",
-      remember: false,
-    });
-    if (canRemember) {
-      options.push({
-        key: "chat",
-        label: "Yes, and don't ask again in this chat",
-        decision: "approve",
-        remember: true,
-      });
-    }
+      grant: null,
+    },
+  ];
+
+  const grants = canRemember ? grantLadder(preview) : [];
+  const visible = expanded ? grants : grants.slice(0, INLINE_GRANTS);
+  options.push(...visible);
+  if (grants.length > visible.length) {
+    options.push({ kind: "more", key: "more", label: "More options" });
   }
-  options.push({
+  options.push(declineOption());
+  return options;
+}
+
+function declineOption(): ApprovalOption {
+  return {
+    kind: "decide",
     key: "decline",
     label: "No, don't allow this",
     decision: "reject",
-    remember: false,
-  });
-  return options;
+    grant: null,
+  };
+}
+
+/**
+ * The standing grants on offer, narrowest first.
+ *
+ * A command names itself, so consent can be about that command rather than
+ * about commands in general. A tool with nothing to describe can only be
+ * granted wholesale — there is no narrower thing to name.
+ */
+export function grantLadder(preview: ToolActionPreview | null): ApprovalOption[] {
+  const wholeTool: ApprovalOption = {
+    kind: "decide",
+    key: "whole-tool",
+    label:
+      preview?.tool === "exec"
+        ? "Yes, and don't ask again about commands in this chat"
+        : "Yes, and don't ask again in this chat",
+    decision: "approve",
+    grant: "whole_tool",
+  };
+  if (preview?.tool !== "exec") return [wholeTool];
+
+  const spoken = [preview.command, ...preview.args].join(" ");
+  return [
+    {
+      kind: "decide",
+      key: "exact",
+      label: `Yes, and always allow exactly \u201c${spoken}\u201d`,
+      decision: "approve",
+      grant: "exact_command",
+    },
+    // With no arguments this would be the same grant as the exact one.
+    ...(preview.args.length > 0
+      ? [
+          {
+            kind: "decide" as const,
+            key: "any-args",
+            label: `Yes, and always allow any \u201c${preview.command}\u201d command`,
+            decision: "approve" as const,
+            grant: "any_args_for_command" as const,
+          },
+        ]
+      : []),
+    wholeTool,
+  ];
 }

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -153,7 +153,7 @@ describe("ChatView", () => {
         "chat-1",
         "call-a",
         "approve",
-        false,
+        null,
       ),
     );
   });

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -24,11 +24,12 @@ function card(overrides: Partial<Parameters<typeof ApprovalCard>[0]> = {}) {
 
 const ONCE = "1.Yes, allow it once";
 const REMEMBER = "2.Yes, and don't ask again in this chat";
+const MORE = "More options";
 
 afterEach(cleanup);
 
 describe("approval card interactions", () => {
-  it("propagates each decision with its remember flag", async () => {
+  it("propagates each decision with the grant it names", async () => {
     const user = userEvent.setup();
     const onDecide = vi.fn();
     render(card({ onDecide }));
@@ -41,13 +42,13 @@ describe("approval card interactions", () => {
     ]);
 
     await user.click(options[0]!);
-    expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", false);
+    expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", null);
 
     await user.click(options[1]!);
-    expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", true);
+    expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", "whole_tool");
 
     await user.click(options[2]!);
-    expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", false);
+    expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", null);
   });
 
   it("starts on the narrowest grant so a stray Enter cannot widen scope", () => {
@@ -81,10 +82,10 @@ describe("approval card interactions", () => {
     render(card({ onDecide }));
 
     await user.keyboard("{ArrowDown}{Enter}");
-    expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", true);
+    expect(onDecide).toHaveBeenLastCalledWith("call-1", "approve", "whole_tool");
 
     await user.keyboard("3{Enter}");
-    expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", false);
+    expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", null);
   });
 
   it("wraps around the ends of the list", async () => {
@@ -93,7 +94,7 @@ describe("approval card interactions", () => {
     render(card({ onDecide }));
 
     await user.keyboard("{ArrowUp}{Enter}");
-    expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", false);
+    expect(onDecide).toHaveBeenLastCalledWith("call-1", "reject", null);
   });
 
   it("blocks every decision while one is in flight", async () => {
@@ -119,7 +120,7 @@ describe("approval card interactions", () => {
       "Could not send your decision",
     );
     await user.click(screen.getAllByRole("option")[0]!);
-    expect(onDecide).toHaveBeenCalledWith("call-1", "approve", false);
+    expect(onDecide).toHaveBeenCalledWith("call-1", "approve", null);
   });
 
   it("offers only rejection when the action kind is not approvable", () => {
@@ -136,6 +137,77 @@ describe("approval card interactions", () => {
     expect(
       screen.getAllByRole("option").map((option) => option.textContent),
     ).toEqual([ONCE, "2.No, don't allow this"]);
+  });
+
+  it("hides the broader grants behind one more keystroke", async () => {
+    const user = userEvent.setup();
+    const onDecide = vi.fn();
+    render(
+      card({
+        onDecide,
+        preview: {
+          tool: "exec",
+          command: "cargo",
+          args: ["test"],
+          cwd: ".",
+        },
+      }),
+    );
+
+    // Every option on screen is one keystroke away, so the narrowest grant is
+    // inline and the wider ones are not.
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual([
+      "1.Yes, run it once",
+      "2.Yes, and always allow exactly \u201ccargo test\u201d",
+      `3.${MORE}`,
+      "4.No, don't allow this",
+    ]);
+
+    await user.click(screen.getByText(MORE));
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual([
+      "1.Yes, run it once",
+      "2.Yes, and always allow exactly \u201ccargo test\u201d",
+      "3.Yes, and always allow any \u201ccargo\u201d command",
+      "4.Yes, and don't ask again about commands in this chat",
+      "5.No, don't allow this",
+    ]);
+    expect(onDecide).not.toHaveBeenCalled();
+  });
+
+  it("returns the highlight to the narrowest grant when it widens the list", async () => {
+    const user = userEvent.setup();
+    const onDecide = vi.fn();
+    render(
+      card({
+        onDecide,
+        preview: { tool: "exec", command: "cargo", args: ["test"], cwd: "." },
+      }),
+    );
+
+    // "More options" sat at row 3; expanding puts a broader grant there. A
+    // stray Enter must not commit whatever moved under the cursor.
+    await user.keyboard("3{Enter}");
+    expect(screen.getAllByRole("option")[0]).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await user.keyboard("{Enter}");
+    expect(onDecide).toHaveBeenCalledWith("call-1", "approve", null);
+  });
+
+  it("offers only the whole tool when the action names nothing narrower", async () => {
+    const user = userEvent.setup();
+    render(card());
+
+    expect(screen.queryByText(MORE)).not.toBeInTheDocument();
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual([ONCE, REMEMBER, "3.No, don't allow this"]);
+    await user.click(screen.getAllByRole("option")[1]!);
   });
 
   it("asks about the command rather than about commands in general", () => {
@@ -155,7 +227,9 @@ describe("approval card interactions", () => {
     expect(
       screen.getByRole("heading", { name: "Run this command?" }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/cargo test --workspace/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/cargo test --workspace/, { selector: "pre" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/# working directory: checkout/),
     ).toBeInTheDocument();
@@ -257,7 +331,9 @@ describe("activity phases", () => {
 
     // One copy of the command, on the card that can act on it, and no rail
     // line announcing the same pending action a second time.
-    expect(screen.getAllByText(/cargo build/)).toHaveLength(1);
+    expect(screen.getAllByText(/cargo build/, { selector: "pre" })).toHaveLength(
+      1,
+    );
     expect(
       screen.queryByRole("button", { name: /Running a command/ }),
     ).toBeNull();

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo } from "react";
 import type { ReactNode, RefObject, UIEvent } from "react";
 import type {
+  ApprovalGrantRung,
   PendingFolderAccessRequest,
   PendingUserQuestions,
   ToolActionPreview,
@@ -74,7 +75,7 @@ type MessageListProps = {
   onApproval: (
     callId: string,
     decision: "approve" | "reject",
-    remember?: boolean,
+    grant: ApprovalGrantRung | null,
   ) => void;
   onFolderAccessDecision: (
     callId: string,
@@ -198,7 +199,7 @@ export function groupMessageItems(
   onApproval: (
     callId: string,
     decision: "approve" | "reject",
-    remember?: boolean,
+    grant: ApprovalGrantRung | null,
   ) => void,
   approvalState?: {
     decidingApprovalCalls: Set<string>;
@@ -290,7 +291,7 @@ function surfacedCards(
   onApproval: (
     callId: string,
     decision: "approve" | "reject",
-    remember?: boolean,
+    grant: ApprovalGrantRung | null,
   ) => void,
   approvalState?: {
     decidingApprovalCalls: Set<string>;

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -347,6 +347,18 @@ export function isApprovableKind(kind: RendererApprovalKind): boolean {
   );
 }
 
+/**
+ * How wide a standing grant to remember, narrowest first.
+ *
+ * The renderer only names the rung. The server builds the concrete grant from
+ * the arguments the call is parked on, so a grant can never describe a broader
+ * action than the one the human was shown.
+ */
+export type ApprovalGrantRung =
+  | "exact_command"
+  | "any_args_for_command"
+  | "whole_tool";
+
 /** Approval kinds whose authority is stable enough to remember by tool name. */
 export function isRememberableKind(kind: RendererApprovalKind): boolean {
   return isApprovableKind(kind) && kind !== "external_mcp_may_call_server";
@@ -718,12 +730,12 @@ export class ApiClient {
     chatId: string,
     callId: string,
     decision: "approve" | "reject",
-    remember = false,
+    grant: ApprovalGrantRung | null = null,
   ): Promise<void> {
     return this.json(`/chats/${chatId}/approvals/${callId}`, {
       method: "POST",
       headers: this.headers(true),
-      body: JSON.stringify({ decision, remember }),
+      body: JSON.stringify({ decision, grant }),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/useToolApprovals.test.ts
+++ b/crates/openwave-desktop/ui/src/useToolApprovals.test.ts
@@ -56,13 +56,13 @@ describe("useToolApprovals", () => {
     const client = stubClient();
     const { result } = renderHook(() => useToolApprovals(client, "chat-1"));
 
-    await act(async () => result.current.decide("call-1", "approve", true));
+    await act(async () => result.current.decide("call-1", "approve", "whole_tool"));
 
     expect(client.decideApproval).toHaveBeenCalledWith(
       "chat-1",
       "call-1",
       "approve",
-      true,
+      "whole_tool",
     );
     const [message] = useChatSessionStore.getState().messages;
     expect(message.role === "approval" && message.resolved).toBe(true);
@@ -78,7 +78,7 @@ describe("useToolApprovals", () => {
       "chat-1",
       "call-1",
       "reject",
-      false,
+      null,
     );
   });
 

--- a/crates/openwave-desktop/ui/src/useToolApprovals.ts
+++ b/crates/openwave-desktop/ui/src/useToolApprovals.ts
@@ -1,3 +1,4 @@
+import type { ApprovalGrantRung } from "./api";
 import { useRef, useState } from "react";
 import type { ApiClient } from "./api";
 import { useChatSessionStore } from "./ChatSessionStore";
@@ -9,7 +10,7 @@ export type ToolApprovals = {
   decide: (
     callId: string,
     decision: "approve" | "reject",
-    remember?: boolean,
+    grant?: ApprovalGrantRung | null,
   ) => void;
 };
 
@@ -33,7 +34,7 @@ export function useToolApprovals(
   async function send(
     callId: string,
     decision: "approve" | "reject",
-    remember: boolean,
+    grant: ApprovalGrantRung | null,
   ) {
     if (!client || !chatId || decidingRef.current.has(callId)) return;
     const startedChatId = chatId;
@@ -45,7 +46,7 @@ export function useToolApprovals(
       return next;
     });
     try {
-      await client.decideApproval(startedChatId, callId, decision, remember);
+      await client.decideApproval(startedChatId, callId, decision, grant);
       useChatSessionStore.getState().update((session) => ({
         ...session,
         messages: session.messages.map((message) =>
@@ -76,7 +77,7 @@ export function useToolApprovals(
   return {
     deciding,
     errors,
-    decide: (callId, decision, remember = false) =>
-      void send(callId, decision, remember),
+    decide: (callId, decision, grant = null) =>
+      void send(callId, decision, grant),
   };
 }

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -69,7 +69,11 @@ impl ApprovalBridge {
         arguments: &Value,
     ) -> Option<String> {
         let kind = ToolApprovalKind::for_tool_name(tool_name);
-        if self.grants.covers(chat_id, tool_name, kind) {
+        let action = ToolActionPreview::build(tool_name, arguments);
+        if self
+            .grants
+            .covers(chat_id, tool_name, kind, action.as_ref())
+        {
             return None;
         }
         let request = ApprovalRequest {
@@ -79,7 +83,7 @@ impl ApprovalBridge {
             tool_name: tool_name.to_string(),
             class,
             kind,
-            preview: ToolActionPreview::build(tool_name, arguments),
+            preview: action,
             summary: format!("{tool_name} requires approval"),
         };
         // MCP has no durable steer journal, so register without a journal identity.

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -14,8 +14,8 @@ use tokio::sync::Notify;
 use openwave_core::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
     ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, CallId, ChatId,
-    DecideToolApprovalOutcome, RequestToolApprovalOutcome, Result, StandingGrant, StandingGrants,
-    Store,
+    DecideToolApprovalOutcome, GrantScope, RequestToolApprovalOutcome, Result, StandingGrant,
+    StandingGrants, Store,
 };
 
 /// Coordinates durable approval state with local low-latency waiters.
@@ -48,18 +48,18 @@ impl ApprovalBroker {
         call_id: CallId,
         decision: ApprovalDecision,
     ) -> Result<ResolveApprovalOutcome> {
-        self.resolve_with_remember(chat_id, call_id, decision, false)
+        self.resolve_with_grant(chat_id, call_id, decision, None)
             .await
     }
 
     /// Decide one exact request and optionally remember an approval for later
     /// matching calls in the same chat.
-    pub async fn resolve_with_remember(
+    pub async fn resolve_with_grant(
         &self,
         chat_id: ChatId,
         call_id: CallId,
         decision: ApprovalDecision,
-        remember: bool,
+        rung: Option<crate::routes::ApprovalGrantRung>,
     ) -> Result<ResolveApprovalOutcome> {
         let Some(current) = self.store.get_tool_call_approval(call_id).await? else {
             return Ok(ResolveApprovalOutcome::NotPending);
@@ -70,17 +70,28 @@ impl ApprovalBroker {
         if matches!(decision, ApprovalDecision::Approve) && !current.kind.is_approvable() {
             return Ok(ResolveApprovalOutcome::NotApprovable);
         }
+        // Resolve the scope from durable state before deciding, so a rung the
+        // call cannot support fails the request instead of silently landing a
+        // broader grant after the call has already run.
+        let scope = match rung {
+            None => None,
+            Some(rung) => match grant_scope(rung, current.preview.as_ref()) {
+                Some(scope) => Some(scope),
+                None => return Ok(ResolveApprovalOutcome::GrantNotAvailable),
+            },
+        };
         let outcome = self
             .store
             .decide_tool_call_approval(chat_id, call_id, &decision, Utc::now())
             .await?;
         match outcome {
             DecideToolApprovalOutcome::Decided(_) | DecideToolApprovalOutcome::Existing(_) => {
-                if remember && matches!(&decision, ApprovalDecision::Approve) {
-                    if let Some(grant) = StandingGrant::new(
+                if let Some(scope) = scope {
+                    if let Some(grant) = StandingGrant::scoped(
                         current.chat_id,
                         current.tool_name,
                         current.kind,
+                        scope,
                         Utc::now(),
                     ) {
                         self.standing_grants.record(grant);
@@ -104,7 +115,35 @@ pub enum ResolveApprovalOutcome {
     NotPending,
     WrongChat,
     NotApprovable,
+    /// The chosen rung does not exist for this call.
+    GrantNotAvailable,
     DecisionConflict,
+}
+
+/// Build the concrete grant a rung names, from the action the call is parked
+/// on. A narrow rung over an action the renderer could not describe has nothing
+/// to name, so it is refused rather than widened.
+fn grant_scope(
+    rung: crate::routes::ApprovalGrantRung,
+    action: Option<&openwave_core::ToolActionPreview>,
+) -> Option<GrantScope> {
+    use crate::routes::ApprovalGrantRung;
+    use openwave_core::ToolActionPreview;
+    match (rung, action) {
+        (ApprovalGrantRung::WholeTool, _) => Some(GrantScope::WholeTool),
+        (ApprovalGrantRung::ExactCommand, Some(ToolActionPreview::Exec { command, args, .. })) => {
+            Some(GrantScope::ExactCommand {
+                command: command.clone(),
+                args: args.clone(),
+            })
+        }
+        (ApprovalGrantRung::AnyArgsForCommand, Some(ToolActionPreview::Exec { command, .. })) => {
+            Some(GrantScope::AnyArgsFor {
+                command: command.clone(),
+            })
+        }
+        _ => None,
+    }
 }
 
 impl ApprovalGate for ApprovalBroker {
@@ -248,6 +287,13 @@ mod tests {
     use serde_json::json;
 
     async fn setup(tool_name: &str) -> (Arc<dyn Store>, ApprovalRequest) {
+        setup_with_arguments(tool_name, json!({"query": "private"})).await
+    }
+
+    async fn setup_with_arguments(
+        tool_name: &str,
+        arguments: serde_json::Value,
+    ) -> (Arc<dyn Store>, ApprovalRequest) {
         let db = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -281,7 +327,7 @@ mod tests {
                     turn_id,
                     provider_id: "provider-call".into(),
                     name: tool_name.into(),
-                    arguments: json!({"query": "private"}),
+                    arguments,
                     execution: ToolCallExecution::Server,
                     status: ToolCallStatus::Pending,
                     result: None,
@@ -411,19 +457,96 @@ mod tests {
 
         assert_eq!(
             broker
-                .resolve_with_remember(
+                .resolve_with_grant(
                     request.chat_id,
                     request.call_id,
                     ApprovalDecision::Approve,
-                    true,
+                    Some(crate::routes::ApprovalGrantRung::WholeTool),
                 )
                 .await
                 .unwrap(),
             ResolveApprovalOutcome::Resolved
         );
-        assert!(broker
+        assert!(broker.standing_grants().covers(
+            request.chat_id,
+            &request.tool_name,
+            request.kind,
+            None
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_narrow_grant_covers_the_command_it_named_and_nothing_else() {
+        // The grant is derived from the arguments the call is durably parked
+        // on, never from what the request carried in memory.
+        let (store, request) = setup_with_arguments(
+            "exec",
+            json!({ "command": "cargo", "args": ["test"], "cwd": "." }),
+        )
+        .await;
+        let broker = ApprovalBroker::new(store);
+        let _pending = broker.register(request.clone(), None).await;
+
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    Some(crate::routes::ApprovalGrantRung::ExactCommand),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+
+        let grants = broker.standing_grants();
+        let exec = |command: &str, args: &[&str]| openwave_core::ToolActionPreview::Exec {
+            command: command.into(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            cwd: ".".into(),
+        };
+        assert!(grants.covers(
+            request.chat_id,
+            "exec",
+            request.kind,
+            Some(&exec("cargo", &["test"])),
+        ));
+        // The grant was built from the arguments the call was parked on, so it
+        // cannot stretch to a command the human never saw.
+        assert!(!grants.covers(
+            request.chat_id,
+            "exec",
+            request.kind,
+            Some(&exec("cargo", &["publish"])),
+        ));
+        assert!(!grants.covers(request.chat_id, "exec", request.kind, None));
+    }
+
+    #[tokio::test]
+    async fn a_rung_the_call_cannot_describe_is_refused_rather_than_widened() {
+        // The approval carries no action, so "always allow exactly this" has
+        // nothing to name. Falling back to a broader grant would hand out more
+        // authority than the human chose.
+        let (store, request) = setup("exec").await;
+        let broker = ApprovalBroker::new(store);
+        let _pending = broker.register(request.clone(), None).await;
+
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    Some(crate::routes::ApprovalGrantRung::ExactCommand),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::GrantNotAvailable
+        );
+        assert!(!broker
             .standing_grants()
-            .covers(request.chat_id, &request.tool_name, request.kind,));
+            .covers(request.chat_id, "exec", request.kind, None));
     }
 
     #[tokio::test]
@@ -437,19 +560,22 @@ mod tests {
 
         assert_eq!(
             broker
-                .resolve_with_remember(
+                .resolve_with_grant(
                     request.chat_id,
                     request.call_id,
                     ApprovalDecision::Approve,
-                    true,
+                    Some(crate::routes::ApprovalGrantRung::WholeTool),
                 )
                 .await
                 .unwrap(),
             ResolveApprovalOutcome::Resolved
         );
-        assert!(broker
-            .standing_grants()
-            .covers(request.chat_id, &request.tool_name, request.kind));
+        assert!(broker.standing_grants().covers(
+            request.chat_id,
+            &request.tool_name,
+            request.kind,
+            None
+        ));
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1550,9 +1550,26 @@ pub struct ApprovalBody {
     /// Optional reject reason (invalid on approve).
     #[serde(default)]
     pub reason: Option<String>,
-    /// Remember an approval for matching calls in this chat.
+    /// How much of an approval to remember for this chat. Absent means this
+    /// call only.
     #[serde(default)]
-    pub remember: bool,
+    pub grant: Option<ApprovalGrantRung>,
+}
+
+/// How wide a standing grant the human chose, narrowest first.
+///
+/// The renderer names a rung; the server builds the concrete grant from the
+/// arguments the call is parked on. A grant can therefore only ever describe
+/// the action that was actually under review.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalGrantRung {
+    /// Exactly this argument vector.
+    ExactCommand,
+    /// This executable, with any arguments.
+    AnyArgsForCommand,
+    /// Every call to this tool.
+    WholeTool,
 }
 
 /// Wire form of an approval decision.
@@ -1590,6 +1607,22 @@ pub(crate) struct PendingApprovalSnapshot {
     pub can_remember: bool,
 }
 
+impl PendingApprovalSnapshot {
+    fn from_approval(approval: openwave_core::ToolApproval) -> Self {
+        let kind = approval.kind;
+        Self {
+            call_id: approval.call_id,
+            turn_id: approval.turn_id,
+            action: crate::event_projection::RendererToolName::from(approval.tool_name.as_str()),
+            approval: kind,
+            class: approval.class,
+            preview: approval.preview,
+            can_approve: kind.is_approvable(),
+            can_remember: kind.is_standing_grantable(),
+        }
+    }
+}
+
 /// `GET /chats/{id}/approvals` — recover a bounded page of pending cards.
 pub(crate) async fn list_pending_approvals(
     State(state): State<AppState>,
@@ -1611,21 +1644,7 @@ pub(crate) async fn list_pending_approvals(
     Ok(Json(
         approvals
             .into_iter()
-            .map(|approval| {
-                let action =
-                    crate::event_projection::RendererToolName::from(approval.tool_name.as_str());
-                let kind = approval.kind;
-                PendingApprovalSnapshot {
-                    call_id: approval.call_id,
-                    turn_id: approval.turn_id,
-                    action,
-                    approval: kind,
-                    class: approval.class,
-                    preview: approval.preview,
-                    can_approve: kind.is_approvable(),
-                    can_remember: kind.is_standing_grantable(),
-                }
-            })
+            .map(PendingApprovalSnapshot::from_approval)
             .collect(),
     ))
 }
@@ -1660,7 +1679,7 @@ pub async fn post_approval(
                 .unwrap_or_else(|| "user denied approval".into()),
         },
     };
-    if body.remember && !matches!(&decision, ApprovalDecision::Approve) {
+    if body.grant.is_some() && !matches!(&decision, ApprovalDecision::Approve) {
         return Err(ServerError::bad_request(
             "only an approval can be remembered",
         ));
@@ -1675,7 +1694,7 @@ pub async fn post_approval(
     }
     match state
         .approvals
-        .resolve_with_remember(chat_id, call_id, decision, body.remember)
+        .resolve_with_grant(chat_id, call_id, decision, body.grant)
         .await?
     {
         crate::approvals::ResolveApprovalOutcome::Resolved => Ok(StatusCode::NO_CONTENT),
@@ -1689,6 +1708,12 @@ pub async fn post_approval(
             "approval_action_not_presentable",
             "this action cannot be approved from the renderer",
         )),
+        // Refusing beats widening: a rung the parked call cannot describe
+        // would otherwise have to fall back to a broader grant than the human
+        // was shown.
+        crate::approvals::ResolveApprovalOutcome::GrantNotAvailable => Err(
+            ServerError::bad_request("this action cannot be granted at that scope"),
+        ),
         crate::approvals::ResolveApprovalOutcome::DecisionConflict => {
             Err(ServerError::conflict_kind(
                 "approval_already_decided",

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -11727,7 +11727,7 @@ async fn approval_endpoint_unparks_a_sensitive_tool() {
     // decision, leaving the exact approval actionable.
     for body in [
         serde_json::json!({"decision": "reject", "reason": "bad\0reason"}),
-        serde_json::json!({"decision": "reject", "remember": true}),
+        serde_json::json!({"decision": "reject", "grant": "whole_tool"}),
         serde_json::json!({"decision": "approve", "unexpected": true}),
     ] {
         let invalid = router
@@ -11764,7 +11764,7 @@ async fn approval_endpoint_unparks_a_sensitive_tool() {
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({"decision": "approve", "remember": true}).to_string(),
+                    serde_json::json!({"decision": "approve", "grant": "whole_tool"}).to_string(),
                 ))
                 .unwrap(),
         )
@@ -12245,7 +12245,7 @@ async fn ingest_index_search_then_chat_through_the_approval_gate() {
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({"decision": "approve", "remember": true}).to_string(),
+                    serde_json::json!({"decision": "approve", "grant": "whole_tool"}).to_string(),
                 ))
                 .unwrap(),
         )


### PR DESCRIPTION
Closes #491

Approving a command offered two options: allow it once, or stop asking about `exec` entirely for the chat. So someone who approves `cargo test` twenty times in a session either keeps answering the same question, or hands over every future command — including ones they would have refused.

## Scoped grants

`StandingGrant` gains a `GrantScope`:

- `ExactCommand` — this argument vector and nothing else
- `AnyArgsFor` — this executable, any arguments
- `WholeTool` — every call, as today

`StandingGrants::covers` now matches against the action the call is about to take. A narrow grant only ever covers what it named, and an action the renderer could not describe is never covered by a narrow grant — matching it would mean guessing at what the call will do.

## The renderer names a rung; the server builds the grant

The decision endpoint takes `grant: "exact_command" | "any_args_for_command" | "whole_tool"` rather than `remember: bool`. The server resolves it against the arguments the call is **durably parked on**, so a grant can never describe a broader action than the one the human was shown — not even if the renderer asked for one.

A rung the call cannot describe is **refused** (`400`), not widened. Falling back to a broader grant would hand out more authority than was chosen. The scope is resolved *before* the decision commits, so a bad rung fails the request rather than landing a grant after the call has already run.

## The ladder

The card offers the rungs narrowest first, with the broader ones behind **"More options"**. Every visible option is one keystroke away, so a list showing "don't ask again" beside "just this once" makes the widest grant exactly as cheap as the narrowest.

Expanding **resets the highlight to row 1**: the revealed grants take the indices "More options" occupied, so a stray Enter would otherwise commit whatever moved under the cursor — the one thing the numbered list exists to prevent.

A command with no arguments skips the `AnyArgsFor` rung, since "exactly this" and "any arguments to this" would be two names for one grant. A tool with nothing to describe offers only the whole-tool grant, because there is nothing narrower to name.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`; `tsc`, 369 vitest tests, production build. Rendered the collapsed and expanded ladder in both themes; screenshot at `.context/screenshots/grant-ladder.png`.

Note: `openwave-cli`'s `tests/serve.rs` cases fail on a cold rebuild — they wait 15s for a spawned child to exit and lose that race while the machine is still compiling. They pass in isolation and on a warm full-workspace run, and are untouched by this change.
