### PR TITLE
refactor(server): make the transcript's narrow role a type, not a filter

### DIFF
--- a/crates/openwave-core/src/citation.rs
+++ b/crates/openwave-core/src/citation.rs
@@ -40,7 +40,7 @@ pub struct ParsedAssistantCitations {
 }
 
 /// Renderer-safe historical citation projected from immutable evidence.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, ts_rs::TS)]
 pub struct AssistantCitationSnapshot {
     pub id: AssistantCitationId,
     #[serde(skip)]

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -1,12 +1,15 @@
 import {
   RENDERER_TOOL_NAMES,
   type ApprovalClass,
+  type AssistantCitationSnapshot,
+  type ChatMessageSnapshot,
   type ChatToolActivitySnapshot,
   type ChatToolActivityStatus,
   type RendererAgentEvent,
   type RendererSequencedEvent,
   type RendererToolName,
   type ToolActionPreview,
+  type TranscriptRole,
   type ToolApprovalKind,
   type ToolResultPreview as WireToolResultPreview,
 } from "./generated/wire";
@@ -14,6 +17,7 @@ import {
 export type {
   ApprovalClass,
   ChatToolActivityStatus,
+  TranscriptRole,
   RendererToolName,
   ToolActionPreview,
 };
@@ -171,19 +175,17 @@ export type Chat = {
   created_at: string;
 };
 
-/** One visible, durable transcript entry in conversation order. */
-export type ChatMessage = {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  created_at: string;
-  /**
-   * Deliberately wider than the wire: the server always serializes this, as
-   * `[]` when empty. It is optional here because the transcript is not run
-   * through a validator — it arrives as a parsed cast — so the `?` is what
-   * makes the compiler demand a guard at the one place that reads it. Narrowing
-   * this to match the wire would delete that guard, not earn it.
-   */
+/**
+ * One visible, durable transcript entry in conversation order.
+ *
+ * Generated apart from `citations`, which is deliberately wider than the wire:
+ * the server always serializes it, as `[]` when empty. It is optional here
+ * because the transcript is not run through a validator — it arrives as a parsed
+ * cast — so the `?` is what makes the compiler demand a guard at the one place
+ * that reads it. Narrowing it to match the wire would delete that guard rather
+ * than earn it, so the override is spelled out instead of hidden.
+ */
+export type ChatMessage = Omit<ChatMessageSnapshot, "citations"> & {
   citations?: ChatMessageCitation[];
 };
 
@@ -193,13 +195,7 @@ export type ChatMessage = {
  * Ownership is positional: the server nests each citation under its message and
  * deliberately skips `message_id` on the wire. Do not reintroduce it.
  */
-export type ChatMessageCitation = {
-  id: string;
-  ordinal: number;
-  excerpt: string;
-  heading: string | null;
-  pages: number[];
-};
+export type ChatMessageCitation = AssistantCitationSnapshot;
 
 /**
  * A fixed, terminal tool-card projection with no canonical tool data.

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -18,9 +18,25 @@
 export type ApprovalClass = "read_only" | "workspace" | "sensitive";
 
 /**
+ * Opaque renderer identity for one assistant-message citation.
+ */
+export type AssistantCitationId = string;
+
+/**
+ * Renderer-safe historical citation projected from immutable evidence.
+ */
+export type AssistantCitationSnapshot = { id: AssistantCitationId, ordinal: number, excerpt: string, heading: string | null, pages: Array<number>, };
+
+/**
  * Identifies one tool call, stable across its request/approval/result.
  */
 export type CallId = string;
+
+/**
+ * A renderer-safe durable transcript entry. Internal routing and tool state
+ * deliberately remain behind the server boundary.
+ */
+export type ChatMessageSnapshot = { id: MessageId, role: TranscriptRole, content: string, created_at: string, citations: Array<AssistantCitationSnapshot>, };
 
 /**
  * A completed tool invocation with no results, tool identity, provider
@@ -142,6 +158,22 @@ timed_out: boolean,
  * Whether the provider dropped output past its capture limit.
  */
 output_truncated: boolean, stdout: string, stderr: string, };
+
+/**
+ * The roles a visible transcript entry can have.
+ *
+ * Narrower than [`Role`] on purpose. The transcript shows the conversation, not
+ * the model's plumbing, so `System` and `Tool` never appear — and that was
+ * previously guaranteed only by a `matches!` filter at the one call site, while
+ * the snapshot's own type still admitted all four. The renderer mirrored the
+ * narrow version and branched on `assistant` with no third arm, so a `system`
+ * entry reaching it would have rendered as a user message.
+ *
+ * Encoding it here makes the guarantee the type's rather than the caller's, and
+ * makes a new [`Role`] variant a decision in [`Self::for_transcript`] instead of
+ * something that silently appears in the transcript.
+ */
+export type TranscriptRole = "user" | "assistant";
 
 /**
  * Identifies one turn: a single user input through to the final answer.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -731,10 +731,10 @@ pub async fn patch_chat(
 
 /// A renderer-safe durable transcript entry. Internal routing and tool state
 /// deliberately remain behind the server boundary.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ts_rs::TS)]
 pub struct ChatMessageSnapshot {
     pub id: MessageId,
-    pub role: Role,
+    pub role: TranscriptRole,
     pub content: String,
     pub created_at: chrono::DateTime<Utc>,
     pub citations: Vec<openwave_core::AssistantCitationSnapshot>,
@@ -752,15 +752,50 @@ pub struct ChatTranscript {
     pub last_event_seq: i64,
 }
 
-impl From<StoredMessage> for ChatMessageSnapshot {
-    fn from(message: StoredMessage) -> Self {
-        Self {
+/// The roles a visible transcript entry can have.
+///
+/// Narrower than [`Role`] on purpose. The transcript shows the conversation, not
+/// the model's plumbing, so `System` and `Tool` never appear — and that was
+/// previously guaranteed only by a `matches!` filter at the one call site, while
+/// the snapshot's own type still admitted all four. The renderer mirrored the
+/// narrow version and branched on `assistant` with no third arm, so a `system`
+/// entry reaching it would have rendered as a user message.
+///
+/// Encoding it here makes the guarantee the type's rather than the caller's, and
+/// makes a new [`Role`] variant a decision in [`Self::for_transcript`] instead of
+/// something that silently appears in the transcript.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum TranscriptRole {
+    User,
+    Assistant,
+}
+
+impl TranscriptRole {
+    /// `None` for roles the transcript does not show.
+    fn for_transcript(role: Role) -> Option<Self> {
+        match role {
+            Role::User => Some(Self::User),
+            Role::Assistant => Some(Self::Assistant),
+            Role::System | Role::Tool => None,
+        }
+    }
+}
+
+impl ChatMessageSnapshot {
+    /// `None` when the message is not part of the visible conversation.
+    ///
+    /// Replaces a separate `matches!` filter followed by an infallible
+    /// conversion: the two could disagree, and only the filter was enforcing the
+    /// narrowing the type claimed.
+    fn for_transcript(message: StoredMessage) -> Option<Self> {
+        Some(Self {
             id: message.id,
-            role: message.role,
+            role: TranscriptRole::for_transcript(message.role)?,
             content: message.content,
             created_at: message.created_at,
             citations: Vec::new(),
-        }
+        })
     }
 }
 
@@ -786,13 +821,12 @@ pub async fn list_chat_messages(
     let messages = transcript
         .messages
         .into_iter()
-        .filter(|message| matches!(message.role, Role::User | Role::Assistant))
-        .map(|message| {
-            let mut snapshot = ChatMessageSnapshot::from(message);
+        .filter_map(|message| {
+            let mut snapshot = ChatMessageSnapshot::for_transcript(message)?;
             snapshot.citations = citations_by_message
                 .remove(&snapshot.id)
                 .unwrap_or_default();
-            snapshot
+            Some(snapshot)
         })
         .collect();
     Ok(Json(ChatTranscript {

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -41,7 +41,7 @@ fn transcript_citation_json_is_closed_and_renderer_bounded() {
     let message_id = MessageId::new();
     let snapshot = crate::routes::ChatMessageSnapshot {
         id: message_id,
-        role: Role::Assistant,
+        role: crate::routes::TranscriptRole::Assistant,
         content: "answer".into(),
         created_at: chrono::Utc::now(),
         citations: vec![openwave_core::AssistantCitationSnapshot {

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -303,6 +303,10 @@ mod tests {
         // vocabulary and the action preview with the live stream, which is why
         // it belongs with them rather than with the rest of the REST surface.
         generate::collect_from::<openwave_core::ChatToolActivitySnapshot>(&cfg, &mut out);
+        // The visible transcript entry. Its role is deliberately narrower than
+        // the stored one, and generating it is what keeps the renderer's
+        // two-arm branch honest.
+        generate::collect_from::<crate::routes::ChatMessageSnapshot>(&cfg, &mut out);
         out
     }
 
@@ -639,6 +643,10 @@ mod tests {
             ("status", "RendererToolStatus"),
             ("approval", "ToolApprovalKind"),
             ("class", "ApprovalClass"),
+            // Four variants in the stored Role, two here. A widened union
+            // renders a system message as a user bubble, and the two-arm
+            // branch that reads it still compiles.
+            ("role", "TranscriptRole"),
         ] {
             assert!(
                 generated.contains(&format!("{field}: {expected}")),

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -80,6 +80,14 @@ reading the code. They all run in existing lanes; nothing needs a new job.
 | Ids generate as bare strings | `#[serde(transparent)]` being ignored in a way that stops coinciding with the right answer |
 | The journal event shape is pinned | A rename in a persisted type, which stops existing chats loading |
 
+Several of those are backstops rather than the primary defence, and it is worth
+knowing which, so nobody weakens the real guard thinking a test still covers it.
+The strongest protection is **not deriving `TS` on types that must not reach the
+renderer**: `serde_json::Value` and the stored four-variant `Role` both fail to
+compile if a generated type tries to carry them, which no assertion can match.
+The tests catch the cases that would compile — a new field, or a type swapped
+along with its call sites.
+
 The fixture check is the one worth understanding, because it closes the failure
 this document opens with. The validators are a trust boundary and stay
 hand-written, so generation cannot check them — but their *tests* used to build


### PR DESCRIPTION
Closes the second and last **silent** hazard in #548. Stacked on #558.

## The hazard

`ChatMessageSnapshot.role` was the stored `Role`, which has four variants — `System`, `User`, `Assistant`, `Tool`. The renderer declared two.

The narrowing was real, but it lived in a `matches!` filter at the one call site:

```rust
.filter(|message| matches!(message.role, Role::User | Role::Assistant))
.map(|message| ChatMessageSnapshot::from(message))
```

So the type admitted all four and only the caller stopped them. `ChatTranscriptPresentation.ts` branches `entry.role === "assistant" ? … : …` with **no third arm**, so a `system` entry reaching it renders as a user message — and that ternary still compiles, which is why nothing would have failed.

## The fix

Give the transcript its own two-variant role, and make the filter and the conversion the same step:

```rust
fn for_transcript(role: Role) -> Option<Self> {
    match role {
        Role::User => Some(Self::User),
        Role::Assistant => Some(Self::Assistant),
        Role::System | Role::Tool => None,
    }
}
```

A new `Role` variant is now a decision in an exhaustive match rather than something that silently appears in the transcript.

## Generated, so the narrowing is visible rather than asserted

`ChatMessageSnapshot` and `AssistantCitationSnapshot` are now generation roots:

```ts
export type TranscriptRole = "user" | "assistant";
export type ChatMessageSnapshot = { id: MessageId, role: TranscriptRole, … };
```

Generating the citation also **confirms** something that was previously only a comment — `message_id` carries `#[serde(skip)]` and the TypeScript said "Do not reintroduce it". The generated type drops it, so ts-rs honors the skip. That was an open question in the #548 survey; now it is checked.

## What actually prevents re-widening

Not the test. `Role` deliberately does not derive `TS`, so a generated type carrying it **does not compile**:

```
error[E0277]: the trait bound `openwave_core::Role: TS` is not satisfied
```

I verified that by trying it. The precision-critical-fields test (from #558, with `role` added here) is a backstop for the case where a change is consistent enough to compile — a new field, or a type swapped along with its call sites. Worth being explicit about which is which, so nobody weakens the real guard thinking a test still covers it.

## One override kept, and spelled out

`ChatMessage` is `Omit<ChatMessageSnapshot, "citations"> & { citations?: … }`. The server always serializes `citations`, so the generated type says it is required — but the transcript arrives as a parsed cast with no validation, and the `?` is what forces the guard at `TranscriptHistory.ts:41`. Narrowing it would delete that guard rather than earn it, so the divergence is written out with `Omit` instead of hidden by hand-writing the whole type.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --no-fail-fast` (28 binaries, **1272 passed, 0 failed**), `tsc --noEmit`, `vitest run` (**57 files, 410 passed**), production `vite build`.