### PR TITLE
refactor(agent): derive tool schemas from typed arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6663,6 +6663,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "keyring",
+ "schemars 1.2.1",
  "sea-orm",
  "sea-orm-migration",
  "serde",
@@ -8411,7 +8412,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -8438,8 +8439,10 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -8447,6 +8450,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ all = { level = "warn", priority = -1 }
 [workspace.dependencies]
 serde = { version = "=1.0.229", features = ["derive"] }
 serde_json = "=1.0.151"
+schemars = { version = "=1.2.1", features = ["uuid1"] }
 async-trait = "=0.1.91"
 cap-std = "=4.0.2"
 cap-fs-ext = "=4.0.2"

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -42,6 +42,7 @@ futures = { workspace = true }
 futures-timer = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+schemars = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["v5"] }

--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -5,6 +5,8 @@
 //! so the model can never bypass its lease, steer, or accounting fences. The
 //! production registry exposes them only to durably claimed foreground turns.
 
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
@@ -34,6 +36,14 @@ pub const SANDBOX_READ_DELEGATED_FILE_TOOL: &str = "read_delegated_file";
 pub const MAX_SANDBOX_AGENT_TASK_CHARS: usize = 16_000;
 /// Maximum number of depth-one children in one foreground wait request.
 pub const MAX_WAIT_FOR_AGENTS_CHILDREN: usize = TurnAgentRunWaitSet::MAX_CHILDREN;
+/// Maximum web-search query length advertised to a model.
+pub const MAX_WEB_SEARCH_QUERY_CHARS: usize = 400;
+/// Maximum requested web-search result count.
+pub const MAX_WEB_SEARCH_RESULTS: usize = 10;
+/// Maximum number of web-search domain filters.
+pub const MAX_WEB_SEARCH_DOMAINS: usize = 20;
+/// Default result count when a model omits `max_results`.
+pub const DEFAULT_WEB_SEARCH_RESULTS: usize = 5;
 
 /// Maximum serialized JSON bytes allocated to one model-facing child result.
 ///
@@ -49,10 +59,14 @@ pub(crate) const WAIT_CANCELLED_WITH_TURN_RESULT: &str =
     "Wait cancelled because the foreground turn was cancelled.";
 
 /// Canonical model proposal for one isolated sandbox task.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SpawnSandboxAgentArgs {
     /// A self-contained task for the isolated child. It cannot spawn children.
+    #[schemars(
+        length(min = 1, max = MAX_SANDBOX_AGENT_TASK_CHARS),
+        description = "A concise, self-contained task for one isolated background agent."
+    )]
     pub task: String,
     /// Optional exact file a compatible native executor may make available.
     ///
@@ -60,16 +74,25 @@ pub struct SpawnSandboxAgentArgs {
     /// executor advertises the read only while the root remains attached, then
     /// revalidates authority with the host broker before bytes move.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(
+        with = "SandboxAgentFileResource",
+        description = "Optional exact file identity within a folder already connected to this conversation. This delegates only its identity; a compatible native executor must revalidate current access before any read."
+    )]
     pub resource: Option<SandboxAgentFileResource>,
 }
 
 /// One exact, pathless-root file identity delegated to a sandbox child.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SandboxAgentFileResource {
     /// Opaque host-broker root identity attached to the foreground chat.
+    #[schemars(with = "uuid::Uuid", description = "")]
     pub root_id: HostRootId,
     /// Nonempty path relative to that root; absolute and parent paths are invalid.
+    #[schemars(
+        length(min = 1, max = crate::client_tools::MAX_CONNECTED_FOLDER_PATH_BYTES),
+        description = "Nonempty root-relative file path."
+    )]
     pub relative_path: String,
 }
 
@@ -98,12 +121,65 @@ pub struct SpawnSandboxAgentResult {
 /// every listed child has delivered an immutable result. The durable runtime
 /// additionally verifies that each id belongs to a depth-one child owned by
 /// the exact foreground turn; UUID shape alone cannot prove that authority.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct WaitForAgentsArgs {
     /// Unique child identities in the order their results must be returned.
+    #[schemars(
+        with = "Vec<uuid::Uuid>",
+        length(min = 1, max = MAX_WAIT_FOR_AGENTS_CHILDREN),
+        extend("uniqueItems" = true),
+        description = "Opaque depth-one child agent IDs, in the order their results should be returned."
+    )]
     pub agent_ids: Vec<AgentRunId>,
 }
