### PR TITLE
refactor(desktop): generate the renderer's event wire types from Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6671,6 +6671,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "ts-rs",
  "uuid",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,13 @@ chrono = { version = "=0.4.45", features = ["serde"] }
 # `serde-compat` is what makes the output trustworthy: ts-rs reads the same
 # `tag`, `rename_all`, and `skip` attributes serde does, so the generated type
 # describes the bytes that actually go out. See docs/wire-types.md.
-ts-rs = { version = "=12.0.1", features = ["chrono-impl", "uuid-impl"] }
+#
+# `no-serde-warnings` silences one specific piece of noise: ts-rs cannot parse
+# `#[serde(transparent)]`, which every id newtype carries, so it printed a
+# warning per id on every build. It reaches the right answer anyway, because a
+# single-field tuple struct already renders as its inner type — and that is
+# pinned by a test rather than left to coincidence.
+ts-rs = { version = "=12.0.1", features = ["chrono-impl", "uuid-impl", "no-serde-warnings"] }
 windows-sys = "=0.61.2"
 sea-orm = { version = "=2.0.0", default-features = false, features = ["macros", "runtime-tokio-rustls", "with-uuid", "with-chrono", "with-json"] }
 sea-orm-migration = { version = "=2.0.0", default-features = false, features = ["runtime-tokio-rustls"] }

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -46,6 +46,7 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["v5"] }
 chrono = { workspace = true }
+ts-rs = { workspace = true }
 sea-orm = { workspace = true, optional = true }
 sea-orm-migration = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -18,6 +18,7 @@ use crate::id::{CallId, ChatId, TurnId};
 use crate::preview::ToolActionPreview;
 use crate::tool::ApprovalClass;
 use chrono::{DateTime, Utc};
