### PR TITLE
feat(desktop): attach images to a message from the composer

### DIFF
--- a/crates/openwave-desktop/src/image_attachments.rs
+++ b/crates/openwave-desktop/src/image_attachments.rs
@@ -39,12 +39,16 @@ pub(crate) struct AttachImageRequest {
 
 /// What the renderer learns about an attached image.
 ///
-/// Identity plus geometry, nothing else. There is no path, no directory, and no
-/// way back to the bytes from here.
+/// Identity, geometry, and the leaf file name the picker returned — nothing
+/// else. There is no directory, no path, and no way back to the bytes from
+/// here. The name is included because it is the one thing the composer cannot
+/// invent for itself: without it every picked image reads as an anonymous tile,
+/// and a reader with three attached cannot tell which one to remove.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AttachedImage {
     attachment_id: String,
+    file_name: String,
     media_type: String,
     width: u32,
     height: u32,
@@ -66,16 +70,39 @@ struct ServerErrorBody {
     kind: String,
 }
 
-impl From<PublishedImageAttachment> for AttachedImage {
-    fn from(published: PublishedImageAttachment) -> Self {
+impl AttachedImage {
+    fn new(published: PublishedImageAttachment, file_name: String) -> Self {
         Self {
             attachment_id: published.attachment_id.to_string(),
+            file_name,
             media_type: published.media_type,
             width: published.width,
             height: published.height,
             byte_len: published.byte_len,
         }
     }
+}
+
+/// The leaf name of the picked file, bounded and safe to render.
+///
+/// Only the last component crosses, so the directories the user browsed through
+/// stay in the host. The character check is the same one the document import
+/// applies: a name is written by whoever wrote the file, and control or
+/// formatting characters in one can reorder or hide the rest of a composer
+/// chip's text.
+fn picked_image_name(path: &Path) -> Result<String, String> {
+    if !path.is_absolute() {
+        return Err("The image picker returned an invalid file".to_owned());
+    }
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| {
+            !name.is_empty()
+                && name.chars().count() <= 255
+                && name.chars().all(crate::documents::is_safe_title_char)
+        })
+        .map(str::to_owned)
+        .ok_or_else(|| "The selected image has an invalid name".to_owned())
 }
 
 /// Pick one image from disk and publish it for a conversation.
@@ -99,6 +126,7 @@ pub(crate) async fn attach_chat_image(
     let Some(path) = pick_image(&app).await? else {
         return Ok(None);
     };
+    let file_name = picked_image_name(&path)?;
     let bytes = tauri::async_runtime::spawn_blocking(move || read_selected_image(&path))
         .await
         .map_err(|_| "Could not read the selected image".to_owned())??;
@@ -135,7 +163,7 @@ pub(crate) async fn attach_chat_image(
         .json::<PublishedImageAttachment>()
         .await
         .map_err(|_| "Attaching the image returned an invalid response".to_owned())?;
-    Ok(Some(AttachedImage::from(published)))
+    Ok(Some(AttachedImage::new(published, file_name)))
 }
 
 fn image_attachments_path(chat_id: ChatId) -> String {
@@ -276,14 +304,17 @@ mod tests {
     }
 
     #[test]
-    fn the_renderer_projection_is_identity_and_geometry_only() {
-        let attached = AttachedImage::from(PublishedImageAttachment {
-            attachment_id: Uuid::nil(),
-            media_type: "image/png".to_owned(),
-            width: 800,
-            height: 600,
-            byte_len: 1_024,
-        });
+    fn the_renderer_projection_is_identity_geometry_and_a_leaf_name_only() {
+        let attached = AttachedImage::new(
+            PublishedImageAttachment {
+                attachment_id: Uuid::nil(),
+                media_type: "image/png".to_owned(),
+                width: 800,
+                height: 600,
+                byte_len: 1_024,
+            },
+            "diagram.png".to_owned(),
+        );
         let json = serde_json::to_value(attached).unwrap();
         let mut keys = json
             .as_object()
@@ -294,12 +325,33 @@ mod tests {
         keys.sort();
         assert_eq!(
             keys,
-            ["attachmentId", "byteLen", "height", "mediaType", "width"]
+            [
+                "attachmentId",
+                "byteLen",
+                "fileName",
+                "height",
+                "mediaType",
+                "width"
+            ]
         );
         let serialized = json.to_string();
         for forbidden in ["path", "bytes", "data", "base64", "Users", "token"] {
             assert!(!serialized.contains(forbidden), "leaked {forbidden}");
         }
+    }
+
+    #[test]
+    fn the_picked_name_is_a_bounded_leaf_and_never_the_directories_above_it() {
+        assert_eq!(
+            picked_image_name(Path::new("/Users/private/holiday/beach.png")).unwrap(),
+            "beach.png"
+        );
+        // A relative path cannot have come from the picker, and a name carrying
+        // a bidi override could redraw the rest of the chip's text.
+        assert!(picked_image_name(Path::new("beach.png")).is_err());
+        assert!(picked_image_name(Path::new("/Users/private/bad\u{202e}gnp.png")).is_err());
+        let overlong = format!("/Users/private/{}.png", "a".repeat(300));
+        assert!(picked_image_name(Path::new(&overlong)).is_err());
     }
 
     #[test]

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -26,6 +26,7 @@
         "minHeight": 480,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
+        "dragDropEnabled": false,
         "trafficLightPosition": {
           "x": 16,
           "y": 23
@@ -33,7 +34,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' customprotocol: asset:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; img-src 'self' asset: data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
+      "csp": "default-src 'self' customprotocol: asset:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; img-src 'self' asset: blob: data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
     }
   },
   "plugins": {

--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -170,7 +170,12 @@ describe("app shell", () => {
     // Home writes the message but does not post it — the chat route does, so
     // there is only one send path.
     await waitFor(() =>
-      expect(postMessage).toHaveBeenCalledWith("chat-1", expect.any(String), "summarise the filing"),
+      expect(postMessage).toHaveBeenCalledWith(
+        "chat-1",
+        expect.any(String),
+        "summarise the filing",
+        [],
+      ),
     );
   });
 

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
-import type { ModelSelectionKey, ReasoningEffort, SequencedEvent } from "./api";
+import type {
+  ModelInfo,
+  ModelSelectionKey,
+  ReasoningEffort,
+  SequencedEvent,
+} from "./api";
 import { useApp } from "./AppContext";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
 import { reconcilePendingApprovalCards } from "./ApprovalHistory";
@@ -26,6 +31,8 @@ import { DocumentsView } from "./DocumentsView";
 import { FoldersView } from "./FoldersView";
 import { hasNativeHost } from "./host";
 import { importLibraryDocument, type ImportedDocument } from "./documents";
+import { readyImageAttachmentIds } from "./ImageAttachments";
+import { useImageAttachments } from "./useImageAttachments";
 import { modelForSelection } from "./ModelSelection";
 import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
 import {
@@ -79,6 +86,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const [attachingSource, setAttachingSource] = useState(false);
   const [recentSource, setRecentSource] = useState<ImportedDocument | null>(null);
   const [sourceAttachmentError, setSourceAttachmentError] = useState<string | null>(null);
+  const images = useImageAttachments(client, chatId);
   const handleEventRef = useRef<(event: SequencedEvent) => void>(() => {});
   const terminalHydrationGenerationRef = useRef(0);
   const draftRef = useRef("");
@@ -239,6 +247,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
    */
   async function sendMessage(content: string) {
     if (!chat || !content || busy || deletingChatId !== null) return;
+    const attachments = readyImageAttachmentIds(images.attachments);
     const turnId = crypto.randomUUID();
     terminalHydrationGenerationRef.current += 1;
     setComposerDraft("");
@@ -253,8 +262,12 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     }));
     signalTurnLifecycle("submitted");
     try {
-      await client.postMessage(chatId, turnId, content);
+      await client.postMessage(chatId, turnId, content, attachments);
       setRecentSource(null);
+      // Only once the turn is durably accepted. A refused send — an image the
+      // selected model cannot read, say — must leave the attachments where the
+      // reader can fix the problem and try again.
+      images.clear();
     } catch (err) {
       updateSession((session) => ({
         ...session,
@@ -312,6 +325,19 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             attachingSource={attachingSource}
             attachedSourceName={recentSource?.displayName ?? null}
             sourceAttachmentError={sourceAttachmentError}
+            composerImages={{
+              items: images.attachments,
+              // Drop and paste hand the composer the bytes directly; only the
+              // picker needs the host, so only it is withheld in a browser.
+              canPick: hasNativeHost(),
+              picking: images.attachingFromPicker,
+              error: images.error,
+              unsupportedModel: textOnlyModelLabel(models, chat!.model),
+              onPick: images.attachFromPicker,
+              onAttachFiles: images.attachFiles,
+              onRemove: images.remove,
+              onRetry: images.retry,
+            }}
             composerModelMenu={
               <>
                 <ModelMenu
@@ -391,6 +417,21 @@ export function ChatRoute({ chatId }: { chatId: string }) {
 
 function withoutConnectionState(status: string): string {
   return status.replace(/ · (?:live|reconnecting)$/, "");
+}
+
+/**
+ * The label of the chat's model when it cannot read images, or `null`.
+ *
+ * A chat with no model of its own follows the global default, which the
+ * renderer does not resolve; the server still refuses such a turn, so the
+ * composer stays quiet rather than guessing at a name it would have to print.
+ */
+function textOnlyModelLabel(
+  models: ModelInfo[],
+  selection: string | null,
+): string | null {
+  const model = modelForSelection(models, selection);
+  return model && !model.multimodal ? model.display_name : null;
 }
 
 function friendlySourceAttachmentError(error: unknown): string {

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -5,6 +5,7 @@ import { useRef, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, Chat } from "./api";
 import { ChatView, type ChatViewProps } from "./ChatView";
+import type { ComposerImages } from "./Composer";
 import { useChatSessionStore } from "./ChatSessionStore";
 import { usePendingPrompts } from "./PendingPrompts";
 
@@ -28,6 +29,20 @@ const client = {
   answerUserQuestions: vi.fn().mockResolvedValue(undefined),
 } as unknown as ApiClient;
 
+function noImages(): ComposerImages {
+  return {
+    items: [],
+    canPick: false,
+    picking: false,
+    error: null,
+    unsupportedModel: null,
+    onPick: vi.fn(),
+    onAttachFiles: vi.fn(),
+    onRemove: vi.fn(),
+    onRetry: vi.fn(),
+  };
+}
+
 /**
  * The pane with the draft wired up the way the root wires it: state for
  * rendering, a ref for reading it at the moment guidance is sent.
@@ -45,6 +60,7 @@ function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
       draft={draft}
       draftRef={draftRef}
       composerModelMenu={null}
+      composerImages={noImages()}
       attachingSource={false}
       attachedSourceName={null}
       sourceAttachmentError={null}
@@ -71,6 +87,7 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
     draft: "",
     draftRef: { current: "" },
     composerModelMenu: null,
+    composerImages: noImages(),
     attachingSource: false,
     attachedSourceName: null,
     sourceAttachmentError: null,

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -8,7 +8,7 @@ import {
 import type { ApiClient, Chat } from "./api";
 import { followScrollBehavior, isNearBottom, scrollToLatest } from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
-import { Composer } from "./Composer";
+import { Composer, type ComposerImages } from "./Composer";
 import { MessageList } from "./MessageList";
 import { useTranscriptVisible } from "./TranscriptVisibility";
 import { useFolderAccessRequests } from "./useFolderAccessRequests";
@@ -27,6 +27,7 @@ export type ChatViewProps = {
   /** The same draft, readable synchronously — see [useTurnControls]. */
   draftRef: RefObject<string>;
   composerModelMenu: ReactNode;
+  composerImages: ComposerImages;
   attachingSource: boolean;
   attachedSourceName: string | null;
   sourceAttachmentError: string | null;
@@ -53,6 +54,7 @@ export function ChatView({
   draft,
   draftRef,
   composerModelMenu,
+  composerImages,
   attachingSource,
   attachedSourceName,
   sourceAttachmentError,
@@ -172,6 +174,7 @@ export function ChatView({
         disabled={deletingChat}
         draft={draft}
         modelMenu={composerModelMenu}
+        images={composerImages}
         canAttachSource={nativeHost}
         attachingSource={attachingSource}
         attachedSourceName={attachedSourceName}

--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -3,12 +3,67 @@ import { describe, expect, it, vi } from "vitest";
 import {
   boundedComposerHeight,
   Composer,
+  imageSendBlocker,
   MAX_COMPOSER_LINES,
   shouldRestoreComposerFocus,
   shouldSubmitComposerKey,
+  type ComposerImages,
 } from "./Composer";
+import {
+  queuedImageAttachment,
+  readyImageAttachment,
+  withUploadFailed,
+  withUploadProgress,
+  withUploadStarted,
+  type ImageAttachment,
+} from "./ImageAttachments";
 
 const noop = async () => undefined;
+
+function images(overrides: Partial<ComposerImages> = {}): ComposerImages {
+  return {
+    items: [],
+    canPick: true,
+    picking: false,
+    error: null,
+    unsupportedModel: null,
+    onPick: vi.fn(),
+    onAttachFiles: vi.fn(),
+    onRemove: vi.fn(),
+    onRetry: vi.fn(),
+    ...overrides,
+  };
+}
+
+function attached(id: string, name: string): ImageAttachment {
+  return queuedImageAttachment(id, {
+    name,
+    byteLen: 1_000,
+    previewUrl: `blob:${id}`,
+  });
+}
+
+function composerWithImages(overrides: Partial<ComposerImages>): string {
+  return renderToStaticMarkup(
+    <Composer
+      activeTurnId={null}
+      busy={false}
+      cancelError={null}
+      cancelPending={false}
+      disabled={false}
+      draft="What is in this?"
+      images={images(overrides)}
+      onDraftChange={vi.fn()}
+      onSend={noop}
+      onSteer={noop}
+      onStop={noop}
+      resetKey="chat-1"
+      steerError={null}
+      steerPending={false}
+      steerStatus={null}
+    />,
+  );
+}
 
 describe("Composer", () => {
   it("submits only an unmodified Enter outside IME composition", () => {
@@ -265,5 +320,123 @@ describe("Composer", () => {
     expect(markup).toContain("brief.pdf");
     expect(markup).toContain("Added to this conversation");
     expect(markup).toContain('aria-label="Dismiss brief.pdf"');
+  });
+
+  it("previews an uploading image from the local file with determinate progress", () => {
+    const uploading = withUploadProgress(
+      withUploadStarted([attached("a", "chart.png")], "a"),
+      "a",
+      250,
+    );
+    const markup = composerWithImages({ items: uploading });
+
+    expect(markup).toContain('src="blob:a"');
+    expect(markup).toContain("chart.png");
+    expect(markup).toContain("Uploading 25%");
+    expect(markup).toContain('<progress class="composer-image-progress"');
+    expect(markup).toContain('max="100"');
+    expect(markup).toContain('value="25"');
+    expect(markup).toContain('aria-label="Uploading chart.png"');
+    // Sending mid-upload would drop the image the reader is waiting for.
+    expect(markup).toContain('aria-label="Send message" disabled=""');
+  });
+
+  it("keeps a failed image on screen with a way to try again", () => {
+    const failed = withUploadFailed(
+      withUploadStarted([attached("a", "chart.png")], "a"),
+      "a",
+      "That image file is damaged",
+    );
+    const markup = composerWithImages({ items: failed });
+
+    expect(markup).toContain("chart.png");
+    expect(markup).toContain("That image file is damaged");
+    expect(markup).toContain("Try again");
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain('aria-label="Send message" disabled=""');
+  });
+
+  it("labels removal per image and never hides it behind a pointer", () => {
+    const markup = composerWithImages({
+      items: [
+        attached("a", "chart.png"),
+        readyImageAttachment("b", {
+          attachmentId: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+          fileName: "beach.png",
+          mediaType: "image/png",
+          width: 800,
+          height: 600,
+          byteLen: 2_048,
+        }),
+      ],
+    });
+
+    // A shared label leaves a screen reader with two identical controls.
+    expect(markup).toContain('aria-label="Remove chart.png"');
+    expect(markup).toContain('aria-label="Remove beach.png"');
+    // The picker cannot show pixels the renderer never received, so a picked
+    // image is identified by its name and geometry instead.
+    expect(markup).toContain("beach.png");
+    expect(markup).toContain("800 × 600");
+  });
+
+  it("says which model cannot read the attached image, and blocks the send", () => {
+    const markup = composerWithImages({
+      items: [
+        readyImageAttachment("b", {
+          attachmentId: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+          fileName: "beach.png",
+          mediaType: "image/png",
+          width: 800,
+          height: 600,
+          byteLen: 2_048,
+        }),
+      ],
+      unsupportedModel: "Local Model",
+    });
+
+    expect(markup).toContain("Local Model can’t read images.");
+    expect(markup).toContain("Choose a model that");
+    expect(markup).toContain("remove the attached image");
+    expect(markup).toContain('aria-label="Send message" disabled=""');
+  });
+
+  it("offers the picker only where a host can open one", () => {
+    expect(composerWithImages({})).toContain('aria-label="Attach image"');
+    // Drop and paste still work in a browser; only the native picker does not.
+    expect(composerWithImages({ canPick: false })).not.toContain(
+      'aria-label="Attach image"',
+    );
+  });
+
+  it("explains why a turn carrying images is not sendable yet", () => {
+    expect(imageSendBlocker(undefined)).toBeNull();
+    expect(imageSendBlocker(images())).toBeNull();
+    expect(
+      imageSendBlocker(images({ items: [attached("a", "chart.png")] })),
+    ).toBe("Waiting for images to upload");
+    expect(
+      imageSendBlocker(
+        images({
+          items: withUploadFailed([attached("a", "chart.png")], "a", "damaged"),
+        }),
+      ),
+    ).toBe("An image did not upload");
+    const ready = readyImageAttachment("b", {
+      attachmentId: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+      fileName: "beach.png",
+      mediaType: "image/png",
+      width: 800,
+      height: 600,
+      byteLen: 2_048,
+    });
+    expect(
+      imageSendBlocker(
+        images({ items: [ready], unsupportedModel: "Local Model" }),
+      ),
+    ).toBe("Local Model cannot read images");
+    expect(imageSendBlocker(images({ items: [ready] }))).toBeNull();
+    // A text-only model is only a problem for a turn that carries an image.
+    expect(imageSendBlocker(images({ unsupportedModel: "Local Model" }))).toBeNull();
   });
 });

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -1,12 +1,30 @@
 import {
   type ChangeEvent,
+  type ClipboardEvent,
+  type DragEvent,
   type KeyboardEvent,
   type ReactNode,
   useLayoutEffect,
   useRef,
+  useState,
 } from "react";
-import { ArrowUp, FileText, Paperclip, Square, X } from "lucide-react";
+import {
+  ArrowUp,
+  FileText,
+  Image as ImageIcon,
+  Paperclip,
+  Square,
+  X,
+} from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
+import {
+  describeImageAttachment,
+  imageFilesFrom,
+  imageUploadPercent,
+  imageUploadsInFlight,
+  transferCarriesFiles,
+  type ImageAttachment,
+} from "./ImageAttachments";
 import { WithTooltip } from "@/components/ui/tooltip";
 
 const MIN_COMPOSER_LINES = 1;
@@ -72,6 +90,42 @@ function resizeComposerTextarea(textarea: HTMLTextAreaElement): void {
   textarea.style.overflowY = textarea.scrollHeight > maximum ? "auto" : "hidden";
 }
 
+/**
+ * Everything the composer needs to present attached images.
+ *
+ * Grouped rather than spread across the prop list because these move together:
+ * a surface either offers image attachment or it does not.
+ */
+export type ComposerImages = {
+  items: ImageAttachment[];
+  /** Whether the host can open a picker; drop and paste work regardless. */
+  canPick: boolean;
+  picking: boolean;
+  error: string | null;
+  /**
+   * The selected model's label when it cannot read images, so the composer can
+   * say so before the send that would be refused.
+   */
+  unsupportedModel: string | null;
+  onPick: () => void;
+  onAttachFiles: (files: readonly File[]) => void;
+  onRemove: (id: string) => void;
+  onRetry: (id: string) => void;
+};
+
+/** Whether attached images stop this turn from being sent, and why. */
+export function imageSendBlocker(images: ComposerImages | undefined): string | null {
+  if (!images || images.items.length === 0) return null;
+  if (imageUploadsInFlight(images.items)) return "Waiting for images to upload";
+  if (images.items.some((item) => item.status === "failed")) {
+    return "An image did not upload";
+  }
+  if (images.unsupportedModel) {
+    return `${images.unsupportedModel} cannot read images`;
+  }
+  return null;
+}
+
 export type ComposerProps = {
   activeTurnId: string | null;
   busy: boolean;
@@ -80,6 +134,7 @@ export type ComposerProps = {
   disabled: boolean;
   draft: string;
   modelMenu?: ReactNode;
+  images?: ComposerImages;
   canAttachSource?: boolean;
   attachingSource?: boolean;
   attachedSourceName?: string | null;
@@ -104,6 +159,7 @@ export function Composer({
   disabled,
   draft,
   modelMenu,
+  images,
   canAttachSource = false,
   attachingSource = false,
   attachedSourceName = null,
@@ -122,12 +178,17 @@ export function Composer({
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const latestResetKeyRef = useRef(resetKey);
   latestResetKeyRef.current = resetKey;
+  // dragenter and dragleave fire for every descendant the pointer crosses, so a
+  // boolean flickers the drop hint on and off while the file is held still.
+  const dragDepthRef = useRef(0);
+  const [dragging, setDragging] = useState(false);
   const inputDisabled = disabled;
   const active = busy && activeTurnId !== null;
   const hasDraft = Boolean(draft.trim());
   const steerHasUnsupportedCharacter = active && draft.includes("\0");
   const steerTooLong =
     active && [...draft.trim()].length > MAX_STEER_CHARACTERS;
+  const imageBlocker = imageSendBlocker(images);
   const canSubmit =
     !inputDisabled &&
     !steerPending &&
@@ -135,6 +196,7 @@ export function Composer({
     hasDraft &&
     !steerHasUnsupportedCharacter &&
     !steerTooLong &&
+    imageBlocker === null &&
     (!busy || active);
 
   useLayoutEffect(() => {
@@ -168,14 +230,59 @@ export function Composer({
     onDraftChange(event.target.value);
   }
 
+  function endDrag() {
+    dragDepthRef.current = 0;
+    setDragging(false);
+  }
+
+  /**
+   * Images from a drop or a paste take the same route as the picker's, so the
+   * chip, the progress, and the failure behave identically whichever way the
+   * reader chose. A paste that carries no image is left alone: it is text.
+   */
+  function acceptTransfer(transfer: DataTransfer | null): boolean {
+    if (!images || inputDisabled) return false;
+    const files = imageFilesFrom(transfer);
+    if (files.length === 0) return false;
+    images.onAttachFiles(files);
+    return true;
+  }
+
+  function onDrop(event: DragEvent<HTMLFormElement>) {
+    endDrag();
+    // The webview, not the host, receives file drops (`dragDropEnabled: false`),
+    // and its own handling of one is to navigate away from the app and display
+    // the file — so a drop must be claimed here whether or not it is taken.
+    event.preventDefault();
+    acceptTransfer(event.dataTransfer);
+  }
+
+  function onPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
+    if (acceptTransfer(event.clipboardData)) event.preventDefault();
+  }
+
   return (
     <div className="composer-wrap">
       <form
-        className="composer"
+        className={`composer${dragging ? " is-dropping" : ""}`}
         onSubmit={(event) => {
           event.preventDefault();
           void submit();
         }}
+        onDragEnter={(event) => {
+          if (!images || inputDisabled) return;
+          if (!transferCarriesFiles(event.dataTransfer)) return;
+          dragDepthRef.current += 1;
+          setDragging(true);
+        }}
+        onDragOver={(event) => {
+          if (dragDepthRef.current > 0) event.preventDefault();
+        }}
+        onDragLeave={() => {
+          dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+          if (dragDepthRef.current === 0) setDragging(false);
+        }}
+        onDrop={onDrop}
       >
         {attachedSourceName && (
           <div className="composer-source" role="status">
@@ -195,6 +302,24 @@ export function Composer({
             )}
           </div>
         )}
+        {dragging && (
+          <div className="composer-drop-hint" role="status">
+            <ImageIcon size={15} aria-hidden="true" />
+            Drop an image to attach it
+          </div>
+        )}
+        {images && images.items.length > 0 && (
+          <ul className="composer-images" aria-label="Attached images">
+            {images.items.map((item) => (
+              <ImageAttachmentChip
+                key={item.id}
+                attachment={item}
+                onRemove={() => images.onRemove(item.id)}
+                onRetry={() => images.onRetry(item.id)}
+              />
+            ))}
+          </ul>
+        )}
         <textarea
           ref={textareaRef}
           value={draft}
@@ -204,6 +329,7 @@ export function Composer({
           aria-label="Message"
           disabled={inputDisabled}
           onChange={onChange}
+          onPaste={onPaste}
           onKeyDown={(event) => {
             if (!shouldSubmitComposerKey(event.nativeEvent)) return;
             event.preventDefault();
@@ -222,6 +348,21 @@ export function Composer({
                   onClick={() => void onAddSource()}
                 >
                   <Paperclip size={15} aria-hidden="true" />
+                </button>
+              </WithTooltip>
+            )}
+            {images?.canPick && (
+              <WithTooltip
+                label={images.picking ? "Choosing image…" : "Attach image"}
+              >
+                <button
+                  type="button"
+                  className="composer-attach"
+                  aria-label={images.picking ? "Choosing image" : "Attach image"}
+                  disabled={inputDisabled || images.picking}
+                  onClick={images.onPick}
+                >
+                  <ImageIcon size={15} aria-hidden="true" />
                 </button>
               </WithTooltip>
             )}
@@ -255,7 +396,7 @@ export function Composer({
                 </WithTooltip>
               </>
             ) : (
-              <WithTooltip label="Send · Enter">
+              <WithTooltip label={imageBlocker ?? "Send · Enter"}>
                 <button
                   type="submit"
                   className="composer-icon-btn composer-send"
@@ -301,7 +442,85 @@ export function Composer({
             Couldn’t add source: {sourceAttachmentError}
           </span>
         )}
+        {images?.error && (
+          <span className="composer-turn-error" role="alert">
+            Couldn’t attach image: {images.error}
+          </span>
+        )}
+        {images?.unsupportedModel && images.items.length > 0 && (
+          <span className="composer-turn-error" role="alert">
+            {images.unsupportedModel} can’t read images. Choose a model that
+            accepts image input, or remove the attached image.
+          </span>
+        )}
       </form>
     </div>
+  );
+}
+
+/**
+ * One attached image, from the moment it is attached to the moment it is sent.
+ *
+ * A failed chip stays put and offers another attempt. Removing it silently
+ * would leave the reader believing the image went with their message; making
+ * them attach it again would throw away a file the composer is still holding.
+ */
+function ImageAttachmentChip({
+  attachment,
+  onRemove,
+  onRetry,
+}: {
+  attachment: ImageAttachment;
+  onRemove: () => void;
+  onRetry: () => void;
+}) {
+  const uploading =
+    attachment.status === "queued" || attachment.status === "uploading";
+  const failed = attachment.status === "failed";
+  return (
+    <li className={`composer-image is-${attachment.status}`}>
+      <span className="composer-image-thumb">
+        {attachment.previewUrl ? (
+          // Shown from the bytes already in hand rather than fetched back from
+          // the server, so the reader sees what they attached immediately.
+          <img src={attachment.previewUrl} alt="" />
+        ) : (
+          <ImageIcon size={16} aria-hidden="true" />
+        )}
+      </span>
+      <span className="composer-image-body">
+        <strong title={attachment.name}>{attachment.name}</strong>
+        {/* Only the outcome is announced. A live region on the percentage
+            would read every tick of a bar that is already on screen. */}
+        <small role={failed ? "alert" : uploading ? undefined : "status"}>
+          {describeImageAttachment(attachment)}
+        </small>
+        {uploading && (
+          <progress
+            className="composer-image-progress"
+            max={100}
+            value={imageUploadPercent(attachment)}
+            aria-label={`Uploading ${attachment.name}`}
+          />
+        )}
+      </span>
+      {failed && (
+        <button
+          type="button"
+          className="composer-image-retry"
+          onClick={onRetry}
+        >
+          Try again
+        </button>
+      )}
+      <button
+        type="button"
+        className="composer-image-remove"
+        aria-label={`Remove ${attachment.name}`}
+        onClick={onRemove}
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
+    </li>
   );
 }

--- a/crates/openwave-desktop/ui/src/ImageAttachments.test.ts
+++ b/crates/openwave-desktop/ui/src/ImageAttachments.test.ts
@@ -1,0 +1,315 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import {
+  describeImageAttachment,
+  imageFilesFrom,
+  refuseStrayFileDrops,
+  transferCarriesFiles,
+  imageAttachmentName,
+  imageAttachmentRefusal,
+  imageAttachmentRejection,
+  imageUploadPercent,
+  imageUploadsInFlight,
+  parseAttachedImage,
+  parsePublishedImage,
+  queuedImageAttachment,
+  readyImageAttachment,
+  readyImageAttachmentIds,
+  withRetryQueued,
+  withUploadFailed,
+  withUploadProgress,
+  withUploadPublished,
+  withUploadStarted,
+  withoutAttachment,
+  type ImageAttachment,
+} from "./ImageAttachments";
+
+const ATTACHMENT_ID = "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21";
+const OTHER_ATTACHMENT_ID = "2d3e2b55-3a4c-4b2f-8e1b-3c7e6d5f4b32";
+
+function published(attachmentId = ATTACHMENT_ID) {
+  return {
+    attachmentId,
+    mediaType: "image/png" as const,
+    width: 800,
+    height: 600,
+    byteLen: 2_048,
+  };
+}
+
+function queued(id: string, byteLen = 1_000): ImageAttachment {
+  return queuedImageAttachment(id, {
+    name: `${id}.png`,
+    byteLen,
+    previewUrl: `blob:${id}`,
+  });
+}
+
+describe("image attachment state machine", () => {
+  it("walks one attachment from attached to sendable", () => {
+    let list = [queued("a")];
+    expect(list[0].status).toBe("queued");
+    expect(imageUploadsInFlight(list)).toBe(true);
+    expect(readyImageAttachmentIds(list)).toEqual([]);
+
+    list = withUploadStarted(list, "a");
+    expect(list[0].status).toBe("uploading");
+
+    list = withUploadProgress(list, "a", 500);
+    expect(imageUploadPercent(list[0])).toBe(50);
+
+    list = withUploadPublished(list, "a", published());
+    expect(list[0].status).toBe("ready");
+    expect(imageUploadsInFlight(list)).toBe(false);
+    expect(readyImageAttachmentIds(list)).toEqual([ATTACHMENT_ID]);
+    expect(describeImageAttachment(list[0])).toBe("800 × 600");
+  });
+
+  it("keeps a failed attachment visible and puts it back in line on retry", () => {
+    let list = withUploadStarted([queued("a")], "a");
+    list = withUploadProgress(list, "a", 400);
+    list = withUploadFailed(list, "a", "That image file is damaged");
+
+    // The chip stays: a message sent without an image the reader attached is
+    // the failure this is preventing.
+    expect(list).toHaveLength(1);
+    expect(list[0].status).toBe("failed");
+    expect(describeImageAttachment(list[0])).toBe("That image file is damaged");
+    expect(imageUploadsInFlight(list)).toBe(false);
+    // Nor is it sendable while it is broken.
+    expect(readyImageAttachmentIds(list)).toEqual([]);
+
+    list = withRetryQueued(list, "a");
+    expect(list[0]).toMatchObject({
+      status: "queued",
+      uploadedBytes: 0,
+      error: null,
+      previewUrl: "blob:a",
+    });
+    list = withUploadStarted(list, "a");
+    list = withUploadPublished(list, "a", published());
+    expect(readyImageAttachmentIds(list)).toEqual([ATTACHMENT_ID]);
+  });
+
+  it("only retries what actually failed", () => {
+    const uploading = withUploadStarted([queued("a")], "a");
+    expect(withRetryQueued(uploading, "a")[0].status).toBe("uploading");
+    const ready = withUploadPublished(uploading, "a", published());
+    expect(withRetryQueued(ready, "a")[0].status).toBe("ready");
+  });
+
+  it("ignores everything addressed to an attachment the reader removed", () => {
+    const list = withoutAttachment(withUploadStarted([queued("a")], "a"), "a");
+    expect(list).toEqual([]);
+    // A progress tick or a completion that arrives after removal must not put
+    // the chip back on screen.
+    expect(withUploadProgress(list, "a", 900)).toEqual([]);
+    expect(withUploadPublished(list, "a", published())).toEqual([]);
+    expect(withUploadFailed(list, "a", "boom")).toEqual([]);
+  });
+
+  it("never lets progress go backwards or past the total", () => {
+    let list = withUploadStarted([queued("a", 1_000)], "a");
+    list = withUploadProgress(list, "a", 900);
+    list = withUploadProgress(list, "a", 100);
+    expect(list[0].uploadedBytes).toBe(900);
+    list = withUploadProgress(list, "a", 5_000);
+    expect(list[0].uploadedBytes).toBe(1_000);
+    expect(imageUploadPercent(list[0])).toBe(100);
+    // A queued attachment is not receiving bytes yet.
+    expect(withUploadProgress([queued("b")], "b", 500)[0].uploadedBytes).toBe(0);
+  });
+
+  it("touches only the attachment it names", () => {
+    const list = withUploadStarted([queued("a"), queued("b")], "b");
+    expect(list.map((item) => item.status)).toEqual(["queued", "uploading"]);
+  });
+
+  it("names each published image once, however many chips point at it", () => {
+    // Attachment identity is derived from the bytes, so the same screenshot
+    // attached twice is one image with two chips.
+    const list = [
+      readyImageAttachment("a", { ...published(), fileName: "one.png" }),
+      readyImageAttachment("b", { ...published(), fileName: "two.png" }),
+      readyImageAttachment("c", {
+        ...published(OTHER_ATTACHMENT_ID),
+        fileName: "three.png",
+      }),
+    ];
+    expect(readyImageAttachmentIds(list)).toEqual([
+      ATTACHMENT_ID,
+      OTHER_ATTACHMENT_ID,
+    ]);
+  });
+
+  it("describes where an attachment stands in one line", () => {
+    expect(describeImageAttachment(queued("a"))).toBe("Waiting to upload");
+    const uploading = withUploadProgress(
+      withUploadStarted([queued("a", 1_000)], "a"),
+      "a",
+      250,
+    );
+    expect(describeImageAttachment(uploading[0])).toBe("Uploading 25%");
+  });
+});
+
+describe("attaching images", () => {
+  it("replaces a name that says nothing about the image", () => {
+    const at = new Date("2026-07-27T12:34:56.789Z");
+    // A pasted screenshot arrives as a generic name, or none at all.
+    expect(imageAttachmentName({ name: "image.png", type: "image/png" }, at)).toBe(
+      "pasted-image-2026-07-27-12-34-56.png",
+    );
+    expect(imageAttachmentName({ name: "", type: "image/jpeg" }, at)).toBe(
+      "pasted-image-2026-07-27-12-34-56.jpeg",
+    );
+    expect(imageAttachmentName({ type: "image/webp" }, at)).toBe(
+      "pasted-image-2026-07-27-12-34-56.webp",
+    );
+    // A name the reader would recognize is left alone.
+    expect(
+      imageAttachmentName({ name: "quarterly-chart.png", type: "image/png" }, at),
+    ).toBe("quarterly-chart.png");
+  });
+
+  it("refuses a batch before any bytes move", () => {
+    expect(imageAttachmentRejection([], [])).toBeNull();
+    expect(
+      imageAttachmentRejection([], [{ type: "image/png", size: 10 }]),
+    ).toBeNull();
+    expect(
+      imageAttachmentRejection([], [{ type: "application/pdf", size: 10 }]),
+    ).toMatch(/PNG, JPEG, WebP, or GIF/);
+    expect(
+      imageAttachmentRejection(
+        [],
+        [{ type: "image/png", size: 17 * 1024 * 1024 }],
+      ),
+    ).toMatch(/16 MB or smaller/);
+    expect(
+      imageAttachmentRejection([], [{ type: "image/png", size: 0 }]),
+    ).toMatch(/empty/);
+    const full = Array.from({ length: 16 }, (_, index) => queued(`a${index}`));
+    expect(
+      imageAttachmentRejection(full, [{ type: "image/png", size: 10 }]),
+    ).toMatch(/at most 16 images/);
+  });
+
+  it("gives every server refusal its own sentence", () => {
+    const kinds = [
+      "image_attachment_empty",
+      "image_attachment_too_large",
+      "image_attachment_not_an_image",
+      "image_attachment_unsupported_format",
+      "image_attachment_media_type_mismatch",
+      "image_attachment_dimensions_too_large",
+    ];
+    const generic = imageAttachmentRefusal("something_new");
+    for (const kind of kinds) {
+      expect(imageAttachmentRefusal(kind)).not.toBe(generic);
+    }
+  });
+});
+
+describe("drags and drops", () => {
+  it("reads a drag from its advertised types and a drop from its files", () => {
+    // `files` is empty until the drop lands, so the hint has to come from the
+    // types the drag advertises.
+    const dragging = { types: ["Files"], files: [] } as unknown as DataTransfer;
+    expect(transferCarriesFiles(dragging)).toBe(true);
+    expect(transferCarriesFiles({ types: ["text/plain"] } as unknown as DataTransfer)).toBe(false);
+    expect(transferCarriesFiles(null)).toBe(false);
+
+    const dropped = {
+      types: ["Files"],
+      files: [
+        new File([""], "chart.png", { type: "image/png" }),
+        new File([""], "notes.txt", { type: "text/plain" }),
+      ],
+    } as unknown as DataTransfer;
+    expect(imageFilesFrom(dropped).map((file) => file.name)).toEqual([
+      "chart.png",
+    ]);
+    expect(imageFilesFrom(null)).toEqual([]);
+  });
+
+  it("makes a drop the app did not claim inert instead of navigating", () => {
+    const dragOver = (dropEffect: string) => {
+      const transfer = { dropEffect } as DataTransfer;
+      const event = Object.assign(
+        new Event("dragover", { bubbles: true, cancelable: true }),
+        { dataTransfer: transfer },
+      );
+      window.dispatchEvent(event);
+      return { event, transfer };
+    };
+
+    const stop = refuseStrayFileDrops(window);
+    const stray = new Event("drop", { bubbles: true, cancelable: true });
+    window.dispatchEvent(stray);
+    // Without this the webview navigates away from the app to show the file.
+    expect(stray.defaultPrevented).toBe(true);
+    expect(dragOver("copy").transfer.dropEffect).toBe("none");
+
+    // A surface that took the drop itself keeps its own answer.
+    const claim = (event: Event) => event.preventDefault();
+    window.addEventListener("dragover", claim, { capture: true });
+    expect(dragOver("copy").transfer.dropEffect).toBe("copy");
+    window.removeEventListener("dragover", claim, { capture: true });
+
+    stop();
+    const afterStop = new Event("drop", { bubbles: true, cancelable: true });
+    window.dispatchEvent(afterStop);
+    expect(afterStop.defaultPrevented).toBe(false);
+  });
+});
+
+describe("image attachment responses", () => {
+  it("accepts what the host and the server actually send", () => {
+    expect(
+      parseAttachedImage({
+        attachmentId: ATTACHMENT_ID,
+        fileName: "beach.png",
+        mediaType: "image/png",
+        width: 800,
+        height: 600,
+        byteLen: 2_048,
+      }),
+    ).toEqual({ ...published(), fileName: "beach.png" });
+    // Dismissing the picker is a normal outcome, not a failure.
+    expect(parseAttachedImage(null)).toBeNull();
+    expect(
+      parsePublishedImage({
+        attachment_id: ATTACHMENT_ID,
+        media_type: "image/png",
+        width: 800,
+        height: 600,
+        byte_len: 2_048,
+      }),
+    ).toEqual(published());
+  });
+
+  it("rejects a response the composer could not safely render", () => {
+    const valid = {
+      attachmentId: ATTACHMENT_ID,
+      fileName: "beach.png",
+      mediaType: "image/png",
+      width: 800,
+      height: 600,
+      byteLen: 2_048,
+    };
+    // A name carrying a bidi override could redraw the rest of the chip.
+    expect(() =>
+      parseAttachedImage({ ...valid, fileName: "gnp.\u{202e}png" }),
+    ).toThrow();
+    expect(() => parseAttachedImage({ ...valid, fileName: "" })).toThrow();
+    expect(() =>
+      parseAttachedImage({ ...valid, mediaType: "image/svg+xml" }),
+    ).toThrow();
+    expect(() => parseAttachedImage({ ...valid, width: 0 })).toThrow();
+    expect(() => parseAttachedImage({ ...valid, height: 8_001 })).toThrow();
+    expect(() => parseAttachedImage({ ...valid, attachmentId: "nope" })).toThrow();
+    // An unexpected field means this is not the shape it claims to be.
+    expect(() => parseAttachedImage({ ...valid, path: "/Users/me" })).toThrow();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ImageAttachments.ts
+++ b/crates/openwave-desktop/ui/src/ImageAttachments.ts
@@ -1,0 +1,597 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Composer image attachments: what one is, how it moves between states, and the
+ * two ways its bytes reach the server.
+ *
+ * An attachment is published before the turn that carries it, so the composer
+ * holds renderer-local identity (`id`) for a while before the server hands back
+ * durable identity (`attachmentId`). Everything here is written around that gap:
+ * the chip exists, and can be named, removed, and retried, from the moment the
+ * user attaches something.
+ */
+
+/**
+ * How many images one turn may carry, mirroring the server's ceiling so the
+ * refusal lands on the attach that broke it rather than on send.
+ */
+export const MAX_IMAGE_ATTACHMENTS = 16;
+
+/** Per-image byte ceiling, mirroring the server's. */
+export const MAX_IMAGE_ATTACHMENT_BYTES = 16 * 1024 * 1024;
+
+/** Per-side pixel ceiling, mirroring the server's. */
+export const MAX_IMAGE_DIMENSION = 8_000;
+
+/** The formats the server will publish. */
+export const IMAGE_MEDIA_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+] as const;
+
+export type ImageMediaType = (typeof IMAGE_MEDIA_TYPES)[number];
+
+/** Durable identity and geometry for one published image. */
+export type PublishedImage = {
+  attachmentId: string;
+  mediaType: ImageMediaType;
+  width: number;
+  height: number;
+  byteLen: number;
+};
+
+/** A published image plus the name the host picker read it under. */
+export type PickedImage = PublishedImage & { fileName: string };
+
+export type ImageAttachmentStatus = "queued" | "uploading" | "ready" | "failed";
+
+export type ImageAttachment = {
+  /**
+   * Renderer-local identity, minted when the user attaches and never reused.
+   * The chip is addressable — removable, retryable — before the server has an
+   * opinion about the bytes, which is the whole point of not keying on
+   * `attachmentId`.
+   */
+  id: string;
+  /** What the chip calls this image. Never sent anywhere. */
+  name: string;
+  /** Total bytes, or `null` while only the host knows them. */
+  byteLen: number | null;
+  uploadedBytes: number;
+  status: ImageAttachmentStatus;
+  /**
+   * Object URL for a locally held file, or `null` when the bytes never entered
+   * the renderer — images chosen through the native picker are read and
+   * uploaded entirely in the host process, so there is nothing here to preview
+   * and the chip falls back to format and geometry.
+   */
+  previewUrl: string | null;
+  /** Server identity, set once the upload is accepted. */
+  attachmentId: string | null;
+  mediaType: string | null;
+  width: number | null;
+  height: number | null;
+  error: string | null;
+};
+
+/** A newly attached image, before any bytes have moved. */
+export function queuedImageAttachment(
+  id: string,
+  file: { name: string; byteLen: number; previewUrl: string | null },
+): ImageAttachment {
+  return {
+    id,
+    name: file.name,
+    byteLen: file.byteLen,
+    uploadedBytes: 0,
+    status: "queued",
+    previewUrl: file.previewUrl,
+    attachmentId: null,
+    mediaType: null,
+    width: null,
+    height: null,
+    error: null,
+  };
+}
+
+/** An image the host picked, read, and published in one step. */
+export function readyImageAttachment(
+  id: string,
+  published: PickedImage,
+): ImageAttachment {
+  return {
+    id,
+    name: published.fileName,
+    byteLen: published.byteLen,
+    uploadedBytes: published.byteLen,
+    status: "ready",
+    previewUrl: null,
+    attachmentId: published.attachmentId,
+    mediaType: published.mediaType,
+    width: published.width,
+    height: published.height,
+    error: null,
+  };
+}
+
+/**
+ * Every transition below is a no-op for an id the list no longer holds. That is
+ * what makes removal safe mid-upload: a progress tick or a late completion for
+ * a chip the user already dismissed finds nothing to write to, rather than
+ * resurrecting it.
+ */
+function mapAttachment(
+  attachments: readonly ImageAttachment[],
+  id: string,
+  change: (attachment: ImageAttachment) => ImageAttachment,
+): ImageAttachment[] {
+  return attachments.map((attachment) =>
+    attachment.id === id ? change(attachment) : attachment,
+  );
+}
+
+export function withUploadStarted(
+  attachments: readonly ImageAttachment[],
+  id: string,
+): ImageAttachment[] {
+  return mapAttachment(attachments, id, (attachment) =>
+    attachment.status === "queued"
+      ? { ...attachment, status: "uploading", uploadedBytes: 0, error: null }
+      : attachment,
+  );
+}
+
+/**
+ * Progress only ever moves forward and never past the total. A browser that
+ * reports the final `loaded` twice, or a retry that starts over, must not make
+ * the bar jump backwards under the reader.
+ */
+export function withUploadProgress(
+  attachments: readonly ImageAttachment[],
+  id: string,
+  uploadedBytes: number,
+): ImageAttachment[] {
+  return mapAttachment(attachments, id, (attachment) => {
+    if (attachment.status !== "uploading") return attachment;
+    const capped =
+      attachment.byteLen === null
+        ? uploadedBytes
+        : Math.min(uploadedBytes, attachment.byteLen);
+    const next = Math.max(attachment.uploadedBytes, capped);
+    return next === attachment.uploadedBytes
+      ? attachment
+      : { ...attachment, uploadedBytes: next };
+  });
+}
+
+export function withUploadPublished(
+  attachments: readonly ImageAttachment[],
+  id: string,
+  published: PublishedImage,
+): ImageAttachment[] {
+  return mapAttachment(attachments, id, (attachment) => ({
+    ...attachment,
+    status: "ready",
+    byteLen: published.byteLen,
+    uploadedBytes: published.byteLen,
+    attachmentId: published.attachmentId,
+    mediaType: published.mediaType,
+    width: published.width,
+    height: published.height,
+    error: null,
+  }));
+}
+
+/**
+ * A failed attachment keeps its place in the strip. A chip that vanishes on
+ * error tells the reader nothing went wrong and quietly sends a turn without
+ * the image they attached.
+ */
+export function withUploadFailed(
+  attachments: readonly ImageAttachment[],
+  id: string,
+  message: string,
+): ImageAttachment[] {
+  return mapAttachment(attachments, id, (attachment) => ({
+    ...attachment,
+    status: "failed",
+    uploadedBytes: 0,
+    error: message,
+  }));
+}
+
+/** Put a failed attachment back in line for another attempt. */
+export function withRetryQueued(
+  attachments: readonly ImageAttachment[],
+  id: string,
+): ImageAttachment[] {
+  return mapAttachment(attachments, id, (attachment) =>
+    attachment.status === "failed"
+      ? { ...attachment, status: "queued", uploadedBytes: 0, error: null }
+      : attachment,
+  );
+}
+
+export function withoutAttachment(
+  attachments: readonly ImageAttachment[],
+  id: string,
+): ImageAttachment[] {
+  return attachments.filter((attachment) => attachment.id !== id);
+}
+
+/** Whether bytes are still moving for any attachment. */
+export function imageUploadsInFlight(
+  attachments: readonly ImageAttachment[],
+): boolean {
+  return attachments.some(
+    (attachment) =>
+      attachment.status === "queued" || attachment.status === "uploading",
+  );
+}
+
+/**
+ * The ids a turn should carry, in display order.
+ *
+ * Deduplicated because attachment identity is content-derived: attaching the
+ * same screenshot twice yields two chips holding one id, and naming it twice
+ * would ask the model to look at the same picture two times.
+ */
+export function readyImageAttachmentIds(
+  attachments: readonly ImageAttachment[],
+): string[] {
+  const ids = attachments
+    .filter((attachment) => attachment.status === "ready")
+    .map((attachment) => attachment.attachmentId)
+    .filter((id): id is string => id !== null);
+  return [...new Set(ids)];
+}
+
+/** Whole-percent upload progress for the chip's bar. */
+export function imageUploadPercent(attachment: ImageAttachment): number {
+  if (attachment.status === "ready") return 100;
+  if (!attachment.byteLen) return 0;
+  const ratio = attachment.uploadedBytes / attachment.byteLen;
+  return Math.max(0, Math.min(100, Math.round(ratio * 100)));
+}
+
+/** The one line under the file name that says where this attachment stands. */
+export function describeImageAttachment(attachment: ImageAttachment): string {
+  switch (attachment.status) {
+    case "queued":
+      return "Waiting to upload";
+    case "uploading":
+      return `Uploading ${imageUploadPercent(attachment)}%`;
+    case "ready":
+      return attachment.width && attachment.height
+        ? `${attachment.width} × ${attachment.height}`
+        : "Ready to send";
+    case "failed":
+      return attachment.error ?? "Upload failed";
+  }
+}
+
+/**
+ * A name worth showing for a dropped or pasted image.
+ *
+ * A pasted screenshot arrives unnamed, or as a generic `image.png` the browser
+ * invented. Three of those in the strip are indistinguishable, so anything that
+ * carries no information is replaced with the moment it was pasted.
+ */
+export function imageAttachmentName(
+  file: { name?: string; type: string },
+  at: Date,
+): string {
+  const given = file.name?.trim() ?? "";
+  if (given && !/^image\.(png|jpe?g|webp|gif)$/i.test(given)) return given;
+  const stamp = at.toISOString().slice(0, 19).replace("T", "-").replace(/:/g, "-");
+  const extension = file.type.split("/")[1] || "png";
+  return `pasted-image-${stamp}.${extension}`;
+}
+
+export function isSupportedImageType(type: string): type is ImageMediaType {
+  return (IMAGE_MEDIA_TYPES as readonly string[]).includes(type);
+}
+
+/**
+ * Why this batch of files cannot be attached, or `null` when it can.
+ *
+ * Checked before any bytes move so the reader learns the file is too large from
+ * the file they just dropped, not from a failed chip a second later.
+ */
+export function imageAttachmentRejection(
+  attached: readonly ImageAttachment[],
+  files: readonly { type: string; size: number }[],
+): string | null {
+  if (files.length === 0) return null;
+  if (attached.length + files.length > MAX_IMAGE_ATTACHMENTS) {
+    return `A message can carry at most ${MAX_IMAGE_ATTACHMENTS} images.`;
+  }
+  if (files.some((file) => !isSupportedImageType(file.type))) {
+    return "Attach a PNG, JPEG, WebP, or GIF image.";
+  }
+  if (files.some((file) => file.size > MAX_IMAGE_ATTACHMENT_BYTES)) {
+    return "Images must be 16 MB or smaller.";
+  }
+  if (files.some((file) => file.size === 0)) {
+    return "That image file is empty.";
+  }
+  return null;
+}
+
+/**
+ * Refuse file drops everywhere except where something is listening for them.
+ *
+ * The webview, not the host, receives file drops, and its own answer to one is
+ * to navigate away from the app and display the file — which unmounts the whole
+ * UI and loses the draft. A composer claims its own drops; this makes every
+ * other square inch of the window inert.
+ */
+export function refuseStrayFileDrops(target: EventTarget): () => void {
+  const refuse = (event: Event) => {
+    // A surface that took the drop itself has already said so.
+    if (event.defaultPrevented) return;
+    if (event.type === "dragover") {
+      const transfer = (event as DragEvent).dataTransfer;
+      if (transfer) transfer.dropEffect = "none";
+    }
+    event.preventDefault();
+  };
+  target.addEventListener("dragover", refuse);
+  target.addEventListener("drop", refuse);
+  return () => {
+    target.removeEventListener("dragover", refuse);
+    target.removeEventListener("drop", refuse);
+  };
+}
+
+/** The image files carried by a drop or a paste, in the order they arrived. */
+export function imageFilesFrom(transfer: DataTransfer | null): File[] {
+  if (!transfer) return [];
+  return [...transfer.files].filter((file) => file.type.startsWith("image/"));
+}
+
+/**
+ * Whether a drag in progress is carrying files at all.
+ *
+ * `files` is empty until the drop actually happens — the browser will not let a
+ * page read what is being dragged over it — so the drop hint has to be decided
+ * from the advertised types instead.
+ */
+export function transferCarriesFiles(transfer: DataTransfer | null): boolean {
+  return transfer !== null && [...transfer.types].includes("Files");
+}
+
+/**
+ * Turn a machine-readable server refusal into something worth reading.
+ *
+ * These sentences mirror the ones the host produces for the native picker so a
+ * reader gets the same answer about the same file whichever way they attached
+ * it. Each distinct reason gets its own sentence: "that file is not an image"
+ * and "that image is too large" call for different actions.
+ */
+export function imageAttachmentRefusal(kind: string): string {
+  switch (kind) {
+    case "image_attachment_empty":
+      return "That image file is empty";
+    case "image_attachment_too_large":
+    case "payload_too_large":
+      return "Images must be 16 MB or smaller";
+    case "image_attachment_not_an_image":
+      return "That file is not an image";
+    case "image_attachment_unsupported_format":
+      return "Attach a PNG, JPEG, WebP, or GIF image";
+    case "image_attachment_media_type_mismatch":
+    case "image_attachment_media_type_required":
+      return "That file's contents do not match its type";
+    case "image_attachment_zero_dimension":
+    case "image_attachment_unreadable":
+      return "That image file is damaged";
+    case "image_attachment_dimensions_too_large":
+      return "Images must be 8000 pixels or smaller on a side";
+    default:
+      return "Could not attach that image";
+  }
+}
+
+/**
+ * Publish one locally held image and report how much of it has gone out.
+ *
+ * `XMLHttpRequest` rather than `fetch` because only it reports how far a
+ * request body has got. The byte count is known here, so an indeterminate
+ * shimmer would be hiding information the composer already has.
+ */
+export function uploadImageAttachment(
+  server: { baseUrl: string; token: string },
+  chatId: string,
+  file: File,
+  options: {
+    onProgress: (uploadedBytes: number) => void;
+    signal: AbortSignal;
+  },
+): Promise<PublishedImage> {
+  return new Promise((resolve, reject) => {
+    if (options.signal.aborted) {
+      reject(new DOMException("Upload cancelled", "AbortError"));
+      return;
+    }
+    const request = new XMLHttpRequest();
+    request.open(
+      "POST",
+      `${server.baseUrl}/chats/${chatId}/attachments/images`,
+    );
+    request.setRequestHeader("Authorization", `Bearer ${server.token}`);
+    request.setRequestHeader("Content-Type", file.type);
+    request.upload.onprogress = (event) => {
+      if (event.lengthComputable) options.onProgress(event.loaded);
+    };
+    request.onload = () => {
+      if (request.status !== 201) {
+        reject(new Error(refusalFromBody(request.responseText)));
+        return;
+      }
+      try {
+        resolve(parsePublishedImage(JSON.parse(request.responseText)));
+      } catch {
+        reject(new Error("Attaching the image returned an invalid response"));
+      }
+    };
+    request.onerror = () => reject(new Error("Could not attach that image"));
+    request.onabort = () =>
+      reject(new DOMException("Upload cancelled", "AbortError"));
+    options.signal.addEventListener("abort", () => request.abort(), {
+      once: true,
+    });
+    request.send(file);
+  });
+}
+
+function refusalFromBody(body: string): string {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    if (isRecord(parsed) && typeof parsed.kind === "string") {
+      return imageAttachmentRefusal(parsed.kind);
+    }
+  } catch {
+    /* An unparseable body is just an unknown refusal. */
+  }
+  return imageAttachmentRefusal("");
+}
+
+/** Pick one image through the host's native picker and publish it. */
+export async function attachChatImage(
+  chatId: string,
+): Promise<PickedImage | null> {
+  return parseAttachedImage(
+    await invoke("attach_chat_image", { request: { chatId } }),
+  );
+}
+
+/**
+ * The host's picker result. `null` means the user dismissed the dialog, which
+ * is a normal outcome rather than a failure.
+ */
+export function parseAttachedImage(value: unknown): PickedImage | null {
+  if (value === null) return null;
+  if (
+    !isExactRecord(value, [
+      "attachmentId",
+      "fileName",
+      "mediaType",
+      "width",
+      "height",
+      "byteLen",
+    ])
+  ) {
+    throw new Error("Invalid image attachment response");
+  }
+  if (
+    typeof value.fileName !== "string" ||
+    !isSafeRendererText(value.fileName, 255)
+  ) {
+    throw new Error("Invalid image attachment response");
+  }
+  return {
+    fileName: value.fileName,
+    ...checkedPublishedImage({
+      attachmentId: value.attachmentId,
+      mediaType: value.mediaType,
+      width: value.width,
+      height: value.height,
+      byteLen: value.byteLen,
+    }),
+  };
+}
+
+/**
+ * Whether a host-supplied string is safe to put straight into the composer.
+ *
+ * A file name is chosen by whoever wrote the file, not by us: control and
+ * formatting characters in one can reorder or hide the rest of the chip's text.
+ */
+function isSafeRendererText(value: string, maxCodePoints: number): boolean {
+  const characters = [...value];
+  if (characters.length === 0 || characters.length > maxCodePoints) return false;
+  return characters.every(
+    (character) => !/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u.test(character),
+  );
+}
+
+/** The publish endpoint's result, which uses the server's snake_case shape. */
+export function parsePublishedImage(value: unknown): PublishedImage {
+  if (
+    !isExactRecord(value, [
+      "attachment_id",
+      "media_type",
+      "width",
+      "height",
+      "byte_len",
+    ])
+  ) {
+    throw new Error("Invalid image attachment response");
+  }
+  return checkedPublishedImage({
+    attachmentId: value.attachment_id,
+    mediaType: value.media_type,
+    width: value.width,
+    height: value.height,
+    byteLen: value.byte_len,
+  });
+}
+
+function checkedPublishedImage(candidate: {
+  attachmentId: unknown;
+  mediaType: unknown;
+  width: unknown;
+  height: unknown;
+  byteLen: unknown;
+}): PublishedImage {
+  const { attachmentId, mediaType, width, height, byteLen } = candidate;
+  if (
+    !isUuid(attachmentId) ||
+    typeof mediaType !== "string" ||
+    !isSupportedImageType(mediaType) ||
+    !isBoundedInteger(width, 1, MAX_IMAGE_DIMENSION) ||
+    !isBoundedInteger(height, 1, MAX_IMAGE_DIMENSION) ||
+    !isBoundedInteger(byteLen, 1, MAX_IMAGE_ATTACHMENT_BYTES)
+  ) {
+    throw new Error("Invalid image attachment response");
+  }
+  return { attachmentId, mediaType, width, height, byteLen };
+}
+
+function isBoundedInteger(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= minimum &&
+    value <= maximum
+  );
+}
+
+function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isExactRecord(
+  value: unknown,
+  keys: readonly string[],
+): value is Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  const actual = Object.keys(value);
+  return actual.length === keys.length && actual.every((key) => keys.includes(key));
+}

--- a/crates/openwave-desktop/ui/src/NativePickerLatch.test.ts
+++ b/crates/openwave-desktop/ui/src/NativePickerLatch.test.ts
@@ -46,14 +46,16 @@ describe("native picker latch", () => {
   });
 
   it("names every surface that opens a host picker", () => {
-    // Five Tauri commands take the host picker mutex: resolving a folder-access
+    // Six Tauri commands take the host picker mutex: resolving a folder-access
     // decision (keyed by call id), connecting a folder, confirming a previously
-    // approved one, importing a source, and exporting an output.
+    // approved one, importing a source, exporting an output, and attaching an
+    // image to a message.
     expect(Object.values(PICKER_HOLDERS)).toEqual([
       "connect-folder",
       "confirm-approved-folder",
       "import-source",
       "export-output",
+      "attach-image",
     ]);
   });
 });

--- a/crates/openwave-desktop/ui/src/NativePickerLatch.ts
+++ b/crates/openwave-desktop/ui/src/NativePickerLatch.ts
@@ -27,6 +27,7 @@ export const PICKER_HOLDERS = {
   confirmApprovedFolder: "confirm-approved-folder",
   importSource: "import-source",
   exportOutput: "export-output",
+  attachImage: "attach-image",
 } as const;
 
 /** What to tell a reader who tried to open a second picker. */

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -656,11 +656,21 @@ export class ApiClient {
     return cancellation;
   }
 
-  postMessage(chatId: string, turnId: string, content: string): Promise<void> {
+  /**
+   * `attachments` names images already published for this chat, in the order
+   * they should be shown to the model. Only identity crosses: the server
+   * re-derives every attachment's format and dimensions from the stored bytes.
+   */
+  postMessage(
+    chatId: string,
+    turnId: string,
+    content: string,
+    attachments: readonly string[] = [],
+  ): Promise<void> {
     return this.json(`/chats/${chatId}/messages`, {
       method: "POST",
       headers: this.headers(true),
-      body: JSON.stringify({ turn_id: turnId, content }),
+      body: JSON.stringify({ turn_id: turnId, content, attachments }),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/main.tsx
+++ b/crates/openwave-desktop/ui/src/main.tsx
@@ -2,11 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "@tanstack/react-router";
 import { ErrorBoundary } from "./ErrorBoundary";
+import { refuseStrayFileDrops } from "./ImageAttachments";
 import { router } from "./router";
 import { initTheme } from "./theme";
 import "./styles.css";
 
 initTheme();
+refuseStrayFileDrops(window);
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1608,6 +1608,158 @@ body {
   background: var(--bg-elevated);
 }
 
+.composer.is-dropping {
+  border-color: var(--primary, var(--ink));
+  box-shadow: var(--shadow-lg);
+}
+
+.composer-drop-hint {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  padding: 0.5rem 0.6rem;
+  color: var(--muted-foreground);
+  font-size: 0.78rem;
+}
+
+.composer-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.composer-image {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.4rem 1.6rem 0.4rem 0.45rem;
+  color: var(--muted-foreground);
+  background: var(--muted);
+}
+
+.composer-image.is-failed {
+  border-color: var(--danger, var(--line));
+}
+
+.composer-image-thumb {
+  display: inline-flex;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border-radius: 6px;
+  background: var(--bg-elevated);
+}
+
+.composer-image-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.composer-image-body {
+  display: grid;
+  min-width: 0;
+  gap: 0.1rem;
+}
+
+.composer-image-body strong {
+  max-width: 12rem;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer-image-body small {
+  font-size: 0.68rem;
+}
+
+.composer-image.is-failed .composer-image-body small {
+  color: var(--danger, inherit);
+}
+
+.composer-image-progress {
+  width: 100%;
+  height: 3px;
+  margin-top: 0.15rem;
+  appearance: none;
+  border: 0;
+  border-radius: 999px;
+  background: var(--line);
+}
+
+.composer-image-progress::-webkit-progress-bar {
+  border-radius: 999px;
+  background: var(--line);
+}
+
+.composer-image-progress::-webkit-progress-value {
+  border-radius: 999px;
+  background: var(--ink);
+  transition: width 120ms linear;
+}
+
+/* The bar still fills — it reports real bytes and dropping it would remove
+   information — but it stops sliding between the values it is given. */
+@media (prefers-reduced-motion: reduce) {
+  .composer,
+  .composer-image-progress::-webkit-progress-value {
+    transition: none;
+  }
+}
+
+.composer-image-progress::-moz-progress-bar {
+  border-radius: 999px;
+  background: var(--ink);
+}
+
+.composer-image-retry {
+  flex: 0 0 auto;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.1rem 0.45rem;
+  color: var(--ink);
+  background: var(--bg-elevated);
+  font-size: 0.68rem;
+}
+
+/* Always visible: a control that appears on hover is unreachable by touch and
+   invisible to a keyboard user who has already focused it. */
+.composer-image-remove {
+  position: absolute;
+  top: 0.15rem;
+  right: 0.15rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.1rem;
+  color: inherit;
+  background: transparent;
+}
+
+.composer-image-remove:hover,
+.composer-image-remove:focus-visible {
+  color: var(--ink);
+  background: var(--bg-elevated);
+}
+
 /* ---------- Model menu (composer) ---------- */
 
 .model-menu-trigger {

--- a/crates/openwave-desktop/ui/src/useImageAttachments.test.ts
+++ b/crates/openwave-desktop/ui/src/useImageAttachments.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiClient } from "./api";
+import { useImageAttachments } from "./useImageAttachments";
+
+const ATTACHMENT_ID = "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21";
+
+const PUBLISHED = JSON.stringify({
+  attachment_id: ATTACHMENT_ID,
+  media_type: "image/png",
+  width: 800,
+  height: 600,
+  byte_len: 4,
+});
+
+/** Enough of `XMLHttpRequest` to drive an upload one step at a time. */
+class FakeUpload {
+  static opened: FakeUpload[] = [];
+
+  method = "";
+  url = "";
+  status = 0;
+  responseText = "";
+  body: unknown = null;
+  headers: Record<string, string> = {};
+  aborted = false;
+  upload = { onprogress: null as ((event: ProgressEvent) => void) | null };
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onabort: (() => void) | null = null;
+
+  open(method: string, url: string) {
+    this.method = method;
+    this.url = url;
+  }
+
+  setRequestHeader(name: string, value: string) {
+    this.headers[name] = value;
+  }
+
+  send(body: unknown) {
+    this.body = body;
+    FakeUpload.opened.push(this);
+  }
+
+  abort() {
+    this.aborted = true;
+    this.onabort?.();
+  }
+
+  progress(loaded: number) {
+    this.upload.onprogress?.({ lengthComputable: true, loaded } as ProgressEvent);
+  }
+
+  finish(status: number, responseText: string) {
+    this.status = status;
+    this.responseText = responseText;
+    this.onload?.();
+  }
+}
+
+const client = { baseUrl: "http://127.0.0.1:9", token: "t" } as ApiClient;
+
+function png(name = "chart.png"): File {
+  return new File([new Uint8Array([1, 2, 3, 4])], name, { type: "image/png" });
+}
+
+beforeEach(() => {
+  FakeUpload.opened = [];
+  vi.stubGlobal("XMLHttpRequest", FakeUpload);
+  URL.createObjectURL = vi.fn((): string => "blob:preview");
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("useImageAttachments", () => {
+  it("uploads a dropped file, reporting the bytes that have actually gone out", async () => {
+    const { result } = renderHook(() => useImageAttachments(client, "chat-1"));
+
+    act(() => result.current.attachFiles([png()]));
+    await waitFor(() => expect(FakeUpload.opened).toHaveLength(1));
+    const upload = FakeUpload.opened[0];
+    expect(upload.method).toBe("POST");
+    expect(upload.url).toBe(
+      "http://127.0.0.1:9/chats/chat-1/attachments/images",
+    );
+    expect(upload.headers["Content-Type"]).toBe("image/png");
+    expect(upload.headers.Authorization).toBe("Bearer t");
+    expect(result.current.attachments[0]).toMatchObject({
+      name: "chart.png",
+      status: "uploading",
+      previewUrl: "blob:preview",
+    });
+
+    act(() => upload.progress(2));
+    expect(result.current.attachments[0].uploadedBytes).toBe(2);
+
+    act(() => upload.finish(201, PUBLISHED));
+    await waitFor(() =>
+      expect(result.current.attachments[0]).toMatchObject({
+        status: "ready",
+        attachmentId: ATTACHMENT_ID,
+        width: 800,
+      }),
+    );
+  });
+
+  it("keeps a refused upload retryable from the file it already holds", async () => {
+    const { result } = renderHook(() => useImageAttachments(client, "chat-1"));
+
+    act(() => result.current.attachFiles([png()]));
+    await waitFor(() => expect(FakeUpload.opened).toHaveLength(1));
+    act(() =>
+      FakeUpload.opened[0].finish(
+        400,
+        JSON.stringify({ kind: "image_attachment_unreadable" }),
+      ),
+    );
+
+    await waitFor(() =>
+      expect(result.current.attachments[0]).toMatchObject({
+        status: "failed",
+        error: "That image file is damaged",
+      }),
+    );
+
+    // Retry has to reuse the file the composer kept. Asking the reader to find
+    // it again would be a fresh attach, not a retry.
+    act(() => result.current.retry(result.current.attachments[0].id));
+    await waitFor(() => expect(FakeUpload.opened).toHaveLength(2));
+    expect((FakeUpload.opened[1].body as File).name).toBe("chart.png");
+
+    act(() => FakeUpload.opened[1].finish(201, PUBLISHED));
+    await waitFor(() =>
+      expect(result.current.attachments[0]).toMatchObject({
+        status: "ready",
+        attachmentId: ATTACHMENT_ID,
+      }),
+    );
+  });
+
+  it("gives back the preview and stops the upload when an image is removed", async () => {
+    const { result } = renderHook(() => useImageAttachments(client, "chat-1"));
+
+    act(() => result.current.attachFiles([png()]));
+    await waitFor(() => expect(FakeUpload.opened).toHaveLength(1));
+
+    act(() => result.current.remove(result.current.attachments[0].id));
+    expect(result.current.attachments).toEqual([]);
+    expect(FakeUpload.opened[0].aborted).toBe(true);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:preview");
+    // The cancelled upload must not reappear as a failed chip.
+    await waitFor(() => expect(result.current.attachments).toEqual([]));
+  });
+
+  it("refuses a batch that cannot be attached without touching the network", () => {
+    const { result } = renderHook(() => useImageAttachments(client, "chat-1"));
+
+    act(() =>
+      result.current.attachFiles([
+        new File(["x"], "notes.pdf", { type: "application/pdf" }),
+      ]),
+    );
+    expect(result.current.error).toMatch(/PNG, JPEG, WebP, or GIF/);
+    expect(result.current.attachments).toEqual([]);
+    expect(FakeUpload.opened).toHaveLength(0);
+  });
+
+  it("forgets everything once a turn has carried it", async () => {
+    const { result } = renderHook(() => useImageAttachments(client, "chat-1"));
+
+    act(() => result.current.attachFiles([png()]));
+    await waitFor(() => expect(FakeUpload.opened).toHaveLength(1));
+    act(() => FakeUpload.opened[0].finish(201, PUBLISHED));
+    await waitFor(() =>
+      expect(result.current.attachments[0].status).toBe("ready"),
+    );
+
+    act(() => result.current.clear());
+    expect(result.current.attachments).toEqual([]);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:preview");
+  });
+});

--- a/crates/openwave-desktop/ui/src/useImageAttachments.ts
+++ b/crates/openwave-desktop/ui/src/useImageAttachments.ts
@@ -1,0 +1,206 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { ApiClient } from "./api";
+import {
+  attachChatImage,
+  imageAttachmentName,
+  imageAttachmentRejection,
+  queuedImageAttachment,
+  readyImageAttachment,
+  uploadImageAttachment,
+  withRetryQueued,
+  withUploadFailed,
+  withUploadProgress,
+  withUploadPublished,
+  withUploadStarted,
+  withoutAttachment,
+  MAX_IMAGE_ATTACHMENTS,
+  type ImageAttachment,
+} from "./ImageAttachments";
+import {
+  PICKER_BUSY_MESSAGE,
+  PICKER_HOLDERS,
+  useNativePickerLatch,
+} from "./NativePickerLatch";
+
+export type ImageAttachmentControls = {
+  attachments: ImageAttachment[];
+  /** The native picker is open, so a second one would be refused by the host. */
+  attachingFromPicker: boolean;
+  /** Why the last attach was refused outright, before any bytes moved. */
+  error: string | null;
+  attachFromPicker: () => void;
+  attachFiles: (files: readonly File[]) => void;
+  remove: (id: string) => void;
+  retry: (id: string) => void;
+  /** Forget everything, once a turn has carried it. */
+  clear: () => void;
+};
+
+/**
+ * The images waiting on one conversation's composer.
+ *
+ * Two ways in, one state machine. A file the renderer already holds — dropped
+ * or pasted — is uploaded from here, with real byte progress and a preview made
+ * from the local bytes. A file chosen through the native picker is read and
+ * published entirely in the host, so it arrives already finished and with no
+ * pixels to preview. Both land in the same list, so removal, retry, and send
+ * gating cannot behave differently depending on how the image got here.
+ *
+ * The `File` behind each upload is kept until the attachment leaves the list.
+ * That is what makes retry a retry, rather than an invitation to go and find
+ * the file again.
+ */
+export function useImageAttachments(
+  client: ApiClient,
+  chatId: string,
+): ImageAttachmentControls {
+  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+  const [attachingFromPicker, setAttachingFromPicker] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const attachmentsRef = useRef<ImageAttachment[]>([]);
+  const filesRef = useRef(new Map<string, File>());
+  const abortsRef = useRef(new Map<string, AbortController>());
+  const previewsRef = useRef(new Map<string, string>());
+  const mountedRef = useRef(true);
+
+  attachmentsRef.current = attachments;
+
+  // An object URL outlives the element that rendered it, so it has to be handed
+  // back explicitly. Closing a conversation with images attached would otherwise
+  // pin their bytes in memory for the life of the window, and an upload nobody
+  // is waiting for would keep running.
+  useEffect(() => {
+    mountedRef.current = true;
+    const aborts = abortsRef.current;
+    const previews = previewsRef.current;
+    const files = filesRef.current;
+    return () => {
+      mountedRef.current = false;
+      for (const controller of aborts.values()) controller.abort();
+      for (const url of previews.values()) URL.revokeObjectURL(url);
+      aborts.clear();
+      previews.clear();
+      files.clear();
+    };
+  }, [chatId]);
+
+  function update(
+    change: (current: readonly ImageAttachment[]) => ImageAttachment[],
+  ) {
+    if (!mountedRef.current) return;
+    setAttachments((current) => change(current));
+  }
+
+  function forget(id: string) {
+    abortsRef.current.get(id)?.abort();
+    abortsRef.current.delete(id);
+    const preview = previewsRef.current.get(id);
+    if (preview) URL.revokeObjectURL(preview);
+    previewsRef.current.delete(id);
+    filesRef.current.delete(id);
+  }
+
+  async function upload(id: string) {
+    const file = filesRef.current.get(id);
+    if (!file) return;
+    const controller = new AbortController();
+    abortsRef.current.set(id, controller);
+    update((current) => withUploadStarted(current, id));
+    try {
+      const published = await uploadImageAttachment(client, chatId, file, {
+        onProgress: (uploadedBytes) =>
+          update((current) => withUploadProgress(current, id, uploadedBytes)),
+        signal: controller.signal,
+      });
+      update((current) => withUploadPublished(current, id, published));
+    } catch (err) {
+      // A cancelled upload belongs to an attachment the reader already removed,
+      // so there is no chip left to carry the message.
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      update((current) => withUploadFailed(current, id, failureText(err)));
+    } finally {
+      abortsRef.current.delete(id);
+    }
+  }
+
+  function attachFiles(files: readonly File[]) {
+    if (files.length === 0) return;
+    const rejection = imageAttachmentRejection(attachmentsRef.current, files);
+    if (rejection) {
+      setError(rejection);
+      return;
+    }
+    setError(null);
+    const now = new Date();
+    const queued = files.map((file) => {
+      const id = crypto.randomUUID();
+      filesRef.current.set(id, file);
+      const previewUrl = URL.createObjectURL(file);
+      previewsRef.current.set(id, previewUrl);
+      return queuedImageAttachment(id, {
+        name: imageAttachmentName(file, now),
+        byteLen: file.size,
+        previewUrl,
+      });
+    });
+    update((current) => [...current, ...queued]);
+    for (const attachment of queued) void upload(attachment.id);
+  }
+
+  async function openPicker() {
+    if (attachingFromPicker) return;
+    if (attachmentsRef.current.length >= MAX_IMAGE_ATTACHMENTS) {
+      setError(`A message can carry at most ${MAX_IMAGE_ATTACHMENTS} images.`);
+      return;
+    }
+    if (!useNativePickerLatch.getState().claim(PICKER_HOLDERS.attachImage)) {
+      setError(PICKER_BUSY_MESSAGE);
+      return;
+    }
+    setAttachingFromPicker(true);
+    setError(null);
+    try {
+      const published = await attachChatImage(chatId);
+      // Dismissing the picker is a normal outcome, not a failure.
+      if (!published) return;
+      update((current) => [
+        ...current,
+        readyImageAttachment(crypto.randomUUID(), published),
+      ]);
+    } catch (err) {
+      if (mountedRef.current) setError(failureText(err));
+    } finally {
+      useNativePickerLatch.getState().release(PICKER_HOLDERS.attachImage);
+      if (mountedRef.current) setAttachingFromPicker(false);
+    }
+  }
+
+  return {
+    attachments,
+    attachingFromPicker,
+    error,
+    attachFromPicker: () => void openPicker(),
+    attachFiles,
+    remove: (id) => {
+      forget(id);
+      update((current) => withoutAttachment(current, id));
+    },
+    retry: (id) => {
+      update((current) => withRetryQueued(current, id));
+      void upload(id);
+    },
+    clear: () => {
+      for (const attachment of attachmentsRef.current) forget(attachment.id);
+      update(() => []);
+      setError(null);
+    },
+  };
+}
+
+function failureText(error: unknown): string {
+  const message = String(error).replace(/^Error:\s*/, "").trim();
+  return message && message.length <= 240
+    ? message
+    : "Could not attach that image.";
+}


### PR DESCRIPTION
Images could already be published and carried on a turn, but nothing in the renderer ever offered to attach one. This adds the composer surface on top of that path.

## Three ways in, one state machine

Dropping or pasting an image hands the renderer the bytes, so those upload from the renderer with real byte progress (`XMLHttpRequest`, because `fetch` cannot report how far a request body has got) and a preview made from the local file rather than fetched back from the server. The native picker reads and publishes entirely in the host, so it arrives already finished and with no pixels to show.

All three land in the same list, so removal, retry and send gating cannot behave differently depending on how the image got there. `ImageAttachments.ts` holds the transitions as pure functions; `useImageAttachments` owns the effects around them — the retained `File`, the abort controllers, and the object URLs.

The picker now also returns the leaf file name. It is the one thing a chip cannot work out for itself: without it every picked image is an anonymous tile, and a reader with three attached cannot tell which one to remove. Only the last path component crosses, and it goes through the same character check the document import applies.

## Failure is visible and retryable

A failed upload keeps its chip, shows why, and offers another attempt from the file the composer is still holding. A chip that disappears on error leaves the reader believing the image went with their message. Send is blocked — with a tooltip saying so — while any image is still uploading or broken.

## The model that cannot read images

A text-only model is named in the composer, beside both ways out of it (the model menu below, the remove button on the chip), rather than being discovered when the server refuses the turn. The `model_image_input_unsupported` refusal stays as the backstop. A chat pinned to no model of its own follows the global default, which the renderer does not resolve; it stays quiet there rather than printing a name it would have to guess.

## Drops outside the composer

The window now handles file drops itself (`dragDropEnabled: false`), which is what lets a drop carry a `File` the same way a paste does. Anything dropped outside the composer is made inert, because the webview's own answer to a file drop is to navigate away from the app to display it — unmounting the UI and losing the draft.

## Not in this change

The transcript still shows only the text of a sent turn. Rendering past attachments needs `ChatMessageSnapshot` to carry them, which is a server-side wire change rather than a composer one — #567.

Closes #461