### PR TITLE
feat(models): carry the reasoning-effort levels providers actually accept

### DIFF
--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -452,6 +452,61 @@ async fn set_chat_model_updates_then_clears() {
 }
 
 #[tokio::test]
+async fn chats_stored_before_the_effort_scale_widened_still_load() {
+    let (_dir, store) = temp_store().await;
+    // Written the way a release before `none`/`xhigh`/`max` existed wrote them:
+    // straight into the column, with no chance to migrate the token.
+    for (stored, expected) in [
+        ("low", Some(ReasoningEffort::Low)),
+        ("medium", Some(ReasoningEffort::Medium)),
+        ("high", Some(ReasoningEffort::High)),
+        // A token this build does not recognize is dropped, not fatal — the
+        // chat still opens on the provider default.
+        ("aggressive", None),
+    ] {
+        let chat = sample_chat();
+        entities::chat::ActiveModel {
+            id: Set(chat.id.0),
+            project_id: Set(None),
+            title: Set(chat.title.clone()),
+            model: Set(None),
+            reasoning_effort: Set(Some(stored.to_owned())),
+            attachment_revision: Set(0),
+            created_at: Set(chat.created_at),
+        }
+        .insert(&store.conn)
+        .await
+        .unwrap();
+        assert_eq!(
+            store
+                .get_chat(chat.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .reasoning_effort,
+            expected,
+            "stored effort {stored} no longer loads"
+        );
+    }
+
+    // Every level this build can write reads back as itself.
+    for effort in ReasoningEffort::ALL {
+        let mut chat = sample_chat();
+        chat.reasoning_effort = Some(*effort);
+        store.create_chat(&chat).await.unwrap();
+        assert_eq!(
+            store
+                .get_chat(chat.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .reasoning_effort,
+            Some(*effort)
+        );
+    }
+}
+
+#[tokio::test]
 async fn list_projects_is_newest_first() {
     let (_dir, store) = temp_store().await;
     let mut older = sample_project();

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1104,28 +1104,63 @@ pub enum Role {
 
 /// How hard a reasoning-capable model should think before answering.
 ///
-/// A hint honored only by providers whose models expose it (OpenAI's o-series);
-/// other providers ignore it. Persisted per chat and threaded into the model
-/// request for each turn.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+/// The scale runs from [`Self::None`] to [`Self::Max`] and the ordering is the
+/// scale itself, not an implementation detail: comparisons and
+/// [`Self::clamp_to`] rely on it.
+///
+/// No model accepts the whole scale. `none` is an OpenAI level that the Claude
+/// family rejects, `max` is missing from several rows on both routes, and some
+/// models take no effort control at all. A model's accepted levels live on its
+/// registry entry; a stored choice is mapped onto them with [`Self::clamp_to`]
+/// before a request is built.
+///
+/// Persisted per chat as the token from [`Self::as_str`] and threaded into the
+/// model request for each turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
+    /// Answer without spending reasoning tokens at all.
+    ///
+    /// Distinct from an absent override, which leaves the provider's own
+    /// default in force.
+    None,
     /// Minimize reasoning tokens for the fastest, cheapest response.
     Low,
     /// The provider's balanced default.
     Medium,
     /// Spend more reasoning tokens for harder problems.
     High,
+    /// Above `High`: the level recommended for coding and agentic work.
+    #[serde(rename = "xhigh")]
+    XHigh,
+    /// The most reasoning a model will do, at the highest latency and cost.
+    Max,
 }
 
 impl ReasoningEffort {
+    /// Every level, in ascending order.
+    pub const ALL: &'static [Self] = &[
+        Self::None,
+        Self::Low,
+        Self::Medium,
+        Self::High,
+        Self::XHigh,
+        Self::Max,
+    ];
+
     /// The wire/storage token for this effort level.
+    ///
+    /// Providers spell the level above `high` as one word, so this is not the
+    /// `snake_case` rendering of the variant name.
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::None => "none",
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
+            Self::XHigh => "xhigh",
+            Self::Max => "max",
         }
     }
 
@@ -1136,12 +1171,32 @@ impl ReasoningEffort {
     #[must_use]
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(value: &str) -> Option<Self> {
-        match value {
-            "low" => Some(Self::Low),
-            "medium" => Some(Self::Medium),
-            "high" => Some(Self::High),
-            _ => None,
-        }
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|level| level.as_str() == value)
+    }
+
+    /// The level to actually send to a model that accepts only `supported`.
+    ///
+    /// A chat's effort outlives the model it was chosen for: switching the chat
+    /// to a narrower model, or a provider retiring a level, both leave a stored
+    /// choice the model would reject. Rather than fail a turn on a hint, the
+    /// request degrades to the closest level the model does take — the highest
+    /// at or below the request, or the model's lowest when the request sits
+    /// under its whole range. That matches the degradation Anthropic documents
+    /// for `xhigh` on models without it.
+    ///
+    /// A model that accepts no levels yields `None`, and the parameter is left
+    /// off the request entirely.
+    #[must_use]
+    pub fn clamp_to(self, supported: &[Self]) -> Option<Self> {
+        supported
+            .iter()
+            .copied()
+            .filter(|level| *level <= self)
+            .max()
+            .or_else(|| supported.iter().copied().min())
     }
 }
 
