### PR TITLE
feat(desktop): show the query a search is asking permission to send

### DIFF
--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -40,6 +40,12 @@ pub enum ToolActionPreview {
         /// host path.
         cwd: String,
     },
+    /// A search of this conversation's own sources. The query is the whole
+    /// action, and it is what the excerpts returned will be chosen to match.
+    Search { query: String },
+    /// A public web search. The query leaves the device, which is the entire
+    /// reason this call asks first — so the card has to be able to show it.
+    WebSearch { query: String },
 }
 
 impl ToolActionPreview {
@@ -75,6 +81,16 @@ impl ToolActionPreview {
                     .unwrap_or_else(|| ".".into());
                 Some(Self::Exec { command, args, cwd })
             }
+            // Approving a search without seeing its query is not consent to
+            // anything in particular, and for `web_search` that query is the
+            // thing that leaves the machine. Trimmed, because the tool trims
+            // before searching and a card should show what actually goes out.
+            "search" => Some(Self::Search {
+                query: search_query(arguments)?,
+            }),
+            "web_search" => Some(Self::WebSearch {
+                query: search_query(arguments)?,
+            }),
             _ => None,
         }
     }
@@ -127,6 +143,9 @@ impl ToolActionPreview {
                     Some(_) => false,
                 }
             }
+            // Only `exec` has a scope narrower than the whole tool, so no
+            // other action needs to be exactly describable — and claiming it
+            // was would invite a narrow grant with nothing to narrow to.
             _ => false,
         }
     }
