### PR TITLE
feat(desktop): widen tool previews beyond exec

### DIFF
--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -237,12 +237,14 @@ pub struct StandingGrant {
 /// much larger thing to agree to than "don't ask me about `cargo` again".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GrantScope {
-    /// Exactly this argument vector, in this directory, and nothing else.
-    ExactCommand {
-        command: String,
-        args: Vec<String>,
-        cwd: String,
-    },
+    /// Exactly the action the card showed, and nothing else.
+    ///
+    /// Holding the projection itself rather than one tool's fields is what
+    /// keeps this from being an `exec` scope wearing a general name: every tool
+    /// that can describe its action exactly gets a rung below the whole tool,
+    /// instead of every non-`exec` approval offering "allow all of these" as
+    /// its only standing choice.
+    ExactAction(ToolActionPreview),
     /// This executable, with any arguments.
     AnyArgsFor { command: String },
     /// Every call to the tool.
@@ -264,27 +266,22 @@ impl GrantScope {
     /// asking.
     #[must_use]
     pub fn covers_call(&self, tool_name: &str, arguments: &serde_json::Value) -> bool {
-        use crate::preview::ToolActionPreview;
         if matches!(self, Self::WholeTool) {
             return true;
         }
         if !ToolActionPreview::describes_exactly(tool_name, arguments) {
             return false;
         }
-        let Some(ToolActionPreview::Exec {
-            command: call_command,
-            args: call_args,
-            cwd: call_cwd,
-        }) = ToolActionPreview::build(tool_name, arguments)
-        else {
+        let Some(action) = ToolActionPreview::build(tool_name, arguments) else {
             return false;
         };
         match self {
             Self::WholeTool => true,
-            Self::ExactCommand { command, args, cwd } => {
-                call_command == *command && call_args == *args && call_cwd == *cwd
-            }
-            Self::AnyArgsFor { command } => call_command == *command,
+            Self::ExactAction(granted) => *granted == action,
+            Self::AnyArgsFor { command } => matches!(
+                &action,
+                ToolActionPreview::Exec { command: called, .. } if called == command
+            ),
         }
     }
 
@@ -292,32 +289,31 @@ impl GrantScope {
     ///
     /// A call with nothing to describe — or nothing describable *exactly* —
     /// can only be granted wholesale, because there is no narrower thing that
-    /// could be named without naming it approximately.
+    /// could be named without naming it approximately. Any other call gets the
+    /// exact rung: a search that has to keep asking about the query it already
+    /// asked about is offered "allow every search in this chat" as its only
+    /// alternative, which is the widest thing on the ladder.
     #[must_use]
     pub fn ladder_for(tool_name: &str, arguments: &serde_json::Value) -> Vec<Self> {
-        use crate::preview::ToolActionPreview;
         if !ToolActionPreview::describes_exactly(tool_name, arguments) {
             return vec![Self::WholeTool];
         }
-        match ToolActionPreview::build(tool_name, arguments) {
-            Some(ToolActionPreview::Exec { command, args, cwd }) => {
-                let mut ladder = vec![Self::ExactCommand {
+        let Some(action) = ToolActionPreview::build(tool_name, arguments) else {
+            return vec![Self::WholeTool];
+        };
+        let mut ladder = vec![Self::ExactAction(action.clone())];
+        // A command is the one action with a rung between "this exact call" and
+        // "every call": the executable it runs. With no arguments even that
+        // would read as two names for one grant.
+        if let ToolActionPreview::Exec { command, args, .. } = &action {
+            if !args.is_empty() {
+                ladder.push(Self::AnyArgsFor {
                     command: command.clone(),
-                    args: args.clone(),
-                    cwd: cwd.clone(),
-                }];
-                // With no arguments, "exactly this" and "this executable with
-                // any arguments" would read as two names for one grant.
-                if !args.is_empty() {
-                    ladder.push(Self::AnyArgsFor {
-                        command: command.clone(),
-                    });
-                }
-                ladder.push(Self::WholeTool);
-                ladder
+                });
             }
-            _ => vec![Self::WholeTool],
         }
+        ladder.push(Self::WholeTool);
+        ladder
     }
 }
 
@@ -729,6 +725,25 @@ mod standing_grant_tests {
         serde_json::json!({ "command": command, "args": args })
     }
 
+    /// The exact-action scope for a command run in the default directory.
+    fn exact_command(command: &str, args: &[&str]) -> GrantScope {
+        GrantScope::ExactAction(ToolActionPreview::Exec {
+            command: command.into(),
+            args: args.iter().map(|arg| (*arg).to_owned()).collect(),
+            cwd: ".".into(),
+        })
+    }
+
+    /// The exact-action scope for an unfiltered public web search.
+    fn exact_web_search(query: &str) -> GrantScope {
+        GrantScope::ExactAction(ToolActionPreview::WebSearch {
+            query: query.into(),
+            domains: Vec::new(),
+            start_published_at: None,
+            end_published_at: None,
+        })
+    }
+
     #[test]
     fn an_exact_grant_covers_only_the_vector_it_named() {
         let chat = ChatId::new();
@@ -739,11 +754,7 @@ mod standing_grant_tests {
                 chat,
                 "exec",
                 kind,
-                GrantScope::ExactCommand {
-                    command: "cargo".into(),
-                    args: vec!["test".into()],
-                    cwd: ".".into(),
-                },
+                exact_command("cargo", &["test"]),
                 Utc::now(),
             )
             .unwrap(),
@@ -767,11 +778,7 @@ mod standing_grant_tests {
                 chat,
                 "exec",
                 kind,
-                GrantScope::ExactCommand {
-                    command: "bash".into(),
-                    args: vec!["-c".into(), long.clone()],
-                    cwd: ".".into(),
-                },
+                exact_command("bash", &["-c", &long]),
                 Utc::now(),
             )
             .unwrap(),
@@ -801,11 +808,7 @@ mod standing_grant_tests {
                 chat,
                 "exec",
                 kind,
-                GrantScope::ExactCommand {
-                    command: "foo".into(),
-                    args: vec!["bar".into()],
-                    cwd: ".".into(),
-                },
+                exact_command("foo", &["bar"]),
                 Utc::now(),
             )
             .unwrap(),
@@ -847,11 +850,11 @@ mod standing_grant_tests {
                 chat,
                 "exec",
                 kind,
-                GrantScope::ExactCommand {
+                GrantScope::ExactAction(ToolActionPreview::Exec {
                     command: "npm".into(),
                     args: vec!["install".into()],
                     cwd: "./sandbox".into(),
-                },
+                }),
                 Utc::now(),
             )
             .unwrap(),
@@ -903,11 +906,7 @@ mod standing_grant_tests {
         assert_eq!(
             GrantScope::ladder_for("exec", &exec_args("cargo", &["test"])),
             vec![
-                GrantScope::ExactCommand {
-                    command: "cargo".into(),
-                    args: vec!["test".into()],
-                    cwd: ".".into(),
-                },
+                exact_command("cargo", &["test"]),
                 GrantScope::AnyArgsFor {
                     command: "cargo".into(),
                 },
@@ -918,20 +917,85 @@ mod standing_grant_tests {
         // be two names for the same grant.
         assert_eq!(
             GrantScope::ladder_for("exec", &exec_args("true", &[])),
-            vec![
-                GrantScope::ExactCommand {
-                    command: "true".into(),
-                    args: vec![],
-                    cwd: ".".into(),
-                },
-                GrantScope::WholeTool,
-            ]
+            vec![exact_command("true", &[]), GrantScope::WholeTool,]
         );
         // Nothing to describe means nothing narrower to offer.
         assert_eq!(
             GrantScope::ladder_for("search", &no_args()),
             vec![GrantScope::WholeTool]
         );
+    }
+
+    #[test]
+    fn a_search_is_offered_a_grant_narrower_than_every_search() {
+        // The ladder used to be `exec`-shaped, so approving a Sensitive search
+        // offered "don't ask again about searches" as the only standing choice
+        // — the widest rung there is, from a card that had already shown the
+        // one query the person was actually deciding about.
+        assert_eq!(
+            GrantScope::ladder_for(
+                "web_search",
+                &serde_json::json!({ "query": "quarterly filings" })
+            ),
+            vec![exact_web_search("quarterly filings"), GrantScope::WholeTool,]
+        );
+        // A query is one thing, so there is no middle rung between it and the
+        // whole tool; only a command has an executable to name.
+        assert_eq!(
+            GrantScope::ladder_for("search", &serde_json::json!({ "query": "revenue" })),
+            vec![
+                GrantScope::ExactAction(ToolActionPreview::Search {
+                    query: "revenue".into()
+                }),
+                GrantScope::WholeTool,
+            ]
+        );
+    }
+
+    #[test]
+    fn a_query_grant_covers_that_query_and_no_other_search() {
+        let chat = ChatId::new();
+        let kind = ToolApprovalKind::for_tool_name("web_search");
+        let grants = StandingGrants::new();
+        grants.record(
+            StandingGrant::scoped(
+                chat,
+                "web_search",
+                kind,
+                exact_web_search("quarterly filings"),
+                Utc::now(),
+            )
+            .unwrap(),
+        );
+
+        let query = |query: &str| serde_json::json!({ "query": query });
+        assert!(grants.covers(chat, "web_search", kind, &query("quarterly filings")));
+        // The tool trims before searching, so padding is not a different search.
+        assert!(grants.covers(chat, "web_search", kind, &query("  quarterly filings ")));
+        assert!(!grants.covers(chat, "web_search", kind, &query("payroll")));
+        // Same query, different tool: a grant is scoped to the tool it was
+        // given for, and a private-source search is not a public web search.
+        assert!(!grants.covers(
+            chat,
+            "search",
+            ToolApprovalKind::for_tool_name("search"),
+            &query("quarterly filings"),
+        ));
+        // The filters go to the provider too, so the same query with a domain
+        // filter is a different disclosure and was never the one granted.
+        assert!(!grants.covers(
+            chat,
+            "web_search",
+            kind,
+            &serde_json::json!({ "query": "quarterly filings", "domains": ["sec.gov"] }),
+        ));
+        // Bounding the response is not part of what leaves the machine.
+        assert!(grants.covers(
+            chat,
+            "web_search",
+            kind,
+            &serde_json::json!({ "query": "quarterly filings", "max_results": 10 }),
+        ));
     }
 
     #[test]

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -44,9 +44,20 @@ pub enum ToolActionPreview {
     /// A search of this conversation's own sources. The query is the whole
     /// action, and it is what the excerpts returned will be chosen to match.
     Search { query: String },
-    /// A public web search. The query leaves the device, which is the entire
-    /// reason this call asks first — so the card has to be able to show it.
-    WebSearch { query: String },
+    /// A public web search. What leaves the device is the entire reason this
+    /// call asks first, so the card has to be able to show all of it — the
+    /// filters are told to the provider too, not just the query.
+    WebSearch {
+        query: String,
+        /// Sites the search is confined to, empty when the model named none.
+        domains: Vec<String>,
+        /// Earliest publication date the search will accept, as the model
+        /// wrote it. Kept verbatim rather than reformatted: the card's job is
+        /// to show what the provider is actually told.
+        start_published_at: Option<String>,
+        /// Latest publication date the search will accept.
+        end_published_at: Option<String>,
+    },
 }
 
 impl ToolActionPreview {
@@ -62,24 +73,8 @@ impl ToolActionPreview {
             // the closed mapping from tool name to consent semantics.
             "exec" => {
                 let command = clamp(arguments.get("command")?.as_str()?, MAX_ACTION_FIELD_CHARS)?;
-                let args = arguments
-                    .get("args")
-                    .and_then(Value::as_array)
-                    .map(|args| {
-                        args.iter()
-                            .take(MAX_ACTION_ARGS)
-                            .filter_map(|arg| {
-                                arg.as_str()
-                                    .and_then(|arg| clamp(arg, MAX_ACTION_FIELD_CHARS))
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let cwd = arguments
-                    .get("cwd")
-                    .and_then(Value::as_str)
-                    .and_then(|cwd| clamp(cwd, MAX_ACTION_FIELD_CHARS))
-                    .unwrap_or_else(|| ".".into());
+                let args = clamped_list(arguments.get("args"));
+                let cwd = clamped_field(arguments.get("cwd")).unwrap_or_else(|| ".".into());
                 Some(Self::Exec { command, args, cwd })
             }
             // Approving a search without seeing its query is not consent to
@@ -91,6 +86,9 @@ impl ToolActionPreview {
             }),
             "web_search" => Some(Self::WebSearch {
                 query: search_query(arguments)?,
+                domains: clamped_list(arguments.get("domains")),
+                start_published_at: clamped_field(arguments.get("start_published_at")),
+                end_published_at: clamped_field(arguments.get("end_published_at")),
             }),
             _ => None,
         }
@@ -113,40 +111,33 @@ impl ToolActionPreview {
     pub fn describes_exactly(tool_name: &str, arguments: &Value) -> bool {
         match tool_name {
             "exec" => {
-                let Some(command) = arguments.get("command").and_then(Value::as_str) else {
-                    return false;
-                };
-                if !survives_clamp(command) {
-                    return false;
-                }
-                // An absent `args` is faithfully the empty vector; a present one
-                // must be an array whose every element survives intact, since a
-                // dropped element silently changes the call's arity.
-                match arguments.get("args") {
-                    None => {}
-                    Some(Value::Array(args)) => {
-                        if args.len() > MAX_ACTION_ARGS {
-                            return false;
-                        }
-                        if !args
-                            .iter()
-                            .all(|arg| arg.as_str().is_some_and(survives_clamp))
-                        {
-                            return false;
-                        }
-                    }
-                    Some(_) => return false,
-                }
-                // An absent `cwd` is faithfully the default the preview shows.
-                match arguments.get("cwd") {
-                    None => true,
-                    Some(Value::String(cwd)) => survives_clamp(cwd),
-                    Some(_) => false,
-                }
+                arguments
+                    .get("command")
+                    .and_then(Value::as_str)
+                    .is_some_and(survives_clamp)
+                    // A dropped or elided argument silently changes the call's
+                    // arity, and an absent `cwd` is faithfully the default the
+                    // preview shows.
+                    && list_survives_clamp(arguments.get("args"))
+                    && field_survives_clamp(arguments.get("cwd"))
             }
-            // Only `exec` has a scope narrower than the whole tool, so no
-            // other action needs to be exactly describable — and claiming it
-            // was would invite a narrow grant with nothing to narrow to.
+            // A search's action is its query, so a grant may name that query.
+            // `k` is not part of it: it bounds how many passages come back and
+            // changes nothing about what leaves the machine.
+            "search" => query_survives_clamp(arguments),
+            // `max_results` bounds the response the same way, but the domain
+            // and date filters are told to the provider alongside the query.
+            // They are on the card for that reason, and a grant may only be
+            // built from a call the card showed in full.
+            "web_search" => {
+                query_survives_clamp(arguments)
+                    && list_survives_clamp(arguments.get("domains"))
+                    && field_survives_clamp(arguments.get("start_published_at"))
+                    && field_survives_clamp(arguments.get("end_published_at"))
+            }
+            // A tool with no variant projects nothing, so there is nothing a
+            // narrower scope could name — and claiming otherwise would invite a
+            // narrow grant with nothing to narrow to.
             _ => false,
         }
     }
@@ -228,14 +219,78 @@ fn stream(value: Option<&Value>) -> String {
         .unwrap_or_default()
 }
 
-/// Bound one single-line preview field, dropping control characters that could
-/// forge card structure. An empty or all-control field is not presentable.
 /// The query a search will actually run, as the card should show it.
 fn search_query(arguments: &Value) -> Option<String> {
     clamp(
         arguments.get("query")?.as_str()?.trim(),
         MAX_ACTION_FIELD_CHARS,
     )
+}
+
+/// Bound one optional single-line preview field, dropping control characters
+/// that could forge card structure. An absent, empty, or all-control field is
+/// not presentable.
+fn clamped_field(value: Option<&Value>) -> Option<String> {
+    clamp(value?.as_str()?, MAX_ACTION_FIELD_CHARS)
+}
+
+/// Bound a list of single-line preview fields: surplus entries elided,
+/// unreadable ones dropped.
+fn clamped_list(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .take(MAX_ACTION_ARGS)
+                .filter_map(|value| {
+                    value
+                        .as_str()
+                        .and_then(|value| clamp(value, MAX_ACTION_FIELD_CHARS))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Whether a query reaches the preview intact.
+///
+/// The trim is not a loss. Both search tools trim before searching, so padding
+/// is not a difference between two calls; anything the clamp would actually
+/// remove is.
+fn query_survives_clamp(arguments: &Value) -> bool {
+    arguments
+        .get("query")
+        .and_then(Value::as_str)
+        .is_some_and(|query| survives_clamp(query.trim()))
+}
+
+/// Whether an optional single-line argument reaches the preview intact. An
+/// absent one is faithfully the absence the preview shows.
+fn field_survives_clamp(value: Option<&Value>) -> bool {
+    match value {
+        None | Some(Value::Null) => true,
+        Some(Value::String(text)) => survives_clamp(text),
+        Some(_) => false,
+    }
+}
+
+/// Whether a list argument reaches the preview intact.
+///
+/// An absent list is faithfully the empty one; a present one must be an array
+/// whose every element survives, since a dropped or elided element silently
+/// changes what the call does.
+fn list_survives_clamp(value: Option<&Value>) -> bool {
+    match value {
+        None | Some(Value::Null) => true,
+        Some(Value::Array(values)) => {
+            values.len() <= MAX_ACTION_ARGS
+                && values
+                    .iter()
+                    .all(|value| value.as_str().is_some_and(survives_clamp))
+        }
+        Some(_) => false,
+    }
 }
 
 /// Whether [`clamp`] would return this string unchanged.
@@ -261,15 +316,26 @@ fn clamp(value: &str, max_chars: usize) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A `web_search` action with no filters, which is the common shape.
+    fn plain_web_search(query: &str) -> ToolActionPreview {
+        ToolActionPreview::WebSearch {
+            query: query.into(),
+            domains: Vec::new(),
+            start_published_at: None,
+            end_published_at: None,
+        }
+    }
+
     #[test]
     fn a_search_shows_the_query_it_is_asking_permission_for() {
         // Approving `web_search` used to show nothing about the query, which is
         // the one thing that actually leaves the machine.
         assert_eq!(
             ToolActionPreview::build("web_search", &json!({ "query": "quarterly filings" })),
-            Some(ToolActionPreview::WebSearch {
-                query: "quarterly filings".into()
-            })
+            Some(plain_web_search("quarterly filings"))
         );
         assert_eq!(
             ToolActionPreview::build("search", &json!({ "query": "revenue" })),
@@ -280,9 +346,7 @@ mod tests {
         // Trimmed, because the tool trims before searching.
         assert_eq!(
             ToolActionPreview::build("web_search", &json!({ "query": "  spaced  " })),
-            Some(ToolActionPreview::WebSearch {
-                query: "spaced".into()
-            })
+            Some(plain_web_search("spaced"))
         );
         // Extra arguments are not part of the action under review.
         assert_eq!(
@@ -304,24 +368,78 @@ mod tests {
     }
 
     #[test]
-    fn only_a_command_is_exactly_describable() {
-        // `exec` is the only action with a scope narrower than the whole tool,
-        // so it is the only one that may claim exactness. A search claiming it
-        // would invite a narrow grant with nothing to narrow to.
+    fn a_web_search_shows_the_filters_that_go_out_with_the_query() {
+        // The consent copy promises the query "and its explicit filters", and
+        // the filters reach the provider too — a card that showed only the
+        // query was describing part of the action it asked about.
+        assert_eq!(
+            ToolActionPreview::build(
+                "web_search",
+                &json!({
+                    "query": "quarterly filings",
+                    "max_results": 10,
+                    "domains": ["sec.gov", "ft.com"],
+                    "start_published_at": "2024-01-01T00:00:00Z",
+                }),
+            ),
+            Some(ToolActionPreview::WebSearch {
+                query: "quarterly filings".into(),
+                domains: vec!["sec.gov".into(), "ft.com".into()],
+                start_published_at: Some("2024-01-01T00:00:00Z".into()),
+                end_published_at: None,
+            })
+        );
+    }
+
+    #[test]
+    fn an_action_is_exactly_describable_only_when_the_card_showed_all_of_it() {
         assert!(ToolActionPreview::describes_exactly(
             "exec",
             &json!({ "command": "cargo", "args": ["test"] })
         ));
+        // A search names its query exactly, which is what lets an approval
+        // offer a grant narrower than every search in the chat.
         for tool in ["search", "web_search"] {
-            assert!(!ToolActionPreview::describes_exactly(
+            assert!(ToolActionPreview::describes_exactly(
                 tool,
                 &json!({ "query": "anything" })
             ));
         }
+        // Result counts bound the response, not the disclosure, so they are not
+        // part of the action a grant names.
+        assert!(ToolActionPreview::describes_exactly(
+            "search",
+            &json!({ "query": "anything", "k": 8 })
+        ));
+        assert!(ToolActionPreview::describes_exactly(
+            "web_search",
+            &json!({ "query": "anything", "max_results": 10 })
+        ));
+        // Filters are disclosure, and the card carries them, so a filtered
+        // search is exact too.
+        assert!(ToolActionPreview::describes_exactly(
+            "web_search",
+            &json!({ "query": "anything", "domains": ["sec.gov"] })
+        ));
+        // A filter the card could not show is a filter nobody consented to.
+        for arguments in [
+            json!({ "query": "anything", "domains": ["se\u{0}c.gov"] }),
+            json!({ "query": "anything", "domains": [7] }),
+            json!({ "query": "anything", "domains": "sec.gov" }),
+            json!({ "query": "anything", "end_published_at": 20_240_101 }),
+            json!({ "query": "any\u{0}thing" }),
+        ] {
+            assert!(!ToolActionPreview::describes_exactly(
+                "web_search",
+                &arguments
+            ));
+        }
+        // A tool with no variant has nothing to be exact about.
+        assert!(!ToolActionPreview::describes_exactly(
+            "mcp__server__tool",
+            &json!({ "query": "anything" })
+        ));
     }
-
-    use super::*;
-    use serde_json::json;
 
     #[test]
     fn exec_action_carries_the_argument_vector_and_defaults_its_directory() {

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -279,9 +279,10 @@ function declineOption(): ApprovalOption {
 /**
  * The standing grants on offer, narrowest first.
  *
- * A command names itself, so consent can be about that command rather than
- * about commands in general. A tool with nothing to describe can only be
- * granted wholesale — there is no narrower thing to name.
+ * An action that names itself can be consented to as itself, rather than as
+ * the class of things its tool does — "always allow this query" rather than
+ * "allow every web search in this chat". A tool with nothing to describe can
+ * only be granted wholesale, because there is no narrower thing to name.
  */
 export function grantLadder(preview: ToolActionPreview | null): ApprovalOption[] {
   const wholeTool: ApprovalOption = {
@@ -294,29 +295,50 @@ export function grantLadder(preview: ToolActionPreview | null): ApprovalOption[]
     decision: "approve",
     grant: "whole_tool",
   };
-  if (preview?.tool !== "exec") return [wholeTool];
+  if (!preview) return [wholeTool];
 
-  const spoken = [preview.command, ...preview.args].join(" ");
+  const exact: ApprovalOption = {
+    kind: "decide",
+    key: "exact",
+    label: `Yes, and always allow exactly \u201c${spokenAction(preview)}\u201d`,
+    decision: "approve",
+    grant: "exact_action",
+  };
+  // A command is the one action with a rung between itself and its whole tool:
+  // the executable it runs. With no arguments even that would be the same
+  // grant as the exact one.
+  if (preview.tool !== "exec" || preview.args.length === 0) {
+    return [exact, wholeTool];
+  }
   return [
+    exact,
     {
       kind: "decide",
-      key: "exact",
-      label: `Yes, and always allow exactly \u201c${spoken}\u201d`,
+      key: "any-args",
+      label: `Yes, and always allow any \u201c${preview.command}\u201d command`,
       decision: "approve",
-      grant: "exact_command",
+      grant: "any_args_for_command",
     },
-    // With no arguments this would be the same grant as the exact one.
-    ...(preview.args.length > 0
-      ? [
-          {
-            kind: "decide" as const,
-            key: "any-args",
-            label: `Yes, and always allow any \u201c${preview.command}\u201d command`,
-            decision: "approve" as const,
-            grant: "any_args_for_command" as const,
-          },
-        ]
-      : []),
     wholeTool,
   ];
+}
+
+/** How much of an action fits in one row of the option list. */
+const SPOKEN_ACTION_CHARS = 48;
+
+/**
+ * The action as the grant label names it.
+ *
+ * Bounded, because this is one row of a keyboard-driven list and a
+ * natural-language query runs to hundreds of characters. The unabridged action
+ * is in the block above the list, which is where someone reads it.
+ */
+function spokenAction(preview: ToolActionPreview): string {
+  const spoken =
+    preview.tool === "exec"
+      ? [preview.command, ...preview.args].join(" ")
+      : preview.query;
+  return spoken.length > SPOKEN_ACTION_CHARS
+    ? `${spoken.slice(0, SPOKEN_ACTION_CHARS).trimEnd()}\u2026`
+    : spoken;
 }

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -199,6 +199,67 @@ describe("approval card interactions", () => {
     expect(onDecide).toHaveBeenCalledWith("call-1", "approve", null);
   });
 
+  it("offers a search the query it showed, not every search in the chat", async () => {
+    const user = userEvent.setup();
+    const onDecide = vi.fn();
+    render(
+      card({
+        onDecide,
+        summary:
+          "Allow web search to send this query and its explicit filters to the configured search provider outside OpenWave?",
+        preview: {
+          tool: "web_search",
+          query: "quarterly filings",
+          domains: ["sec.gov"],
+          start_published_at: null,
+          end_published_at: null,
+        },
+      }),
+    );
+
+    // The ladder used to be exec-shaped, so this card's only standing option
+    // was the widest rung there is.
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual([
+      ONCE,
+      "2.Yes, and always allow exactly “quarterly filings”",
+      `3.${MORE}`,
+      "4.No, don't allow this",
+    ]);
+    // The filters are part of what is being consented to, so the card shows
+    // them alongside the query it leads with.
+    expect(screen.getByText(/# limited to sec.gov/)).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("option")[1]!);
+    expect(onDecide).toHaveBeenLastCalledWith(
+      "call-1",
+      "approve",
+      "exact_action",
+    );
+  });
+
+  it("keeps a long query to one row of the option list", () => {
+    render(
+      card({
+        preview: {
+          tool: "web_search",
+          query:
+            "what did the company say about revenue recognition in the most recent quarter",
+          domains: [],
+          start_published_at: null,
+          end_published_at: null,
+        },
+      }),
+    );
+
+    // A natural-language query runs to hundreds of characters; the unabridged
+    // one is in the block above, which is where it is meant to be read.
+    expect(screen.getAllByRole("option")[1]?.textContent).toBe(
+      "2.Yes, and always allow exactly “what did the company say about revenue recogniti…”",
+    );
+  });
+
   it("offers only the whole tool when the action names nothing narrower", async () => {
     const user = userEvent.setup();
     render(card());

--- a/crates/openwave-desktop/ui/src/ToolPreview.test.ts
+++ b/crates/openwave-desktop/ui/src/ToolPreview.test.ts
@@ -43,12 +43,19 @@ describe("toolPreviewPresentation", () => {
 });
 
 describe("search previews", () => {
+  const unfiltered = {
+    domains: [] as string[],
+    start_published_at: null,
+    end_published_at: null,
+  };
+
   it("makes the query the headline and says where it goes", () => {
     // The consent question for a web search is "what leaves this machine",
     // and the answer is the query.
     const web = toolPreviewPresentation({
       tool: "web_search",
       query: "quarterly filings",
+      ...unfiltered,
     });
     expect(web.headline).toBe("quarterly filings");
     expect(web.detail).toContain("web search provider");
@@ -58,5 +65,37 @@ describe("search previews", () => {
     // A local search shares nothing outward, and the copy must not imply it does.
     expect(local.detail).not.toContain("provider");
     expect(local.detail).toContain("this conversation's sources");
+  });
+
+  it("shows the filters that go out with the query", () => {
+    // The consent copy promises the query "and its explicit filters", and the
+    // filters reach the provider too — a card that showed only the query was
+    // describing part of the action it asked about.
+    expect(
+      toolPreviewPresentation({
+        tool: "web_search",
+        query: "quarterly filings",
+        domains: ["sec.gov", "ft.com"],
+        start_published_at: "2024-01-01T00:00:00Z",
+        end_published_at: "2024-06-30T00:00:00Z",
+      }).detail,
+    ).toBe(
+      "quarterly filings\n" +
+        "# limited to sec.gov, ft.com\n" +
+        "# published between 2024-01-01T00:00:00Z and 2024-06-30T00:00:00Z\n" +
+        "# sent to the configured web search provider",
+    );
+  });
+
+  it("states an open-ended window from the end that is actually set", () => {
+    expect(
+      toolPreviewPresentation({
+        tool: "web_search",
+        query: "layoffs",
+        domains: [],
+        start_published_at: "2025-01-01T00:00:00Z",
+        end_published_at: null,
+      }).detail,
+    ).toContain("# published on or after 2025-01-01T00:00:00Z");
   });
 });

--- a/crates/openwave-desktop/ui/src/ToolPreview.tsx
+++ b/crates/openwave-desktop/ui/src/ToolPreview.tsx
@@ -18,14 +18,26 @@ export function toolPreviewPresentation(
   preview: ToolActionPreview,
   result: ToolResultPreview | null = null,
 ): ToolPreviewPresentation {
-  if (preview.tool === "search" || preview.tool === "web_search") {
-    // The query is the whole action. For a web search it is also the thing
-    // that leaves the device, which is what the reader is being asked about.
+  if (preview.tool === "search") {
     const headline = preview.query;
-    const detail =
-      preview.tool === "web_search"
-        ? `${headline}\n# sent to the configured web search provider`
-        : `${headline}\n# searched against this conversation's sources`;
+    return {
+      headline,
+      detail: `${headline}\n# searched against this conversation's sources`,
+    };
+  }
+  if (preview.tool === "web_search") {
+    // The query leads because it is the action, but the filters go to the
+    // provider with it. Leaving them off described part of the thing the card
+    // was asking about.
+    const headline = preview.query;
+    const detail = [
+      headline,
+      preview.domains.length > 0 && `# limited to ${preview.domains.join(", ")}`,
+      publishedWindow(preview),
+      "# sent to the configured web search provider",
+    ]
+      .filter((line): line is string => typeof line === "string")
+      .join("\n");
     return { headline, detail };
   }
   const headline = [preview.command, ...preview.args]
@@ -46,6 +58,22 @@ export function toolPreviewPresentation(
     .filter((line): line is string => typeof line === "string")
     .join("\n");
   return { headline, detail };
+}
+
+/**
+ * The publication window a web search will accept, or nothing when it is open
+ * at both ends. Dates are shown as the model wrote them, because what the card
+ * is for is showing what the provider is told.
+ */
+function publishedWindow(
+  preview: Extract<ToolActionPreview, { tool: "web_search" }>,
+): string | null {
+  const from = preview.start_published_at;
+  const to = preview.end_published_at;
+  if (from && to) return `# published between ${from} and ${to}`;
+  if (from) return `# published on or after ${from}`;
+  if (to) return `# published on or before ${to}`;
+  return null;
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -5,6 +5,7 @@ import {
   parsePendingUserQuestions,
   parsePendingToolApproval,
   parseSandboxAgentCancellation,
+  parseToolActionPreview,
 } from "./api";
 
 afterEach(() => {
@@ -370,6 +371,43 @@ describe("pending approval recovery", () => {
         /pending approval response/,
       );
     }
+  });
+});
+
+describe("parseToolActionPreview", () => {
+  const filtered = {
+    tool: "web_search",
+    query: "quarterly filings",
+    domains: ["sec.gov"],
+    start_published_at: "2024-01-01T00:00:00Z",
+    end_published_at: null,
+  };
+
+  it("keeps the filters that go to the provider with the query", () => {
+    expect(parseToolActionPreview(filtered)).toEqual(filtered);
+  });
+
+  it("drops a preview whose filters it cannot verify", () => {
+    // A card that describes the wrong action is worse than one that describes
+    // no action, and the filters are part of the action being consented to.
+    for (const broken of [
+      { ...filtered, domains: "sec.gov" },
+      { ...filtered, domains: [7] },
+      { ...filtered, domains: undefined },
+      { ...filtered, start_published_at: 20240101 },
+      { ...filtered, end_published_at: undefined },
+    ]) {
+      expect(parseToolActionPreview(broken)).toBeNull();
+    }
+  });
+
+  it("leaves a source search to its query alone", () => {
+    // The private-source search has no filters to show, and inventing keys for
+    // it would put a web search's copy on a local one.
+    expect(parseToolActionPreview({ tool: "search", query: "revenue" })).toEqual({
+      tool: "search",
+      query: "revenue",
+    });
   });
 });
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -307,7 +307,7 @@ export function isApprovableKind(kind: RendererApprovalKind): boolean {
  * action than the one the human was shown.
  */
 export type ApprovalGrantRung =
-  | "exact_command"
+  | "exact_action"
   | "any_args_for_command"
   | "whole_tool";
 
@@ -1046,10 +1046,30 @@ export function parseToolActionPreview(
 ): ToolActionPreview | null {
   if (value === undefined || value === null) return null;
   if (!isRecord(value)) return null;
-  if (value.tool === "search" || value.tool === "web_search") {
+  if (value.tool === "search") {
     const { query } = value;
     if (typeof query !== "string" || query.length === 0) return null;
-    return { tool: value.tool, query };
+    return { tool: "search", query };
+  }
+  if (value.tool === "web_search") {
+    const { query, domains, start_published_at, end_published_at } = value;
+    if (
+      typeof query !== "string" ||
+      query.length === 0 ||
+      !Array.isArray(domains) ||
+      !domains.every((domain): domain is string => typeof domain === "string") ||
+      !isOptionalString(start_published_at) ||
+      !isOptionalString(end_published_at)
+    ) {
+      return null;
+    }
+    return {
+      tool: "web_search",
+      query,
+      domains,
+      start_published_at,
+      end_published_at,
+    };
   }
   if (value.tool !== "exec") return null;
   const { command, args, cwd } = value;
@@ -1135,4 +1155,14 @@ function isRendererApprovalKind(value: unknown): value is RendererApprovalKind {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * A field the server sends as `null` when the model did not set it.
+ *
+ * `undefined` is not accepted: a missing key on this surface means the payload
+ * is not the shape it claims to be, which is what the validator is for.
+ */
+function isOptionalString(value: unknown): value is string | null {
+  return value === null || (typeof value === "string" && value.length > 0);
 }

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -163,7 +163,21 @@ args: Array<string>,
  * Working directory relative to the chat's private scratch, never a
  * host path.
  */
-cwd: string, } | { "tool": "search", query: string, } | { "tool": "web_search", query: string, };
+cwd: string, } | { "tool": "search", query: string, } | { "tool": "web_search", query: string, 
+/**
+ * Sites the search is confined to, empty when the model named none.
+ */
+domains: Array<string>, 
+/**
+ * Earliest publication date the search will accept, as the model
+ * wrote it. Kept verbatim rather than reformatted: the card's job is
+ * to show what the provider is actually told.
+ */
+start_published_at: string | null, 
+/**
+ * Latest publication date the search will accept.
+ */
+end_published_at: string | null, };
 
 /**
  * Closed immutable consent semantics stored with each approval request.

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -135,28 +135,24 @@ fn grant_scope(
     if matches!(rung, ApprovalGrantRung::WholeTool) {
         return Some(GrantScope::WholeTool);
     }
-    // A narrow rung names a command, and the preview it would be named from is
+    // A narrow rung names the action, and the preview it would be named from is
     // clamped for display. Naming one from a clamped preview would authorize
     // every other call that clamps to the same text, so an approximate
     // description is refused rather than turned into standing authority.
     if !action_is_exact {
         return None;
     }
-    match (rung, action) {
+    match (rung, action?) {
         (ApprovalGrantRung::WholeTool, _) => Some(GrantScope::WholeTool),
-        (ApprovalGrantRung::ExactCommand, Some(ToolActionPreview::Exec { command, args, cwd })) => {
-            Some(GrantScope::ExactCommand {
-                command: command.clone(),
-                args: args.clone(),
-                cwd: cwd.clone(),
-            })
-        }
-        (ApprovalGrantRung::AnyArgsForCommand, Some(ToolActionPreview::Exec { command, .. })) => {
+        (ApprovalGrantRung::ExactAction, action) => Some(GrantScope::ExactAction(action.clone())),
+        (ApprovalGrantRung::AnyArgsForCommand, ToolActionPreview::Exec { command, .. }) => {
             Some(GrantScope::AnyArgsFor {
                 command: command.clone(),
             })
         }
-        _ => None,
+        // Only a command has an executable to name, so no other action can
+        // reach the rung between exact and whole-tool.
+        (ApprovalGrantRung::AnyArgsForCommand, _) => None,
     }
 }
 
@@ -507,7 +503,7 @@ mod tests {
                     request.chat_id,
                     request.call_id,
                     ApprovalDecision::Approve,
-                    Some(crate::routes::ApprovalGrantRung::ExactCommand),
+                    Some(crate::routes::ApprovalGrantRung::ExactAction),
                 )
                 .await
                 .unwrap(),
@@ -535,6 +531,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_search_can_be_remembered_for_its_query_rather_than_for_every_search() {
+        // The narrow rung used to exist only for `exec`, so approving a
+        // Sensitive search offered nothing between "this once" and "every
+        // search in this chat".
+        let (store, request) =
+            setup_with_arguments("web_search", json!({ "query": "quarterly filings" })).await;
+        let broker = ApprovalBroker::new(store);
+        let _pending = broker.register(request.clone(), None).await;
+
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    Some(crate::routes::ApprovalGrantRung::ExactAction),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+
+        let grants = broker.standing_grants();
+        let query = |query: &str| json!({ "query": query });
+        assert!(grants.covers(
+            request.chat_id,
+            "web_search",
+            request.kind,
+            &query("quarterly filings"),
+        ));
+        // The grant names the query the card showed, so the next search still
+        // asks.
+        assert!(!grants.covers(
+            request.chat_id,
+            "web_search",
+            request.kind,
+            &query("payroll")
+        ));
+        // Only a command has an executable to name, so the middle rung has
+        // nothing to build from and is refused rather than widened.
+        let (store, request) =
+            setup_with_arguments("web_search", json!({ "query": "payroll" })).await;
+        let broker = ApprovalBroker::new(store);
+        let _pending = broker.register(request.clone(), None).await;
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    Some(crate::routes::ApprovalGrantRung::AnyArgsForCommand),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::GrantNotAvailable
+        );
+    }
+
+    #[tokio::test]
     async fn a_rung_the_call_cannot_describe_is_refused_rather_than_widened() {
         // The approval carries no action, so "always allow exactly this" has
         // nothing to name. Falling back to a broader grant would hand out more
@@ -549,7 +604,7 @@ mod tests {
                     request.chat_id,
                     request.call_id,
                     ApprovalDecision::Approve,
-                    Some(crate::routes::ApprovalGrantRung::ExactCommand),
+                    Some(crate::routes::ApprovalGrantRung::ExactAction),
                 )
                 .await
                 .unwrap(),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1738,8 +1738,8 @@ pub struct ApprovalBody {
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ApprovalGrantRung {
-    /// Exactly this argument vector.
-    ExactCommand,
+    /// Exactly the action the card showed.
+    ExactAction,
     /// This executable, with any arguments.
     AnyArgsForCommand,
     /// Every call to this tool.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -12078,10 +12078,17 @@ async fn foreground_web_search_runs_end_to_end_through_durable_approval() {
     // about nothing in particular.
     assert_eq!(pending[0]["preview"]["tool"], "web_search");
     assert_eq!(pending[0]["preview"]["query"], "OpenWave release");
+    // The domain filter is told to the provider alongside the query, so it is
+    // part of what the card has to show. A grant may only be built from a call
+    // the card showed in full.
+    assert_eq!(pending[0]["preview"]["domains"][0], "Example.com");
     let pending_json = pending.to_string();
     // What came *back* is still private: the query is the action under review,
-    // the results are the answer the model works from.
-    assert!(!pending_json.contains("Example.com"));
+    // the results are the answer the model works from. The snippet is the only
+    // token unique to a result — the stub's title repeats the query and its URL
+    // repeats the domain filter, so neither would notice a leak.
+    assert!(!pending_json.contains("OpenWave web search is ready."));
+    assert!(!pending_json.contains("example.com/openwave"));
 
     let decide = router
         .clone()


### PR DESCRIPTION
Closes #506.

`ToolActionPreview` and `ToolResultPreview` were single-member unions — both `match tool_name { "exec" => ..., _ => None }`. The visible cost was that only exec calls got a rich card. The real cost was quieter.

## The narrow-grant ladder was dead for every tool but one

Every non-exec Sensitive tool parked with `preview: None`, so `GrantScope::ladder_for` could only ever offer `WholeTool`. Approving a `search` — or `web_search`, or any MCP tool — offered *"allow every search in this chat"* as the only standing choice. The widest rung was the only rung.

The fix is to make the narrow rung the projection itself. `GrantScope::ExactCommand { command, args, cwd }` held one tool's fields; it becomes `ExactAction(ToolActionPreview)`, and coverage is equality against the action the card showed. That is what keeps it from being an exec scope wearing a general name — any tool that can describe its action exactly now gets a rung below the whole tool. `AnyArgsFor` stays exec-only, because the executable-with-any-arguments middle rung is genuinely specific to commands.

## Web search shows all of what it sends

`web_search` previews now carry the domain and date filters alongside the query. They are told to the provider too, so they are part of what leaves the device, and a grant may only be built from a call the card showed **in full**. `describes_exactly` checks them for the same reason — while continuing to ignore `k` and `max_results`, which bound the response and change nothing about what is sent.

## A test that did not test what it said

The end-to-end web search test asserted the pending approval did not contain `Example.com`, under a comment about keeping results private. It never tested that. The stub's result URL is lowercase `example.com`, so the only thing that string ever matched was the **domain filter from the call** — an argument, not a result. It passed for the wrong reason and would not have noticed a real leak.

It now checks the result snippet, the one token unique to a response: the stub's title repeats the query and its URL repeats the domain filter, so neither would catch anything. And it pins the domain filter as something the card *must* show, which is the new behaviour.

## Verification

`cargo fmt --all --check`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, `cargo check --workspace --locked` (no lock drift), and in the UI `tsc`, 452 tests across 62 files, production build.

One note for whoever sees it in CI: `openwave-cli`'s `serve` tests spawn a daemon and wait on a fixed timeout for it to exit. They failed on my first full-workspace run and passed in isolation and on a second run — they are timing-sensitive under parallel load rather than affected by this change. Worth a look on its own if it recurs.