+use ts_rs::TS;
 
 /// The human's decision on a parked tool call.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,7 +69,7 @@ pub enum ToolApprovalStatus {
 /// renderer can describe the action without ever seeing the model-authored
 /// summary or arguments. `Unsupported` is the fail-closed default: a Sensitive
 /// action the server can only reject, never approve.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolApprovalKind {
     /// A library search may share the query and matched excerpts with the

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -7,13 +7,14 @@
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use ts_rs::TS;
 use uuid::Uuid;
 
 /// Declares a UUID-backed identifier newtype with the common impls.
 macro_rules! id_type {
     ($(#[$meta:meta])* $name:ident) => {
         $(#[$meta])*
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
         #[serde(transparent)]
         pub struct $name(pub Uuid);
 

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -10,6 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use ts_rs::TS;
 
 /// Longest command, argument, or directory string an action preview carries.
 pub const MAX_ACTION_FIELD_CHARS: usize = 512;
@@ -26,7 +27,7 @@ pub const MAX_RESULT_STREAM_CHARS: usize = 40_000;
 /// Approval cards need this because consent to an action you cannot see is not
 /// consent. Result cards reuse it so the same action is described the same way
 /// before and after it runs.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "tool", rename_all = "snake_case")]
 pub enum ToolActionPreview {
     /// A command execution, as the argument vector it will actually run. There
@@ -155,7 +156,7 @@ impl ToolActionPreview {
 ///
 /// A command's output is the whole reason to run it. Withholding it leaves the
 /// transcript asserting that something happened without ever showing what.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(tag = "tool", rename_all = "snake_case")]
 pub enum ToolResultPreview {
     Exec {

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -17,6 +17,7 @@ use cap_std::fs::Dir;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use ts_rs::TS;
 
 use crate::error::Result;
 use crate::id::{CallId, ChatId, ProjectId};
@@ -56,7 +57,7 @@ impl ToolScratch {
 /// Policy maps class → auto-approve / ask / deny. In v1: `ReadOnly` and
 /// `Workspace` auto-approve; `Sensitive` parks on the approval gate unless a
 /// matching standing grant covers the call.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum ApprovalClass {
     /// Never mutates anything (e.g. `read_file`, `list_dir`, `search`).

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -1,6 +1,28 @@
-import { RENDERER_TOOL_NAMES, type RendererToolName } from "./generated/wire";
+import {
+  RENDERER_TOOL_NAMES,
+  type ApprovalClass,
+  type RendererAgentEvent,
+  type RendererSequencedEvent,
+  type RendererToolName,
+  type ToolActionPreview,
+  type ToolApprovalKind,
+  type ToolResultPreview as WireToolResultPreview,
+} from "./generated/wire";
 
-export type { RendererToolName };
+export type { ApprovalClass, RendererToolName, ToolActionPreview };
+
+/**
+ * The WebSocket frame and the events it carries, generated from the server's
+ * renderer projection.
+ *
+ * Named for the renderer on the Rust side; the shorter names are what the app
+ * has always used, so they are aliased rather than renamed everywhere.
+ */
+export type SequencedEvent = RendererSequencedEvent;
+export type AgentEvent = RendererAgentEvent;
+
+/** Generated from `ToolApprovalKind`. */
+export type RendererApprovalKind = ToolApprovalKind;
 
 /** Connection details from the Tauri host (`server_info` command). */
 export type ServerInfo = {
@@ -242,61 +264,7 @@ export type AgentActivity = {
   status: "waiting" | "running";
 };
 
-export type SequencedEvent = {
-  seq: number;
-  event: AgentEvent;
-};
 
-export type AgentEvent =
-  | { type: "turn_started"; turn_id: string }
-  | { type: "text_delta"; text: string }
-  | { type: "reasoning_delta" }
-  | { type: "stream_interrupted" }
-  | { type: "tool_call_started"; call_id: string; name: RendererToolName }
-  | { type: "tool_call_args_delta"; call_id: string }
-  | { type: "user_questions_asked"; call_id: string; turn_id: string }
-  | {
-      type: "approval_required";
-      call_id: string;
-      action: RendererToolName;
-      approval: RendererApprovalKind;
-      class: "read_only" | "workspace" | "sensitive";
-      preview?: ToolActionPreview;
-    }
-  | { type: "approval_decided"; call_id: string; approved: boolean }
-  | {
-      type: "tool_call_completed";
-      call_id: string;
-      status: "completed" | "failed";
-      action?: ToolActionPreview;
-      result?: ToolResultPreview;
-    }
-  | { type: "turn_completed" }
-  | { type: "turn_failed" }
-  | { type: "turn_cancelled" }
-  | { type: "user_steered"; message_id: string; text: string }
-  | { type: "context_truncated" }
-  | { type: "event_omitted" };
-
-/**
- * The action a call will take, in a form a human can inspect.
- *
- * The renderer boundary otherwise carries no tool arguments. This is one of two
- * exceptions: a tool may project a closed, field-by-field view of what it is
- * about to do, because consent to an action you cannot see is not consent, and
- * because a result is unreadable without knowing what produced it.
- */
-export type ToolActionPreview =
-  | {
-      tool: "exec";
-      command: string;
-      args: string[];
-      cwd: string;
-    }
-  /** A search of this conversation's own sources. */
-  | { tool: "search"; query: string }
-  /** A public web search, whose query leaves the device. */
-  | { tool: "web_search"; query: string };
 
 /**
  * What a call produced.
@@ -304,6 +272,12 @@ export type ToolActionPreview =
  * The other exception. A command's output is the whole reason to run it;
  * withholding it leaves the transcript asserting that something happened
  * without ever showing what.
+ *
+ * Hand-written and camelCase, unlike its snake_case wire form. The Rust type is
+ * carried in the journal, so renaming its fields would stop existing chats from
+ * loading — the remap in `parseToolResultPreview` is the cheaper side to keep.
+ * That remap reads the generated wire type, so a field renamed in Rust breaks
+ * there at compile time rather than silently producing `undefined`.
  */
 export type ToolResultPreview = {
   tool: "exec";
@@ -314,12 +288,6 @@ export type ToolResultPreview = {
   stderr: string;
 };
 
-export type RendererApprovalKind =
-  | "search_may_share_query_and_excerpts"
-  | "web_search_may_share_query"
-  | "exec_may_run_networked_command"
-  | "external_mcp_may_call_server"
-  | "unsupported";
 
 /** Approval kinds a human may approve from the renderer. */
 export function isApprovableKind(kind: RendererApprovalKind): boolean {
@@ -1054,6 +1022,19 @@ export function parseToolActionPreview(
 }
 
 /**
+ * The wire shape this validator reads, with every value still unverified.
+ *
+ * Keyed on the generated type rather than on `string`, because the destructuring
+ * below is the one place the snake_case wire form is written out by hand. If a
+ * field is renamed in Rust, the name disappears from `keyof` and this fails to
+ * compile — instead of quietly destructuring to `undefined` and dropping every
+ * result preview at runtime, which no test would have caught.
+ */
+type UncheckedExecResult = Partial<
+  Record<keyof Extract<WireToolResultPreview, { tool: "exec" }>, unknown>
+>;
+
+/**
  * Validate a result field by field, on the same terms as an action: anything
  * that cannot be fully verified is dropped rather than half-rendered.
  */
@@ -1062,7 +1043,7 @@ export function parseToolResultPreview(
 ): ToolResultPreview | null {
   if (value === undefined || value === null) return null;
   if (!isRecord(value) || value.tool !== "exec") return null;
-  const { exit_code, timed_out, output_truncated, stdout, stderr } = value;
+  const { exit_code, timed_out, output_truncated, stdout, stderr }: UncheckedExecResult = value;
   if (
     (exit_code !== null && typeof exit_code !== "number") ||
     typeof timed_out !== "boolean" ||

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1,17 +1,133 @@
 // Generated from Rust. Do not edit.
 //
-// Source: `RendererToolName` in crates/openwave-server/src/event_projection.rs
 // Regenerate: UPDATE_WIRE_TYPES=1 cargo test -p openwave-server
 //
-// The runtime list and the type are emitted together so a tool cannot
-// exist in one and not the other. See docs/wire-types.md.
+// These describe the JSON the server actually sends, derived from the same
+// serde attributes serde itself reads. They are the input to the runtime
+// validators in api.ts, not a replacement for them: the validators enforce
+// bounds, reject control characters, and cross-check server policy, none of
+// which a type can express. See docs/wire-types.md.
 
 /**
- * Every tool name the renderer will accept.
+ * The approval policy class a tool declares for itself.
  *
- * This is an allowlist, not a display transformation. Tool events come from
- * providers, so a name outside this set must never reach a card, an icon, or
- * a copy table. The server folds anything unrecognized to `other`.
+ * Policy maps class → auto-approve / ask / deny. In v1: `ReadOnly` and
+ * `Workspace` auto-approve; `Sensitive` parks on the approval gate unless a
+ * matching standing grant covers the call.
+ */
+export type ApprovalClass = "read_only" | "workspace" | "sensitive";
+
+/**
+ * Identifies one tool call, stable across its request/approval/result.
+ */
+export type CallId = string;
+
+/**
+ * Identifies a persisted message within a chat.
+ */
+export type MessageId = string;
+
+export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | { "type": "text_delta", text: string, } | { "type": "reasoning_delta" } | { "type": "stream_interrupted" } | { "type": "tool_call_started", call_id: CallId, name: RendererToolName, } | { "type": "tool_call_args_delta", call_id: CallId, } | { "type": "user_questions_asked", call_id: CallId, turn_id: TurnId, } | { "type": "approval_required", call_id: CallId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass, 
+/**
+ * The one deliberate opening in this boundary. A human cannot consent
+ * to a command they are not shown, so a tool may project a closed,
+ * field-by-field view of the action under review. Tools without one
+ * send nothing, as every tool did before.
+ */
+preview?: ToolActionPreview, } | { "type": "approval_decided", call_id: CallId, approved: boolean, } | { "type": "tool_call_completed", call_id: CallId, status: RendererToolStatus, 
+/**
+ * What the call did, when its tool projects it. Approval is not the
+ * only moment a person needs to see the action.
+ */
+action?: ToolActionPreview, 
+/**
+ * What the call produced. A command's output is the reason it ran;
+ * withholding it leaves the transcript asserting that something
+ * happened without ever showing what.
+ */
+result?: ToolResultPreview, } | { "type": "turn_completed" } | { "type": "turn_failed" } | { "type": "turn_cancelled" } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated" } | { "type": "event_omitted" };
+
+export type RendererSequencedEvent = { seq: number, event: RendererAgentEvent, };
+
+/**
+ * Tool names are model-controlled. Only names with fixed renderer
+ * presentations cross the boundary; everything else becomes `other`.
+ *
+ * This enum is the renderer's tool vocabulary. The desktop's union, its
+ * runtime guard, its copy table, and its icon table all derive from the
+ * TypeScript generated here, so adding a variant cannot leave one of them
+ * behind — see `docs/wire-types.md`.
+ */
+export type RendererToolName = "search" | "list_sources" | "read_source" | "read_tool_result" | "web_search" | "read_delegated_file" | "read_file" | "list_dir" | "write_file" | "create_deliverable" | "request_folder_access" | "connect_folder" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file" | "spawn_sandbox_agent" | "wait_for_agents" | "ask_user_questions" | "exec" | "other";
+
+export type RendererToolStatus = "completed" | "failed";
+
+/**
+ * The action a call will take, in a form a human can inspect.
+ *
+ * Approval cards need this because consent to an action you cannot see is not
+ * consent. Result cards reuse it so the same action is described the same way
+ * before and after it runs.
+ */
+export type ToolActionPreview = { "tool": "exec", 
+/**
+ * Executable name or path the model chose.
+ */
+command: string, 
+/**
+ * Arguments passed directly to the executable.
+ */
+args: Array<string>, 
+/**
+ * Working directory relative to the chat's private scratch, never a
+ * host path.
+ */
+cwd: string, } | { "tool": "search", query: string, } | { "tool": "web_search", query: string, };
+
+/**
+ * Closed immutable consent semantics stored with each approval request.
+ *
+ * Each presentable variant names the egress a human is consenting to, so the
+ * renderer can describe the action without ever seeing the model-authored
+ * summary or arguments. `Unsupported` is the fail-closed default: a Sensitive
+ * action the server can only reject, never approve.
+ */
+export type ToolApprovalKind = "search_may_share_query_and_excerpts" | "web_search_may_share_query" | "exec_may_run_networked_command" | "external_mcp_may_call_server" | "unsupported";
+
+/**
+ * What a call produced, in a form a human can read.
+ *
+ * A command's output is the whole reason to run it. Withholding it leaves the
+ * transcript asserting that something happened without ever showing what.
+ */
+export type ToolResultPreview = { "tool": "exec", 
+/**
+ * Process exit status, or `None` when it was killed by a signal.
+ */
+exit_code: number | null, 
+/**
+ * Whether the provider stopped the command at its time limit.
+ */
+timed_out: boolean, 
+/**
+ * Whether the provider dropped output past its capture limit.
+ */
+output_truncated: boolean, stdout: string, stderr: string, };
+
+/**
+ * Identifies one turn: a single user input through to the final answer.
+ */
+export type TurnId = string;
+
+/**
+ * Every tool name the renderer will accept, at runtime.
+ *
+ * An allowlist, not a display transformation. Tool events come from
+ * providers, so a name outside this set must never reach a card, an icon,
+ * or a copy table. The server folds anything unrecognized to `other`.
+ *
+ * Emitted from the same enum as `RendererToolName` above, so the runtime
+ * list and the type cannot disagree.
  */
 export const RENDERER_TOOL_NAMES = [
   "search",
@@ -36,5 +152,3 @@ export const RENDERER_TOOL_NAMES = [
   "exec",
   "other",
 ] as const;
-
-export type RendererToolName = (typeof RENDERER_TOOL_NAMES)[number];

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -12,13 +12,13 @@ use openwave_core::{
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 pub(crate) struct RendererSequencedEvent {
     pub seq: i64,
     pub event: RendererAgentEvent,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum RendererAgentEvent {
     TurnStarted {
@@ -52,6 +52,7 @@ pub(crate) enum RendererAgentEvent {
         /// field-by-field view of the action under review. Tools without one
         /// send nothing, as every tool did before.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
         preview: Option<ToolActionPreview>,
     },
     ApprovalDecided {
@@ -64,11 +65,13 @@ pub(crate) enum RendererAgentEvent {
         /// What the call did, when its tool projects it. Approval is not the
         /// only moment a person needs to see the action.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
         action: Option<ToolActionPreview>,
         /// What the call produced. A command's output is the reason it ran;
         /// withholding it leaves the transcript asserting that something
         /// happened without ever showing what.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
         result: Option<ToolResultPreview>,
     },
     TurnCompleted,
@@ -119,7 +122,7 @@ pub(crate) enum RendererToolName {
     Other,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum RendererToolStatus {
     Completed,
@@ -477,127 +480,6 @@ mod tests {
         assert!(json.contains("quarterly filings"), "{json}");
         // Only the query. The other arguments are not what consent is about.
         assert!(!json.contains("max_results"), "{json}");
-    }
-
-    /// Path of the generated renderer bindings, relative to this crate.
-    const GENERATED_BINDINGS: &str = "../openwave-desktop/ui/src/generated/wire.ts";
-
-    /// Wire spellings of the vocabulary, taken from the generated union rather
-    /// than from a second hand-written list.
-    ///
-    /// `ts-rs` renders a unit-variant enum as a union of string literals, which
-    /// is exactly the shape the desktop needs — but the desktop also needs the
-    /// names at *runtime*, to check a provider-supplied string against the
-    /// allowlist, and TypeScript types are erased. So the union is parsed back
-    /// into the names it is made of, and [`render_bindings`] emits both from the
-    /// one list. The parse is verified by reconstruction, below.
-    fn tool_names_from_union(decl: &str) -> Vec<String> {
-        let body = decl
-            .split_once('=')
-            .expect("a ts-rs type alias always has a right-hand side")
-            .1;
-        body.trim()
-            .trim_end_matches(';')
-            .split('|')
-            .map(|member| member.trim().trim_matches('"').to_owned())
-            .collect()
-    }
-
-    /// The whole generated file, so ordering and header are part of the diff.
-    fn render_bindings() -> String {
-        let cfg = ts_rs::Config::default();
-        let union = RendererToolName::decl(&cfg);
-        let names = tool_names_from_union(&union);
-
-        let listed = names
-            .iter()
-            .map(|name| format!("  \"{name}\",\n"))
-            .collect::<String>();
-        format!(
-            "// Generated from Rust. Do not edit.\n\
-             //\n\
-             // Source: `RendererToolName` in crates/openwave-server/src/event_projection.rs\n\
-             // Regenerate: UPDATE_WIRE_TYPES=1 cargo test -p openwave-server\n\
-             //\n\
-             // The runtime list and the type are emitted together so a tool cannot\n\
-             // exist in one and not the other. See docs/wire-types.md.\n\
-             \n\
-             /**\n\
-             \x20* Every tool name the renderer will accept.\n\
-             \x20*\n\
-             \x20* This is an allowlist, not a display transformation. Tool events come from\n\
-             \x20* providers, so a name outside this set must never reach a card, an icon, or\n\
-             \x20* a copy table. The server folds anything unrecognized to `other`.\n\
-             \x20*/\n\
-             export const RENDERER_TOOL_NAMES = [\n{listed}] as const;\n\
-             \n\
-             export type RendererToolName = (typeof RENDERER_TOOL_NAMES)[number];\n"
-        )
-    }
-
-    /// The desktop keys a union, a runtime guard, a copy table, and an icon
-    /// table on this vocabulary. All four now derive from the file this test
-    /// writes, so a tool cannot reach one and miss another.
-    ///
-    /// Regenerate with `UPDATE_WIRE_TYPES=1 cargo test -p openwave-server`.
-    /// The check is the guarantee, not the generation: CI fails on a diff.
-    #[test]
-    fn the_generated_renderer_bindings_are_current() {
-        let rendered = render_bindings();
-        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(GENERATED_BINDINGS);
-        if std::env::var_os("UPDATE_WIRE_TYPES").is_some() {
-            std::fs::create_dir_all(path.parent().expect("the bindings path has a parent"))
-                .expect("the bindings directory is creatable");
-            std::fs::write(&path, &rendered).expect("the bindings path is writable");
-            return;
-        }
-        let existing = std::fs::read_to_string(&path).unwrap_or_default();
-        assert_eq!(
-            existing, rendered,
-            "the generated renderer bindings are out of date; regenerate with \
-             UPDATE_WIRE_TYPES=1 cargo test -p openwave-server"
-        );
-    }
-
-    /// The runtime list is parsed out of the generated union, so the parse has to
-    /// be exact. Rebuilding the union from the parsed names and comparing it to
-    /// what `ts-rs` produced is what makes that safe: a dropped, merged, or
-    /// mis-trimmed member cannot survive the round trip.
-    #[test]
-    fn the_runtime_tool_list_reconstructs_the_generated_union() {
-        let cfg = ts_rs::Config::default();
-        let union = RendererToolName::decl(&cfg);
-        let names = tool_names_from_union(&union);
-
-        let rebuilt = format!(
-            "type RendererToolName = {};",
-            names
-                .iter()
-                .map(|name| format!("\"{name}\""))
-                .collect::<Vec<_>>()
-                .join(" | ")
-        );
-        assert_eq!(
-            rebuilt, union,
-            "the tool-name parse does not reproduce what ts-rs generated"
-        );
-
-        // A duplicate spelling would silently shrink the allowlist.
-        assert_eq!(
-            names.iter().collect::<std::collections::HashSet<_>>().len(),
-            names.len(),
-            "two variants share a wire spelling"
-        );
-        // Guards against the union collapsing to a single `string`, which would
-        // turn the allowlist into a passthrough without failing anything else.
-        assert!(names.len() > 1, "the vocabulary did not render as a union");
-        assert!(
-            names.iter().all(|name| !name.is_empty()
-                && name
-                    .chars()
-                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')),
-            "a tool name is not a plain snake_case identifier: {names:?}"
-        );
     }
 
     #[test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -40,6 +40,7 @@ mod state;
 mod turn_worker;
 /// Host-owned, inert web-search configuration and provider selection.
 pub mod web_search;
+mod wire_types;
 
 use std::fs::{OpenOptions, TryLockError};
 use std::net::{Ipv4Addr, SocketAddr};

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -1,0 +1,478 @@
+//! Generation of the desktop's TypeScript wire types from these Rust
+//! definitions.
+//!
+//! The renderer used to describe the server's JSON in hand-written TypeScript.
+//! Nothing connected the two, so both sides could be green over a broken
+//! contract — and twice were, both times on optionality.
+//!
+//! Everything here is test-only. The generator is a test so that the checked-in
+//! output is verified by the same command that produces it: run normally it
+//! compares and fails on a diff, and CI therefore fails on a stale file. The
+//! check is the guarantee, not the generation.
+//!
+//! See `docs/wire-types.md` for the workflow and for what is deliberately left
+//! hand-written.
+
+#[cfg(test)]
+pub(crate) mod generate {
+    use std::any::TypeId;
+    use std::collections::{BTreeMap, HashSet};
+
+    use ts_rs::{Config, Dependency, TypeVisitor, TS};
+
+    /// One generated declaration, keyed by its TypeScript name.
+    type Declarations = BTreeMap<String, String>;
+
+    /// The generator settings, which are part of the contract.
+    ///
+    /// `ts-rs` renders `i64` as `bigint` by default. That is the right choice for
+    /// a language binding and the wrong one here: these types describe what
+    /// `JSON.parse` produces from the server's response, and `JSON.parse` yields
+    /// a `number` for a JSON number. A `bigint` declaration would be false about
+    /// every value the renderer actually receives.
+    ///
+    /// The cost is the usual one — a JSON number above 2^53 loses precision in
+    /// JavaScript. The only `i64` on this surface is the journal sequence
+    /// counter, which is nowhere near that, and declaring `bigint` would not
+    /// have prevented the loss anyway since it happens during parsing.
+    pub(crate) fn config() -> Config {
+        Config::new().with_large_int("number")
+    }
+
+    /// Collects the declaration of every type reachable from the roots.
+    ///
+    /// Walking the closure rather than listing every type is what keeps this
+    /// honest: adding a field of a new type to something already generated
+    /// pulls that type in automatically, so the output cannot quietly describe
+    /// fewer types than the server can send.
+    struct Collect<'a> {
+        cfg: &'a Config,
+        seen: HashSet<TypeId>,
+        out: &'a mut Declarations,
+    }
+
+    impl TypeVisitor for Collect<'_> {
+        fn visit<T: TS + 'static + ?Sized>(&mut self) {
+            // `Dependency::from_ty` is `None` for anything without its own
+            // declaration — primitives, `Vec`, `Option`, `String`. Those still
+            // need visiting so the recursion reaches their inner types, but they
+            // are not themselves declarations.
+            let declares = Dependency::from_ty::<T>(self.cfg).is_some();
+            if !self.seen.insert(TypeId::of::<T>()) {
+                return;
+            }
+            if declares {
+                let name = T::ident(self.cfg);
+                let docs = T::docs().unwrap_or_default();
+                self.out
+                    .insert(name, format!("{docs}export {}\n", T::decl(self.cfg)));
+            }
+            T::visit_dependencies(self);
+        }
+    }
+
+    /// Add `T` and everything it references to `out`.
+    pub(crate) fn collect_from<T: TS + 'static>(cfg: &Config, out: &mut Declarations) {
+        let mut visitor = Collect {
+            cfg,
+            seen: HashSet::new(),
+            out,
+        };
+        visitor.visit::<T>();
+    }
+
+    /// The runtime tool-name list, emitted beside the generated union.
+    ///
+    /// The desktop needs these names at runtime to check a provider-supplied
+    /// string against the allowlist, and TypeScript types are erased. So the
+    /// generated union is parsed back into its members and re-emitted as a
+    /// `const`, with [`super::tests::the_runtime_tool_list_reconstructs_the_union`]
+    /// verifying the parse by rebuilding the union from it.
+    pub(crate) fn tool_names_from_union(decl: &str) -> Vec<String> {
+        let body = decl
+            .split_once('=')
+            .expect("a ts-rs type alias always has a right-hand side")
+            .1;
+        body.trim()
+            .trim_end_matches(';')
+            .split('|')
+            .map(|member| member.trim().trim_matches('"').to_owned())
+            .collect()
+    }
+
+    /// The `RENDERER_TOOL_NAMES` const declaration.
+    pub(crate) fn render_tool_name_list(names: &[String]) -> String {
+        let listed = names
+            .iter()
+            .map(|name| format!("  \"{name}\",\n"))
+            .collect::<String>();
+        format!(
+            "/**\n\
+             \x20* Every tool name the renderer will accept, at runtime.\n\
+             \x20*\n\
+             \x20* An allowlist, not a display transformation. Tool events come from\n\
+             \x20* providers, so a name outside this set must never reach a card, an icon,\n\
+             \x20* or a copy table. The server folds anything unrecognized to `other`.\n\
+             \x20*\n\
+             \x20* Emitted from the same enum as `RendererToolName` above, so the runtime\n\
+             \x20* list and the type cannot disagree.\n\
+             \x20*/\n\
+             export const RENDERER_TOOL_NAMES = [\n{listed}] as const;\n"
+        )
+    }
+
+    /// Render the generated module, header and all, so ordering and preamble are
+    /// part of the diff a reviewer sees.
+    pub(crate) fn render(declarations: &Declarations, trailing: &[String]) -> String {
+        let body = declarations
+            .values()
+            .map(String::as_str)
+            .chain(trailing.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            "// Generated from Rust. Do not edit.\n\
+             //\n\
+             // Regenerate: UPDATE_WIRE_TYPES=1 cargo test -p openwave-server\n\
+             //\n\
+             // These describe the JSON the server actually sends, derived from the same\n\
+             // serde attributes serde itself reads. They are the input to the runtime\n\
+             // validators in api.ts, not a replacement for them: the validators enforce\n\
+             // bounds, reject control characters, and cross-check server policy, none of\n\
+             // which a type can express. See docs/wire-types.md.\n\
+             \n\
+             {body}"
+        )
+    }
+
+    /// Every field of a `TS`-deriving type whose key serde may omit, paired with
+    /// whether the type will be told to declare it optional.
+    ///
+    /// This exists because of the one thing `ts-rs` gets wrong for this codebase.
+    /// It decides a field is optional from `maybe_omitted && has_default`, and
+    /// serde treats a missing `Option` as `None` without needing
+    /// `#[serde(default)]` — so an `Option` field with only
+    /// `skip_serializing_if` renders as `T | null`, claiming a key the server
+    /// never sends. That is exactly the mismatch that shipped twice before any
+    /// of this was generated, and generating it does not fix it by itself.
+    ///
+    /// Scoped to the span of each `TS`-deriving item, so a `skip_serializing_if`
+    /// on a neighbouring non-generated type in the same file is not flagged.
+    pub(crate) fn omittable_fields_missing_optional(source: &str) -> Vec<String> {
+        let mut findings = Vec::new();
+        for span in ts_deriving_items(source) {
+            // Attributes accumulate above a field, so split on the field
+            // boundary: each chunk is one field's attribute cluster plus its
+            // declaration.
+            for cluster in span.split(",\n") {
+                let omits = cluster.contains("skip_serializing_if")
+                    || cluster.contains("skip_serializing)")
+                    || cluster.contains("skip_serializing,");
+                if !omits {
+                    continue;
+                }
+                let declared_optional =
+                    cluster.contains("ts(optional") || cluster.contains("serde(default");
+                if !declared_optional {
+                    let field = cluster
+                        .lines()
+                        .filter(|line| !line.trim_start().starts_with('#'))
+                        .find(|line| line.contains(':'))
+                        .unwrap_or("<unknown field>")
+                        .trim();
+                    findings.push(field.to_owned());
+                }
+            }
+        }
+        findings
+    }
+
+    /// Text spans of items whose derive list includes `TS`, from the derive to
+    /// the closing brace of the item.
+    fn ts_deriving_items(source: &str) -> Vec<&str> {
+        let mut spans = Vec::new();
+        let mut rest = source;
+        while let Some(at) = rest.find("#[derive(") {
+            let after = &rest[at..];
+            let Some(close) = after.find(")]") else { break };
+            const DERIVE: &str = "#[derive(";
+            let derives = &after[DERIVE.len()..close];
+            rest = &after[close + 2..];
+            if !derives.split(',').any(|d| d.trim() == "TS") {
+                continue;
+            }
+            // Walk to the closing brace of the item this derive belongs to.
+            let mut depth = 0usize;
+            let mut end = rest.len();
+            for (index, ch) in rest.char_indices() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = index + 1;
+                            break;
+                        }
+                    }
+                    // A unit struct or tuple struct ends at the semicolon.
+                    ';' if depth == 0 => {
+                        end = index + 1;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            spans.push(&rest[..end]);
+        }
+        spans
+    }
+
+    /// Compare `rendered` against the checked-in file, or rewrite it when
+    /// `UPDATE_WIRE_TYPES` is set.
+    pub(crate) fn check_or_update(relative_path: &str, rendered: &str, regenerate_with: &str) {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(relative_path);
+        if std::env::var_os("UPDATE_WIRE_TYPES").is_some() {
+            std::fs::create_dir_all(path.parent().expect("the bindings path has a parent"))
+                .expect("the bindings directory is creatable");
+            std::fs::write(&path, rendered).expect("the bindings path is writable");
+            return;
+        }
+        let existing = std::fs::read_to_string(&path).unwrap_or_default();
+        assert_eq!(
+            existing, rendered,
+            "the generated wire types are out of date; regenerate with {regenerate_with}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generate;
+    use std::collections::BTreeMap;
+
+    /// Path of the generated bindings, relative to this crate.
+    ///
+    /// One module, not one per root: the roots share types, and two files would
+    /// each declare `RendererToolName`, which cannot both be imported.
+    const BINDINGS: &str = "../openwave-desktop/ui/src/generated/wire.ts";
+
+    const REGENERATE: &str = "UPDATE_WIRE_TYPES=1 cargo test -p openwave-server";
+
+    fn event_declarations() -> BTreeMap<String, String> {
+        let cfg = generate::config();
+        let mut out = BTreeMap::new();
+        // One root. Everything the event stream can carry is reachable from it,
+        // including the shared preview and approval types the REST surface uses.
+        generate::collect_from::<crate::event_projection::RendererSequencedEvent>(&cfg, &mut out);
+        out
+    }
+
+    fn rendered_bindings() -> String {
+        let declarations = event_declarations();
+        let union = declarations
+            .get("RendererToolName")
+            .expect("the vocabulary is reachable from the event root");
+        let names = generate::tool_names_from_union(union);
+        generate::render(&declarations, &[generate::render_tool_name_list(&names)])
+    }
+
+    /// The WebSocket frame types, which until now had no contract at all: the
+    /// renderer parses each frame with a bare cast and no runtime validation, so
+    /// the generated type is the only thing describing that payload.
+    #[test]
+    fn the_generated_bindings_are_current() {
+        generate::check_or_update(BINDINGS, &rendered_bindings(), REGENERATE);
+    }
+
+    /// The runtime list is parsed out of the generated union, so the parse has to
+    /// be exact. Rebuilding the union from the parsed names and comparing it to
+    /// what `ts-rs` produced is what makes that safe: a dropped, merged, or
+    /// mis-trimmed member cannot survive the round trip.
+    #[test]
+    fn the_runtime_tool_list_reconstructs_the_union() {
+        let declarations = event_declarations();
+        let decl = declarations["RendererToolName"].clone();
+        let union = decl
+            .lines()
+            .find(|line| line.starts_with("export type"))
+            .expect("the union is declared")
+            .trim_start_matches("export ")
+            .to_owned();
+        let names = generate::tool_names_from_union(&union);
+
+        let rebuilt = format!(
+            "type RendererToolName = {};",
+            names
+                .iter()
+                .map(|name| format!("\"{name}\""))
+                .collect::<Vec<_>>()
+                .join(" | ")
+        );
+        assert_eq!(
+            rebuilt, union,
+            "the tool-name parse does not reproduce what ts-rs generated"
+        );
+        assert_eq!(
+            names.iter().collect::<std::collections::HashSet<_>>().len(),
+            names.len(),
+            "two variants share a wire spelling"
+        );
+        // Guards against the union collapsing to a single `string`, which would
+        // turn the allowlist into a passthrough without failing anything else.
+        assert!(names.len() > 1, "the vocabulary did not render as a union");
+        assert!(
+            names.iter().all(|name| !name.is_empty()
+                && name
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')),
+            "a tool name is not a plain snake_case identifier: {names:?}"
+        );
+    }
+
+    /// Rust sources that can contribute a generated type.
+    fn generated_sources() -> Vec<(String, String)> {
+        let crate_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let mut files = Vec::new();
+        for relative in ["src", "../openwave-core/src"] {
+            collect_rust_files(&crate_root.join(relative), &mut files);
+        }
+        assert!(
+            files.len() > 20,
+            "expected to scan the server and core sources, found {}",
+            files.len()
+        );
+        files
+    }
+
+    fn collect_rust_files(dir: &std::path::Path, out: &mut Vec<(String, String)>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_rust_files(&path, out);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                // This file holds deliberately-wrong examples, in the scanner's
+                // own self-test. Scanning it flags those, which is the scanner
+                // working rather than a real finding.
+                if path.file_name().is_some_and(|name| name == "wire_types.rs") {
+                    continue;
+                }
+                if let Ok(text) = std::fs::read_to_string(&path) {
+                    out.push((path.display().to_string(), text));
+                }
+            }
+        }
+    }
+
+    /// A field serde omits must be declared optional, not nullable.
+    ///
+    /// `ts-rs` will not do this for you: it requires `#[serde(default)]` to infer
+    /// optionality, while serde treats a missing `Option` as `None` regardless.
+    /// So an `Option` field carrying only `skip_serializing_if` generates
+    /// `T | null` — a claim that the key is always present, which is the exact
+    /// mismatch that shipped twice before any of this was generated.
+    #[test]
+    fn a_field_serde_omits_is_declared_optional() {
+        let mut problems = Vec::new();
+        for (path, source) in generated_sources() {
+            for field in generate::omittable_fields_missing_optional(&source) {
+                problems.push(format!("{path}: {field}"));
+            }
+        }
+        assert!(
+            problems.is_empty(),
+            "these fields are omitted by serde but not declared optional in \
+             TypeScript. Add #[ts(optional)] beside the skip_serializing_if, or \
+             the generated type will claim a key the server never sends:\n{}",
+            problems.join("\n")
+        );
+    }
+
+    /// The scanner above only helps if it can actually see the mistake, and a
+    /// silently-matching-nothing scanner would pass forever. Feed it both shapes.
+    #[test]
+    fn the_optional_scanner_detects_a_missing_annotation() {
+        let bad = r#"
+            #[derive(Serialize, TS)]
+            pub struct Snapshot {
+                pub id: String,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                pub title: Option<String>,
+            }
+        "#;
+        assert_eq!(
+            generate::omittable_fields_missing_optional(bad),
+            vec!["pub title: Option<String>".to_owned()],
+            "the scanner missed an unannotated omittable field"
+        );
+
+        let annotated = r#"
+            #[derive(Serialize, TS)]
+            pub struct Snapshot {
+                #[serde(skip_serializing_if = "Option::is_none")]
+                #[ts(optional)]
+                pub title: Option<String>,
+            }
+        "#;
+        assert!(generate::omittable_fields_missing_optional(annotated).is_empty());
+
+        // A type that does not derive TS is not generated, so it is not this
+        // test's business — flagging it would be a false failure.
+        let not_generated = r#"
+            #[derive(Serialize)]
+            pub struct StoredOnly {
+                #[serde(skip_serializing_if = "Option::is_none")]
+                pub title: Option<String>,
+            }
+        "#;
+        assert!(generate::omittable_fields_missing_optional(not_generated).is_empty());
+    }
+
+    /// Ids serialize as a bare UUID string, and must generate as one.
+    ///
+    /// `ts-rs` cannot parse `#[serde(transparent)]` — the attribute every id
+    /// carries — and ignores it. It happens to reach the right answer because a
+    /// single-field tuple struct already renders as its inner type. That is a
+    /// coincidence of two independent rules agreeing, so it is pinned here
+    /// rather than trusted, especially now that the warning is silenced.
+    #[test]
+    fn ids_generate_as_bare_strings() {
+        let declarations = event_declarations();
+        for id in ["CallId", "TurnId", "MessageId"] {
+            let decl = declarations
+                .get(id)
+                .unwrap_or_else(|| panic!("{id} is reachable from the event root"));
+            assert!(
+                decl.contains(&format!("export type {id} = string;")),
+                "{id} should generate as a bare string, got: {decl}"
+            );
+        }
+    }
+
+    /// The closure walk is the reason only one root is named, so assert it
+    /// actually reached past that root. A visitor that silently stopped at the
+    /// top level would still produce a file, and the diff check would happily
+    /// pin a nearly empty one.
+    #[test]
+    fn the_walk_reaches_the_types_the_root_only_references() {
+        let declarations = event_declarations();
+        for expected in [
+            "RendererSequencedEvent",
+            "RendererAgentEvent",
+            "RendererToolName",
+            "RendererToolStatus",
+            "ToolActionPreview",
+            "ToolResultPreview",
+            "ToolApprovalKind",
+            "ApprovalClass",
+        ] {
+            assert!(
+                declarations.contains_key(expected),
+                "{expected} was not reached from the root; generated: {:?}",
+                declarations.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+}

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -52,19 +52,50 @@ actually is:
 
 ## Adding a type
 
-1. Derive `TS` on the Rust type.
-2. If a field is `#[serde(skip_serializing_if = "Option::is_none")]`, add
-   `#[ts(optional)]`. Serde omits the key; without the annotation `ts-rs` emits
-   `field: T | null`, which claims the key is always present. This is the exact
-   mismatch that shipped twice, and it is the one thing the generator will not
-   catch for you.
-3. Regenerate, and check the diff reads the way you expect.
+1. Derive `TS` on the Rust type. If it is reachable from a type already
+   generated, that is all — the generator walks the dependency closure from a
+   small set of roots, so a new field of a new type pulls it in automatically.
+2. If a field is `#[serde(skip_serializing_if = "…")]`, add `#[ts(optional)]`.
+   Serde omits the key, but `ts-rs` only infers optionality from
+   `maybe_omitted && has_default`, and serde treats a missing `Option` as `None`
+   without needing `#[serde(default)]` — so without the annotation you get
+   `field: T | null`, claiming a key the server never sends. **This is the exact
+   mismatch that shipped twice, and generating the type does not fix it.** A test
+   scans for it and fails with the field name, so you do not have to remember.
+3. Regenerate, and read the diff. A change here is a change to what the server
+   promises.
+
+## Two things the generator gets wrong by default
+
+Both are configured or annotated, and both are pinned by tests, but they are
+worth knowing before adding types.
+
+- **Large integers.** `ts-rs` renders `i64`/`u64` as `bigint`. These types
+  describe what `JSON.parse` produces, and that is a `number` — a `bigint`
+  declaration would be false about every value received, and would break
+  arithmetic against existing `number` state. The generator sets
+  `large_int` to `number`.
+- **`#[serde(transparent)]`.** `ts-rs` cannot parse it and ignores it. Every id
+  newtype carries it, and the right output happens anyway because a single-field
+  tuple struct already renders as its inner type. That coincidence is pinned by a
+  test, and the resulting per-id build warning is silenced by the
+  `no-serde-warnings` feature.
 
 ## Scope today
 
-Generation currently covers the renderer's tool vocabulary. The remaining wire
-types — the snapshot DTOs and the event projection — are still hand-written; see
-the tracking issue. Two known mismatches are already documented there rather than
-silently corrected: `CustomModelConfig.display_name` is `skip_serializing_if` but
-typed as required in TypeScript, and `ChatMessageSnapshot.citations` is always
-serialized but typed optional.
+Generated: the renderer's tool vocabulary and the whole WebSocket event surface —
+the frame, the event union, the tool previews, and the approval kinds. The event
+surface mattered most because the renderer parses each frame with a bare cast and
+no runtime validation, so the generated type is the only contract on that path.
+
+Not yet generated: the ~37 REST snapshot DTOs. A naive derive sweep over them
+would cause two silent regressions — `ChatToolActivity.tool` would widen from an
+allowlist to `string`, and `ChatMessage.role` would widen from two variants to
+four, making a `system` message render as a user bubble. Neither produces a
+compile error. Those and five other hazards are enumerated on the tracking issue;
+do not sweep without reading it.
+
+`ChatMessageSnapshot.citations` is deliberately wider in TypeScript than on the
+wire: the server always sends it, but the transcript is not validated, so the `?`
+is what forces the guard that reads it. Narrowing it would delete that guard
+rather than earn it.


### PR DESCRIPTION
Part of #478. Follows #529, which generated the tool vocabulary; this does the whole WebSocket event surface.

## Why this surface first

It had **no contract at all**. The renderer parses each frame with a bare `JSON.parse(...) as SequencedEvent` cast — no runtime validation on that path, unlike the REST approval and question routes. So a hand-written type was the only thing describing the payload, and nothing tied it to the server.

Eleven types now generated from **one named root**: `ts-rs` walks the dependency closure, so a new field of a new type is pulled in automatically instead of quietly missing. A test asserts the walk actually reached past the root, because a visitor that silently stopped at the top level would still produce a file and the diff check would happily pin a nearly empty one.

## Two generator defaults that are wrong here

Both read as correct, which is what makes them worth calling out.

**`i64` → `bigint`.** These types describe what `JSON.parse` produces, and that is a `number`. A `bigint` declaration would be false about every value received and would not typecheck against the existing sequence state (`framed.seq <= state.lastSeq` where `lastSeq: number`). The generator sets `large_int` to `number`, and documents the 2^53 trade.

**`skip_serializing_if` → `T | null`.** Serde omits the key, so this claims a key the server never sends — **the exact mismatch that shipped twice and motivated generating anything at all.** `ts-rs` infers optionality from `maybe_omitted && has_default`, and serde needs no `default` to treat a missing `Option` as `None`, so `#[ts(optional)]` is required and its absence is silent.

That second one gets a guard rather than a doc note: a test scans every `TS`-deriving item and names any field serde omits that is not declared optional. It is itself checked against a wrong example, a right one, and a non-generated type — because a scanner that matches nothing passes forever. It caught its own self-test fixtures on first run, which is how I know it works.

## The remap is now compile-checked

`ToolResultPreview` stays hand-written and camelCase. Its Rust type is carried in the journal, so renaming those fields would stop existing chats from loading — that makes the remap the cheaper side to keep, not the wire.

But the remap now destructures through the generated wire type:

```ts
type UncheckedExecResult = Partial<
  Record<keyof Extract<WireToolResultPreview, { tool: "exec" }>, unknown>
>;
```

Verified by renaming the Rust field:

```
src/api.ts(1046,22): error TS2339: Property 'timed_out' does not exist on
type 'Partial<Record<keyof ToolResultPreview, unknown>>'.
```

Previously that rename would have silently destructured to `undefined` and dropped every result preview at runtime, with nothing failing.

## One consolidation

#529 emitted `wire.ts` and this initially emitted `events.ts`, but both declared `RendererToolName` — two files that cannot both be imported. Merged into one generated module, with the runtime tool-name list emitted beside its own union.

## A build-noise fix, made safe first

`ts-rs` cannot parse `#[serde(transparent)]`, which every id newtype carries, so it printed a warning per id on every build. It reaches the right answer anyway — but only because a single-field tuple struct already renders as its inner type, which is two independent rules coinciding rather than the attribute being honored. Pinned that with a test, *then* silenced the warning via `no-serde-warnings`.

## Deliberately not included: the REST DTOs

A naive derive sweep over them would cause two **silent** regressions — no compile error, wrong behaviour:

- `ChatToolActivity.tool` is `&'static str` in Rust and `RendererToolName` in TypeScript. It would widen to `string`, deleting the `Record<RendererToolName, _>` compile-time coverage that #529 exists to provide. The consumers re-guard at runtime, so nothing would fail.
- `ChatMessage.role` is two variants in TypeScript and **four** in Rust (`Role` has `System` and `Tool`). Widening makes a `system` message render as a user bubble; the ternary that reads it still compiles.

Those plus five more — the camelCase collisions, the `ModelSelectionKey` brand, an optionality inversion on `PendingApprovalSnapshot.preview`, `HostRootId`, and six `#[non_exhaustive]` enums — are enumerated in **#548**. I would rather that sweep be deliberate than fast.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --no-fail-fast` (28 binaries, 1264 passed, 0 failed), `tsc --noEmit`, `vitest run` (400 passed), production `vite build`. `Cargo.lock` unchanged apart from the new feature flag — no existing version moved.