### PR TITLE
fix(desktop): stop a slow approval writing into the chat you moved to

### DIFF
--- a/crates/openwave-desktop/ui/src/OpenConversation.test.ts
+++ b/crates/openwave-desktop/ui/src/OpenConversation.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useOpenConversation } from "./OpenConversation";
+import { useChatListStore } from "./ChatListStore";
+
+describe("useOpenConversation", () => {
+  beforeEach(() => {
+    useChatListStore.setState({ deletingChatId: null });
+  });
+
+  it("accepts a response for the conversation it started in", () => {
+    const { result } = renderHook(() => useOpenConversation("chat-1"));
+    expect(result.current("chat-1")).toBe(true);
+    expect(result.current("chat-2")).toBe(false);
+  });
+
+  it("rejects a response for a conversation being deleted", () => {
+    const { result } = renderHook(() => useOpenConversation("chat-1"));
+    // The ref is written while rendering, so the store change has to land as a
+    // render for the predicate to see it.
+    act(() => useChatListStore.setState({ deletingChatId: "chat-1" }));
+    // Deletion is the case keying misses: the doomed chat stays mounted with a
+    // matching id for the whole round trip.
+    expect(result.current("chat-1")).toBe(false);
+  });
+
+  it("reads current truth rather than the value captured at render", () => {
+    const { result, rerender } = renderHook(
+      ({ chatId }) => useOpenConversation(chatId),
+      { initialProps: { chatId: "chat-1" } },
+    );
+    const captured = result.current;
+    rerender({ chatId: "chat-2" });
+    // A handler captures the predicate before an await and asks afterwards.
+    expect(captured("chat-1")).toBe(false);
+    expect(captured("chat-2")).toBe(true);
+  });
+
+  it("reports nothing open once the hook is gone", () => {
+    const { result, unmount } = renderHook(() => useOpenConversation("chat-1"));
+    const captured = result.current;
+    expect(captured("chat-1")).toBe(true);
+    unmount();
+    // Its inputs are only written while rendering, so without an unmount
+    // cleanup this keeps calling a conversation that no longer exists open —
+    // and disagrees with the self-resets its callers run on the same event.
+    expect(captured("chat-1")).toBe(false);
+  });
+});

--- a/crates/openwave-desktop/ui/src/OpenConversation.ts
+++ b/crates/openwave-desktop/ui/src/OpenConversation.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useChatListStore } from "./ChatListStore";
 
 /**
@@ -14,13 +14,29 @@ import { useChatListStore } from "./ChatListStore";
  * Returns a stable predicate that reads current truth when it is called, so a
  * handler can capture it before an await and still ask an up-to-date question
  * afterwards.
+ *
+ * The predicate also has to answer for a hook that is already gone. Its inputs
+ * are only written while rendering, so without the unmount cleanup below it
+ * would keep reporting the last conversation it saw as open forever — which is
+ * the opposite of what an unmounted hook means, and would make it disagree with
+ * the self-resets the hooks using it perform on the same event.
  */
 export function useOpenConversation(
   chatId: string | null,
 ): (startedChatId: string) => boolean {
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
-  const current = useRef({ chatId, deletingChatId });
+  const current = useRef<{ chatId: string | null; deletingChatId: string | null }>({
+    chatId,
+    deletingChatId,
+  });
   current.current = { chatId, deletingChatId };
+
+  useEffect(
+    () => () => {
+      current.current = { chatId: null, deletingChatId: null };
+    },
+    [],
+  );
 
   return useRef(
     (startedChatId: string) =>

--- a/crates/openwave-desktop/ui/src/useToolApprovals.ts
+++ b/crates/openwave-desktop/ui/src/useToolApprovals.ts
@@ -60,14 +60,21 @@ export function useToolApprovals(
     });
     try {
       await client.decideApproval(startedChatId, callId, decision, grant);
-      useChatSessionStore.getState().update((session) => ({
-        ...session,
-        messages: session.messages.map((message) =>
-          message.role === "approval" && message.callId === callId
-            ? { ...message, resolved: true }
-            : message,
-        ),
-      }));
+      // The session store holds whichever conversation is open now, not the one
+      // this decision was made in. Marking the card resolved without checking
+      // would rewrite a different chat's transcript — and because the map
+      // allocates unconditionally, that is a visible re-render even though no
+      // message matches.
+      if (stillOpen(startedChatId)) {
+        useChatSessionStore.getState().update((session) => ({
+          ...session,
+          messages: session.messages.map((message) =>
+            message.role === "approval" && message.callId === callId
+              ? { ...message, resolved: true }
+              : message,
+          ),
+        }));
+      }
     } catch (err) {
       // A decision that fails against a chat on its way out has nowhere to be
       // read; the conversation it belonged to is going with it.


### PR DESCRIPTION
Closes #510.

`useToolApprovals` fences its **failure** path against a conversation that is on its way out, with a comment explaining why. Its **success** path was unfenced — and that is the path that writes to `useChatSessionStore`, a singleton holding whichever conversation is open *now*.

### The failure

Approve a tool call in chat A, switch to chat B before the request lands, and the resolved decision rewrites **B's** messages array. Call ids are UUIDs so nothing actually flips `resolved`, but `.map()` allocates unconditionally, so the `messages` selector sees a new reference and re-renders B's entire transcript on A's stale reply.

This is the exact path #489 was written to close.

### The predicate had the same gap from the other side

`useOpenConversation` writes its inputs **only during render**, so after unmount it kept answering `true` for a conversation that no longer exists — the opposite of what an unmounted hook means, and in direct disagreement with the self-resets #495 added to the five hooks that call it. It now clears itself on unmount.

Worth stating plainly: nothing was visibly broken by that, because every post-unmount caller happened to hit a nulled `refreshRef` or a no-op `setState` first. That containment was accidental and written down nowhere.

### Tests

Four cases on the predicate, including the unmount one. I verified it catches the bug by deleting the cleanup and watching only that test fail:

```
✓ accepts a response for the conversation it started in
✓ rejects a response for a conversation being deleted
✓ reads current truth rather than the value captured at render
× reports nothing open once the hook is gone
```

`tsc --noEmit`, `vitest run` (390 passed), production `vite build`. No Rust changes.
