### PR TITLE
test(desktop): check the renderer's validators against real server output

### DIFF
--- a/crates/openwave-desktop/ui/src/WireFixtures.test.ts
+++ b/crates/openwave-desktop/ui/src/WireFixtures.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  RENDERER_FOLDER_ACCESS_REASON,
+  parseFolderAccessRequest,
+  parsePendingToolApproval,
+} from "./api";
+import {
+  PENDING_APPROVAL,
+  PENDING_APPROVAL_WITHOUT_PREVIEW,
+  PENDING_FOLDER_ACCESS_REQUEST,
+} from "./generated/fixtures";
+
+/**
+ * The validators, run against the server's real output.
+ *
+ * Every other test of these functions builds its own input, which means it
+ * encodes what the author believed the wire looked like. That is how a field
+ * renamed server-side leaves both test suites green and the app broken — the
+ * failure mode this whole effort exists to remove, and the one place generated
+ * types cannot help, because these validators are a trust boundary and stay
+ * hand-written.
+ *
+ * The fixtures here are serialized from the server's own types by a Rust test,
+ * so they cannot drift from it. A rename changes the fixture, and these fail.
+ *
+ * Rejection cases deliberately stay hand-authored elsewhere: malformed input is
+ * not something the server can produce, so there is nothing to generate.
+ */
+describe("validators against real server output", () => {
+  it("accepts a pending approval and remaps it to the app shape", () => {
+    const parsed = parsePendingToolApproval(PENDING_APPROVAL);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed).toEqual({
+      callId: "00000000-0000-0000-0000-000000000001",
+      turnId: "00000000-0000-0000-0000-000000000002",
+      action: "exec",
+      approval: "exec_may_run_networked_command",
+      class: "sensitive",
+      preview: { tool: "exec", command: "git", args: ["status"], cwd: "." },
+      canApprove: true,
+      canRemember: true,
+    });
+  });
+
+  it("accepts an approval whose optional preview key is absent", () => {
+    // The server omits `preview` rather than sending null. Hand-authored inputs
+    // habitually send null instead, so this case went untested.
+    expect("preview" in PENDING_APPROVAL_WITHOUT_PREVIEW).toBe(false);
+
+    const parsed = parsePendingToolApproval(PENDING_APPROVAL_WITHOUT_PREVIEW);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.preview).toBeNull();
+    expect(parsed?.canApprove).toBe(false);
+    expect(parsed?.canRemember).toBe(false);
+  });
+
+  it("accepts a folder access request and renames claimed for the app", () => {
+    const parsed = parseFolderAccessRequest(PENDING_FOLDER_ACCESS_REQUEST);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed).toEqual({
+      callId: "00000000-0000-0000-0000-000000000003",
+      turnId: "00000000-0000-0000-0000-000000000004",
+      reason: RENDERER_FOLDER_ACCESS_REASON,
+      folderHint: "documents",
+      claimedByDesktop: true,
+    });
+  });
+
+  it("agrees with the server on the frozen consent prose", () => {
+    // The validator rejects any request whose reason is not byte-identical to
+    // this constant, so no server-authored text can reach a consent prompt. The
+    // two literals live in different languages; the fixture is what ties them.
+    expect(PENDING_FOLDER_ACCESS_REQUEST.reason).toBe(
+      RENDERER_FOLDER_ACCESS_REASON,
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -367,7 +367,15 @@ export type UserQuestionAnswer = {
   freeForm?: string;
 };
 
-const RENDERER_FOLDER_ACCESS_REASON =
+/**
+ * The only consent prose a folder-access prompt will render.
+ *
+ * `parseFolderAccessRequest` rejects any request whose `reason` is not
+ * byte-identical to this, so no server-authored text can reach a consent prompt.
+ * The server holds the same literal; exported so a test can compare the two
+ * across the language boundary rather than trusting they match.
+ */
+export const RENDERER_FOLDER_ACCESS_REASON =
   "The assistant needs read access to files outside the folders connected to this conversation.";
 
 const WS_HANDSHAKE = "openwave-v1";

--- a/crates/openwave-desktop/ui/src/generated/fixtures.ts
+++ b/crates/openwave-desktop/ui/src/generated/fixtures.ts
@@ -1,0 +1,45 @@
+// Generated from Rust. Do not edit.
+//
+// Regenerate: UPDATE_WIRE_TYPES=1 cargo test -p openwave-server
+//
+// Real serialized output from the server's own types, for the renderer's
+// validator tests to consume. Hand-authored inputs encode what the author
+// believed the wire looked like, which is how a rename can leave both test
+// suites green and the app broken. These cannot drift from the server
+// without this file changing. See docs/wire-types.md.
+
+export const PENDING_APPROVAL = {
+  "action": "exec",
+  "approval": "exec_may_run_networked_command",
+  "call_id": "00000000-0000-0000-0000-000000000001",
+  "can_approve": true,
+  "can_remember": true,
+  "class": "sensitive",
+  "preview": {
+    "args": [
+      "status"
+    ],
+    "command": "git",
+    "cwd": ".",
+    "tool": "exec"
+  },
+  "turn_id": "00000000-0000-0000-0000-000000000002"
+} as const;
+
+export const PENDING_APPROVAL_WITHOUT_PREVIEW = {
+  "action": "ask_user_questions",
+  "approval": "unsupported",
+  "call_id": "00000000-0000-0000-0000-000000000005",
+  "can_approve": false,
+  "can_remember": false,
+  "class": "read_only",
+  "turn_id": "00000000-0000-0000-0000-000000000002"
+} as const;
+
+export const PENDING_FOLDER_ACCESS_REQUEST = {
+  "call_id": "00000000-0000-0000-0000-000000000003",
+  "claimed": true,
+  "folder_hint": "documents",
+  "reason": "The assistant needs read access to files outside the folders connected to this conversation.",
+  "turn_id": "00000000-0000-0000-0000-000000000004"
+} as const;

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -37,7 +37,7 @@ use crate::web_search::{
     WebSearchCredentialsInfo,
 };
 
-mod client_execution;
+pub(crate) mod client_execution;
 mod delegated_file_execution;
 mod document;
 pub(crate) mod image_attachment;

--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -23,7 +23,9 @@ use crate::extract::{Json, Path};
 use crate::state::AppState;
 
 const CLIENT_EXECUTION_LEASE: Duration = Duration::seconds(60);
-const RENDERER_FOLDER_ACCESS_REASON: &str =
+/// Frozen consent prose. The renderer pins this byte-for-byte so no
+/// server-authored text can reach a consent prompt.
+pub(crate) const RENDERER_FOLDER_ACCESS_REASON: &str =
     "The assistant needs read access to files outside the folders connected to this conversation.";
 
 /// Caller-owned claim identity. The lease token is a secret capability and

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -227,6 +227,41 @@ pub(crate) mod generate {
         spans
     }
 
+    /// Render a TypeScript module of real serialized server values.
+    ///
+    /// The renderer's validators are a trust boundary and stay hand-written, so
+    /// generation cannot check them. What it can do is stop them being *tested*
+    /// against hand-authored objects: until now every validator test built its
+    /// own input from the TypeScript author's belief about the wire, so a field
+    /// renamed server-side left both suites green and the app broken. That is
+    /// the failure this closes.
+    ///
+    /// Each entry is serialized from a real Rust value, so the fixture is the
+    /// server's actual output rather than a description of it.
+    pub(crate) fn render_fixtures(entries: &[(&str, serde_json::Value)]) -> String {
+        let body = entries
+            .iter()
+            .map(|(name, value)| {
+                let json = serde_json::to_string_pretty(value).expect("a fixture serializes");
+                format!("export const {name} = {json} as const;\n")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            "// Generated from Rust. Do not edit.\n\
+             //\n\
+             // Regenerate: UPDATE_WIRE_TYPES=1 cargo test -p openwave-server\n\
+             //\n\
+             // Real serialized output from the server's own types, for the renderer's\n\
+             // validator tests to consume. Hand-authored inputs encode what the author\n\
+             // believed the wire looked like, which is how a rename can leave both test\n\
+             // suites green and the app broken. These cannot drift from the server\n\
+             // without this file changing. See docs/wire-types.md.\n\
+             \n\
+             {body}"
+        )
+    }
+
     /// Compare `rendered` against the checked-in file, or rewrite it when
     /// `UPDATE_WIRE_TYPES` is set.
     pub(crate) fn check_or_update(relative_path: &str, rendered: &str, regenerate_with: &str) {
@@ -432,6 +467,192 @@ mod tests {
             }
         "#;
         assert!(generate::omittable_fields_missing_optional(not_generated).is_empty());
+    }
+
+    /// Path of the generated validator fixtures, relative to this crate.
+    const FIXTURES: &str = "../openwave-desktop/ui/src/generated/fixtures.ts";
+
+    /// Fixed ids, so the fixture does not change on every run.
+    fn id(n: u128) -> uuid::Uuid {
+        uuid::Uuid::from_u128(n)
+    }
+
+    /// Real server values for the shapes the renderer validates by hand.
+    ///
+    /// These are the five camelCase types whose TypeScript describes the
+    /// *validator's output* rather than the wire, so their remaps cannot be
+    /// generated away. Serializing the real value is what ties them to the
+    /// server: a field renamed here changes this file, and the renderer test
+    /// that consumes it fails.
+    fn validator_fixtures() -> Vec<(&'static str, serde_json::Value)> {
+        let approval = crate::routes::PendingApprovalSnapshot {
+            call_id: openwave_core::CallId(id(1)),
+            turn_id: openwave_core::TurnId(id(2)),
+            action: openwave_core::RendererToolName::Exec,
+            approval: openwave_core::ToolApprovalKind::ExecMayRunNetworkedCommand,
+            class: openwave_core::ApprovalClass::Sensitive,
+            preview: Some(openwave_core::ToolActionPreview::Exec {
+                command: "git".into(),
+                args: vec!["status".into()],
+                cwd: ".".into(),
+            }),
+            can_approve: true,
+            can_remember: true,
+        };
+        // The same shape with the omittable field absent, because "the key is
+        // missing" is a distinct case the validator has to survive and the one
+        // that hand-authored inputs habitually get wrong.
+        let approval_without_preview = crate::routes::PendingApprovalSnapshot {
+            call_id: openwave_core::CallId(id(5)),
+            turn_id: openwave_core::TurnId(id(2)),
+            action: openwave_core::RendererToolName::AskUserQuestions,
+            approval: openwave_core::ToolApprovalKind::Unsupported,
+            class: openwave_core::ApprovalClass::ReadOnly,
+            preview: None,
+            can_approve: false,
+            can_remember: false,
+        };
+
+        let folder_access = crate::routes::client_execution::PendingFolderAccessRequest {
+            call_id: openwave_core::CallId(id(3)),
+            turn_id: openwave_core::TurnId(id(4)),
+            reason: crate::routes::client_execution::RENDERER_FOLDER_ACCESS_REASON.to_owned(),
+            folder_hint: Some(openwave_core::RequestedFolderHint::Documents),
+            claimed: true,
+        };
+
+        vec![
+            (
+                "PENDING_APPROVAL",
+                serde_json::to_value(&approval).expect("an approval serializes"),
+            ),
+            (
+                "PENDING_APPROVAL_WITHOUT_PREVIEW",
+                serde_json::to_value(&approval_without_preview).expect("an approval serializes"),
+            ),
+            (
+                "PENDING_FOLDER_ACCESS_REQUEST",
+                serde_json::to_value(&folder_access).expect("a folder request serializes"),
+            ),
+        ]
+    }
+
+    /// The renderer's validators are tested against these exact bytes.
+    ///
+    /// Regenerate with `UPDATE_WIRE_TYPES=1 cargo test -p openwave-server`. A diff
+    /// here means the wire changed under a hand-written validator, which is the
+    /// one thing generation cannot check for us.
+    #[test]
+    fn the_validator_fixtures_are_current() {
+        let rendered = generate::render_fixtures(&validator_fixtures());
+        generate::check_or_update(FIXTURES, &rendered, REGENERATE);
+    }
+
+    /// A fixture that silently lost its interesting field would still pass the
+    /// diff check, so assert the two properties the renderer tests depend on.
+    #[test]
+    fn the_fixtures_cover_the_omitted_key_case() {
+        let fixtures = validator_fixtures();
+        let with = &fixtures
+            .iter()
+            .find(|(name, _)| *name == "PENDING_APPROVAL")
+            .expect("the approval fixture exists")
+            .1;
+        let without = &fixtures
+            .iter()
+            .find(|(name, _)| *name == "PENDING_APPROVAL_WITHOUT_PREVIEW")
+            .expect("the no-preview approval fixture exists")
+            .1;
+        assert!(
+            with.get("preview").is_some(),
+            "the approval fixture should carry a preview"
+        );
+        assert!(
+            without.get("preview").is_none(),
+            "serde omits an absent preview, so the fixture must not contain the key"
+        );
+    }
+
+    /// Shapes that must never appear in generated output.
+    ///
+    /// Each one is a whole class of mistake rather than a named case, which is
+    /// the point: the named hazards were found by reading the code, and reading
+    /// does not scale. These fail on the *next* one.
+    ///
+    /// This is a backstop, not the primary defence. `serde_json::Value` cannot
+    /// reach a generated type at all today, because `serde-json-impl` is
+    /// deliberately off and so `Value` does not implement `TS` — a field holding
+    /// one is a compile error, which is stronger than any assertion here. This
+    /// test is what catches it if that feature is ever switched on.
+    #[test]
+    fn the_generated_types_contain_no_imprecise_shapes() {
+        let generated = rendered_bindings();
+        for (shape, why) in [
+            (
+                ": any",
+                "a Rust type reached the roots that ts-rs cannot express — most \
+                 likely serde_json::Value, which means the serde-json-impl \
+                 feature was enabled. Restrict the roots or give the field a \
+                 concrete type; `any` disables checking for every consumer",
+            ),
+            (
+                "bigint",
+                "an integer rendered as bigint. These types describe what \
+                 JSON.parse produces, which is a number, so a bigint \
+                 declaration is false about every value received. The generator \
+                 sets large_int to number — check it is being used",
+            ),
+            (
+                ": unknown",
+                "a field rendered as unknown, which tells a consumer nothing \
+                 and forces a cast at every use",
+            ),
+            ("Record<string, any>", "an untyped map reached the output"),
+        ] {
+            assert!(
+                !generated.contains(shape),
+                "generated wire types contain `{shape}`: {why}"
+            );
+        }
+    }
+
+    /// Fields whose precision the renderer depends on, and which would silently
+    /// widen to `string` if their Rust type were loosened.
+    ///
+    /// A short, purposeful list rather than a copy of any vocabulary: each entry
+    /// is a field where a compile-time guarantee elsewhere is keyed on the union.
+    /// `ChatToolActivitySnapshot.tool` was `&'static str` and generated as
+    /// `string`, which compiled on both sides while deleting the totality check
+    /// that makes a tool without an icon a compile error.
+    ///
+    /// Also a backstop rather than the only defence: now that those fields hold
+    /// enums, loosening one back to a string breaks the code that assigns to it.
+    /// This catches the case where a change is consistent enough to compile —
+    /// a new field, or a type swapped along with its call sites.
+    #[test]
+    fn precision_critical_fields_generate_as_unions() {
+        let generated = rendered_bindings();
+        for (field, expected) in [
+            ("tool", "RendererToolName"),
+            ("name", "RendererToolName"),
+            ("action", "RendererToolName"),
+            ("status", "RendererToolStatus"),
+            ("approval", "ToolApprovalKind"),
+            ("class", "ApprovalClass"),
+        ] {
+            assert!(
+                generated.contains(&format!("{field}: {expected}")),
+                "expected `{field}: {expected}` in the generated types. If the \
+                 Rust field was loosened to a String it now generates as \
+                 `string`, which compiles everywhere and silently drops the \
+                 allowlist the renderer's tables are keyed on"
+            );
+            assert!(
+                !generated.contains(&format!("{field}: string")),
+                "`{field}` generates as a bare string, losing the {expected} \
+                 union the renderer depends on"
+            );
+        }
     }
 
     /// Ids serialize as a bare UUID string, and must generate as one.

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -65,6 +65,32 @@ actually is:
 3. Regenerate, and read the diff. A change here is a change to what the server
    promises.
 
+## What CI checks, and which mistake each check catches
+
+Every one of these is a class of mistake that previously had to be caught by
+reading the code. They all run in existing lanes; nothing needs a new job.
+
+| Check | Catches |
+|---|---|
+| The generated file matches the Rust types | Any wire change that was not regenerated |
+| A field serde omits is declared optional | `skip_serializing_if` rendering as `T \| null`, the mismatch that shipped twice |
+| Precision-critical fields generate as unions | A field loosened to a string, silently dropping an allowlist the renderer's tables are keyed on |
+| No `any`, `bigint`, or `unknown` in the output | A type reaching the roots that cannot be expressed, or an integer rendered as `bigint` |
+| Validators run against generated fixtures | A field renamed server-side under a hand-written validator — the case where both suites stayed green |
+| Ids generate as bare strings | `#[serde(transparent)]` being ignored in a way that stops coinciding with the right answer |
+| The journal event shape is pinned | A rename in a persisted type, which stops existing chats loading |
+
+The fixture check is the one worth understanding, because it closes the failure
+this document opens with. The validators are a trust boundary and stay
+hand-written, so generation cannot check them — but their *tests* used to build
+their own inputs, which encoded what the author believed the wire looked like. A
+field renamed server-side left both suites green and the app broken. Those tests
+now consume `generated/fixtures.ts`, serialized from real server values, so a
+rename changes the fixture and the renderer test fails.
+
+Rejection cases stay hand-authored: malformed input is not something the server
+can produce, so there is nothing to generate from.
+
 ## Two things the generator gets wrong by default
 
 Both are configured or annotated, and both are pinned by tests, but they are


### PR DESCRIPTION
Closes the failure mode #478 opens with, in the one place generation cannot reach. Part of #548.

## The hole

The validators (`parsePendingToolApproval` and friends) are a trust boundary and stay hand-written — they enforce character bounds, reject control characters, refuse duplicate ids, pin one server string to a frozen constant, and re-derive the server's policy booleans to check they agree. Generation cannot replace any of that.

But their *tests* built their own inputs:

```ts
parseFolderAccessRequest({ call_id: "call-1", turn_id: "turn-1", …, claimed: true })
```

That object encodes what the TypeScript author believed the wire looked like. If the server renames `claimed`, the test still passes and the app breaks — **two green suites, one broken contract**, which is exactly the phrase #478 uses.

## Measured, not asserted

With `claimed` renamed server-side, the full renderer suite:

```
× validators against real server output > accepts a folder access request …
  → expected null not to be null
Tests  1 failed | 409 passed (410)
```

**409 tests pass, including the existing validator tests**, because they hand-author `claimed: true`. And the Rust side fails first, on the fixture diff — so the loop closes from both ends.

## What it does

A Rust test serializes real values of the renderer-facing snapshot types into `generated/fixtures.ts`, and the renderer tests consume those exact bytes.

Two details worth review:

- **The fixture carries an approval both with and without its preview.** Serde omits the key rather than sending null, and hand-authored inputs habitually send null instead — so the absent-key path went untested. A second test asserts the fixture really contains one of each, because a fixture that quietly lost its interesting case would still pass the diff check.
- **Rejection cases stay hand-authored.** Malformed input is not something the server can produce, so there is nothing to generate from.

## Two generic checks, and an honest note on both

The hazards in #548 were all found by reading code, which does not scale. These fail on the next one:

- **No `any` / `bigint` / `unknown` in the generated output.**
- **Precision-critical fields generate as unions** — the class of hazard 1, where a field loosened to a string compiles everywhere while silently dropping an allowlist.

Both are **backstops, not the primary defence**, and I would rather say so than let them look load-bearing:

- `serde_json::Value` cannot reach a generated type at all today. `serde-json-impl` is deliberately off, so `Value: TS` is unsatisfied and a field holding one is a **compile error** — stronger than the assertion. The test matters only if that feature is switched on. Verified: `the trait bound Value: TS is not satisfied`.
- Now that the precision-critical fields hold enums, loosening one breaks its call sites. Verified: reverting `tool` to `&'static str` fails with `expected &str, found RendererToolName` before any test runs. The test covers the case where a change is consistent enough to compile.

## CI

No gate change needed. Both generated files sit under `src/generated/`, which #551 already made Rust-scoped, and the logic holds either way: a wire change that was not regenerated fails the Rust lane, and one that was regenerated touches that directory and runs both lanes.

`docs/wire-types.md` now has a table of every check and the specific mistake it catches.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --no-fail-fast` (28 binaries, **1272 passed, 0 failed**), `tsc --noEmit`, `vitest run` (**57 files, 410 passed**), production `vite build`.