### PR TITLE
test(core): pin the journal's serialized event shape

### DIFF
--- a/crates/openwave-core/fixtures/journal-events.json
+++ b/crates/openwave-core/fixtures/journal-events.json
@@ -1,0 +1,116 @@
+[
+  {
+    "type": "turn_started",
+    "turn_id": "00000000-0000-0000-0000-000000000001"
+  },
+  {
+    "type": "text_delta",
+    "text": "assistant text"
+  },
+  {
+    "type": "reasoning_delta",
+    "text": "reasoning text"
+  },
+  {
+    "type": "stream_interrupted"
+  },
+  {
+    "type": "tool_call_started",
+    "call_id": "00000000-0000-0000-0000-000000000002",
+    "name": "exec"
+  },
+  {
+    "type": "tool_call_args_delta",
+    "call_id": "00000000-0000-0000-0000-000000000002",
+    "fragment": "{\"command\":"
+  },
+  {
+    "type": "user_questions_asked",
+    "call_id": "00000000-0000-0000-0000-000000000003",
+    "turn_id": "00000000-0000-0000-0000-000000000001"
+  },
+  {
+    "type": "approval_required",
+    "call_id": "00000000-0000-0000-0000-000000000002",
+    "tool_name": "exec",
+    "class": "sensitive",
+    "kind": "exec_may_run_networked_command",
+    "preview": {
+      "tool": "exec",
+      "command": "git",
+      "args": [
+        "status"
+      ],
+      "cwd": "."
+    },
+    "summary": "Run a command"
+  },
+  {
+    "type": "approval_decided",
+    "call_id": "00000000-0000-0000-0000-000000000002",
+    "approved": true
+  },
+  {
+    "type": "tool_call_completed",
+    "call_id": "00000000-0000-0000-0000-000000000002",
+    "output": {
+      "content": "on branch main",
+      "data": {
+        "exit_code": 0
+      },
+      "is_error": false
+    },
+    "action": {
+      "tool": "exec",
+      "command": "git",
+      "args": [
+        "status"
+      ],
+      "cwd": "."
+    },
+    "result": {
+      "tool": "exec",
+      "exit_code": 0,
+      "timed_out": false,
+      "output_truncated": false,
+      "stdout": "on branch main",
+      "stderr": ""
+    }
+  },
+  {
+    "type": "turn_completed",
+    "usage": {
+      "input_tokens": 11,
+      "output_tokens": 22,
+      "cache_read_input_tokens": 33,
+      "cache_creation_input_tokens": 44
+    },
+    "stop_reason": "end_turn"
+  },
+  {
+    "type": "turn_failed",
+    "error": {
+      "kind": "config",
+      "message": "configuration error: no provider"
+    }
+  },
+  {
+    "type": "turn_cancelled",
+    "usage": {
+      "input_tokens": 5,
+      "output_tokens": 6,
+      "cache_read_input_tokens": 0,
+      "cache_creation_input_tokens": 0
+    }
+  },
+  {
+    "type": "user_steered",
+    "message_id": "00000000-0000-0000-0000-000000000004",
+    "content": "steered text"
+  },
+  {
+    "type": "context_truncated",
+    "original_tokens": 100000,
+    "fitted_tokens": 60000
+  }
+]

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -208,4 +208,206 @@ mod tests {
         assert_eq!(json["message_id"], message_id.to_string());
         assert_eq!(serde_json::from_value::<AgentEvent>(json).unwrap(), ev);
     }
