### PR TITLE
feat(agent): ask Anthropic models to think, and send the chat's effort

### DIFF
--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -177,7 +177,66 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
     if let Some(temperature) = req.temperature {
         body["temperature"] = json!(temperature);
     }
+    if req.reasoning_model && takes_adaptive_thinking(&req.model) {
+        // An omitted `thinking` means thinking is *off* on Opus 4.7 and later,
+        // so a reasoning model only reasons when the request says so.
+        //
+        // `display` is an opt-in: the API default, `omitted`, still streams
+        // thinking blocks but with empty text, which reads in a live transcript
+        // as a long silent pause before the answer. `summarized` is what makes
+        // the reasoning stream the renderer already draws worth drawing.
+        body["thinking"] = json!({ "type": "adaptive", "display": "summarized" });
+        if let Some(effort) = req.reasoning_effort {
+            body["output_config"] = json!({ "effort": effort.as_str() });
+        }
+    }
     Ok(body)
+}
+
+/// Whether `model` takes the adaptive-thinking request shape.
+///
+/// Anthropic split the reasoning switch at Claude 4.6. That generation and
+/// later take `thinking: {"type": "adaptive"}` (plus `output_config.effort`)
+/// and reject a `budget_tokens` thinking block outright; earlier models are the
+/// mirror image, understanding only the budget form. Curated ids carry the
+/// generation in the id itself, so it is read from there rather than pinned to
+/// a list that goes stale on the next release — and going stale here means the
+/// newest model silently stops thinking, which is the bug this exists to
+/// prevent.
+///
+/// An id with no readable generation keeps the request it has today. Sending a
+/// parameter the model rejects fails the whole turn; omitting one only leaves
+/// the model where it already was.
+fn takes_adaptive_thinking(model: &str) -> bool {
+    /// First Claude generation that reasons on `thinking: {"type": "adaptive"}`.
+    const FIRST_ADAPTIVE: (u32, u32) = (4, 6);
+    claude_generation(model).is_some_and(|generation| generation >= FIRST_ADAPTIVE)
+}
+
+/// Read the `(major, minor)` generation out of a Claude model id.
+///
+/// Handles the shapes Anthropic ships: split across tokens (`claude-opus-4-8`),
+/// major only (`claude-opus-5`), and either with a trailing dated snapshot
+/// (`claude-haiku-4-5-20251001`). A trailing date is not a minor version, so
+/// anything longer than two digits does not count as one.
+fn claude_generation(model: &str) -> Option<(u32, u32)> {
+    let starts_with_digit = |token: &&str| token.starts_with(|c: char| c.is_ascii_digit());
+    let mut tokens = model
+        .strip_prefix("claude-")?
+        .split('-')
+        .skip_while(|token| !starts_with_digit(token));
+
+    let major = tokens.next()?;
+    // A dotted generation keeps both halves in one token.
+    if let Some((major, minor)) = major.split_once('.') {
+        return Some((major.parse().ok()?, minor.parse().ok()?));
+    }
+    let minor = tokens
+        .next()
+        .filter(|token| token.len() <= 2)
+        .and_then(|token| token.parse().ok())
+        .unwrap_or(0);
+    Some((major.parse().ok()?, minor))
 }
 
 /// Shape one message's blocks into Anthropic's `content` array.
