### PR TITLE
feat(server): accept native image attachments on a turn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6780,6 +6780,7 @@ dependencies = [
  "cap-std",
  "chrono",
  "futures",
+ "image",
  "openwave-code-execution",
  "openwave-core",
  "openwave-mcp",

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -44,7 +44,7 @@ use crate::context;
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{AgentRunId, CallId, ChatId, MessageId, TurnId};
-use crate::image::ImageRef;
+use crate::image::{ImageAttachments, ImageData, ImageRef};
 use crate::model::{
     Chat, Message, MessageAttachment, Role, ToolCallExecution, ToolCallRecord, ToolCallResolution,
     ToolCallStatus, TurnRunStatus,
@@ -56,7 +56,7 @@ use crate::provider::{
 use crate::steer::SteerInbox;
 use crate::storage::{
     AcceptClaimedToolCallOutcome, AcceptToolCallOutcome, AppendClaimedMessageOutcome,
-    ApplyTurnSteerOutcome, JournaledTurnSteerOutcome, ResolveToolCallOutcome, Store,
+    ApplyTurnSteerOutcome, BlobStore, JournaledTurnSteerOutcome, ResolveToolCallOutcome, Store,
     TurnLeaseFence,
 };
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
@@ -771,6 +771,7 @@ pub struct Agent {
     provider: Arc<dyn ModelProvider>,
     tools: Arc<ToolRegistry>,
     store: Arc<dyn Store>,
+    blobs: Option<Arc<dyn BlobStore>>,
     config: AgentConfig,
     approvals: Arc<dyn ApprovalGate>,
     standing_grants: Arc<StandingGrants>,
@@ -824,6 +825,7 @@ impl Agent {
             provider,
             tools,
             store,
+            blobs: None,
             config,
             approvals: Arc::new(RefuseGate),
             standing_grants: Arc::new(StandingGrants::new()),
@@ -833,6 +835,18 @@ impl Agent {
             agent_orchestration_enabled: false,
             continuation_instruction: None,
         }
+    }
+
+    /// Hydrate image attachments for outbound requests from `blobs`.
+    ///
+    /// Without a byte source an agent cannot honour a transcript that carries
+    /// image blocks, so it evicts them to text stand-ins rather than handing an
+    /// adapter a block it must refuse. Wire this wherever the store can return
+    /// messages with attachments.
+    #[must_use]
+    pub fn with_blobs(mut self, blobs: Arc<dyn BlobStore>) -> Self {
+        self.blobs = Some(blobs);
+        self
     }
 
     /// Use `gate` for Sensitive-tool decisions (park-and-resume on the server).
@@ -1060,7 +1074,10 @@ impl Agent {
             // Fit the transcript to the context window, retrying with tighter
             // budgets on prompt-too-long errors from the provider.
             let mut stream = loop {
-                let (fitted, reduced) = self.fit_transcript(&transcript, reduction_level);
+                let (mut fitted, reduced) = self.fit_transcript(&transcript, reduction_level);
+                // Hydration can evict an image that no longer fits the outbound
+                // bound, so the token estimate is taken after it, not before.
+                let images = self.hydrate_images(&mut fitted).await?;
                 let fitted_tokens = context::estimate_transcript_tokens(&fitted);
                 let request = ChatRequest {
                     provider: self.config.provider.clone(),
@@ -1074,10 +1091,7 @@ impl Agent {
                     max_tokens: self.config.max_tokens,
                     temperature: self.config.temperature,
                     reasoning_effort: self.config.reasoning_effort,
-                    // Empty until message attachments are persisted and the
-                    // transcript can carry image blocks; hydration from the
-                    // blob store hangs here.
-                    images: crate::image::ImageAttachments::new(),
+                    images,
                 };
 
                 progress.model_steps = step + 1;
@@ -2569,6 +2583,69 @@ impl Agent {
         );
         let floor = context::content_floor_for_level(reduction_level);
         context::fit_to_budget(transcript, budget, floor)
+    }
+
+    /// Load the pixels for the image blocks left in `messages`.
+    ///
+    /// Blocks and bytes are deliberately separate: the transcript carries
+    /// identity, and this is the one place bytes join a request. Two bounds
+    /// apply, both newest-first, because a long conversation would otherwise
+    /// re-upload every image it has ever accumulated on every turn: at most
+    /// [`context::MAX_HYDRATED_IMAGES`] attachments and at most
+    /// [`context::MAX_HYDRATED_IMAGE_BYTES`] of pixels.
+    ///
+    /// Anything not hydrated — over a bound, or whose bytes are simply gone —
+    /// is rewritten as a text stand-in in `messages` before the request is
+    /// built. That keeps the invariant adapters rely on: a surviving
+    /// [`ContentBlock::Image`] always has bytes, so an adapter that finds none
+    /// is looking at a real fault rather than an intended drop.
+    async fn hydrate_images(&self, messages: &mut [ChatMessage]) -> Result<ImageAttachments> {
+        let carries_image = messages.iter().any(|message| {
+            message
+                .content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::Image { .. }))
+        });
+        if !carries_image {
+            return Ok(ImageAttachments::new());
+        }
+        let Some(blobs) = self.blobs.as_ref() else {
+            context::evict_all_images(messages);
+            return Ok(ImageAttachments::new());
+        };
+        context::evict_images_beyond(messages, context::MAX_HYDRATED_IMAGES);
+
+        let mut attachments = ImageAttachments::new();
+        let mut hydrated_bytes = 0usize;
+        for message in messages.iter_mut().rev() {
+            for block in message.content.iter_mut().rev() {
+                // `ImageRef` is `Copy`, so take it by value and release the
+                // borrow before the block may be rewritten below.
+                let ContentBlock::Image { image } = *block else {
+                    continue;
+                };
+                // The same attachment can appear in several messages; its bytes
+                // are uploaded once and counted once.
+                if attachments.contains(image.blob_id) {
+                    continue;
+                }
+                let fits = match blobs.get(image.blob_id).await? {
+                    Some(bytes)
+                        if hydrated_bytes.saturating_add(bytes.len())
+                            <= context::MAX_HYDRATED_IMAGE_BYTES =>
+                    {
+                        hydrated_bytes += bytes.len();
+                        attachments.insert(image.blob_id, ImageData::new(image.media_type, bytes));
+                        true
+                    }
+                    _ => false,
+                };
+                if !fits {
+                    *block = context::evict_image_block(block);
+                }
+            }
+        }
+        Ok(attachments)
     }
 }
 
@@ -7313,5 +7390,260 @@ mod tests {
             }),
             "expected rebuilt ToolResult in cross-turn transcript: {messages:?}"
         );
+    }
+}
+
+// Image hydration needs the SQLite store to persist attachments end to end.
+#[cfg(all(test, feature = "sqlite"))]
+mod image_hydration_tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use futures::channel::mpsc::unbounded;
+    use futures::stream::{self, BoxStream};
+    use futures::StreamExt;
+
+    use super::*;
+    use crate::db::DbStore;
+    use crate::image::{ImageMediaType, ImageRef};
+    use crate::provider::ProviderId;
+
+    /// An in-memory blob store: enough to prove hydration reads the bytes the
+    /// attachment names, without a filesystem in the way.
+    #[derive(Default)]
+    struct MemBlobs {
+        bytes: Mutex<HashMap<uuid::Uuid, Vec<u8>>>,
+    }
+
+    #[async_trait]
+    impl BlobStore for MemBlobs {
+        async fn put(&self, id: uuid::Uuid, bytes: Vec<u8>) -> Result<()> {
+            self.bytes.lock().unwrap().insert(id, bytes);
+            Ok(())
+        }
+
+        async fn get(&self, id: uuid::Uuid) -> Result<Option<Vec<u8>>> {
+            Ok(self.bytes.lock().unwrap().get(&id).cloned())
+        }
+
+        fn delete(&self, id: uuid::Uuid) -> Result<()> {
+            self.bytes.lock().unwrap().remove(&id);
+            Ok(())
+        }
+    }
+
+    /// Captures the exact request an adapter would have serialized.
+    struct CaptureProvider {
+        seen: Arc<Mutex<Option<ChatRequest>>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for CaptureProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("capture")
+        }
+
+        async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            *self.seen.lock().unwrap() = Some(req);
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta { text: "ok".into() },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    fn image_ref(blob_id: uuid::Uuid, bytes: &[u8]) -> ImageRef {
+        ImageRef {
+            blob_id,
+            media_type: ImageMediaType::Png,
+            width: 64,
+            height: 48,
+            byte_len: bytes.len() as u64,
+        }
+    }
+
+    async fn store_with_chat(name: &str) -> (Arc<DbStore>, Chat, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join(name).display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        (store, chat, dir)
+    }
+
+    /// Run one turn against a capturing provider and return the request it saw.
+    async fn captured_request(
+        store: Arc<DbStore>,
+        blobs: Option<Arc<dyn BlobStore>>,
+        chat: &Chat,
+        input: &str,
+    ) -> ChatRequest {
+        let seen: Arc<Mutex<Option<ChatRequest>>> = Arc::new(Mutex::new(None));
+        let mut agent = Agent::new(
+            Arc::new(CaptureProvider { seen: seen.clone() }),
+            Arc::new(ToolRegistry::new()),
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        );
+        if let Some(blobs) = blobs {
+            agent = agent.with_blobs(blobs);
+        }
+        let (tx, rx) = unbounded();
+        agent.run_turn(chat, input, &tx).await.unwrap();
+        drop(tx);
+        let _: Vec<AgentEvent> = rx.collect().await;
+        let request = seen.lock().unwrap().take();
+        request.expect("provider was called")
+    }
+
+    #[tokio::test]
+    async fn hydration_gives_the_adapter_bytes_for_every_surviving_image_block() {
+        let (store, chat, _dir) = store_with_chat("hydrate.db").await;
+        let blobs = Arc::new(MemBlobs::default());
+        let pixels = b"\x89PNG\r\n\x1a\n pretend pixels".to_vec();
+        let blob_id = uuid::Uuid::from_u128(7);
+        blobs.put(blob_id, pixels.clone()).await.unwrap();
+        let image = image_ref(blob_id, &pixels);
+        store
+            .accept_turn_with_attachments(
+                TurnId::new(),
+                chat.id,
+                "fake",
+                "what is in this screenshot?",
+                &[image],
+            )
+            .await
+            .unwrap();
+
+        let request = captured_request(
+            store,
+            Some(blobs as Arc<dyn BlobStore>),
+            &chat,
+            "and what about the corner?",
+        )
+        .await;
+
+        let block_ids: Vec<uuid::Uuid> = request
+            .messages
+            .iter()
+            .flat_map(|message| message.content.iter())
+            .filter_map(|block| match block {
+                ContentBlock::Image { image } => Some(image.blob_id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(block_ids, vec![blob_id], "the image block must survive");
+        let data = request
+            .images
+            .get(blob_id)
+            .expect("an adapter must find bytes for a surviving image block");
+        assert_eq!(data.bytes(), pixels.as_slice());
+        assert_eq!(data.media_type(), ImageMediaType::Png);
+    }
+
+    #[tokio::test]
+    async fn an_agent_without_a_byte_source_tells_the_model_instead_of_sending_a_bare_block() {
+        let (store, chat, _dir) = store_with_chat("no-blobs.db").await;
+        let pixels = b"pixels".to_vec();
+        let image = image_ref(uuid::Uuid::from_u128(9), &pixels);
+        store
+            .accept_turn_with_attachments(TurnId::new(), chat.id, "fake", "look", &[image])
+            .await
+            .unwrap();
+
+        let request = captured_request(store, None, &chat, "again").await;
+        assert!(request.images.is_empty());
+        assert!(
+            !request.messages.iter().any(|message| message
+                .content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::Image { .. }))),
+            "an unhydratable block must become a stand-in, never reach an adapter"
+        );
+        assert!(request.messages.iter().any(|message| message
+            .content
+            .iter()
+            .any(|block| matches!(block, ContentBlock::Text { text } if text.contains("image omitted")))));
+    }
+
+    #[tokio::test]
+    async fn hydration_is_bounded_so_a_long_chat_cannot_grow_the_outbound_body() {
+        let (store, chat, _dir) = store_with_chat("bounded.db").await;
+        let blobs = Arc::new(MemBlobs::default());
+        let total = context::MAX_HYDRATED_IMAGES + 3;
+        let mut newest = Vec::new();
+        for index in 0..total {
+            let pixels = format!("pixels-{index}").into_bytes();
+            let blob_id = uuid::Uuid::from_u128(100 + index as u128);
+            blobs.put(blob_id, pixels.clone()).await.unwrap();
+            let turn_id = TurnId::new();
+            store
+                .accept_turn_with_attachments(
+                    turn_id,
+                    chat.id,
+                    "fake",
+                    &format!("image {index}"),
+                    &[image_ref(blob_id, &pixels)],
+                )
+                .await
+                .unwrap();
+            // A chat holds one live turn at a time, so each history entry has to
+            // reach a terminal state before the next is accepted.
+            store
+                .request_turn_cancellation_and_append_event(turn_id, Utc::now())
+                .await
+                .unwrap();
+            newest.push(blob_id);
+        }
+
+        let request =
+            captured_request(store, Some(blobs as Arc<dyn BlobStore>), &chat, "summarize").await;
+        assert_eq!(request.images.len(), context::MAX_HYDRATED_IMAGES);
+        // The newest attachments keep their pixels; the oldest become stand-ins.
+        for blob_id in &newest[total - context::MAX_HYDRATED_IMAGES..] {
+            assert!(
+                request.images.contains(*blob_id),
+                "{blob_id} lost its bytes"
+            );
+        }
+        for blob_id in &newest[..total - context::MAX_HYDRATED_IMAGES] {
+            assert!(
+                !request.images.contains(*blob_id),
+                "{blob_id} was hydrated past the bound"
+            );
+        }
+        // Every block that kept its identity has bytes, so the adapter contract
+        // ("a surviving image block is hydrated") still holds after the bound.
+        for block in request
+            .messages
+            .iter()
+            .flat_map(|message| message.content.iter())
+        {
+            if let ContentBlock::Image { image } = block {
+                assert!(request.images.contains(image.blob_id));
+            }
+        }
     }
 }

