### PR TITLE
fix(desktop): keep one bad tool row from blanking the transcript

### DIFF
--- a/crates/openwave-desktop/ui/src/ErrorBoundary.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ErrorBoundary.dom.test.tsx
@@ -50,3 +50,27 @@ describe("ErrorBoundary", () => {
     expect(onReload).toHaveBeenCalledOnce();
   });
 });
+
+describe("ErrorBoundary with an inline fallback", () => {
+  it("contains a throw to its own region instead of replacing the page", () => {
+    const Boom = () => {
+      throw new Error("tool row exploded");
+    };
+    render(
+      <div>
+        <p>the conversation around it</p>
+        <ErrorBoundary
+          fallback={<p>This step could not be displayed.</p>}
+        >
+          <Boom />
+        </ErrorBoundary>
+      </div>,
+    );
+
+    expect(screen.getByText("This step could not be displayed.")).toBeTruthy();
+    // The point of the inline fallback: the rest of the transcript survives,
+    // and the reader is not offered a reload for one bad row.
+    expect(screen.getByText("the conversation around it")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Reload" })).toBeNull();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ErrorBoundary.tsx
+++ b/crates/openwave-desktop/ui/src/ErrorBoundary.tsx
@@ -5,6 +5,15 @@ type ErrorBoundaryProps = {
   children: ReactNode;
   /** Injectable for tests; defaults to a real page reload. */
   onReload?: () => void;
+  /**
+   * Rendered instead of the full-page recovery screen.
+   *
+   * Supplied when the boundary wraps one part of the page rather than the
+   * whole tree: a transcript row that cannot render should degrade to a note
+   * in its own place, not replace the conversation around it with a reload
+   * prompt.
+   */
+  fallback?: ReactNode;
 };
 
 type ErrorBoundaryState = {
@@ -32,6 +41,7 @@ export class ErrorBoundary extends Component<
 
   render() {
     if (!this.state.error) return this.props.children;
+    if (this.props.fallback !== undefined) return this.props.fallback;
     return (
       <div className="boot" role="alert">
         <div className="boot-brand">

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -16,6 +16,7 @@ import { MessageMarkdown } from "./MessageMarkdown";
 import { MessageFooter } from "./MessageFooter";
 import { AssistantSources, type AssistantSource } from "./AssistantSources";
 import { ToolCommandCard, type ToolCallStatus } from "./ToolCallCard";
+import { ErrorBoundary } from "./ErrorBoundary";
 import { ToolActivityGroup } from "./ToolActivityGroup";
 import { WelcomeState } from "./WelcomeState";
 import { UserQuestionsCard } from "./UserQuestionsCard";
@@ -263,14 +264,22 @@ export function groupMessageItems(
     );
     const cards = surfacedCards(phase, parked, onApproval, approvalState);
 
+    // A tool row renders model-influenced data through several defensive
+    // parsers. If one of them is ever wrong, the throw should cost this phase
+    // and not the conversation around it.
     items.push(
-      <ToolActivityGroup
+      <ErrorBoundary
         key={`tool-activity-group-${groupIndex}`}
-        activities={activities}
-        groupIndex={groupIndex}
+        fallback={
+          <p className="tool-activity-unavailable" role="status">
+            This step could not be displayed.
+          </p>
+        }
       >
-        {cards.length > 0 ? cards : undefined}
-      </ToolActivityGroup>,
+        <ToolActivityGroup activities={activities} groupIndex={groupIndex}>
+          {cards.length > 0 ? cards : undefined}
+        </ToolActivityGroup>
+      </ErrorBoundary>,
     );
     groupIndex += 1;
   }

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -2407,6 +2407,15 @@ body {
   font-size: 0.74rem;
 }
 
+/* A transcript phase whose row threw while rendering. Deliberately quiet: the
+   conversation around it is intact, and the step itself is recoverable from the
+   durable record. */
+.tool-activity-unavailable {
+  padding: 0.5rem 0.75rem;
+  color: var(--muted-foreground);
+  font-size: 0.82rem;
+}
+
 .document-status {
   padding: 0.2rem 0.5rem;
   border-radius: 999px;


### PR DESCRIPTION
Closes #507.

Nothing guarded the message or tool-call render path. A tool row parses model-influenced data through several defensive validators, and if one of them is ever wrong, the throw unmounts the whole tree — the conversation, not the row.

The app already has an `ErrorBoundary`, but it is the last-resort kind that replaces the page with a reload prompt. Offering *that* for one unrenderable step is a worse outcome than the step being missing, so it now takes an optional inline `fallback` and each transcript phase gets one. A phase that throws degrades to a quiet note in its own place and everything around it stays readable.

The reference implementation does the same thing — every tool result and every background-agent row sits in its own boundary, precisely so one bad tool cannot blank the conversation.

**Latent, not active.** The `parse*` validators and `normalizeActivities` are why no payload currently gets far enough to throw. The containment is worth having anyway, since today's safety depends on every *future* validator also being right.

## Verification

`tsc --noEmit`, `vitest run` (395 passed), production `vite build`. A test asserts a throwing child yields the fallback, that the surrounding transcript survives, and that no reload button is offered for an inline failure.
