### PR TITLE
feat(server): serve original document bytes

### DIFF
--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -34,7 +34,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' customprotocol: asset:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; img-src 'self' asset: blob: data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
+      "csp": "default-src 'self' customprotocol: asset:; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:* ws://127.0.0.1:* http://localhost:* ws://localhost:*; img-src 'self' asset: blob: data:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; worker-src 'self' blob:"
     }
   },
   "plugins": {

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -100,6 +100,10 @@ pub fn app(state: AppState) -> Router {
             get(routes::get_chat_document).delete(routes::delete_chat_document),
         )
         .route(
+            "/chats/{chat_id}/documents/{document_id}/file-content",
+            get(routes::get_chat_document_file_content),
+        )
+        .route(
             "/chats/{chat_id}/documents/{document_id}/retry",
             post(routes::retry_chat_document),
         )
@@ -121,6 +125,10 @@ pub fn app(state: AppState) -> Router {
             get(routes::get_project_document).delete(routes::delete_project_document),
         )
         .route(
+            "/projects/{project_id}/documents/{document_id}/file-content",
+            get(routes::get_project_document_file_content),
+        )
+        .route(
             "/projects/{project_id}/documents/{document_id}/retry",
             post(routes::retry_project_document),
         )
@@ -139,6 +147,10 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/documents/{id}",
             get(routes::get_document).delete(routes::delete_document),
+        )
+        .route(
+            "/documents/{id}/file-content",
+            get(routes::get_document_file_content),
         )
         .route("/documents/{id}/retry", post(routes::retry_document))
         .route("/search", post(routes::search_documents))
@@ -334,7 +346,18 @@ pub fn app(state: AppState) -> Router {
             Method::DELETE,
             Method::OPTIONS,
         ])