+
+/// Canonical arguments for the shared provider-backed web-search contract.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct WebSearchArgs {
+    /// Focused public-web query.
+    #[schemars(
+        length(min = 1, max = MAX_WEB_SEARCH_QUERY_CHARS),
+        description = ""
+    )]
+    pub query: String,
+    /// Requested result count.
+    #[serde(default = "default_web_search_results")]
+    #[schemars(
+        range(min = 1, max = MAX_WEB_SEARCH_RESULTS),
+        description = ""
+    )]
+    pub max_results: usize,
+    /// Optional exact domain filters.
+    #[serde(default)]
+    #[schemars(length(max = MAX_WEB_SEARCH_DOMAINS), description = "")]
+    pub domains: Vec<String>,
+    /// Optional inclusive lower publication-time bound.
+    #[serde(default)]
+    #[schemars(
+        with = "String",
+        extend("format" = "date-time"),
+        description = ""
+    )]
+    pub start_published_at: Option<DateTime<Utc>>,
+    /// Optional inclusive upper publication-time bound.
+    #[serde(default)]
+    #[schemars(
+        with = "String",
+        extend("format" = "date-time"),
+        description = ""
+    )]
+    pub end_published_at: Option<DateTime<Utc>>,
+}
+
+const fn default_web_search_results() -> usize {
+    DEFAULT_WEB_SEARCH_RESULTS
+}
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct SandboxReadDelegatedFileArgs {}
 
 impl WaitForAgentsArgs {
     /// Whether this proposal has a non-empty, bounded, unique list of IDs.
@@ -264,38 +340,10 @@ pub fn validate_wait_for_agents_arguments(arguments: &Value) -> bool {
 /// recurse past depth one.
 #[must_use]
 pub fn spawn_sandbox_agent_tool_spec() -> ToolSpec {
-    ToolSpec {
-        name: SPAWN_SANDBOX_AGENT_TOOL.into(),
-        description: "Delegate one self-contained task to an isolated background agent and continue immediately. Save every returned agent_id. Before final completion, include every spawned agent_id in a wait_for_agents call; batch independent IDs into one wait, and do not ask it to spawn more agents.".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "task": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": MAX_SANDBOX_AGENT_TASK_CHARS,
-                    "description": "A concise, self-contained task for one isolated background agent."
-                },
-                "resource": {
-                    "type": "object",
-                    "description": "Optional exact file identity within a folder already connected to this conversation. This delegates only its identity; a compatible native executor must revalidate current access before any read.",
-                    "properties": {
-                        "root_id": { "type": "string", "format": "uuid" },
-                        "relative_path": {
-                            "type": "string",
-                            "minLength": 1,
-                            "maxLength": crate::client_tools::MAX_CONNECTED_FOLDER_PATH_BYTES,
-                            "description": "Nonempty root-relative file path."
-                        }
-                    },
-                    "required": ["root_id", "relative_path"],
-                    "additionalProperties": false
-                }
-            },
-            "required": ["task"],
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<SpawnSandboxAgentArgs>(
+        SPAWN_SANDBOX_AGENT_TOOL,
+        "Delegate one self-contained task to an isolated background agent and continue immediately. Save every returned agent_id. Before final completion, include every spawned agent_id in a wait_for_agents call; batch independent IDs into one wait, and do not ask it to spawn more agents.",
+    )
 }
 
 /// Prepared foreground-only contract for waiting on depth-one children.
@@ -304,25 +352,10 @@ pub fn spawn_sandbox_agent_tool_spec() -> ToolSpec {
 /// durably claimed foreground turn.
 #[must_use]
 pub fn wait_for_agents_tool_spec() -> ToolSpec {
-    ToolSpec {
-        name: WAIT_FOR_AGENTS_TOOL.into(),
-        description: "Wait until all specified background agents finish, then return their results in the same order. Use only depth-one agent IDs returned by spawn_sandbox_agent.".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "agent_ids": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": MAX_WAIT_FOR_AGENTS_CHILDREN,
-                    "uniqueItems": true,
-                    "items": { "type": "string", "format": "uuid" },
-                    "description": "Opaque depth-one child agent IDs, in the order their results should be returned."
-                }
-            },
-            "required": ["agent_ids"],
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<WaitForAgentsArgs>(
+        WAIT_FOR_AGENTS_TOOL,
+        "Wait until all specified background agents finish, then return their results in the same order. Use only depth-one agent IDs returned by spawn_sandbox_agent.",
+    )
 }
 
 /// Narrow, host-executed web-search contract shared by trusted runtimes.
@@ -332,22 +365,10 @@ pub fn wait_for_agents_tool_spec() -> ToolSpec {
 /// same closed arguments without depending on a network integration crate.
 #[must_use]
 pub fn web_search_tool_spec() -> ToolSpec {
-    ToolSpec {
-        name: WEB_SEARCH_TOOL.into(),
-        description: "Search the public web for current information. Use focused queries and cite sources with the exact result URLs. Results may be unavailable when the host has not configured web search.".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "query": { "type": "string", "minLength": 1, "maxLength": 400 },
-                "max_results": { "type": "integer", "minimum": 1, "maximum": 10 },
-                "domains": { "type": "array", "items": { "type": "string" }, "maxItems": 20 },
-                "start_published_at": { "type": "string", "format": "date-time" },
-                "end_published_at": { "type": "string", "format": "date-time" }
-            },
-            "required": ["query"],
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<WebSearchArgs>(
+        WEB_SEARCH_TOOL,
+        "Search the public web for current information. Use focused queries and cite sources with the exact result URLs. Results may be unavailable when the host has not configured web search.",
+    )
 }
 
 /// Sandbox-specific presentation of the shared web-search contract.
@@ -370,21 +391,16 @@ pub fn sandbox_web_search_tool_spec() -> ToolSpec {
 /// widening its own authority.
 #[must_use]
 pub fn sandbox_read_delegated_file_tool_spec() -> ToolSpec {
-    ToolSpec {
-        name: SANDBOX_READ_DELEGATED_FILE_TOOL.into(),
-        description: "Read the exact UTF-8 file delegated to this background task.".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {},
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<SandboxReadDelegatedFileArgs>(
+        SANDBOX_READ_DELEGATED_FILE_TOOL,
+        "Read the exact UTF-8 file delegated to this background task.",
+    )
 }
 
 /// Whether arguments are the one canonical argument-free payload.
 #[must_use]
 pub fn validate_sandbox_read_delegated_file_arguments(arguments: &Value) -> bool {
-    arguments.as_object().is_some_and(serde_json::Map::is_empty)
+    serde_json::from_value::<SandboxReadDelegatedFileArgs>(arguments.clone()).is_ok()
 }
 
 #[cfg(test)]
@@ -475,12 +491,18 @@ mod tests {
     fn sandbox_spawn_spec_describes_a_single_bounded_task() {
         let spec = spawn_sandbox_agent_tool_spec();
         assert_eq!(spec.name, SPAWN_SANDBOX_AGENT_TOOL);
+        assert!(spec.input_schema.get("title").is_none());
+        assert!(spec.input_schema.get("$schema").is_none());
         assert_eq!(spec.input_schema["additionalProperties"], false);
         assert_eq!(spec.input_schema["required"], serde_json::json!(["task"]));
         assert_eq!(spec.input_schema["properties"]["task"]["maxLength"], 16_000);
         assert_eq!(
             spec.input_schema["properties"]["resource"]["required"],
             serde_json::json!(["root_id", "relative_path"])
+        );
+        assert_eq!(
+            spec.input_schema["properties"]["resource"]["properties"]["root_id"],
+            serde_json::json!({"type": "string", "format": "uuid"})
         );
         assert!(spec.description.contains("do not ask it to spawn"));
     }
@@ -544,6 +566,10 @@ mod tests {
         assert_eq!(
             spec.input_schema["properties"]["agent_ids"]["uniqueItems"],
             true
+        );
+        assert_eq!(
+            spec.input_schema["properties"]["agent_ids"]["items"],
+            serde_json::json!({"type": "string", "format": "uuid"})
         );
         assert!(spec.description.contains("all specified"));
         assert!(spec.description.contains("same order"));
@@ -613,6 +639,19 @@ mod tests {
             foreground.input_schema["properties"]["domains"]["maxItems"],
             20
         );
+        assert_eq!(
+            foreground.input_schema["required"],
+            serde_json::json!(["query"])
+        );
+        assert_eq!(
+            foreground.input_schema["properties"]["start_published_at"],
+            serde_json::json!({"type": "string", "format": "date-time"})
+        );
+        assert_eq!(
+            foreground.input_schema["properties"]["end_published_at"],
+            serde_json::json!({"type": "string", "format": "date-time"})
+        );
+        assert!(!foreground.input_schema.to_string().contains("\"default\""));
         assert_eq!(foreground.input_schema["additionalProperties"], false);
         assert!(foreground.description.contains("exact result URLs"));
         assert!(sandbox.description.contains("at most once"));

--- a/crates/openwave-core/src/client_tools.rs
+++ b/crates/openwave-core/src/client_tools.rs
@@ -4,6 +4,7 @@
 //! trusted client must still validate the payload, obtain explicit user
 //! consent, and derive the actual host-broker grant itself.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
@@ -32,11 +33,13 @@ pub const MAX_FOLDER_ACCESS_REASON_CHARS: usize = 500;
 ///
 /// The trusted host derives the granted capabilities after consent; it must not
 /// copy this list directly into a grant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[schemars(description = "", transform = preserve_enum_wire_shape)]
 #[non_exhaustive]
 pub enum RequestedFolderCapability {
     /// List directories and read files below the selected folder.
+    #[schemars(description = "")]
     ReadFiles,
 }
 
@@ -44,29 +47,62 @@ pub enum RequestedFolderCapability {
 ///
 /// This is deliberately not a free-form path. The trusted desktop decides how
 /// (or whether) to map it to a local picker location.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
+#[schemars(description = "", transform = preserve_enum_wire_shape)]
 #[non_exhaustive]
 pub enum RequestedFolderHint {
     /// Start the picker near the user's documents folder when supported.
+    #[schemars(description = "")]
     Documents,
     /// Start the picker near the user's downloads folder when supported.
+    #[schemars(description = "")]
     Downloads,
 }
 
+// Unit-variant docs make Schemars prefer `oneOf`; providers already consume
+// these two contracts as compact enum-only schemas.
+fn preserve_enum_wire_shape(schema: &mut schemars::Schema) {
+    if let Some(Value::Array(variants)) = schema.remove("oneOf") {
+        let values = variants
+            .iter()
+            .map(|variant| variant.get("const").cloned())
+            .collect::<Option<Vec<_>>>();
+        if let Some(values) = values {
+            schema.insert("enum".into(), Value::Array(values));
+        } else {
+            schema.insert("oneOf".into(), Value::Array(variants));
+        }
+    }
+    schema.remove("type");
+}
+
 /// Canonical arguments for [`REQUEST_FOLDER_ACCESS_TOOL`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RequestFolderAccessArgs {
     /// Short explanation shown to the user before any picker opens.
+    #[schemars(
+        length(min = 1, max = MAX_FOLDER_ACCESS_REASON_CHARS),
+        description = "Why access is needed, shown to the user."
+    )]
     pub reason: String,
     /// Capabilities the model believes it needs; these are proposals only.
+    #[schemars(
+        length(min = 1, max = 1),
+        extend("uniqueItems" = true),
+        description = "Untrusted capability proposals; the host derives any actual grant."
+    )]
     pub requested_capabilities: Vec<RequestedFolderCapability>,
     /// Optional non-authoritative well-known picker hint.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
         deserialize_with = "deserialize_optional_hint"
+    )]
+    #[schemars(
+        with = "RequestedFolderHint",
+        description = "Optional well-known picker hint, never an absolute path."
     )]
     pub folder_hint: Option<RequestedFolderHint>,
 }
