### PR TITLE
test(desktop): update refusal fixtures for generated wire

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -181,6 +181,7 @@ describe("terminal transcript presentation", () => {
           role: "assistant",
           content: "",
           created_at: "2026-07-19T10:00:00Z",
+          citations: [],
           refusal: { category: "cyber", partial_output: false },
         },
         {
@@ -188,6 +189,7 @@ describe("terminal transcript presentation", () => {
           role: "assistant",
           content: "Visible partial",
           created_at: "2026-07-19T10:01:00Z",
+          citations: [],
           refusal: { category: "general_harms", partial_output: true },
         },
       ],


### PR DESCRIPTION
## Summary

- add the now-required empty `citations` field to the two refusal transcript fixtures
- restore the final merged-main TypeScript build after #575 and #580 landed independently

This is a generated-wire compatibility fix only; it does not change product behavior or introduce any divergence from Alpha.

## Validation

- `pnpm build`
- `pnpm test` — 62 files / 456 tests passed
