### PR TITLE
feat(desktop): give the app a home, a chat explorer, and a persistent rail

### DIFF
--- a/crates/openwave-desktop/ui/src/AppContext.tsx
+++ b/crates/openwave-desktop/ui/src/AppContext.tsx
@@ -19,6 +19,8 @@ export type AppContextValue = {
   refreshCatalog: () => Promise<void>;
   status: string;
   setStatus: (next: string | ((current: string) => string)) => void;
+  /** Start a conversation and open it. Fenced against a second in-flight create. */
+  newChat: () => void;
   themeMode: ThemeMode;
   setThemeMode: (mode: ThemeMode) => void;
   updateState: DesktopUpdateState;

--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -26,6 +26,7 @@ const createChat = vi.fn(async () => chats[0]);
 const listPendingUserQuestions = vi.fn(async () => [] as unknown[]);
 const listPendingFolderAccessRequests = vi.fn(async () => [] as unknown[]);
 const requestUserAttention = vi.fn(async () => {});
+const postMessage = vi.fn(async () => {});
 
 vi.mock("./boot", () => ({
   resolveServerInfo: vi.fn(async () => ({ baseUrl: "http://127.0.0.1:1", token: "t" })),
@@ -39,6 +40,7 @@ vi.mock("./api", () => ({
     createChat = createChat;
     listPendingUserQuestions = listPendingUserQuestions;
     listPendingFolderAccessRequests = listPendingFolderAccessRequests;
+    postMessage = postMessage;
     openEvents = vi.fn(() => ({ close: vi.fn() }));
   },
 }));
@@ -96,7 +98,8 @@ vi.mock("react-resizable-panels", () => ({
   PanelResizeHandle: () => <div />,
 }));
 
-async function mountApp() {
+async function mountApp({ at }: { at?: string } = {}) {
+  if (at) window.location.hash = `#${at}`;
   const { createHashHistory, createRouter, RouterProvider } = await import(
     "@tanstack/react-router"
   );
@@ -120,6 +123,7 @@ beforeEach(() => {
   listPendingUserQuestions.mockResolvedValue([]);
   listPendingFolderAccessRequests.mockClear();
   requestUserAttention.mockClear();
+  postMessage.mockClear();
   usePendingPrompts.setState({ chatId: null, userQuestions: [], folderAccess: [] });
   // The stores outlive a test file's renders, so a chat list left behind would
   // decide the next test's routing before its own boot ever ran.
@@ -129,25 +133,65 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("app shell", () => {
-  it("opens on a conversation once the chat list resolves", async () => {
+  it("opens on home rather than on a conversation", async () => {
     const { router } = await mountApp();
 
-    await waitFor(() => expect(router.state.location.pathname).toBe("/c/chat-1"));
-    expect(await screen.findByTestId("transcript")).toBeInTheDocument();
+    expect(await screen.findByText("What are we working on?")).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe("/");
+    // Home used to create a chat on every cold start, leaving an empty one
+    // behind whenever the reader did not use it.
     expect(createChat).not.toHaveBeenCalled();
   });
 
-  it("makes a conversation when there is nothing to open", async () => {
-    listChats.mockResolvedValueOnce([]);
+  it("lists recent conversations to pick up again", async () => {
+    await mountApp();
+
+    const recent = await screen.findAllByRole("button", { name: "Roadmap" });
+    expect(recent.length).toBeGreaterThan(0);
+  });
+
+  it("says so when there is nothing to pick up", async () => {
+    listChats.mockResolvedValue([]);
+    await mountApp();
+
+    expect(await screen.findByText("No chats yet")).toBeInTheDocument();
+  });
+
+  it("starts a conversation from the home composer and sends what was written", async () => {
+    const user = userEvent.setup();
     const { router } = await mountApp();
+    await screen.findByText("What are we working on?");
+
+    await user.type(screen.getByRole("textbox"), "summarise the filing");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
 
     await waitFor(() => expect(createChat).toHaveBeenCalledOnce());
     await waitFor(() => expect(router.state.location.pathname).toBe("/c/chat-1"));
+    // Home writes the message but does not post it — the chat route does, so
+    // there is only one send path.
+    await waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith("chat-1", expect.any(String), "summarise the filing"),
+    );
+  });
+
+  it("opens a conversation from the sidebar", async () => {
+    const user = userEvent.setup();
+    const { router } = await mountApp();
+    await screen.findByText("What are we working on?");
+
+    const recentList = screen.getByLabelText("Chats");
+    const [row] = screen
+      .getAllByRole("button", { name: "Roadmap" })
+      .filter((button) => recentList.contains(button));
+    await user.click(row);
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/c/chat-1"));
+    expect(await screen.findByTestId("transcript")).toBeInTheDocument();
   });
 
   it("arranges panels beside the conversation from the sidebar", async () => {
     const user = userEvent.setup();
-    const { router } = await mountApp();
+    const { router } = await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
 
     await user.click(screen.getByRole("button", { name: "Sources" }));
@@ -162,7 +206,7 @@ describe("app shell", () => {
 
   it("closes a panel back to the conversation alone", async () => {
     const user = userEvent.setup();
-    const { router } = await mountApp();
+    const { router } = await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
     await user.click(screen.getByRole("button", { name: "Sources" }));
     await screen.findByTestId("sources");
@@ -174,15 +218,30 @@ describe("app shell", () => {
   });
 
   it("restores the arrangement a deep link describes", async () => {
-    window.location.hash = "#/c/chat-2?left=outputs&right=chat";
-    await mountApp();
+    await mountApp({ at: "/c/chat-2?left=outputs&right=chat" });
 
     expect(await screen.findByTestId("outputs")).toBeInTheDocument();
   });
 
+  it("finds a conversation through the chats panel's search", async () => {
+    const user = userEvent.setup();
+    await mountApp({ at: "/c/chat-1" });
+    await screen.findByTestId("transcript");
+
+    await user.click(screen.getByRole("button", { name: "All chats" }));
+    const search = await screen.findByRole("textbox", { name: "Search chats" });
+
+    await user.type(search, "roadmap");
+    expect(screen.getAllByRole("button", { name: "Roadmap" }).length).toBeGreaterThan(0);
+
+    await user.clear(search);
+    await user.type(search, "nothing matches this");
+    expect(await screen.findByText("No matches")).toBeInTheDocument();
+  });
+
   it("keeps watching for the agent's questions while settings is open", async () => {
     const user = userEvent.setup();
-    const { router } = await mountApp();
+    const { router } = await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
     await waitFor(() => expect(listPendingUserQuestions).toHaveBeenCalled());
 
@@ -213,7 +272,7 @@ describe("app shell", () => {
 
   it("returns from settings to the conversation that was open", async () => {
     const user = userEvent.setup();
-    const { router } = await mountApp();
+    const { router } = await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
     await user.click(screen.getByText("Settings"));
     await screen.findByTestId("settings");

--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -241,6 +241,7 @@ export function AppShell() {
         refreshCatalog,
         status,
         setStatus,
+        newChat: () => void onNewChat(),
         themeMode,
         setThemeMode,
         updateState: desktopUpdates.state,
@@ -248,11 +249,7 @@ export function AppShell() {
         restartForUpdate: onRestartForUpdate,
       }}
     >
-      <div
-        className={`app-shell${hasMacOverlayTitlebar() ? " with-titlebar" : ""}${
-          sidebarCollapsed ? " sidebar-collapsed" : ""
-        }`}
-      >
+      <div className={`app-shell${hasMacOverlayTitlebar() ? " with-titlebar" : ""}`}>
         {confirmDialog}
         {hasMacOverlayTitlebar() && (
           <div className="titlebar" data-tauri-drag-region>
@@ -268,32 +265,18 @@ export function AppShell() {
           </div>
         )}
         <div className="app-body">
-          {!hasMacOverlayTitlebar() && sidebarCollapsed && (
-            <button
-              type="button"
-              className="sidebar-expand"
-              aria-label="Show sidebar"
-              title="Show sidebar"
-              onClick={() => useUiStore.getState().toggleSidebar()}
-            >
-              <PanelLeftOpen size={15} />
-            </button>
-          )}
-          {!sidebarCollapsed && (
-            <Sidebar
-              collapseControl={!hasMacOverlayTitlebar()}
-              themeMode={themeMode}
-              updateReady={desktopUpdates.state.status === "ready"}
-              updateVersion={desktopUpdates.state.version ?? null}
-              onCycleTheme={cycleTheme}
-              onNewChat={() => void onNewChat()}
-              onStartRename={startChatRename}
-              onCommitRename={(target) => void commitChatRename(target)}
-              onCancelRename={cancelChatRename}
-              onDeleteChat={(target) => void onDeleteChat(target)}
-              onRestartForUpdate={() => void onRestartForUpdate()}
-            />
-          )}
+          <Sidebar
+            themeMode={themeMode}
+            updateReady={desktopUpdates.state.status === "ready"}
+            updateVersion={desktopUpdates.state.version ?? null}
+            onCycleTheme={cycleTheme}
+            onNewChat={() => void onNewChat()}
+            onStartRename={startChatRename}
+            onCommitRename={(target) => void commitChatRename(target)}
+            onCancelRename={cancelChatRename}
+            onDeleteChat={(target) => void onDeleteChat(target)}
+            onRestartForUpdate={() => void onRestartForUpdate()}
+          />
           <div className="main">
             <Outlet />
           </div>

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -18,6 +18,8 @@ import {
   loadCurrentTerminalTranscript,
   presentChatTranscript,
 } from "./ChatTranscriptPresentation";
+import { ChatsPanel } from "./ChatsPanel";
+import { useFirstMessage } from "./FirstMessage";
 import { ChatView } from "./ChatView";
 import { DeliverablesView } from "./DeliverablesView";
 import { DocumentsView } from "./DocumentsView";
@@ -53,6 +55,7 @@ const sessionDeps = {
 };
 
 const chatListActions = useChatListStore.getState();
+const firstMessageActions = useFirstMessage.getState();
 const { signal: signalRefresh } = useRefreshSignals.getState();
 const { signal: signalTurnLifecycle } = useTurnLifecycle.getState();
 
@@ -66,7 +69,7 @@ const { signal: signalTurnLifecycle } = useTurnLifecycle.getState();
  */
 export function ChatRoute({ chatId }: { chatId: string }) {
   const navigate = useNavigate();
-  const { client, models, status, setStatus } = useApp();
+  const { client, models, status, setStatus, newChat } = useApp();
   const { layout } = usePanelNav();
   const chats = useChatListStore((state) => state.chats);
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
@@ -98,6 +101,15 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   useEffect(() => {
     setStatus(`chat ${chatId.slice(0, 8)}…`);
   }, [chatId, setStatus]);
+
+  // A conversation opened from the home composer arrives with its first message
+  // already written. `take` clears it, so a re-render cannot send it twice.
+  useEffect(() => {
+    if (!chat) return;
+    const pending = firstMessageActions.take(chatId);
+    if (pending) void sendMessage(pending);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chat, chatId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -217,8 +229,16 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   }
 
   async function onSend() {
-    if (!chat || !draft.trim() || busy || deletingChatId !== null) return;
-    const content = draft.trim();
+    await sendMessage(draft.trim());
+  }
+
+  /**
+   * The one path a message takes. Home writes the first message of a new chat
+   * but does not post it, so this has to be reachable with text that was never
+   * in this route's draft.
+   */
+  async function sendMessage(content: string) {
+    if (!chat || !content || busy || deletingChatId !== null) return;
     const turnId = crypto.randomUUID();
     terminalHydrationGenerationRef.current += 1;
     setComposerDraft("");
@@ -321,6 +341,12 @@ export function ChatRoute({ chatId }: { chatId: string }) {
 
     const side = position === "right" ? "right" : "left";
     switch (panel.type) {
+      case "chats":
+        return (
+          <PanelFrame position={side} spaceBetween>
+            <ChatsPanel activeChatId={chatId} onNewChat={newChat} />
+          </PanelFrame>
+        );
       case "sources":
         return (
           <PanelFrame position={side} spaceBetween>

--- a/crates/openwave-desktop/ui/src/ChatsPanel.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatsPanel.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import type { Chat } from "./api";
+import { matchesChatSearch } from "./ChatsPanel";
+
+function chat(title: string | null): Chat {
+  return { id: "chat-1", title } as unknown as Chat;
+}
+
+describe("matchesChatSearch", () => {
+  it("keeps everything when nothing has been typed", () => {
+    expect(matchesChatSearch(chat("Roadmap"), "")).toBe(true);
+    expect(matchesChatSearch(chat(null), "   ")).toBe(true);
+  });
+
+  it("matches part of a title, ignoring case", () => {
+    expect(matchesChatSearch(chat("Q3 Roadmap"), "roadmap")).toBe(true);
+    expect(matchesChatSearch(chat("Q3 Roadmap"), "ROAD")).toBe(true);
+    expect(matchesChatSearch(chat("Q3 Roadmap"), "budget")).toBe(false);
+  });
+
+  it("searches an untitled chat under the name it is shown by", () => {
+    // The list labels these "New chat", so that is what searching for them has
+    // to find — matching nothing would make them unreachable.
+    expect(matchesChatSearch(chat(null), "new")).toBe(true);
+    expect(matchesChatSearch(chat("   "), "new chat")).toBe(true);
+    expect(matchesChatSearch(chat(null), "roadmap")).toBe(false);
+  });
+
+  it("ignores surrounding whitespace in the query", () => {
+    expect(matchesChatSearch(chat("Roadmap"), "  road  ")).toBe(true);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/ChatsPanel.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { MessageCircleMore, Search } from "lucide-react";
+
+import type { Chat } from "./api";
+import { useChatListStore } from "./ChatListStore";
+import { PanelSecondaryHeader } from "./components/PanelHeader";
+import { Button } from "./components/ui/button";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "./components/ui/empty";
+import { Input } from "./components/ui/input";
+
+/** Case-insensitive match on the title, with untitled chats matching "new chat". */
+export function matchesChatSearch(chat: Chat, query: string): boolean {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return true;
+  const title = chat.title?.trim() || "New chat";
+  return title.toLowerCase().includes(trimmed);
+}
+
+/**
+ * Every conversation, searchable. The sidebar shows only the most recent few,
+ * so this is where a chat that has scrolled off it is found again.
+ */
+export function ChatsPanel({
+  activeChatId,
+  onNewChat,
+}: {
+  activeChatId: string | null;
+  onNewChat: () => void;
+}) {
+  const navigate = useNavigate();
+  const chats = useChatListStore((state) => state.chats);
+  const creatingChat = useChatListStore((state) => state.creatingChat);
+  const deletingChatId = useChatListStore((state) => state.deletingChatId);
+  const [query, setQuery] = useState("");
+
+  const matches = useMemo(
+    () => chats.filter((chat) => matchesChatSearch(chat, query)),
+    [chats, query],
+  );
+
+  return (
+    <>
+      <PanelSecondaryHeader className="px-4">
+        <h1 className="text-lg font-medium">Chats</h1>
+        <span className="text-sm text-muted-foreground">{chats.length}</span>
+        <span className="grow" />
+        <Button size="sm" onClick={onNewChat} disabled={creatingChat}>
+          New chat
+        </Button>
+      </PanelSecondaryHeader>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 p-4">
+        <div className="relative">
+          <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            className="pl-8"
+            placeholder="Search chats"
+            aria-label="Search chats"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </div>
+
+        {matches.length === 0 ? (
+          <Empty className="border">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <MessageCircleMore />
+              </EmptyMedia>
+              <EmptyTitle>{chats.length === 0 ? "No chats yet" : "No matches"}</EmptyTitle>
+              <EmptyDescription>
+                {chats.length === 0
+                  ? "Start one and it will show up here."
+                  : "No chat title contains that."}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto">
+            {matches.map((chat) => {
+              const title = chat.title?.trim() || "New chat";
+              const isActive = chat.id === activeChatId;
+              return (
+                <li key={chat.id}>
+                  <button
+                    type="button"
+                    aria-current={isActive ? "page" : undefined}
+                    disabled={deletingChatId !== null}
+                    onClick={() =>
+                      void navigate({ to: "/c/$chatId", params: { chatId: chat.id } })
+                    }
+                    className={`flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50 ${
+                      isActive ? "bg-muted" : ""
+                    }`}
+                  >
+                    <MessageCircleMore className="size-4 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 truncate">{title}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </>
+  );
+}

--- a/crates/openwave-desktop/ui/src/FirstMessage.test.ts
+++ b/crates/openwave-desktop/ui/src/FirstMessage.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { createFirstMessageStore } from "./FirstMessage";
+
+describe("first message handover", () => {
+  it("hands the text to the chat it was written for", () => {
+    const store = createFirstMessageStore();
+    store.getState().hold("chat-1", "summarise the filing");
+
+    expect(store.getState().take("chat-1")).toBe("summarise the filing");
+  });
+
+  it("gives it up only once", () => {
+    // The chat route's effect can run again on a re-render, and a second read
+    // would post the message twice.
+    const store = createFirstMessageStore();
+    store.getState().hold("chat-1", "hello");
+
+    expect(store.getState().take("chat-1")).toBe("hello");
+    expect(store.getState().take("chat-1")).toBeNull();
+  });
+
+  it("withholds it from a conversation it was not meant for", () => {
+    const store = createFirstMessageStore();
+    store.getState().hold("chat-1", "hello");
+
+    expect(store.getState().take("chat-2")).toBeNull();
+    // Still waiting for the chat it belongs to.
+    expect(store.getState().take("chat-1")).toBe("hello");
+  });
+
+  it("has nothing to give when nothing was written", () => {
+    const store = createFirstMessageStore();
+
+    expect(store.getState().take("chat-1")).toBeNull();
+  });
+});

--- a/crates/openwave-desktop/ui/src/FirstMessage.ts
+++ b/crates/openwave-desktop/ui/src/FirstMessage.ts
@@ -1,0 +1,35 @@
+import { create } from "zustand";
+
+/**
+ * A message written on the home screen, waiting for the conversation it will
+ * open in.
+ *
+ * Home creates the chat and navigates; the chat route is what actually posts.
+ * Handing the text over in a store rather than posting from home keeps one
+ * send path — the same optimistic transcript entry, turn id, and failure
+ * handling — instead of a second copy that would drift.
+ */
+export type FirstMessageStore = {
+  /** The chat the pending text belongs to; null when there is nothing waiting. */
+  chatId: string | null;
+  text: string;
+  hold: (chatId: string, text: string) => void;
+  /** Read and clear in one step, so a remount cannot send it twice. */
+  take: (chatId: string) => string | null;
+};
+
+export function createFirstMessageStore() {
+  return create<FirstMessageStore>()((set, get) => ({
+    chatId: null,
+    text: "",
+    hold: (chatId, text) => set({ chatId, text }),
+    take: (chatId) => {
+      const { chatId: heldFor, text } = get();
+      if (heldFor !== chatId || !text) return null;
+      set({ chatId: null, text: "" });
+      return text;
+    },
+  }));
+}
+
+export const useFirstMessage = createFirstMessageStore();

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -1,49 +1,134 @@
-import { useEffect, useRef } from "react";
+import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { MessageCircleMore } from "lucide-react";
 
 import { useApp } from "./AppContext";
 import { useChatListStore } from "./ChatListStore";
+import { Composer } from "./Composer";
+import { useFirstMessage } from "./FirstMessage";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "./components/ui/empty";
 
 const chatListActions = useChatListStore.getState();
+const firstMessageActions = useFirstMessage.getState();
+
+/** Shown on the rail and here; the Chats panel has the rest. */
+const HOME_RECENT_LIMIT = 6;
 
 /**
- * The app opens on a conversation, so the root route resolves one and steps
- * out of the way. A first run with nothing to open makes a chat rather than
- * showing an empty frame.
+ * Where the app opens, and where the logo goes back to.
  *
- * This is where the home page will go once there is more to show than the
- * conversation you had open last.
+ * The composer here starts a conversation rather than posting into one. It
+ * hands the text to the chat it creates instead of sending it directly, so
+ * there is still exactly one send path — see [useFirstMessage].
  */
 export function HomeRoute() {
   const navigate = useNavigate();
   const { client } = useApp();
   const chats = useChatListStore((state) => state.chats);
   const chatsLoaded = useChatListStore((state) => state.chatsLoaded);
-  const creatingRef = useRef(false);
+  const creatingChat = useChatListStore((state) => state.creatingChat);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!chatsLoaded) return;
-    const existing = chats[0];
-    if (existing) {
-      void navigate({ to: "/c/$chatId", params: { chatId: existing.id }, replace: true });
-      return;
+  async function startChat() {
+    const content = draft.trim();
+    if (!content || creatingChat) return;
+    chatListActions.setCreatingChat(true);
+    setError(null);
+    try {
+      const created = await client.createChat();
+      chatListActions.prependChat(created);
+      chatListActions.setChatsError(null);
+      firstMessageActions.hold(created.id, content);
+      setDraft("");
+      await navigate({ to: "/c/$chatId", params: { chatId: created.id } });
+    } catch (err) {
+      setError(`Could not start a chat: ${String(err)}`);
+    } finally {
+      chatListActions.setCreatingChat(false);
     }
-    // Guarded because the effect reruns while the request is in flight, and a
-    // second create would leave an orphan chat behind on every cold start.
-    if (creatingRef.current) return;
-    creatingRef.current = true;
-    void (async () => {
-      try {
-        const created = await client.createChat();
-        chatListActions.prependChat(created);
-        await navigate({ to: "/c/$chatId", params: { chatId: created.id }, replace: true });
-      } catch (err) {
-        chatListActions.setChatsError(`Could not create a chat: ${String(err)}`);
-      } finally {
-        creatingRef.current = false;
-      }
-    })();
-  }, [chatsLoaded, chats, client, navigate]);
+  }
 
-  return <div className="routed-surface-loading" />;
+  const recent = chats.slice(0, HOME_RECENT_LIMIT);
+
+  return (
+    <div className="content-container flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="flex flex-1 items-center justify-center overflow-y-auto px-[clamp(0.5rem,4%,5rem)]">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 py-10">
+          <div className="space-y-2 text-center">
+            <p className="text-3xl font-normal text-foreground">What are we working on?</p>
+            <p className="text-muted-foreground">
+              Start a chat, or pick up where you left off.
+            </p>
+          </div>
+
+          {chatsLoaded && recent.length === 0 ? (
+            <Empty className="border">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <MessageCircleMore />
+                </EmptyMedia>
+                <EmptyTitle>No chats yet</EmptyTitle>
+                <EmptyDescription>
+                  Ask a question below and OpenWave will open your first chat.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : (
+            recent.length > 0 && (
+              <div className="flex flex-col gap-1">
+                <p className="px-2 text-sm font-medium text-muted-foreground">Recent</p>
+                <ul className="flex flex-col gap-0.5">
+                  {recent.map((chat) => (
+                    <li key={chat.id}>
+                      <button
+                        type="button"
+                        className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted"
+                        onClick={() =>
+                          void navigate({ to: "/c/$chatId", params: { chatId: chat.id } })
+                        }
+                      >
+                        <MessageCircleMore className="size-4 shrink-0 text-muted-foreground" />
+                        <span className="min-w-0 truncate">
+                          {chat.title?.trim() || "New chat"}
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )
+          )}
+        </div>
+      </div>
+
+      <div className="z-10 px-[clamp(0.5rem,4%,5rem)] pb-2">
+        <div className="mx-auto w-full max-w-3xl">
+          {error && <p className="pb-2 text-sm text-critical">{error}</p>}
+          <Composer
+            activeTurnId={null}
+            busy={false}
+            cancelError={null}
+            cancelPending={false}
+            disabled={creatingChat}
+            draft={draft}
+            resetKey="home"
+            steerError={null}
+            steerPending={false}
+            steerStatus={null}
+            onDraftChange={setDraft}
+            onSend={startChat}
+            onSteer={async () => {}}
+            onStop={async () => {}}
+          />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
@@ -79,7 +79,13 @@ describe("Sidebar", () => {
     seedStores({ deletingChatId: "chat-2" });
     await renderSidebar();
     expect(screen.getByRole("button", { name: "Roadmap" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Deleting…" })).toBeDisabled();
+    // An untitled conversation is also labelled "New chat", so the action has
+    // to be picked out from the list rows that share its name.
+    const recentList = screen.getByLabelText("Chats");
+    const [startChat] = screen
+      .getAllByRole("button", { name: "New chat" })
+      .filter((button) => !recentList.contains(button));
+    expect(startChat).toBeDisabled();
   });
 
   it("re-renders when the store's chat list changes", async () => {

--- a/crates/openwave-desktop/ui/src/Sidebar.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.tsx
@@ -1,13 +1,13 @@
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import type { Chat } from "./api";
-import { Logomark } from "./Logomark";
 import {
   Ellipsis,
   FolderOpen,
   Library,
+  MessageCircleMore,
   Monitor,
-  PanelLeftClose,
   Moon,
+  PanelLeftClose,
+  PanelLeftOpen,
   Pencil,
   RotateCw,
   Settings,
@@ -16,6 +16,9 @@ import {
   Sun,
   Trash2,
 } from "lucide-react";
+
+import type { Chat } from "./api";
+import { useChatListStore } from "./ChatListStore";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -24,15 +27,25 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
-import type { ThemeMode } from "./theme";
-import { useChatListStore } from "./ChatListStore";
+import { Logomark } from "./Logomark";
+import type { PanelContent, PanelType } from "./panel/panelTypes";
 import { usePanelNav } from "./panel/usePanelNav";
-import type { PanelContent } from "./panel/panelTypes";
+import {
+  Sidebar as SidebarRail,
+  SidebarButton,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarSectionTitle,
+  useSidebarWidth,
+} from "./sidebar/primitives";
+import type { ThemeMode } from "./theme";
 import { useUiStore } from "./UiStore";
 
+/** How many conversations the rail shows before deferring to the Chats panel. */
+export const RECENT_CHAT_LIMIT = 8;
+
 export type SidebarProps = {
-  /** Render the in-sidebar hide control (off when the titlebar owns it). */
-  collapseControl?: boolean;
   themeMode: ThemeMode;
   updateReady: boolean;
   updateVersion: string | null;
@@ -46,8 +59,8 @@ export type SidebarProps = {
 };
 
 /**
- * The navigation aside: brand and theme, the panels of the open conversation,
- * the chat list, and footer actions.
+ * The navigation rail: the way home, the panels of the open conversation, the
+ * conversations themselves, and the app's own controls.
  *
  * List state comes straight from the chat-list store; the callback props are
  * the mutations whose orchestration (fences, confirm dialog, chat lifecycle)
@@ -55,7 +68,6 @@ export type SidebarProps = {
  * selecting a chat or a panel here is navigation rather than a store write.
  */
 export function Sidebar({
-  collapseControl = true,
   themeMode,
   updateReady,
   updateVersion,
@@ -67,6 +79,7 @@ export function Sidebar({
   onDeleteChat,
   onRestartForUpdate,
 }: SidebarProps) {
+  const navigate = useNavigate();
   const chats = useChatListStore((state) => state.chats);
   const activeChatId = useChatListStore((state) => state.selected?.id ?? null);
   const chatsError = useChatListStore((state) => state.chatsError);
@@ -77,232 +90,286 @@ export function Sidebar({
   const savingTitle = useChatListStore((state) => state.savingTitle);
   const setRenameDraft = useChatListStore((state) => state.setRenameDraft);
   const toggleSidebar = useUiStore((state) => state.toggleSidebar);
-  const navigate = useNavigate();
-  const settingsOpen = useRouterState({
-    select: (state) => state.location.pathname === "/settings",
-  });
+  const isCompact = useSidebarWidth() === "compact";
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
   const { layout, openPanel } = usePanelNav();
 
-  const openPanelTypes = new Set(
-    layout.mode === "split" ? [layout.left.type, layout.right.type] : ["chat"],
-  );
+  const onChatRoute = pathname.startsWith("/c/");
+  const openPanelTypes: Set<PanelType> =
+    onChatRoute && layout.mode === "split"
+      ? new Set([layout.left.type, layout.right.type])
+      : new Set<PanelType>(["chat"]);
 
   function showPanel(panel: PanelContent) {
-    if (settingsOpen && activeChatId) {
-      void navigate({ to: "/c/$chatId", params: { chatId: activeChatId } });
+    // The panels belong to a conversation, so reaching one from home or from
+    // settings has to arrive at the conversation first.
+    if (!onChatRoute && activeChatId) {
+      void navigate({
+        to: "/c/$chatId",
+        params: { chatId: activeChatId },
+        search: { left: panel.type, right: "chat" },
+      });
+      return;
     }
     openPanel(panel);
   }
 
-  function openChat(chat: Chat) {
-    void navigate({ to: "/c/$chatId", params: { chatId: chat.id } });
-  }
+  // Sources, outputs and folders belong to a conversation. With none open —
+  // a first run, before anything has been started — there is nothing for them
+  // to show, so they read as unavailable rather than as a dead click.
+  const hasConversation = activeChatId !== null;
+
+  const recentChats = chats.slice(0, RECENT_CHAT_LIMIT);
+
   return (
-    <aside className="sidebar">
-      <div className="sidebar-brand">
-        <Logomark />
-        <span>OpenWave</span>
-        {collapseControl && (
-          <WithTooltip label="Hide sidebar" side="bottom">
+    <SidebarRail>
+      <SidebarHeader>
+        <button
+          type="button"
+          className="inline-flex min-w-0 cursor-pointer items-center gap-2 rounded-md p-1 transition-colors hover:bg-muted"
+          aria-label="Home"
+          onClick={() => void navigate({ to: "/" })}
+        >
+          <Logomark />
+          {!isCompact && <span className="truncate text-sm font-medium">OpenWave</span>}
+        </button>
+        <span className="grow" />
+        {!isCompact && (
+          <WithTooltip label="Collapse sidebar" side="bottom">
             <button
               type="button"
-              className="theme-toggle"
-              aria-label="Hide sidebar"
+              className="cursor-pointer rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              aria-label="Collapse sidebar"
               onClick={toggleSidebar}
             >
               <PanelLeftClose size={15} />
             </button>
           </WithTooltip>
         )}
-        <WithTooltip
-          label={`Theme: ${themeMode} — click to change`}
-          side="bottom"
-        >
-          <button
-            type="button"
-            className="theme-toggle"
-            aria-label={`Theme: ${themeMode}. Click to change.`}
-            onClick={onCycleTheme}
-          >
-            {themeMode === "light" ? (
-              <Sun size={15} />
-            ) : themeMode === "dark" ? (
-              <Moon size={15} />
-            ) : (
-              <Monitor size={15} />
-            )}
-          </button>
-        </WithTooltip>
-      </div>
+      </SidebarHeader>
 
-      <button
-        type="button"
-        className="new-chat"
-        onClick={onNewChat}
-        disabled={creatingChat || deletingChatId !== null}
-      >
-        <SquarePen size={15} />
-        {creatingChat
-          ? "Starting…"
-          : deletingChatId
-            ? "Deleting…"
-            : "New chat"}
-      </button>
+      <SidebarContent className="gap-1 overflow-y-auto px-2">
+        {isCompact && (
+          <SidebarButton aria-label="Expand sidebar" onClick={toggleSidebar}>
+            <PanelLeftOpen />
+            <span>Expand sidebar</span>
+          </SidebarButton>
+        )}
 
-      <div className="sidebar-section">
-        <div className="conversation-list" aria-label="Workspace">
-          <SidebarPanelButton
-            label="Sources"
-            icon={<Library size={15} />}
-            active={!settingsOpen && openPanelTypes.has("sources")}
-            onClick={() => showPanel({ type: "sources" })}
-          />
-          <SidebarPanelButton
-            label="Outputs"
-            icon={<Shapes size={15} />}
-            active={!settingsOpen && openPanelTypes.has("outputs")}
-            onClick={() => showPanel({ type: "outputs" })}
-          />
-          <SidebarPanelButton
-            label="Folders"
-            icon={<FolderOpen size={15} />}
-            active={!settingsOpen && openPanelTypes.has("folders")}
-            onClick={() => showPanel({ type: "folders" })}
-          />
+        <SidebarButton onClick={onNewChat} disabled={creatingChat || deletingChatId !== null}>
+          <SquarePen />
+          <span>{creatingChat ? "Starting…" : "New chat"}</span>
+        </SidebarButton>
+
+        <WorkspacePanelButton
+          label="Sources"
+          icon={<Library />}
+          active={openPanelTypes.has("sources")}
+          disabled={!hasConversation}
+          onClick={() => showPanel({ type: "sources" })}
+        />
+        <WorkspacePanelButton
+          label="Outputs"
+          icon={<Shapes />}
+          active={openPanelTypes.has("outputs")}
+          disabled={!hasConversation}
+          onClick={() => showPanel({ type: "outputs" })}
+        />
+        <WorkspacePanelButton
+          label="Folders"
+          icon={<FolderOpen />}
+          active={openPanelTypes.has("folders")}
+          disabled={!hasConversation}
+          onClick={() => showPanel({ type: "folders" })}
+        />
+        <WorkspacePanelButton
+          label="All chats"
+          icon={<MessageCircleMore />}
+          active={openPanelTypes.has("chats")}
+          disabled={!hasConversation}
+          onClick={() => showPanel({ type: "chats" })}
+        />
+
+        <SidebarSectionTitle className="mt-4">Recent</SidebarSectionTitle>
+        <div className={isCompact ? "hidden" : "flex flex-col gap-0.5"} aria-label="Chats">
+          {recentChats.map((chat) => (
+            <RecentChatRow
+              key={chat.id}
+              chat={chat}
+              active={onChatRoute && chat.id === activeChatId}
+              renaming={renamingChatId === chat.id}
+              renameDraft={renameChatDraft}
+              savingTitle={savingTitle}
+              mutating={deletingChatId !== null || creatingChat}
+              onRenameDraftChange={setRenameDraft}
+              onOpen={() => void navigate({ to: "/c/$chatId", params: { chatId: chat.id } })}
+              onStartRename={() => onStartRename(chat)}
+              onCommitRename={() => onCommitRename(chat)}
+              onCancelRename={onCancelRename}
+              onDelete={() => onDeleteChat(chat)}
+            />
+          ))}
+          {chats.length > RECENT_CHAT_LIMIT && (
+            <button
+              type="button"
+              className="cursor-pointer rounded-md px-2 py-1.5 text-left text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              onClick={() => showPanel({ type: "chats" })}
+            >
+              More…
+            </button>
+          )}
+          {chatsError && <p className="px-2 py-1 text-xs text-critical">{chatsError}</p>}
         </div>
-      </div>
+      </SidebarContent>
 
-      <div className="sidebar-section">
-        <span className="sidebar-label">Chats</span>
-        <div className="conversation-list" aria-label="Chats">
-          {chats.map((item) => {
-            const chatTitle = item.title?.trim() || "New chat";
-            const isActive = !settingsOpen && item.id === activeChatId;
-            const mutating = deletingChatId !== null || creatingChat;
-
-            if (renamingChatId === item.id) {
-              return (
-                <div key={item.id} className="conversation-row is-renaming">
-                  <input
-                    className="conversation-rename-input"
-                    autoFocus
-                    aria-label="Chat title"
-                    value={renameChatDraft}
-                    disabled={savingTitle}
-                    onChange={(event) => setRenameDraft(event.target.value)}
-                    onBlur={() => onCommitRename(item)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter") {
-                        event.preventDefault();
-                        event.currentTarget.blur();
-                      }
-                      if (event.key === "Escape") {
-                        event.preventDefault();
-                        onCancelRename();
-                      }
-                    }}
-                  />
-                </div>
-              );
-            }
-
-            return (
-              <div
-                key={item.id}
-                className={`conversation-row${isActive ? " is-active" : ""}`}
-              >
-                <button
-                  type="button"
-                  className="conversation-item"
-                  aria-current={isActive ? "page" : undefined}
-                  disabled={mutating}
-                  onClick={() => openChat(item)}
-                >
-                  <span className="conversation-title">{chatTitle}</span>
-                </button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      className="conversation-menu"
-                      aria-label={`Actions for ${chatTitle}`}
-                      title="Chat actions"
-                      disabled={mutating}
-                    >
-                      <Ellipsis size={15} />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" side="right">
-                    <DropdownMenuItem onSelect={() => onStartRename(item)}>
-                      <Pencil />
-                      Rename
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      variant="destructive"
-                      onSelect={() => onDeleteChat(item)}
-                    >
-                      <Trash2 />
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            );
-          })}
-        </div>
-        {chatsError && <p className="sidebar-error">{chatsError}</p>}
-      </div>
-
-      <div className="sidebar-footer">
+      <SidebarFooter className="flex flex-col gap-0.5">
         {updateReady && (
-          <button
-            type="button"
-            className="sidebar-action sidebar-update"
-            onClick={onRestartForUpdate}
-          >
-            <RotateCw size={16} />
+          <SidebarButton onClick={onRestartForUpdate}>
+            <RotateCw />
             <span>Restart to update</span>
             {updateVersion && (
-              <span className="sidebar-update-version">v{updateVersion}</span>
+              <span className="ml-auto text-xs text-muted-foreground">v{updateVersion}</span>
             )}
-          </button>
+          </SidebarButton>
         )}
-        <button
-          type="button"
-          className={`sidebar-action${settingsOpen ? " is-active" : ""}`}
+        <SidebarButton aria-label={`Theme: ${themeMode}. Click to change.`} onClick={onCycleTheme}>
+          {themeMode === "light" ? <Sun /> : themeMode === "dark" ? <Moon /> : <Monitor />}
+          <span>Theme</span>
+        </SidebarButton>
+        <SidebarButton
+          aria-current={pathname === "/settings" ? "page" : undefined}
+          data-active={pathname === "/settings" || undefined}
+          className="data-[active]:bg-muted"
           onClick={() => void navigate({ to: "/settings" })}
         >
-          <Settings size={16} />
-          Settings
-        </button>
-      </div>
-    </aside>
+          <Settings />
+          <span>Settings</span>
+        </SidebarButton>
+      </SidebarFooter>
+    </SidebarRail>
   );
 }
 
-function SidebarPanelButton({
+function WorkspacePanelButton({
   label,
   icon,
   active,
+  disabled,
   onClick,
 }: {
   label: string;
   icon: React.ReactNode;
   active: boolean;
+  disabled?: boolean;
   onClick: () => void;
 }) {
   return (
-    <div className={`conversation-row${active ? " is-active" : ""}`}>
+    <SidebarButton
+      aria-current={active ? "page" : undefined}
+      data-active={active || undefined}
+      className="data-[active]:bg-muted"
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {icon}
+      <span>{label}</span>
+    </SidebarButton>
+  );
+}
+
+function RecentChatRow({
+  chat,
+  active,
+  renaming,
+  renameDraft,
+  savingTitle,
+  mutating,
+  onRenameDraftChange,
+  onOpen,
+  onStartRename,
+  onCommitRename,
+  onCancelRename,
+  onDelete,
+}: {
+  chat: Chat;
+  active: boolean;
+  renaming: boolean;
+  renameDraft: string;
+  savingTitle: boolean;
+  mutating: boolean;
+  onRenameDraftChange: (draft: string) => void;
+  onOpen: () => void;
+  onStartRename: () => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+  onDelete: () => void;
+}) {
+  const title = chat.title?.trim() || "New chat";
+
+  if (renaming) {
+    return (
+      <input
+        className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        autoFocus
+        aria-label="Chat title"
+        value={renameDraft}
+        disabled={savingTitle}
+        onChange={(event) => onRenameDraftChange(event.target.value)}
+        onBlur={onCommitRename}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            event.currentTarget.blur();
+          }
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onCancelRename();
+          }
+        }}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`group flex items-center rounded-md transition-colors hover:bg-muted ${
+        active ? "bg-muted" : ""
+      }`}
+    >
       <button
         type="button"
-        className="conversation-item sidebar-panel-item"
+        className="min-w-0 flex-1 cursor-pointer truncate px-2 py-1.5 text-left text-sm disabled:pointer-events-none disabled:opacity-50"
         aria-current={active ? "page" : undefined}
-        onClick={onClick}
+        disabled={mutating}
+        onClick={onOpen}
       >
-        {icon}
-        <span className="conversation-title">{label}</span>
+        {title}
       </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            // Revealed on hover, but kept in the layout so the row does not
+            // reflow under the cursor.
+            className="mr-1 cursor-pointer rounded p-1 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 disabled:pointer-events-none"
+            aria-label={`Actions for ${title}`}
+            disabled={mutating}
+          >
+            <Ellipsis size={15} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" side="right">
+          <DropdownMenuItem onSelect={onStartRename}>
+            <Pencil />
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onSelect={onDelete}>
+            <Trash2 />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/crates/openwave-desktop/ui/src/SidebarCollapse.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/SidebarCollapse.dom.test.tsx
@@ -34,7 +34,7 @@ describe("sidebar collapse", () => {
   it("collapses from the sidebar control and persists the preference", async () => {
     const user = userEvent.setup();
     await renderSidebar();
-    await user.click(screen.getByRole("button", { name: "Hide sidebar" }));
+    await user.click(screen.getByRole("button", { name: "Collapse sidebar" }));
     expect(useUiStore.getState().sidebarCollapsed).toBe(true);
     expect(window.localStorage.getItem("openwave.sidebar-collapsed")).toBe(
       "true",

--- a/crates/openwave-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelTypes.ts
@@ -6,6 +6,7 @@
  */
 export type PanelContent =
   | { type: "chat" }
+  | { type: "chats" }
   | { type: "sources"; documentId?: string }
   | { type: "outputs"; filename?: string }
   | { type: "folders" };
@@ -41,6 +42,7 @@ export function areSamePanelType(a: PanelContent, b: PanelContent): boolean {
 export function isContentPanel(panel: PanelContent): boolean {
   switch (panel.type) {
     case "chat":
+    case "chats":
     case "sources":
     case "outputs":
     case "folders":

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.ts
@@ -13,6 +13,7 @@ import {
  * The grammar is `{type}` or `{type}.{id}`:
  *
  *   chat
+ *   chats
  *   sources
  *   sources.{documentId}
  *   outputs
@@ -31,6 +32,8 @@ export function parsePanelSegment(segment: string): PanelContent | null {
   switch (type) {
     case "chat":
       return id ? null : { type: "chat" };
+    case "chats":
+      return id ? null : { type: "chats" };
     case "folders":
       return id ? null : { type: "folders" };
     case "sources":
@@ -46,6 +49,8 @@ export function encodePanelSegment(panel: PanelContent): string {
   switch (panel.type) {
     case "chat":
       return "chat";
+    case "chats":
+      return "chats";
     case "folders":
       return "folders";
     case "sources":

--- a/crates/openwave-desktop/ui/src/sidebar/primitives.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/primitives.tsx
@@ -1,0 +1,137 @@
+import { forwardRef, useState, type ComponentProps } from "react";
+import { Slot } from "@radix-ui/react-slot";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useUiStore } from "@/UiStore";
+
+/**
+ * The navigation rail, in two widths.
+ *
+ * Compact keeps the rail rather than hiding it: a sidebar that disappears takes
+ * the way back with it, and the reader is left hunting for a control to bring
+ * it back. Collapsed here means icons only, still reachable, with each item's
+ * name in a tooltip.
+ */
+export type SidebarWidth = "compact" | "expanded";
+
+export function useSidebarWidth(): SidebarWidth {
+  return useUiStore((state) => (state.sidebarCollapsed ? "compact" : "expanded"));
+}
+
+export function Sidebar({ className, children, ...props }: ComponentProps<"div">) {
+  const width = useSidebarWidth();
+  const isCompact = width === "compact";
+
+  return (
+    <TooltipProvider>
+      <div
+        {...props}
+        className={cn(
+          "relative flex flex-col overflow-hidden transition-all duration-200",
+          isCompact && "shrink-0",
+          className,
+        )}
+        style={{
+          flex: isCompact ? "0 0 calc(var(--spacing) * 14)" : "var(--sidebar-expanded-flex)",
+        }}
+        data-sidebar={width}
+      >
+        {children}
+      </div>
+    </TooltipProvider>
+  );
+}
+
+export function SidebarHeader({
+  asChild = false,
+  className,
+  ...props
+}: ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "div";
+  return (
+    <Comp className={cn("mt-2 flex h-9 shrink-0 items-center gap-2 px-2", className)} {...props} />
+  );
+}
+
+export const SidebarContent = forwardRef<
+  HTMLDivElement,
+  ComponentProps<"div"> & { asChild?: boolean }
+>(function SidebarContent({ asChild = false, className, ...props }, ref) {
+  const Comp = asChild ? Slot : "div";
+  return <Comp ref={ref} className={cn("mt-4 flex grow flex-col", className)} {...props} />;
+});
+
+export function SidebarFooter({
+  asChild = false,
+  className,
+  ...props
+}: ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "div";
+  return <Comp className={cn("shrink-0 p-2", className)} {...props} />;
+}
+
+export function SidebarSectionTitle({ className, ...props }: ComponentProps<"div">) {
+  const isCompact = useSidebarWidth() === "compact";
+  return (
+    <div
+      className={cn(
+        "line-clamp-1 shrink-0 truncate px-2 py-1 text-sm font-medium text-muted-foreground opacity-100 transition-opacity",
+        isCompact && "opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * A row in the rail. Compact hides everything but the leading icon and moves
+ * the label — taken from the first `span` — into a tooltip, so one definition
+ * serves both widths.
+ */
+export function SidebarButton({
+  asChild = false,
+  children,
+  className,
+  ...props
+}: ComponentProps<"button"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "button";
+  const [label, setLabel] = useState("");
+  const isCompact = useSidebarWidth() === "compact";
+
+  const measureLabel = (element: HTMLButtonElement | null) => {
+    if (!element) return;
+    setLabel(element.querySelector("span")?.textContent ?? "");
+  };
+
+  const button = (
+    <Comp
+      ref={measureLabel}
+      className={cn(
+        "inline-flex w-full cursor-pointer items-center gap-2 rounded-md p-2 text-left text-sm font-[450] whitespace-nowrap ring-offset-background transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
+        isCompact && "justify-center [&>*:not(:first-child)]:hidden",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+
+  if (!isCompact) return button;
+
+  return (
+    <Tooltip delayDuration={150}>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent side="right" align="center">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -297,159 +297,27 @@ body {
   background: var(--page-background);
 }
 
-.sidebar {
-  display: flex;
-  flex: 0 0 224px;
-  min-width: 0;
-  flex-direction: column;
-  gap: 0.15rem;
-  padding: 0.5rem;
-  overflow: hidden;
-}
-
-.sidebar-brand {
+/* The settings sidebar is still hand-styled; the app rail moved to the
+   Tailwind primitives in `sidebar/primitives.tsx`. */
+.sidebar-action {
   display: flex;
   align-items: center;
   gap: 0.55rem;
-  height: 2.25rem;
-  padding: 0 0.5rem;
-  margin-bottom: 0.85rem;
-  font-weight: 600;
-  font-size: 0.95rem;
-  letter-spacing: -0.01em;
-}
-
-.sidebar-brand > svg {
-  width: 1.15rem;
-  height: auto;
-  color: var(--ink);
-}
-
-.theme-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
-  flex: 0 0 auto;
-  margin-left: auto;
-  border: 0;
-  border-radius: 6px;
-  color: var(--muted-foreground);
-  background: transparent;
-  transition: background-color 100ms ease, color 100ms ease;
-}
-
-.theme-toggle:hover {
-  color: var(--ink);
-  background: var(--accent);
-}
-
-.new-chat {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem;
-  border: 0;
-  border-radius: 6px;
-  color: var(--ink);
-  background: transparent;
-  font-size: 0.875rem;
-  font-weight: 500;
-  text-align: left;
-  transition: background-color 100ms ease;
-}
-
-.new-chat:hover:not(:disabled) {
-  background: var(--accent);
-}
-
-.new-chat svg {
-  flex: 0 0 auto;
-  color: var(--muted-foreground);
-}
-
-.sidebar-section {
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 auto;
-  gap: 0.15rem;
-  min-height: 0;
-  margin-top: 0.85rem;
-  overflow: hidden;
-}
-
-.conversation-list {
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 auto;
-  align-content: flex-start;
-  gap: 1px;
-  min-height: 0;
-  overflow-y: auto;
-}
-
-.sidebar-label {
-  padding: 0.25rem 0.5rem;
-  color: var(--muted-foreground);
-  font-size: 0.8125rem;
-  font-weight: 500;
-}
-
-.conversation-item,
-.sidebar-action {
-  display: flex;
   width: 100%;
-  min-width: 0;
-  align-items: center;
-  gap: 0.5rem;
+  padding: 0.4rem 0.55rem;
   border: 0;
   border-radius: 6px;
-  padding: 0.5rem;
-  color: var(--ink);
   background: transparent;
-  font-size: 0.875rem;
-  font-weight: 450;
+  color: var(--muted-foreground);
+  font-size: 0.85rem;
   text-align: left;
-}
-
-.conversation-row {
-  display: flex;
-  flex: 0 0 auto;
-  height: 2.25rem;
-  align-items: center;
-  min-width: 0;
-  border-radius: 6px;
-  transition: background-color 100ms ease;
-}
-
-.conversation-row:hover,
-.conversation-row.is-active {
-  background: var(--accent);
-}
-
-.conversation-row:hover .conversation-item,
-.conversation-row.is-active .conversation-item {
-  color: var(--ink);
-}
-
-.conversation-item:hover {
-  color: var(--ink);
-  background: transparent;
-}
-
-.conversation-title {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 0.84rem;
-  font-weight: 500;
+  cursor: pointer;
 }
 
 .sidebar-action.is-active,
 .sidebar-action:hover {
+  background: var(--sidebar-active);
   color: var(--ink);
-  background: var(--accent);
 }
 
 .sidebar-action svg {
@@ -462,98 +330,6 @@ body {
   color: var(--ink);
 }
 
-.conversation-item {
-  flex: 1 1 auto;
-}
-
-.conversation-menu {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.65rem;
-  height: 1.65rem;
-  flex: 0 0 auto;
-  margin-right: 0.15rem;
-  border: 0;
-  border-radius: 5px;
-  color: var(--muted-foreground);
-  background: transparent;
-  line-height: 1;
-  opacity: 0;
-  transition: opacity 100ms ease, background-color 100ms ease;
-}
-
-.conversation-row:hover .conversation-menu,
-.conversation-row.is-active .conversation-menu,
-.conversation-menu:focus-visible,
-.conversation-menu[data-state="open"] {
-  opacity: 1;
-}
-
-.conversation-menu:hover:not(:disabled),
-.conversation-menu[data-state="open"] {
-  color: var(--ink);
-  background: color-mix(in srgb, var(--accent) 70%, transparent);
-}
-
-.conversation-menu:disabled {
-  cursor: not-allowed;
-}
-
-.conversation-row.is-renaming {
-  padding: 0 0.15rem;
-  background: var(--accent);
-}
-
-.conversation-rename-input {
-  width: 100%;
-  min-width: 0;
-  height: 1.85rem;
-  border: 0;
-  border-radius: 5px;
-  padding: 0 0.35rem;
-  background: transparent;
-  color: var(--ink);
-  font-size: 0.84rem;
-  font-weight: 500;
-  outline: none;
-}
-
-
-.sidebar-error {
-  margin: 0;
-  padding: 0 0.4rem;
-  color: var(--danger);
-  font-size: 0.75rem;
-}
-
-.sidebar-footer {
-  display: grid;
-  gap: 2px;
-  margin-top: auto;
-}
-
-.sidebar-update {
-  color: var(--success-foreground);
-  background: var(--success-background);
-}
-
-.sidebar-update:hover {
-  color: var(--success-foreground);
-  background: color-mix(in srgb, var(--success-background) 78%, var(--success));
-}
-
-.sidebar-update svg,
-.sidebar-update:hover svg {
-  color: var(--success-foreground);
-}
-
-.sidebar-update-version {
-  margin-left: auto;
-  color: inherit;
-  font-size: 0.7rem;
-  opacity: 0.75;
-}
 
 /* ---------- Buttons ---------- */
 
@@ -2903,37 +2679,12 @@ body {
   scrollbar-width: thin;
 }
 
-/* ---------- Sidebar collapse ---------- */
-
-.sidebar-expand {
-  position: absolute;
-  top: 0.6rem;
-  left: 0.6rem;
-  z-index: 20;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.8rem;
-  height: 1.8rem;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  background: var(--bg-elevated);
-  color: var(--muted-foreground);
-}
-
-.sidebar-expand:hover {
-  color: var(--ink);
-}
+/* ---------- Window chrome ---------- */
 
 .app-shell {
   position: relative;
 }
 
-/* With the sidebar collapsed the main surface reaches the window's left
-   edge; restore the same gutter the other sides get. */
-.app-shell.sidebar-collapsed .main {
-  margin-left: 0.5rem;
-}
 
 /* macOS overlay titlebar: one strip carries the traffic lights, panel
    toggle, brand, and theme control, and drags the window. */


### PR DESCRIPTION
Part of #533, closes #537. Completes phase A — the shell is now in place for the uploader and the viewers to live in.

## Home

The app had no home. It opened by silently creating a chat, so every cold start the reader didn't use left an empty conversation behind. Now `/` is a place: a greeting, a composer that starts a conversation, and the work to pick up again. The logo goes back to it, and nothing is created until something is written.

**The composer on home starts a chat but doesn't post into it.** The text is handed to the conversation it opens and sent from the chat route. That keeps exactly one send path — one optimistic transcript entry, one turn id, one failure story — instead of a second copy that drifts from the first. The handover reads once and clears, so a re-render can't send it twice.

## The rail

Rebuilt on sidebar primitives with two widths. **Collapsed now keeps an icon rail with tooltips instead of hiding**, which fixes a real trap: the sidebar used to disappear entirely, taking the only way to change conversations with it. It carries the way home, the panels of the open conversation, recent conversations with inline rename and delete, and the app's own controls.

The panel entries are disabled when no conversation is open — on a first run they'd otherwise be a dead click.

## Chats panel

`?left=chats` lists every conversation with search, so one that has scrolled off the rail can be found again. Untitled chats are searchable under "New chat", the name they're actually shown by — matching nothing would make them unreachable.

## Cleanup

Roughly 250 lines of hand-written sidebar CSS go; what's left is the one rule the settings sidebar still uses, which is a separate thing wearing the same class name.

## Verification

`tsc`, 418 tests across 60 files (12 new), production build.

The shell test now drives the real router through the new flow: open on home, type into the composer, confirm the chat is created *and* the message posted from the chat route, arrange and close panels, search the chats panel, and step into settings and back. Same caveat as before — `react-resizable-panels` is stubbed there because jsdom can't lay it out, so the panel group's rendering still wants a manual pass.