+
+    /// Path of the checked-in journal fixture, relative to this crate.
+    const JOURNAL_FIXTURE: &str = "fixtures/journal-events.json";
+
+    /// Fixed ids, because a fixture with a fresh UUID in it would differ on every
+    /// run and the comparison below would be meaningless.
+    fn id(n: u128) -> uuid::Uuid {
+        uuid::Uuid::from_u128(n)
+    }
+
+    /// Declaration index of a variant.
+    ///
+    /// The enum is `#[non_exhaustive]`, but that only binds other crates — the
+    /// match here is exhaustive, so a new variant does not compile until it is
+    /// added, and [`journal_samples`] is then checked for covering it.
+    fn variant_index(event: &AgentEvent) -> usize {
+        match event {
+            AgentEvent::TurnStarted { .. } => 0,
+            AgentEvent::TextDelta { .. } => 1,
+            AgentEvent::ReasoningDelta { .. } => 2,
+            AgentEvent::StreamInterrupted => 3,
+            AgentEvent::ToolCallStarted { .. } => 4,
+            AgentEvent::ToolCallArgsDelta { .. } => 5,
+            AgentEvent::UserQuestionsAsked { .. } => 6,
+            AgentEvent::ApprovalRequired { .. } => 7,
+            AgentEvent::ApprovalDecided { .. } => 8,
+            AgentEvent::ToolCallCompleted { .. } => 9,
+            AgentEvent::TurnCompleted { .. } => 10,
+            AgentEvent::TurnFailed { .. } => 11,
+            AgentEvent::TurnCancelled { .. } => 12,
+            AgentEvent::UserSteered { .. } => 13,
+            AgentEvent::ContextTruncated { .. } => 14,
+        }
+    }
+
+    /// One journal row per variant.
+    ///
+    /// Optional fields are populated rather than left `None`: a `None` field is
+    /// skipped or written as null and would pin nothing, so the nested storage
+    /// types — `ToolActionPreview`, `ToolResultPreview`, `ToolOutput` — would go
+    /// unguarded exactly where the risk is.
+    fn journal_samples() -> Vec<AgentEvent> {
+        vec![
+            AgentEvent::TurnStarted {
+                turn_id: TurnId(id(1)),
+            },
+            AgentEvent::TextDelta {
+                text: "assistant text".into(),
+            },
+            AgentEvent::ReasoningDelta {
+                text: "reasoning text".into(),
+            },
+            AgentEvent::StreamInterrupted,
+            AgentEvent::ToolCallStarted {
+                call_id: CallId(id(2)),
+                name: "exec".into(),
+            },
+            AgentEvent::ToolCallArgsDelta {
+                call_id: CallId(id(2)),
+                fragment: "{\"command\":".into(),
+            },
+            AgentEvent::UserQuestionsAsked {
+                call_id: CallId(id(3)),
+                turn_id: TurnId(id(1)),
+            },
+            AgentEvent::ApprovalRequired {
+                call_id: CallId(id(2)),
+                tool_name: "exec".into(),
+                class: ApprovalClass::Sensitive,
+                kind: crate::approval::ToolApprovalKind::ExecMayRunNetworkedCommand,
+                preview: Some(crate::preview::ToolActionPreview::Exec {
+                    command: "git".into(),
+                    args: vec!["status".into()],
+                    cwd: ".".into(),
+                }),
+                summary: "Run a command".into(),
+            },
+            AgentEvent::ApprovalDecided {
+                call_id: CallId(id(2)),
+                approved: true,
+            },
+            AgentEvent::ToolCallCompleted {
+                call_id: CallId(id(2)),
+                output: ToolOutput {
+                    content: "on branch main".into(),
+                    data: Some(serde_json::json!({"exit_code": 0})),
+                    is_error: false,
+                    error_category: None,
+                    private_evidence: Vec::new(),
+                },
+                action: Some(crate::preview::ToolActionPreview::Exec {
+                    command: "git".into(),
+                    args: vec!["status".into()],
+                    cwd: ".".into(),
+                }),
+                result: Some(crate::preview::ToolResultPreview::Exec {
+                    exit_code: Some(0),
+                    timed_out: false,
+                    output_truncated: false,
+                    stdout: "on branch main".into(),
+                    stderr: String::new(),
+                }),
+            },
+            AgentEvent::TurnCompleted {
+                usage: Usage {
+                    input_tokens: 11,
+                    output_tokens: 22,
+                    cache_read_input_tokens: 33,
+                    cache_creation_input_tokens: 44,
+                },
+                stop_reason: StopReason::EndTurn,
+            },
+            AgentEvent::TurnFailed {
+                error: (&AgentError::config("no provider")).into(),
+            },
+            AgentEvent::TurnCancelled {
+                usage: Usage {
+                    input_tokens: 5,
+                    output_tokens: 6,
+                    cache_read_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                },
+            },
+            AgentEvent::UserSteered {
+                message_id: MessageId(id(4)),
+                content: "steered text".into(),
+            },
+            AgentEvent::ContextTruncated {
+                original_tokens: 100_000,
+                fitted_tokens: 60_000,
+            },
+        ]
+    }
+
+    /// Every variant has a sample, so the fixture cannot silently cover fewer
+    /// event kinds than the journal can contain.
+    #[test]
+    fn every_journal_event_kind_has_a_sample() {
+        let samples = journal_samples();
+        let covered: std::collections::BTreeSet<usize> =
+            samples.iter().map(variant_index).collect();
+        assert_eq!(
+            covered.len(),
+            samples.len(),
+            "two samples describe the same variant"
+        );
+        assert_eq!(
+            covered,
+            (0..samples.len()).collect(),
+            "a variant is missing from journal_samples"
+        );
+    }
+
+    /// `AgentEvent` is written into `event.payload` and read back, so its field
+    /// names are a storage format, not only a wire format. Nothing else pins
+    /// them: the desktop schema epoch covers SQLite migrations, and a rename
+    /// changes no table. `list_events` collects into `Result<Vec<_>>`, so one
+    /// unreadable row fails a whole chat's history rather than one message.
+    ///
+    /// Regenerate with `UPDATE_JOURNAL_FIXTURE=1 cargo test -p openwave-core`.
+    /// A diff here means the journal format changed, which needs a
+    /// `#[serde(alias)]` or a migration — not a refreshed fixture.
+    #[test]
+    fn the_journal_event_shape_is_pinned() {
+        let rendered = format!(
+            "{}\n",
+            serde_json::to_string_pretty(&journal_samples()).expect("events serialize")
+        );
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(JOURNAL_FIXTURE);
+        if std::env::var_os("UPDATE_JOURNAL_FIXTURE").is_some() {
+            std::fs::create_dir_all(path.parent().expect("the fixture path has a parent"))
+                .expect("the fixture directory is creatable");
+            std::fs::write(&path, &rendered).expect("the fixture path is writable");
+            return;
+        }
+        let existing = std::fs::read_to_string(&path).unwrap_or_default();
+        assert_eq!(
+            existing, rendered,
+            "the journal event shape changed; existing chats may no longer load. \
+             If this is deliberate, add #[serde(alias)] or a migration, then \
+             regenerate with UPDATE_JOURNAL_FIXTURE=1 cargo test -p openwave-core"
+        );
+    }
+
+    /// The direct statement of the compatibility property: bytes that a previous
+    /// binary wrote still parse, and parse back to the same value.
+    ///
+    /// Separate from the comparison above because it fails for a different
+    /// reason. A rename shows up in both, but a field that stops being optional
+    /// only shows up here.
+    #[test]
+    fn journal_rows_written_before_this_build_still_load() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(JOURNAL_FIXTURE);
+        let stored = std::fs::read_to_string(&path).expect("the journal fixture is checked in");
+        let loaded: Vec<AgentEvent> =
+            serde_json::from_str(&stored).expect("stored journal rows still deserialize");
+        assert_eq!(
+            loaded,
+            journal_samples(),
+            "a stored journal row no longer round-trips to the value it was written from"
+        );
+    }
 }