@@ -2465,6 +2520,93 @@ impl ToolCallRecord {
 mod tests {
     use super::*;
     use std::num::NonZeroU32;
+
+    #[test]
+    fn reasoning_effort_tokens_round_trip_and_keep_the_original_three() {
+        for level in ReasoningEffort::ALL {
+            assert_eq!(ReasoningEffort::from_str(level.as_str()), Some(*level));
+            assert_eq!(
+                serde_json::to_string(level).unwrap(),
+                format!("\"{}\"", level.as_str())
+            );
+            assert_eq!(
+                serde_json::from_str::<ReasoningEffort>(&format!("\"{}\"", level.as_str()))
+                    .unwrap(),
+                *level
+            );
+        }
+        // The three levels that shipped before the scale widened are stored in
+        // chat rows and must keep parsing to the same variants.
+        assert_eq!(ReasoningEffort::from_str("low"), Some(ReasoningEffort::Low));
+        assert_eq!(
+            ReasoningEffort::from_str("medium"),
+            Some(ReasoningEffort::Medium)
+        );
+        assert_eq!(
+            ReasoningEffort::from_str("high"),
+            Some(ReasoningEffort::High)
+        );
+        // The level above `high` is one word on the wire, not the snake_case
+        // rendering of its variant name.
+        assert_eq!(ReasoningEffort::XHigh.as_str(), "xhigh");
+        assert!(ReasoningEffort::from_str("x_high").is_none());
+        assert!(ReasoningEffort::from_str("").is_none());
+        assert!(ReasoningEffort::from_str("HIGH").is_none());
+    }
+
+    #[test]
+    fn reasoning_effort_orders_from_none_to_max() {
+        assert!(ReasoningEffort::ALL
+            .windows(2)
+            .all(|pair| pair[0] < pair[1]));
+        assert_eq!(ReasoningEffort::ALL.first(), Some(&ReasoningEffort::None));
+        assert_eq!(ReasoningEffort::ALL.last(), Some(&ReasoningEffort::Max));
+    }
+
+    #[test]
+    fn an_unsupported_effort_degrades_to_the_closest_level_the_model_takes() {
+        let anthropic = &[
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::XHigh,
+            ReasoningEffort::Max,
+        ];
+        let no_max = &[
+            ReasoningEffort::None,
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::XHigh,
+        ];
+        let classic = &[
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+        ];
+
+        // A supported level passes through untouched.
+        for level in anthropic {
+            assert_eq!(level.clamp_to(anthropic), Some(*level));
+        }
+        // Above the range: down to the highest level on offer.
+        assert_eq!(
+            ReasoningEffort::Max.clamp_to(no_max),
+            Some(ReasoningEffort::XHigh)
+        );
+        assert_eq!(
+            ReasoningEffort::XHigh.clamp_to(classic),
+            Some(ReasoningEffort::High)
+        );
+        // Below the range: up to the lowest level on offer, because a model
+        // that reasons at all cannot be told to stop.
+        assert_eq!(
+            ReasoningEffort::None.clamp_to(anthropic),
+            Some(ReasoningEffort::Low)
+        );
+        // No control at all: the parameter is dropped.
+        assert_eq!(ReasoningEffort::High.clamp_to(&[]), None);
+    }
 
     #[test]
     fn document_processing_enums_have_stable_snake_case_values() {

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -312,6 +312,10 @@ export function ChatRoute({ chatId }: { chatId: string }) {
 
   function renderPanel(panel: PanelContent, position: "left" | "right" | "chat", visible: boolean) {
     if (panel.type === "chat") {
+      // Only the levels the selected model accepts are offerable, and a model
+      // that accepts none gets no selector at all.
+      const efforts =
+        modelForSelection(models, chat!.model)?.reasoning_efforts ?? [];
       return (
         <TranscriptVisibilityProvider value={visible}>
           <ChatView
@@ -346,8 +350,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
                   disabled={deletingChatId !== null}
                   onChange={onModelChange}
                 />
-                {modelForSelection(models, chat!.model)?.supports_reasoning_effort && (
+                {efforts.length > 0 && (
                   <ReasoningEffortMenu
+                    levels={efforts}
                     value={chat!.reasoning_effort}
                     disabled={deletingChatId !== null}
                     onChange={onReasoningEffortChange}

--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -6,6 +6,7 @@ import {
   ProviderIcon,
   ReasoningEffortMenu,
   formatContextWindow,
+  reasoningEffortOptions,
 } from "./ModelMenu";
 import type { ModelInfo } from "./api";
 
@@ -19,7 +20,7 @@ const MODELS: ModelInfo[] = [
     max_output_tokens: 64_000,
     input_modalities: ["text", "image"],
     supports_reasoning: true,
-    supports_reasoning_effort: true,
+    reasoning_efforts: ["low", "medium", "high", "xhigh", "max"],
     multimodal: true,
     available: true,
   },
@@ -32,7 +33,7 @@ const MODELS: ModelInfo[] = [
     max_output_tokens: 16_384,
     input_modalities: ["text", "image"],
     supports_reasoning: false,
-    supports_reasoning_effort: false,
+    reasoning_efforts: [],
     multimodal: true,
     available: true,
   },
@@ -126,10 +127,43 @@ describe("ModelCapabilities", () => {
   });
 });
 
+describe("reasoningEffortOptions", () => {
+  it("offers exactly the levels the model accepts, in scale order", () => {
+    expect(
+      reasoningEffortOptions(["high", "low", "xhigh", "medium", "max"]).map(
+        (option) => option.value,
+      ),
+    ).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    // The GPT-5 line adds an off level; generations before 5.6 stop at xhigh.
+    expect(
+      reasoningEffortOptions(["none", "low", "medium", "high", "xhigh"]).map(
+        (option) => option.value,
+      ),
+    ).toEqual(["none", "low", "medium", "high", "xhigh"]);
+    expect(reasoningEffortOptions([])).toEqual([]);
+  });
+
+  it("drops a level this build cannot label", () => {
+    expect(
+      reasoningEffortOptions([
+        "low",
+        "ultra" as never,
+        "max",
+      ]).map((option) => option.value),
+    ).toEqual(["low", "max"]);
+  });
+
+  it("labels the off level as Off, distinct from the menu's Default entry", () => {
+    expect(reasoningEffortOptions(["none"])[0].label).toBe("Off");
+  });
+});
+
 describe("ReasoningEffortMenu", () => {
+  const LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+
   it("labels the trigger 'Default' when no effort is set", () => {
     const markup = renderToStaticMarkup(
-      <ReasoningEffortMenu value={null} onChange={() => {}} />,
+      <ReasoningEffortMenu levels={LEVELS} value={null} onChange={() => {}} />,
     );
     expect(markup).toContain('aria-label="Reasoning effort: Default"');
     expect(markup).toContain(">Default<");
@@ -137,15 +171,38 @@ describe("ReasoningEffortMenu", () => {
 
   it("labels the trigger with the selected effort level", () => {
     const markup = renderToStaticMarkup(
-      <ReasoningEffortMenu value="high" onChange={() => {}} />,
+      <ReasoningEffortMenu levels={LEVELS} value="high" onChange={() => {}} />,
     );
     expect(markup).toContain('aria-label="Reasoning effort: High"');
     expect(markup).toContain(">High<");
   });
 
+  it("labels a level above high without falling back to its wire token", () => {
+    const markup = renderToStaticMarkup(
+      <ReasoningEffortMenu levels={LEVELS} value="xhigh" onChange={() => {}} />,
+    );
+    expect(markup).toContain('aria-label="Reasoning effort: Extra High"');
+  });
+
+  it("still labels a stored level the current model no longer accepts", () => {
+    const markup = renderToStaticMarkup(
+      <ReasoningEffortMenu
+        levels={["none", "low", "medium", "high", "xhigh"]}
+        value="max"
+        onChange={() => {}}
+      />,
+    );
+    expect(markup).toContain('aria-label="Reasoning effort: Max"');
+  });
+
   it("disables the trigger when asked", () => {
     const markup = renderToStaticMarkup(
-      <ReasoningEffortMenu value={null} disabled onChange={() => {}} />,
+      <ReasoningEffortMenu
+        levels={LEVELS}
+        value={null}
+        disabled
+        onChange={() => {}}
+      />,
     );
     expect(markup).toContain("disabled");
   });

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -85,7 +85,7 @@ export function ModelCapabilities({ model }: { model: ModelInfo }) {
       {model.multimodal && (
         <ImageIcon size={12} aria-label="Accepts image input" />
       )}
-      {model.supports_reasoning_effort && (
+      {model.reasoning_efforts.length > 0 && (
         <Brain size={12} aria-label="Adjustable reasoning effort" />
       )}
     </div>
@@ -199,33 +199,64 @@ export function ModelMenu({
   );
 }
 
-/** The effort levels offered by the picker, in ascending order. */
-const REASONING_EFFORT_OPTIONS: { value: ReasoningEffort; label: string }[] = [
+/**
+ * Every effort level in ascending order, with its menu label.
+ *
+ * "Off" rather than "None" for the lowest level, because the menu already has
+ * a "Default" entry: one means "do not reason", the other means "leave the
+ * provider's own default alone".
+ */
+const REASONING_EFFORT_SCALE: { value: ReasoningEffort; label: string }[] = [
+  { value: "none", label: "Off" },
   { value: "low", label: "Low" },
   { value: "medium", label: "Medium" },
   { value: "high", label: "High" },
+  { value: "xhigh", label: "Extra High" },
+  { value: "max", label: "Max" },
 ];
 
 const REASONING_EFFORT_LABELS: Record<ReasoningEffort, string> =
   Object.fromEntries(
-    REASONING_EFFORT_OPTIONS.map((option) => [option.value, option.label]),
+    REASONING_EFFORT_SCALE.map((option) => [option.value, option.label]),
   ) as Record<ReasoningEffort, string>;
 
 /**
+ * The levels to offer for a model, ordered by the scale rather than by the
+ * order the server happened to send. Filtering against the known scale also
+ * drops a level a newer server knows about and this build does not, so the
+ * menu never offers an option it cannot label.
+ */
+export function reasoningEffortOptions(
+  accepted: readonly ReasoningEffort[],
+): { value: ReasoningEffort; label: string }[] {
+  return REASONING_EFFORT_SCALE.filter((option) =>
+    accepted.includes(option.value),
+  );
+}
+
+/**
  * Per-chat reasoning-effort selector, shown next to the model picker. `null`
- * means "use the provider default". The control is interactive only when the
- * chat's selected model advertises `supports_reasoning_effort`; the caller hides
- * it otherwise, since the field is inert for models without the capability.
+ * means "use the provider default".
+ *
+ * `levels` is the selected model's accepted range, and the menu offers exactly
+ * those, since no model takes the whole scale. The caller hides the control
+ * entirely when that range is empty. A level already stored on the chat still
+ * labels the trigger even when the current model does not accept it — the chat
+ * keeps its choice, and the server degrades it to the closest level the model
+ * does take rather than sending one the model would reject.
  */
 export function ReasoningEffortMenu({
+  levels,
   value,
   disabled,
   onChange,
 }: {
+  levels: readonly ReasoningEffort[];
   value: ReasoningEffort | null;
   disabled?: boolean;
   onChange: (effort: ReasoningEffort | null) => void | Promise<void>;
 }) {
+  const options = reasoningEffortOptions(levels);
   const label = value ? REASONING_EFFORT_LABELS[value] : "Default";
   return (
     <DropdownMenu>
@@ -256,7 +287,7 @@ export function ReasoningEffortMenu({
           {value === null && <Check className="ml-auto" />}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        {REASONING_EFFORT_OPTIONS.map((option) => {
+        {options.map((option) => {
           const selected = value === option.value;
           return (
             <DropdownMenuItem

--- a/crates/openwave-desktop/ui/src/ModelSelection.test.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.test.ts
@@ -12,7 +12,7 @@ const base = {
   max_output_tokens: 4_000,
   input_modalities: ["text"] as const,
   supports_reasoning: false,
-  supports_reasoning_effort: false,
+  reasoning_efforts: [],
   multimodal: false,
   available: true,
 };

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -331,9 +331,15 @@ input_modalities: Array<InputModality>,
  */
 supports_reasoning: boolean, 
 /**
- * Whether the model exposes a reasoning-effort control.
+ * The reasoning-effort levels this model accepts, ascending. Empty when
+ * the model exposes no effort control, which is what a client checks
+ * before offering the selector at all.
+ *
+ * Carries the enum rather than plain strings so the generated TypeScript
+ * is the same union a chat's stored effort has, and a client cannot offer
+ * a level it could not then set.
  */
-supports_reasoning_effort: boolean, 
+reasoning_efforts: Array<ReasoningEffort>, 
 /**
  * Whether the model accepts image input alongside text.
  */
@@ -434,11 +440,20 @@ export type ProviderKind = "anthropic" | "openai" | "openai_compatible";
 /**
  * How hard a reasoning-capable model should think before answering.
  *
- * A hint honored only by providers whose models expose it (OpenAI's o-series);
- * other providers ignore it. Persisted per chat and threaded into the model
- * request for each turn.
+ * The scale runs from [`Self::None`] to [`Self::Max`] and the ordering is the
+ * scale itself, not an implementation detail: comparisons and
+ * [`Self::clamp_to`] rely on it.
+ *
+ * No model accepts the whole scale. `none` is an OpenAI level that the Claude
+ * family rejects, `max` is missing from several rows on both routes, and some
+ * models take no effort control at all. A model's accepted levels live on its
+ * registry entry; a stored choice is mapped onto them with [`Self::clamp_to`]
+ * before a request is built.
+ *
+ * Persisted per chat as the token from [`Self::as_str`] and threaded into the
+ * model request for each turn.
  */
-export type ReasoningEffort = "low" | "medium" | "high";
+export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max";
 
 export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | { "type": "text_delta", text: string, } | { "type": "reasoning_delta" } | { "type": "stream_interrupted" } | { "type": "tool_call_started", call_id: CallId, name: RendererToolName, } | { "type": "tool_call_args_delta", call_id: CallId, } | { "type": "user_questions_asked", call_id: CallId, turn_id: TurnId, } | { "type": "approval_required", call_id: CallId, action: RendererToolName, approval: ToolApprovalKind, class: ApprovalClass, 
 /**

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -16,7 +16,7 @@ const models: ModelInfo[] = [
     max_output_tokens: 128_000,
     input_modalities: ["text"],
     supports_reasoning: true,
-    supports_reasoning_effort: false,
+    reasoning_efforts: [],
     multimodal: false,
   },
   {
@@ -29,7 +29,7 @@ const models: ModelInfo[] = [
     max_output_tokens: 16_384,
     input_modalities: ["text"],
     supports_reasoning: false,
-    supports_reasoning_effort: false,
+    reasoning_efforts: [],
     multimodal: false,
   },
 ];

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -4,6 +4,8 @@
 //! provider routing. Provider configuration decides which registry entries are
 //! available; it does not duplicate model ids or capabilities.
 
+use openwave_core::ReasoningEffort;
+
 use crate::providers::ProviderKind;
 
 /// An input modality a model accepts.
@@ -38,6 +40,36 @@ impl InputModality {
 
 const TEXT_ONLY: &[InputModality] = &[InputModality::Text];
 
+/// The reasoning-effort scales the curated rows draw from, ascending.
+///
+/// No provider offers one scale across its whole line, so these are named for
+/// their contents rather than for a provider or a generation.
+const EFFORT_NONE_TO_MAX: &[ReasoningEffort] = &[
+    ReasoningEffort::None,
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+    ReasoningEffort::XHigh,
+    ReasoningEffort::Max,
+];
+const EFFORT_NONE_TO_XHIGH: &[ReasoningEffort] = &[
+    ReasoningEffort::None,
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+    ReasoningEffort::XHigh,
+];
+const EFFORT_LOW_TO_MAX: &[ReasoningEffort] = &[
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+    ReasoningEffort::XHigh,
+    ReasoningEffort::Max,
+];
+/// For a model that takes no effort parameter at all. Not the same as a model
+/// that ignores one: Claude Haiku 4.5 rejects the request.
+const EFFORT_UNSUPPORTED: &[ReasoningEffort] = &[];
+
 /// Separator in the stable provider-scoped selection key persisted for new
 /// defaults, chat overrides, and turn receipts.
 pub const MODEL_KEY_SEPARATOR: &str = "::";
@@ -59,8 +91,12 @@ pub struct ModelSpec {
     pub input_modalities: &'static [InputModality],
     /// Whether the model can produce an internal reasoning stream.
     pub supports_reasoning: bool,
-    /// Whether callers can choose a reasoning-effort level.
-    pub supports_reasoning_effort: bool,
+    /// The reasoning-effort levels this model accepts, ascending.
+    ///
+    /// A single flag cannot describe the range: a model may take `high` and
+    /// reject `xhigh`, or take `xhigh` and reject `max`. Empty means the model
+    /// exposes no effort control, and the parameter is left off its requests.
+    pub reasoning_efforts: &'static [ReasoningEffort],
 }
 
 impl ModelSpec {
@@ -68,6 +104,12 @@ impl ModelSpec {
     #[cfg(test)]
     pub fn accepts(&self, modality: InputModality) -> bool {
         self.input_modalities.contains(&modality)
+    }
+
+    /// Whether callers can choose a reasoning-effort level at all.
+    #[cfg(test)]
+    pub const fn supports_reasoning_effort(&self) -> bool {
+        !self.reasoning_efforts.is_empty()
     }
 }
 
@@ -87,8 +129,10 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
         // Claude 4.6 and later reason on an adaptive thinking block, and the
-        // Anthropic adapter sends one along with the chat's chosen effort.
-        supports_reasoning_effort: true,
+        // Anthropic adapter sends one along with the chat's chosen effort. That
+        // generation onward takes `low` through `max`; there is no `none`,
+        // because a model on the adaptive block always reasons.
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
         id: "claude-sonnet-5",
@@ -98,7 +142,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: true,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
         id: "claude-haiku-4-5-20251001",
@@ -110,7 +154,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_reasoning: true,
         // Haiku 4.5 predates the adaptive switch: it rejects the effort
         // control, so the adapter leaves both off and the picker hides it.
-        supports_reasoning_effort: false,
+        reasoning_efforts: EFFORT_UNSUPPORTED,
     },
     ModelSpec {
         id: "claude-opus-4-8",
@@ -120,7 +164,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: true,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
         id: "claude-opus-4-7",
@@ -130,7 +174,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: true,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
         id: "claude-opus-4-6",
@@ -140,7 +184,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: true,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
         id: "claude-sonnet-4-6",
@@ -150,7 +194,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: true,
+        reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
     ModelSpec {
         id: "gpt-5.6-sol",
@@ -162,8 +206,8 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_reasoning: true,
         // The whole GPT-5 line reasons on a caller-selected effort, which the
         // OpenAI-compatible adapter already sends alongside
-        // `max_completion_tokens`.
-        supports_reasoning_effort: true,
+        // `max_completion_tokens`. Only the 5.6 generation added `max`.
+        reasoning_efforts: EFFORT_NONE_TO_MAX,
     },
     ModelSpec {
         id: "gpt-5.6-terra",
@@ -173,7 +217,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: true,
+        reasoning_efforts: EFFORT_NONE_TO_MAX,
     },
     ModelSpec {
         id: "gpt-5.6-luna",
@@ -183,7 +227,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: true,
+        reasoning_efforts: EFFORT_NONE_TO_MAX,
     },
     ModelSpec {
         id: "gpt-5.5",
@@ -193,7 +237,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: true,
+        reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
     ModelSpec {
         id: "gpt-5.4-mini",
@@ -203,7 +247,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: true,
+        reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
     ModelSpec {
         id: "gpt-5.4-nano",
@@ -213,7 +257,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         max_output_tokens: 128_000,
         input_modalities: TEXT_ONLY,
         supports_reasoning: true,
-        supports_reasoning_effort: true,
+        reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
 ];
 
@@ -354,8 +398,15 @@ mod tests {
                 spec.id
             );
             assert!(
-                !spec.supports_reasoning_effort || spec.supports_reasoning,
+                !spec.supports_reasoning_effort() || spec.supports_reasoning,
                 "{} exposes reasoning effort without reasoning",
+                spec.id
+            );
+            assert!(
+                spec.reasoning_efforts
+                    .windows(2)
+                    .all(|pair| pair[0] < pair[1]),
+                "{} lists reasoning-effort levels out of order or with duplicates",
                 spec.id
             );
         }
@@ -389,7 +440,7 @@ mod tests {
         assert_eq!(sonnet.context_window, 1_000_000);
         assert_eq!(sonnet.max_output_tokens, 128_000);
         assert!(sonnet.supports_reasoning);
-        assert!(sonnet.supports_reasoning_effort);
+        assert_eq!(sonnet.reasoning_efforts, EFFORT_LOW_TO_MAX);
 
         // Haiku 4.5 predates the adaptive thinking switch and rejects the
         // effort control, so it is the one Anthropic row without it.
@@ -397,7 +448,26 @@ mod tests {
         assert_eq!(haiku.context_window, 200_000);
         assert_eq!(haiku.max_output_tokens, 64_000);
         assert!(haiku.supports_reasoning);
-        assert!(!haiku.supports_reasoning_effort);
+        assert!(!haiku.supports_reasoning_effort());
+        assert!(haiku.reasoning_efforts.is_empty());
+    }
+
+    #[test]
+    fn every_anthropic_entry_that_takes_an_effort_takes_xhigh_and_refuses_none() {
+        for spec in
+            models_for(ProviderKind::Anthropic).filter(|spec| spec.supports_reasoning_effort())
+        {
+            assert!(
+                spec.reasoning_efforts.contains(&ReasoningEffort::XHigh),
+                "{} omits the level recommended for coding and agentic work",
+                spec.id
+            );
+            assert!(
+                !spec.reasoning_efforts.contains(&ReasoningEffort::None),
+                "{} offers an OpenAI-only level the Anthropic route rejects",
+                spec.id
+            );
+        }
     }
 
     #[test]
@@ -406,8 +476,13 @@ mod tests {
         assert!(!openai.is_empty());
         for spec in openai {
             assert!(
-                spec.supports_reasoning && spec.supports_reasoning_effort,
+                spec.supports_reasoning && spec.supports_reasoning_effort(),
                 "{} is curated on the OpenAI route without the reasoning shape that route sends",
+                spec.id
+            );
+            assert!(
+                spec.reasoning_efforts.contains(&ReasoningEffort::None),
+                "{} drops the level that turns GPT-5 reasoning off",
                 spec.id
             );
             assert_eq!(
@@ -416,6 +491,24 @@ mod tests {
                 spec.id
             );
         }
+        // `max` arrived with the 5.6 generation; the rows behind it stop at
+        // `xhigh` and would reject it.
+        assert_eq!(
+            find("gpt-5.6-sol").unwrap().reasoning_efforts,
+            EFFORT_NONE_TO_MAX
+        );
+        assert_eq!(
+            find("gpt-5.5").unwrap().reasoning_efforts,
+            EFFORT_NONE_TO_XHIGH
+        );
+        assert_eq!(
+            find("gpt-5.4-mini").unwrap().reasoning_efforts,
+            EFFORT_NONE_TO_XHIGH
+        );
+        assert_eq!(
+            find("gpt-5.4-nano").unwrap().reasoning_efforts,
+            EFFORT_NONE_TO_XHIGH
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -196,8 +196,9 @@ pub struct ResolvedModelPolicy {
     pub input_modalities: Vec<InputModality>,
     /// Whether the provider request uses a reasoning-model shape.
     pub supports_reasoning: bool,
-    /// Whether the chat may set a reasoning-effort override.
-    pub supports_reasoning_effort: bool,
+    /// The reasoning-effort levels this model accepts, ascending. Empty when
+    /// the model takes no effort control.
+    pub reasoning_efforts: Vec<ReasoningEffort>,
 }
 
 impl ResolvedModelPolicy {
@@ -211,7 +212,7 @@ impl ResolvedModelPolicy {
             max_output_tokens: spec.max_output_tokens,
             input_modalities: spec.input_modalities.to_vec(),
             supports_reasoning: spec.supports_reasoning,
-            supports_reasoning_effort: spec.supports_reasoning_effort,
+            reasoning_efforts: spec.reasoning_efforts.to_vec(),
         }
     }
 
@@ -230,7 +231,7 @@ impl ResolvedModelPolicy {
             // Unknown endpoints get deliberately conservative request shaping.
             // Capability editing can be added later without changing the key.
             supports_reasoning: false,
-            supports_reasoning_effort: false,
+            reasoning_efforts: Vec::new(),
         }
     }
 
@@ -247,8 +248,11 @@ impl ResolvedModelPolicy {
 /// Apply one resolved registry row to the provider-neutral agent config.
 ///
 /// The stored selection key never reaches an adapter: requests carry the raw
-/// model id plus the exact provider hint. Unsupported reasoning controls are
-/// normalized away before provider dispatch.
+/// model id plus the exact provider hint. This is the one place a chat's stored
+/// reasoning effort is reconciled with the model actually about to run, so a
+/// level the model does not accept can never reach an adapter: it degrades to
+/// the closest level the model does take, or is dropped when the model exposes
+/// no effort control at all.
 pub fn apply_model_policy(
     config: &mut AgentConfig,
     policy: &ResolvedModelPolicy,
@@ -260,10 +264,8 @@ pub fn apply_model_policy(
     config.context_window = usize::try_from(policy.context_window)
         .map_err(|_| openwave_core::AgentError::config("model context window is unsupported"))?;
     config.max_tokens = Some(policy.max_output_tokens);
-    config.reasoning_effort = policy
-        .supports_reasoning_effort
-        .then_some(reasoning_effort)
-        .flatten();
+    config.reasoning_effort =
+        reasoning_effort.and_then(|effort| effort.clamp_to(&policy.reasoning_efforts));
     if policy.supports_reasoning {
         config.temperature = None;
     }
@@ -859,12 +861,12 @@ mod tests {
         let opus = ResolvedModelPolicy::curated(
             model_registry::find_for(ProviderKind::Anthropic, "claude-opus-4-8").unwrap(),
         );
-        apply_model_policy(&mut config, &opus, Some(ReasoningEffort::High)).unwrap();
+        apply_model_policy(&mut config, &opus, Some(ReasoningEffort::XHigh)).unwrap();
         assert_eq!(config.provider, Some(ProviderId::new("anthropic")));
         assert_eq!(config.model, "claude-opus-4-8");
         assert_eq!(config.context_window, 1_000_000);
         assert_eq!(config.max_tokens, Some(128_000));
-        assert_eq!(config.reasoning_effort, Some(ReasoningEffort::High));
+        assert_eq!(config.reasoning_effort, Some(ReasoningEffort::XHigh));
         assert_eq!(config.temperature, None);
 
         // Haiku 4.5 reasons but rejects the effort control, so the request is
@@ -907,6 +909,56 @@ mod tests {
     }
 
     #[test]
+    fn a_level_a_model_does_not_accept_never_survives_policy_application() {
+        let apply = |id: &str, provider: ProviderKind, effort: ReasoningEffort| {
+            let mut config = AgentConfig::default();
+            let policy =
+                ResolvedModelPolicy::curated(model_registry::find_for(provider, id).unwrap());
+            apply_model_policy(&mut config, &policy, Some(effort)).unwrap();
+            config.reasoning_effort
+        };
+
+        // `max` arrived with GPT-5.6; on 5.5 the same stored choice degrades to
+        // the top level that generation takes rather than failing the turn.
+        assert_eq!(
+            apply("gpt-5.6-sol", ProviderKind::Openai, ReasoningEffort::Max),
+            Some(ReasoningEffort::Max)
+        );
+        assert_eq!(
+            apply("gpt-5.5", ProviderKind::Openai, ReasoningEffort::Max),
+            Some(ReasoningEffort::XHigh)
+        );
+        // Anthropic has no "don't reason" level, so `none` comes up to `low`.
+        assert_eq!(
+            apply(
+                "claude-opus-5",
+                ProviderKind::Anthropic,
+                ReasoningEffort::None
+            ),
+            Some(ReasoningEffort::Low)
+        );
+        assert_eq!(
+            apply(
+                "claude-opus-5",
+                ProviderKind::Anthropic,
+                ReasoningEffort::XHigh
+            ),
+            Some(ReasoningEffort::XHigh)
+        );
+        // Haiku 4.5 errors on the parameter, so it is dropped outright.
+        for effort in ReasoningEffort::ALL {
+            assert_eq!(
+                apply(
+                    "claude-haiku-4-5-20251001",
+                    ProviderKind::Anthropic,
+                    *effort
+                ),
+                None
+            );
+        }
+    }
+
+    #[test]
     fn every_curated_model_applies_its_exact_runtime_contract() {
         for &provider in ProviderKind::ALL {
             for spec in model_registry::models_for(provider) {
@@ -928,8 +980,7 @@ mod tests {
                 assert_eq!(config.reasoning_model, spec.supports_reasoning);
                 assert_eq!(
                     config.reasoning_effort,
-                    spec.supports_reasoning_effort
-                        .then_some(ReasoningEffort::Low)
+                    ReasoningEffort::Low.clamp_to(spec.reasoning_efforts)
                 );
                 assert_eq!(
                     config.temperature,

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -466,8 +466,14 @@ pub struct ModelInfo {
     pub input_modalities: Vec<crate::model_registry::InputModality>,
     /// Whether the model can produce an internal reasoning stream.
     pub supports_reasoning: bool,
-    /// Whether the model exposes a reasoning-effort control.
-    pub supports_reasoning_effort: bool,
+    /// The reasoning-effort levels this model accepts, ascending. Empty when
+    /// the model exposes no effort control, which is what a client checks
+    /// before offering the selector at all.
+    ///
+    /// Carries the enum rather than plain strings so the generated TypeScript
+    /// is the same union a chat's stored effort has, and a client cannot offer
+    /// a level it could not then set.
+    pub reasoning_efforts: Vec<ReasoningEffort>,
     /// Whether the model accepts image input alongside text.
     pub multimodal: bool,
 }
@@ -497,7 +503,7 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCata
             max_output_tokens: entry.policy.max_output_tokens,
             input_modalities: entry.policy.input_modalities.clone(),
             supports_reasoning: entry.policy.supports_reasoning,
-            supports_reasoning_effort: entry.policy.supports_reasoning_effort,
+            reasoning_efforts: entry.policy.reasoning_efforts.clone(),
             multimodal: entry
                 .policy
                 .input_modalities
@@ -1446,7 +1452,7 @@ mod image_capability_tests {
         max_output_tokens: 64_000,
         input_modalities: &[InputModality::Text],
         supports_reasoning: false,
-        supports_reasoning_effort: false,
+        reasoning_efforts: &[],
     };
 
     const MULTIMODAL: ModelSpec = ModelSpec {

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -8735,17 +8735,30 @@ async fn models_catalog_is_served() {
     assert!(opus["supports_reasoning"].as_bool().unwrap());
     assert!(!opus["multimodal"].as_bool().unwrap());
     assert!(!opus["available"].as_bool().unwrap());
-    // Capabilities describe what the current adapter implements, not only
-    // what the upstream model could support with a different request shape:
-    // the Anthropic adapter sends the chat's effort on every model that takes
-    // an adaptive thinking block, and none of the ones that don't.
-    assert!(opus["supports_reasoning_effort"].as_bool().unwrap());
+    // The catalog carries the effort levels the model itself accepts, so a
+    // client can offer exactly those and no more.
+    assert_eq!(
+        opus["reasoning_efforts"],
+        serde_json::json!(["low", "medium", "high", "xhigh", "max"])
+    );
+    // A model that reasons but rejects the effort parameter advertises no
+    // levels at all, which is what tells a client to hide the control.
     let haiku = models
         .iter()
         .find(|m| m["id"] == "claude-haiku-4-5-20251001")
         .expect("curated Anthropic model is present");
     assert!(haiku["supports_reasoning"].as_bool().unwrap());
-    assert!(!haiku["supports_reasoning_effort"].as_bool().unwrap());
+    assert_eq!(haiku["reasoning_efforts"], serde_json::json!([]));
+    // The GPT-5 line adds an off level, and only the 5.6 generation reaches
+    // `max`.
+    let gpt = models
+        .iter()
+        .find(|m| m["id"] == "gpt-5.5")
+        .expect("curated OpenAI model is present");
+    assert_eq!(
+        gpt["reasoning_efforts"],
+        serde_json::json!(["none", "low", "medium", "high", "xhigh"])
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
`ReasoningEffort` was `Low | Medium | High`, and `ModelSpec` described support with a single `supports_reasoning_effort: bool`. Neither matches what the curated models take:

| models | accepted levels |
|---|---|
| `gpt-5.6-sol` / `-terra` / `-luna` | none, low, medium, high, xhigh, max |
| `gpt-5.5`, `gpt-5.4-mini`, `gpt-5.4-nano` | none, low, medium, high, xhigh |
| Claude 4.6 and later | low, medium, high, xhigh, max |
| Claude Haiku 4.5 | rejects the control outright |

A bool cannot say "takes `high` but not `xhigh`". The practical consequence: `xhigh` is what Anthropic recommends for coding and agentic work — and it was the one level OpenWave could not express.

## What changed

The enum widens to `None | Low | Medium | High | XHigh | Max`, and the bool becomes the set of levels each registry row accepts. `xhigh` carries an explicit `#[serde(rename)]` because providers spell it as one word rather than the snake_case rendering of the variant name.

**Degradation over failure.** A chat's effort outlives the model it was chosen for — switching to a narrower model, or a provider retiring a level, both leave a stored choice the model would reject. Rather than fail a turn over what is only a hint, the request degrades to the closest level the model does take: the highest at or below the request, or the model's lowest when the request sits under its whole range. That matches the degradation Anthropic documents for `xhigh` on models without it, and it means a model switch never strands a chat.

The effort menu offers what the selected model accepts instead of a fixed three, and still labels a stored level the current model no longer takes, so the value renders as "Max" rather than a raw wire token.

## Migration

The effort is persisted per chat and crosses the wire as a snake_case token, so old stored values had to keep loading. `chats_stored_before_the_effort_scale_widened_still_load` pins that against values written the way a release before `none`/`xhigh`/`max` wrote them, rather than leaving it as an assertion in prose.

## Verification

Full local gate: `cargo fmt --all --check` clean, `cargo test --workspace` green across 28 binaries, `cargo check --workspace --locked` with no `Cargo.lock` diff. Desktop UI: `tsc` clean, **461 tests across 62 files**, production build fine.

Clippy needs #594 first — `main` currently fails `-D warnings` on an unrelated lint from #580, which aborts the run before it reaches this crate. This branch rebases onto that fix before merge.

Closes #554