@@ -343,6 +402,7 @@ mod tests {
     use super::*;
     use openwave_core::provider::ChatMessage;
     use openwave_core::tool::ToolSpec;
+    use openwave_core::ReasoningEffort;
 
     #[test]
     fn request_maps_system_messages_and_tools() {
@@ -371,6 +431,99 @@ mod tests {
         assert_eq!(body["messages"][0]["content"][0]["type"], "text");
         assert_eq!(body["tools"][0]["name"], "read_file");
         assert_eq!(body["temperature"], 0.5);
+    }
+
+    fn reasoning_request(model: &str, effort: Option<ReasoningEffort>) -> ChatRequest {
+        ChatRequest {
+            provider: Some(ProviderId::new("anthropic")),
+            model: model.into(),
+            reasoning_model: true,
+            system: None,
+            messages: vec![ChatMessage::text(Role::User, "hi")],
+            tools: vec![],
+            max_tokens: None,
+            temperature: None,
+            reasoning_effort: effort,
+            images: ImageAttachments::new(),
+        }
+    }
+
+    #[test]
+    fn a_reasoning_model_is_asked_to_think_out_loud() {
+        // Omitting `thinking` means thinking is off on Opus 4.7 and later, and
+        // the default `display` streams empty thinking blocks — a silent pause
+        // where the transcript should be showing reasoning.
+        let body = build_request_json(&reasoning_request("claude-opus-5", None)).unwrap();
+        assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["thinking"]["display"], "summarized");
+        // Absent a per-chat override the provider's own effort default holds.
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn a_per_chat_effort_override_reaches_the_wire() {
+        let body = build_request_json(&reasoning_request(
+            "claude-opus-5",
+            Some(ReasoningEffort::Low),
+        ))
+        .unwrap();
+        assert_eq!(body["output_config"]["effort"], "low");
+    }
+
+    #[test]
+    fn a_non_reasoning_request_asks_for_no_thinking() {
+        let req = request_with(
+            vec![ContentBlock::Text { text: "hi".into() }],
+            ImageAttachments::new(),
+        );
+        assert!(!req.reasoning_model);
+        let body = build_request_json(&req).unwrap();
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn a_pre_adaptive_model_keeps_the_request_it_understands() {
+        // Claude Haiku 4.5 rejects both an adaptive thinking block and
+        // `output_config.effort`; sending either would fail the whole turn.
+        let body = build_request_json(&reasoning_request(
+            "claude-haiku-4-5-20251001",
+            Some(ReasoningEffort::High),
+        ))
+        .unwrap();
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn the_adaptive_switch_follows_the_generation_in_the_model_id() {
+        for id in [
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-opus-6.2",
+            "claude-opus-5-20260101",
+        ] {
+            assert!(takes_adaptive_thinking(id), "{id} should reason adaptively");
+        }
+        for id in [
+            "claude-haiku-4-5-20251001",
+            "claude-opus-4-5",
+            "claude-opus-4-1-20250805",
+            "claude-3-5-sonnet-20241022",
+            // No readable generation: keep today's request rather than risk a
+            // parameter the endpoint rejects.
+            "some-gateway-alias",
+            "claude-next",
+        ] {
+            assert!(!takes_adaptive_thinking(id), "{id} should not");
+        }
+        assert_eq!(claude_generation("claude-haiku-4-5-20251001"), Some((4, 5)));
+        assert_eq!(claude_generation("claude-opus-5"), Some((5, 0)));
+        assert_eq!(claude_generation("claude-opus-6.2"), Some((6, 2)));
     }
 
     fn run(events: &[Value]) -> Vec<ProviderEvent> {

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -75,9 +75,9 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         // cannot make it through the complete request path.
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        // The Anthropic adapter can stream thinking blocks, but it does not
-        // currently send a caller-selected effort or thinking budget.
-        supports_reasoning_effort: false,
+        // Claude 4.6 and later reason on an adaptive thinking block, and the
+        // Anthropic adapter sends one along with the chat's chosen effort.
+        supports_reasoning_effort: true,
     },
     ModelSpec {
         id: "claude-sonnet-5",
@@ -87,7 +87,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: false,
+        supports_reasoning_effort: true,
     },
     ModelSpec {
         id: "claude-haiku-4-5-20251001",
@@ -97,6 +97,8 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 64_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
+        // Haiku 4.5 predates the adaptive switch: it rejects the effort
+        // control, so the adapter leaves both off and the picker hides it.
         supports_reasoning_effort: false,
     },
     ModelSpec {
@@ -107,7 +109,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: false,
+        supports_reasoning_effort: true,
     },
     ModelSpec {
         id: "claude-opus-4-7",
@@ -117,7 +119,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: false,
+        supports_reasoning_effort: true,
     },
     ModelSpec {
         id: "claude-opus-4-6",
@@ -127,7 +129,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: false,
+        supports_reasoning_effort: true,
     },
     ModelSpec {
         id: "claude-sonnet-4-6",
@@ -137,7 +139,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: false,
+        supports_reasoning_effort: true,
     },
     ModelSpec {
         id: "gpt-5.6-sol",
@@ -376,8 +378,10 @@ mod tests {
         assert_eq!(sonnet.context_window, 1_000_000);
         assert_eq!(sonnet.max_output_tokens, 128_000);
         assert!(sonnet.supports_reasoning);
-        assert!(!sonnet.supports_reasoning_effort);
+        assert!(sonnet.supports_reasoning_effort);
 
+        // Haiku 4.5 predates the adaptive thinking switch and rejects the
+        // effort control, so it is the one Anthropic row without it.
         let haiku = find("claude-haiku-4-5-20251001").unwrap();
         assert_eq!(haiku.context_window, 200_000);
         assert_eq!(haiku.max_output_tokens, 64_000);

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -863,8 +863,18 @@ mod tests {
         assert_eq!(config.model, "claude-opus-4-8");
         assert_eq!(config.context_window, 1_000_000);
         assert_eq!(config.max_tokens, Some(128_000));
-        assert_eq!(config.reasoning_effort, None);
+        assert_eq!(config.reasoning_effort, Some(ReasoningEffort::High));
         assert_eq!(config.temperature, None);
+
+        // Haiku 4.5 reasons but rejects the effort control, so the request is
+        // shaped without it rather than with something the model would refuse.
+        let mut config = AgentConfig::default();
+        let haiku = ResolvedModelPolicy::curated(
+            model_registry::find_for(ProviderKind::Anthropic, "claude-haiku-4-5-20251001").unwrap(),
+        );
+        apply_model_policy(&mut config, &haiku, Some(ReasoningEffort::High)).unwrap();
+        assert!(config.reasoning_model);
+        assert_eq!(config.reasoning_effort, None);
 
         let mut config = AgentConfig::default();
         let gpt = ResolvedModelPolicy::curated(

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -8337,8 +8337,16 @@ async fn models_catalog_is_served() {
     assert!(!opus["multimodal"].as_bool().unwrap());
     assert!(!opus["available"].as_bool().unwrap());
     // Capabilities describe what the current adapter implements, not only
-    // what the upstream model could support with a different request shape.
-    assert!(!opus["supports_reasoning_effort"].as_bool().unwrap());
+    // what the upstream model could support with a different request shape:
+    // the Anthropic adapter sends the chat's effort on every model that takes
+    // an adaptive thinking block, and none of the ones that don't.
+    assert!(opus["supports_reasoning_effort"].as_bool().unwrap());
+    let haiku = models
+        .iter()
+        .find(|m| m["id"] == "claude-haiku-4-5-20251001")
+        .expect("curated Anthropic model is present");
+    assert!(haiku["supports_reasoning"].as_bool().unwrap());
+    assert!(!haiku["supports_reasoning_effort"].as_bool().unwrap());
 }
 
 #[tokio::test]


### PR DESCRIPTION
`build_request_json` in the Anthropic adapter never sent a `thinking` block. On Claude 4.7 and later an omitted `thinking` parameter means thinking is **off**, so Claude Opus 5 — the model OpenWave defaults to — answered every turn without reasoning, even though the adapter already streams `thinking_delta` into `ProviderEvent::ReasoningDelta` and the renderer already draws it. Sonnet 5 was the accidental exception, because it runs adaptive when the field is absent.

The same gap is why every Anthropic row carried `supports_reasoning_effort: false`: there was nowhere for a chosen effort to go, so the picker hid the control for Claude while showing it for GPT-5.6.

## What changed

Reasoning requests now carry `thinking: {"type": "adaptive", "display": "summarized"}` and map the chat's effort onto `output_config.effort`.

`display` is deliberate rather than left at its default. The API default `omitted` still streams thinking blocks, but with empty text — in a live transcript that is a long silent pause before the answer arrives. `summarized` is what makes the reasoning stream the renderer already draws worth drawing.

## Reading the generation instead of listing models

Anthropic split the switch at Claude 4.6: that generation and later take adaptive thinking and reject a `budget_tokens` block outright, and earlier ones are the mirror image. Rather than pin a list of ids, `takes_adaptive_thinking` reads the generation out of the model id and compares it against `(4, 6)`.

The reason is failure direction. A stale list means the *newest* model silently stops thinking — precisely the bug this PR exists to fix, reintroduced on the next release. Parsing handles the shapes Anthropic actually ships: split across tokens (`claude-opus-4-8`), major only (`claude-opus-5`), and either with a trailing dated snapshot (`claude-haiku-4-5-20251001`, where the date must not be read as a minor version).

An id with no readable generation keeps the request it has today. Sending a parameter the model rejects fails the whole turn; omitting one only leaves the model where it already was.

## Registry

The Anthropic rows that take effort now advertise it. **Claude Haiku 4.5 stays `false`** — it predates the adaptive switch and rejects the effort control, so its request is shaped without one rather than with something the model would refuse.

## Verification

Full local gate, since CI's change-scope gate skips lanes: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace` (28 binaries), `cargo check --workspace --locked` — all clean, no `Cargo.lock` diff.

Driven against the live Anthropic API, which is the only check that proves the point. A chat pinned to `anthropic::claude-opus-5` with `reasoning_effort: "high"`, asked a question with a trap in it, journaled:

```
1 turn_started
2 reasoning_delta      <- zero of these before this change
5 text_delta
1 turn_completed
```

with the reasoning text populated (`So "all but 9 run away" means 9 are left behind.`) and arriving before the answer. Unit tests cover the request body for each generation on both sides of the 4.6 line, including that Haiku is shaped without thinking or effort.

Closes #553