### PR TITLE
feat(models): refresh and widen the curated model catalog

### DIFF
--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -84,6 +84,11 @@ describe("formatContextWindow", () => {
     expect(formatContextWindow(1_500_000)).toBe("1.5M");
   });
 
+  it("truncates millions so a limit never reads larger than it is", () => {
+    expect(formatContextWindow(1_050_000)).toBe("1M");
+    expect(formatContextWindow(1_990_000)).toBe("1.9M");
+  });
+
   it("renders small counts verbatim", () => {
     expect(formatContextWindow(512)).toBe("512");
   });

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -55,11 +55,15 @@ export function ProviderIcon({
   );
 }
 
-/** Compact token count, e.g. 200000 -> "200K", 1000000 -> "1M". */
+/**
+ * Compact token count, e.g. 200000 -> "200K", 1000000 -> "1M".
+ *
+ * Millions truncate rather than round, so a 1,050,000-token window reads as
+ * "1M". A limit that rounds up reads as more headroom than the model has.
+ */
 export function formatContextWindow(tokens: number): string {
   if (tokens >= 1_000_000) {
-    const millions = tokens / 1_000_000;
-    return `${Number.isInteger(millions) ? millions : millions.toFixed(1)}M`;
+    return `${Math.floor(tokens / 100_000) / 10}M`;
   }
   if (tokens >= 1_000) {
     return `${Math.round(tokens / 1_000)}K`;

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -440,7 +440,7 @@ impl Server {
 
 /// Default model when none is configured via settings or per-chat. Overridable
 /// with `OPENWAVE_MODEL`.
-const DEFAULT_MODEL: &str = "claude-opus-4-8";
+const DEFAULT_MODEL: &str = "claude-opus-5";
 
 /// Wire the store from `config` and bind the API to an ephemeral loopback port.
 ///

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -61,12 +61,12 @@ impl ModelSpec {
 }
 
 /// Curated models in picker display order: each provider's current generation
-/// first, then the previous generations a chat can pin when the newest one
+/// first, then the earlier generations a chat can pin when the newest one
 /// regresses on its workload.
 const MODEL_REGISTRY: &[ModelSpec] = &[
     ModelSpec {
-        id: "claude-opus-4-8",
-        display_name: "Claude Opus 4.8",
+        id: "claude-opus-5",
+        display_name: "Claude Opus 5",
         provider: ProviderKind::Anthropic,
         context_window: 1_000_000,
         max_output_tokens: 128_000,
@@ -95,6 +95,16 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 200_000,
         max_output_tokens: 64_000,
+        input_modalities: TEXT_ONLY,
+        supports_reasoning: true,
+        supports_reasoning_effort: false,
+    },
+    ModelSpec {
+        id: "claude-opus-4-8",
+        display_name: "Claude Opus 4.8",
+        provider: ProviderKind::Anthropic,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
         supports_reasoning_effort: false,
@@ -343,9 +353,21 @@ mod tests {
         for &provider in ProviderKind::ALL {
             assert!(models_for(provider).all(|spec| spec.provider == provider));
         }
-        assert_eq!(models_for(ProviderKind::Anthropic).count(), 6);
+        assert_eq!(models_for(ProviderKind::Anthropic).count(), 7);
         assert_eq!(models_for(ProviderKind::Openai).count(), 6);
         assert_eq!(models_for(ProviderKind::OpenaiCompatible).count(), 0);
+    }
+
+    #[test]
+    fn the_built_in_default_is_the_first_curated_row_of_its_provider() {
+        let spec = find(crate::DEFAULT_MODEL).expect("the default model must be curated");
+        assert_eq!(spec.provider, ProviderKind::Anthropic);
+        // The default has to be the current generation, not a pin that happened
+        // to be current when it was written down.
+        assert_eq!(
+            models_for(ProviderKind::Anthropic).next().map(|s| s.id),
+            Some(crate::DEFAULT_MODEL),
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -88,6 +88,18 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_reasoning_effort: false,
     },
     ModelSpec {
+        // The previous Opus generation, kept so a chat can pin it when 4.8
+        // regresses on that chat's workload.
+        id: "claude-opus-4-7",
+        display_name: "Claude Opus 4.7",
+        provider: ProviderKind::Anthropic,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_ONLY,
+        supports_reasoning: true,
+        supports_reasoning_effort: false,
+    },
+    ModelSpec {
         id: "claude-haiku-4-5-20251001",
         display_name: "Claude Haiku 4.5",
         provider: ProviderKind::Anthropic,
@@ -98,41 +110,34 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_reasoning_effort: false,
     },
     ModelSpec {
-        id: "gpt-4o",
-        display_name: "GPT-4o",
+        id: "gpt-5.6-sol",
+        display_name: "GPT-5.6 Sol",
         provider: ProviderKind::Openai,
-        context_window: 128_000,
-        max_output_tokens: 16_384,
+        context_window: 1_050_000,
+        max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
-        supports_reasoning: false,
-        supports_reasoning_effort: false,
+        supports_reasoning: true,
+        // The whole GPT-5.6 family reasons on a caller-selected effort, which
+        // the OpenAI-compatible adapter already sends alongside
+        // `max_completion_tokens`.
+        supports_reasoning_effort: true,
     },
     ModelSpec {
-        id: "gpt-4o-mini",
-        display_name: "GPT-4o mini",
+        id: "gpt-5.6-terra",
+        display_name: "GPT-5.6 Terra",
         provider: ProviderKind::Openai,
-        context_window: 128_000,
-        max_output_tokens: 16_384,
-        input_modalities: TEXT_ONLY,
-        supports_reasoning: false,
-        supports_reasoning_effort: false,
-    },
-    ModelSpec {
-        id: "o3",
-        display_name: "o3",
-        provider: ProviderKind::Openai,
-        context_window: 200_000,
-        max_output_tokens: 100_000,
+        context_window: 1_050_000,
+        max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
         supports_reasoning_effort: true,
     },
     ModelSpec {
-        id: "o4-mini",
-        display_name: "o4-mini",
+        id: "gpt-5.6-luna",
+        display_name: "GPT-5.6 Luna",
         provider: ProviderKind::Openai,
-        context_window: 200_000,
-        max_output_tokens: 100_000,
+        context_window: 1_050_000,
+        max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
         supports_reasoning_effort: true,
@@ -288,8 +293,8 @@ mod tests {
         for &provider in ProviderKind::ALL {
             assert!(models_for(provider).all(|spec| spec.provider == provider));
         }
-        assert_eq!(models_for(ProviderKind::Anthropic).count(), 3);
-        assert_eq!(models_for(ProviderKind::Openai).count(), 4);
+        assert_eq!(models_for(ProviderKind::Anthropic).count(), 4);
+        assert_eq!(models_for(ProviderKind::Openai).count(), 3);
         assert_eq!(models_for(ProviderKind::OpenaiCompatible).count(), 0);
     }
 
@@ -309,9 +314,25 @@ mod tests {
     }
 
     #[test]
+    fn every_openai_entry_reasons_on_a_caller_selected_effort() {
+        let openai: Vec<_> = models_for(ProviderKind::Openai).collect();
+        assert!(!openai.is_empty());
+        for spec in openai {
+            assert!(
+                spec.supports_reasoning && spec.supports_reasoning_effort,
+                "{} is curated on the OpenAI route without the reasoning shape that route sends",
+                spec.id
+            );
+            assert_eq!(spec.context_window, 1_050_000);
+            assert_eq!(spec.max_output_tokens, 128_000);
+        }
+    }
+
+    #[test]
     fn display_name_prefers_registry_and_falls_back_for_unknown_ids() {
         assert_eq!(display_name_for("claude-opus-4-8"), "Claude Opus 4.8");
-        assert_eq!(display_name_for("gpt-4o-mini"), "GPT-4o mini");
+        assert_eq!(display_name_for("gpt-5.6-sol"), "GPT-5.6 Sol");
+        assert_eq!(display_name_for("gpt-4o-mini"), "GPT 4o Mini");
         assert_eq!(
             display_name_for("claude-sonnet-9-20260101"),
             "Claude Sonnet 9"
@@ -322,21 +343,24 @@ mod tests {
 
     #[test]
     fn selection_keys_are_provider_scoped_and_legacy_ids_migrate_losslessly() {
-        let key = selection_key(ProviderKind::Openai, "gpt-4o");
-        assert_eq!(key, "openai::gpt-4o");
+        let key = selection_key(ProviderKind::Openai, "gpt-5.6-sol");
+        assert_eq!(key, "openai::gpt-5.6-sol");
         assert_eq!(
             parse_selection_key(&key),
-            Some((ProviderKind::Openai, "gpt-4o"))
+            Some((ProviderKind::Openai, "gpt-5.6-sol"))
         );
         assert_eq!(
             parse_selection_key("openai_compatible::vendor::model"),
             Some((ProviderKind::OpenaiCompatible, "vendor::model"))
         );
         assert_eq!(
-            migrate_curated_selection("gpt-4o").as_deref(),
-            Some("openai::gpt-4o")
+            migrate_curated_selection("gpt-5.6-sol").as_deref(),
+            Some("openai::gpt-5.6-sol")
         );
-        assert!(migrate_curated_selection("anthropic::gpt-4o").is_none());
-        assert!(parse_selection_key("unknown::gpt-4o").is_none());
+        assert!(migrate_curated_selection("anthropic::gpt-5.6-sol").is_none());
+        assert!(parse_selection_key("unknown::gpt-5.6-sol").is_none());
+        // A retired curated id no longer resolves; the picker surfaces it as
+        // unavailable rather than silently routing it somewhere else.
+        assert!(migrate_curated_selection("gpt-4o").is_none());
     }
 }

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -60,7 +60,9 @@ impl ModelSpec {
     }
 }
 
-/// Curated models in picker display order.
+/// Curated models in picker display order: each provider's current generation
+/// first, then the previous generations a chat can pin when the newest one
+/// regresses on its workload.
 const MODEL_REGISTRY: &[ModelSpec] = &[
     ModelSpec {
         id: "claude-opus-4-8",
@@ -88,8 +90,16 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_reasoning_effort: false,
     },
     ModelSpec {
-        // The previous Opus generation, kept so a chat can pin it when 4.8
-        // regresses on that chat's workload.
+        id: "claude-haiku-4-5-20251001",
+        display_name: "Claude Haiku 4.5",
+        provider: ProviderKind::Anthropic,
+        context_window: 200_000,
+        max_output_tokens: 64_000,
+        input_modalities: TEXT_ONLY,
+        supports_reasoning: true,
+        supports_reasoning_effort: false,
+    },
+    ModelSpec {
         id: "claude-opus-4-7",
         display_name: "Claude Opus 4.7",
         provider: ProviderKind::Anthropic,
@@ -100,11 +110,21 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_reasoning_effort: false,
     },
     ModelSpec {
-        id: "claude-haiku-4-5-20251001",
-        display_name: "Claude Haiku 4.5",
+        id: "claude-opus-4-6",
+        display_name: "Claude Opus 4.6",
         provider: ProviderKind::Anthropic,
-        context_window: 200_000,
-        max_output_tokens: 64_000,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_ONLY,
+        supports_reasoning: true,
+        supports_reasoning_effort: false,
+    },
+    ModelSpec {
+        id: "claude-sonnet-4-6",
+        display_name: "Claude Sonnet 4.6",
+        provider: ProviderKind::Anthropic,
+        context_window: 1_000_000,
+        max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
         supports_reasoning_effort: false,
@@ -117,8 +137,8 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        // The whole GPT-5.6 family reasons on a caller-selected effort, which
-        // the OpenAI-compatible adapter already sends alongside
+        // The whole GPT-5 line reasons on a caller-selected effort, which the
+        // OpenAI-compatible adapter already sends alongside
         // `max_completion_tokens`.
         supports_reasoning_effort: true,
     },
@@ -137,6 +157,36 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         display_name: "GPT-5.6 Luna",
         provider: ProviderKind::Openai,
         context_window: 1_050_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_ONLY,
+        supports_reasoning: true,
+        supports_reasoning_effort: true,
+    },
+    ModelSpec {
+        id: "gpt-5.5",
+        display_name: "GPT-5.5",
+        provider: ProviderKind::Openai,
+        context_window: 1_050_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_ONLY,
+        supports_reasoning: true,
+        supports_reasoning_effort: true,
+    },
+    ModelSpec {
+        id: "gpt-5.4-mini",
+        display_name: "GPT-5.4 mini",
+        provider: ProviderKind::Openai,
+        context_window: 400_000,
+        max_output_tokens: 128_000,
+        input_modalities: TEXT_ONLY,
+        supports_reasoning: true,
+        supports_reasoning_effort: true,
+    },
+    ModelSpec {
+        id: "gpt-5.4-nano",
+        display_name: "GPT-5.4 nano",
+        provider: ProviderKind::Openai,
+        context_window: 400_000,
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
@@ -293,8 +343,8 @@ mod tests {
         for &provider in ProviderKind::ALL {
             assert!(models_for(provider).all(|spec| spec.provider == provider));
         }
-        assert_eq!(models_for(ProviderKind::Anthropic).count(), 4);
-        assert_eq!(models_for(ProviderKind::Openai).count(), 3);
+        assert_eq!(models_for(ProviderKind::Anthropic).count(), 6);
+        assert_eq!(models_for(ProviderKind::Openai).count(), 6);
         assert_eq!(models_for(ProviderKind::OpenaiCompatible).count(), 0);
     }
 
@@ -323,8 +373,11 @@ mod tests {
                 "{} is curated on the OpenAI route without the reasoning shape that route sends",
                 spec.id
             );
-            assert_eq!(spec.context_window, 1_050_000);
-            assert_eq!(spec.max_output_tokens, 128_000);
+            assert_eq!(
+                spec.max_output_tokens, 128_000,
+                "{} carries an output cap the GPT-5 line does not have",
+                spec.id
+            );
         }
     }
 

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -868,22 +868,31 @@ mod tests {
 
         let mut config = AgentConfig::default();
         let gpt = ResolvedModelPolicy::curated(
-            model_registry::find_for(ProviderKind::Openai, "gpt-4o").unwrap(),
+            model_registry::find_for(ProviderKind::Openai, "gpt-5.6-sol").unwrap(),
         );
-        apply_model_policy(&mut config, &gpt, Some(ReasoningEffort::High)).unwrap();
+        apply_model_policy(&mut config, &gpt, Some(ReasoningEffort::Low)).unwrap();
         assert_eq!(config.provider, Some(ProviderId::new("openai")));
-        assert_eq!(config.context_window, 128_000);
-        assert_eq!(config.max_tokens, Some(16_384));
-        assert!(!config.reasoning_model);
-        assert_eq!(config.reasoning_effort, None);
-
-        let mut config = AgentConfig::default();
-        let o3 = ResolvedModelPolicy::curated(
-            model_registry::find_for(ProviderKind::Openai, "o3").unwrap(),
-        );
-        apply_model_policy(&mut config, &o3, Some(ReasoningEffort::Low)).unwrap();
+        assert_eq!(config.context_window, 1_050_000);
+        assert_eq!(config.max_tokens, Some(128_000));
         assert!(config.reasoning_model);
         assert_eq!(config.reasoning_effort, Some(ReasoningEffort::Low));
+
+        // A custom endpoint keeps the conservative shape: no reasoning, and the
+        // requested effort is dropped rather than sent to something that would
+        // reject it.
+        let mut config = AgentConfig::default();
+        let custom = ResolvedModelPolicy::custom(&CustomModelConfig {
+            id: "local-model".into(),
+            display_name: None,
+            context_window: 32_768,
+            max_output_tokens: 4_096,
+        });
+        apply_model_policy(&mut config, &custom, Some(ReasoningEffort::High)).unwrap();
+        assert_eq!(config.provider, Some(ProviderId::new("openai_compatible")));
+        assert_eq!(config.context_window, 32_768);
+        assert_eq!(config.max_tokens, Some(4_096));
+        assert!(!config.reasoning_model);
+        assert_eq!(config.reasoning_effort, None);
     }
 
     #[test]

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -9857,7 +9857,7 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
         Arc::new(ToolRegistry::new()),
         retrieval,
         AgentConfig {
-            model: "gpt-4o".into(),
+            model: "gpt-5.6-sol".into(),
             ..AgentConfig::default()
         },
     );
@@ -9865,15 +9865,20 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
     let router = app(state);
 
     // Old bare curated ids are accepted but persisted under their exact owner.
-    let configured = put_settings(&router, &bearer, serde_json::json!({"model": "gpt-4o"})).await;
+    let configured = put_settings(
+        &router,
+        &bearer,
+        serde_json::json!({"model": "gpt-5.6-sol"}),
+    )
+    .await;
     assert_eq!(configured.status(), StatusCode::OK);
     let settings: serde_json::Value = json_body(configured).await;
-    assert_eq!(settings["model"], "openai::gpt-4o");
+    assert_eq!(settings["model"], "openai::gpt-5.6-sol");
 
     let wrong_provider = put_settings(
         &router,
         &bearer,
-        serde_json::json!({"model": "anthropic::gpt-4o"}),
+        serde_json::json!({"model": "anthropic::gpt-5.6-sol"}),
     )
     .await;
     assert_eq!(wrong_provider.status(), StatusCode::BAD_REQUEST);
@@ -9899,7 +9904,7 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({"model": "openai::gpt-4o"}).to_string(),
+                    serde_json::json!({"model": "openai::gpt-5.6-sol"}).to_string(),
                 ))
                 .unwrap(),
         )
@@ -9907,14 +9912,14 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
         .unwrap();
     assert_eq!(chat_response.status(), StatusCode::CREATED);
     let chat: Chat = json_body(chat_response).await;
-    assert_eq!(chat.model.as_deref(), Some("openai::gpt-4o"));
+    assert_eq!(chat.model.as_deref(), Some("openai::gpt-5.6-sol"));
 
     let turn_id = TurnId::new();
     let accepted = send_message_with_id(&router, &bearer, chat.id, turn_id, "hello").await;
     assert_eq!(accepted, StatusCode::ACCEPTED);
     assert_eq!(
         store.get_turn_run(turn_id).await.unwrap().unwrap().model,
-        "openai::gpt-4o"
+        "openai::gpt-5.6-sol"
     );
 
     // The same raw id may be explicitly configured under another provider.
@@ -9933,7 +9938,7 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
                         "base_url": "http://127.0.0.1:1234/v1",
                         "credential": {"type": "api_key", "key": "sk-local"},
                         "models": [{
-                            "id": "gpt-4o",
+                            "id": "gpt-5.6-sol",
                             "context_window": 32768,
                             "max_output_tokens": 4096
                         }]
@@ -9946,12 +9951,17 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
         .unwrap();
     assert_eq!(configure_compatible.status(), StatusCode::OK);
 
-    let ambiguous = put_settings(&router, &bearer, serde_json::json!({"model": "gpt-4o"})).await;
+    let ambiguous = put_settings(
+        &router,
+        &bearer,
+        serde_json::json!({"model": "gpt-5.6-sol"}),
+    )
+    .await;
     assert_eq!(ambiguous.status(), StatusCode::BAD_REQUEST);
     let error: AgentErrorInfo = json_body(ambiguous).await;
     assert_eq!(error.kind, "unknown_model");
 
-    for qualified in ["openai::gpt-4o", "openai_compatible::gpt-4o"] {
+    for qualified in ["openai::gpt-5.6-sol", "openai_compatible::gpt-5.6-sol"] {
         let exact = put_settings(&router, &bearer, serde_json::json!({"model": qualified})).await;
         assert_eq!(exact.status(), StatusCode::OK);
         let settings: serde_json::Value = json_body(exact).await;
@@ -10126,7 +10136,7 @@ async fn resolver_includes_openai_when_enabled() {
     // (no anthropic route, no openai_compatible fallback).
     let router = openwave_router::Router::build(routes);
     assert_eq!(
-        router.select("gpt-4o"),
+        router.select("gpt-5.6-sol"),
         Some(openwave_router::RouteKind::Openai)
     );
     assert_eq!(router.select("claude-opus-4-8"), None);


### PR DESCRIPTION
The OpenAI half of the model picker still offered `gpt-4o`, `gpt-4o-mini`, `o3`, and `o4-mini` — all pre-GPT-5. The Anthropic half had drifted too: Claude Opus 5 shipped as the current Opus generation, moving Opus 4.8/4.7/4.6 into Anthropic's legacy set, and `DEFAULT_MODEL` still pointed at Opus 4.8 — so a fresh install with no configured model ran a superseded generation. And with three rows per provider there was no cheap tier for a throwaway question and no way to pin a previous generation after a regression.

## The catalog now

**Anthropic** — current generation first, then the pins:

| id | display name | context | max output |
|---|---|---|---|
| `claude-opus-5` | Claude Opus 5 | 1,000,000 | 128,000 |
| `claude-sonnet-5` | Claude Sonnet 5 | 1,000,000 | 128,000 |
| `claude-haiku-4-5-20251001` | Claude Haiku 4.5 | 200,000 | 64,000 |
| `claude-opus-4-8` | Claude Opus 4.8 | 1,000,000 | 128,000 |
| `claude-opus-4-7` | Claude Opus 4.7 | 1,000,000 | 128,000 |
| `claude-opus-4-6` | Claude Opus 4.6 | 1,000,000 | 128,000 |
| `claude-sonnet-4-6` | Claude Sonnet 4.6 | 1,000,000 | 128,000 |

**OpenAI** — the GPT-5.6 family plus the previous frontier and the small tiers. All six take a caller-selected reasoning effort, which the OpenAI-compatible adapter already sends alongside `max_completion_tokens`:

| id | display name | context | max output |
|---|---|---|---|
| `gpt-5.6-sol` | GPT-5.6 Sol | 1,050,000 | 128,000 |
| `gpt-5.6-terra` | GPT-5.6 Terra | 1,050,000 | 128,000 |
| `gpt-5.6-luna` | GPT-5.6 Luna | 1,050,000 | 128,000 |
| `gpt-5.5` | GPT-5.5 | 1,050,000 | 128,000 |
| `gpt-5.4-mini` | GPT-5.4 mini | 400,000 | 128,000 |
| `gpt-5.4-nano` | GPT-5.4 nano | 400,000 | 128,000 |

`DEFAULT_MODEL` now points at `claude-opus-5`, and a test asserts it is both curated and the first row of its provider. The drift this fixes was invisible precisely because nothing tied the default to the catalog's notion of current, and it would have recurred on the next generation.

## What is deliberately absent

- **The `-pro` variants and `o3-pro`** are served only on the Responses API. Every OpenWave request goes out over Chat Completions, so curating them would offer a selection that cannot be fulfilled.
- **Claude Fable 5** waits on #555. It runs safety classifiers on input, and until `refusal` is a stop reason the transcript understands, a declined turn reads as a turn that finished with nothing to say.
- Every row stays `TEXT_ONLY`, and the guard test forbidding image input stays in place — that flag flips with the rest of the attachment path in #462.

## Retiring a curated id is user-visible

`resolve_model_policy` returns `None` for an id that leaves the registry, so a chat still pinned to `openai::gpt-4o` fails its next turn with `unknown_model` and the picker renders it as unavailable. That is what a curated catalog is for, and the failure is legible rather than a silent reroute, but it is worth knowing about.

## Also

Millions in the context-window label truncate instead of rounding, so a 1,050,000 token window reads as "1M" rather than "1.1M". A limit that rounds up reads as more headroom than the model has.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, and `cargo check --workspace --locked` all pass with no lockfile diff; `tsc`, `vitest` (401 tests), and a production build pass under `crates/openwave-desktop/ui`.

Driven against a running server rather than only the test suite:

- `GET /models` returns all thirteen rows with the right limits and capability flags, in the intended picker order.
- `PUT /settings {"model": "gpt-4o"}` → `400 unknown_model`.
- `PUT /settings {"model": "gpt-5.6-sol"}` → `409 model_provider_unavailable` with no OpenAI credential configured.
- Real turns on chats pinned to `anthropic::claude-opus-5`, `claude-opus-4-7`, `claude-sonnet-4-6`, and `claude-opus-4-6` each completed against the live Anthropic API and journaled `turn_completed` / `end_turn` with no failure record, so every newly added row routes end to end.

Closes #549