@@ -131,35 +167,10 @@ pub fn validate_request_folder_access_arguments(arguments: &Value) -> bool {
 /// Tool contract advertised by the local control plane.
 #[must_use]
 pub fn request_folder_access_tool_spec() -> ToolSpec {
-    ToolSpec {
-        name: REQUEST_FOLDER_ACCESS_TOOL.into(),
-        description: "Ask the user to connect another folder through a native consent flow. This request grants no access by itself. Provide a short reason, the read capability proposal, and optionally a label such as Documents or Downloads; never provide an absolute path.".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "reason": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": MAX_FOLDER_ACCESS_REASON_CHARS,
-                    "description": "Why access is needed, shown to the user."
-                },
-                "requested_capabilities": {
-                    "type": "array",
-                    "description": "Untrusted capability proposals; the host derives any actual grant.",
-                    "items": { "enum": ["read_files"] },
-                    "minItems": 1,
-                    "maxItems": 1,
-                    "uniqueItems": true
-                },
-                "folder_hint": {
-                    "enum": ["documents", "downloads"],
-                    "description": "Optional well-known picker hint, never an absolute path."
-                }
-            },
-            "required": ["reason", "requested_capabilities"],
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<RequestFolderAccessArgs>(
+        REQUEST_FOLDER_ACCESS_TOOL,
+        "Ask the user to connect another folder through a native consent flow. This request grants no access by itself. Provide a short reason, the read capability proposal, and optionally a label such as Documents or Downloads; never provide an absolute path.",
+    )
 }
 
 /// Sandbox-only contract for proposing that the foreground parent consider
@@ -172,37 +183,52 @@ pub fn sandbox_folder_access_proposal_tool_spec() -> ToolSpec {
 }
 
 /// Canonical arguments for [`LIST_CONNECTED_FOLDERS_TOOL`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ListConnectedFoldersArgs {}
 
 /// Canonical arguments for [`LIST_FOLDER_TOOL`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ListFolderArgs {
     /// Opaque id returned by `list_connected_folders` or folder consent.
+    #[schemars(description = "")]
     pub root_id: uuid::Uuid,
     /// Root-relative directory path; an empty path means the connected root.
+    #[schemars(
+        length(max = MAX_CONNECTED_FOLDER_PATH_BYTES),
+        description = "Root-relative directory path; empty means the folder root."
+    )]
     pub path: String,
 }
 
 /// Canonical arguments for [`READ_CONNECTED_FILE_TOOL`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ReadConnectedFileArgs {
     /// Opaque id returned by `list_connected_folders` or folder consent.
