### PR TITLE
refactor(desktop): finish or remove the half-built surface targeting

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatDeletion.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatDeletion.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Chat } from "./api";
-import { existingChatAfterDeletion, prependReplacementChat } from "./ChatDeletion";
+import { prependReplacementChat } from "./ChatDeletion";
 
 function chat(id: string, projectId: string | null): Chat {
   return {
@@ -16,21 +16,13 @@ function chat(id: string, projectId: string | null): Chat {
 }
 
 describe("chat deletion replacement", () => {
-  it("preserves loose scope without hiding project conversations", () => {
+  it("puts a new loose replacement ahead of the chats that remain", () => {
     const projectChat = chat("project-chat", "project-1");
     const refreshed = [projectChat];
-
-    expect(existingChatAfterDeletion(refreshed, null)).toBeUndefined();
-
     const replacement = chat("loose-replacement", null);
     expect(prependReplacementChat(refreshed, replacement)).toEqual([
       replacement,
       projectChat,
     ]);
-  });
-
-  it("leaves an emptied project by selecting another existing chat", () => {
-    const loose = chat("loose-chat", null);
-    expect(existingChatAfterDeletion([loose], "project-1")).toBe(loose);
   });
 });

--- a/crates/openwave-desktop/ui/src/ChatDeletion.ts
+++ b/crates/openwave-desktop/ui/src/ChatDeletion.ts
@@ -1,15 +1,5 @@
 import type { Chat } from "./api";
 
-/** Choose an existing post-delete selection without collapsing loose scope. */
-export function existingChatAfterDeletion(
-  chats: Chat[],
-  deletedProjectId: string | null,
-): Chat | undefined {
-  const sameScope = chats.find((chat) => chat.project_id === deletedProjectId);
-  if (sameScope) return sameScope;
-  return deletedProjectId === null ? undefined : chats[0];
-}
-
 /** Retain every refreshed chat when a new loose replacement is required. */
 export function prependReplacementChat(chats: Chat[], replacement: Chat): Chat[] {
   return [replacement, ...chats];

--- a/crates/openwave-desktop/ui/src/DeliverablesView.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.tsx
@@ -95,6 +95,11 @@ export function DeliverablesView({
     setError(null);
     setPreviewError(null);
     setExportStatus(null);
+    // The requested filename belongs to the conversation that asked for it. Its
+    // only other clear sits after the stale-generation bail, which a chat switch
+    // always takes — so without resetting here the next conversation opens on
+    // the file the previous one wanted.
+    pendingFilenameRef.current = initialFilename ?? null;
     void refresh(true);
     return () => {
       catalogGenerationRef.current += 1;
@@ -112,7 +117,10 @@ export function DeliverablesView({
     } else {
       pendingFilenameRef.current = initialFilename;
     }
-  }, [initialFilename]);
+    // `catalog` is read here, so it belongs in the dependencies: a target set
+    // before the list arrived has to re-resolve when it does, by any path and
+    // not only through an explicit refresh.
+  }, [initialFilename, catalog]);
 
   useEffect(() => {
     if (!selected) {

--- a/crates/openwave-desktop/ui/src/Surface.test.ts
+++ b/crates/openwave-desktop/ui/src/Surface.test.ts
@@ -1,23 +1,24 @@
 import { describe, expect, it } from "vitest";
-import {
-  CHAT_SURFACE,
-  isSurfaceKind,
-  normalizeSurface,
-  sameSurface,
-} from "./Surface";
+import { CHAT_SURFACE, normalizeSurface, sameSurface } from "./Surface";
 
 describe("normalizeSurface", () => {
   it("keeps a surface with no target", () => {
     expect(normalizeSurface({ kind: "folders" })).toEqual({ kind: "folders" });
   });
 
-  it("keeps an item and its anchor where both are accepted", () => {
-    expect(
-      normalizeSurface({ kind: "documents", itemId: "doc-1", anchor: "c-2" }),
-    ).toEqual({ kind: "documents", itemId: "doc-1", anchor: "c-2" });
+  it("keeps an item on the surface whose view resolves one", () => {
+    expect(normalizeSurface({ kind: "deliverables", itemId: "report.md" })).toEqual(
+      { kind: "deliverables", itemId: "report.md" },
+    );
   });
 
-  it("drops an anchor from a surface that only addresses items", () => {
+  it("drops a target no view can act on, and anything left over", () => {
+    // Sources takes only a conversation, so a target aimed at it opens the
+    // list rather than an empty pane.
+    expect(normalizeSurface({ kind: "documents", itemId: "doc-1" })).toEqual({
+      kind: "documents",
+    });
+    // A stored descriptor from an older build may still carry an anchor.
     expect(
       normalizeSurface({
         kind: "deliverables",
@@ -69,25 +70,34 @@ describe("normalizeSurface", () => {
   });
 
   it("survives a round trip through storage", () => {
-    const surface = { kind: "documents", itemId: "doc-1", anchor: "c-2" };
+    const surface = { kind: "deliverables", itemId: "notes.md" };
     expect(normalizeSurface(JSON.parse(JSON.stringify(surface)))).toEqual(
       surface,
     );
   });
 
   it("does not inherit object prototype keys as surfaces", () => {
-    expect(isSurfaceKind("toString")).toBe(false);
-    expect(isSurfaceKind("constructor")).toBe(false);
+    // A prototype key must not pass for a surface name, or a stored layout
+    // could name one that has no view.
+    for (const key of ["toString", "constructor", "__proto__"]) {
+      expect(normalizeSurface({ kind: key })).toEqual(CHAT_SURFACE);
+    }
   });
 });
 
 describe("sameSurface", () => {
   it("compares kind and target together", () => {
     expect(
-      sameSurface({ kind: "documents", itemId: "a" }, { kind: "documents", itemId: "a" }),
+      sameSurface(
+        { kind: "deliverables", itemId: "a" },
+        { kind: "deliverables", itemId: "a" },
+      ),
     ).toBe(true);
     expect(
-      sameSurface({ kind: "documents", itemId: "a" }, { kind: "documents", itemId: "b" }),
+      sameSurface(
+        { kind: "deliverables", itemId: "a" },
+        { kind: "deliverables", itemId: "b" },
+      ),
     ).toBe(false);
     expect(sameSurface({ kind: "documents" }, { kind: "folders" })).toBe(false);
   });

--- a/crates/openwave-desktop/ui/src/Surface.ts
+++ b/crates/openwave-desktop/ui/src/Surface.ts
@@ -1,9 +1,8 @@
 /**
  * Where the chat workspace is pointed.
  *
- * A surface name alone cannot express "open this source at this citation" or
- * "open this output", so the selection is a descriptor: a surface, optionally
- * an item owned by that surface, and optionally a position within that item.
+ * A surface name alone cannot express "open this output", so the selection is a
+ * descriptor: a surface plus, optionally, an item owned by that surface.
  * Identifiers are opaque and come from the API or the native catalog — never a
  * host path.
  */
@@ -17,54 +16,47 @@ export type SurfaceKind =
 export type Surface = {
   kind: SurfaceKind;
   itemId?: string;
-  anchor?: string;
 };
 
-type TargetSupport = { item: boolean; anchor: boolean };
-
 /**
- * What each surface can be pointed at. Surfaces gain targets as the views that
- * resolve them land, so this table is the single place that has to change.
+ * Which surfaces can be pointed at an item, and so which ones have a view that
+ * resolves one. A surface gains an entry when the view can act on it, not when
+ * the descriptor could carry it: a target nothing consumes reads as a feature
+ * and behaves as dead weight.
  */
-const SURFACE_TARGETS: Record<SurfaceKind, TargetSupport> = {
-  chat: { item: false, anchor: false },
-  documents: { item: true, anchor: true },
-  deliverables: { item: true, anchor: false },
-  folders: { item: false, anchor: false },
-  settings: { item: false, anchor: false },
+const SURFACE_TARGETS: Record<SurfaceKind, { item: boolean }> = {
+  chat: { item: false },
+  documents: { item: false },
+  deliverables: { item: true },
+  folders: { item: false },
+  settings: { item: false },
 };
 
 export const CHAT_SURFACE: Surface = { kind: "chat" };
 
-export function isSurfaceKind(value: unknown): value is SurfaceKind {
+function isSurfaceKind(value: unknown): value is SurfaceKind {
   return typeof value === "string" && Object.hasOwn(SURFACE_TARGETS, value);
 }
 
 /**
  * Reduce an arbitrary value — a caller's argument, or a descriptor restored
  * from storage — to one the workspace can render. An unrecognised surface
- * falls back to the transcript. A target the surface does not accept, or an
- * anchor with no item to anchor to, is dropped so the surface opens on its own
- * list instead of an empty pane.
+ * falls back to the transcript. A target the surface does not accept is
+ * dropped so it opens on its own list instead of an empty pane.
  */
 export function normalizeSurface(value: unknown): Surface {
   if (!isRecord(value) || !isSurfaceKind(value.kind)) return CHAT_SURFACE;
 
   const kind = value.kind;
-  const supports = SURFACE_TARGETS[kind];
-  const itemId = supports.item ? nonEmptyString(value.itemId) : null;
-  if (!itemId) return { kind };
-
-  const anchor = supports.anchor ? nonEmptyString(value.anchor) : null;
-  return anchor ? { kind, itemId, anchor } : { kind, itemId };
+  const itemId = SURFACE_TARGETS[kind].item
+    ? nonEmptyString(value.itemId)
+    : null;
+  return itemId ? { kind, itemId } : { kind };
 }
 
+/** Whether two descriptors point at the same thing. */
 export function sameSurface(left: Surface, right: Surface): boolean {
-  return (
-    left.kind === right.kind &&
-    left.itemId === right.itemId &&
-    left.anchor === right.anchor
-  );
+  return left.kind === right.kind && left.itemId === right.itemId;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/crates/openwave-desktop/ui/src/UiStore.test.ts
+++ b/crates/openwave-desktop/ui/src/UiStore.test.ts
@@ -22,40 +22,30 @@ describe("UiStore", () => {
     expect(store.getState().surface).toEqual({ kind: "chat" });
   });
 
-  it("carries a target into the surface that accepts it", () => {
+  it("carries a target into the one surface whose view resolves it", () => {
     const store = createUiStore();
-
-    store.getState().showDocuments({ documentId: "doc-1", citationId: "c-4" });
-    expect(store.getState().surface).toEqual({
-      kind: "documents",
-      itemId: "doc-1",
-      anchor: "c-4",
-    });
 
     store.getState().showDeliverables({ filename: "summary.md" });
     expect(store.getState().surface).toEqual({
       kind: "deliverables",
       itemId: "summary.md",
     });
-  });
 
-  it("drops a citation that has no source to anchor to", () => {
-    const store = createUiStore();
-    store.getState().showDocuments({ citationId: "c-4" });
+    // Sources has no target: the view takes only a conversation, so carrying
+    // one would read as a feature and behave as dead weight.
+    store.getState().showDocuments();
     expect(store.getState().surface).toEqual({ kind: "documents" });
   });
 
-  it("validates a descriptor opened directly", () => {
+  it("does not republish the surface already open", () => {
     const store = createUiStore();
+    store.getState().showDeliverables({ filename: "summary.md" });
+    const opened = store.getState().surface;
 
-    store.getState().openSurface({ kind: "deliverables", itemId: "notes.md" });
-    expect(store.getState().surface).toEqual({
-      kind: "deliverables",
-      itemId: "notes.md",
-    });
-
-    store.getState().openSurface({ kind: "nope" } as never);
-    expect(store.getState().surface).toEqual({ kind: "chat" });
+    store.getState().showDeliverables({ filename: "summary.md" });
+    // Same identity, not merely equal: a fresh descriptor would re-render every
+    // subscriber for a navigation that did not happen.
+    expect(store.getState().surface).toBe(opened);
   });
 });
 

--- a/crates/openwave-desktop/ui/src/UiStore.ts
+++ b/crates/openwave-desktop/ui/src/UiStore.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
-import { CHAT_SURFACE, normalizeSurface, type Surface } from "./Surface";
+import {
+  CHAT_SURFACE,
+  normalizeSurface,
+  sameSurface,
+  type Surface,
+} from "./Surface";
 import {
   EMPTY_LAYOUTS,
   WORKSPACE_LAYOUT_KEY,
@@ -56,12 +61,8 @@ export type UiStore = {
   surface: Surface;
   expanded: boolean;
   fraction: number;
-  openSurface: (surface: Surface) => void;
   showChat: () => void;
-  showDocuments: (target?: {
-    documentId?: string;
-    citationId?: string;
-  }) => void;
+  showDocuments: () => void;
   showDeliverables: (target?: { filename?: string }) => void;
   showFolders: () => void;
   showSettings: () => void;
@@ -91,6 +92,12 @@ export function createUiStore() {
       const next = normalizeSurface(surface);
       const nextExpanded = next.kind === "chat" ? false : expanded;
       remember(next, nextExpanded);
+      // Re-selecting the surface already open would otherwise publish a fresh
+      // descriptor object and re-render every subscriber for no change.
+      const current = get();
+      if (sameSurface(current.surface, next) && current.expanded === nextExpanded) {
+        return;
+      }
       set({ surface: next, expanded: nextExpanded });
     }
 
@@ -98,14 +105,8 @@ export function createUiStore() {
       surface: CHAT_SURFACE,
       expanded: false,
       fraction: layouts.fraction,
-      openSurface: (surface) => go(surface),
       showChat: () => go(CHAT_SURFACE),
-      showDocuments: (target) =>
-        go({
-          kind: "documents",
-          itemId: target?.documentId,
-          anchor: target?.citationId,
-        }),
+      showDocuments: () => go({ kind: "documents" }),
       showDeliverables: (target) =>
         go({ kind: "deliverables", itemId: target?.filename }),
       showFolders: () => go({ kind: "folders" }),


### PR DESCRIPTION
Closes #511.

The workspace refactor (#453/#455/#466) built a way to open a surface *pointed at something* and wired up only part of it. The issue said wire it or remove it — this does both, per surface, according to whether a view can actually act on the target.

## Removed, because nothing could consume it

- **Sources' target.** It declared `item: true, anchor: true`; `DocumentsView` takes a conversation and nothing else, and no caller ever passed one. The `anchor` concept goes with it — a stored descriptor carrying one is still normalized away, so older layouts stay loadable.
- **`openSurface`** and **`existingChatAfterDeletion`** — reachable only from their own tests. (`prependReplacementChat` beside the latter *is* live and stays.)
- The `isSurfaceKind` export, used only inside its own module.

## Kept and finished

Outputs is the one surface whose view resolves a target, so it keeps it — and the two latent defects behind that path are fixed. Both would have gone live the moment a caller passed a filename:

1. **The requested filename was not reset on a chat change**, and its only clear sits *after* the stale-generation bail that a chat switch always takes. `DeliverablesView` is not keyed, so the next conversation would have opened on the file the previous one asked for.
2. **The effect resolving the target read `catalog` but depended only on `initialFilename`**, so a target set before the list arrived never re-resolved except through an explicit refresh.

## `sameSurface` was the bug it would have prevented

It was written for this and never called. Meanwhile `UiStore.go()` always published a freshly allocated descriptor, so re-selecting the surface already open re-rendered every subscriber for a navigation that did not happen. It now decides whether to publish at all, and a test asserts the surface keeps its *identity* rather than merely being equal.

## Verification

`tsc --noEmit`, `vitest run` (392 passed, 54 files), production `vite build`. No Rust changes.