@@ -210,6 +229,14 @@ fn stream(value: Option<&Value>) -> String {
 
 /// Bound one single-line preview field, dropping control characters that could
 /// forge card structure. An empty or all-control field is not presentable.
+/// The query a search will actually run, as the card should show it.
+fn search_query(arguments: &Value) -> Option<String> {
+    clamp(
+        arguments.get("query")?.as_str()?.trim(),
+        MAX_ACTION_FIELD_CHARS,
+    )
+}
+
 /// Whether [`clamp`] would return this string unchanged.
 ///
 /// Deliberately mirrors `clamp`'s three lossy steps rather than calling it and
@@ -233,7 +260,67 @@ fn clamp(value: &str, max_chars: usize) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_search_shows_the_query_it_is_asking_permission_for() {
+        // Approving `web_search` used to show nothing about the query, which is
+        // the one thing that actually leaves the machine.
+        assert_eq!(
+            ToolActionPreview::build("web_search", &json!({ "query": "quarterly filings" })),
+            Some(ToolActionPreview::WebSearch {
+                query: "quarterly filings".into()
+            })
+        );
+        assert_eq!(
+            ToolActionPreview::build("search", &json!({ "query": "revenue" })),
+            Some(ToolActionPreview::Search {
+                query: "revenue".into()
+            })
+        );
+        // Trimmed, because the tool trims before searching.
+        assert_eq!(
+            ToolActionPreview::build("web_search", &json!({ "query": "  spaced  " })),
+            Some(ToolActionPreview::WebSearch {
+                query: "spaced".into()
+            })
+        );
+        // Extra arguments are not part of the action under review.
+        assert_eq!(
+            ToolActionPreview::build("search", &json!({ "query": "revenue", "k": 8 })),
+            Some(ToolActionPreview::Search {
+                query: "revenue".into()
+            })
+        );
+        // A query the card cannot show is no preview at all, rather than a card
+        // that describes an empty search.
+        for arguments in [
+            json!({}),
+            json!({ "query": "" }),
+            json!({ "query": "   " }),
+            json!({ "query": 3 }),
+        ] {
+            assert_eq!(ToolActionPreview::build("search", &arguments), None);
+        }
+    }
+
+    #[test]
+    fn only_a_command_is_exactly_describable() {
+        // `exec` is the only action with a scope narrower than the whole tool,
+        // so it is the only one that may claim exactness. A search claiming it
+        // would invite a narrow grant with nothing to narrow to.
+        assert!(ToolActionPreview::describes_exactly(
+            "exec",
+            &json!({ "command": "cargo", "args": ["test"] })
+        ));
+        for tool in ["search", "web_search"] {
+            assert!(!ToolActionPreview::describes_exactly(
+                tool,
+                &json!({ "query": "anything" })
+            ));
+        }
+    }
+
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn exec_action_carries_the_argument_vector_and_defaults_its_directory() {
@@ -253,8 +340,6 @@ mod tests {
     #[test]
     fn only_tools_with_a_variant_project_anything() {
         for (tool, arguments) in [
-            ("search", serde_json::json!({ "query": "private" })),
-            ("web_search", serde_json::json!({ "query": "private" })),
             (
                 "write_file",
                 serde_json::json!({ "path": "/Users/private" }),
@@ -262,6 +347,15 @@ mod tests {
             ("mcp__server__tool", serde_json::json!({ "any": "thing" })),
         ] {
             assert_eq!(ToolActionPreview::build(tool, &arguments), None);
+            assert_eq!(ToolResultPreview::build(tool, Some(&arguments)), None);
+        }
+
+        // The searches project an *action* so their query can be reviewed, and
+        // deliberately no *result*: what a search returned is the answer the
+        // model works from, not something the transcript restates.
+        for tool in ["search", "web_search"] {
+            let arguments = serde_json::json!({ "query": "private" });
+            assert!(ToolActionPreview::build(tool, &arguments).is_some());
             assert_eq!(ToolResultPreview::build(tool, Some(&arguments)), None);
         }
     }

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -333,6 +333,11 @@ function surfacedCards(
     if (entry.role !== "tool") continue;
     // The approval card already shows this command and owns the decision.
     if (!entry.preview || parked.has(entry.callId)) continue;
+    // A card earns its place by carrying something the rail cannot: a command
+    // and its output. A search's query is fully said by the rail line and by
+    // the approval card that asked about it, so it does not get an
+    // exec-shaped card with tabs and an exit code.
+    if (entry.preview.tool !== "exec") continue;
     cards.push(
       <ToolCommandCard
         key={entry.id}

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -22,8 +22,14 @@ export type ToolCallStatus =
 type ToolCommandCardProps = {
   name: string;
   status: ToolCallStatus;
-  /** The tool's own view of the command, which is what the card is for. */
-  preview: ToolActionPreview;
+  /**
+   * The tool's own view of the command, which is what the card is for.
+   *
+   * Narrowed to `exec`: this card has tabs and an exit code, which describe a
+   * command and nothing else. A tool whose action is fully said by one line
+   * belongs in the rail, not here.
+   */
+  preview: Extract<ToolActionPreview, { tool: "exec" }>;
   /** What the command produced, once it has produced anything. */
   result: ToolResultPreview | null;
 };

--- a/crates/openwave-desktop/ui/src/ToolPreview.test.ts
+++ b/crates/openwave-desktop/ui/src/ToolPreview.test.ts
@@ -41,3 +41,22 @@ describe("toolPreviewPresentation", () => {
     ).toBe(`python3 -c 'print('\\''two words'\\'')' '' 'a;rm -rf /'`);
   });
 });
+
+describe("search previews", () => {
+  it("makes the query the headline and says where it goes", () => {
+    // The consent question for a web search is "what leaves this machine",
+    // and the answer is the query.
+    const web = toolPreviewPresentation({
+      tool: "web_search",
+      query: "quarterly filings",
+    });
+    expect(web.headline).toBe("quarterly filings");
+    expect(web.detail).toContain("web search provider");
+
+    const local = toolPreviewPresentation({ tool: "search", query: "revenue" });
+    expect(local.headline).toBe("revenue");
+    // A local search shares nothing outward, and the copy must not imply it does.
+    expect(local.detail).not.toContain("provider");
+    expect(local.detail).toContain("this conversation's sources");
+  });
+});

--- a/crates/openwave-desktop/ui/src/ToolPreview.tsx
+++ b/crates/openwave-desktop/ui/src/ToolPreview.tsx
@@ -18,6 +18,16 @@ export function toolPreviewPresentation(
   preview: ToolActionPreview,
   result: ToolResultPreview | null = null,
 ): ToolPreviewPresentation {
+  if (preview.tool === "search" || preview.tool === "web_search") {
+    // The query is the whole action. For a web search it is also the thing
+    // that leaves the device, which is what the reader is being asked about.
+    const headline = preview.query;
+    const detail =
+      preview.tool === "web_search"
+        ? `${headline}\n# sent to the configured web search provider`
+        : `${headline}\n# searched against this conversation's sources`;
+    return { headline, detail };
+  }
   const headline = [preview.command, ...preview.args]
     .map(quoteArgument)
     .join(" ");

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -297,12 +297,17 @@ export type RendererToolName =
  * about to do, because consent to an action you cannot see is not consent, and
  * because a result is unreadable without knowing what produced it.
  */
-export type ToolActionPreview = {
-  tool: "exec";
-  command: string;
-  args: string[];
-  cwd: string;
-};
+export type ToolActionPreview =
+  | {
+      tool: "exec";
+      command: string;
+      args: string[];
+      cwd: string;
+    }
+  /** A search of this conversation's own sources. */
+  | { tool: "search"; query: string }
+  /** A public web search, whose query leaves the device. */
+  | { tool: "web_search"; query: string };
 
 /**
  * What a call produced.
@@ -1038,7 +1043,13 @@ export function parseToolActionPreview(
   value: unknown,
 ): ToolActionPreview | null {
   if (value === undefined || value === null) return null;
-  if (!isRecord(value) || value.tool !== "exec") return null;
+  if (!isRecord(value)) return null;
+  if (value.tool === "search" || value.tool === "web_search") {
+    const { query } = value;
+    if (typeof query !== "string" || query.length === 0) return null;
+    return { tool: value.tool, query };
+  }
+  if (value.tool !== "exec") return null;
   const { command, args, cwd } = value;
   if (
     typeof command !== "string" ||

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -403,12 +403,15 @@ mod tests {
                 output: ToolOutput::text("private result").with_data(serde_json::json!({
                     "stdout": "private stream",
                 })),
+                // `write_file` projects neither an action nor a result, so
+                // nothing about it may cross — not the output text, and not
+                // the structured payload beside it.
                 action: ToolActionPreview::build(
-                    "web_search",
-                    &serde_json::json!({ "query": "private query" }),
+                    "write_file",
+                    &serde_json::json!({ "path": "private/path" }),
                 ),
                 result: ToolResultPreview::build(
-                    "web_search",
+                    "write_file",
                     Some(&serde_json::json!({ "stdout": "private stream" })),
                 ),
             },
@@ -425,19 +428,47 @@ mod tests {
             seq: 11,
             event: AgentEvent::ApprovalRequired {
                 call_id: CallId::new(),
+                tool_name: "write_file".into(),
+                class: ApprovalClass::Workspace,
+                kind: ToolApprovalKind::Unsupported,
+                // A tool with no variant projects nothing, so the card has no
+                // action to show and the summary is all that crosses.
+                preview: ToolActionPreview::build(
+                    "write_file",
+                    &serde_json::json!({ "path": "private/path" }),
+                ),
+                summary: "a write".into(),
+            },
+        });
+        let json = serde_json::to_string(&projected).unwrap();
+        assert!(!json.contains("preview"));
+        assert!(!json.contains("private"));
+    }
+
+    /// Consent to an action you cannot see is not consent, and for a web search
+    /// the action *is* the query — it is the thing that leaves the device. So
+    /// this one has to cross, while everything else about the call still does
+    /// not.
+    #[test]
+    fn a_web_search_approval_carries_the_query_being_shared() {
+        let projected = RendererSequencedEvent::from(&SequencedEvent {
+            seq: 11,
+            event: AgentEvent::ApprovalRequired {
+                call_id: CallId::new(),
                 tool_name: "web_search".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::WebSearchMayShareQuery,
                 preview: ToolActionPreview::build(
                     "web_search",
-                    &serde_json::json!({ "query": "private query" }),
+                    &serde_json::json!({ "query": "quarterly filings", "max_results": 5 }),
                 ),
-                summary: "private query".into(),
+                summary: "a web search".into(),
             },
         });
         let json = serde_json::to_string(&projected).unwrap();
-        assert!(!json.contains("preview"));
-        assert!(!json.contains("private query"));
+        assert!(json.contains("quarterly filings"), "{json}");
+        // Only the query. The other arguments are not what consent is about.
+        assert!(!json.contains("max_results"), "{json}");
     }
 
     #[test]

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -12063,11 +12063,14 @@ async fn foreground_web_search_runs_end_to_end_through_durable_approval() {
     assert_eq!(pending[0]["class"], "sensitive");
     assert_eq!(pending[0]["can_approve"], true);
     assert_eq!(pending[0]["can_remember"], true);
-    // Web search consents to an egress class, not to an inspectable action, so
-    // recovery carries no preview of the query.
-    assert!(pending[0].get("preview").is_none());
+    // Web search consents to sending a query off the device, so recovery has to
+    // carry that query — a card asking about a search it cannot show is asking
+    // about nothing in particular.
+    assert_eq!(pending[0]["preview"]["tool"], "web_search");
+    assert_eq!(pending[0]["preview"]["query"], "OpenWave release");
     let pending_json = pending.to_string();
-    assert!(!pending_json.contains("OpenWave release"));
+    // What came *back* is still private: the query is the action under review,
+    // the results are the answer the model works from.
     assert!(!pending_json.contains("Example.com"));
 
     let decide = router


### PR DESCRIPTION
Part of #506.

## The consent gap

Approving a web search showed `web_search requires approval` and nothing else. The **query** — the one thing that actually leaves the device, and the entire reason the call asks first — was not on the card.

That contradicts the stated reason previews exist: *"Approval cards need this because consent to an action you cannot see is not consent."* `exec` was the only action that had one.

## What changed

Both searches project their query, trimmed the way the tools trim before searching, so the card shows what actually goes out. A local search says it searched this conversation's sources; a web search names the provider it was sent to.

## What I deliberately did not widen

- **No result preview.** What a search returned is the answer the model works from, not something the transcript should restate.
- **Only the query.** `max_results`, `k`, and `domains` are not what consent is about — a test asserts `max_results` does not cross.
- **Neither is exactly describable.** `exec` is the only action with a scope narrower than the whole tool, so claiming exactness for a search would invite a narrow grant with nothing to narrow to. This matters because of #508: a projection may describe an action, but must never decide authority over one.
- **The command card stays exec-only**, and its prop type is now `Extract<ToolActionPreview, { tool: "exec" }>` so the type system enforces that rather than a comment. A search's query is fully said by one line, and that line belongs in the rail — routing it into a card with Command/Output tabs and an exit code would be worse than the rail.

## A note on the tests I changed

Two projection tests asserted that a `web_search` approval carries **no** preview — they were using it as their example of a tool that projects nothing, which is exactly the absence this fixes. They now use `write_file`, which genuinely projects nothing, so the closed-boundary invariant keeps its coverage. A new test asserts the positive case.

The integration test's comment claimed "web search consents to an egress class, not to an inspectable action". That framing is what produced the gap, so it is now the opposite assertion — with the results still verified private.

## Remaining in #506

The grant-ladder half. Non-exec Sensitive tools still only offer `WholeTool`, which for a search is arguably correct — a per-query grant is close to useless. Worth deciding rather than assuming, so the issue stays open.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `tsc --noEmit`, `vitest run` (394 passed), production `vite build`.