+    #[schemars(description = "")]
     pub root_id: uuid::Uuid,
     /// Nonempty root-relative file path.
+    #[schemars(
+        length(min = 1, max = MAX_CONNECTED_FOLDER_PATH_BYTES),
+        description = "Root-relative text file path."
+    )]
     pub path: String,
 }
 
 /// Canonical arguments for [`IMPORT_CONNECTED_FILE_TOOL`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ImportConnectedFileArgs {
     /// Opaque id returned by `list_connected_folders` or folder consent.
+    #[schemars(description = "")]
     pub root_id: uuid::Uuid,
     /// Nonempty root-relative file path.
+    #[schemars(
+        length(min = 1, max = MAX_CONNECTED_FOLDER_PATH_BYTES),
+        description = "Root-relative file path."
+    )]
     pub path: String,
 }
 
@@ -285,66 +311,34 @@ pub fn validate_import_connected_file_arguments(arguments: &Value) -> bool {
 
 #[must_use]
 pub fn list_connected_folders_tool_spec() -> ToolSpec {
-    ToolSpec {
-        name: LIST_CONNECTED_FOLDERS_TOOL.into(),
-        description: "List folders already connected to this conversation. Results contain opaque root IDs and display names only; use request_folder_access to ask the user to choose another folder.".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {},
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<ListConnectedFoldersArgs>(
+        LIST_CONNECTED_FOLDERS_TOOL,
+        "List folders already connected to this conversation. Results contain opaque root IDs and display names only; use request_folder_access to ask the user to choose another folder.",
+    )
 }
 
 #[must_use]
 pub fn list_folder_tool_spec() -> ToolSpec {
-    ToolSpec {
-        name: LIST_FOLDER_TOOL.into(),
-        description: "List a directory below an already connected folder. Use only an opaque root_id and a root-relative path; never use an absolute path or parent traversal.".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "root_id": { "type": "string", "format": "uuid" },
-                "path": { "type": "string", "maxLength": MAX_CONNECTED_FOLDER_PATH_BYTES, "description": "Root-relative directory path; empty means the folder root." }
-            },
-            "required": ["root_id", "path"],
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<ListFolderArgs>(
+        LIST_FOLDER_TOOL,
+        "List a directory below an already connected folder. Use only an opaque root_id and a root-relative path; never use an absolute path or parent traversal.",
+    )
 }
 
 #[must_use]
 pub fn read_connected_file_tool_spec() -> ToolSpec {
-    ToolSpec {
-        name: READ_CONNECTED_FILE_TOOL.into(),
-        description: "Read a UTF-8 text file below an already connected folder. Use only an opaque root_id and a nonempty root-relative path; never use an absolute path or parent traversal.".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "root_id": { "type": "string", "format": "uuid" },
-                "path": { "type": "string", "minLength": 1, "maxLength": MAX_CONNECTED_FOLDER_PATH_BYTES, "description": "Root-relative text file path." }
-            },
-            "required": ["root_id", "path"],
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<ReadConnectedFileArgs>(
+        READ_CONNECTED_FILE_TOOL,
+        "Read a UTF-8 text file below an already connected folder. Use only an opaque root_id and a nonempty root-relative path; never use an absolute path or parent traversal.",
+    )
 }
 
 #[must_use]
 pub fn import_connected_file_tool_spec() -> ToolSpec {
-    ToolSpec {
-        name: IMPORT_CONNECTED_FILE_TOOL.into(),
-        description: "Add one file below an already connected folder to this conversation as a source, so it can be searched and cited. Use this for a PDF, Office document, or any other file that read_connected_file cannot return as text. Use only an opaque root_id and a nonempty root-relative path; never use an absolute path or parent traversal. Importing the same file again recovers the same single source rather than adding a duplicate. The result is normally still processing: check list_sources for whether it became searchable.".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "root_id": { "type": "string", "format": "uuid" },
-                "path": { "type": "string", "minLength": 1, "maxLength": MAX_CONNECTED_FOLDER_PATH_BYTES, "description": "Root-relative file path." }
-            },
-            "required": ["root_id", "path"],
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<ImportConnectedFileArgs>(
+        IMPORT_CONNECTED_FILE_TOOL,
+        "Add one file below an already connected folder to this conversation as a source, so it can be searched and cited. Use this for a PDF, Office document, or any other file that read_connected_file cannot return as text. Use only an opaque root_id and a nonempty root-relative path; never use an absolute path or parent traversal. Importing the same file again recovers the same single source rather than adding a duplicate. The result is normally still processing: check list_sources for whether it became searchable.",
+    )
 }
 
 pub(crate) fn valid_connected_folder_path(path: &str, allow_root: bool) -> bool {
@@ -434,6 +428,21 @@ mod tests {
         assert_eq!(
             spec.input_schema["required"],
             serde_json::json!(["reason", "requested_capabilities"])
+        );
+        assert_eq!(
+            spec.input_schema["properties"]["reason"]["maxLength"],
+            MAX_FOLDER_ACCESS_REASON_CHARS
+        );
+        assert_eq!(
+            spec.input_schema["properties"]["requested_capabilities"]["items"],
+            serde_json::json!({"enum": ["read_files"]})
+        );
+        assert_eq!(
+            spec.input_schema["properties"]["folder_hint"],
+            serde_json::json!({
+                "enum": ["documents", "downloads"],
+                "description": "Optional well-known picker hint, never an absolute path."
+            })
         );
         assert!(spec.description.contains("grants no access"));
     }
@@ -575,6 +584,23 @@ mod tests {
         assert_eq!(file.name, READ_CONNECTED_FILE_TOOL);
         assert_eq!(directory.input_schema["additionalProperties"], false);
         assert_eq!(file.input_schema["additionalProperties"], false);
+        assert_eq!(
+            directory.input_schema["properties"]["path"],
+            serde_json::json!({
+                "type": "string",
+                "maxLength": MAX_CONNECTED_FOLDER_PATH_BYTES,
+                "description": "Root-relative directory path; empty means the folder root."
+            })
+        );
+        assert_eq!(
+            file.input_schema["properties"]["path"],
+            serde_json::json!({
+                "type": "string",
+                "minLength": 1,
+                "maxLength": MAX_CONNECTED_FOLDER_PATH_BYTES,
+                "description": "Root-relative text file path."
+            })
+        );
         assert!(!directory.description.contains("project_id"));
         assert!(!file.description.contains("grant"));
     }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -63,9 +63,10 @@ pub use agent_tools::{
     validate_spawn_sandbox_agent_arguments, validate_wait_for_agents_arguments,
     wait_for_agents_tool_spec, web_search_tool_spec, SandboxAgentFileResource,
     SpawnSandboxAgentArgs, SpawnSandboxAgentResult, WaitForAgentResult, WaitForAgentsArgs,
-    WaitForAgentsResult, MAX_SANDBOX_AGENT_TASK_CHARS, MAX_WAIT_FOR_AGENTS_CHILDREN,
-    SANDBOX_READ_DELEGATED_FILE_TOOL, SANDBOX_WEB_SEARCH_TOOL, SPAWN_SANDBOX_AGENT_TOOL,
-    WAIT_FOR_AGENTS_TOOL, WEB_SEARCH_TOOL,
+    WaitForAgentsResult, WebSearchArgs, DEFAULT_WEB_SEARCH_RESULTS, MAX_SANDBOX_AGENT_TASK_CHARS,
+    MAX_WAIT_FOR_AGENTS_CHILDREN, MAX_WEB_SEARCH_DOMAINS, MAX_WEB_SEARCH_QUERY_CHARS,
+    MAX_WEB_SEARCH_RESULTS, SANDBOX_READ_DELEGATED_FILE_TOOL, SANDBOX_WEB_SEARCH_TOOL,
+    SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL, WEB_SEARCH_TOOL,
 };
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
@@ -162,7 +163,8 @@ pub use storage::{
     SubmitAgentRunResultOutcome, TurnLeaseFence, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{
-    ApprovalClass, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolScratch, ToolSpec,
+    input_schema_for, ApprovalClass, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolScratch,
+    ToolSpec,
 };
 #[cfg(feature = "tools")]
 pub use tools::{CreateDeliverable, ListDir, ReadFile, WriteFile};

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -15,6 +15,7 @@ use cap_std::ambient_authority;
 use cap_std::fs::Dir;
 
 use async_trait::async_trait;
+use schemars::{generate::SchemaSettings, JsonSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use ts_rs::TS;
@@ -91,6 +92,68 @@ pub struct ToolSpec {
     pub description: String,
     /// JSON Schema (draft 2020-12) describing the argument object.
     pub input_schema: Value,
+}
+
+impl ToolSpec {
+    /// Build a tool contract whose input schema comes from its deserialized
+    /// argument type.
+    ///
+    /// The provider-facing schema intentionally omits document metadata and
+    /// inlines nested types. OpenWave advertised that compact shape before
+    /// typed derivation, and provider adapters forward this value unchanged.
+    #[must_use]
+    pub fn for_args<Args: JsonSchema>(
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            input_schema: input_schema_for::<Args>(),
+        }
+    }
+}
+
+/// Generate the compact provider-facing JSON Schema for one argument type.
+#[must_use]
+pub fn input_schema_for<Args: JsonSchema>() -> Value {
+    let schema = SchemaSettings::draft2020_12()
+        .with(|settings| {
+            settings.meta_schema = None;
+            settings.inline_subschemas = true;
+        })
+        .into_generator()
+        .into_root_schema_for::<Args>();
+    let mut schema =
+        serde_json::to_value(schema).expect("a generated JSON Schema always serializes");
+    let root = schema
+        .as_object_mut()
+        .expect("a typed argument schema is an object");
+    root.remove("title");
+    root.remove("description");
+    if root.get("type").and_then(Value::as_str) == Some("object") {
+        root.entry("properties")
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    }
+    remove_schema_defaults(&mut schema);
+    schema
+}
+
+fn remove_schema_defaults(schema: &mut Value) {
+    match schema {
+        Value::Object(object) => {
+            object.remove("default");
+            for value in object.values_mut() {
+                remove_schema_defaults(value);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                remove_schema_defaults(value);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
 }
 
 /// The result of executing a tool.
@@ -358,6 +421,36 @@ pub trait Tool: Send + Sync {
 
 #[cfg(test)]
 mod tests {
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+
+    #[derive(Deserialize, JsonSchema)]
+    #[serde(deny_unknown_fields)]
+    /// Root documentation belongs in Rust docs, not the provider schema.
+    #[allow(dead_code)]
+    struct DerivedArguments {
+        #[serde(default)]
+        #[schemars(with = "String", description = "Optional text.")]
+        optional: Option<String>,
+    }
+
+    #[test]
+    fn typed_argument_schema_keeps_the_compact_provider_shape() {
+        assert_eq!(
+            input_schema_for::<DerivedArguments>(),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "optional": {
+                        "type": "string",
+                        "description": "Optional text."
+                    }
+                },
+                "additionalProperties": false
+            })
+        );
+    }
+
     #[test]
     fn a_reader_choice_is_not_recorded_as_a_product_failure() {
         // The distinction this exists for: a cancelled or declined call is a

--- a/crates/openwave-core/src/tools/arguments.rs
+++ b/crates/openwave-core/src/tools/arguments.rs
@@ -1,13 +1,19 @@
-use serde::Deserialize;
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 
-use crate::tool::ToolOutput;
+use crate::tool::{input_schema_for, ToolOutput};
 
 /// Parse tool arguments into their typed contract, preserving malformed input
 /// as a model-facing result rather than an infrastructure failure.
-pub(super) fn parse<T: for<'de> Deserialize<'de>>(
+pub(super) fn parse<T: DeserializeOwned + JsonSchema>(
     arguments: Value,
 ) -> std::result::Result<T, ToolOutput> {
-    serde_json::from_value(arguments)
-        .map_err(|error| ToolOutput::error(format!("invalid arguments: {error}")))
+    serde_json::from_value(arguments).map_err(|error| {
+        let schema = serde_json::to_string_pretty(&input_schema_for::<T>())
+            .expect("a generated JSON Schema always serializes");
+        ToolOutput::error(format!(
+            "invalid arguments: {error}\n\nExpected schema:\n{schema}"
+        ))
+    })
 }

--- a/crates/openwave-core/src/tools/create_deliverable.rs
+++ b/crates/openwave-core/src/tools/create_deliverable.rs
@@ -1,11 +1,13 @@
 use std::path::Path;
 
 use async_trait::async_trait;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
 
 use crate::deliverable::{
     validate_deliverable_name, DELIVERABLES_DIRECTORY, MAX_DELIVERABLE_BYTES,
+    MAX_DELIVERABLE_NAME_CHARS,
 };
 use crate::error::Result;
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
@@ -17,10 +19,18 @@ use super::private_scratch::write_utf8_file;
 /// `create_deliverable` — create or update a user-visible text artifact.
 pub struct CreateDeliverable;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-struct Arguments {
+pub(super) struct Arguments {
+    #[schemars(
+        length(min = 1, max = MAX_DELIVERABLE_NAME_CHARS),
+        description = "Portable output filename ending in .md, .txt, .csv, .json, or .html."
+    )]
     filename: String,
+    #[schemars(
+        length(min = 1, max = MAX_DELIVERABLE_BYTES),
+        description = "Complete UTF-8 text contents of the output file (maximum 512 KiB)."
+    )]
     content: String,
 }
 

--- a/crates/openwave-core/src/tools/definitions.rs
+++ b/crates/openwave-core/src/tools/definitions.rs
@@ -1,9 +1,11 @@
-//! Model-facing names, descriptions, and JSON Schemas for built-in tools.
+//! Model-facing names and descriptions for built-in tools.
 
-use serde_json::json;
-
-use crate::deliverable::{MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_NAME_CHARS};
 use crate::tool::ToolSpec;
+
+use super::{
+    create_deliverable, list_dir as list_dir_tool, read_file as read_file_tool,
+    write_file as write_file_tool,
+};
 
 pub(super) const READ_FILE: &str = "read_file";
 pub(super) const LIST_DIR: &str = "list_dir";
@@ -11,75 +13,32 @@ pub(super) const WRITE_FILE: &str = "write_file";
 pub(super) const CREATE_DELIVERABLE: &str = "create_deliverable";
 
 pub(super) fn read_file() -> ToolSpec {
-    ToolSpec {
-        name: READ_FILE.into(),
-        description: "Read a UTF-8 text file, relative to the private scratch directory.".into(),
-        input_schema: json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Private-scratch-relative file path." }
-            },
-            "required": ["path"]
-        }),
-    }
+    ToolSpec::for_args::<read_file_tool::Arguments>(
+        READ_FILE,
+        "Read a UTF-8 text file, relative to the private scratch directory.",
+    )
 }
 
 pub(super) fn list_dir() -> ToolSpec {
-    ToolSpec {
-        name: LIST_DIR.into(),
-        description: "List the entries of a private scratch directory (defaults to the root)."
-            .into(),
-        input_schema: json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Private-scratch-relative directory (optional)." }
-            }
-        }),
-    }
+    ToolSpec::for_args::<list_dir_tool::Arguments>(
+        LIST_DIR,
+        "List the entries of a private scratch directory (defaults to the root).",
+    )
 }
 
 pub(super) fn write_file() -> ToolSpec {
-    ToolSpec {
-        name: WRITE_FILE.into(),
-        description: "Write a UTF-8 text file into private scratch, creating parent directories. \
-                      Overwrites an existing file."
-            .into(),
-        input_schema: json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Private-scratch-relative file path." },
-                "content": { "type": "string", "description": "File contents to write." }
-            },
-            "required": ["path", "content"]
-        }),
-    }
+    ToolSpec::for_args::<write_file_tool::Arguments>(
+        WRITE_FILE,
+        "Write a UTF-8 text file into private scratch, creating parent directories. \
+         Overwrites an existing file.",
+    )
 }
 
 pub(super) fn create_deliverable() -> ToolSpec {
-    ToolSpec {
-        name: CREATE_DELIVERABLE.into(),
-        description: "Create or update a user-visible text file for the current conversation. \
-                      Use this when the user asks for a report, plan, table, data file, web page, \
-                      or other file they can preview and save from OpenWave's Outputs view."
-            .into(),
-        input_schema: json!({
-            "type": "object",
-            "properties": {
-                "filename": {
-                    "type": "string",
-                    "description": "Portable output filename ending in .md, .txt, .csv, .json, or .html.",
-                    "minLength": 1,
-                    "maxLength": MAX_DELIVERABLE_NAME_CHARS
-                },
-                "content": {
-                    "type": "string",
-                    "description": "Complete UTF-8 text contents of the output file (maximum 512 KiB).",
-                    "minLength": 1,
-                    "maxLength": MAX_DELIVERABLE_BYTES
-                }
-            },
-            "required": ["filename", "content"],
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<create_deliverable::Arguments>(
+        CREATE_DELIVERABLE,
+        "Create or update a user-visible text file for the current conversation. \
+         Use this when the user asks for a report, plan, table, data file, web page, \
+         or other file they can preview and save from OpenWave's Outputs view.",
+    )
 }

--- a/crates/openwave-core/src/tools/list_dir.rs
+++ b/crates/openwave-core/src/tools/list_dir.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -12,9 +13,13 @@ use super::private_scratch::{list_directory, relative_path};
 /// `list_dir` — list the entries of a private scratch directory.
 pub struct ListDir;
 
-#[derive(Deserialize)]
-struct Arguments {
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct Arguments {
     #[serde(default)]
+    #[schemars(
+        with = "String",
+        description = "Private-scratch-relative directory (optional)."
+    )]
     path: Option<String>,
 }
 

--- a/crates/openwave-core/src/tools/read_file.rs
+++ b/crates/openwave-core/src/tools/read_file.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -12,8 +13,9 @@ use super::private_scratch::{read_utf8_file, relative_path};
 /// `read_file` — read a UTF-8 text file from private scratch.
 pub struct ReadFile;
 
-#[derive(Deserialize)]
-struct Arguments {
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct Arguments {
+    #[schemars(description = "Private-scratch-relative file path.")]
     path: String,
 }
 

--- a/crates/openwave-core/src/tools/tests.rs
+++ b/crates/openwave-core/src/tools/tests.rs
@@ -35,6 +35,93 @@ async fn every_file_tool_fails_closed_without_private_scratch() {
     assert!(deliverable.is_error);
 }
 
+#[test]
+fn built_in_tool_schemas_preserve_their_provider_contracts() {
+    assert_eq!(
+        ReadFile.spec().input_schema,
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Private-scratch-relative file path."
+                }
+            },
+            "required": ["path"]
+        })
+    );
+    assert_eq!(
+        ListDir.spec().input_schema,
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Private-scratch-relative directory (optional)."
+                }
+            }
+        })
+    );
+    assert_eq!(
+        WriteFile.spec().input_schema,
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Private-scratch-relative file path."
+                },
+                "content": {
+                    "type": "string",
+                    "description": "File contents to write."
+                }
+            },
+            "required": ["path", "content"]
+        })
+    );
+    assert_eq!(
+        CreateDeliverable.spec().input_schema,
+        json!({
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "type": "string",
+                    "description": "Portable output filename ending in .md, .txt, .csv, .json, or .html.",
+                    "minLength": 1,
+                    "maxLength": crate::MAX_DELIVERABLE_NAME_CHARS
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Complete UTF-8 text contents of the output file (maximum 512 KiB).",
+                    "minLength": 1,
+                    "maxLength": crate::MAX_DELIVERABLE_BYTES
+                }
+            },
+            "required": ["filename", "content"],
+            "additionalProperties": false
+        })
+    );
+}
+
+#[tokio::test]
+async fn malformed_arguments_include_the_typed_schema() {
+    let output = ReadFile
+        .execute(
+            &ToolCtx::without_private_scratch(ChatId::new(), None),
+            json!({"path": 42}),
+        )
+        .await
+        .unwrap();
+
+    assert!(output.is_error);
+    assert!(output.content.contains("invalid arguments:"));
+    assert!(output.content.contains("Expected schema:"));
+    assert!(output
+        .content
+        .contains("Private-scratch-relative file path."));
+    assert!(output.content.contains("\"required\": ["));
+}
+
 #[tokio::test]
 async fn deliverables_are_isolated_in_their_closed_directory() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/openwave-core/src/tools/write_file.rs