--- a/crates/openwave-core/src/context.rs
+++ b/crates/openwave-core/src/context.rs
@@ -99,6 +99,24 @@ pub fn evict_all_images(messages: &mut [ChatMessage]) {
     }
 }
 
+/// Most image attachments hydrated into a single outbound request.
+///
+/// A long conversation accumulates image blocks without bound, and every one
+/// that keeps its pixels is re-uploaded on every subsequent turn. Capping the
+/// count is what stops the outbound body from growing with chat length. Eight
+/// spans a normal back-and-forth about a handful of screenshots while leaving
+/// the older ones as text stand-ins.
+pub const MAX_HYDRATED_IMAGES: usize = 8;
+
+/// Most image bytes hydrated into a single outbound request.
+///
+/// The count cap alone is not a byte bound — eight attachments at the per-image
+/// ceiling would be 128 MB. Providers cap the whole request (Anthropic at 32 MB)
+/// and image bytes are base64-encoded on the wire, inflating by 4/3, so 20 MiB
+/// of pixels is roughly 27 MB encoded and stays under that with room for the
+/// text of the transcript.
+pub const MAX_HYDRATED_IMAGE_BYTES: usize = 20 * 1024 * 1024;
+
 /// Keep pixels on only the newest `keep_last_n` image blocks, evicting older
 /// ones to text stand-ins.
 ///

