### PR TITLE
fix(desktop): key a tool row on its call, not its position

### DIFF
--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.test.tsx
@@ -144,3 +144,34 @@ describe("ToolActivityGroup", () => {
     expect(markup).not.toContain("private");
   });
 });
+
+describe("row identity", () => {
+  it("carries a call id through without disturbing the phase label", () => {
+    // Rows are keyed on the call rather than its position, so a filtered or
+    // reordered phase cannot re-associate React state with the wrong call.
+    // Phases *are* filtered — a parked call is handled by its approval card —
+    // so the index was never a stable key.
+    const withIds = renderToStaticMarkup(
+      <ToolActivityGroup
+        activities={[
+          { id: "call-a", name: "exec", status: "completed" },
+          { id: "call-b", name: "search", status: "running" },
+        ]}
+        groupIndex={0}
+      />,
+    );
+    const withoutIds = renderToStaticMarkup(
+      <ToolActivityGroup
+        activities={[
+          { name: "exec", status: "completed" },
+          { name: "search", status: "running" },
+        ]}
+        groupIndex={0}
+      />,
+    );
+    // Identity is structural: it changes which row owns which state, not what
+    // the phase says. A row with nothing stable still falls back to position.
+    expect(withIds).toBe(withoutIds);
+    expect(withIds).toContain("Searching sources and 1 other task");
+  });
+});

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
@@ -7,6 +7,14 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export type ToolActivity = {
+  /**
+   * Stable identity for this row.
+   *
+   * Rows were keyed by array index, so filtering or reordering a phase
+   * re-associated React state with the wrong call. Callers pass a transcript
+   * entry id; a row that arrives without one falls back to its position, which
+   * is no worse than before and no better.
+   */
   id?: string;
   name: string;
   status: ToolCallStatus;
@@ -99,7 +107,11 @@ export function ToolActivityGroup({
               activity.status,
             );
             return (
-              <div className="grid gap-1" role="listitem" key={index}>
+              <div
+                className="grid gap-1"
+                role="listitem"
+                key={activity.id ?? `position:${index}`}
+              >
                 <div className="flex items-center gap-1.5 font-medium">
                   {/* Pinned onto the rail, knocking out the border behind it,
                       so the row reads as a stop on the timeline rather than a
@@ -287,6 +299,10 @@ function normalizeActivities(activities: unknown): ToolActivity[] {
     }
     return [
       {
+        // Carried through rather than dropped: it is what keys the row.
+        ...(typeof candidate.id === "string" && candidate.id.length > 0
+          ? { id: candidate.id }
+          : {}),
         name: candidate.name,
         status: candidate.status as ToolCallStatus,
       },


### PR DESCRIPTION
Part of #502 — the concrete keying bug, not the subjective polish.

`ToolActivity` declared an `id`, `normalizeActivities` dropped it, and rows were rendered with `key={index}`.

Phases **are** filtered — a parked call is handled by its approval card rather than by the rail — so the index was never a stable key, and a filtered or reordered phase re-associated React state with the wrong call. `MessageList` was already passing entries that carry a stable id; the normalizer just threw it away.

The id now survives normalization and keys the row. A row arriving without one falls back to its position: no worse than before, no better.

## Being straight about the test

Keying changes *which row owns which state*, not what the phase renders — and the group is collapsed by default, so individual rows aren't in its markup at all. My first attempt at a test asserted row titles appear, which they don't.

So the test asserts what is actually observable: carrying ids leaves the rendering byte-identical, and the phase label is unchanged. The correctness of the keys themselves is structural, and I'd rather say that than dress up a test that doesn't prove it.

## Not in this PR

The rest of #502 — placeholder rows for detected-but-unstarted calls, a latched typewriter, and a settled-vs-live distinction in the group label — is presentation work with real taste decisions in it. The issue stays open for that.

## Verification

`tsc --noEmit`, `vitest run` (392 passed), production `vite build`. No Rust changes.
