### PR TITLE
fix(desktop): give every allowlisted tool its own icon and copy

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -736,6 +736,7 @@ fn historical_tool_title(name: &str) -> &'static str {
         crate::ASK_USER_QUESTIONS_TOOL => "Ask a question",
         "spawn_sandbox_agent" => "Delegate a task",
         "wait_for_agents" => "Wait for background agents",
+        "exec" => "Run a command",
         _ => "Use a tool",
     }
 }
@@ -1175,5 +1176,44 @@ mod historical_tool_title_tests {
             historical_tool_title(crate::ASK_USER_QUESTIONS_TOOL),
             "Ask a question"
         );
+    }
+
+    /// A tool the renderer can name live must also have a historical title.
+    ///
+    /// `exec` had one and not the other, so a command read as "Ran a command"
+    /// while streaming and "Used a tool" after a reload — with its own command
+    /// card still visible underneath. The renderer folds anything it does not
+    /// recognize to `other`, which is the one name that legitimately has no
+    /// title of its own.
+    #[test]
+    fn every_renderer_visible_tool_has_a_historical_title() {
+        for name in [
+            "search",
+            "list_sources",
+            "read_source",
+            "web_search",
+            crate::SANDBOX_READ_DELEGATED_FILE_TOOL,
+            "read_file",
+            "list_dir",
+            "write_file",
+            "create_deliverable",
+            "request_folder_access",
+            "connect_folder",
+            "list_connected_folders",
+            "list_folder",
+            "read_connected_file",
+            "import_connected_file",
+            "spawn_sandbox_agent",
+            "wait_for_agents",
+            crate::ASK_USER_QUESTIONS_TOOL,
+            "exec",
+        ] {
+            assert_ne!(
+                historical_tool_title(name),
+                "Use a tool",
+                "{name} has no historical title"
+            );
+        }
+        assert_eq!(historical_tool_title("other"), "Use a tool");
     }
 }

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,6 +1,11 @@
 import { useId, useState } from "react";
 import { Check, ChevronDown, Clock, Loader2, Terminal, X } from "lucide-react";
