### PR TITLE
fix(core): restore a clean clippy run on main

### DIFF
--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -117,7 +117,8 @@ pub(in crate::db) async fn complete_refused_turn_run_with_citations_and_append_e
     usage: Usage,
     refusal: RefusalOutcome,
 ) -> Result<Option<JournaledTurnOutcome<CompleteTurnRunOutcome>>> {
-    if refusal.partial_output() != !output.content.is_empty() {
+    let carries_output = !output.content.is_empty();
+    if refusal.partial_output() != carries_output {
         return Err(AgentError::Store(format!(
             "turn {id} refusal partial-output metadata does not match its assistant output"
         )));


### PR DESCRIPTION
`main` currently fails the lint gate. `cargo clippy --workspace --all-targets --locked -- -D warnings` — the command `CONTRIBUTING.md` tells everyone to run before opening a PR — errors on:

```
crates/openwave-core/src/db/ops/turn/resolution.rs:120
    if refusal.partial_output() != !output.content.is_empty() {
       ^^^^^^^ this boolean expression can be simplified [clippy::nonminimal_bool]
```

It arrived with the refusal work in #580. I hit it while running the gate on an unrelated branch, which is the expensive part: every branch cut from `main` inherits a red clippy and has to spend time working out the failure is not theirs.

Clippy's literal suggestion is `partial_output() == output.content.is_empty()`. That is minimal but reads backwards — the invariant being checked is that the refusal's partial-output flag *agrees with whether output was actually carried*, and comparing against emptiness inverts that at a glance. Naming the negated side keeps the intent legible and satisfies the lint:

```rust
let carries_output = !output.content.is_empty();
if refusal.partial_output() != carries_output {
```

No behavior change.

## Worth a follow-up

#580 merged with this in it, which means the clippy lane did not gate it — either the change-scope filter skipped the lane or the roll-up did not require it. That is the same class of gap `CLAUDE.md` already warns about ("a green PR page is not proof the code compiles"), and it is worth understanding separately from this fix.