### PR TITLE
refactor(desktop): persist a tool's name in history, not its display copy

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -706,7 +706,7 @@ fn tool_activity_from_call(call: ToolCallRecord) -> ChatToolActivitySnapshot {
         }
     };
     ChatToolActivitySnapshot {
-        title: historical_tool_title(&call.name),
+        tool: historical_tool_name(&call.name),
         action: crate::preview::ToolActionPreview::build(&call.name, &call.arguments),
         status,
         started_at: call.created_at,
@@ -714,30 +714,37 @@ fn tool_activity_from_call(call: ToolCallRecord) -> ChatToolActivitySnapshot {
     }
 }
 
-/// The tool name is canonical but still not renderer-safe: unknown names can
-/// leak provider, extension, or local capability details. Historical cards use
-/// this explicit vocabulary and collapse anything else to a generic action.
-fn historical_tool_title(name: &str) -> &'static str {
+/// The tool name is canonical but still not renderer-safe: an unknown name can
+/// leak provider, extension, or local capability details. Historical cards name
+/// only tools on this list and fold anything else to `other`, which is the same
+/// vocabulary and the same fold the live event projection uses.
+///
+/// Returning the name rather than its copy is deliberate. The renderer already
+/// owns the wording for a live call, so sending prose here meant maintaining a
+/// second copy of it plus an inverse lookup to get back to a name — and a copy
+/// change on either side silently broke hydration.
+fn historical_tool_name(name: &str) -> &'static str {
     match name {
-        "search" => "Search sources",
-        "list_sources" => "Check sources",
-        "read_source" => "Read a source",
-        "web_search" => "Search the web",
-        crate::SANDBOX_READ_DELEGATED_FILE_TOOL => "Read a delegated file",
-        "read_file" | "read_connected_file" => "Read a file",
-        "list_dir" => "Browse files",
-        "write_file" => "Update a file",
-        "create_deliverable" => "Create an output",
-        "request_folder_access" => "Request folder access",
-        "connect_folder" => "Connect a folder",
-        "list_connected_folders" => "Check connected folders",
-        "list_folder" => "Browse a connected folder",
-        "import_connected_file" => "Add a file as a source",
-        crate::ASK_USER_QUESTIONS_TOOL => "Ask a question",
-        "spawn_sandbox_agent" => "Delegate a task",
-        "wait_for_agents" => "Wait for background agents",
-        "exec" => "Run a command",
-        _ => "Use a tool",
+        "search" => "search",
+        "list_sources" => "list_sources",
+        "read_source" => "read_source",
+        "web_search" => "web_search",
+        crate::SANDBOX_READ_DELEGATED_FILE_TOOL => "read_delegated_file",
+        "read_file" => "read_file",
+        "read_connected_file" => "read_connected_file",
+        "list_dir" => "list_dir",
+        "write_file" => "write_file",
+        "create_deliverable" => "create_deliverable",
+        "request_folder_access" => "request_folder_access",
+        "connect_folder" => "connect_folder",
+        "list_connected_folders" => "list_connected_folders",
+        "list_folder" => "list_folder",
+        "import_connected_file" => "import_connected_file",
+        crate::ASK_USER_QUESTIONS_TOOL => "ask_user_questions",
+        "spawn_sandbox_agent" => "spawn_sandbox_agent",
+        "wait_for_agents" => "wait_for_agents",
+        "exec" => "exec",
+        _ => "other",
     }
 }
 
@@ -1155,38 +1162,33 @@ fn role_from_db(text: &str) -> Result<Role> {
 }
 
 #[cfg(test)]