+++ b/crates/openwave-core/src/tools/write_file.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -12,9 +13,11 @@ use super::private_scratch::{relative_path, write_utf8_file};
 /// `write_file` — atomically write a UTF-8 text file into private scratch.
 pub struct WriteFile;
 
-#[derive(Deserialize)]
-struct Arguments {
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct Arguments {
+    #[schemars(description = "Private-scratch-relative file path.")]
     path: String,
+    #[schemars(description = "File contents to write.")]
     content: String,
 }
 

--- a/crates/openwave-core/src/user_questions.rs
+++ b/crates/openwave-core/src/user_questions.rs
@@ -8,6 +8,7 @@
 use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -27,11 +28,15 @@ pub const MAX_QUESTION_OPTION_DESCRIPTION_CHARS: usize = 240;
 pub const MAX_FREE_FORM_ANSWER_CHARS: usize = 2_000;
 
 /// One mutually exclusive answer choice.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, ts_rs::TS)]
 #[serde(deny_unknown_fields)]
+#[schemars(description = "")]
 pub struct UserQuestionOption {
+    #[schemars(length(min = 1, max = MAX_QUESTION_OPTION_ID_CHARS))]
     pub id: String,
+    #[schemars(length(min = 1, max = MAX_QUESTION_OPTION_LABEL_CHARS))]
     pub label: String,
+    #[schemars(length(min = 1, max = MAX_QUESTION_OPTION_DESCRIPTION_CHARS))]
     pub description: String,
 }
 
@@ -45,13 +50,18 @@ impl UserQuestionOption {
 }
 
 /// One bounded question shown to the user.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, ts_rs::TS)]
 #[serde(deny_unknown_fields)]
+#[schemars(description = "")]
 pub struct UserQuestion {
+    #[schemars(length(min = 1, max = MAX_QUESTION_ID_CHARS))]
     pub id: String,
+    #[schemars(length(min = 1, max = MAX_QUESTION_HEADER_CHARS))]
     pub header: String,
+    #[schemars(length(min = 1, max = MAX_QUESTION_PROMPT_CHARS))]
     pub question: String,
     #[serde(default)]
+    #[schemars(length(max = MAX_QUESTION_OPTIONS))]
     pub options: Vec<UserQuestionOption>,
     #[serde(default)]
     pub allow_free_form: bool,
@@ -76,9 +86,10 @@ impl UserQuestion {
 }
 
 /// Canonical model arguments for [`ASK_USER_QUESTIONS_TOOL`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AskUserQuestionsArgs {
+    #[schemars(length(min = 1, max = MAX_USER_QUESTIONS))]
     pub questions: Vec<UserQuestion>,
 }
 
@@ -188,47 +199,10 @@ pub fn validate_ask_user_questions_arguments(arguments: &Value) -> bool {
 
 #[must_use]
 pub fn ask_user_questions_tool_spec() -> ToolSpec {
-    ToolSpec {
-        name: ASK_USER_QUESTIONS_TOOL.into(),
-        description: "Pause the current foreground turn and ask the user up to three short structured questions. Use stable question and option IDs. Options are mutually exclusive; enable allow_free_form only when a custom answer is useful. Call this tool alone, with no assistant text or sibling tools.".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "questions": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": MAX_USER_QUESTIONS,
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": { "type": "string", "minLength": 1, "maxLength": MAX_QUESTION_ID_CHARS },
-                            "header": { "type": "string", "minLength": 1, "maxLength": MAX_QUESTION_HEADER_CHARS },
-                            "question": { "type": "string", "minLength": 1, "maxLength": MAX_QUESTION_PROMPT_CHARS },
-                            "options": {
-                                "type": "array",
-                                "maxItems": MAX_QUESTION_OPTIONS,
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "id": { "type": "string", "minLength": 1, "maxLength": MAX_QUESTION_OPTION_ID_CHARS },
-                                        "label": { "type": "string", "minLength": 1, "maxLength": MAX_QUESTION_OPTION_LABEL_CHARS },
-                                        "description": { "type": "string", "minLength": 1, "maxLength": MAX_QUESTION_OPTION_DESCRIPTION_CHARS }
-                                    },
-                                    "required": ["id", "label", "description"],
-                                    "additionalProperties": false
-                                }
-                            },
-                            "allow_free_form": { "type": "boolean" }
-                        },
-                        "required": ["id", "header", "question"],
-                        "additionalProperties": false
-                    }
-                }
-            },
-            "required": ["questions"],
-            "additionalProperties": false
-        }),
-    }
+    ToolSpec::for_args::<AskUserQuestionsArgs>(
+        ASK_USER_QUESTIONS_TOOL,
+        "Pause the current foreground turn and ask the user up to three short structured questions. Use stable question and option IDs. Options are mutually exclusive; enable allow_free_form only when a custom answer is useful. Call this tool alone, with no assistant text or sibling tools.",
+    )
 }
 
 fn valid_text(value: &str, max_chars: usize) -> bool {
@@ -280,6 +254,42 @@ mod tests {
         let mut unknown = sample();
         unknown["questions"][0]["secret"] = Value::String("no".into());
         assert!(!validate_ask_user_questions_arguments(&unknown));
+    }
+
+    #[test]
+    fn question_schema_is_derived_with_all_nested_bounds() {
+        let schema = ask_user_questions_tool_spec().input_schema;
+        let questions = &schema["properties"]["questions"];
+        let question = &questions["items"];
+        let option = &question["properties"]["options"]["items"];
+
+        assert_eq!(schema["additionalProperties"], false);
+        assert_eq!(schema["required"], serde_json::json!(["questions"]));
+        assert_eq!(questions["minItems"], 1);
+        assert_eq!(questions["maxItems"], MAX_USER_QUESTIONS);
+        assert_eq!(question["additionalProperties"], false);
+        assert_eq!(
+            question["required"],
+            serde_json::json!(["id", "header", "question"])
+        );
+        assert_eq!(
+            question["properties"]["question"]["maxLength"],
+            MAX_QUESTION_PROMPT_CHARS
+        );
+        assert_eq!(
+            question["properties"]["options"]["maxItems"],
+            MAX_QUESTION_OPTIONS
+        );
+        assert_eq!(option["additionalProperties"], false);
+        assert_eq!(
+            option["required"],
+            serde_json::json!(["id", "label", "description"])
+        );
+        assert_eq!(
+            option["properties"]["description"]["maxLength"],
+            MAX_QUESTION_OPTION_DESCRIPTION_CHARS
+        );
+        assert!(!schema.to_string().contains("\"default\""));
     }
 
     #[test]

--- a/crates/openwave-web-search/src/tool.rs
+++ b/crates/openwave-web-search/src/tool.rs
@@ -1,16 +1,14 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
-use openwave_core::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
-use serde::Deserialize;
+use openwave_core::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec, WebSearchArgs};
 use serde_json::Value;
 use thiserror::Error;
 
 use crate::{SearchDomain, WebSearchError, WebSearchProvider, WebSearchRequest, MAX_OUTPUT_BYTES};
 
 /// Default result count when a model omits `max_results`.