--- a/crates/openwave-desktop/src/image_attachments.rs
+++ b/crates/openwave-desktop/src/image_attachments.rs
@@ -1,0 +1,361 @@
+//! Native image attachment bridge.
+//!
+//! Image bytes terminate here. The picker, the read, and the upload all happen
+//! in the host process; the webview receives an opaque attachment id and a few
+//! bounded numbers, and never sees the pixels or the path they came from. That
+//! is what keeps a compromised or merely buggy renderer from being able to
+//! exfiltrate the contents of a file the user only meant to show the model.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
+use openwave_core::{ChatId, MAX_IMAGE_BYTES};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_dialog::DialogExt;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+use crate::documents::resolve_conversation_scope;
+use crate::host_access::HostAccess;
+use crate::{wait_server_info, AppState};
+
+/// Extensions offered in the picker.
+///
+/// This is a convenience filter only, never a trust decision: the server sniffs
+/// the actual format from the bytes and refuses a file whose contents disagree
+/// with what its name claims.
+const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp", "gif"];
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AttachImageRequest {
+    chat_id: Uuid,
+}
+
+/// What the renderer learns about an attached image.
+///
+/// Identity plus geometry, nothing else. There is no path, no directory, and no
+/// way back to the bytes from here.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AttachedImage {
+    attachment_id: String,
+    media_type: String,
+    width: u32,
+    height: u32,
+    byte_len: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct PublishedImageAttachment {
+    attachment_id: Uuid,
+    media_type: String,
+    width: u32,
+    height: u32,
+    byte_len: u64,
+}
+
+/// The `{ kind, message }` shape every server error uses.
+#[derive(Debug, Deserialize)]
+struct ServerErrorBody {
+    kind: String,
+}
+
+impl From<PublishedImageAttachment> for AttachedImage {
+    fn from(published: PublishedImageAttachment) -> Self {
+        Self {
+            attachment_id: published.attachment_id.to_string(),
+            media_type: published.media_type,
+            width: published.width,
+            height: published.height,
+            byte_len: published.byte_len,
+        }
+    }
+}
+
+/// Pick one image from disk and publish it for a conversation.
+///
+/// Returns `None` when the user dismisses the picker, which is a normal outcome
+/// rather than a failure.
+#[tauri::command]
+pub(crate) async fn attach_chat_image(
+    app: AppHandle,
+    app_state: State<'_, Arc<AppState>>,
+    host_access: State<'_, HostAccess>,
+    request: AttachImageRequest,
+) -> Result<Option<AttachedImage>, String> {
+    // Validate before presenting native consent, then resolve again after the
+    // user returns so a long-lived picker cannot retain a deleted conversation.
+    resolve_conversation_scope(&host_access, request.chat_id).await?;
+    let _picker = host_access
+        .picker
+        .try_lock()
+        .map_err(|_| "A file or folder picker is already open".to_owned())?;
+    let Some(path) = pick_image(&app).await? else {
+        return Ok(None);
+    };
+    let bytes = tauri::async_runtime::spawn_blocking(move || read_selected_image(&path))
+        .await
+        .map_err(|_| "Could not read the selected image".to_owned())??;
+
+    let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
+    let info = wait_server_info(app_state.inner()).await?;
+    // The declared type is derived from the bytes, not the file name, so the
+    // server's sniff-versus-declared check stays a genuine cross-check of two
+    // independent claims rather than a comparison of one value with itself.
+    let declared = declared_media_type(&bytes)
+        .ok_or_else(|| "Attach a PNG, JPEG, WebP, or GIF image".to_owned())?;
+    let response = crate::documents::native_auth(
+        crate::documents::local_client().post(format!(
+            "{}{}",
+            info.base_url,
+            image_attachments_path(chat_id)
+        )),
+        &info,
+    )
+    .header(reqwest::header::CONTENT_TYPE, declared)
+    .body(bytes)
+    .send()
+    .await
+    .map_err(|_| "Could not attach the selected image".to_owned())?;
+    if !response.status().is_success() {
+        let kind = response
+            .json::<ServerErrorBody>()
+            .await
+            .map(|error| error.kind)
+            .unwrap_or_default();
+        return Err(refusal_message(&kind));
+    }
+    let published = response
+        .json::<PublishedImageAttachment>()
+        .await
+        .map_err(|_| "Attaching the image returned an invalid response".to_owned())?;
+    Ok(Some(AttachedImage::from(published)))
+}
+
+fn image_attachments_path(chat_id: ChatId) -> String {
+    format!("/chats/{chat_id}/attachments/images")
+}
+
+/// Turn a machine-readable server refusal into something worth reading.
+///
+/// Each distinct reason gets its own sentence, because "that file is not an
+/// image" and "that image is too large" call for different actions from the
+/// user and a single generic failure would hide which one applies.
+fn refusal_message(kind: &str) -> String {
+    match kind {
+        "image_attachment_empty" => "That image file is empty",
+        "image_attachment_too_large" => "Images must be 16 MB or smaller",
+        "payload_too_large" => "Images must be 16 MB or smaller",
+        "image_attachment_not_an_image" => "That file is not an image",
+        "image_attachment_unsupported_format" => "Attach a PNG, JPEG, WebP, or GIF image",
+        "image_attachment_media_type_mismatch" | "image_attachment_media_type_required" => {
+            "That file's contents do not match its type"
+        }
+        "image_attachment_zero_dimension" | "image_attachment_unreadable" => {
+            "That image file is damaged"
+        }
+        "image_attachment_dimensions_too_large" => {
+            "Images must be 8000 pixels or smaller on a side"
+        }
+        _ => "Could not attach the selected image",
+    }
+    .to_owned()
+}
+
+/// The media type these bytes actually are, from their magic bytes.
+///
+/// Deliberately independent of the file name. A `.png` holding a JPEG is
+/// declared as a JPEG here and accepted; the server reaches the same conclusion
+/// from the same bytes.
+fn declared_media_type(bytes: &[u8]) -> Option<&'static str> {
+    const PNG: &[u8] = &[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+    if bytes.starts_with(PNG) {
+        return Some("image/png");
+    }
+    if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        return Some("image/jpeg");
+    }
+    if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        return Some("image/gif");
+    }
+    if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && bytes[8..12] == *b"WEBP" {
+        return Some("image/webp");
+    }
+    None
+}
+
+async fn pick_image(app: &AppHandle) -> Result<Option<PathBuf>, String> {
+    let (tx, rx) = oneshot::channel();
+    let mut picker = app
+        .dialog()
+        .file()
+        .set_title("Attach an image")
+        .add_filter("Images", IMAGE_EXTENSIONS);
+    if let Some(window) = app.get_webview_window("main") {
+        picker = picker.set_parent(&window);
+    }
+    picker.pick_file(move |path| {
+        let _ = tx.send(path);
+    });
+    rx.await
+        .map_err(|_| "The image picker closed unexpectedly".to_owned())?
+        .map(tauri_plugin_dialog::FilePath::into_path)
+        .transpose()
+        .map_err(|_| "The image picker returned an invalid file".to_owned())
+}
+
+/// Read the picked file without following symlinks and without exceeding the
+/// attachment ceiling.
+///
+/// Refusing symlinks is what stops a picker selection from resolving somewhere
+/// the user did not choose, and the read is capped one byte past the limit so a
+/// file that grows between `stat` and `read` is still refused.
+fn read_selected_image(path: &Path) -> Result<Vec<u8>, String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "The image picker returned an invalid file".to_owned())?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| "The image picker returned an invalid file".to_owned())?;
+    let directory = Dir::open_ambient_dir(parent, ambient_authority())
+        .map_err(|_| "Could not read the selected image".to_owned())?;
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = directory
+        .open_with(file_name, &options)
+        .map_err(|_| "Could not read the selected image".to_owned())?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| "Could not read the selected image".to_owned())?;
+    if !metadata.is_file() {
+        return Err("Choose an image file".to_owned());
+    }
+    if metadata.len() > MAX_IMAGE_BYTES {
+        return Err("Images must be 16 MB or smaller".to_owned());
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_IMAGE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| "Could not read the selected image".to_owned())?;
+    if bytes.len() as u64 > MAX_IMAGE_BYTES {
+        return Err("Images must be 16 MB or smaller".to_owned());
+    }
+    if bytes.is_empty() {
+        return Err("That image file is empty".to_owned());
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_declared_type_comes_from_the_bytes_and_never_from_the_name() {
+        let png = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a, 0, 0];
+        assert_eq!(declared_media_type(&png), Some("image/png"));
+        assert_eq!(
+            declared_media_type(&[0xff, 0xd8, 0xff, 0xe0]),
+            Some("image/jpeg")
+        );
+        assert_eq!(declared_media_type(b"GIF89a\0\0"), Some("image/gif"));
+        assert_eq!(
+            declared_media_type(b"RIFF\0\0\0\0WEBPVP8 "),
+            Some("image/webp")
+        );
+        // A RIFF container that is not WebP is not silently promoted.
+        assert_eq!(declared_media_type(b"RIFF\0\0\0\0WAVEfmt "), None);
+        assert_eq!(declared_media_type(b"%PDF-1.7"), None);
+        assert_eq!(declared_media_type(b""), None);
+    }
+
+    #[test]
+    fn the_renderer_projection_is_identity_and_geometry_only() {
+        let attached = AttachedImage::from(PublishedImageAttachment {
+            attachment_id: Uuid::nil(),
+            media_type: "image/png".to_owned(),
+            width: 800,
+            height: 600,
+            byte_len: 1_024,
+        });
+        let json = serde_json::to_value(attached).unwrap();
+        let mut keys = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        keys.sort();
+        assert_eq!(
+            keys,
+            ["attachmentId", "byteLen", "height", "mediaType", "width"]
+        );
+        let serialized = json.to_string();
+        for forbidden in ["path", "bytes", "data", "base64", "Users", "token"] {
+            assert!(!serialized.contains(forbidden), "leaked {forbidden}");
+        }
+    }
+
+    #[test]
+    fn a_renderer_cannot_widen_the_request_beyond_one_conversation() {
+        let injected = serde_json::json!({
+            "chatId": Uuid::nil(),
+            "projectId": Uuid::nil(),
+        });
+        assert!(serde_json::from_value::<AttachImageRequest>(injected).is_err());
+    }
+
+    #[test]
+    fn each_server_refusal_reaches_the_user_as_its_own_sentence() {
+        let kinds = [
+            "image_attachment_empty",
+            "image_attachment_too_large",
+            "image_attachment_not_an_image",
+            "image_attachment_unsupported_format",
+            "image_attachment_media_type_mismatch",
+            "image_attachment_dimensions_too_large",
+        ];
+        let messages: Vec<String> = kinds.iter().map(|kind| refusal_message(kind)).collect();
+        let generic = refusal_message("something_new");
+        for message in &messages {
+            assert_ne!(
+                message, &generic,
+                "a known refusal fell through to the generic message"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_image_reader_refuses_symlinks_and_growth_past_the_limit() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target.png");
+        std::fs::write(&target, [0x89, b'P', b'N', b'G']).unwrap();
+        let link = directory.path().join("link.png");
+        symlink(&target, &link).unwrap();
+        assert!(read_selected_image(&link).is_err());
+
+        let oversized = directory.path().join("oversized.png");
+        let file = std::fs::File::create(&oversized).unwrap();
+        file.set_len(MAX_IMAGE_BYTES + 1).unwrap();
+        assert_eq!(
+            read_selected_image(&oversized).unwrap_err(),
+            "Images must be 16 MB or smaller"
+        );
+
+        let empty = directory.path().join("empty.png");
+        std::fs::write(&empty, []).unwrap();
+        assert_eq!(
+            read_selected_image(&empty).unwrap_err(),
+            "That image file is empty"
+        );
+    }
+}

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -19,6 +19,7 @@ mod client_execution;
 mod deliverables;
 mod documents;
 mod host_access;
+mod image_attachments;
 mod media_type;
 mod updater;
 
@@ -164,6 +165,7 @@ pub fn run() {
             documents::import_library_document,
             documents::list_library_documents,
             documents::search_library_documents,
+            image_attachments::attach_chat_image,
             deliverables::list_deliverables,
             deliverables::read_deliverable,
             deliverables::export_deliverable,

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -48,6 +48,10 @@ unicode-general-category = { workspace = true }
 chrono = { workspace = true }
 sha2 = { workspace = true }
 cap-std = { workspace = true }
+# Image header inspection only: format sniffing from magic bytes and reading
+# dimensions without decoding pixels. Default features are off so the lean build
+# pulls just the four codecs OpenWave's allowlist accepts.
+image = { version = "=0.25.10", default-features = false, features = ["png", "jpeg", "webp", "gif"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }

--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -12,6 +12,7 @@ use axum::Json;
 use openwave_core::{AgentError, AgentErrorInfo};
 
 /// An HTTP-facing error: a status code and a serializable description.
+#[derive(Debug)]
 pub struct ServerError {
     status: StatusCode,
     info: AgentErrorInfo,
@@ -64,6 +65,12 @@ impl ServerError {
                 message: message.into(),
             },
         }
+    }
+
+    /// The stable machine-readable `kind` clients branch on.
+    #[cfg(test)]
+    pub(crate) fn kind(&self) -> &str {
+        &self.info.kind
     }
 
     /// A `409 Conflict` for a request that clashes with current state (e.g. a

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -140,7 +140,15 @@ pub fn app(state: AppState) -> Router {
             get(routes::get_document).delete(routes::delete_document),
         )
         .route("/documents/{id}/retry", post(routes::retry_document))
-        .route("/search", post(routes::search_documents));
+        .route("/search", post(routes::search_documents))
+        // Image attachments sit on the same trust boundary as raw document
+        // ingest — both take bytes off the user's disk for one conversation —
+        // so they follow it into whichever router that boundary lands on.
+        .route(
+            "/chats/{chat_id}/attachments/images",
+            post(routes::publish_chat_image_attachment)
+                .layer(DefaultBodyLimit::max(routes::MAX_IMAGE_ATTACHMENT_BYTES)),
+        );
 
     let client_executor_api = Router::new()
         .route(
@@ -580,6 +588,7 @@ async fn bind_inner(
         Some(state.config.data_dir.join("scratch")),
         turn_worker::TurnWorkerConfig::default(),
     )
+    .with_blobs(state.blobs.clone())
     .with_mcp_runtime(state.mcp.clone());
     let sandbox_worker_config = sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default()
         .with_delegated_file_executor(client_executor_id.is_some());

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -201,7 +201,7 @@ pub struct ResolvedModelPolicy {
 }
 
 impl ResolvedModelPolicy {
-    fn curated(spec: &ModelSpec) -> Self {
+    pub(crate) fn curated(spec: &ModelSpec) -> Self {
         Self {
             key: model_registry::selection_key(spec.provider, spec.id),
             id: spec.id.to_owned(),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -40,11 +40,13 @@ use crate::web_search::{
 mod client_execution;
 mod delegated_file_execution;
 mod document;
+pub(crate) mod image_attachment;
 mod root_attachment;
 mod user_questions;
 pub use client_execution::*;
 pub use delegated_file_execution::*;
 pub use document::*;
+pub use image_attachment::*;
 pub use root_attachment::*;
 pub use user_questions::*;
 
@@ -1297,6 +1299,128 @@ pub struct PostMessage {
     pub turn_id: TurnId,
     /// The user's input for this turn.
     pub content: String,
+    /// Ids returned by the image attachment publish endpoint, in display order.
+    ///
+    /// Only identity crosses the wire. The server re-derives every attachment's
+    /// format and dimensions from the stored bytes, so a caller cannot describe
+    /// an image as something it is not.
+    #[serde(default)]
+    pub attachments: Vec<uuid::Uuid>,
+}
+
+/// Resolve published attachment ids into authoritative image identity.
+///
+/// The bytes are inspected again here rather than trusting what the publish
+/// response said, because nothing durable connects the two requests and the
+/// metadata persisted with the turn must describe the bytes that actually exist.
+async fn resolve_message_attachments(
+    state: &AppState,
+    ids: &[uuid::Uuid],
+) -> Result<Vec<openwave_core::ImageRef>, ServerError> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    if ids.len() > openwave_core::MAX_MESSAGE_ATTACHMENTS {
+        return Err(ServerError::bad_request_kind(
+            "too_many_image_attachments",
+            format!(
+                "a message may carry at most {} image attachments",
+                openwave_core::MAX_MESSAGE_ATTACHMENTS
+            ),
+        ));
+    }
+    let mut images = Vec::with_capacity(ids.len());
+    for &id in ids {
+        let missing = || {
+            ServerError::bad_request_kind(
+                "image_attachment_not_found",
+                format!("image attachment {id} has not been published"),
+            )
+        };
+        let bytes = state.blobs.get(id).await?.ok_or_else(missing)?;
+        let image = image_attachment::inspect_image_bytes(&bytes)?;
+        // Attachment ids are content addresses. Bytes that do not hash back to
+        // the requested id are some other blob, so the reference is unresolved
+        // rather than merely mismatched.
+        if image.blob_id != id {
+            return Err(missing());
+        }
+        images.push(image);
+    }
+    Ok(images)
+}
+
+/// Refuse a turn whose model cannot see the images it carries.
+///
+/// Stripping the images would leave the model answering confidently about
+/// something it never received, and silently switching models would change the
+/// answer's author behind the user's back. Refusing is the only option that
+/// leaves the user in control, so the error is machine-readable and the client
+/// can offer to change the model or drop the attachments.
+async fn require_image_capable_model(state: &AppState, model: &str) -> Result<(), ServerError> {
+    if !state.resolver.enforces_model_registry() {
+        return Ok(());
+    }
+    let Some(policy) = providers::resolve_model_policy(&*state.store, model, true).await? else {
+        return Err(ServerError::bad_request_kind(
+            "unknown_model",
+            format!("model `{model}` is not registered for that provider"),
+        ));
+    };
+    require_image_input(&policy)
+}
+
+/// The capability decision itself, separated so it can be exercised against a
+/// constructed policy rather than only against whatever the registry happens to
+/// advertise today.
+fn require_image_input(policy: &providers::ResolvedModelPolicy) -> Result<(), ServerError> {
+    if policy
+        .input_modalities
+        .contains(&crate::model_registry::InputModality::Image)
+    {
+        return Ok(());
+    }
+    Err(ServerError::conflict_kind(
+        "model_image_input_unsupported",
+        format!(
+            "model `{}` does not accept image input; choose a model that does, or send the message without images",
+            policy.display_name
+        ),
+    ))
+}
+
+#[cfg(test)]
+mod image_capability_tests {
+    use super::*;
+    use crate::model_registry::{InputModality, ModelSpec};
+
+    const TEXT_ONLY: ModelSpec = ModelSpec {
+        id: "text-only-model",
+        display_name: "Text Only Model",
+        provider: ProviderKind::Anthropic,
+        context_window: 200_000,
+        max_output_tokens: 64_000,
+        input_modalities: &[InputModality::Text],
+        supports_reasoning: false,
+        supports_reasoning_effort: false,
+    };
+
+    const MULTIMODAL: ModelSpec = ModelSpec {
+        input_modalities: &[InputModality::Text, InputModality::Image],
+        ..TEXT_ONLY
+    };
+
+    #[test]
+    fn advertised_image_input_is_the_only_thing_that_admits_a_turn_with_images() {
+        // Every curated model is pinned text-only today, so the accepting case
+        // is constructed here rather than read from the registry: the rule has
+        // to hold from the moment a model does advertise image input.
+        assert!(require_image_input(&providers::ResolvedModelPolicy::curated(&MULTIMODAL)).is_ok());
+
+        let refused = require_image_input(&providers::ResolvedModelPolicy::curated(&TEXT_ONLY))
+            .expect_err("a text-only model must refuse a turn carrying images");
+        assert_eq!(refused.kind(), "model_image_input_unsupported");
+    }
 }
 
 /// `POST /chats/{id}/messages` — durably accept a message and queue its turn.
@@ -1306,6 +1430,12 @@ pub struct PostMessage {
 /// Repeating an exact `turn_id` and payload is idempotent. `404` if the chat
 /// doesn't exist, `409` if the identity names different input or another turn
 /// already owns the chat's single durable live slot.
+///
+/// Published image attachments may be referenced by id. They commit with the
+/// message, and a retry that names different images is an identity conflict
+/// rather than a silent acceptance of the first submission's images. A turn
+/// carrying images against a model that does not accept image input is refused
+/// with `model_image_input_unsupported`.
 pub async fn post_message(
     State(state): State<AppState>,
     Path(id): Path<ChatId>,
@@ -1346,9 +1476,13 @@ pub async fn post_message(
         };
         validate_model_selection(&state, &selected, true).await?
     };
+    let images = resolve_message_attachments(&state, &body.attachments).await?;
+    if !images.is_empty() {
+        require_image_capable_model(&state, &model).await?;
+    }
     match state
         .store
-        .accept_turn(body.turn_id, id, &model, &body.content)
+        .accept_turn_with_attachments(body.turn_id, id, &model, &body.content, &images)
         .await?
     {
         AcceptTurnOutcome::Accepted(_) | AcceptTurnOutcome::Existing(_) => {
@@ -1369,7 +1503,13 @@ pub async fn post_message(
                 && matches!(
                     state
                         .store
-                        .accept_turn(body.turn_id, id, &existing.model, &body.content)
+                        .accept_turn_with_attachments(
+                            body.turn_id,
+                            id,
+                            &existing.model,
+                            &body.content,
+                            &images,
+                        )
                         .await?,
                     AcceptTurnOutcome::Existing(_)
                 )

--- a/crates/openwave-server/src/routes/image_attachment.rs
+++ b/crates/openwave-server/src/routes/image_attachment.rs
@@ -1,0 +1,431 @@
+//! Chat-scoped image attachment publication.
+//!
+//! One trusted boundary turns raw bytes into durable identity. What comes back
+//! is an opaque content-addressed id plus bounded metadata — never a filesystem
+//! path, never the pixels — so a caller can reference the attachment on a turn
+//! without ever holding it.
+//!
+//! Two rules make this the only place an image's format is decided.
+//!
+//! The media type is **sniffed from the bytes**. A client-declared
+//! `Content-Type` and a file extension are both attacker- or accident-supplied,
+//! and a file that says `image/png` while holding something else is a mistake
+//! worth surfacing, not one worth silently correcting: a declared type that
+//! disagrees with the sniffed bytes is refused.
+//!
+//! Dimensions are read from the **image header only**. Fully decoding an
+//! untrusted image to learn how big it is buys nothing and opens the classic
+//! decompression bomb — a few kilobytes of deflate that expand to gigabytes of
+//! pixels. The header carries the two numbers this endpoint needs.
+
+use std::io::Cursor;
+
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use image::{ImageFormat, ImageReader};
+use serde::Serialize;
+use uuid::Uuid;
+
+use openwave_core::{
+    ChatId, DocumentSourceBlob, ImageMediaType, ImageRef, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION,
+};
+
+use crate::error::ServerError;
+use crate::extract::{Path, RawBytes};
+use crate::state::AppState;
+
+/// Body limit for the publish endpoint, matching the durable per-image ceiling
+/// so a request that the store would refuse never reaches a handler at all.
+pub const MAX_IMAGE_ATTACHMENT_BYTES: usize = MAX_IMAGE_BYTES as usize;
+
+/// Renderer-safe result of publishing one image.
+///
+/// `attachment_id` is the content-addressed blob id: opaque, derived from the
+/// bytes, and revealing nothing about where they live. Everything else is a
+/// small bounded number a UI can render.
+#[derive(Debug, Serialize)]
+pub struct PublishedImageAttachment {
+    /// Opaque identity to reference on a later turn.
+    pub attachment_id: Uuid,
+    /// Format sniffed from the bytes.
+    pub media_type: String,
+    /// Pixel width read from the image header.
+    pub width: u32,
+    /// Pixel height read from the image header.
+    pub height: u32,
+    /// Size of the stored bytes.
+    pub byte_len: u64,
+}
+
+impl From<ImageRef> for PublishedImageAttachment {
+    fn from(image: ImageRef) -> Self {
+        Self {
+            attachment_id: image.blob_id,
+            media_type: image.media_type.as_str().to_owned(),
+            width: image.width,
+            height: image.height,
+            byte_len: image.byte_len,
+        }
+    }
+}
+
+/// `POST /chats/{chat_id}/attachments/images` — validate and durably retain one
+/// image for a conversation, returning identity a turn can reference.
+///
+/// The bytes become a content-addressed blob immediately but gain no durable
+/// reference until a turn carries them, so an attachment that is published and
+/// never sent is reclaimed by the orphan sweep rather than leaking. Publishing
+/// identical bytes twice yields the same id and one stored copy.
+pub async fn publish_chat_image_attachment(
+    State(state): State<AppState>,
+    Path(chat_id): Path<ChatId>,
+    headers: HeaderMap,
+    RawBytes(bytes): RawBytes,
+) -> Result<impl IntoResponse, ServerError> {
+    if state.store.get_chat(chat_id).await?.is_none() {
+        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
+    }
+    let bytes = bytes.to_vec();
+    let image = inspect_image_bytes(&bytes)?;
+    require_declared_type_matches(&headers, image.media_type)?;
+
+    // Mirrors the raw-document publish path: serialize writers for this exact
+    // content address, then publish before anything can reference it, so an
+    // accepted identity never points at missing bytes.
+    let _blob_write = state.blob_writes.acquire(image.blob_id).await?;
+    state.blobs.put(image.blob_id, bytes).await?;
+    Ok((
+        StatusCode::CREATED,
+        crate::extract::Json(PublishedImageAttachment::from(image)),
+    ))
+}
+
+/// Derive durable identity from candidate image bytes.
+///
+/// Every refusal carries its own machine-readable `kind` so a client can tell
+/// "that is not an image" from "that image is too big" and say something useful
+/// about the file the user actually picked.
+pub(crate) fn inspect_image_bytes(bytes: &[u8]) -> Result<ImageRef, ServerError> {
+    if bytes.is_empty() {
+        return Err(ServerError::bad_request_kind(
+            "image_attachment_empty",
+            "image attachment must not be empty",
+        ));
+    }
+    let byte_len = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    if byte_len > MAX_IMAGE_BYTES {
+        return Err(ServerError::bad_request_kind(
+            "image_attachment_too_large",
+            format!("image attachment must be at most {MAX_IMAGE_BYTES} bytes"),
+        ));
+    }
+    let media_type = sniff_media_type(bytes)?;
+    let (width, height) = read_header_dimensions(bytes, media_type)?;
+    if width == 0 || height == 0 {
+        return Err(ServerError::bad_request_kind(
+            "image_attachment_zero_dimension",
+            "image attachment has a zero width or height",
+        ));
+    }
+    if width > MAX_IMAGE_DIMENSION || height > MAX_IMAGE_DIMENSION {
+        return Err(ServerError::bad_request_kind(
+            "image_attachment_dimensions_too_large",
+            format!("image attachment must be at most {MAX_IMAGE_DIMENSION} pixels on a side"),
+        ));
+    }
+    let image = ImageRef {
+        blob_id: DocumentSourceBlob::from_bytes(bytes).id,
+        media_type,
+        width,
+        height,
+        byte_len,
+    };
+    // The durable bounds are checked above; this is the store's own predicate,
+    // kept here so the two can never drift apart unnoticed.
+    image.validate().map_err(|reason| {
+        ServerError::bad_request_kind("image_attachment_invalid", reason.to_owned())
+    })?;
+    Ok(image)
+}
+
+/// Identify the format from magic bytes, refusing anything off the allowlist.
+///
+/// Two distinct refusals: bytes that are not a recognizable image at all, and
+/// bytes that are a real image in a format OpenWave will not forward to a
+/// provider. A caller can offer to convert in the second case and cannot in the
+/// first.
+fn sniff_media_type(bytes: &[u8]) -> Result<ImageMediaType, ServerError> {
+    let format = image::guess_format(bytes).map_err(|_| {
+        ServerError::bad_request_kind(
+            "image_attachment_not_an_image",
+            "attachment bytes are not a recognized image",
+        )
+    })?;
+    match format {
+        ImageFormat::Png => Ok(ImageMediaType::Png),
+        ImageFormat::Jpeg => Ok(ImageMediaType::Jpeg),
+        ImageFormat::WebP => Ok(ImageMediaType::Webp),
+        ImageFormat::Gif => Ok(ImageMediaType::Gif),
+        _ => Err(ServerError::bad_request_kind(
+            "image_attachment_unsupported_format",
+            "image attachments must be PNG, JPEG, WebP, or GIF",
+        )),
+    }
+}
+
+/// Read `(width, height)` from the image header without decoding pixels.
+///
+/// The format comes from the sniff above rather than being guessed again, so a
+/// container that lies about itself cannot route the bytes to a different
+/// decoder than the one whose media type was recorded.
+fn read_header_dimensions(
+    bytes: &[u8],
+    media_type: ImageMediaType,
+) -> Result<(u32, u32), ServerError> {
+    let format = match media_type {
+        ImageMediaType::Png => ImageFormat::Png,
+        ImageMediaType::Jpeg => ImageFormat::Jpeg,
+        ImageMediaType::Webp => ImageFormat::WebP,
+        ImageMediaType::Gif => ImageFormat::Gif,
+    };
+    ImageReader::with_format(Cursor::new(bytes), format)
+        .into_dimensions()
+        .map_err(|_| {
+            ServerError::bad_request_kind(
+                "image_attachment_unreadable",
+                "image attachment header could not be read",
+            )
+        })
+}
+
+/// Require the declared `Content-Type` to agree with the sniffed bytes.
+///
+/// The header is required rather than optional: a caller that never states a
+/// type can never be caught contradicting one, and the point of this check is
+/// to catch the contradiction.
+fn require_declared_type_matches(
+    headers: &HeaderMap,
+    sniffed: ImageMediaType,
+) -> Result<(), ServerError> {
+    let declared = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            ServerError::bad_request_kind(
+                "image_attachment_media_type_required",
+                "Content-Type header is required for an image attachment",
+            )
+        })?;
+    if ImageMediaType::parse(declared) != Some(sniffed) {
+        return Err(ServerError::bad_request_kind(
+            "image_attachment_media_type_mismatch",
+            format!(
+                "declared Content-Type `{declared}` disagrees with the attachment's actual format `{sniffed}`"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// A PNG that declares `width × height` and carries no pixel data at all.
+///
+/// The whole point of reading dimensions from the header is that the pixels are
+/// never needed, so the test fixtures deliberately have none: an accepted
+/// `8001 × 600` here is proof no decode happened, because 4.8 million pixels
+/// cannot be hiding in sixty bytes.
+#[cfg(test)]
+pub(crate) fn png_header(width: u32, height: u32) -> Vec<u8> {
+    let mut ihdr = Vec::new();
+    ihdr.extend_from_slice(&width.to_be_bytes());
+    ihdr.extend_from_slice(&height.to_be_bytes());
+    // bit depth, color type, compression, filter, interlace
+    ihdr.extend_from_slice(&[8, 6, 0, 0, 0]);
+
+    let mut bytes = vec![0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+    bytes.extend_from_slice(&png_chunk(b"IHDR", &ihdr));
+    bytes.extend_from_slice(&png_chunk(b"IDAT", &[]));
+    bytes.extend_from_slice(&png_chunk(b"IEND", &[]));
+    bytes
+}
+
+#[cfg(test)]
+fn png_chunk(kind: &[u8; 4], data: &[u8]) -> Vec<u8> {
+    let mut payload = kind.to_vec();
+    payload.extend_from_slice(data);
+    let mut chunk = (data.len() as u32).to_be_bytes().to_vec();
+    chunk.extend_from_slice(&payload);
+    chunk.extend_from_slice(&crc32(&payload).to_be_bytes());
+    chunk
+}
+
+/// A one-pixel GIF whose logical screen declares `width × height`.
+///
+/// PNG's own decoder refuses a degenerate header outright, so a GIF is what it
+/// takes to hand the endpoint a well-formed image that genuinely reports a zero
+/// dimension.
+#[cfg(test)]
+pub(crate) fn gif_with_screen_size(width: u16, height: u16) -> Vec<u8> {
+    let mut bytes = b"GIF89a".to_vec();
+    bytes.extend_from_slice(&width.to_le_bytes());
+    bytes.extend_from_slice(&height.to_le_bytes());
+    // Global colour table present, two entries; no background, square pixels.
+    bytes.extend_from_slice(&[0x80, 0x00, 0x00]);
+    bytes.extend_from_slice(&[0, 0, 0, 255, 255, 255]);
+    // One 1×1 frame at the origin with no local colour table.
+    bytes.push(0x2c);
+    bytes.extend_from_slice(&[0, 0, 0, 0, 1, 0, 1, 0, 0x00]);
+    // LZW: minimum code size 2, then clear / pixel 0 / end-of-information.
+    bytes.extend_from_slice(&[0x02, 0x02, 0x44, 0x01, 0x00]);
+    bytes.push(0x3b);
+    bytes
+}
+
+#[cfg(test)]
+fn crc32(bytes: &[u8]) -> u32 {
+    let mut crc = 0xffff_ffffu32;
+    for byte in bytes {
+        crc ^= u32::from(*byte);
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xedb8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kind_of(error: ServerError) -> String {
+        error.kind().to_owned()
+    }
+
+    #[test]
+    fn identity_is_content_addressed_and_dimensions_come_from_the_header() {
+        let bytes = png_header(800, 600);
+        let image = inspect_image_bytes(&bytes).expect("a well-formed PNG header is accepted");
+        assert_eq!(image.media_type, ImageMediaType::Png);
+        assert_eq!((image.width, image.height), (800, 600));
+        assert_eq!(image.byte_len, bytes.len() as u64);
+        // Content-addressed: identical bytes always name the same blob, and the
+        // id reveals nothing about where they came from.
+        assert_eq!(
+            image.blob_id,
+            inspect_image_bytes(&png_header(800, 600)).unwrap().blob_id
+        );
+        assert_ne!(
+            image.blob_id,
+            inspect_image_bytes(&png_header(801, 600)).unwrap().blob_id
+        );
+    }
+
+    #[test]
+    fn every_refusal_has_its_own_machine_readable_reason() {
+        assert_eq!(
+            kind_of(inspect_image_bytes(&[]).unwrap_err()),
+            "image_attachment_empty"
+        );
+        assert_eq!(
+            kind_of(inspect_image_bytes(b"%PDF-1.7\n%not an image").unwrap_err()),
+            "image_attachment_not_an_image"
+        );
+        // A real image in a format outside the allowlist is a different problem
+        // from bytes that are not an image at all.
+        assert_eq!(
+            kind_of(inspect_image_bytes(b"II*\0\0\0\0\0").unwrap_err()),
+            "image_attachment_unsupported_format"
+        );
+        assert_eq!(
+            kind_of(inspect_image_bytes(b"BM\0\0\0\0\0\0\0\0\0\0\0\0").unwrap_err()),
+            "image_attachment_unsupported_format"
+        );
+        // A well-formed image that genuinely reports a zero dimension.
+        assert_eq!(
+            kind_of(inspect_image_bytes(&gif_with_screen_size(0, 8)).unwrap_err()),
+            "image_attachment_zero_dimension"
+        );
+        assert_eq!(
+            kind_of(inspect_image_bytes(&gif_with_screen_size(8, 0)).unwrap_err()),
+            "image_attachment_zero_dimension"
+        );
+        // PNG's own decoder refuses a degenerate header before dimensions come
+        // back, which is a different — but still distinct — refusal.
+        assert_eq!(
+            kind_of(inspect_image_bytes(&png_header(0, 600)).unwrap_err()),
+            "image_attachment_unreadable"
+        );
+        assert_eq!(
+            kind_of(inspect_image_bytes(&png_header(MAX_IMAGE_DIMENSION + 1, 600)).unwrap_err()),
+            "image_attachment_dimensions_too_large"
+        );
+        assert_eq!(
+            kind_of(inspect_image_bytes(&png_header(600, MAX_IMAGE_DIMENSION + 1)).unwrap_err()),
+            "image_attachment_dimensions_too_large"
+        );
+        // PNG magic with a corrupt header: recognized as PNG, unreadable as one.
+        let mut corrupt = png_header(800, 600);
+        corrupt.truncate(12);
+        assert_eq!(
+            kind_of(inspect_image_bytes(&corrupt).unwrap_err()),
+            "image_attachment_unreadable"
+        );
+    }
+
+    #[test]
+    fn a_declared_type_that_disagrees_with_the_bytes_is_refused_not_corrected() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_TYPE, "image/png".parse().unwrap());
+        assert!(require_declared_type_matches(&headers, ImageMediaType::Png).is_ok());
+        // Parameters and casing are noise, not disagreement.
+        headers.insert(
+            header::CONTENT_TYPE,
+            "IMAGE/PNG; charset=binary".parse().unwrap(),
+        );
+        assert!(require_declared_type_matches(&headers, ImageMediaType::Png).is_ok());
+
+        headers.insert(header::CONTENT_TYPE, "image/jpeg".parse().unwrap());
+        assert_eq!(
+            kind_of(require_declared_type_matches(&headers, ImageMediaType::Png).unwrap_err()),
+            "image_attachment_media_type_mismatch"
+        );
+        // A type OpenWave does not even recognize still counts as disagreement.
+        headers.insert(
+            header::CONTENT_TYPE,
+            "application/octet-stream".parse().unwrap(),
+        );
+        assert_eq!(
+            kind_of(require_declared_type_matches(&headers, ImageMediaType::Png).unwrap_err()),
+            "image_attachment_media_type_mismatch"
+        );
+
+        assert_eq!(
+            kind_of(
+                require_declared_type_matches(&HeaderMap::new(), ImageMediaType::Png).unwrap_err()
+            ),
+            "image_attachment_media_type_required"
+        );
+    }
+
+    #[test]
+    fn published_metadata_is_bounded_and_carries_no_pixels_or_paths() {
+        let image = inspect_image_bytes(&png_header(64, 48)).unwrap();
+        let json = serde_json::to_value(PublishedImageAttachment::from(image)).unwrap();
+        let mut keys = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        keys.sort();
+        assert_eq!(
+            keys,
+            ["attachment_id", "byte_len", "height", "media_type", "width"]
+        );
+        assert_eq!(json["media_type"], "image/png");
+        assert_eq!(json["attachment_id"], image.blob_id.to_string());
+    }
+}

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -33,6 +33,7 @@ use tower::ServiceExt;
 
 use crate::event_projection::{RendererAgentEvent, RendererSequencedEvent};
 
+mod image_attachment;
 mod root_attachment;
 
 #[test]
@@ -1208,18 +1209,24 @@ impl Store for PauseTerminalStore {
     async fn list_turn_runs(&self, chat_id: ChatId) -> Result<Vec<openwave_core::TurnRun>> {
         self.inner.list_turn_runs(chat_id).await
     }
-    async fn accept_turn(
+    // Hooked here rather than on `accept_turn`, because the trait's plain
+    // `accept_turn` delegates to this one — overriding only the former would
+    // leave a turn carrying attachments bypassing the pause entirely.
+    async fn accept_turn_with_attachments(
         &self,
         id: TurnId,
         chat_id: ChatId,
         model: &str,
         content: &str,
+        images: &[openwave_core::ImageRef],
     ) -> Result<openwave_core::AcceptTurnOutcome> {
         if self.pause_accept.swap(false, Ordering::SeqCst) {
             self.entered.notify_one();
             self.release.notified().await;
         }
-        self.inner.accept_turn(id, chat_id, model, content).await
+        self.inner
+            .accept_turn_with_attachments(id, chat_id, model, content, images)
+            .await
     }
     async fn accept_turn_steer(
         &self,

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -1,0 +1,464 @@
+//! Image attachment publication and turn acceptance over the HTTP surface.
+
+use super::*;
+
+use crate::routes::image_attachment::{gif_with_screen_size, png_header};
+
+fn image_attachments_uri(chat: ChatId) -> String {
+    format!("/chats/{chat}/attachments/images")
+}
+
+/// Publish `bytes` for `chat` under a declared `Content-Type`.
+async fn publish_image(
+    router: &Router,
+    bearer: &str,
+    chat: ChatId,
+    declared: &str,
+    bytes: Vec<u8>,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(image_attachments_uri(chat))
+                .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, declared)
+                .body(Body::from(bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn publish_png(router: &Router, bearer: &str, chat: ChatId, bytes: Vec<u8>) -> uuid::Uuid {
+    let response = publish_image(router, bearer, chat, "image/png", bytes).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let published: serde_json::Value = json_body(response).await;
+    published["attachment_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+/// POST a message carrying published attachment ids.
+async fn send_message_with_attachments(
+    router: &Router,
+    bearer: &str,
+    chat: ChatId,
+    turn_id: TurnId,
+    content: &str,
+    attachments: &[uuid::Uuid],
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/chats/{chat}/messages"))
+                .header(header::AUTHORIZATION, bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "turn_id": turn_id,
+                        "content": content,
+                        "attachments": attachments,
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+fn stored_blob_count(data_dir: &std::path::Path) -> usize {
+    let blobs = data_dir.join("blobs");
+    let Ok(entries) = std::fs::read_dir(&blobs) else {
+        return 0;
+    };
+    entries
+        .filter_map(std::result::Result::ok)
+        .filter(|entry| {
+            entry.path().extension().and_then(|ext| ext.to_str()) == Some("blob")
+                && entry.metadata().is_ok_and(|meta| meta.is_file())
+        })
+        .count()
+}
+
+#[tokio::test]
+async fn publishing_returns_opaque_identity_and_bounded_metadata_only() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    let response =
+        publish_image(&router, &bearer, chat.id, "image/png", png_header(800, 600)).await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let published: serde_json::Value = json_body(response).await;
+    let mut keys = published
+        .as_object()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    keys.sort();
+    assert_eq!(
+        keys,
+        ["attachment_id", "byte_len", "height", "media_type", "width"]
+    );
+    assert_eq!(published["media_type"], "image/png");
+    assert_eq!(published["width"], 800);
+    assert_eq!(published["height"], 600);
+    // Nothing in the response can be turned back into a location on disk.
+    let serialized = published.to_string();
+    for forbidden in [
+        "blob",
+        "path",
+        "dir",
+        "tmp",
+        ".png",
+        std::env::temp_dir().to_str().unwrap(),
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "publish response leaked {forbidden}: {serialized}"
+        );
+    }
+
+    // An unknown conversation is a 404 before any bytes are retained.
+    let missing = publish_image(
+        &router,
+        &bearer,
+        ChatId::new(),
+        "image/png",
+        png_header(8, 8),
+    )
+    .await;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn a_declared_type_that_disagrees_with_the_sniffed_bytes_is_refused() {
+    let (router, token, _store, dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    // PNG bytes announced as a JPEG: the bytes win, and the disagreement is
+    // reported rather than quietly corrected to the sniffed type.
+    let response = publish_image(&router, &bearer, chat.id, "image/jpeg", png_header(64, 64)).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(response).await;
+    assert_eq!(error.kind, "image_attachment_media_type_mismatch");
+    assert_eq!(
+        stored_blob_count(dir.path()),
+        0,
+        "a refused attachment must not retain bytes"
+    );
+
+    // A file renamed to `.png` and declared as one is caught the same way: the
+    // extension never enters the decision.
+    let response = publish_image(
+        &router,
+        &bearer,
+        chat.id,
+        "image/png",
+        gif_with_screen_size(8, 8),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(response).await;
+    assert_eq!(error.kind, "image_attachment_media_type_mismatch");
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(image_attachments_uri(chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::from(png_header(64, 64)))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(response).await;
+    assert_eq!(error.kind, "image_attachment_media_type_required");
+}
+
+#[tokio::test]
+async fn a_non_image_an_unsupported_format_and_an_oversized_image_are_each_refused() {
+    let (router, token, _store, dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    for (declared, bytes, expected) in [
+        (
+            "image/png",
+            b"%PDF-1.7\n%\xe2\xe3\xcf\xd3 not an image".to_vec(),
+            "image_attachment_not_an_image",
+        ),
+        (
+            "image/png",
+            b"II*\x00\x08\x00\x00\x00".to_vec(),
+            "image_attachment_unsupported_format",
+        ),
+        (
+            "image/png",
+            png_header(openwave_core::MAX_IMAGE_DIMENSION + 1, 600),
+            "image_attachment_dimensions_too_large",
+        ),
+        (
+            "image/gif",
+            gif_with_screen_size(0, 8),
+            "image_attachment_zero_dimension",
+        ),
+        ("image/png", Vec::new(), "image_attachment_empty"),
+    ] {
+        let response = publish_image(&router, &bearer, chat.id, declared, bytes).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{expected}");
+        let error: AgentErrorInfo = json_body(response).await;
+        assert_eq!(error.kind, expected);
+    }
+
+    // Bytes past the per-image ceiling never reach a handler at all.
+    let oversized = vec![0u8; openwave_core::MAX_IMAGE_BYTES as usize + 1];
+    let response = publish_image(&router, &bearer, chat.id, "image/png", oversized).await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+
+    assert_eq!(
+        stored_blob_count(dir.path()),
+        0,
+        "no refusal may retain bytes"
+    );
+}
+
+#[tokio::test]
+async fn a_turn_records_its_attachments_and_an_unpublished_id_is_refused() {
+    let (router, token, state, store, _dir) = test_app_with_state().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let _ = &state;
+
+    let attachment_id = publish_png(&router, &bearer, chat.id, png_header(320, 240)).await;
+    let accepted = send_message_with_attachments(
+        &router,
+        &bearer,
+        chat.id,
+        TurnId::new(),
+        "what is in this?",
+        &[attachment_id],
+    )
+    .await;
+    assert_eq!(accepted.status(), StatusCode::ACCEPTED);
+
+    let attachments = store.list_message_attachments(chat.id).await.unwrap();
+    assert_eq!(attachments.len(), 1);
+    assert_eq!(attachments[0].image.blob_id, attachment_id);
+    assert_eq!(attachments[0].image.width, 320);
+    assert_eq!(attachments[0].image.height, 240);
+    assert_eq!(
+        attachments[0].image.media_type,
+        openwave_core::ImageMediaType::Png
+    );
+
+    // An id that was never published names no bytes, so the turn cannot be
+    // accepted against it.
+    let response = send_message_with_attachments(
+        &router,
+        &bearer,
+        chat.id,
+        TurnId::new(),
+        "and this?",
+        &[uuid::Uuid::new_v4()],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let error: AgentErrorInfo = json_body(response).await;
+    assert_eq!(error.kind, "image_attachment_not_found");
+}
+
+#[tokio::test]
+async fn a_cancelled_and_a_retried_turn_leave_exactly_one_set_of_stored_bytes() {
+    let (router, token, _state, store, dir) = test_app_with_state().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let bytes = png_header(640, 480);
+
+    // The same picture attached twice is one content-addressed blob.
+    let first = publish_png(&router, &bearer, chat.id, bytes.clone()).await;
+    let second = publish_png(&router, &bearer, chat.id, bytes.clone()).await;
+    assert_eq!(first, second);
+    assert_eq!(stored_blob_count(dir.path()), 1);
+
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_attachments(
+            &router,
+            &bearer,
+            chat.id,
+            turn_id,
+            "describe this",
+            &[first],
+        )
+        .await
+        .status(),
+        StatusCode::ACCEPTED
+    );
+    // An ambiguous HTTP retry of the same turn is idempotent, images included.
+    assert_eq!(
+        send_message_with_attachments(
+            &router,
+            &bearer,
+            chat.id,
+            turn_id,
+            "describe this",
+            &[first],
+        )
+        .await
+        .status(),
+        StatusCode::ACCEPTED
+    );
+    assert_eq!(
+        store.list_message_attachments(chat.id).await.unwrap().len(),
+        1
+    );
+    assert_eq!(stored_blob_count(dir.path()), 1);
+
+    // Cancel, then send the same image again as a fresh turn.
+    let cancelled = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/chats/{}/cancel", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"turn_id": turn_id}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(cancelled.status(), StatusCode::ACCEPTED);
+
+    let retried = publish_png(&router, &bearer, chat.id, bytes).await;
+    assert_eq!(retried, first);
+    assert_eq!(
+        send_message_with_attachments(
+            &router,
+            &bearer,
+            chat.id,
+            TurnId::new(),
+            "describe this",
+            &[retried],
+        )
+        .await
+        .status(),
+        StatusCode::ACCEPTED
+    );
+    assert_eq!(
+        store.list_message_attachments(chat.id).await.unwrap().len(),
+        2
+    );
+    assert_eq!(
+        stored_blob_count(dir.path()),
+        1,
+        "publishing, cancelling, and retrying the same image must store one copy"
+    );
+}
+
+#[tokio::test]
+async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("image-capability.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+    providers::write_credential(
+        &*secrets,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderCredential::api_key("sk-anthropic"),
+    )
+    .await
+    .unwrap();
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(resolver::ConfiguredResolver::new(
+            store.clone(),
+            secrets.clone(),
+        )),
+        secrets,
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "anthropic::claude-opus-4-8".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let bearer = format!("Bearer {}", state.token);
+    let router = app(state);
+    let chat = make_chat(&router, &bearer).await;
+
+    // The selected model is a real, available, curated one — it simply does not
+    // advertise image input.
+    let policy = providers::resolve_model_policy(&*store, "anthropic::claude-opus-4-8", false)
+        .await
+        .unwrap()
+        .expect("a curated model resolves");
+    assert!(!policy
+        .input_modalities
+        .contains(&crate::model_registry::InputModality::Image));
+
+    let attachment_id = publish_png(&router, &bearer, chat.id, png_header(200, 150)).await;
+    let response = send_message_with_attachments(
+        &router,
+        &bearer,
+        chat.id,
+        TurnId::new(),
+        "what is in this screenshot?",
+        &[attachment_id],
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let error: AgentErrorInfo = json_body(response).await;
+    assert_eq!(error.kind, "model_image_input_unsupported");
+    // Refused, not silently stripped: no turn and no attachment were recorded.
+    assert!(store.list_messages(chat.id).await.unwrap().is_empty());
+    assert!(store
+        .list_message_attachments(chat.id)
+        .await
+        .unwrap()
+        .is_empty());
+
+    // The same text without images still goes through, so the refusal is about
+    // the attachments rather than the model being unusable.
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "what is in this screenshot?").await,
+        StatusCode::ACCEPTED
+    );
+}

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -16,7 +16,7 @@ use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::StreamExt;
 use openwave_core::{
     Agent, AgentConfig, AgentError, AgentEvent, AgentRunWaitCondition,
-    AgentRunWaitSetCheckpointRequest, AgentTurnOutcome, CheckpointSandboxSpawnOutcome,
+    AgentRunWaitSetCheckpointRequest, AgentTurnOutcome, BlobStore, CheckpointSandboxSpawnOutcome,
     ClaimedAgentEvent, CompleteTurnRunOutcome, ForegroundAgentWaitRequest, MessageId,
     ParkTurnForAgentRunWaitSetOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
     Result, SandboxAgentSpawnRequest, SandboxSpawnCheckpointRequest, SequencedEvent, Store,
@@ -72,6 +72,7 @@ pub(crate) struct TurnWorker {
     store: Arc<dyn Store>,
     resolver: Arc<dyn ProviderResolver>,
     tools: Arc<ToolRegistry>,
+    blobs: Option<Arc<dyn BlobStore>>,
     mcp: Option<Arc<McpRuntime>>,
     approvals: Arc<ApprovalBroker>,
     events: Arc<EventBus>,
@@ -290,6 +291,7 @@ impl TurnWorker {
             store,
             resolver,
             tools,
+            blobs: None,
             mcp: None,
             approvals,
             events,
@@ -300,6 +302,15 @@ impl TurnWorker {
             private_scratch_root,
             config,
         }
+    }
+
+    /// Hydrate image attachments for outbound requests from `blobs`.
+    ///
+    /// Without it an agent evicts every image block to a text stand-in, so a
+    /// turn still runs but the model is told the image is unavailable.
+    pub(crate) fn with_blobs(mut self, blobs: Arc<dyn BlobStore>) -> Self {
+        self.blobs = Some(blobs);
+        self
     }
 
     /// Resolve one immutable registry when a turn begins. Runtime MCP changes
@@ -550,7 +561,7 @@ impl TurnWorker {
             });
             let provider = self.resolver.resolve().await;
             let steer = active.steer_inbox();
-            let agent = Agent::new(provider, surface.tools.clone(), self.store.clone(), config)
+            let mut agent = Agent::new(provider, surface.tools.clone(), self.store.clone(), config)
                 .with_approvals(self.approvals.clone())
                 .with_standing_grants(self.approvals.standing_grants())
                 .with_cancel(cancel.clone())
@@ -558,6 +569,9 @@ impl TurnWorker {
                 .with_durable_steer(lease_token)
                 .with_foreground_agent_orchestration()
                 .with_continuation_instruction(continuation_instruction.clone());
+            if let Some(blobs) = self.blobs.clone() {
+                agent = agent.with_blobs(blobs);
+            }
             let chat = chat.clone();
             let (events_tx, mut events_rx) = unbounded();
             let mut drive = AbortOnDrop(tokio::spawn(async move {


### PR DESCRIPTION
Slice 3 of #415, on top of #459.

Gets real bytes from the user's disk into a blob and lets a turn reference them, without pixels ever passing through the renderer.

## Publishing an attachment

`POST /chats/{chat_id}/attachments/images` takes raw bytes and returns opaque content-addressed identity plus bounded metadata — an attachment id, media type, width, height, byte length. Never a filesystem path, never the pixels. It sits on the same trust boundary as raw document ingest and follows it into whichever router that boundary lands on (native-only on the desktop, primary bearer for a headless embedding).

**Media type is sniffed from the bytes.** The declared `Content-Type` and the file extension are both caller-supplied, so neither is trusted. A file that says `image/png` while holding a GIF is refused, not corrected — the mismatch is worth surfacing.

**Dimensions come from the image header only.** Fully decoding an untrusted image to learn how big it is buys nothing and opens the classic decompression bomb. The test fixtures make this checkable: an accepted `8001 × 600` PNG carrying no pixel data at all is proof no decode happened.

Every refusal has its own machine-readable `kind`, because "that is not an image" and "that image is too large" call for different actions from the user:

| kind | meaning |
| --- | --- |
| `image_attachment_empty` | zero bytes |
| `image_attachment_too_large` | past the 16 MB per-image ceiling |
| `image_attachment_not_an_image` | bytes are not a recognizable image |
| `image_attachment_unsupported_format` | a real image outside the PNG/JPEG/WebP/GIF allowlist |
| `image_attachment_media_type_required` | no declared `Content-Type` |
| `image_attachment_media_type_mismatch` | declared type disagrees with the sniffed bytes |
| `image_attachment_unreadable` | recognized format, unparseable header |
| `image_attachment_zero_dimension` | header reports a zero width or height |
| `image_attachment_dimensions_too_large` | past 8000 px on a side |

## Native upload

The Tauri command opens the picker behind the existing `host_access.picker` mutex, reads with `cap-std` and `FollowSymlinks::No` under a size cap, re-resolves the conversation after the picker returns, and uploads with the executor token. The renderer receives an attachment id and geometry and nothing else; the bytes terminate in the host process. The declared type it sends is derived from the magic bytes rather than the file name, so the server's sniff-versus-declared check stays a cross-check of two independent claims.

## Turn acceptance

`POST /chats/{id}/messages` takes an `attachments` array of published ids and routes them into `Store::accept_turn_with_attachments`. The ids are resolved by re-inspecting the stored bytes rather than trusting what the publish response said — nothing durable ties the two requests together, and the metadata persisted with the turn has to describe the bytes that actually exist. Ids are content addresses, so publishing the same picture twice, cancelling the turn, and retrying it all converge on one stored copy. An attachment published but never sent gains no durable reference and is reclaimed by the existing orphan sweep.

## Hydration

The agent loop no longer sends an empty attachment set. It loads bytes for the image blocks in the fitted transcript from the `BlobStore`, under two newest-first bounds so a long conversation cannot grow the outbound body without limit: at most 8 attachments and at most 20 MiB of pixels (roughly 27 MB once base64-encoded, under Anthropic's 32 MB request cap). Anything not hydrated — over a bound, or whose bytes are gone — is rewritten as a text stand-in *before* the request is built, which preserves the invariant adapters rely on: a surviving `ContentBlock::Image` always has bytes, so an adapter that finds none is looking at a real fault.

## Unsupported-model gating

A turn carrying images against a model that does not advertise `InputModality::Image` is refused with `model_image_input_unsupported` (409). Not stripped: that would leave the model answering confidently about something it never received, and the user could not tell the difference. Not auto-switched: that changes the answer's author behind the user's back.

Every curated model is still pinned text-only in the registry — flipping that is #462 — so the refusing case is tested end to end through HTTP against a real curated model, and the accepting case is tested against a capability constructed in the test rather than read from the registry.

## Notes

- `image` is added to `openwave-server` at `=0.25.10`, the version the lockfile already resolves, with default features off and only the four allowlisted codecs enabled. The only lockfile change is the new dependency edge.
- The test `Store` decorator in `tests.rs` moved its pause hook from `accept_turn` to `accept_turn_with_attachments`, since the former delegates to the latter — overriding only the former would have let a turn carrying attachments slip past the hook.
- `ServerError` gained `Debug` and a test-only `kind()` accessor so tests can assert the exact error contract.
- Not in this slice: a message may still not be image-only (`content` must be non-empty), and no UI surfaces the picker yet — that is #461.

Closes #460
