### PR TITLE
refactor(desktop): generate the rest of the renderer's wire types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6646,6 +6646,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "ts-rs",
 ]
 
 [[package]]
@@ -6820,6 +6821,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
+ "ts-rs",
  "url",
 ]
 

--- a/crates/openwave-code-execution/Cargo.toml
+++ b/crates/openwave-code-execution/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 async-trait = { workspace = true }
 openwave-core = { path = "../openwave-core", default-features = false }
 serde = { workspace = true }
+ts-rs = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/openwave-code-execution/src/types.rs
+++ b/crates/openwave-code-execution/src/types.rs
@@ -17,7 +17,7 @@ pub const MAX_CAPTURE_BYTES: usize = 40_000;
 const MAX_ID_BYTES: usize = 128;
 
 /// A configured code-execution backend.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum CodeExecutionProviderKind {

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -108,7 +108,7 @@ impl ChunkId {
 /// This is product projection data, not authority: possession of an id never
 /// grants access to the corresponding host path. The broker independently
 /// validates live attachments, consent, capabilities, and revocation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, TS)]
 #[serde(transparent)]
 pub struct HostRootId(Uuid);
 

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -114,7 +114,7 @@ pub const MAX_ROOT_ATTACHMENTS: usize = 32;
 pub const MAX_ATTACHMENT_REVISION: i64 = 9_007_199_254_740_991;
 
 /// Why a root appears in one conversation's exact ordered projection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum RootAttachmentOrigin {
     /// Snapshotted from project defaults when the conversation was created.
@@ -124,7 +124,7 @@ pub enum RootAttachmentOrigin {
 }
 
 /// One pathless root in a conversation's exact ordered projection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 pub struct ChatRootAttachment {
     /// Opaque broker root identity. This value grants no authority by itself.
     pub root_id: HostRootId,
@@ -476,7 +476,7 @@ impl RootAttachmentChange {
 /// An optional grouping of chats that share project context and a document
 /// corpus. A chat may belong to a project or stand alone — unlike some designs
 /// that make a project mandatory, OpenWave keeps loose, projectless chats.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 pub struct Project {
     /// Stable identifier.
     pub id: ProjectId,
@@ -1107,7 +1107,7 @@ pub enum Role {
 /// A hint honored only by providers whose models expose it (OpenAI's o-series);
 /// other providers ignore it. Persisted per chat and threaded into the model
 /// request for each turn.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
     /// Minimize reasoning tokens for the fastest, cheapest response.
@@ -1146,7 +1146,7 @@ impl ReasoningEffort {
 }
 
 /// A persistent conversation with an exact, ordered host-root projection.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 pub struct Chat {
     /// Stable identifier.
     pub id: ChatId,
@@ -1563,7 +1563,7 @@ impl AgentRunInboxStatus {
 }
 
 /// Execution boundary for an [`AgentRun`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum AgentRunExecution {
@@ -1585,7 +1585,7 @@ impl AgentRunExecution {
 }
 
 /// Durable lifecycle of an [`AgentRun`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum AgentRunStatus {

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -4,6 +4,27 @@ import {
   type AssistantCitationSnapshot,
   type ChatMessageSnapshot,
   type PendingApprovalSnapshot,
+  type AgentActivitySnapshot,
+  type AgentRunCancellationSnapshot,
+  type AgentRunSnapshot,
+  type Chat as WireChat,
+  type ChatTranscript as WireChatTranscript,
+  type CodeExecutionConfigInfo as WireCodeExecutionConfigInfo,
+  type CodeExecutionProviderKind as WireCodeExecutionProviderKind,
+  type CustomModelConfig as WireCustomModelConfig,
+  type McpHealth as WireMcpHealth,
+  type McpServerDefinition as WireMcpServerDefinition,
+  type McpServerInfo as WireMcpServerInfo,
+  type McpServersInfo as WireMcpServersInfo,
+  type ModelInfo as WireModelInfo,
+  type Project as WireProject,
+  type ProviderInfo as WireProviderInfo,
+  type ProviderKind as WireProviderKind,
+  type ReasoningEffort as WireReasoningEffort,
+  type Settings,
+  type WebSearchConfigInfo as WireWebSearchConfigInfo,
+  type WebSearchCredentialReadiness as WireWebSearchCredentialReadiness,
+  type WebSearchProviderKind as WireWebSearchProviderKind,
   type PendingFolderAccessRequest as WirePendingFolderAccessRequest,
   type PendingUserQuestions as WirePendingUserQuestions,
   type UserQuestion as WireUserQuestion,
@@ -46,139 +67,61 @@ export type ServerInfo = {
   token: string;
 };
 
-export type ProviderKind = "anthropic" | "openai" | "openai_compatible";
+export type ProviderKind = WireProviderKind;
 /** Stable provider-scoped key used for new settings and chat overrides. */
 export type ModelSelectionKey = `${ProviderKind}::${string}`;
 
 /** How hard a reasoning-capable model should think before answering. */
-export type ReasoningEffort = "low" | "medium" | "high";
+export type ReasoningEffort = WireReasoningEffort;
 
-export type ProviderInfo = {
-  kind: ProviderKind;
-  enabled: boolean;
-  has_credential: boolean;
-  /** Absent, not null, when unset — the server skips serializing `None`. */
-  base_url?: string;
-  models: CustomModelConfig[];
-};
+export type ProviderInfo = WireProviderInfo;
 
-export type CustomModelConfig = {
-  id: string;
-  /** Absent, not null, when unset — the server skips serializing `None`. */
-  display_name?: string;
-  context_window: number;
-  max_output_tokens: number;
-};
+export type CustomModelConfig = WireCustomModelConfig;
 
-export type ModelInfo = {
-  /** Stable provider-qualified selection key. */
+/**
+ * A model the picker may offer.
+ *
+ * `key` is re-branded rather than taken from the wire: the server sends a plain
+ * string, and `ModelSelectionKey` is the refinement the app relies on to keep a
+ * provider-qualified key distinct from a bare model id. Written out with `Omit`
+ * so the one divergence from the generated type is visible.
+ */
+export type ModelInfo = Omit<WireModelInfo, "key"> & {
   key: ModelSelectionKey;
-  id: string;
-  /** Human-readable label for the selector (e.g. "Claude Opus 4.8"). */
-  display_name: string;
-  provider: ProviderKind;
-  /** Provider is enabled, configured, and credentialed. */
-  available: boolean;
-  /** Approximate context window in tokens. */
-  context_window: number;
-  /** Maximum response size in tokens. */
-  max_output_tokens: number;
-  /** Input modalities accepted by the model. */
-  input_modalities: Array<"text" | "image">;
-  /** Whether the model can produce an internal reasoning stream. */
-  supports_reasoning: boolean;
-  /** Whether the model exposes a reasoning-effort control. */
-  supports_reasoning_effort: boolean;
-  /** Whether the model accepts image input alongside text. */
-  multimodal: boolean;
 };
 
 /** Global runtime settings (`GET/PUT /settings`). */
-export type RuntimeSettings = {
-  /** The default model, or `null` when the server default is in effect. */
-  model: string | null;
-  has_api_key: boolean;
-};
+/** Global runtime settings (`GET/PUT /settings`). */
+export type RuntimeSettings = Settings;
 
-export type Project = {
-  id: string;
-  title: string | null;
-  attachment_revision: number;
-  root_attachments: string[];
-  created_at: string;
-};
+export type Project = WireProject;
 
 /** The fixed, host-owned search providers supported by this build. */
-export type WebSearchProviderKind = "exa" | "tavily";
+export type WebSearchProviderKind = WireWebSearchProviderKind;
 
 /** Non-secret web-search policy and readiness for its selected provider. */
-export type WebSearchConfigInfo = {
-  provider?: WebSearchProviderKind;
-  timeout_ms: number;
-  has_credential: boolean;
-};
+export type WebSearchConfigInfo = WireWebSearchConfigInfo;
 
 /** Readiness only: the API never returns an existing provider key. */
-export type WebSearchCredentialReadiness = {
-  provider: WebSearchProviderKind;
-  has_credential: boolean;
-};
+export type WebSearchCredentialReadiness = WireWebSearchCredentialReadiness;
 
 /** The fixed, host-owned code-execution providers supported by this build. */
-export type CodeExecutionProviderKind = "local";
+export type CodeExecutionProviderKind = WireCodeExecutionProviderKind;
 
 /** Non-secret code-execution selection, timeout policy, and host readiness. */
-export type CodeExecutionConfigInfo = {
-  provider?: CodeExecutionProviderKind;
-  timeout_ms: number;
-  available: boolean;
-};
+export type CodeExecutionConfigInfo = WireCodeExecutionConfigInfo;
 
-export type McpHealth =
-  | "initializing"
-  | "healthy"
-  | "degraded"
-  | "reconnecting"
-  | "disabled";
+export type McpHealth = WireMcpHealth;
 
 /** Typed stdio process data. Values are argv entries, never shell source. */
-export type McpServerDefinition = {
-  name: string;
-  command: string;
-  args: string[];
-  /** Literal values must be non-secret; credentials use `env_from` names. */
-  env: Record<string, string>;
-  env_from: string[];
-  cwd: string | null;
-  request_timeout_ms: number;
-  enabled: boolean;
-};
+export type McpServerDefinition = WireMcpServerDefinition;
 
 /** Renderer-safe health projection. Resolved `env_from` values are never sent. */
-export type McpServerInfo = McpServerDefinition & {
-  health: McpHealth;
-  tool_count: number;
-  diagnostic: string | null;
-};
+export type McpServerInfo = WireMcpServerInfo;
 
-export type McpServersInfo = {
-  servers: McpServerInfo[];
-};
+export type McpServersInfo = WireMcpServersInfo;
 
-export type Chat = {
-  id: string;
-  title: string | null;
-  model: string | null;
-  /** Reasoning-effort override, or `null` to use the provider default. */
-  reasoning_effort: ReasoningEffort | null;
-  attachment_revision: number;
-  root_attachments: Array<{
-    root_id: string;
-    origin: "project_default" | "conversation";
-  }>;
-  project_id: string | null;
-  created_at: string;
-};
+export type Chat = WireChat;
 
 /**
  * One visible, durable transcript entry in conversation order.
@@ -212,57 +155,27 @@ export type ChatMessageCitation = AssistantCitationSnapshot;
  */
 export type ChatToolActivity = ChatToolActivitySnapshot;
 
-export type ChatTranscript = {
-  messages: ChatMessage[];
-  tool_activity: ChatToolActivity[];
-  last_event_seq: number;
-};
+export type ChatTranscript = WireChatTranscript;
 
 /** A durable foreground coordinator or sandboxed background run. */
-export type AgentRun = {
-  id: string;
-  parent_id: string | null;
-  execution: "foreground" | "sandbox";
-  status:
-    | "active"
-    | "queued"
-    | "running"
-    | "cancelling"
-    | "waiting"
-    | "retry_wait"
-    | "completed"
-    | "failed"
-    | "cancelled";
-  started_at: string | null;
-  finished_at: string | null;
-  last_error_code: string | null;
-  /** A fixed, renderer-safe description of the currently live agent task. */
-  activity: AgentActivity | null;
-  created_at: string;
-  updated_at: string;
-};
+/** A durable foreground coordinator or sandboxed background run. */
+export type AgentRun = AgentRunSnapshot;
 
 /** The complete renderer projection returned by one sandbox stop request. */
-export type SandboxAgentCancellation = {
-  id: string;
-  status: "cancelling" | "cancelled";
-};
+/** The complete renderer projection returned by one sandbox stop request. */
+export type SandboxAgentCancellation = AgentRunCancellationSnapshot;
 
 /**
  * Live agent activity is intentionally a closed vocabulary. The server never
  * sends tool inputs, results, host paths, grants, executor identities, leases,
  * provider identities, or diagnostics.
  */
-export type AgentActivity = {
-  kind:
-    | "web_search"
-    | "read_delegated_file"
-    | "list_connected_folders"
-    | "list_folder"
-    | "read_connected_file"
-    | "import_connected_file";
-  status: "waiting" | "running";
-};
+/**
+ * Live agent activity is intentionally a closed vocabulary. The server never
+ * sends tool inputs, results, host paths, grants, executor identities, leases,
+ * provider identities, or diagnostics.
+ */
+export type AgentActivity = AgentActivitySnapshot;
 
 
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -9,6 +9,69 @@
 // which a type can express. See docs/wire-types.md.
 
 /**
+ * Fixed, renderer-safe names for supported live work.
+ *
+ * Adding a durable tool does not automatically expose it to a renderer: it
+ * must be deliberately admitted here with a safe label.
+ */
+export type AgentActivityKind = "web_search" | "read_delegated_file" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file";
+
+/**
+ * Renderer-safe projection of one live supported checkpoint.
+ */
+export type AgentActivitySnapshot = { kind: AgentActivityKind, status: AgentActivityStatus, };
+
+/**
+ * Coarse checkpoint lifecycle suitable for display.
+ *
+ * This intentionally does not mirror all durable executor states; only live
+ * work is represented, and terminal checkpoints produce no activity.
+ */
+export type AgentActivityStatus = "waiting" | "running";
+
+/**
+ * Closed renderer-safe acknowledgement for sandbox cancellation.
+ */
+export type AgentRunCancellationSnapshot = { id: AgentRunId, status: AgentRunCancellationStatus, };
+
+export type AgentRunCancellationStatus = "cancelling" | "cancelled";
+
+/**
+ * Execution boundary for an [`AgentRun`].
+ */
+export type AgentRunExecution = "foreground" | "sandbox";
+
+/**
+ * Identifies one durable foreground or sandboxed background agent run.
+ */
+export type AgentRunId = string;
+
+/**
+ * Renderer-safe state for one agent run.
+ *
+ * Worker lease tokens, delegated inputs, scheduling budgets, and other
+ * executor-facing fields intentionally remain inside the server/store boundary.
+ */
+export type AgentRunSnapshot = { id: AgentRunId, parent_id: AgentRunId | null, execution: AgentRunExecution, status: AgentRunStatus, started_at: string | null, finished_at: string | null, 
+/**
+ * Stable, bounded classification suitable for renderer display.
+ */
+last_error_code: string | null, 
+/**
+ * The currently checkpointed, renderer-safe activity, if any.
+ *
+ * This is intentionally a small fixed vocabulary. It never exposes tool
+ * arguments, results, provider call identities, executor leases, or raw
+ * executor diagnostics.
+ */
+activity: AgentActivitySnapshot | null, created_at: string, updated_at: string, };
+
+/**
+ * Durable lifecycle of an [`AgentRun`].
+ */
+export type AgentRunStatus = "active" | "queued" | "running" | "cancelling" | "waiting" | "retry_wait" | "completed" | "failed" | "cancelled";
+
+/**
  * The approval policy class a tool declares for itself.
  *
  * Policy maps class → auto-approve / ask / deny. In v1: `ReadOnly` and
@@ -33,10 +96,68 @@ export type AssistantCitationSnapshot = { id: AssistantCitationId, ordinal: numb
 export type CallId = string;
 
 /**
+ * A persistent conversation with an exact, ordered host-root projection.
+ */
+export type Chat = { 
+/**
+ * Stable identifier.
+ */
+id: ChatId, 
+/**
+ * The project this chat belongs to, or `None` for a loose (projectless) chat.
+ */
+project_id: ProjectId | null, 
+/**
+ * Human-facing title; `None` until one is set or derived.
+ */
+title: string | null, 
+/**
+ * The model this chat runs against, or `None` to use the configured default.
+ */
+model: string | null, 
+/**
+ * Reasoning-effort override for this chat, honored only by models that
+ * expose the control; `None` leaves the provider's default in force.
+ */
+reasoning_effort: ReasoningEffort | null, 
+/**
+ * CAS revision of this conversation's exact root projection.
+ */
+attachment_revision: number, 
+/**
+ * Ordered opaque roots available for future broker-backed operations.
+ * Live broker authorization remains mandatory and may revoke access at any
+ * time, regardless of this projection.
+ */
+root_attachments: Array<ChatRootAttachment>, 
+/**
+ * When the chat was created.
+ */
+created_at: string, };
+
+/**
+ * Identifies a persistent conversation.
+ */
+export type ChatId = string;
+
+/**
  * A renderer-safe durable transcript entry. Internal routing and tool state
  * deliberately remain behind the server boundary.
  */
 export type ChatMessageSnapshot = { id: MessageId, role: TranscriptRole, content: string, created_at: string, citations: Array<AssistantCitationSnapshot>, };
+
+/**
+ * One pathless root in a conversation's exact ordered projection.
+ */
+export type ChatRootAttachment = { 
+/**
+ * Opaque broker root identity. This value grants no authority by itself.
+ */
+root_id: HostRootId, 
+/**
+ * Product-level provenance for ordering and future management UI.
+ */
+origin: RootAttachmentOrigin, };
 
 /**
  * A completed tool invocation with no results, tool identity, provider
@@ -70,9 +191,153 @@ action?: ToolActionPreview, status: ChatToolActivityStatus, started_at: string, 
 export type ChatToolActivityStatus = "completed" | "failed" | "cancelled";
 
 /**
+ * One visible transcript plus the durable journal watermark that produced it.
+ * The renderer uses the watermark to subscribe only to future events, avoiding
+ * duplicate text when reopening a completed conversation.
+ */
+export type ChatTranscript = { messages: Array<ChatMessageSnapshot>, 
+/**
+ * Finished tool activity from terminal turns, projected through a fixed
+ * renderer-safe allowlist. Canonical tool records never cross this API.
+ */
+tool_activity: Array<ChatToolActivitySnapshot>, last_event_seq: number, };
+
+/**
+ * Renderer-safe configuration and readiness.
+ */
+export type CodeExecutionConfigInfo = { provider?: CodeExecutionProviderKind, timeout_ms: number, available: boolean, };
+
+/**
+ * A configured code-execution backend.
+ */
+export type CodeExecutionProviderKind = "local";
+
+/**
+ * Conservative, user-inspectable capabilities for one model served by an
+ * OpenAI-compatible endpoint.
+ */
+export type CustomModelConfig = { 
+/**
+ * Exact model id sent to the endpoint.
+ */
+id: string, 
+/**
+ * Optional human-facing label.
+ */
+display_name?: string | null, 
+/**
+ * Context limit used by OpenWave's reducer.
+ */
+context_window: number, 
+/**
+ * Maximum output sent to the endpoint.
+ */
+max_output_tokens: number, };
+
+/**
+ * Opaque identifier for a folder registered with a host broker.
+ *
+ * This is product projection data, not authority: possession of an id never
+ * grants access to the corresponding host path. The broker independently
+ * validates live attachments, consent, capabilities, and revocation.
+ */
+export type HostRootId = string;
+
+/**
+ * An input modality a model accepts.
+ *
+ * `snake_case` matches the strings `as_str` has always produced, so the enum
+ * serializes exactly as the hand-built list of strings it replaces on the wire.
+ */
+export type InputModality = "text" | "image";
+
+/**
+ * Renderer-safe connection lifecycle.
+ */
+export type McpHealth = "initializing" | "healthy" | "degraded" | "reconnecting" | "disabled";
+
+/**
+ * One local stdio MCP process definition.
+ */
+export type McpServerDefinition = { name: string, command: string, args: Array<string>, 
+/**
+ * Explicit literal values. The UI labels these as non-secret.
+ */
+env: { [key in string]: string }, 
+/**
+ * Parent environment names to forward. Their values never enter this type.
+ */
+env_from: Array<string>, cwd: string | null, request_timeout_ms: number, enabled: boolean, };
+
+/**
+ * One renderer-safe server projection. Resolved `env_from` values and child
+ * process details are intentionally absent.
+ */
+export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null, name: string, command: string, args: Array<string>, 
+/**
+ * Explicit literal values. The UI labels these as non-secret.
+ */
+env: { [key in string]: string }, 
+/**
+ * Parent environment names to forward. Their values never enter this type.
+ */
+env_from: Array<string>, cwd: string | null, request_timeout_ms: number, enabled: boolean, };
+
+export type McpServersInfo = { servers: Array<McpServerInfo>, };
+
+/**
  * Identifies a persisted message within a chat.
  */
 export type MessageId = string;
+
+/**
+ * A selectable model in the catalog.
+ */
+export type ModelInfo = { 
+/**
+ * Stable provider-qualified selection key used by settings and chats.
+ */
+key: string, 
+/**
+ * The identifier passed to the provider and stored as `chat.model`.
+ */
+id: string, 
+/**
+ * Human-readable label for the selector (e.g. `"Claude Opus 4.8"`).
+ */
+display_name: string, 
+/**
+ * The provider that serves the model.
+ */
+provider: ProviderKind, 
+/**
+ * Whether the provider is enabled, configured, and credentialed.
+ */
+available: boolean, 
+/**
+ * Approximate context window in tokens.
+ */
+context_window: number, 
+/**
+ * Maximum model output in tokens.
+ */
+max_output_tokens: number, 
+/**
+ * Input modalities accepted by the model.
+ */
+input_modalities: Array<InputModality>, 
+/**
+ * Whether the model can produce an internal reasoning stream.
+ */
+supports_reasoning: boolean, 
+/**
+ * Whether the model exposes a reasoning-effort control.
+ */
+supports_reasoning_effort: boolean, 
+/**
+ * Whether the model accepts image input alongside text.
+ */
+multimodal: boolean, };
 
 /**
  * Closed renderer-safe pending approval projection. Canonical arguments,
@@ -101,6 +366,79 @@ export type PendingFolderAccessRequest = { call_id: CallId, turn_id: TurnId, rea
  * behind the server boundary.
  */
 export type PendingUserQuestions = { call_id: CallId, turn_id: TurnId, questions: Array<UserQuestion>, asked_at: string, };
+
+/**
+ * An optional grouping of chats that share project context and a document
+ * corpus. A chat may belong to a project or stand alone — unlike some designs
+ * that make a project mandatory, OpenWave keeps loose, projectless chats.
+ */
+export type Project = { 
+/**
+ * Stable identifier.
+ */
+id: ProjectId, 
+/**
+ * Human-facing title.
+ */
+title: string | null, 
+/**
+ * CAS revision of the ordered root projection.
+ */
+attachment_revision: number, 
+/**
+ * Ordered opaque root defaults for conversations created in this project.
+ * These ids are product state, never host authorization.
+ */
+root_attachments: Array<HostRootId>, 
+/**
+ * When the project was created.
+ */
+created_at: string, };
+
+/**
+ * Identifies a project: an optional grouping a chat may belong to.
+ */
+export type ProjectId = string;
+
+/**
+ * Public view of a provider — never includes the credential itself.
+ */
+export type ProviderInfo = { 
+/**
+ * Provider kind.
+ */
+kind: ProviderKind, 
+/**
+ * Whether the provider is enabled for routing.
+ */
+enabled: boolean, 
+/**
+ * Configured base URL, if any.
+ */
+base_url?: string, 
+/**
+ * Whether a credential is stored (never the credential itself).
+ */
+has_credential: boolean, 
+/**
+ * Explicit custom model entries for this endpoint.
+ */
+models: Array<CustomModelConfig>, };
+
+/**
+ * The known provider kinds. `#[non_exhaustive]` so new kinds can land without
+ * breaking wire clients that match on the string form.
+ */
+export type ProviderKind = "anthropic" | "openai" | "openai_compatible";
+
+/**
+ * How hard a reasoning-capable model should think before answering.
+ *
+ * A hint honored only by providers whose models expose it (OpenAI's o-series);
+ * other providers ignore it. Persisted per chat and threaded into the model
+ * request for each turn.
+ */
+export type ReasoningEffort = "low" | "medium" | "high";
 
 export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | { "type": "text_delta", text: string, } | { "type": "reasoning_delta" } | { "type": "stream_interrupted" } | { "type": "tool_call_started", call_id: CallId, name: RendererToolName, } | { "type": "tool_call_args_delta", call_id: CallId, } | { "type": "user_questions_asked", call_id: CallId, turn_id: TurnId, } | { "type": "approval_required", call_id: CallId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass, 
 /**
@@ -142,6 +480,25 @@ export type RendererToolStatus = "completed" | "failed";
  * (or whether) to map it to a local picker location.
  */
 export type RequestedFolderHint = "documents" | "downloads";
+
+/**
+ * Why a root appears in one conversation's exact ordered projection.
+ */
+export type RootAttachmentOrigin = "project_default" | "conversation";
+
+/**
+ * Runtime settings a client can read. The API key itself is never returned —
+ * it lives in the `SecretProvider`, not the store — only whether one is set.
+ */
+export type Settings = { 
+/**
+ * The model turns run against, or `None` to use the server's default.
+ */
+model: string | null, 
+/**
+ * Whether a model API key is configured (never the key itself).
+ */
+has_api_key: boolean, };
 
 /**
  * The action a call will take, in a form a human can inspect.
@@ -225,6 +582,25 @@ export type UserQuestion = { id: string, header: string, question: string, optio
  * One mutually exclusive answer choice.
  */
 export type UserQuestionOption = { id: string, label: string, description: string, };
+
+/**
+ * Public state returned by the local API. It intentionally reports only
+ * selection and credential presence — key material never crosses the secret
+ * boundary.
+ */
+export type WebSearchConfigInfo = { provider?: WebSearchProviderKind, timeout_ms: number, has_credential: boolean, };
+
+/**
+ * Credential readiness for one fixed web-search provider. This public shape
+ * deliberately carries no secret material.
+ */
+export type WebSearchCredentialReadiness = { provider: WebSearchProviderKind, has_credential: boolean, };
+
+/**
+ * A configured web-search backend. The stable string also selects its secret
+ * reference; it is intentionally not a model-controlled argument.
+ */
+export type WebSearchProviderKind = "exa" | "tavily";
 
 /**
  * Every tool name the renderer will accept, at runtime.

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -69,9 +69,10 @@ const fn default_timeout_ms() -> u64 {
 }
 
 /// Renderer-safe configuration and readiness.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct CodeExecutionConfigInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub provider: Option<CodeExecutionProviderKind>,
     pub timeout_ms: u64,
     pub available: bool,

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -88,7 +88,7 @@ pub(crate) struct McpServersConfig {
 }
 
 /// One local stdio MCP process definition.
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct McpServerDefinition {
     pub(crate) name: String,
@@ -167,7 +167,7 @@ const fn enabled_by_default() -> bool {
 }
 
 /// Renderer-safe connection lifecycle.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum McpHealth {
     Initializing,
@@ -179,7 +179,7 @@ pub(crate) enum McpHealth {
 
 /// One renderer-safe server projection. Resolved `env_from` values and child
 /// process details are intentionally absent.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub(crate) struct McpServerInfo {
     #[serde(flatten)]
     pub(crate) definition: McpServerDefinition,
@@ -188,7 +188,7 @@ pub(crate) struct McpServerInfo {
     pub(crate) diagnostic: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ts_rs::TS)]
 pub(crate) struct McpServersInfo {
     pub(crate) servers: Vec<McpServerInfo>,
 }

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -7,7 +7,11 @@
 use crate::providers::ProviderKind;
 
 /// An input modality a model accepts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// `snake_case` matches the strings `as_str` has always produced, so the enum
+/// serializes exactly as the hand-built list of strings it replaces on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
 pub enum InputModality {
     /// Plain text and structured text content.
     Text,
@@ -16,7 +20,14 @@ pub enum InputModality {
 }
 
 impl InputModality {
-    /// Stable wire representation used by `GET /models`.
+    /// The wire spelling this modality has always had.
+    ///
+    /// Serde owns the wire form now that `ModelInfo` carries the enum, so this is
+    /// no longer what produces it — it is the independently written expectation
+    /// that the move did not change it, checked by the test below. Test-only,
+    /// because a second live spelling of the same strings is the duplication this
+    /// replaced.
+    #[cfg(test)]
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Text => "text",
@@ -437,5 +448,24 @@ mod tests {
         // A retired curated id no longer resolves; the picker surfaces it as
         // unavailable rather than silently routing it somewhere else.
         assert!(migrate_curated_selection("gpt-4o").is_none());
+    }
+
+    /// `ModelInfo.input_modalities` used to be a hand-built `Vec<String>` filled
+    /// from `as_str`; it now carries the enum so the generated TypeScript is a
+    /// union rather than `Array<string>`. That is only safe if serde produces the
+    /// same strings, so this pins the two together instead of assuming.
+    ///
+    /// It is also what keeps `as_str` honest: with serde owning the wire form,
+    /// an unchecked second spelling of it would be exactly the kind of duplicate
+    /// that drifts.
+    #[test]
+    fn a_modality_serializes_as_the_string_it_has_always_been() {
+        for modality in [InputModality::Text, InputModality::Image] {
+            assert_eq!(
+                serde_json::to_value(modality).expect("a modality serializes"),
+                serde_json::json!(modality.as_str()),
+                "{modality:?} changed its wire spelling"
+            );
+        }
     }
 }

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -28,7 +28,7 @@ pub const LEGACY_ANTHROPIC_API_KEY: &str = "provider.anthropic.api_key";
 
 /// The known provider kinds. `#[non_exhaustive]` so new kinds can land without
 /// breaking wire clients that match on the string form.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ProviderKind {
@@ -161,7 +161,7 @@ fn default_custom_max_output_tokens() -> u32 {
 
 /// Conservative, user-inspectable capabilities for one model served by an
 /// OpenAI-compatible endpoint.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(deny_unknown_fields)]
 pub struct CustomModelConfig {
     /// Exact model id sent to the endpoint.
@@ -278,7 +278,7 @@ pub struct CatalogModel {
 }
 
 /// Public view of a provider — never includes the credential itself.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct ProviderInfo {
     /// Provider kind.
     pub kind: ProviderKind,
@@ -286,6 +286,7 @@ pub struct ProviderInfo {
     pub enabled: bool,
     /// Configured base URL, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub base_url: Option<String>,
     /// Whether a credential is stored (never the credential itself).
     pub has_credential: bool,

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -110,7 +110,7 @@ pub const MAX_PROJECT_METADATA_BODY_BYTES: usize = 1_024;
 
 /// Runtime settings a client can read. The API key itself is never returned —
 /// it lives in the `SecretProvider`, not the store — only whether one is set.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ts_rs::TS)]
 pub struct Settings {
     /// The model turns run against, or `None` to use the server's default.
     #[serde(default)]
@@ -446,7 +446,7 @@ pub async fn delete_provider_credential(
 }
 
 /// A selectable model in the catalog.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ts_rs::TS)]
 pub struct ModelInfo {
     /// Stable provider-qualified selection key used by settings and chats.
     pub key: String,
@@ -463,7 +463,7 @@ pub struct ModelInfo {
     /// Maximum model output in tokens.
     pub max_output_tokens: u32,
     /// Input modalities accepted by the model.
-    pub input_modalities: Vec<String>,
+    pub input_modalities: Vec<crate::model_registry::InputModality>,
     /// Whether the model can produce an internal reasoning stream.
     pub supports_reasoning: bool,
     /// Whether the model exposes a reasoning-effort control.
@@ -495,12 +495,7 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCata
             available: entry.available,
             context_window: entry.policy.context_window,
             max_output_tokens: entry.policy.max_output_tokens,
-            input_modalities: entry
-                .policy
-                .input_modalities
-                .iter()
-                .map(|modality| modality.as_str().to_string())
-                .collect(),
+            input_modalities: entry.policy.input_modalities.clone(),
             supports_reasoning: entry.policy.supports_reasoning,
             supports_reasoning_effort: entry.policy.supports_reasoning_effort,
             multimodal: entry
@@ -743,7 +738,7 @@ pub struct ChatMessageSnapshot {
 /// One visible transcript plus the durable journal watermark that produced it.
 /// The renderer uses the watermark to subscribe only to future events, avoiding
 /// duplicate text when reopening a completed conversation.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ts_rs::TS)]
 pub struct ChatTranscript {
     pub messages: Vec<ChatMessageSnapshot>,
     /// Finished tool activity from terminal turns, projected through a fixed
@@ -946,7 +941,7 @@ fn remove_private_chat_scratch(root: &FsPath, id: ChatId) -> std::io::Result<()>
 ///
 /// Worker lease tokens, delegated inputs, scheduling budgets, and other
 /// executor-facing fields intentionally remain inside the server/store boundary.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AgentRunSnapshot {
     pub id: openwave_core::AgentRunId,
     pub parent_id: Option<openwave_core::AgentRunId>,
@@ -987,7 +982,7 @@ impl AgentRunSnapshot {
 ///
 /// Adding a durable tool does not automatically expose it to a renderer: it
 /// must be deliberately admitted here with a safe label.
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentActivityKind {
     WebSearch,
@@ -1002,7 +997,7 @@ pub enum AgentActivityKind {
 ///
 /// This intentionally does not mirror all durable executor states; only live
 /// work is represented, and terminal checkpoints produce no activity.
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentActivityStatus {
     Waiting,
@@ -1010,7 +1005,7 @@ pub enum AgentActivityStatus {
 }
 
 /// Renderer-safe projection of one live supported checkpoint.
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
 pub struct AgentActivitySnapshot {
     pub kind: AgentActivityKind,
     pub status: AgentActivityStatus,
@@ -1102,13 +1097,13 @@ pub async fn list_agent_runs(
 }
 
 /// Closed renderer-safe acknowledgement for sandbox cancellation.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AgentRunCancellationSnapshot {
     pub id: openwave_core::AgentRunId,
     pub status: AgentRunCancellationStatus,
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentRunCancellationStatus {
     Cancelling,

--- a/crates/openwave-server/src/web_search.rs
+++ b/crates/openwave-server/src/web_search.rs
@@ -72,9 +72,10 @@ const fn default_timeout_ms() -> u64 {
 /// Public state returned by the local API. It intentionally reports only
 /// selection and credential presence — key material never crosses the secret
 /// boundary.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct WebSearchConfigInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
     pub provider: Option<WebSearchProviderKind>,
     pub timeout_ms: u64,
     pub has_credential: bool,
@@ -82,7 +83,7 @@ pub struct WebSearchConfigInfo {
 
 /// Credential readiness for one fixed web-search provider. This public shape
 /// deliberately carries no secret material.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct WebSearchCredentialReadiness {
     pub provider: WebSearchProviderKind,
     pub has_credential: bool,

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -322,6 +322,25 @@ mod tests {
         generate::collect_from::<crate::routes::client_execution::PendingFolderAccessRequest>(
             &cfg, &mut out,
         );
+        // Configuration, catalog, and project surfaces. These carry no shared
+        // types with the conversation path, but one generated module keeps the
+        // renderer importing from a single place.
+        generate::collect_from::<crate::routes::Settings>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::ModelInfo>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::ChatTranscript>(&cfg, &mut out);
+        generate::collect_from::<crate::providers::ProviderInfo>(&cfg, &mut out);
+        generate::collect_from::<crate::web_search::WebSearchConfigInfo>(&cfg, &mut out);
+        generate::collect_from::<crate::web_search::WebSearchCredentialReadiness>(&cfg, &mut out);
+        generate::collect_from::<crate::code_execution::CodeExecutionConfigInfo>(&cfg, &mut out);
+        generate::collect_from::<crate::mcp_config::McpServersInfo>(&cfg, &mut out);
+        // Named separately because `serde(flatten)` inlines it into
+        // `McpServerInfo` rather than referencing it, so the walk never reaches
+        // it — and the renderer uses it on its own as the PUT body shape.
+        generate::collect_from::<crate::mcp_config::McpServerDefinition>(&cfg, &mut out);
+        generate::collect_from::<openwave_core::Project>(&cfg, &mut out);
+        generate::collect_from::<openwave_core::Chat>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::AgentRunSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::AgentRunCancellationSnapshot>(&cfg, &mut out);
         out
     }
 
@@ -644,36 +663,53 @@ mod tests {
     /// `string`, which compiled on both sides while deleting the totality check
     /// that makes a tool without an icon a compile error.
     ///
+    /// Scoped per declaration, not per field name. A global check read
+    /// `McpServerDefinition.name: string` as the event stream's `name:
+    /// RendererToolName` having been widened — a false alarm on a field that is
+    /// legitimately a string, and unrelated.
+    ///
     /// Also a backstop rather than the only defence: now that those fields hold
     /// enums, loosening one back to a string breaks the code that assigns to it.
     /// This catches the case where a change is consistent enough to compile —
     /// a new field, or a type swapped along with its call sites.
     #[test]
     fn precision_critical_fields_generate_as_unions() {
-        let generated = rendered_bindings();
-        for (field, expected) in [
-            ("tool", "RendererToolName"),
-            ("name", "RendererToolName"),
-            ("action", "RendererToolName"),
-            ("status", "RendererToolStatus"),
-            ("approval", "ToolApprovalKind"),
-            ("class", "ApprovalClass"),
+        let declarations = event_declarations();
+        for (declaration, field, expected) in [
+            ("RendererAgentEvent", "name", "RendererToolName"),
+            ("RendererAgentEvent", "action", "RendererToolName"),
+            ("RendererAgentEvent", "approval", "ToolApprovalKind"),
+            ("RendererAgentEvent", "class", "ApprovalClass"),
+            ("RendererAgentEvent", "status", "RendererToolStatus"),
+            ("ChatToolActivitySnapshot", "tool", "RendererToolName"),
+            (
+                "ChatToolActivitySnapshot",
+                "status",
+                "ChatToolActivityStatus",
+            ),
+            ("PendingApprovalSnapshot", "action", "RendererToolName"),
+            ("PendingApprovalSnapshot", "approval", "ToolApprovalKind"),
+            ("PendingApprovalSnapshot", "class", "ApprovalClass"),
             // Four variants in the stored Role, two here. A widened union
-            // renders a system message as a user bubble, and the two-arm
-            // branch that reads it still compiles.
-            ("role", "TranscriptRole"),
+            // renders a system message as a user bubble, and the two-arm branch
+            // that reads it still compiles.
+            ("ChatMessageSnapshot", "role", "TranscriptRole"),
+            ("ModelInfo", "input_modalities", "Array<InputModality>"),
         ] {
+            let decl = declarations.get(declaration).unwrap_or_else(|| {
+                panic!("{declaration} is not generated; the precision list is stale")
+            });
             assert!(
-                generated.contains(&format!("{field}: {expected}")),
-                "expected `{field}: {expected}` in the generated types. If the \
-                 Rust field was loosened to a String it now generates as \
-                 `string`, which compiles everywhere and silently drops the \
-                 allowlist the renderer's tables are keyed on"
+                decl.contains(&format!("{field}: {expected}")),
+                "expected `{field}: {expected}` in {declaration}. If the Rust \
+                 field was loosened to a String it now generates as `string`, \
+                 which compiles everywhere and silently drops the allowlist the \
+                 renderer's tables are keyed on.\n{decl}"
             );
             assert!(
-                !generated.contains(&format!("{field}: string")),
-                "`{field}` generates as a bare string, losing the {expected} \
-                 union the renderer depends on"
+                !decl.contains(&format!("{field}: string")),
+                "{declaration}.{field} generates as a bare string, losing the \
+                 {expected} union the renderer depends on"
             );
         }
     }

--- a/crates/openwave-web-search/Cargo.toml
+++ b/crates/openwave-web-search/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 openwave-core = { path = "../openwave-core", default-features = false }
 serde = { workspace = true }
+ts-rs = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 url = "=2.5.8"

--- a/crates/openwave-web-search/src/types.rs
+++ b/crates/openwave-web-search/src/types.rs
@@ -31,7 +31,7 @@ const MAX_METADATA_VALUE_CHARS: usize = 256;
 
 /// A configured web-search backend. The stable string also selects its secret
 /// reference; it is intentionally not a model-controlled argument.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum WebSearchProviderKind {
     Exa,

--- a/docs/wire-types.md
+++ b/docs/wire-types.md
@@ -117,33 +117,31 @@ worth knowing before adding types.
 
 ## Scope today
 
-Generated: the renderer's tool vocabulary and the whole WebSocket event surface —
-the frame, the event union, the tool previews, and the approval kinds. The event
-surface mattered most because the renderer parses each frame with a bare cast and
-no runtime validation, so the generated type is the only contract on that path.
+**Generated: the whole renderer surface.** The WebSocket frame and event union, the
+tool vocabulary and previews, approval kinds, the transcript and its citations,
+all three consent surfaces, and the configuration, catalog, project, chat, and
+agent-run DTOs.
 
-Also generated: `ChatToolActivitySnapshot`, the terminal tool card rebuilt from
-the journal. It shares the vocabulary and the action preview with the live stream,
-so it belongs with them rather than with the rest of the REST surface. Its `tool`
-field was `&'static str`, which generated as `string` and silently dropped the
-allowlist the copy and icon tables are keyed on; it is now typed as the enum.
+**Hand-written, deliberately.** Nine declarations, each for a reason:
 
-Also generated: the visible transcript entry and its citations, and all three
-consent surfaces — the pending approval, the pending user questions, and the
-folder-access request. Their TypeScript is camelCase because it describes the
-*validator's output*, not the wire, so the generated types are what the
-validators narrow **from**.
+| Type | Why |
+|---|---|
+| `PendingToolApproval`, `PendingFolderAccessRequest`, `PendingUserQuestions`, `UserQuestion`, `UserQuestionOption` | camelCase app types describing the *validator's output*, not the wire. Their wire counterparts are generated and imported as `Wire*`, and each validator's key allowlist is tied to `keyof` that type. |
+| `ToolResultPreview` | Same, and its Rust type is carried in the journal — renaming those fields would stop existing chats loading. |
+| `ServerInfo` | Tauri IPC, a different contract from REST. |
+| `ApprovalGrantRung`, `UserQuestionAnswer` | Inbound request bodies. |
+| `ModelSelectionKey` | A template-literal brand over a plain Rust `String`; no generator expresses it. |
 
-Every validator now spells its key allowlist with the generated type's own keys,
-via a generic `onlyKeys<Wire>` or a `satisfies` clause. A field renamed in Rust
-drops out of `keyof` and the allowlist fails to compile, naming the new key. That
-matters more than it sounds: an untied allowlist keeps naming the *old* key after
-a rename, so the validator rejects every payload and the surface silently stops
-appearing — no error, no failing test, just a consent prompt that never shows.
+Two generated types carry a visible override rather than being aliased, both
+written with `Omit` so the divergence is legible:
 
-Not yet generated: the settings, provider, model, MCP, project, and agent-run
-DTOs. Nothing known blocks them; they are simply not done. The remaining notes
-are on the tracking issue.
+- **`ChatMessage.citations`** stays optional. The server always sends it, but the
+  transcript arrives as a parsed cast with no validation, so the `?` is what
+  forces the guard that reads it. Narrowing it would delete that guard rather
+  than earn it.
+- **`ModelInfo.key`** is re-branded as `ModelSelectionKey`. The wire is honestly
+  a string; the brand is the app-level refinement that keeps a
+  provider-qualified key distinct from a bare model id.
 
 `ChatMessageSnapshot.citations` is deliberately wider in TypeScript than on the
 wire: the server always sends it, but the transcript is not validated, so the `?`


### PR DESCRIPTION
Closes #478. Finishes the sweep: the configuration, catalog, project, chat, and agent-run DTOs join the conversation surface, so `api.ts` holds **nine** hand-written declarations instead of thirty-four.

## The checks earned their place

Two fired on this change, and reporting both matters because one of them was the check being wrong rather than the code.

**Three real findings.** The omission scanner caught `CodeExecutionConfigInfo.provider`, `WebSearchConfigInfo.provider`, and `ProviderInfo.base_url` — all carrying `skip_serializing_if` with no `#[ts(optional)]`, so each would have generated as `T | null` for a key the server omits. That is the #475 class, caught automatically this time instead of by reading.

It also correctly **skipped** `CustomModelConfig.display_name`, which pairs `skip_serializing_if` with `serde(default)` — the combination `ts-rs` already infers optionality from. So the scanner is discriminating, not just noisy.

**One false alarm, in my own check.** The precision test matched field names across the whole generated file, so `McpServerDefinition.name: string` read as the event stream's `name: RendererToolName` having been widened — a legitimately-a-string field on an unrelated type. It now matches **per declaration**, which is what it should have done from the start. I would rather flag that than quietly fix it, because a guard with a false-positive habit gets disabled.

## Not all mechanical

**`ModelInfo.input_modalities`** was a hand-built `Vec<String>` filled from `as_str`, which generates as `Array<string>`. It carries `InputModality` now, so the union is generated. `as_str` becomes test-only, holding the wire spelling the enum must keep producing — a second *live* spelling of the same strings would be the duplication this removes. A test pins them equal, so the change is provably a no-op on the wire.

**`McpServerDefinition` is named as its own root.** `serde(flatten)` inlines it into `McpServerInfo` rather than referencing it, so the dependency walk never reaches it — and the renderer uses it independently as the PUT body shape. Worth knowing for anyone adding a flattened type later.

**Two overrides, written out rather than hidden.** Both use `Omit` so the divergence is legible instead of buried in a hand-written type:

- `ModelInfo.key` is re-branded as `ModelSelectionKey`. The wire is honestly a string; the brand is the app-level refinement that keeps a provider-qualified key distinct from a bare model id. **This closes the last hazard in #548.**
- `ChatMessage.citations` stays optional. The server always sends it, but the transcript arrives as a parsed cast with no validation, so the `?` is what forces the guard that reads it.

## What stays hand-written, and why

Nine declarations, tabulated in `docs/wire-types.md`: the five camelCase app types that describe validator *output* (their wire counterparts are generated and their key allowlists tied to `keyof`), `ToolResultPreview` (same, plus journaled), `ServerInfo` (Tauri IPC, not REST), two inbound request bodies, and `ModelSelectionKey`.

## On `AgentRun`

Generated, though `listAgentRuns`/`cancelAgentRun`/`AgentRun` are referenced only from `api.ts` and tests — dead in production code today. I generated rather than deleted because #499 plans to surface background agents, and removing the client for planned work is the more expensive mistake. Flagging it so the choice is visible; deleting instead is a one-line follow-up if that plan changes.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --no-fail-fast` (28 binaries, **1275 passed, 0 failed**), `tsc --noEmit`, `vitest run` (**60 files, 419 passed**), production `vite build`. `Cargo.lock` purely additive — `ts-rs` added to two more crates, no existing version moved.

56 generated declarations; `api.ts` net −205 lines.