-        .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE, header::ACCEPT]);
+        .allow_headers([
+            header::AUTHORIZATION,
+            header::CONTENT_TYPE,
+            header::ACCEPT,
+            header::IF_RANGE,
+            header::RANGE,
+        ])
+        .expose_headers([
+            header::ACCEPT_RANGES,
+            header::CONTENT_LENGTH,
+            header::CONTENT_RANGE,
+        ]);
 
     Router::new()
         .route("/healthz", get(healthz))

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -773,11 +773,9 @@ async fn serve_document_file_content(
     if let Some(content_range) = content_range {
         response = response.header(header::CONTENT_RANGE, content_range);
     }
-    response
-        .body(Body::from(body))
-        .map_err(|error| {
-            ServerError::internal(format!("failed to build document response: {error}"))
-        })
+    response.body(Body::from(body)).map_err(|error| {
+        ServerError::internal(format!("failed to build document response: {error}"))
+    })
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -786,10 +784,7 @@ struct ByteRange {
     end_inclusive: u64,
 }
 
-fn requested_byte_range(
-    headers: &HeaderMap,
-    full_len: u64,
-) -> Result<Option<ByteRange>, ()> {
+fn requested_byte_range(headers: &HeaderMap, full_len: u64) -> Result<Option<ByteRange>, ()> {
     // This route does not expose an HTTP validator in this slice. Treat
     // conditional ranges as a request for the complete representation so a
     // stale validator can never produce bytes from the wrong generation.

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -1,8 +1,9 @@
 //! Document ingestion, catalog, lifecycle, and search HTTP handlers.
 
+use axum::body::Body;
 use axum::extract::State;
-use axum::http::{header, HeaderMap, StatusCode};
-use axum::response::IntoResponse;
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use unicode_general_category::{get_general_category, GeneralCategory};
@@ -668,6 +669,258 @@ pub async fn get_chat_document(
         .map(DocumentDetail::from)
         .map(Json)
         .ok_or_else(|| ServerError::not_found(format!("document {document_id} not found")))
+}
+
+/// `GET /documents/{id}/file-content` — serve the original bytes for one
+/// explicitly unscoped document.
+pub async fn get_document_file_content(
+    State(state): State<AppState>,
+    Path(id): Path<DocumentId>,
+    headers: HeaderMap,
+) -> Result<Response, ServerError> {
+    serve_document_file_content(&state, id, None, None, &headers).await
+}
+
+/// `GET /projects/{project_id}/documents/{document_id}/file-content` — serve
+/// original bytes only when the path project owns the document.
+pub async fn get_project_document_file_content(
+    State(state): State<AppState>,
+    Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
+    headers: HeaderMap,
+) -> Result<Response, ServerError> {
+    require_project(&state, project_id).await?;
+    serve_document_file_content(&state, document_id, None, Some(project_id), &headers).await
+}
+
+/// `GET /chats/{chat_id}/documents/{document_id}/file-content` — serve original
+/// bytes only when the path conversation owns the document.
+pub async fn get_chat_document_file_content(
+    State(state): State<AppState>,
+    Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
+    headers: HeaderMap,
+) -> Result<Response, ServerError> {
+    require_chat(&state, chat_id).await?;
+    serve_document_file_content(&state, document_id, Some(chat_id), None, &headers).await
+}
+
+async fn serve_document_file_content(
+    state: &AppState,
+    document_id: DocumentId,
+    chat_id: Option<ChatId>,
+    project_id: Option<ProjectId>,
+    headers: &HeaderMap,
+) -> Result<Response, ServerError> {
+    let Some(document) = state
+        .store
+        .get_document(document_id)
+        .await?
+        .filter(|document| document.chat_id == chat_id && document.project_id == project_id)
+    else {
+        return Err(ServerError::not_found(format!(
+            "document {document_id} not found"
+        )));
+    };
+    let Some(source_blob) = document.source_blob else {
+        return Err(ServerError::not_found(format!(
+            "original bytes for document {document_id} not found"
+        )));
+    };
+    let bytes = state.blobs.get(source_blob.id).await?.ok_or_else(|| {
+        ServerError::internal(format!(
+            "original bytes for document {document_id} are missing from blob storage"
+        ))
+    })?;
+    let actual_len = u64::try_from(bytes.len())
+        .map_err(|_| ServerError::internal("document byte length exceeds u64"))?;
+    if actual_len != source_blob.byte_len {
+        return Err(ServerError::internal(format!(
+            "original byte length for document {document_id} does not match its descriptor"
+        )));
+    }
+    let content_type = HeaderValue::from_str(&document.media_type).map_err(|_| {
+        ServerError::internal(format!(
+            "document {document_id} has an invalid stored media type"
+        ))
+    })?;
+
+    let requested_range = match requested_byte_range(headers, actual_len) {
+        Ok(range) => range,
+        Err(()) => return Ok(range_not_satisfiable_response(actual_len)),
+    };
+    let (status, content_range, body) = match requested_range {
+        Some(range) => {
+            let start = usize::try_from(range.start)
+                .map_err(|_| ServerError::internal("document range start exceeds usize"))?;
+            let end_exclusive = usize::try_from(range.end_inclusive + 1)
+                .map_err(|_| ServerError::internal("document range end exceeds usize"))?;
+            (
+                StatusCode::PARTIAL_CONTENT,
+                Some(format!(
+                    "bytes {}-{}/{}",
+                    range.start, range.end_inclusive, actual_len
+                )),
+                bytes[start..end_exclusive].to_vec(),
+            )
+        }
+        None => (StatusCode::OK, None, bytes),
+    };
+
+    let mut response = Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::ACCEPT_RANGES, "bytes")
+        .header(header::CONTENT_LENGTH, body.len().to_string());
+    if let Some(content_range) = content_range {
+        response = response.header(header::CONTENT_RANGE, content_range);
+    }
+    response
+        .body(Body::from(body))
+        .map_err(|error| {
+            ServerError::internal(format!("failed to build document response: {error}"))
+        })
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ByteRange {
+    start: u64,
+    end_inclusive: u64,
+}
+
+fn requested_byte_range(
+    headers: &HeaderMap,
+    full_len: u64,
+) -> Result<Option<ByteRange>, ()> {
+    // This route does not expose an HTTP validator in this slice. Treat
+    // conditional ranges as a request for the complete representation so a
+    // stale validator can never produce bytes from the wrong generation.
+    if headers.contains_key(header::IF_RANGE) {
+        return Ok(None);
+    }
+    let mut values = headers.get_all(header::RANGE).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    if values.next().is_some() {
+        return Err(());
+    }
+    let value = value.to_str().map_err(|_| ())?.trim();
+    let (unit, range) = value.split_once('=').ok_or(())?;
+    if !unit.trim().eq_ignore_ascii_case("bytes") || range.contains(',') {
+        return Err(());
+    }
+    let (start, end) = range.trim().split_once('-').ok_or(())?;
+    if start.is_empty() {
+        let suffix_len = end.parse::<u64>().map_err(|_| ())?;
+        if suffix_len == 0 || full_len == 0 {
+            return Err(());
+        }
+        return Ok(Some(ByteRange {
+            start: full_len.saturating_sub(suffix_len),
+            end_inclusive: full_len - 1,
+        }));
+    }
+
+    let start = start.parse::<u64>().map_err(|_| ())?;
+    if start >= full_len {
+        return Err(());
+    }
+    let end_inclusive = if end.is_empty() {
+        full_len - 1
+    } else {
+        let requested_end = end.parse::<u64>().map_err(|_| ())?;
+        if requested_end < start {
+            return Err(());
+        }
+        requested_end.min(full_len - 1)
+    };
+    Ok(Some(ByteRange {
+        start,
+        end_inclusive,
+    }))
+}
+
+fn range_not_satisfiable_response(full_len: u64) -> Response {
+    Response::builder()
+        .status(StatusCode::RANGE_NOT_SATISFIABLE)
+        .header(header::ACCEPT_RANGES, "bytes")
+        .header(header::CONTENT_RANGE, format!("bytes */{full_len}"))
+        .header(header::CONTENT_LENGTH, "0")
+        .body(Body::empty())
+        .expect("fixed range response headers are valid")
+}
+
+#[cfg(test)]
+mod byte_range_tests {
+    use super::*;
+
+    fn parse(value: &str, full_len: u64) -> Result<Option<ByteRange>, ()> {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::RANGE, HeaderValue::from_str(value).unwrap());
+        requested_byte_range(&headers, full_len)
+    }
+
+    #[test]
+    fn parses_bounded_open_ended_and_suffix_ranges() {
+        assert_eq!(
+            parse("bytes=2-5", 10),
+            Ok(Some(ByteRange {
+                start: 2,
+                end_inclusive: 5,
+            }))
+        );
+        assert_eq!(
+            parse("bytes=7-", 10),
+            Ok(Some(ByteRange {
+                start: 7,
+                end_inclusive: 9,
+            }))
+        );
+        assert_eq!(
+            parse("bytes=-3", 10),
+            Ok(Some(ByteRange {
+                start: 7,
+                end_inclusive: 9,
+            }))
+        );
+        assert_eq!(
+            parse("bytes=8-99", 10),
+            Ok(Some(ByteRange {
+                start: 8,
+                end_inclusive: 9,
+            }))
+        );
+        assert_eq!(
+            parse("bytes=-99", 10),
+            Ok(Some(ByteRange {
+                start: 0,
+                end_inclusive: 9,
+            }))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_unsatisfiable_and_multi_ranges() {
+        for value in [
+            "bytes=10-",
+            "bytes=5-2",
+            "bytes=-0",
+            "bytes=",
+            "bytes=one-two",
+            "items=0-1",
+            "bytes=0-1,3-4",
+        ] {
+            assert_eq!(parse(value, 10), Err(()), "{value}");
+        }
+        assert_eq!(parse("bytes=0-", 0), Err(()));
+    }
+
+    #[test]
+    fn ignores_range_when_if_range_cannot_be_validated() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::RANGE, HeaderValue::from_static("bytes=2-5"));
+        headers.insert(header::IF_RANGE, HeaderValue::from_static("\"old-etag\""));
+        assert_eq!(requested_byte_range(&headers, 10), Ok(None));
+    }
 }
 
 /// `DELETE /documents/{id}` — atomically delete authoritative source/jobs and

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -4659,16 +4659,9 @@ async fn document_file_content_supports_full_head_and_single_range_responses() {
     );
 
     assert_eq!(
-        request_document_file_content(
-            &router,
-            axum::http::Method::GET,
-            &uri,
-            None,
-            None,
-            None,
-        )
-        .await
-        .status(),
+        request_document_file_content(&router, axum::http::Method::GET, &uri, None, None, None,)
+            .await
+            .status(),
         StatusCode::UNAUTHORIZED
     );
 
@@ -4779,9 +4772,7 @@ async fn document_file_content_supports_full_head_and_single_range_responses() {
             "{range}"
         );
         assert_eq!(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap(),
+            to_bytes(response.into_body(), usize::MAX).await.unwrap(),
             expected,
             "{range}"
         );
@@ -4799,9 +4790,7 @@ async fn document_file_content_supports_full_head_and_single_range_responses() {
     assert_eq!(conditional.status(), StatusCode::OK);
     assert!(conditional.headers().get(header::CONTENT_RANGE).is_none());
     assert_eq!(
-        to_bytes(conditional.into_body(), usize::MAX)
-            .await
-            .unwrap(),
+        to_bytes(conditional.into_body(), usize::MAX).await.unwrap(),
         raw.as_slice()
     );
 
@@ -4896,7 +4885,10 @@ async fn document_file_content_preserves_document_scope_before_blob_access() {
             "/projects/{}/documents/{project_document_id}/file-content",
             other_project.id
         ),
-        format!("/chats/{}/documents/{project_document_id}/file-content", chat.id),
+        format!(
+            "/chats/{}/documents/{project_document_id}/file-content",
+            chat.id
+        ),
     ] {
         assert_eq!(
             request_document_file_content(

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -4612,6 +4612,412 @@ async fn post_raw(
         .unwrap()
 }
 
+async fn request_document_file_content(
+    router: &Router,
+    method: axum::http::Method,
+    uri: &str,
+    bearer: Option<&str>,
+    range: Option<&str>,
+    if_range: Option<&str>,
+) -> axum::response::Response {
+    let mut request = Request::builder().method(method).uri(uri);
+    if let Some(bearer) = bearer {
+        request = request.header(header::AUTHORIZATION, bearer);
+    }
+    if let Some(range) = range {
+        request = request.header(header::RANGE, range);
+    }
+    if let Some(if_range) = if_range {
+        request = request.header(header::IF_RANGE, if_range);
+    }
+    router
+        .clone()
+        .oneshot(request.body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn document_file_content_supports_full_head_and_single_range_responses() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let raw = b"0123456789".to_vec();
+    let accepted: serde_json::Value = json_body(
+        post_raw(
+            &router,
+            &bearer,
+            "/documents/raw?title=sample.pdf",
+            Some("application/pdf"),
+            raw.clone(),
+        )
+        .await,
+    )
+    .await;
+    let uri = format!(
+        "/documents/{}/file-content",
+        accepted["document_id"].as_str().unwrap()
+    );
+
+    assert_eq!(
+        request_document_file_content(
+            &router,
+            axum::http::Method::GET,
+            &uri,
+            None,
+            None,
+            None,
+        )
+        .await
+        .status(),
+        StatusCode::UNAUTHORIZED
+    );
+
+    let full = request_document_file_content(
+        &router,
+        axum::http::Method::GET,
+        &uri,
+        Some(&bearer),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(full.status(), StatusCode::OK);
+    assert_eq!(
+        full.headers()
+            .get(header::CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "application/pdf"
+    );
+    assert_eq!(
+        full.headers()
+            .get(header::CONTENT_LENGTH)
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "10"
+    );
+    assert_eq!(
+        full.headers()
+            .get(header::ACCEPT_RANGES)
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "bytes"
+    );
+    assert_eq!(
+        to_bytes(full.into_body(), usize::MAX).await.unwrap(),
+        raw.as_slice()
+    );
+
+    let head = request_document_file_content(
+        &router,
+        axum::http::Method::HEAD,
+        &uri,
+        Some(&bearer),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(head.status(), StatusCode::OK);
+    assert_eq!(
+        head.headers()
+            .get(header::CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "application/pdf"
+    );
+    assert_eq!(
+        head.headers()
+            .get(header::CONTENT_LENGTH)
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "10"
+    );
+    assert!(to_bytes(head.into_body(), usize::MAX)
+        .await
+        .unwrap()
+        .is_empty());
+
+    for (range, expected_range, expected) in [
+        ("bytes=2-5", "bytes 2-5/10", &b"2345"[..]),
+        ("bytes=7-", "bytes 7-9/10", &b"789"[..]),
+        ("bytes=-3", "bytes 7-9/10", &b"789"[..]),
+        ("bytes=8-99", "bytes 8-9/10", &b"89"[..]),
+    ] {
+        let response = request_document_file_content(
+            &router,
+            axum::http::Method::GET,
+            &uri,
+            Some(&bearer),
+            Some(range),
+            None,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT, "{range}");
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_RANGE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            expected_range,
+            "{range}"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_LENGTH)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            expected.len().to_string(),
+            "{range}"
+        );
+        assert_eq!(
+            to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+            expected,
+            "{range}"
+        );
+    }
+
+    let conditional = request_document_file_content(
+        &router,
+        axum::http::Method::GET,
+        &uri,
+        Some(&bearer),
+        Some("bytes=2-5"),
+        Some("\"unsupported-validator\""),
+    )
+    .await;
+    assert_eq!(conditional.status(), StatusCode::OK);
+    assert!(conditional.headers().get(header::CONTENT_RANGE).is_none());
+    assert_eq!(
+        to_bytes(conditional.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        raw.as_slice()
+    );
+
+    for range in [
+        "bytes=10-",
+        "bytes=5-2",
+        "bytes=-0",
+        "bytes=0-1,3-4",
+        "items=0-1",
+        "malformed",
+    ] {
+        let response = request_document_file_content(
+            &router,
+            axum::http::Method::GET,
+            &uri,
+            Some(&bearer),
+            Some(range),
+            None,
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::RANGE_NOT_SATISFIABLE,
+            "{range}"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_RANGE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "bytes */10",
+            "{range}"
+        );
+        assert!(to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+}
+
+#[tokio::test]
+async fn document_file_content_preserves_document_scope_before_blob_access() {
+    let (router, token, store, dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let project = make_project(&router, &bearer).await;
+    let other_project = make_project(&router, &bearer).await;
+    let chat = make_chat(&router, &bearer).await;
+    let other_chat = make_chat(&router, &bearer).await;
+
+    let project_document: serde_json::Value = json_body(
+        post_raw(
+            &router,
+            &bearer,
+            &format!("/projects/{}/documents/raw", project.id),
+            Some("text/plain"),
+            b"project original".to_vec(),
+        )
+        .await,
+    )
+    .await;
+    let project_document_id: openwave_core::DocumentId = project_document["document_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    let project_uri = format!(
+        "/projects/{}/documents/{project_document_id}/file-content",
+        project.id
+    );
+    let project_response = request_document_file_content(
+        &router,
+        axum::http::Method::GET,
+        &project_uri,
+        Some(&bearer),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(project_response.status(), StatusCode::OK);
+    assert_eq!(
+        to_bytes(project_response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        &b"project original"[..]
+    );
+
+    for uri in [
+        format!("/documents/{project_document_id}/file-content"),
+        format!(
+            "/projects/{}/documents/{project_document_id}/file-content",
+            other_project.id
+        ),
+        format!("/chats/{}/documents/{project_document_id}/file-content", chat.id),
+    ] {
+        assert_eq!(
+            request_document_file_content(
+                &router,
+                axum::http::Method::GET,
+                &uri,
+                Some(&bearer),
+                None,
+                None,
+            )
+            .await
+            .status(),
+            StatusCode::NOT_FOUND,
+            "{uri}"
+        );
+    }
+
+    let chat_document: serde_json::Value = json_body(
+        post_raw(
+            &router,
+            &bearer,
+            &format!("/chats/{}/documents/raw", chat.id),
+            Some("text/markdown"),
+            b"# chat original".to_vec(),
+        )
+        .await,
+    )
+    .await;
+    let chat_document_id: openwave_core::DocumentId = chat_document["document_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    let chat_uri = format!(
+        "/chats/{}/documents/{chat_document_id}/file-content",
+        chat.id
+    );
+    let chat_response = request_document_file_content(
+        &router,
+        axum::http::Method::GET,
+        &chat_uri,
+        Some(&bearer),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(chat_response.status(), StatusCode::OK);
+    assert_eq!(
+        to_bytes(chat_response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+        &b"# chat original"[..]
+    );
+    assert_eq!(
+        request_document_file_content(
+            &router,
+            axum::http::Method::GET,
+            &format!(
+                "/chats/{}/documents/{chat_document_id}/file-content",
+                other_chat.id
+            ),
+            Some(&bearer),
+            None,
+            None,
+        )
+        .await
+        .status(),
+        StatusCode::NOT_FOUND
+    );
+
+    let source_blob = store
+        .get_document(project_document_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .source_blob
+        .unwrap();
+    openwave_core::FsBlobStore::new(dir.path().join("blobs"))
+        .delete(source_blob.id)
+        .unwrap();
+    assert_eq!(
+        request_document_file_content(
+            &router,
+            axum::http::Method::GET,
+            &project_uri,
+            None,
+            None,
+            None,
+        )
+        .await
+        .status(),
+        StatusCode::UNAUTHORIZED
+    );
+    assert_eq!(
+        request_document_file_content(
+            &router,
+            axum::http::Method::GET,
+            &format!("/documents/{project_document_id}/file-content"),
+            Some(&bearer),
+            None,
+            None,
+        )
+        .await
+        .status(),
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        request_document_file_content(
+            &router,
+            axum::http::Method::GET,
+            &project_uri,
+            Some(&bearer),
+            None,
+            None,
+        )
+        .await
+        .status(),
+        StatusCode::INTERNAL_SERVER_ERROR
+    );
+}
+
 #[tokio::test]
 async fn raw_ingest_retains_exact_bytes_and_runs_the_async_pipeline() {
     let (router, token, store, dir, worker) = test_app_with_worker().await;
@@ -12550,7 +12956,7 @@ async fn cors_preflight_allows_localhost_origin() {
         .header(reqwest::header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
         .header(
             reqwest::header::ACCESS_CONTROL_REQUEST_HEADERS,
-            "authorization",
+            "authorization,range,if-range",
         )
         .send()
         .await
@@ -12561,6 +12967,19 @@ async fn cors_preflight_allows_localhost_origin() {
         .get(reqwest::header::ACCESS_CONTROL_ALLOW_ORIGIN)
         .and_then(|v| v.to_str().ok());
     assert_eq!(allow_origin, Some("http://localhost:1420"));
+    let allow_headers = preflight
+        .headers()
+        .get(reqwest::header::ACCESS_CONTROL_ALLOW_HEADERS)
+        .and_then(|value| value.to_str().ok())
+        .unwrap();
+    for expected in ["authorization", "range", "if-range"] {
+        assert!(
+            allow_headers
+                .split(',')
+                .any(|header| header.trim().eq_ignore_ascii_case(expected)),
+            "missing {expected} in {allow_headers}"
+        );
+    }
 }
 
 // --- WebSocket event stream ---


### PR DESCRIPTION
## Summary

- add bearer-protected GET/HEAD `file-content` routes for unscoped, project, and chat documents
- enforce exact document scope before opening blob storage
- return content type, length, and byte-range headers
- support bounded, open-ended, suffix, and clamped single ranges with correct 206/416 behavior
- expose range headers through CORS and allow bundled/blob PDF workers in the desktop CSP

## Alpha cross-reference

Alpha's permission-checked document content route establishes the access boundary and route naming. OpenWave keeps its three explicit corpus scopes instead of copying Alpha's ACL decorator, and adds the byte-range behavior required by this issue because Alpha currently has no equivalent.

## Known limitation

The current `BlobStore::get` API materializes the complete blob before the handler slices a requested range. This bounds renderer/network reads, but not server memory or storage I/O. Follow-up #579 defines the BlobStore-level streaming/ranged-read work and regression criteria.

## Validation

- `bw --repo-root "$PWD" dev lint --rust --check`
- `cargo test --locked -p openwave-server`
- 354 server tests passed on current `origin/main`

Closes #542