### PR DESCRIPTION
Closes #531. Found while scoping the event-projection slice of #478.

## The gap

`AgentEvent` is persisted — `serde_json::to_value(event)` into `event.payload` (`db/ops/conversation.rs:1027`), read back with `from_value::<AgentEvent>` in at least eight places. Its field names, and those of every type reachable from it, are a **storage** format.

Nothing pinned them:

- `DESKTOP_SCHEMA_EPOCH` covers **SQLite migrations**. A field rename changes no table, so the epoch stays valid and the database is never rebuilt.
- No test asserted that previously written bytes still parse.
- The discipline was by hand. `ApprovalRequired.preview` and `ToolCallCompleted.action`/`result` carry `#[serde(default)]` with the comment *"Absent on journal rows written before previews existed"* — correct, and entirely dependent on someone remembering.

`list_events` collects into `Result<Vec<_>>`, so the blast radius is not one message. **One unreadable row fails a whole chat's history** — the conversation stops opening.

## Measured, not assumed

I renamed `Usage.cache_read_input_tokens`, a field that appears **only** in the journal and nowhere in the renderer projection, and ran the full workspace with `--no-fail-fast`:

```
test event::tests::journal_rows_written_before_this_build_still_load ... FAILED
test event::tests::the_journal_event_shape_is_pinned ... FAILED
passed=1260 failed=2
```

The two new tests are the only failures.

I also want to correct a sharper claim I nearly made. Renaming a field inside `ToolResultPreview` **is** additionally caught by an existing test (`exec_completion_projects_what_ran_and_what_it_produced`), because that type happens to sit on the renderer boundary as well as in the journal. So the pre-existing coverage was not zero — it was accidental, and limited to the types that are also projected.

## What it does

One serialized sample per variant, checked in, with two assertions that fail for different reasons:

- **The rendered form matches the fixture.** Catches a rename.
- **The stored bytes still deserialize and round-trip.** The compatibility property stated directly, and it additionally catches a field that stops being optional — which the comparison alone would not.

Both messages point at the real consequence:

```
the journal event shape changed; existing chats may no longer load. If this is
deliberate, add #[serde(alias)] or a migration, then regenerate with
UPDATE_JOURNAL_FIXTURE=1 cargo test -p openwave-core
```

## Two details worth review

- **Optional fields are populated, not `None`.** A `None` field is skipped or written as null and pins nothing, which would leave `ToolActionPreview`, `ToolResultPreview`, and `ToolOutput` unguarded — precisely where the risk is. The fixture carries a real `exec` preview and result.
- **Coverage is by construction.** `variant_index` matches exhaustively (`#[non_exhaustive]` binds other crates, not this one), so a new variant does not compile until it has an arm, and the test then fails until it has a sample.

## Known limitation

The fixture pins today's shape. It does not preserve genuinely historical shapes once regenerated — regeneration is a deliberate act whose diff is the review signal, the same trade the generated wire contract makes. If real historical coverage is wanted, this should become an append-only corpus with one entry per format generation. Noted on the issue rather than silently assumed away.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --no-fail-fast` (1262 passed, 0 failed).