### PR TITLE
refactor(desktop): let a conversation's hooks reset themselves

### DIFF
--- a/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
@@ -327,4 +327,29 @@ describe("useAgentRuns", () => {
     await waitFor(() => expect(result.current.runs).toHaveLength(0));
     expect(client.listAgentRuns).toHaveBeenLastCalledWith("chat-2");
   });
+
+  it("does not carry a stop error into the next conversation", async () => {
+    const stop = deferred<never>();
+    const client = stubClient({
+      listAgentRuns: vi.fn().mockResolvedValue([run()]),
+      cancelAgentRun: vi.fn(() => stop.promise),
+    });
+    const { result, rerender } = renderHook(
+      ({ chatId }) => useAgentRuns(client, chatId),
+      { initialProps: { chatId: "chat-1" } },
+    );
+    await waitFor(() => expect(result.current.runs).toHaveLength(1));
+
+    act(() => result.current.stop("run-1"));
+    await act(async () => {
+      stop.reject(new Error("gone"));
+      await stop.promise.catch(() => {});
+    });
+    expect(result.current.stopErrorRunIds.size).toBe(1);
+
+    rerender({ chatId: "chat-2" });
+
+    expect(result.current.stopErrorRunIds.size).toBe(0);
+    expect(result.current.stoppingRunIds.size).toBe(0);
+  });
 });

--- a/crates/openwave-desktop/ui/src/useAgentRuns.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.ts
@@ -125,6 +125,22 @@ export function useAgentRuns(
     setStopErrorRunIds(new Set());
   }, [chatId, deletingChatId]);
 
