### PR TITLE
fix(agent): record why a tool call failed, not just that it did

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -59,7 +59,9 @@ use crate::storage::{
     ApplyTurnSteerOutcome, BlobStore, JournaledTurnSteerOutcome, ResolveToolCallOutcome, Store,
     TurnLeaseFence,
 };
-use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
+use crate::tool::{
+    ApprovalClass, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolScratch, ToolSpec,
+};
 
 /// A name-keyed registry of the tools available to the agent.
 #[derive(Clone, Default)]
@@ -1645,6 +1647,10 @@ impl Agent {
                                 content,
                                 data: None,
                                 is_error: existing.status != ToolCallStatus::Completed,
+                                // Recovered from a durable row, whose category
+                                // is already recorded there; re-deriving one
+                                // here would be a guess.
+                                error_category: None,
                                 private_evidence: Vec::new(),
                             },
                         );
@@ -1766,7 +1772,10 @@ impl Agent {
                 let (output, needs_resolution) = match recovered_results.remove(&call.call_id) {
                     Some(output) => (output, false),
                     None if self.cancel.is_cancelled() => (
-                        ToolOutput::error("turn cancelled before tool execution"),
+                        ToolOutput::failed(
+                            ToolErrorCategory::UserCancelled,
+                            "turn cancelled before tool execution",
+                        ),
                         true,
                     ),
                     None => {
@@ -1784,7 +1793,11 @@ impl Agent {
                     let resolution = if output.is_error {
                         ToolCallResolution::Failed {
                             result: output.content.clone(),
-                            error_code: "tool_error".into(),
+                            error_code: output
+                                .error_category
+                                .unwrap_or(ToolErrorCategory::ToolFailed)
+                                .as_str()
+                                .into(),
                             error_detail: None,
                         }
                     } else {
@@ -2251,7 +2264,10 @@ impl Agent {
         durable_approval: Option<&crate::approval::ToolApproval>,
     ) -> ToolOutput {
         let Some(tool) = self.tools.get(&call.name) else {
-            return ToolOutput::error(format!("unknown tool: {}", call.name));
+            return ToolOutput::failed(
+                ToolErrorCategory::NotFound,
+                format!("unknown tool: {}", call.name),
+            );
         };
         // Policy: ReadOnly/Workspace auto; uncovered Sensitive calls park on the
         // approval gate.
@@ -2324,7 +2340,10 @@ impl Agent {
             let registration = match future::select(registering, self.cancel.cancelled()).await {
                 Either::Left((registration, _)) if !self.cancel.is_cancelled() => registration,
                 Either::Left(_) | Either::Right(((), _)) => {
-                    return ToolOutput::error("turn cancelled while registering approval");
+                    return ToolOutput::failed(
+                        ToolErrorCategory::UserCancelled,
+                        "turn cancelled while registering approval",
+                    );
                 }
             };
             let required = AgentEvent::ApprovalRequired {
@@ -2378,7 +2397,10 @@ impl Agent {
                         call_id: call.call_id,
                         approved: false,
                     });
-                    return ToolOutput::error("turn cancelled while awaiting approval");
+                    return ToolOutput::failed(
+                        ToolErrorCategory::UserCancelled,
+                        "turn cancelled while awaiting approval",
+                    );
                 }
             };
             let approved = matches!(decision, ApprovalDecision::Approve);
@@ -2387,12 +2409,15 @@ impl Agent {
                 approved,
             });
             if let ApprovalDecision::Reject { reason } = decision {
-                return ToolOutput::error(reason);
+                return ToolOutput::failed(ToolErrorCategory::UserDeclined, reason);
             }
             // A cancel that lands after Approve won `select` but before execute
             // (concurrent trip of the token) must not run the Sensitive tool.
             if self.cancel.is_cancelled() {
-                return ToolOutput::error("turn cancelled while awaiting approval");
+                return ToolOutput::failed(
+                    ToolErrorCategory::UserCancelled,
+                    "turn cancelled while awaiting approval",
+                );
             }
         }
         // Cancellation can land after the caller's loop-level fence or while a
@@ -2400,7 +2425,10 @@ impl Agent {
         // before any ReadOnly, Workspace, or approved Sensitive implementation
         // can observe arguments or perform a side effect.
         if self.cancel.is_cancelled() {
-            return ToolOutput::error("turn cancelled before tool execution");
+            return ToolOutput::failed(
+                ToolErrorCategory::UserCancelled,
+                "turn cancelled before tool execution",
+            );
         }
         let ctx = self
             .config
@@ -2417,10 +2445,14 @@ impl Agent {
         // Recheck after the execution arm wins to close a same-tick race.
         let executing = tool.execute(&ctx, parse_args(&call.args));
         let mut output = match future::select(self.cancel.cancelled(), executing).await {
-            Either::Left(((), _)) => ToolOutput::error("turn cancelled during tool execution"),
-            Either::Right((_, _)) if self.cancel.is_cancelled() => {
-                ToolOutput::error("turn cancelled during tool execution")
-            }
+            Either::Left(((), _)) => ToolOutput::failed(
+                ToolErrorCategory::UserCancelled,
+                "turn cancelled during tool execution",
+            ),
+            Either::Right((_, _)) if self.cancel.is_cancelled() => ToolOutput::failed(
+                ToolErrorCategory::UserCancelled,
+                "turn cancelled during tool execution",
+            ),
             Either::Right((result, _)) => match result {
                 Ok(output) => output,
                 Err(err) => ToolOutput::error(err.to_string()),
@@ -2546,7 +2578,10 @@ impl Agent {
             let tool_available = self.tools.get(&call.name).is_some();
             let cancelled_before_run = self.cancel.is_cancelled();
             let output = if cancelled_before_run {
-                ToolOutput::error("turn cancelled before recovered tool execution")
+                ToolOutput::failed(
+                    ToolErrorCategory::UserCancelled,
+                    "turn cancelled before recovered tool execution",
+                )
             } else {
                 self.run_tool(chat, turn_id, &call, events, durable_approval.as_ref())
                     .await
@@ -2554,7 +2589,11 @@ impl Agent {
             let resolution = if output.is_error {
                 ToolCallResolution::Failed {
                     result: output.content.clone(),
-                    error_code: "tool_error".into(),
+                    error_code: output
+                        .error_category
+                        .unwrap_or(ToolErrorCategory::ToolFailed)
+                        .as_str()
+                        .into(),
                     error_detail: None,
                 }
             } else {

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -159,7 +159,9 @@ pub use storage::{
     ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, SecretProvider, Store,
     SubmitAgentRunResultOutcome, TurnLeaseFence, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
-pub use tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolScratch, ToolSpec};
+pub use tool::{
+    ApprovalClass, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolScratch, ToolSpec,
+};
 #[cfg(feature = "tools")]
 pub use tools::{CreateDeliverable, ListDir, ReadFile, WriteFile};
 pub use user_questions::{

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -97,6 +97,50 @@ pub struct ToolSpec {
 /// `content` is the model-readable result folded back into the conversation;
 /// `data` is an optional structured payload for clients that can render it
 /// (e.g. a tool-call card). A failing tool returns `is_error = true` rather than
+/// Why a tool call failed.
+///
+/// A boolean says something went wrong; a category says whether anything *is*
+/// wrong. A call the reader cancelled and a call the reader declined are not
+/// failures of the tool, of the model, or of the product, and recording them
+/// the same way as a crash makes every later question about reliability
+/// unanswerable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ToolErrorCategory {
+    /// The reader stopped the turn before or during the call.
+    UserCancelled,
+    /// The reader declined the call at the approval gate.
+    UserDeclined,
+    /// The model named a tool this turn does not advertise.
+    NotFound,
+    /// The tool ran and reported a failure of its own.
+    ToolFailed,
+}
+
+impl ToolErrorCategory {
+    /// Stable durable and wire representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UserCancelled => "user_cancelled",
+            Self::UserDeclined => "user_declined",
+            Self::NotFound => "not_found",
+            Self::ToolFailed => "tool_failed",
+        }
+    }
+
+    /// Whether this counts against the product rather than describing a choice
+    /// the reader made or a request the model got wrong.
+    #[must_use]
+    pub const fn is_product_failure(self) -> bool {
+        match self {
+            Self::UserCancelled | Self::UserDeclined | Self::NotFound => false,
+            Self::ToolFailed => true,
+        }
+    }
+}
+
 /// an `Err` so the model sees the failure and can adapt.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ToolOutput {
@@ -108,6 +152,9 @@ pub struct ToolOutput {
     /// Whether the tool reported a failure.
     #[serde(default)]
     pub is_error: bool,
+    /// Why it failed, when it did. `None` on success.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_category: Option<ToolErrorCategory>,
     /// Server-private durable sidecar committed with the canonical tool result.
     #[serde(skip)]
     pub private_evidence: Vec<crate::RetrievalEvidenceInput>,
@@ -120,16 +167,27 @@ impl ToolOutput {
             content: content.into(),
             data: None,
             is_error: false,
+            error_category: None,
             private_evidence: Vec::new(),
         }
     }
 
     /// A failure the model should see and react to.
+    ///
+    /// Categorized as the tool's own failure. Callers that know better — the
+    /// loop, which is the only thing that can tell a cancellation from a
+    /// crash — use [`Self::failed`].
     pub fn error(content: impl Into<String>) -> Self {
+        Self::failed(ToolErrorCategory::ToolFailed, content)
+    }
+
+    /// A failure whose cause the caller can name.
+    pub fn failed(category: ToolErrorCategory, content: impl Into<String>) -> Self {
         Self {
             content: content.into(),
             data: None,
             is_error: true,
+            error_category: Some(category),
             private_evidence: Vec::new(),
         }
     }
@@ -299,6 +357,56 @@ pub trait Tool: Send + Sync {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_reader_choice_is_not_recorded_as_a_product_failure() {
+        // The distinction this exists for: a cancelled or declined call is a
+        // choice, not a defect, and counting it as one makes any later question
+        // about reliability unanswerable.
+        for category in [
+            ToolErrorCategory::UserCancelled,
+            ToolErrorCategory::UserDeclined,
+            ToolErrorCategory::NotFound,
+        ] {
+            assert!(!category.is_product_failure(), "{}", category.as_str());
+        }
+        assert!(ToolErrorCategory::ToolFailed.is_product_failure());
+
+        // Every category has a distinct durable spelling.
+        let spellings = [
+            ToolErrorCategory::UserCancelled,
+            ToolErrorCategory::UserDeclined,
+            ToolErrorCategory::NotFound,
+            ToolErrorCategory::ToolFailed,
+        ]
+        .map(ToolErrorCategory::as_str);
+        assert_eq!(
+            spellings.len(),
+            spellings
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len()
+        );
+    }
+
+    #[test]
+    fn an_uncategorized_failure_reads_as_the_tool_failing() {
+        // `error` is what an ordinary tool calls, and a tool reporting a failure
+        // is exactly the tool failing. Only the loop can distinguish more.
+        let plain = ToolOutput::error("boom");
+        assert!(plain.is_error);
+        assert_eq!(plain.error_category, Some(ToolErrorCategory::ToolFailed));
+
+        let cancelled = ToolOutput::failed(ToolErrorCategory::UserCancelled, "stopped");
+        assert_eq!(
+            cancelled.error_category,
+            Some(ToolErrorCategory::UserCancelled)
+        );
+
+        // Success carries no category at all rather than a benign-looking one.
+        assert_eq!(ToolOutput::text("fine").error_category, None);
+        assert!(!ToolOutput::text("fine").is_error);
+    }
+
     use super::*;
 
     #[test]

--- a/crates/openwave-mcp/src/client.rs
+++ b/crates/openwave-mcp/src/client.rs
@@ -678,6 +678,11 @@ impl Tool for McpTool {
             content,
             data: result.structured_content,
             is_error: result.is_error,
+            // The external server reports that it failed, not why in terms this
+            // side can classify, so it is the tool's own failure.
+            error_category: result
+                .is_error
+                .then_some(openwave_core::ToolErrorCategory::ToolFailed),
             private_evidence: Vec::new(),
         })
     }


### PR DESCRIPTION
Closes #501.

Every server-tool failure was stored with a hardcoded `error_code: "tool_error"`, and `ToolOutput` distinguished success from failure with a single `is_error: bool`.

So four quite different outcomes were indistinguishable in durable state:

- the reader cancelled the turn
- the reader **declined** the call at the approval gate
- the model named a tool the turn does not advertise
- a tool genuinely broke

The `error_code` and `error_detail` columns existed and carried no information.

## What changed

The loop already knows which of those it produced — it just threw the distinction away. Failures now carry a `ToolErrorCategory`, and the loop names the ones it creates: cancellation at each of the six points it can land, declination at the gate, and an unknown tool.

The categories also answer which outcomes are **not** product failures:

```rust
Self::UserCancelled | Self::UserDeclined | Self::NotFound => false,
Self::ToolFailed => true,
```

A reader stopping a turn or declining a command is a choice, not a defect. Counting it as one makes any later question about reliability unanswerable — which is the reason the reference implementation carries this distinction too.

## What did not change

- **No tool had to be touched.** `ToolOutput::error` keeps its meaning: a tool reporting a failure *is* the tool failing. Callers that know better use `ToolOutput::failed(category, …)`, and the loop is the only thing that can tell a cancellation from a crash.
- **A recovered result carries no category** rather than a re-derived guess, because the durable row it came from already holds the real one.
- Success carries `None`, not a benign-looking category.

This is the classification half of #501. Retryable-vs-terminal routing — re-raising a transient provider error instead of persisting it as a tool failure — is the other half and is not here; it needs a decision about which errors the turn worker should retry.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`. Tests cover the product-failure split, distinct durable spellings, and that an uncategorized failure reads as the tool failing.
