### PR TITLE
refactor(core): keep the renderer tool vocabulary in one place

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -706,7 +706,7 @@ fn tool_activity_from_call(call: ToolCallRecord) -> ChatToolActivitySnapshot {
         }
     };
     ChatToolActivitySnapshot {
-        tool: historical_tool_name(&call.name),
+        tool: crate::RendererToolName::from(call.name.as_str()),
         action: crate::preview::ToolActionPreview::build(&call.name, &call.arguments),
         status,
         started_at: call.created_at,
@@ -723,32 +723,6 @@ fn tool_activity_from_call(call: ToolCallRecord) -> ChatToolActivitySnapshot {
 /// owns the wording for a live call, so sending prose here meant maintaining a
 /// second copy of it plus an inverse lookup to get back to a name — and a copy
 /// change on either side silently broke hydration.
-fn historical_tool_name(name: &str) -> &'static str {
-    match name {
-        "search" => "search",
-        "list_sources" => "list_sources",
-        "read_source" => "read_source",
-        "read_tool_result" => "read_tool_result",
-        "web_search" => "web_search",
-        crate::SANDBOX_READ_DELEGATED_FILE_TOOL => "read_delegated_file",
-        "read_file" => "read_file",
-        "read_connected_file" => "read_connected_file",
-        "list_dir" => "list_dir",
-        "write_file" => "write_file",
-        "create_deliverable" => "create_deliverable",
-        "request_folder_access" => "request_folder_access",
-        "connect_folder" => "connect_folder",
-        "list_connected_folders" => "list_connected_folders",
-        "list_folder" => "list_folder",
-        "import_connected_file" => "import_connected_file",
-        crate::ASK_USER_QUESTIONS_TOOL => "ask_user_questions",
-        "spawn_sandbox_agent" => "spawn_sandbox_agent",
-        "wait_for_agents" => "wait_for_agents",
-        "exec" => "exec",
-        _ => "other",
-    }
-}
-
 async fn terminal_event_cursor_on<C>(conn: &C, chat_id: ChatId) -> Result<i64>
 where
     C: ConnectionTrait,
@@ -1159,67 +1133,5 @@ fn role_from_db(text: &str) -> Result<Role> {
         "assistant" => Ok(Role::Assistant),
         "tool" => Ok(Role::Tool),
         other => Err(AgentError::Store(format!("unknown role: {other}"))),
-    }
-}
-
-#[cfg(test)]
-mod historical_tool_name_tests {
-    use super::historical_tool_name;
-
-    #[test]
-    fn a_private_tool_name_never_reaches_the_renderer() {
-        assert_eq!(
-            historical_tool_name(crate::SANDBOX_READ_DELEGATED_FILE_TOOL),
-            "read_delegated_file"
-        );
-        // The allowlist is the point: an unrecognized name folds rather than
-        // travelling, so it cannot leak a provider or extension detail.
-        assert_eq!(historical_tool_name("private_read_variant"), "other");
-        assert_eq!(historical_tool_name("mcp__vendor__search"), "other");
-        assert_eq!(historical_tool_name("search"), "search");
-        assert_eq!(
-            historical_tool_name(crate::ASK_USER_QUESTIONS_TOOL),
-            "ask_user_questions"
-        );
-    }
-
-    /// A tool the renderer can name live must survive the round trip.
-    ///
-    /// `exec` used to be absent here, so a command read as "Ran a command"
-    /// while streaming and "Used a tool" after a reload — with its own command
-    /// card still visible underneath.
-    #[test]
-    fn every_renderer_visible_tool_keeps_its_name_through_history() {
-        for name in [
-            "search",
-            "list_sources",
-            "read_source",
-            "read_tool_result",
-            "web_search",
-            crate::SANDBOX_READ_DELEGATED_FILE_TOOL,
-            "read_file",
-            "list_dir",
-            "write_file",
-            "create_deliverable",
-            "request_folder_access",
-            "connect_folder",
-            "list_connected_folders",
-            "list_folder",
-            "read_connected_file",
-            "import_connected_file",
-            "spawn_sandbox_agent",
-            "wait_for_agents",
-            crate::ASK_USER_QUESTIONS_TOOL,
-            "exec",
-        ] {
-            // Round-trips as itself, except the one private name that is
-            // deliberately renamed for the renderer.
-            let projected = historical_tool_name(name);
-            assert_ne!(projected, "other", "{name} does not survive history");
-            if name != crate::SANDBOX_READ_DELEGATED_FILE_TOOL {
-                assert_eq!(projected, name);
-            }
-        }
-        assert_eq!(historical_tool_name("other"), "other");
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -45,6 +45,7 @@ pub mod keychain;
 pub mod model;
 pub mod preview;
 pub mod provider;
+mod renderer_tool;
 pub mod steer;
 pub mod storage;
 pub mod tool;
@@ -138,6 +139,7 @@ pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason,
     Usage,
 };
+pub use renderer_tool::RendererToolName;
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
     AcceptAgentRunOutcome, AcceptClaimedToolCallOutcome, AcceptSandboxAgentRunAndParkTurnOutcome,

--- a/crates/openwave-core/src/renderer_tool.rs
+++ b/crates/openwave-core/src/renderer_tool.rs
@@ -1,0 +1,165 @@
+//! The renderer's tool vocabulary.
+//!
+//! Tool names are model-controlled. Only names with a fixed renderer
+//! presentation cross the boundary; everything else folds to
+//! [`RendererToolName::Other`] rather than becoming a display path for a
+//! provider-supplied string.
+//!
+//! This lives in `openwave-core` because three places need the same closed set:
+//! the live event projection in the server, the history lookup that rebuilds a
+//! terminal tool card from the journal, and [`ChatToolActivitySnapshot`]'s own
+//! field type. Two of those are here, and until this module existed each kept
+//! its own copy of the list. The copies drifted: `exec` was missing from the
+//! history lookup, so a command relabelled itself as a generic tool on reload.
+//!
+//! [`ChatToolActivitySnapshot`]: crate::storage::ChatToolActivitySnapshot
+
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+/// A tool name the renderer is allowed to present.
+///
+/// The desktop's union, its runtime guard, its copy table, and its icon table
+/// are all generated from this enum, so a variant added here cannot leave one of
+/// them behind — see `docs/wire-types.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum RendererToolName {
+    Search,
+    ListSources,
+    ReadSource,
+    ReadToolResult,
+    WebSearch,
+    ReadDelegatedFile,
+    ReadFile,
+    ListDir,
+    WriteFile,
+    CreateDeliverable,
+    RequestFolderAccess,
+    ConnectFolder,
+    ListConnectedFolders,
+    ListFolder,
+    ReadConnectedFile,
+    ImportConnectedFile,
+    SpawnSandboxAgent,
+    WaitForAgents,
+    AskUserQuestions,
+    Exec,
+    /// The fold for anything unrecognized, including a tool that has since been
+    /// removed and any name a provider invented.
+    Other,
+}
+
+impl From<&str> for RendererToolName {
+    /// Fold a registered tool name onto the vocabulary.
+    ///
+    /// Written as literals rather than against the server's tool-name constants,
+    /// which this crate cannot see. `source_tools_use_fixed_renderer_names` in
+    /// the server holds those constants to these spellings.
+    fn from(name: &str) -> Self {
+        match name {
+            "search" => Self::Search,
+            "list_sources" => Self::ListSources,
+            "read_source" => Self::ReadSource,
+            "read_tool_result" => Self::ReadToolResult,
+            "web_search" => Self::WebSearch,
+            crate::SANDBOX_READ_DELEGATED_FILE_TOOL => Self::ReadDelegatedFile,
+            "read_file" => Self::ReadFile,
+            "list_dir" => Self::ListDir,
+            "write_file" => Self::WriteFile,
+            "create_deliverable" => Self::CreateDeliverable,
+            "request_folder_access" => Self::RequestFolderAccess,
+            "connect_folder" => Self::ConnectFolder,
+            "list_connected_folders" => Self::ListConnectedFolders,
+            "list_folder" => Self::ListFolder,
+            "read_connected_file" => Self::ReadConnectedFile,
+            "import_connected_file" => Self::ImportConnectedFile,
+            "spawn_sandbox_agent" => Self::SpawnSandboxAgent,
+            "wait_for_agents" => Self::WaitForAgents,
+            crate::ASK_USER_QUESTIONS_TOOL => Self::AskUserQuestions,
+            "exec" => Self::Exec,
+            _ => Self::Other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every registered tool name the renderer can present must survive the
+    /// fold, both live and when a terminal card is rebuilt from the journal.
+    ///
+    /// `exec` used to be absent from the history lookup, which was a second copy
+    /// of this mapping, so a command read as "Ran a command" while streaming and
+    /// "Used a tool" after a reload — with its own command card still visible
+    /// underneath. One enum now serves both, and this covers the behaviour that
+    /// regressed.
+    ///
+    /// The input list is the registered *tool* names, which are not derivable
+    /// from this enum: the fold exists precisely because the two vocabularies
+    /// are different sets that happen to agree on spelling.
+    #[test]
+    fn every_renderer_visible_tool_keeps_its_name() {
+        for name in [
+            "search",
+            "list_sources",
+            "read_source",
+            "read_tool_result",
+            "web_search",
+            crate::SANDBOX_READ_DELEGATED_FILE_TOOL,
+            "read_file",
+            "list_dir",
+            "write_file",
+            "create_deliverable",
+            "request_folder_access",
+            "connect_folder",
+            "list_connected_folders",
+            "list_folder",
+            "read_connected_file",
+            "import_connected_file",
+            "spawn_sandbox_agent",
+            "wait_for_agents",
+            crate::ASK_USER_QUESTIONS_TOOL,
+            "exec",
+        ] {
+            let folded = RendererToolName::from(name);
+            assert_ne!(
+                folded,
+                RendererToolName::Other,
+                "{name} folded to Other, so it would render as a generic tool"
+            );
+            assert_eq!(
+                serde_json::to_value(folded).unwrap(),
+                serde_json::json!(name),
+                "{name} does not serialize back to its own wire spelling"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unregistered_name_folds_to_other() {
+        for name in [
+            "mcp__vendor__exfiltrate",
+            "private_read_variant",
+            "",
+            "SEARCH",
+            "other",
+        ] {
+            assert_eq!(RendererToolName::from(name), RendererToolName::Other);
+        }
+    }
+
+    /// The two names that come from constants rather than literals here.
+    #[test]
+    fn the_shared_tool_constants_still_match_their_spellings() {
+        assert_eq!(
+            RendererToolName::from(crate::SANDBOX_READ_DELEGATED_FILE_TOOL),
+            RendererToolName::ReadDelegatedFile
+        );
+        assert_eq!(
+            RendererToolName::from(crate::ASK_USER_QUESTIONS_TOOL),
+            RendererToolName::AskUserQuestions
+        );
+    }
+}

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -96,7 +96,7 @@ pub enum DeleteProjectOutcome {
 }
 
 /// Fixed lifecycle vocabulary exposed for a historical tool card.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum ChatToolActivityStatus {
     Completed,
@@ -107,18 +107,24 @@ pub enum ChatToolActivityStatus {
 /// A completed tool invocation with no results, tool identity, provider
 /// metadata, executor identity, lease, or diagnostic detail. The only arguments
 /// it can carry are the ones a tool explicitly projects for display.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct ChatToolActivitySnapshot {
     /// Allowlisted renderer tool name, never a provider-supplied one.
     ///
     /// A name rather than display copy: the renderer already derives a live
     /// call's wording from its name, and sending prose here made a copy change
     /// silently break history hydration.
-    pub tool: &'static str,
+    ///
+    /// Typed as the vocabulary rather than a string so the generated TypeScript
+    /// stays a union. As `&'static str` it generated as `string`, which compiles
+    /// on both sides while silently dropping the allowlist the renderer's copy
+    /// and icon tables are keyed on.
+    pub tool: crate::RendererToolName,
     /// Closed projection of what the call did, when its tool has one. Rebuilt
     /// from the arguments it ran with, so history describes the same action
     /// the live stream did.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub action: Option<crate::preview::ToolActionPreview>,
     pub status: ChatToolActivityStatus,
     pub started_at: chrono::DateTime<chrono::Utc>,

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -1,6 +1,8 @@
 import {
   RENDERER_TOOL_NAMES,
   type ApprovalClass,
+  type ChatToolActivitySnapshot,
+  type ChatToolActivityStatus,
   type RendererAgentEvent,
   type RendererSequencedEvent,
   type RendererToolName,
@@ -9,7 +11,12 @@ import {
   type ToolResultPreview as WireToolResultPreview,
 } from "./generated/wire";
 
-export type { ApprovalClass, RendererToolName, ToolActionPreview };
+export type {
+  ApprovalClass,
+  ChatToolActivityStatus,
+  RendererToolName,
+  ToolActionPreview,
+};
 
 /**
  * The WebSocket frame and the events it carries, generated from the server's
@@ -194,23 +201,15 @@ export type ChatMessageCitation = {
   pages: number[];
 };
 
-/** A fixed, terminal tool-card projection with no canonical tool data. */
-export type ChatToolActivity = {
-  /** What the call did, when its tool projects it. */
-  action?: ToolActionPreview;
-  /**
-   * Allowlisted renderer tool name, folded server-side.
-   *
-   * A name rather than display copy: the renderer derives a live call's
-   * wording from its name, and carrying prose here meant a second copy of it
-   * plus an inverse lookup, where a change on either side silently broke
-   * hydration.
-   */
-  tool: RendererToolName;
-  status: "completed" | "failed" | "cancelled";
-  started_at: string;
-  finished_at: string | null;
-};
+/**
+ * A fixed, terminal tool-card projection with no canonical tool data.
+ *
+ * `tool` is the allowlisted renderer name rather than display copy: the renderer
+ * derives a live call's wording from its name, and carrying prose here meant a
+ * second copy of it plus an inverse lookup, where a change on either side
+ * silently broke hydration.
+ */
+export type ChatToolActivity = ChatToolActivitySnapshot;
 
 export type ChatTranscript = {
   messages: ChatMessage[];

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -23,6 +23,37 @@ export type ApprovalClass = "read_only" | "workspace" | "sensitive";
 export type CallId = string;
 
 /**
+ * A completed tool invocation with no results, tool identity, provider
+ * metadata, executor identity, lease, or diagnostic detail. The only arguments
+ * it can carry are the ones a tool explicitly projects for display.
+ */
+export type ChatToolActivitySnapshot = { 
+/**
+ * Allowlisted renderer tool name, never a provider-supplied one.
+ *
+ * A name rather than display copy: the renderer already derives a live
+ * call's wording from its name, and sending prose here made a copy change
+ * silently break history hydration.
+ *
+ * Typed as the vocabulary rather than a string so the generated TypeScript
+ * stays a union. As `&'static str` it generated as `string`, which compiles
+ * on both sides while silently dropping the allowlist the renderer's copy
+ * and icon tables are keyed on.
+ */
+tool: RendererToolName, 
+/**
+ * Closed projection of what the call did, when its tool has one. Rebuilt
+ * from the arguments it ran with, so history describes the same action
+ * the live stream did.
+ */
+action?: ToolActionPreview, status: ChatToolActivityStatus, started_at: string, finished_at: string | null, };
+
+/**
+ * Fixed lifecycle vocabulary exposed for a historical tool card.
+ */
+export type ChatToolActivityStatus = "completed" | "failed" | "cancelled";
+
+/**
  * Identifies a persisted message within a chat.
  */
 export type MessageId = string;
@@ -50,13 +81,11 @@ result?: ToolResultPreview, } | { "type": "turn_completed" } | { "type": "turn_f
 export type RendererSequencedEvent = { seq: number, event: RendererAgentEvent, };
 
 /**
- * Tool names are model-controlled. Only names with fixed renderer
- * presentations cross the boundary; everything else becomes `other`.
+ * A tool name the renderer is allowed to present.
  *
- * This enum is the renderer's tool vocabulary. The desktop's union, its
- * runtime guard, its copy table, and its icon table all derive from the
- * TypeScript generated here, so adding a variant cannot leave one of them
- * behind — see `docs/wire-types.md`.
+ * The desktop's union, its runtime guard, its copy table, and its icon table
+ * are all generated from this enum, so a variant added here cannot leave one of
+ * them behind — see `docs/wire-types.md`.
  */
 export type RendererToolName = "search" | "list_sources" | "read_source" | "read_tool_result" | "web_search" | "read_delegated_file" | "read_file" | "list_dir" | "write_file" | "create_deliverable" | "request_folder_access" | "connect_folder" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file" | "spawn_sandbox_agent" | "wait_for_agents" | "ask_user_questions" | "exec" | "other";
 

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -6,8 +6,8 @@
 //! projection instead.
 
 use openwave_core::{
-    AgentEvent, ApprovalClass, CallId, MessageId, SequencedEvent, ToolActionPreview,
-    ToolApprovalKind, ToolResultPreview, TurnId,
+    AgentEvent, ApprovalClass, CallId, MessageId, RendererToolName, SequencedEvent,
+    ToolActionPreview, ToolApprovalKind, ToolResultPreview, TurnId,
 };
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
@@ -89,72 +89,11 @@ pub(crate) enum RendererAgentEvent {
     EventOmitted,
 }
 
-/// Tool names are model-controlled. Only names with fixed renderer
-/// presentations cross the boundary; everything else becomes `other`.
-///
-/// This enum is the renderer's tool vocabulary. The desktop's union, its
-/// runtime guard, its copy table, and its icon table all derive from the
-/// TypeScript generated here, so adding a variant cannot leave one of them
-/// behind — see `docs/wire-types.md`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum RendererToolName {
-    Search,
-    ListSources,
-    ReadSource,
-    ReadToolResult,
-    WebSearch,
-    ReadDelegatedFile,
-    ReadFile,
-    ListDir,
-    WriteFile,
-    CreateDeliverable,
-    RequestFolderAccess,
-    ConnectFolder,
-    ListConnectedFolders,
-    ListFolder,
-    ReadConnectedFile,
-    ImportConnectedFile,
-    SpawnSandboxAgent,
-    WaitForAgents,
-    AskUserQuestions,
-    Exec,
-    Other,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum RendererToolStatus {
     Completed,
     Failed,
-}
-
-impl From<&str> for RendererToolName {
-    fn from(name: &str) -> Self {
-        match name {
-            "search" => Self::Search,
-            crate::source_tools::LIST_SOURCES_TOOL => Self::ListSources,
-            crate::source_tools::READ_SOURCE_TOOL => Self::ReadSource,
-            crate::source_tools::READ_TOOL_RESULT_TOOL => Self::ReadToolResult,
-            "web_search" => Self::WebSearch,
-            openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL => Self::ReadDelegatedFile,
-            "read_file" => Self::ReadFile,
-            "list_dir" => Self::ListDir,
-            "write_file" => Self::WriteFile,
-            "create_deliverable" => Self::CreateDeliverable,
-            "request_folder_access" => Self::RequestFolderAccess,
-            "connect_folder" => Self::ConnectFolder,
-            "list_connected_folders" => Self::ListConnectedFolders,
-            "list_folder" => Self::ListFolder,
-            "read_connected_file" => Self::ReadConnectedFile,
-            "import_connected_file" => Self::ImportConnectedFile,
-            "spawn_sandbox_agent" => Self::SpawnSandboxAgent,
-            "wait_for_agents" => Self::WaitForAgents,
-            openwave_core::ASK_USER_QUESTIONS_TOOL => Self::AskUserQuestions,
-            "exec" => Self::Exec,
-            _ => Self::Other,
-        }
-    }
 }
 
 impl From<&SequencedEvent> for RendererSequencedEvent {

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1738,7 +1738,7 @@ fn default_pending_approvals_limit() -> u64 {
 pub(crate) struct PendingApprovalSnapshot {
     pub call_id: CallId,
     pub turn_id: TurnId,
-    pub action: crate::event_projection::RendererToolName,
+    pub action: openwave_core::RendererToolName,
     pub approval: openwave_core::ToolApprovalKind,
     pub class: openwave_core::ApprovalClass,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1753,7 +1753,7 @@ impl PendingApprovalSnapshot {
         Self {
             call_id: approval.call_id,
             turn_id: approval.turn_id,
-            action: crate::event_projection::RendererToolName::from(approval.tool_name.as_str()),
+            action: openwave_core::RendererToolName::from(approval.tool_name.as_str()),
             approval: kind,
             class: approval.class,
             preview: approval.preview,

--- a/crates/openwave-server/src/source_tools.rs
+++ b/crates/openwave-server/src/source_tools.rs
@@ -463,8 +463,8 @@ impl Tool for ReadToolResultTool {
 /// The tool's own name is model-supplied in principle, so a result header uses
 /// the same closed vocabulary the rest of the renderer boundary does.
 fn historical_safe_name(name: &str) -> &'static str {
-    match crate::event_projection::RendererToolName::from(name) {
-        crate::event_projection::RendererToolName::Other => "a tool",
+    match openwave_core::RendererToolName::from(name) {
+        openwave_core::RendererToolName::Other => "a tool",
         _ => "the tool call",
     }
 }

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -264,6 +264,10 @@ mod tests {
         // One root. Everything the event stream can carry is reachable from it,
         // including the shared preview and approval types the REST surface uses.
         generate::collect_from::<crate::event_projection::RendererSequencedEvent>(&cfg, &mut out);
+        // The terminal tool card rebuilt from the journal. Shares the tool
+        // vocabulary and the action preview with the live stream, which is why
+        // it belongs with them rather than with the rest of the REST surface.
+        generate::collect_from::<openwave_core::ChatToolActivitySnapshot>(&cfg, &mut out);
         out
     }
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -63,11 +63,15 @@ union and its runtime guard are now generated from `RendererToolName`, and its
 copy and icon tables are keyed on the generated union, so a missing entry is a
 compile error. [Wire types](wire-types.md) covers the generator and how to run it.
 
-Two places still hold the vocabulary by hand, because both map *tool* names onto
-it rather than restating it: the `From<&str>` fold in `event_projection.rs`, for
-live calls, and `historical_tool_name` in the store, for names read back from the
-journal. Their sets agree today; folding them into the enum is tracked
-separately.
+There is now one copy of the vocabulary: `RendererToolName` in `openwave-core`,
+which owns the enum and the single `From<&str>` fold that maps a registered tool
+name onto it. The live event projection, the history lookup that rebuilds a
+terminal card from the journal, and `ChatToolActivitySnapshot`'s own field type
+all use it.
+
+They did not always. The history lookup was a second 20-arm match, and `exec` was
+missing from it, so a command read as "Ran a command" while streaming and "Used a
+tool" after a reload — with its own command card still visible underneath.
 
 Normal foreground turns also receive a
 [host-owned operating prompt](agent-operating-prompt.md). It composes fixed

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -88,12 +88,17 @@ the frame, the event union, the tool previews, and the approval kinds. The event
 surface mattered most because the renderer parses each frame with a bare cast and
 no runtime validation, so the generated type is the only contract on that path.
 
+Also generated: `ChatToolActivitySnapshot`, the terminal tool card rebuilt from
+the journal. It shares the vocabulary and the action preview with the live stream,
+so it belongs with them rather than with the rest of the REST surface. Its `tool`
+field was `&'static str`, which generated as `string` and silently dropped the
+allowlist the copy and icon tables are keyed on; it is now typed as the enum.
+
 Not yet generated: the ~37 REST snapshot DTOs. A naive derive sweep over them
-would cause two silent regressions — `ChatToolActivity.tool` would widen from an
-allowlist to `string`, and `ChatMessage.role` would widen from two variants to
-four, making a `system` message render as a user bubble. Neither produces a
-compile error. Those and five other hazards are enumerated on the tracking issue;
-do not sweep without reading it.
+would still widen `ChatMessage.role` from two variants to four — `Role` has
+`System` and `Tool` — making a `system` message render as a user bubble, with no
+compile error. That and the remaining hazards are enumerated on the tracking
+issue; do not sweep without reading it.
 
 `ChatMessageSnapshot.citations` is deliberately wider in TypeScript than on the
 wire: the server always sends it, but the transcript is not validated, so the `?`


### PR DESCRIPTION
Closes #528. Also closes the first of the seven hazards in #548, which is what motivated doing it now.

## Three copies, one of which had already drifted

The vocabulary existed in three places:

1. `RendererToolName` and its `From<&str>` fold, in `openwave-server`.
2. A separate 20-arm match in the store (`historical_tool_name`), for names read back from the journal.
3. `ChatToolActivitySnapshot.tool`, typed `&'static str`.

Copy 2 had already drifted. `exec` was missing from it, so a command read as "Ran a command" while streaming and "Used a tool" after a reload — with its own command card still visible underneath. That was fixed by hand in #497; nothing stopped it recurring.

The enum and one fold now live in `openwave-core`, where the store can see them, and the store's match is **deleted** rather than checked against the enum. One mapping cannot disagree with itself.

## Why this closes a hazard rather than just tidying

`ChatToolActivitySnapshot.tool` was `&'static str`. `&'static str` implements `TS` and generates as `string`, so a derive sweep would have compiled cleanly on both sides while **silently dropping the allowlist** — the `Record<RendererToolName, _>` totality that makes a tool without copy or an icon a compile error, which is the whole point of #529.

Typed as the enum, it generates correctly:

```ts
export type ChatToolActivitySnapshot = { tool: RendererToolName, action?: ToolActionPreview, … };
```

And the snapshot is now generated rather than hand-written, so `ChatToolActivity` in `api.ts` is an alias and the two cannot drift. Its `action` field needed `#[ts(optional)]`, which the scanner from #551 demanded — the guard working as intended on its first real use.

## One deliberate compromise

The fold uses string literals where it previously referenced `crate::source_tools::LIST_SOURCES_TOOL` and friends, because `openwave-core` cannot see the server's constants. That looks like a step backwards, but `source_tools_use_fixed_renderer_names` already holds those constants to these exact spellings, so the link is kept where it was rather than reintroduced. The two names that come from shared `openwave-core` constants still reference them.

## What is left of #548

Six hazards, of which one is still silent: `ChatMessage.role` is two variants in TypeScript and four in Rust, so a sweep would render a `system` message as a user bubble with no compile error. Next.

## A correction on my earlier numbers

Local `vitest` runs I quoted in #530, #532, and #551 said 55 files / ~400 tests. The real count is 56 / 406 — my `node_modules` was in a partially-installed state and one `.dom.test.tsx` was failing to collect, which `vitest` reported as simply fewer files. CI does a clean install, so those PRs were genuinely verified against the full suite and are unaffected; my local figures were understated. Fixed with `pnpm install --frozen-lockfile`, and the lockfile is unchanged.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --no-fail-fast` (28 binaries, **1268 passed, 0 failed**), `tsc --noEmit`, `vitest run` (**56 files, 406 passed**), production `vite build`.

Net −100 lines.