-pub const DEFAULT_MAX_RESULTS: usize = 5;
+pub const DEFAULT_MAX_RESULTS: usize = openwave_core::DEFAULT_WEB_SEARCH_RESULTS;
 
 /// Opaque failure to resolve current host policy or credentials.
 ///
@@ -27,30 +25,12 @@ pub trait WebSearchResolver: Send + Sync {
     async fn resolve(&self) -> Result<Option<Arc<dyn WebSearchProvider>>, WebSearchResolverError>;
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct WebSearchArguments {
-    query: String,
-    #[serde(default = "default_max_results")]
-    max_results: usize,
-    #[serde(default)]
-    domains: Vec<String>,
-    #[serde(default)]
-    start_published_at: Option<DateTime<Utc>>,
-    #[serde(default)]
-    end_published_at: Option<DateTime<Utc>>,
-}
-
-const fn default_max_results() -> usize {
-    DEFAULT_MAX_RESULTS
-}
-
 /// Decode and validate the one canonical model-facing argument shape.
 ///
 /// This is shared by the ordinary foreground tool and the durable sandbox
 /// checkpoint worker so both execution paths enforce identical bounds.
 pub fn request_from_tool_arguments(arguments: Value) -> Result<WebSearchRequest, WebSearchError> {
-    let arguments: WebSearchArguments = serde_json::from_value(arguments)
+    let arguments: WebSearchArgs = serde_json::from_value(arguments)
         .map_err(|_| WebSearchError::InvalidRequest("invalid tool arguments".into()))?;
     let domains = arguments
         .domains
@@ -174,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_schema_matches_request_contract_bounds() {
+    fn shared_typed_schema_preserves_request_bounds() {
         let spec = openwave_core::web_search_tool_spec();
         assert_eq!(spec.name, "web_search");
         assert_eq!(

--- a/crates/openwave-web-search/src/types.rs
+++ b/crates/openwave-web-search/src/types.rs
@@ -7,11 +7,11 @@ use thiserror::Error;
 use url::Url;
 
 /// Maximum Unicode scalar values accepted in a search query.
-pub const MAX_QUERY_CHARS: usize = 400;
+pub const MAX_QUERY_CHARS: usize = openwave_core::MAX_WEB_SEARCH_QUERY_CHARS;
 /// A provider request may ask for no more than this many normalized results.
-pub const MAX_RESULTS: usize = 10;
+pub const MAX_RESULTS: usize = openwave_core::MAX_WEB_SEARCH_RESULTS;
 /// A request may restrict results to no more than this many domains.
-pub const MAX_DOMAINS: usize = 20;
+pub const MAX_DOMAINS: usize = openwave_core::MAX_WEB_SEARCH_DOMAINS;
 /// Maximum title length preserved from a provider response.
 pub const MAX_RESULT_TITLE_CHARS: usize = 300;
 /// Maximum snippet length preserved from a provider response.


### PR DESCRIPTION
## Summary

- derive provider-facing tool schemas from the same typed Rust argument structures used at runtime
- preserve the existing compact schema contract, bounds, optionality, formats, and closed-object behavior
- unify foreground and sandbox web-search arguments and validation
- include the derived expected schema in malformed built-in tool errors

## Alpha cross-reference

Alpha derives provider schemas and validation errors from its Pydantic tool definitions. OpenWave now follows the same single-source-of-truth approach through `ToolSpec::for_args`, rather than introducing a blanket executable-tool trait for client/checkpoint tools that are not server `Tool` implementations. Provider-facing schemas remain byte-for-byte compatible with OpenWave's existing contract.

## Validation

- `bw --repo-root "$PWD" dev lint --rust --check`
- `cargo test --locked -p openwave-core --features tools -p openwave-web-search`
- 502 Rust tests passed on current `origin/main`

Closes #498
