### PR TITLE
docs: say that tests have to earn their build time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,45 @@ agent sessions can see where things stand without reading commit logs.
 - **Bump versions deliberately.** Dependabot edits the pin in its own PR; that's
   the intended upgrade path, not `cargo update` / `pnpm update` drift.
 
+## Tests earn their place or come out
+
+Build time is a first-class cost here — the workspace is large and the Rust lanes
+dominate CI. A test that would never change what we do is not free; it is paid
+for on every build, by everyone, forever. Write fewer, better tests.
+
+The bar for adding one: **would this failing tell us something we'd act on?**
+
+Worth writing, and worth defending in review:
+
+- **Contracts that cross a boundary** — wire types, persisted shapes, migration
+  compatibility. Breaking these silently is expensive to discover.
+- **Decisions that are easy to reverse by accident** — the model registry's
+  honesty invariants, the guard that no model advertises image input before the
+  path carries it, the check that the default model is curated and current.
+- **Reproductions of bugs we actually hit.** These are the highest-value tests
+  in the repo.
+- **Behavior, driven end to end.** One test that runs a real turn and reads the
+  journal beats ten that assert on intermediate structs.
+
+Not worth writing, and fair game to delete on sight:
+
+- Tests that assert the code *exists* — constructing a struct and reading its
+  fields back, or checking a constant equals itself.
+- Duplicate coverage: several tests walking one path with cosmetically different
+  inputs. Keep the one that best localizes a regression.
+- Assertions pinned to internals that break on every refactor without ever
+  catching a defect. These tax exactly the changes we want to be cheap.
+- Over-specified assertions — matching a whole serialized payload when the test
+  is about one field. They fail for unrelated reasons and train people to update
+  expectations without reading them.
+- Setup-heavy tests whose assertion is trivial next to the scaffolding.
+
+When you delete tests, justify each one in the PR body in a line. "Removed 14
+tests" is not reviewable; "removed 14 that re-asserted serde round-tripping
+already covered by the wire-type fixtures" is.
+
+Coverage percentage is not a goal and is not tracked. Confidence is.
+
 ## Verify locally — CI does not cover every change
 
 CI has a change-scope gate that **skips** the heavy Rust build/test/clippy lanes


### PR DESCRIPTION
`CLAUDE.md` told agents how to run the suite but never what belongs in it. The result is visible: `crates/openwave-server/src/tests.rs` is 13,101 lines holding 111 test functions, with no stated bar for entry.

That has a cost we can now put a number on. Measured today (#586): CI's `test` lane is 591s and `clippy` is 461s, the workspace pulls 683 crates, and a `target/` directory reaches 35GB. A test that would never change what we do is not free — it is paid for on every build, by everyone, forever.

So write down the bar: **would this failing tell us something we'd act on?**

Then the two lists that follow from it. Worth writing — contracts that cross a boundary (wire types, persisted shapes, migration compatibility), invariants that are easy to reverse by accident (the registry's honesty guards, the default-model check), reproductions of bugs we actually hit, and behavior driven end to end. Not worth writing — existence checks, duplicate coverage of one path, assertions pinned to internals that break on every refactor, whole-payload matches when the test is about one field, and setup-heavy tests with trivial assertions.

It also asks that deletions be justified per-test in the PR body, so a pruning pass stays reviewable instead of arriving as a bare count. And it states plainly that coverage percentage is not a goal and is not tracked — confidence is.

Docs-only, so CI's change-scope gate will skip the Rust lanes by design.

Companion to #590, which does the first pruning pass under this policy.