### PR TITLE
refactor(desktop): generate the consent surfaces and fix the check that missed one

### DIFF
--- a/crates/openwave-core/src/client_tools.rs
+++ b/crates/openwave-core/src/client_tools.rs
@@ -44,7 +44,7 @@ pub enum RequestedFolderCapability {
 ///
 /// This is deliberately not a free-form path. The trusted desktop decides how
 /// (or whether) to map it to a local picker location.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum RequestedFolderHint {

--- a/crates/openwave-core/src/user_questions.rs
+++ b/crates/openwave-core/src/user_questions.rs
@@ -27,7 +27,7 @@ pub const MAX_QUESTION_OPTION_DESCRIPTION_CHARS: usize = 240;
 pub const MAX_FREE_FORM_ANSWER_CHARS: usize = 2_000;
 
 /// One mutually exclusive answer choice.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(deny_unknown_fields)]
 pub struct UserQuestionOption {
     pub id: String,
@@ -45,7 +45,7 @@ impl UserQuestionOption {
 }
 
 /// One bounded question shown to the user.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(deny_unknown_fields)]
 pub struct UserQuestion {
     pub id: String,
@@ -143,7 +143,7 @@ impl AnswerUserQuestions {
 /// It contains only the validated presentation contract. Provider metadata,
 /// raw tool arguments, leases, executor identities, and diagnostics stay
 /// behind the server boundary.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 pub struct PendingUserQuestions {
     pub call_id: CallId,
     pub turn_id: TurnId,

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -3,6 +3,11 @@ import {
   type ApprovalClass,
   type AssistantCitationSnapshot,
   type ChatMessageSnapshot,
+  type PendingApprovalSnapshot,
+  type PendingFolderAccessRequest as WirePendingFolderAccessRequest,
+  type PendingUserQuestions as WirePendingUserQuestions,
+  type UserQuestion as WireUserQuestion,
+  type UserQuestionOption as WireUserQuestionOption,
   type ChatToolActivitySnapshot,
   type ChatToolActivityStatus,
   type RendererAgentEvent,
@@ -802,16 +807,14 @@ export function parseFolderAccessRequest(
   value: unknown,
 ): PendingFolderAccessRequest | null {
   if (!isRecord(value)) return null;
-  const keys = Object.keys(value);
   if (
-    keys.some(
-      (key) =>
-        key !== "call_id" &&
-        key !== "turn_id" &&
-        key !== "reason" &&
-        key !== "folder_hint" &&
-        key !== "claimed",
-    ) ||
+    !onlyKeys<WirePendingFolderAccessRequest>(value, [
+      "call_id",
+      "turn_id",
+      "reason",
+      "folder_hint",
+      "claimed",
+    ]) ||
     typeof value.call_id !== "string" ||
     value.call_id.length === 0 ||
     typeof value.turn_id !== "string" ||
@@ -845,7 +848,12 @@ export function parsePendingUserQuestions(
 ): PendingUserQuestions | null {
   if (
     !isRecord(value) ||
-    !onlyKeys(value, ["call_id", "turn_id", "questions", "asked_at"]) ||
+    !onlyKeys<WirePendingUserQuestions>(value, [
+      "call_id",
+      "turn_id",
+      "questions",
+      "asked_at",
+    ]) ||
     !nonEmptyBounded(value.call_id, 128) ||
     !nonEmptyBounded(value.turn_id, 128) ||
     typeof value.asked_at !== "string" ||
@@ -861,7 +869,7 @@ export function parsePendingUserQuestions(
   for (const item of value.questions) {
     if (
       !isRecord(item) ||
-      !onlyKeys(item, [
+      !onlyKeys<WireUserQuestion>(item, [
         "id",
         "header",
         "question",
@@ -885,7 +893,7 @@ export function parsePendingUserQuestions(
     for (const option of item.options) {
       if (
         !isRecord(option) ||
-        !onlyKeys(option, ["id", "label", "description"]) ||
+        !onlyKeys<WireUserQuestionOption>(option, ["id", "label", "description"]) ||
         !nonEmptyBounded(option.id, 64) ||
         optionIds.has(option.id) ||
         !nonEmptyBounded(option.label, 80) ||
@@ -916,8 +924,20 @@ export function parsePendingUserQuestions(
   };
 }
 
-function onlyKeys(value: Record<string, unknown>, allowed: string[]): boolean {
-  const set = new Set(allowed);
+/**
+ * Whether `value` carries no key outside `allowed`.
+ *
+ * Generic over the wire type so the allowlist has to be spelled with that type's
+ * own keys: a field renamed in Rust drops out of `keyof` and the call below
+ * fails to compile. Without that, a rename left the allowlist naming the old key
+ * and rejecting the new one, so the validator would reject every payload and the
+ * surface would simply stop appearing — with nothing failing.
+ */
+function onlyKeys<Wire>(
+  value: Record<string, unknown>,
+  allowed: readonly (keyof Wire & string)[],
+): boolean {
+  const set = new Set<string>(allowed);
   return Object.keys(value).every((key) => set.has(key));
 }
 
@@ -949,6 +969,26 @@ export function parseSandboxAgentCancellation(
   return { id: value.id, status: value.status };
 }
 
+/**
+ * Every key a pending approval may carry.
+ *
+ * `satisfies` ties this to the generated wire type, so a field renamed
+ * server-side fails to compile here. It used to be eight string literals
+ * compared by hand: a rename would have left them allowing the old name and
+ * rejecting the new one, so the validator would reject every approval and the
+ * consent prompt would simply stop appearing, with nothing failing.
+ */
+const PENDING_APPROVAL_KEYS = [
+  "call_id",
+  "turn_id",
+  "action",
+  "approval",
+  "class",
+  "preview",
+  "can_approve",
+  "can_remember",
+] as const satisfies readonly (keyof PendingApprovalSnapshot)[];
+
 export function parsePendingToolApproval(
   value: unknown,
 ): PendingToolApproval | null {
@@ -956,15 +996,7 @@ export function parsePendingToolApproval(
   const keys = Object.keys(value);
   if (
     keys.some(
-      (key) =>
-        key !== "call_id" &&
-        key !== "turn_id" &&
-        key !== "action" &&
-        key !== "approval" &&
-        key !== "class" &&
-        key !== "preview" &&
-        key !== "can_approve" &&
-        key !== "can_remember",
+      (key) => !(PENDING_APPROVAL_KEYS as readonly string[]).includes(key),
     ) ||
     typeof value.call_id !== "string" ||
     value.call_id.length === 0 ||

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -74,6 +74,34 @@ export type ChatToolActivityStatus = "completed" | "failed" | "cancelled";
  */
 export type MessageId = string;
 
+/**
+ * Closed renderer-safe pending approval projection. Canonical arguments,
+ * model-authored summaries, and unknown tool names never cross this boundary;
+ * only a tool's own closed preview of the action under review does.
+ */
+export type PendingApprovalSnapshot = { call_id: CallId, turn_id: TurnId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass, 
+/**
+ * Absent, not null, when the tool projects no action.
+ */
+preview?: ToolActionPreview, can_approve: boolean, can_remember: boolean, };
+
+/**
+ * One folder-access request that is safe for an untrusted renderer to present.
+ *
+ * This intentionally omits the canonical tool name and arguments, chat and
+ * executor identities, provider metadata, lifecycle details, and diagnostics.
+ */
+export type PendingFolderAccessRequest = { call_id: CallId, turn_id: TurnId, reason: string, folder_hint: RequestedFolderHint | null, claimed: boolean, };
+
+/**
+ * Renderer-safe, durable card projection.
+ *
+ * It contains only the validated presentation contract. Provider metadata,
+ * raw tool arguments, leases, executor identities, and diagnostics stay
+ * behind the server boundary.
+ */
+export type PendingUserQuestions = { call_id: CallId, turn_id: TurnId, questions: Array<UserQuestion>, asked_at: string, };
+
 export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | { "type": "text_delta", text: string, } | { "type": "reasoning_delta" } | { "type": "stream_interrupted" } | { "type": "tool_call_started", call_id: CallId, name: RendererToolName, } | { "type": "tool_call_args_delta", call_id: CallId, } | { "type": "user_questions_asked", call_id: CallId, turn_id: TurnId, } | { "type": "approval_required", call_id: CallId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass, 
 /**
  * The one deliberate opening in this boundary. A human cannot consent
@@ -106,6 +134,14 @@ export type RendererSequencedEvent = { seq: number, event: RendererAgentEvent, }
 export type RendererToolName = "search" | "list_sources" | "read_source" | "read_tool_result" | "web_search" | "read_delegated_file" | "read_file" | "list_dir" | "write_file" | "create_deliverable" | "request_folder_access" | "connect_folder" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file" | "spawn_sandbox_agent" | "wait_for_agents" | "ask_user_questions" | "exec" | "other";
 
 export type RendererToolStatus = "completed" | "failed";
+
+/**
+ * Non-authoritative, well-known starting location for the native picker.
+ *
+ * This is deliberately not a free-form path. The trusted desktop decides how
+ * (or whether) to map it to a local picker location.
+ */
+export type RequestedFolderHint = "documents" | "downloads";
 
 /**
  * The action a call will take, in a form a human can inspect.
@@ -179,6 +215,16 @@ export type TranscriptRole = "user" | "assistant";
  * Identifies one turn: a single user input through to the final answer.
  */
 export type TurnId = string;
+
+/**
+ * One bounded question shown to the user.
+ */
+export type UserQuestion = { id: string, header: string, question: string, options: Array<UserQuestionOption>, allow_free_form: boolean, };
+
+/**
+ * One mutually exclusive answer choice.
+ */
+export type UserQuestionOption = { id: string, label: string, description: string, };
 
 /**
  * Every tool name the renderer will accept, at runtime.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1768,14 +1768,16 @@ fn default_pending_approvals_limit() -> u64 {
 /// Closed renderer-safe pending approval projection. Canonical arguments,
 /// model-authored summaries, and unknown tool names never cross this boundary;
 /// only a tool's own closed preview of the action under review does.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ts_rs::TS)]
 pub(crate) struct PendingApprovalSnapshot {
     pub call_id: CallId,
     pub turn_id: TurnId,
     pub action: openwave_core::RendererToolName,
     pub approval: openwave_core::ToolApprovalKind,
     pub class: openwave_core::ApprovalClass,
+    /// Absent, not null, when the tool projects no action.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub preview: Option<openwave_core::ToolActionPreview>,
     pub can_approve: bool,
     pub can_remember: bool,

--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -132,7 +132,7 @@ pub struct ResolvedClientExecution {
 ///
 /// This intentionally omits the canonical tool name and arguments, chat and
 /// executor identities, provider metadata, lifecycle details, and diagnostics.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct PendingFolderAccessRequest {
     pub call_id: CallId,
     pub turn_id: TurnId,

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -198,7 +198,14 @@ pub(crate) mod generate {
             const DERIVE: &str = "#[derive(";
             let derives = &after[DERIVE.len()..close];
             rest = &after[close + 2..];
-            if !derives.split(',').any(|d| d.trim() == "TS") {
+            // Match the last path segment: the derive is written both as `TS`
+            // and as `ts_rs::TS`, and matching only the bare name silently
+            // skipped every type that used the qualified form — which was most
+            // of them.
+            if !derives
+                .split(',')
+                .any(|d| d.trim().rsplit("::").next() == Some("TS"))
+            {
                 continue;
             }
             // Walk to the closing brace of the item this derive belongs to.
@@ -307,6 +314,14 @@ mod tests {
         // the stored one, and generating it is what keeps the renderer's
         // two-arm branch honest.
         generate::collect_from::<crate::routes::ChatMessageSnapshot>(&cfg, &mut out);
+        // The two consent surfaces. Their TypeScript describes the validator's
+        // output rather than the wire, so the generated types are what the
+        // validators narrow *from* — see the aliases in api.ts.
+        generate::collect_from::<crate::routes::PendingApprovalSnapshot>(&cfg, &mut out);
+        generate::collect_from::<openwave_core::PendingUserQuestions>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::client_execution::PendingFolderAccessRequest>(
+            &cfg, &mut out,
+        );
         out
     }
 

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -128,11 +128,22 @@ so it belongs with them rather than with the rest of the REST surface. Its `tool
 field was `&'static str`, which generated as `string` and silently dropped the
 allowlist the copy and icon tables are keyed on; it is now typed as the enum.
 
-Not yet generated: the ~37 REST snapshot DTOs. A naive derive sweep over them
-would still widen `ChatMessage.role` from two variants to four — `Role` has
-`System` and `Tool` — making a `system` message render as a user bubble, with no
-compile error. That and the remaining hazards are enumerated on the tracking
-issue; do not sweep without reading it.
+Also generated: the visible transcript entry and its citations, and all three
+consent surfaces — the pending approval, the pending user questions, and the
+folder-access request. Their TypeScript is camelCase because it describes the
+*validator's output*, not the wire, so the generated types are what the
+validators narrow **from**.
+
+Every validator now spells its key allowlist with the generated type's own keys,
+via a generic `onlyKeys<Wire>` or a `satisfies` clause. A field renamed in Rust
+drops out of `keyof` and the allowlist fails to compile, naming the new key. That
+matters more than it sounds: an untied allowlist keeps naming the *old* key after
+a rename, so the validator rejects every payload and the surface silently stops
+appearing — no error, no failing test, just a consent prompt that never shows.
+
+Not yet generated: the settings, provider, model, MCP, project, and agent-run
+DTOs. Nothing known blocks them; they are simply not done. The remaining notes
+are on the tracking issue.
 
 `ChatMessageSnapshot.citations` is deliberately wider in TypeScript than on the
 wire: the server always sends it, but the transcript is not validated, so the `?`


### PR DESCRIPTION
Closes hazards 3 and 5 of #548. But the reason to read this is the check that was broken.

## A guard that was hiding the bug it exists for

`omittable_fields_missing_optional` — added in #558 to catch a serde-omitted field declared as nullable — decided whether a type was generated like this:

```rust
derives.split(',').any(|d| d.trim() == "TS")
```

`event_projection.rs` imports the trait and writes `#[derive(..., TS)]`. **Every other file writes the qualified `ts_rs::TS`, which does not match.** So the scanner silently skipped most of the types it was meant to cover, and a scanner that matches nothing passes forever.

It was concealing a live instance of the defect it exists for. `PendingApprovalSnapshot.preview` carries `skip_serializing_if` with no `#[ts(optional)]` and generated as:

```ts
preview: ToolActionPreview | null
```

A key the server omits, declared as always present — the #475 mismatch, in `main`, with a dedicated check watching it and seeing nothing.

I found it because I expected a failure that did not arrive. Matching the last path segment surfaced it immediately:

```
these fields are omitted by serde but not declared optional in TypeScript:
  crates/openwave-server/src/routes.rs: pub preview: Option<openwave_core::ToolActionPreview>
```

### Why the scanner's own self-test did not catch this

I wrote that self-test in #558 specifically so the scanner could not match nothing — it feeds a wrong example, a right one, and a non-generated type. It passed throughout, because it feeds **inline source strings**, written with the bare `TS` form. The fixtures agreed with the scanner, and both disagreed with the codebase.

That is the same failure as a validator test authoring its own input, one level up. What found it was running the scanner over the real source tree — the same fix as everywhere else here: feed the checker real material.

## What else is in this

All three consent surfaces and the user-question types are now generated (12 → 24 declarations), including `PendingFolderAccessRequest`, which was not generated at all before. Their TypeScript is camelCase because it describes the *validator's output* rather than the wire, so the generated types are what the validators narrow **from**.

### Every validator's key allowlist is now tied to its wire type

This is the part I originally understated. **Five** allowlists were plain string literals maintained by hand — the approval's eight keys, the folder-access request's five, and one each for pending questions, a question, and an option. `onlyKeys` is now generic over the wire type, so an allowlist has to be spelled with that type's own keys:

```ts
function onlyKeys<Wire>(value: Record<string, unknown>, allowed: readonly (keyof Wire & string)[]): boolean
```

The failure an untied allowlist permits is a quiet one: after a rename it keeps naming the *old* key, so the validator rejects every payload and the surface simply stops appearing — no error, no failing test, just a consent prompt that never shows.

Verified on three of them by renaming the Rust field:

```
Type '"asked_at"' is not assignable to type '"call_id" | "turn_id" | "questions" | "asked"'
Type '"allow_free_form"' is not assignable to type '"id" | "header" | "question" | "options" | "free_form_ok"'
Type '"can_remember"' is not assignable to type 'keyof PendingApprovalSnapshot'. Did you mean '"may_remember"'?
```

`parsePendingToolApproval`'s allowlist uses the `satisfies` form:

```ts
] as const satisfies readonly (keyof PendingApprovalSnapshot)[];
```

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --no-fail-fast` (28 binaries, **1272 passed, 0 failed**), `tsc --noEmit`, `vitest run` (**58 files, 406 passed**), production `vite build`.

Rebased onto `main` after #557 landed the router work; `pnpm install --frozen-lockfile` picked up the new dependency and the lockfile is unchanged.
