### PR TITLE
fix(desktop): agree with the server on what an unset display name looks like

### DIFF
--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -26,7 +26,8 @@ export type ProviderInfo = {
 
 export type CustomModelConfig = {
   id: string;
-  display_name: string | null;
+  /** Absent, not null, when unset — the server skips serializing `None`. */
+  display_name?: string;
   context_window: number;
   max_output_tokens: number;
 };
@@ -147,7 +148,13 @@ export type ChatMessage = {
   role: "user" | "assistant";
   content: string;
   created_at: string;
-  /** Optional so a partial renderer-boundary response remains non-fatal. */
+  /**
+   * Deliberately wider than the wire: the server always serializes this, as
+   * `[]` when empty. It is optional here because the transcript is not run
+   * through a validator — it arrives as a parsed cast — so the `?` is what
+   * makes the compiler demand a guard at the one place that reads it. Narrowing
+   * this to match the wire would delete that guard, not earn it.
+   */
   citations?: ChatMessageCitation[];
 };
 

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -67,6 +67,43 @@ describe("ProvidersPanel", () => {
     );
   });
 
+  it("omits an unset display name instead of sending null", async () => {
+    const putProvider = vi.fn().mockResolvedValue(compatible);
+    const client = { putProvider } as unknown as ApiClient;
+
+    render(
+      <ProvidersPanel
+        providers={[compatible]}
+        client={client}
+        onChanged={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add model" }));
+    fireEvent.change(screen.getByLabelText("Custom model 1 ID"), {
+      target: { value: "vendor/model" },
+    });
+    // Display name left blank, which is the case the server represents by
+    // omitting the key. It used to be sent as an explicit null.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+
+    await waitFor(() => expect(putProvider).toHaveBeenCalled());
+
+    // Asserted through JSON rather than the argument object: `toEqual` treats an
+    // absent key and an explicit `undefined` as the same thing, so only the
+    // serialized form shows what actually reaches the server.
+    const [, body] = putProvider.mock.calls[0];
+    const sent = JSON.parse(JSON.stringify(body));
+    expect(sent.models[0]).toEqual({
+      id: "vendor/model",
+      context_window: 32_768,
+      max_output_tokens: 4_096,
+    });
+    expect("display_name" in sent.models[0]).toBe(false);
+  });
+
   it("does not expose custom model registration for curated providers", () => {
     render(
       <ProvidersPanel

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -60,7 +60,10 @@ function ProviderRow({
         body.models = models.map((model) => ({
           ...model,
           id: model.id.trim(),
-          display_name: model.display_name?.trim() || null,
+          // Omitted rather than null, which is how the server represents an
+          // unset display name and what it sends back. `models` is a full
+          // replacement list, so an absent key clears it just as null did.
+          display_name: model.display_name?.trim() || undefined,
         }));
       }
       if (key.trim()) {
@@ -126,7 +129,6 @@ function ProviderRow({
                     ...current,
                     {
                       id: "",
-                      display_name: null,
                       context_window: 32_768,
                       max_output_tokens: 4_096,
                     },
@@ -173,7 +175,7 @@ function ProviderRow({
                         itemIndex === index
                           ? {
                               ...item,
-                              display_name: event.target.value || null,
+                              display_name: event.target.value || undefined,
                             }
                           : item,
                       ),

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -782,6 +782,41 @@ mod tests {
         assert_eq!(ProviderKind::Openai.setting_key(), "provider.openai");
     }
 
+    /// An unset display name is represented by the key being absent, in both
+    /// directions. The desktop used to send an explicit `null` while declaring
+    /// the field non-optional, so its type claimed a key the server never sends.
+    ///
+    /// `deny_unknown_fields` makes the inbound half worth asserting rather than
+    /// assuming: the body has to be accepted with the key missing entirely.
+    #[test]
+    fn an_unset_display_name_is_absent_rather_than_null() {
+        let unset = CustomModelConfig {
+            id: "local/model".into(),
+            display_name: None,
+            context_window: 32_768,
+            max_output_tokens: 4_096,
+        };
+        let json = serde_json::to_value(&unset).expect("a model config serializes");
+        assert!(
+            json.get("display_name").is_none(),
+            "the server should omit an unset display name, not send null: {json}"
+        );
+
+        // What the desktop now sends: no key at all.
+        let parsed: CustomModelConfig = serde_json::from_str(
+            r#"{"id":"local/model","context_window":32768,"max_output_tokens":4096}"#,
+        )
+        .expect("an absent display name is accepted");
+        assert_eq!(parsed, unset);
+
+        // Still accepted, so an older client is not broken by the change.
+        let explicit_null: CustomModelConfig = serde_json::from_str(
+            r#"{"id":"local/model","display_name":null,"context_window":32768,"max_output_tokens":4096}"#,
+        )
+        .expect("an explicit null is still accepted");
+        assert_eq!(explicit_null, unset);
+    }
+
     #[test]
     fn custom_model_validation_is_conservative_and_rejects_duplicates() {
         let valid = CustomModelConfig {


### PR DESCRIPTION
Closes #527, with one of the two reported items deliberately not changed — see below.

## The mismatch

`CustomModelConfig.display_name` is `#[serde(default, skip_serializing_if = "Option::is_none")]`, so when it is `None` **the key is absent from the JSON**. `api.ts` declared it `display_name: string | null` — required, always present.

The type was wrong on its own, but the more interesting part is that the desktop was also *sending* an explicit `null` on save. So the two sides had different representations of "unset" and neither matched the other. TypeScript believed the value was `string | null` when it can in fact be `undefined`.

The fix uses the server's representation in both directions. `models` is a full replacement list and the field is `#[serde(default)]`, so an omitted key clears the display name exactly as `null` did — same outcome, one representation. The neighbouring `base_url?: string` already worked this way and even carries the explanatory comment; `display_name` just missed the rule.

## `citations`: reported, then withdrawn

I filed the second item in #527 and it is wrong. `ChatMessageSnapshot.citations` is a plain `Vec`, always serialized, while `api.ts` declares `citations?` — a real divergence from the wire, but narrowing it would be a regression:

- The transcript is **not** validated. It arrives as `await this.json(...)`, a parsed cast, with no runtime checking on that path at all.
- So the `?` is load-bearing: it is what makes the compiler demand the guard at `TranscriptHistory.ts:41` (`message.citations ?? []`).
- Matching the type to the wire would delete that guard on an unvalidated path — trading a real runtime protection for type tidiness.

The existing comment was already saying this and I misread it as an accident. It now states explicitly that the server always sends the field and that narrowing would remove the guard rather than earn it, so nobody generating this type later quietly "corrects" it.

## Tests, and why they are shaped this way

**Desktop** — the outbound body carries no `display_name` key. Asserted through `JSON.stringify` rather than on the argument object, because `toEqual` treats an absent key and an explicit `undefined` as identical and would have passed against the old code too. Verified it fails against the previous `|| null`:

```
× ProvidersPanel > omits an unset display name instead of sending null
  → expected { id: 'vendor/model', …(3) } to deeply equal { id: 'vendor/model', …(2) }
```

**Server** — an unset name serializes without the key; a body with the key missing deserializes, which is worth asserting rather than assuming because the type is `deny_unknown_fields`; and an explicit `null` is still accepted, so an older client is not broken by the change.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace` (1260 passed, 0 failed), `tsc --noEmit`, `vitest run` (400 passed), production `vite build`.