-import type { ToolActionPreview, ToolResultPreview } from "./api";
+import {
+  isRendererToolName,
+  type RendererToolName,
+  type ToolActionPreview,
+  type ToolResultPreview,
+} from "./api";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { ToolTone } from "./ToolStatusIcon";
@@ -53,7 +58,15 @@ export type ToolApprovalPresentation = {
 // side channel for an unexpected tool name, arguments, output, file path, or
 // provider diagnostic. The one exception is a tool's own `preview`, a closed
 // per-tool projection built server-side.
-const TOOL_PRESENTATIONS: Record<string, ToolPresentation> = {
+//
+// Keyed by [`RendererToolName`] so a tool added to that union without copy
+// fails to compile instead of silently reading as "Use a tool". `other` is
+// excluded: it is the server's fold for anything unrecognized, and the
+// fallback below is deliberately its wording.
+const TOOL_PRESENTATIONS: Record<
+  Exclude<RendererToolName, "other">,
+  ToolPresentation
+> = {
   search: {
     label: "Search sources",
     active: "Searching sources",
@@ -373,7 +386,10 @@ export function toolCallPresentation(
   name: string,
   status: ToolCallStatus,
 ): ToolCallPresentation & { icon: string } {
-  const tool = TOOL_PRESENTATIONS[name] ?? FALLBACK_TOOL;
+  const tool =
+    isRendererToolName(name) && name !== "other"
+      ? TOOL_PRESENTATIONS[name]
+      : FALLBACK_TOOL;
   const statusPresentationResult = statusPresentation(tool, status);
 
   return {

--- a/crates/openwave-desktop/ui/src/ToolIcon.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolIcon.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ToolIcon } from "./ToolIcon";
+import { toolCallPresentation, type ToolCallStatus } from "./ToolCallCard";
+
+/**
+ * Every renderer tool name, in the order the union declares them. The point of
+ * listing them here is that the union is the contract: `Record<RendererToolName, _>`
+ * makes a missing icon a compile error, and this asserts the runtime half —
+ * that each one actually resolves to distinct, non-fallback presentation.
+ */
+const TOOL_NAMES = [
+  "search",
+  "list_sources",
+  "read_source",
+  "web_search",
+  "read_delegated_file",
+  "read_file",
+  "list_dir",
+  "write_file",
+  "create_deliverable",
+  "request_folder_access",
+  "connect_folder",
+  "list_connected_folders",
+  "list_folder",
+  "read_connected_file",
+  "import_connected_file",
+  "spawn_sandbox_agent",
+  "wait_for_agents",
+  "ask_user_questions",
+  "exec",
+] as const;
+
+describe("tool presentation coverage", () => {
+  it("gives every allowlisted tool its own copy rather than the fallback", () => {
+    // `list_folder` and `import_connected_file` both reached the allowlist
+    // without copy or an icon and silently read as "Use a tool".
+    for (const name of TOOL_NAMES) {
+      const presentation = toolCallPresentation(name, "running" as ToolCallStatus);
+      expect(presentation.label, `${name} has no label`).not.toBe("Use a tool");
+      expect(presentation.title, `${name} has no title`).not.toBe("Using a tool");
+    }
+  });
+
+  it("renders an icon for every allowlisted tool", () => {
+    for (const name of TOOL_NAMES) {
+      const markup = renderToStaticMarkup(<ToolIcon name={name} />);
+      expect(markup, `${name} rendered nothing`).toContain("<svg");
+    }
+  });
+
+  it("folds an unrecognized name to the generic tool rather than guessing", () => {
+    const presentation = toolCallPresentation("mcp__evil__exfiltrate", "running");
+    expect(presentation.label).toBe("Use a tool");
+    // `other` is the server's own fold, and shares that treatment.
+    expect(toolCallPresentation("other", "running").label).toBe("Use a tool");
+    expect(renderToStaticMarkup(<ToolIcon name="mcp__evil__exfiltrate" />)).toContain(
+      "<svg",
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/ToolIcon.tsx
+++ b/crates/openwave-desktop/ui/src/ToolIcon.tsx
@@ -2,12 +2,14 @@ import {
   BookOpenText,
   CircleHelp,
   Clock,
+  FileInput,
   FilePenLine,
   FilePlus2,
   FileSearch,
   FileText,
   FolderOpen,
   FolderPlus,
+  FolderTree,
   Globe,
   List,
   Bot as Robot,
@@ -16,14 +18,20 @@ import {
   type LucideIcon,
 } from "lucide-react";
 
+import { isRendererToolName, type RendererToolName } from "./api";
+
 /**
  * The icon for a tool, derived only from its allowlisted renderer name.
  *
  * A row's icon says which capability ran; its status is carried separately by
  * [`ToolStatusIcon`]. Anything outside the allowlist gets the generic wrench
  * rather than leaking a provider-supplied name into an icon choice.
+ *
+ * Keyed by [`RendererToolName`] rather than `string` so adding a tool to that
+ * union without giving it an icon fails to compile. Two tools had already
+ * reached the allowlist without one and were silently rendering the wrench.
  */
-const TOOL_ICONS: Record<string, LucideIcon> = {
+const TOOL_ICONS: Record<RendererToolName, LucideIcon> = {
   search: FileSearch,
   list_sources: List,
   read_source: BookOpenText,
@@ -36,14 +44,17 @@ const TOOL_ICONS: Record<string, LucideIcon> = {
   request_folder_access: FolderPlus,
   connect_folder: FolderPlus,
   list_connected_folders: FolderOpen,
+  list_folder: FolderTree,
   read_connected_file: FileText,
+  import_connected_file: FileInput,
   ask_user_questions: CircleHelp,
   spawn_sandbox_agent: Robot,
   wait_for_agents: Clock,
   exec: Terminal,
+  // The server folds every unrecognized tool name to `other`, so this is the
+  // one entry that is genuinely "some tool ran" rather than a missing icon.
+  other: Wrench,
 };
-
-const FALLBACK_ICON = Wrench;
 
 export function ToolIcon({
   name,
@@ -52,6 +63,6 @@ export function ToolIcon({
   name: string;
   className?: string;
 }) {
-  const Icon = TOOL_ICONS[name] ?? FALLBACK_ICON;
+  const Icon = isRendererToolName(name) ? TOOL_ICONS[name] : TOOL_ICONS.other;
   return <Icon className={className} />;
 }

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -42,6 +42,7 @@ const HISTORY_TOOL_NAMES: Record<ChatToolActivity["title"], string> = {
   "Ask a question": "ask_user_questions",
   "Delegate a task": "spawn_sandbox_agent",
   "Wait for background agents": "wait_for_agents",
+  "Run a command": "exec",
   "Use a tool": "historical_unknown_tool",
 };
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -183,6 +183,7 @@ export type ChatToolActivity = {
     | "Ask a question"
     | "Delegate a task"
     | "Wait for background agents"
+    | "Run a command"
     | "Use a tool";
   status: "completed" | "failed" | "cancelled";
   started_at: string;

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -1092,7 +1092,7 @@ export function parseToolResultPreview(
   };
 }
 
-function isRendererToolName(value: unknown): value is RendererToolName {
+export function isRendererToolName(value: unknown): value is RendererToolName {
   return (
     value === "search" ||
     value === "list_sources" ||

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -272,11 +272,15 @@ provider identifiers, executor leases, and raw failures remain server-side.
 New tools are invisible to the renderer until they receive their own safe
 activity projection.
 
-The desktop Agent activity panel turns that projection into foreground and
-background status rows. It offers Stop only for sandbox states that can still
-be cancelled, binds each request to the exact chat and run, and keeps a pending
-or retryable error state until polling confirms the durable transition. The
-panel never receives a worker lease or direct scheduler control.
+No desktop surface consumes that projection today. An activity panel used to
+render it as foreground and background status rows with a Stop control for
+cancellable sandbox states, but it restated what the transcript already showed
+and was removed. The projection, the run routes, and the cancellation route all
+remain, so a future surface can render them without rebuilding the server side.
+Whatever renders it next must keep the same posture: bind every request to the
+exact chat and run, hold a pending or retryable error state until polling
+confirms the durable transition, and never receive a worker lease or direct
+scheduler control.
 
 ## Reliability contract
 

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -702,15 +702,17 @@ The current UI is a workspace-style conversation shell, not the complete
 product. It reopens durable chats and supports conversation create/list/switch/
 rename/delete, transcript hydration, Markdown messages, live and historical
 tool-call rendering, reconnectable streaming, provider and web-search setup,
-model selection, a foreground-turn stop control, approval prompts, native
-connected-folder pick/list/revoke, and a dedicated foreground/background agent
-activity panel. That panel renders safe lifecycle and activity status and can
-stop an eligible sandbox task through its exact run identity. The foreground
-stop control sends cancellation for the exact active turn, prevents duplicate
-requests, and stays in a pending state until an authoritative terminal event
-arrives; neither control treats a request as a locally completed cancellation.
-That surface reads a redacted durable snapshot and is only an observer: worker
-leases, delegated inputs, and scheduler control remain server-private.
+model selection, a foreground-turn stop control, approval prompts, and native
+connected-folder pick/list/revoke. The foreground stop control sends
+cancellation for the exact active turn, prevents duplicate requests, and stays
+in a pending state until an authoritative terminal event arrives; it never
+treats a request as a locally completed cancellation.
+
+Background agent runs currently have no renderer surface. The server projects a
+redacted, observer-only snapshot of them (see
+[`docs/agent-runs.md`](agent-runs.md)), but nothing renders it, and there is no
+way to stop a sandbox run from the UI. Worker leases, delegated inputs, and
+scheduler control remain server-private regardless.
 OpenWave's operational scratch stays in private app storage; user-selected paths
 cross only the native host-to-broker control boundary, while the renderer sees
 opaque folder summaries. Chats store only ordered opaque root IDs and attachment
@@ -867,8 +869,7 @@ and ownership, atomic client-wait checkpoints, terminal turn commits,
 cancellation, reconnectable event stream, durable foreground/sandbox agent-run
 leases and result delivery, bounded non-blocking child admission, ordered
 multi-child waits, the foreground terminal guard, Markdown and tool-call
-transcript rendering, the agent activity/status-and-stop surface, and
-fail-closed provider routing. The first native Outputs loop also closes the path
+transcript rendering, and fail-closed provider routing. The first native Outputs loop also closes the path
 from a bounded conversation-private text file to an explicit user-selected
 export.
 


### PR DESCRIPTION
Three fixes from auditing what the recent merge wave left behind. All three are the same failure mode: a tool vocabulary maintained by hand in several places at once, with nothing checking the copies agree.

## 1. Two tools rendered a generic wrench

`list_folder` and `import_connected_file` were in the renderer tool-name union and had copy in `TOOL_PRESENTATIONS`, but no icon. `import_connected_file` shipped that way in #465.

Both lookup tables were keyed by `string`, so a tool could join the union unnoticed. They are now keyed by `RendererToolName`, making a missing entry a **compile error**. Verified by deleting an entry:

```
error TS2741: Property 'import_connected_file' is missing in type
'{ ... }' but required in type 'Record<RendererToolName, LucideIcon>'.
```

`other` keeps the generic wrench deliberately — it is the server's fold for anything unrecognized — and is excluded from the copy table, whose fallback already says "Use a tool". The runtime allowlist guard is now exported and used by both tables, so a provider-supplied name still cannot select an icon or a label.

## 2. A command lost its label when the chat was reopened

`exec` had live copy and an icon but no *historical* title, so it read "Ran a command" while streaming and "Used a tool" with a wrench after a reload — with its own command card still sitting underneath the mislabelled row. #483 made this visible by attaching the exec preview to the historical record; #465 edited the same function that afternoon and didn't add `exec`.

The title crosses the wire as **display copy** and the renderer maps it back to a tool name, so filling the gap took three edits in three languages with nothing checking they agree. A Rust test now asserts every renderer-visible tool has a historical title, and that `other` keeps the generic one.

## 3. Docs still described the removed activity panel

#496 removed the panel but left three passages claiming the UI has a foreground/background activity surface with a Stop control — one listing it among the strongest parts of the system. Corrected; `docs/agent-runs.md` keeps a note on the posture a replacement must preserve. That replacement is tracked as #499.

## Follow-ups filed

This is one of five parallel hand-maintained tool vocabularies (two Rust, three TS) with no drift detection. #478 tracks generating them; #503 tracks removing the display-copy round trip that made fix 2 a three-language edit.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `tsc --noEmit`, `vitest run` (386 passed), production `vite build`.