+  // The pane is keyed on the conversation, so this hook is normally replaced
+  // rather than reused. Reset anyway: nothing held here belongs to a different
+  // conversation, and leaving the keying to do it makes removing that key a
+  // silent bug rather than a loud one.
+  useEffect(
+    () => () => {
+      stopFenceRef.current.invalidate();
+      setRuns([]);
+      setLoading(true);
+      setError(null);
+      setStoppingRunIds(new Set());
+      setStopErrorRunIds(new Set());
+    },
+    [chatId],
+  );
+
   /**
    * The chat a stop completion should be measured against: this conversation
    * while it is still open, and nothing once it is not. Naming no chat makes

--- a/crates/openwave-desktop/ui/src/useFolderAccessRequests.test.ts
+++ b/crates/openwave-desktop/ui/src/useFolderAccessRequests.test.ts
@@ -181,4 +181,29 @@ describe("useFolderAccessRequests", () => {
     });
     expect(second.result.current.resolving.size).toBe(0);
   });
+
+  it("does not carry a decision error into the next conversation", async () => {
+    const client = stubClient({
+      listPendingFolderAccessRequests: vi.fn().mockResolvedValue([
+        request("call-1"),
+      ]),
+    });
+    vi.mocked(host.resolveFolderAccessRequest).mockRejectedValue(
+      new Error("no such folder"),
+    );
+    const { result, rerender } = renderHook(
+      ({ chatId }) => useFolderAccessRequests(client, chatId),
+      { initialProps: { chatId: "chat-1" } },
+    );
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+
+    await act(async () => {
+      result.current.decide("call-1", "allow");
+    });
+    await waitFor(() => expect(result.current.errors).not.toEqual({}));
+
+    rerender({ chatId: "chat-2" });
+
+    expect(result.current.errors).toEqual({});
+  });
 });

--- a/crates/openwave-desktop/ui/src/useFolderAccessRequests.ts
+++ b/crates/openwave-desktop/ui/src/useFolderAccessRequests.ts
@@ -70,6 +70,14 @@ export function useFolderAccessRequests(
     };
   }, [client, chatId]);
 
+  // The pane is keyed on the conversation, so this hook is normally replaced
+  // rather than reused. Reset anyway: nothing held here belongs to a different
+  // conversation, and leaving the keying to do it makes removing that key a
+  // silent bug rather than a loud one.
+  // The decision latch is deliberately absent: it is the host picker's, not this
+  // conversation's, and releasing it on a chat switch is the bug #481 fixed.
+  useEffect(() => () => setErrors({}), [chatId]);
+
   // Only a signal raised after this hook mounted means anything to it; the
   // counter is app-wide and may already be well past zero on arrival.
   const lastSignalRef = useRef(signal);

--- a/crates/openwave-desktop/ui/src/useToolApprovals.test.ts
+++ b/crates/openwave-desktop/ui/src/useToolApprovals.test.ts
@@ -153,4 +153,29 @@ describe("useToolApprovals", () => {
 
     expect(result.current.errors).toEqual({});
   });
+
+  it("does not carry a decision error into the next conversation", async () => {
+    // The pane is keyed today, so this hook is replaced rather than reused.
+    // Switching in place is what a caller without that key would do, and the
+    // previous conversation's error must not follow the reader across.
+    const decision = deferred<void>();
+    const client = stubClient({ decideApproval: vi.fn(() => decision.promise) });
+    seedApprovalCard("call-1");
+    const { result, rerender } = renderHook(
+      ({ chatId }) => useToolApprovals(client, chatId),
+      { initialProps: { chatId: "chat-1" } },
+    );
+
+    act(() => result.current.decide("call-1", "approve"));
+    await act(async () => {
+      decision.reject(new Error("gone"));
+      await decision.promise.catch(() => {});
+    });
+    expect(result.current.errors).not.toEqual({});
+
+    rerender({ chatId: "chat-2" });
+
+    expect(result.current.errors).toEqual({});
+    expect(result.current.deciding.size).toBe(0);
+  });
 });

--- a/crates/openwave-desktop/ui/src/useToolApprovals.ts
+++ b/crates/openwave-desktop/ui/src/useToolApprovals.ts
@@ -1,5 +1,5 @@
 import type { ApprovalGrantRung } from "./api";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ApiClient } from "./api";
 import { useChatSessionStore } from "./ChatSessionStore";
 import { useOpenConversation } from "./OpenConversation";
@@ -30,6 +30,19 @@ export function useToolApprovals(
   const [errors, setErrors] = useState<Record<string, string>>({});
   const decidingRef = useRef<Set<string>>(new Set());
   const stillOpen = useOpenConversation(chatId);
+
+  // The pane is keyed on the conversation, so this hook is normally replaced
+  // rather than reused. Reset anyway: nothing held here belongs to a different
+  // conversation, and leaving the keying to do it makes removing that key a
+  // silent bug rather than a loud one.
+  useEffect(
+    () => () => {
+      setDeciding(new Set());
+      setErrors({});
+      decidingRef.current = new Set();
+    },
+    [chatId],
+  );
 
   async function send(
     callId: string,

--- a/crates/openwave-desktop/ui/src/useTurnControls.test.ts
+++ b/crates/openwave-desktop/ui/src/useTurnControls.test.ts
@@ -413,4 +413,21 @@ describe("useTurnControls turn lifecycle", () => {
       expect(result.current.steerStatus).toBeNull();
     }
   });
+
+  it("does not carry turn-control state into the next conversation", async () => {
+    const client = stubClient({
+      cancel: vi.fn().mockRejectedValue(new Error("gone")),
+    });
+    const { result, rerender } = mount(client);
+    act(() => runTurn());
+
+    await act(async () => result.current.cancel());
+    expect(result.current.cancelError).not.toBeNull();
+
+    rerender({ id: "chat-2" });
+
+    expect(result.current.cancelError).toBeNull();
+    expect(result.current.cancelPendingTurnId).toBeNull();
+    expect(result.current.steerStatus).toBeNull();
+  });
 });

--- a/crates/openwave-desktop/ui/src/useTurnControls.ts
+++ b/crates/openwave-desktop/ui/src/useTurnControls.ts
@@ -113,6 +113,18 @@ export function useTurnControls(
     clearSteerRequestState();
   }, [chatId, deletingChatId]);
 
+  // The pane is keyed on the conversation, so this hook is normally replaced
+  // rather than reused. Reset anyway: nothing held here belongs to a different
+  // conversation, and leaving the keying to do it makes removing that key a
+  // silent bug rather than a loud one.
+  useEffect(
+    () => () => {
+      clearSteerRequestState();
+      clearCancelRequestState();
+    },
+    [chatId],
+  );
+
   /**
    * Whether a steer reply may still be applied. The current chat is named only
    * while this conversation is genuinely open — a chat being deleted keeps its

--- a/crates/openwave-desktop/ui/src/useUserQuestions.test.ts
+++ b/crates/openwave-desktop/ui/src/useUserQuestions.test.ts
@@ -152,4 +152,29 @@ describe("useUserQuestions", () => {
 
     expect(result.current.errors).toEqual({});
   });
+
+  it("does not carry an answer error into the next conversation", async () => {
+    const answer = deferred<void>();
+    const client = stubClient({
+      listPendingUserQuestions: vi.fn().mockResolvedValue([pending("call-1")]),
+      answerUserQuestions: vi.fn(() => answer.promise),
+    });
+    const { result, rerender } = renderHook(
+      ({ chatId }) => useUserQuestions(client, chatId),
+      { initialProps: { chatId: "chat-1" } },
+    );
+    await waitFor(() => expect(result.current.requests).toHaveLength(1));
+
+    act(() => result.current.answer("call-1", []));
+    await act(async () => {
+      answer.reject(new Error("gone"));
+      await answer.promise.catch(() => {});
+    });
+    expect(result.current.errors).not.toEqual({});
+
+    rerender({ chatId: "chat-2" });
+
+    expect(result.current.errors).toEqual({});
+    expect(result.current.answering.size).toBe(0);
+  });
 });

--- a/crates/openwave-desktop/ui/src/useUserQuestions.ts
+++ b/crates/openwave-desktop/ui/src/useUserQuestions.ts
@@ -78,6 +78,19 @@ export function useUserQuestions(
     };
   }, [client, chatId]);
 
+  // The pane is keyed on the conversation, so this hook is normally replaced
+  // rather than reused. Reset anyway: nothing held here belongs to a different
+  // conversation, and leaving the keying to do it makes removing that key a
+  // silent bug rather than a loud one.
+  useEffect(
+    () => () => {
+      setAnswering(new Set());
+      setErrors({});
+      answeringRef.current = new Set();
+    },
+    [chatId],
+  );
+
   // Only a signal raised after this hook mounted means anything to it; the
   // counter is app-wide and may already be well past zero on arrival.
   const lastSignalRef = useRef(signal);


### PR DESCRIPTION
The five hooks that own a conversation's requests are correct today, but by accident rather than construction.

`ChatView` carries `key={chat.id}`, so switching chats destroys and rebuilds the subtree — and *that* is what clears their state, not the hooks. Their own cleanup was partial:

| hook | cleared on a `chatId` change | survived it |
|---|---|---|
| `useToolApprovals` | nothing — no effect at all | `deciding`, `errors`, `decidingRef` |
| `useUserQuestions` | `requests`, `seenCallIdsRef` | `answering`, `errors`, `answeringRef` |
| `useFolderAccessRequests` | `requests` | `errors` |
| `useAgentRuns` | nothing (reset only on deletion) | `runs`, `loading`, `error`, stop markers, fence |
| `useTurnControls` | nothing (reset only on deletion) | cancel and steer state, steer fence |

Unreachable today, since the id never changes without the key changing with it. But remove that one line, or mount any of these somewhere that never had it, and a failed answer in chat A leaves its red error sitting on chat B.

The tests didn't stand in the way: several of them change `chatId` **in place** without remounting — exactly the breaking case — and passed. So the change that introduces the bug would have gone green through CI.

## The change

Each hook clears what belongs to the conversation when the conversation changes. The keying becomes a detail of how the pane is built rather than the thing holding correctness together.

One deliberate exception: the folder-decision latch is *not* reset. It belongs to the host's picker rather than to any conversation, and releasing it on a chat switch is precisely the bug #481 fixed. There's a comment saying so at the point someone would be tempted to add it.

## Verification

`tsc`, 409 vitest tests (from 404), production build. Each of the five new cases switches the chat in place and asserts the previous conversation's state is gone. Mutation-checked together: narrowing every reset effect's deps from `[chatId]` to `[]` — which reproduces the old "relies on the remount" behaviour exactly — fails all five and nothing else.

Closes #494