-mod historical_tool_title_tests {
-    use super::historical_tool_title;
+mod historical_tool_name_tests {
+    use super::historical_tool_name;
 
     #[test]
-    fn delegated_file_reads_have_a_fixed_renderer_title() {
+    fn a_private_tool_name_never_reaches_the_renderer() {
         assert_eq!(
-            historical_tool_title(crate::SANDBOX_READ_DELEGATED_FILE_TOOL),
-            "Read a delegated file"
+            historical_tool_name(crate::SANDBOX_READ_DELEGATED_FILE_TOOL),
+            "read_delegated_file"
         );
-        assert_eq!(historical_tool_title("private_read_variant"), "Use a tool");
-        assert_eq!(historical_tool_title("search"), "Search sources");
-        assert_eq!(historical_tool_title("list_sources"), "Check sources");
-        assert_eq!(historical_tool_title("read_source"), "Read a source");
+        // The allowlist is the point: an unrecognized name folds rather than
+        // travelling, so it cannot leak a provider or extension detail.
+        assert_eq!(historical_tool_name("private_read_variant"), "other");
+        assert_eq!(historical_tool_name("mcp__vendor__search"), "other");
+        assert_eq!(historical_tool_name("search"), "search");
         assert_eq!(
-            historical_tool_title("create_deliverable"),
-            "Create an output"
-        );
-        assert_eq!(
-            historical_tool_title(crate::ASK_USER_QUESTIONS_TOOL),
-            "Ask a question"
+            historical_tool_name(crate::ASK_USER_QUESTIONS_TOOL),
+            "ask_user_questions"
         );
     }
 
-    /// A tool the renderer can name live must also have a historical title.
+    /// A tool the renderer can name live must survive the round trip.
     ///
-    /// `exec` had one and not the other, so a command read as "Ran a command"
+    /// `exec` used to be absent here, so a command read as "Ran a command"
     /// while streaming and "Used a tool" after a reload — with its own command
-    /// card still visible underneath. The renderer folds anything it does not
-    /// recognize to `other`, which is the one name that legitimately has no
-    /// title of its own.
+    /// card still visible underneath.
     #[test]
-    fn every_renderer_visible_tool_has_a_historical_title() {
+    fn every_renderer_visible_tool_keeps_its_name_through_history() {
         for name in [
             "search",
             "list_sources",
@@ -1208,12 +1210,14 @@ mod historical_tool_title_tests {
             crate::ASK_USER_QUESTIONS_TOOL,
             "exec",
         ] {
-            assert_ne!(
-                historical_tool_title(name),
-                "Use a tool",
-                "{name} has no historical title"
-            );
+            // Round-trips as itself, except the one private name that is
+            // deliberately renamed for the renderer.
+            let projected = historical_tool_name(name);
+            assert_ne!(projected, "other", "{name} does not survive history");
+            if name != crate::SANDBOX_READ_DELEGATED_FILE_TOOL {
+                assert_eq!(projected, name);
+            }
         }
-        assert_eq!(historical_tool_title("other"), "Use a tool");
+        assert_eq!(historical_tool_name("other"), "other");
     }
 }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -109,8 +109,12 @@ pub enum ChatToolActivityStatus {
 /// it can carry are the ones a tool explicitly projects for display.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ChatToolActivitySnapshot {
-    /// Fixed allowlisted presentation title, never a provider-supplied name.
-    pub title: &'static str,
+    /// Allowlisted renderer tool name, never a provider-supplied one.
+    ///
+    /// A name rather than display copy: the renderer already derives a live
+    /// call's wording from its name, and sending prose here made a copy change
+    /// silently break history hydration.
+    pub tool: &'static str,
     /// Closed projection of what the call did, when its tool has one. Rebuilt
     /// from the arguments it ran with, so history describes the same action
     /// the live stream did.

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
@@ -22,7 +22,7 @@ describe("hydrateTranscriptHistory", () => {
       ],
       [
         {
-          title: "Search the web",
+          tool: "web_search",
           status: "completed",
           started_at: "2026-07-16T10:00:01Z",
           finished_at: "2026-07-16T10:00:01Z",
@@ -45,13 +45,13 @@ describe("hydrateTranscriptHistory", () => {
   it("hydrates background delegation and wait activity with fixed tool kinds", () => {
     const entries = hydrateTranscriptHistory([], [
       {
-        title: "Delegate a task",
+        tool: "spawn_sandbox_agent",
         status: "completed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: "2026-07-16T10:00:00Z",
       },
       {
-        title: "Wait for background agents",
+        tool: "wait_for_agents",
         status: "completed",
         started_at: "2026-07-16T10:00:01Z",
         finished_at: "2026-07-16T10:00:02Z",
@@ -68,7 +68,7 @@ describe("hydrateTranscriptHistory", () => {
   it("hydrates answered questions with a fixed presentation kind", () => {
     const entries = hydrateTranscriptHistory([], [
       {
-        title: "Ask a question",
+        tool: "ask_user_questions",
         status: "completed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: "2026-07-16T10:00:01Z",
@@ -83,7 +83,7 @@ describe("hydrateTranscriptHistory", () => {
   it("hydrates delegated file reads as their fixed presentation kind", () => {
     const entries = hydrateTranscriptHistory([], [
       {
-        title: "Read a delegated file",
+        tool: "read_delegated_file",
         status: "completed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: "2026-07-16T10:00:01Z",
@@ -99,19 +99,19 @@ describe("hydrateTranscriptHistory", () => {
   it("hydrates source discovery, direct reads, and semantic search distinctly", () => {
     const entries = hydrateTranscriptHistory([], [
       {
-        title: "Check sources",
+        tool: "list_sources",
         status: "completed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: "2026-07-16T10:00:00Z",
       },
       {
-        title: "Read a source",
+        tool: "read_source",
         status: "completed",
         started_at: "2026-07-16T10:00:01Z",
         finished_at: "2026-07-16T10:00:01Z",
       },
       {
-        title: "Search sources",
+        tool: "search",
         status: "completed",
         started_at: "2026-07-16T10:00:02Z",
         finished_at: "2026-07-16T10:00:02Z",
@@ -128,7 +128,7 @@ describe("hydrateTranscriptHistory", () => {
   it("hydrates generated outputs with fixed renderer copy", () => {
     const entries = hydrateTranscriptHistory([], [
       {
-        title: "Create an output",
+        tool: "create_deliverable",
         status: "completed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: "2026-07-16T10:00:01Z",
@@ -200,19 +200,22 @@ describe("hydrateTranscriptHistory", () => {
     });
   });
 
-  it("keeps the server's generic historical title on the generic card path", () => {
+  it("folds an unrecognized historical tool to the generic card", () => {
     const [entry] = hydrateTranscriptHistory([], [
       {
-        title: "Use a tool",
+        tool: "other",
         status: "failed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: null,
       },
     ]);
 
+    // `other` is the server's own fold and a real member of the renderer's
+    // tool vocabulary, so it resolves to the generic presentation. The previous
+    // sentinel name existed in neither the copy nor the icon table.
     expect(entry).toMatchObject({
       kind: "tool",
-      name: "historical_unknown_tool",
+      name: "other",
       status: "failed",
     });
   });

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -21,31 +21,6 @@ export type HydratedTranscriptEntry =
       createdAt: string;
     };
 
-// The history endpoint exposes titles rather than canonical tool names. Keep
-// the renderer on an explicit inverse allowlist so a server-side title change
-// cannot become a display path for provider names, arguments, or output.
-const HISTORY_TOOL_NAMES: Record<ChatToolActivity["title"], string> = {
-  "Search sources": "search",
-  "Check sources": "list_sources",
-  "Read a source": "read_source",
-  "Search the web": "web_search",
-  "Read a delegated file": "read_delegated_file",
-  "Read a file": "read_file",
-  "Browse files": "list_dir",
-  "Update a file": "write_file",
-  "Create an output": "create_deliverable",
-  "Request folder access": "request_folder_access",
-  "Connect a folder": "connect_folder",
-  "Check connected folders": "list_connected_folders",
-  "Browse a connected folder": "list_folder",
-  "Add a file as a source": "import_connected_file",
-  "Ask a question": "ask_user_questions",
-  "Delegate a task": "spawn_sandbox_agent",
-  "Wait for background agents": "wait_for_agents",
-  "Run a command": "exec",
-  "Use a tool": "historical_unknown_tool",
-};
-
 /** Build a stable, presentation-only transcript from one durable snapshot. */
 export function hydrateTranscriptHistory(
   messages: ChatMessage[],
@@ -81,7 +56,9 @@ export function hydrateTranscriptHistory(
       // it is never used to resolve or replay a tool operation.
       id: `tool-history:${activity.started_at}:${index}`,
       kind: "tool" as const,
-      name: HISTORY_TOOL_NAMES[activity.title],
+      // Already an allowlisted renderer tool name, folded server-side, so the
+      // same presentation the live stream uses applies directly.
+      name: activity.tool,
       status: activity.status,
       // History carries what the call did but not what it produced: results
       // are not persisted, so a reloaded command card shows its command alone.

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -165,26 +165,15 @@ export type ChatMessageCitation = {
 export type ChatToolActivity = {
   /** What the call did, when its tool projects it. */
   action?: ToolActionPreview;
-  title:
-    | "Search sources"
-    | "Check sources"
-    | "Read a source"
-    | "Search the web"
-    | "Read a delegated file"
-    | "Read a file"
-    | "Browse files"
-    | "Update a file"
-    | "Create an output"
-    | "Request folder access"
-    | "Connect a folder"
-    | "Check connected folders"
-    | "Browse a connected folder"
-    | "Add a file as a source"
-    | "Ask a question"
-    | "Delegate a task"
-    | "Wait for background agents"
-    | "Run a command"
-    | "Use a tool";
+  /**
+   * Allowlisted renderer tool name, folded server-side.
+   *
+   * A name rather than display copy: the renderer derives a live call's
+   * wording from its name, and carrying prose here meant a second copy of it
+   * plus an inverse lookup, where a change on either side silently broke
+   * hydration.
+   */
+  tool: RendererToolName;
   status: "completed" | "failed" | "cancelled";
   started_at: string;
   finished_at: string | null;

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -8795,14 +8795,14 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
     let activity = transcript["tool_activity"].as_array().unwrap();
     assert_eq!(activity.len(), 2);
     assert!(activity.iter().any(|card| {
-        card["title"] == "Use a tool"
+        card["tool"] == "other"
             && card["status"] == "failed"
             && card["started_at"].is_string()
             && card["finished_at"].is_string()
     }));
     assert!(activity
         .iter()
-        .any(|card| { card["title"] == "Request folder access" && card["status"] == "cancelled" }));
+        .any(|card| { card["tool"] == "request_folder_access" && card["status"] == "cancelled" }));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #503.

Durable tool history sent **display strings** over the wire — `ChatToolActivity.title` was a union of literals like `"Check connected folders"` — and the renderer kept an inverse table (`HISTORY_TOOL_NAMES`) mapping them back to tool names so it could pick copy and an icon.

So a wording change on either side silently broke hydration: an unmapped title became `undefined`, which fell through to the generic wrench and "Use a tool". That is exactly how `exec` came to read differently before and after a reload (fixed in #497). The inverse table even had an entry pointing at `historical_unknown_tool` — a name present in neither the copy nor the icon table.

## What changed

Send the allowlisted **tool name** and let the renderer derive wording the way it already does for a live call.

The allowlist is the security property here and it stays intact: an unrecognized name folds to `other` **server-side**, which is the same vocabulary and the same fold the live event projection already uses. A provider-supplied name still cannot reach a card.

That deletes `HISTORY_TOOL_NAMES` entirely and removes one of the parallel tool vocabularies. The two that remain (the core allowlist and the server's `RendererToolName`) now at least speak the *same* vocabulary rather than needing a translation between them — #478 still covers generating them.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `tsc --noEmit`, `vitest run` (394 passed), production `vite build`.

Core tests assert an unrecognized name folds rather than travelling, and that every renderer-visible tool round-trips as itself — with the one private sandbox name deliberately renamed. The server test that checked for `"Use a tool"` now checks for `"other"`.
