### PR TITLE
build(server): put the LanceDB vector store behind a feature

### DIFF
--- a/.github/workflows/cache-macos.yml
+++ b/.github/workflows/cache-macos.yml
@@ -133,7 +133,9 @@ jobs:
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         with:
           projectPath: crates/openwave-desktop
-          args: --target ${{ matrix.target }} --no-bundle --ci
+          # Match the release build, which compiles the durable vector store;
+          # a cache warmed without it would miss on every release compile.
+          args: --target ${{ matrix.target }} --features vec-lance --no-bundle --ci
 
       - name: Report unsigned Rust build cache size
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,17 +206,15 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         with:
           version: v0.16.0
-      - name: Install system deps (Tauri; protobuf for the LanceDB vector store)
+      - name: Install system deps (Tauri)
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
-            libprotobuf-dev \
             librsvg2-dev \
             mold \
-            patchelf \
-            protobuf-compiler
+            patchelf
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
@@ -257,17 +255,15 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         with:
           version: v0.16.0
-      - name: Install system deps (Tauri; protobuf for the LanceDB vector store)
+      - name: Install system deps (Tauri)
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
-            libprotobuf-dev \
             librsvg2-dev \
             mold \
-            patchelf \
-            protobuf-compiler
+            patchelf
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
@@ -301,13 +297,10 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         with:
           version: v0.16.0
-      - name: Install headless system deps (protobuf for the LanceDB vector store)
+      - name: Install headless system deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libprotobuf-dev \
-            mold \
-            protobuf-compiler
+          sudo apt-get install -y --no-install-recommends mold
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
@@ -324,6 +317,64 @@ jobs:
         run: cargo fetch --locked
       - name: headless tests
         run: cargo test --workspace --exclude openwave-desktop --locked
+
+  vectors:
+    name: durable vector store
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}
+      RUSTC_WRAPPER: sccache
+      RUSTFLAGS: -C link-arg=-fuse-ld=mold
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install toolchain (honors rust-toolchain.toml)
+        run: rustup show
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: v0.16.0
+      # The only lane that compiles LanceDB, so the only one that needs protoc.
+      - name: Install headless system deps (protobuf for the LanceDB vector store)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libprotobuf-dev \
+            mold \
+            protobuf-compiler
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: false
+      # The build script has no build-dependencies, so it runs and fails long
+      # before the dependency tree is built: seconds of runner time to prove a
+      # shipped binary cannot silently lose the durable store.
+      - name: A release build without the durable store must fail
+        run: |
+          if cargo check -p openwave-server --release --locked \
+            > "$RUNNER_TEMP/durable-guard.log" 2>&1; then
+            echo "A release build without vec-lance succeeded; the guard is gone." >&2
+            exit 1
+          fi
+          grep -q "durable vector store" "$RUNNER_TEMP/durable-guard.log" || {
+            echo "The release build failed for some other reason:" >&2
+            cat "$RUNNER_TEMP/durable-guard.log" >&2
+            exit 1
+          }
+      - name: LanceDB-backed tests
+        run: |
+          cargo test -p openwave-retrieval --features vec-lance --locked
+          cargo test -p openwave-server --features vec-lance --locked
 
   postgres:
     name: postgres state machine
@@ -415,6 +466,7 @@ jobs:
         lint,
         desktop,
         test,
+        vectors,
         postgres,
         ui,
       ]
@@ -426,6 +478,7 @@ jobs:
           LINT_RESULT: ${{ needs.lint.result }}
           DESKTOP_RESULT: ${{ needs.desktop.result }}
           TEST_RESULT: ${{ needs.test.result }}
+          VECTORS_RESULT: ${{ needs.vectors.result }}
           POSTGRES_RESULT: ${{ needs.postgres.result }}
           UI_RESULT: ${{ needs.ui.result }}
           PR_TITLE_RESULT: ${{ needs.pr-title.result }}
@@ -457,6 +510,7 @@ jobs:
               test "$LINT_RESULT" = success
               test "$DESKTOP_RESULT" = success
               test "$TEST_RESULT" = success
+              test "$VECTORS_RESULT" = success
               test "$POSTGRES_RESULT" = success
               ;;
             false)
@@ -464,6 +518,7 @@ jobs:
               test "$LINT_RESULT" = skipped
               test "$DESKTOP_RESULT" = skipped
               test "$TEST_RESULT" = skipped
+              test "$VECTORS_RESULT" = skipped
               test "$POSTGRES_RESULT" = skipped
               ;;
             *)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,7 +330,10 @@ jobs:
         uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1
         with:
           projectPath: crates/openwave-desktop
-          args: --target ${{ matrix.target }} --no-bundle --ci
+          # `vec-lance` carries the durable, on-disk vector store into the
+          # shipped app; the server's build script rejects a release build
+          # without it.
+          args: --target ${{ matrix.target }} --features vec-lance --no-bundle --ci
 
       - name: Save release-specific unsigned Rust build cache
         if: ${{ !cancelled() && steps.rust-build-cache.outputs.cache-hit != 'true' }}
@@ -570,6 +573,7 @@ jobs:
           projectPath: crates/openwave-desktop
           args: >-
             --target ${{ matrix.target }}
+            --features vec-lance
             --config ${{ runner.temp }}/openwave-release.json
             --bundles app,dmg
 

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -10,6 +10,12 @@ authors.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Forwards the server's durable, on-disk vector store. Off by default so an
+# ordinary build and the workspace tests skip the LanceDB dependency tree; a
+# release build has to enable it (`openwave-server`'s build script says so).
+vec-lance = ["openwave-server/vec-lance"]
+
 # The binary is `openwave` (not `openwave-cli`), so `openwave serve` is the command.
 [[bin]]
 name = "openwave"

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -10,6 +10,13 @@ authors.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Forwards the server's durable, on-disk vector store. Off by default so a dev
+# build and the workspace tests skip the LanceDB dependency tree; every shipped
+# bundle enables it (`cargo tauri build --features vec-lance`), and
+# `openwave-server`'s build script fails a release build that does not.
+vec-lance = ["openwave-server/vec-lance"]
+
 [lib]
 name = "openwave_desktop_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]

--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -50,12 +50,22 @@ Rust host boots the in-process API; the webview calls `server_info` to learn the
 base URL and token. The Tauri pre-dev command builds and stages the broker
 sidecar for the current target automatically.
 
+A dev build leaves out `vec-lance`, so document search runs on an in-memory
+index that is discarded when the app exits — the LanceDB tree it replaces is
+about 330 crates of build time. Add `--features vec-lance` when you are working
+on retrieval and want the index to survive a restart.
+
 Create an installable bundle. The before-build hook compiles the target-specific
 broker and the default Tauri configuration includes it automatically:
 
 ```sh
-cargo tauri build
+cargo tauri build --features vec-lance
 ```
+
+`vec-lance` carries the durable, on-disk vector store into the bundle. It is not
+optional for a shipped build: `openwave-server`'s build script fails any release
+build that leaves it out, rather than quietly shipping an app whose documents
+disappear on exit.
 
 ## PDFium runtime for packaged apps
 

--- a/crates/openwave-retrieval/Cargo.toml
+++ b/crates/openwave-retrieval/Cargo.toml
@@ -23,8 +23,9 @@ tool = []
 embed-openai = ["dep:reqwest", "dep:sha2"]
 # A durable, embedded vector store backed by LanceDB (pure-Rust, on-disk). Not a
 # default feature for library consumers because it pulls a large dependency tree
-# and needs `protoc` at build time. OpenWave's workspace CI installs `protoc`, and
-# the server enables this feature explicitly.
+# and needs `protoc` at build time. `openwave-server` forwards it under the same
+# name, off by default there too and required for its release builds, so only the
+# CI lane that compiles this backend installs `protoc`.
 vec-lance = ["dep:lancedb", "dep:arrow-array", "dep:arrow-schema", "dep:arrow-select", "dep:futures", "dep:tokio"]
 # Rich PDF parsing via the local, PDFium-backed `liteparse` engine. Not a default
 # feature: it pulls a large dependency tree. Tesseract OCR is disabled

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -28,13 +28,21 @@ parse-office = ["openwave-retrieval/parse-office"]
 # later); routing them to a dedicated parser gives a stable fingerprint and keeps
 # them out of the generic fallback.
 parse-image = ["openwave-retrieval/parse-image"]
+# The durable, on-disk vector store (LanceDB). Off by default because it is the
+# most expensive thing this workspace compiles — roughly 330 crates of arrow,
+# datafusion, parquet, and lance, plus a `protoc` requirement — and the tests
+# that need it are a handful. With the feature off, `connect_vector_store`
+# stands up an in-memory index instead, which is fine for a dev build and would
+# be data loss in a shipped one: `build.rs` fails any release build that leaves
+# this feature out.
+vec-lance = ["openwave-retrieval/vec-lance"]
 
 [dependencies]
 openwave-code-execution = { path = "../openwave-code-execution" }
 openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools", "keychain", "blob-fs"] }
 openwave-mcp = { path = "../openwave-mcp" }
 openwave-router = { path = "../openwave-router" }
-openwave-retrieval = { path = "../openwave-retrieval", features = ["vec-lance"] }
+openwave-retrieval = { path = "../openwave-retrieval" }
 openwave-web-search = { path = "../openwave-web-search", features = ["http"] }
 axum = { workspace = true }
 tokio = { workspace = true, features = ["net", "process", "rt", "sync", "macros", "time"] }

--- a/crates/openwave-server/build.rs
+++ b/crates/openwave-server/build.rs
@@ -1,0 +1,29 @@
+//! Refuse to produce a release build without the durable vector store.
+//!
+//! `vec-lance` is off by default so ordinary builds and tests skip the LanceDB
+//! dependency tree; retrieval then runs on an in-memory index that is discarded
+//! when the process exits. That trade is right for a dev build and wrong for a
+//! shipped one — a packaged app whose documents vanish on restart is data loss,
+//! and it would look like a working build. So the release profile has to opt in
+//! explicitly, and this check fails the build when it does not.
+//!
+//! `PROFILE` is `release` for the release profile and any profile inheriting it,
+//! independent of `debug_assertions` and of any profile tuning, which is why the
+//! check lives here rather than in a `cfg(not(debug_assertions))` assertion.
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let release = std::env::var("PROFILE").as_deref() == Ok("release");
+    let durable = std::env::var_os("CARGO_FEATURE_VEC_LANCE").is_some();
+    if release && !durable {
+        eprintln!(
+            "openwave-server: a release build must keep the durable vector store, \
+             but the `vec-lance` feature is off. Without it, document search runs \
+             on an in-memory index that is lost when the process exits. Build with \
+             `--features vec-lance` (openwave-cli, openwave-desktop, and \
+             `cargo tauri build` all forward it), or use a dev profile."
+        );
+        std::process::exit(1);
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -67,9 +67,11 @@ use openwave_core::{
     KeychainSecretProvider, ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool,
     ToolRegistry, WriteFile,
 };
+#[cfg(feature = "vec-lance")]
+use openwave_retrieval::LanceVectorStore;
 use openwave_retrieval::{
-    Embedder, FallbackParser, HashEmbedder, LanceVectorStore, OpenAiEmbedder, ParserRegistry,
-    PlainTextParser, Retriever, SearchTool, TextChunker, VectorStore,
+    Embedder, FallbackParser, HashEmbedder, OpenAiEmbedder, ParserRegistry, PlainTextParser,
+    Retriever, SearchTool, TextChunker, VectorStore,
 };
 
 use resolver::KeyedResolver;
@@ -757,7 +759,7 @@ const EMBED_DIMS: usize = 1536;
 ///
 /// Chosen once at startup: the vector index is dimension-bound to the embedder, so
 /// enabling OpenAI (or adding a key) takes effect on restart — where a change in
-/// embedding width rebuilds the persistent index (see [`LanceVectorStore::connect`]).
+/// embedding width rebuilds the persistent index (see `connect_vector_store`).
 async fn resolve_embedder(store: &dyn Store, secrets: &dyn SecretProvider) -> Arc<dyn Embedder> {
     let enabled = providers::read_config(store, providers::ProviderKind::Openai)
         .await
@@ -823,6 +825,7 @@ fn document_parser_registry() -> ParserRegistry {
 /// index is derived, rebuildable data with a different lifecycle). Sized to the
 /// embedder's dimensionality; a change in that width rebuilds the index (see
 /// [`LanceVectorStore::connect`]).
+#[cfg(feature = "vec-lance")]
 async fn connect_vector_store(config: &Config, dims: usize) -> Result<Arc<dyn VectorStore>> {
     let dir = config.data_dir.join("vectors");
     let uri = dir
@@ -832,6 +835,22 @@ async fn connect_vector_store(config: &Config, dims: usize) -> Result<Arc<dyn Ve
         .await
         .map_err(|e| AgentError::config(format!("failed to open vector store: {e}")))?;
     Ok(Arc::new(store))
+}
+
+/// Stand in for the durable index when the build left LanceDB out.
+///
+/// Ingestion and search behave the same, but nothing survives the process, so a
+/// restart starts from an empty index. This exists to keep a lean build — the
+/// default for tests and dev — usable without compiling the LanceDB tree; a
+/// release build cannot take this path, because `build.rs` rejects a release
+/// build that does not enable `vec-lance`.
+#[cfg(not(feature = "vec-lance"))]
+async fn connect_vector_store(_config: &Config, dims: usize) -> Result<Arc<dyn VectorStore>> {
+    eprintln!(
+        "openwave: built without the `vec-lance` feature; document search runs on an \
+         in-memory index that is discarded when this process exits"
+    );
+    Ok(Arc::new(openwave_retrieval::InMemoryVectorStore::new(dims)))
 }
 
 /// Open the durable store the profile selects.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -7162,6 +7162,7 @@ async fn resolve_embedder_uses_openai_only_when_enabled_and_keyed() {
     assert_eq!(offline.dimensions(), HashEmbedder::default().dimensions());
 }
 
+#[cfg(feature = "vec-lance")]
 #[tokio::test(flavor = "multi_thread")]
 async fn connect_vector_store_opens_a_durable_lance_index_under_data_dir() {
     let dir = tempfile::tempdir().unwrap();
@@ -7193,6 +7194,42 @@ async fn connect_vector_store_opens_a_durable_lance_index_under_data_dir() {
     );
     let reopened = connect_vector_store(&config, 2).await.unwrap();
     assert_eq!(reopened.len().await.unwrap(), 1);
+}
+
+/// The lean build's stand-in still ingests and searches — it just forgets. A
+/// release build never reaches it (`build.rs` rejects a release build without
+/// `vec-lance`), so this pins the development behaviour rather than a shipped
+/// one: the store works, sized to the embedder, and writes nothing to disk.
+#[cfg(not(feature = "vec-lance"))]
+#[tokio::test(flavor = "multi_thread")]
+async fn connect_vector_store_falls_back_to_an_in_memory_index_without_vec_lance() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = Config::desktop(dir.path());
+
+    let store = connect_vector_store(&config, 2).await.unwrap();
+    let doc = openwave_retrieval::DocumentId::new();
+    let chunk =
+        openwave_retrieval::Chunk::new(doc, 0, openwave_retrieval::ByteSpan::new(0, 4), "note");
+    store
+        .upsert(vec![openwave_retrieval::VectorRecord {
+            chat_id: None,
+            project_id: None,
+            source: openwave_retrieval::DocumentSource::Inline,
+            generation: None,
+            chunk,
+            embedding: openwave_retrieval::Embedding(vec![1.0, 0.0]),
+        }])
+        .await
+        .unwrap();
+    assert_eq!(store.len().await.unwrap(), 1);
+
+    assert!(
+        !dir.path().join("vectors").exists(),
+        "the in-memory store leaves no index on disk"
+    );
+    // A second connect starts empty: nothing carried over from the first.
+    let reopened = connect_vector_store(&config, 2).await.unwrap();
+    assert_eq!(reopened.len().await.unwrap(), 0);
 }
 
 #[tokio::test]

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -112,7 +112,10 @@ Asynchronous parsing, structural chunking, embeddings, scoped hybrid
 lexical+dense search, reranking, and grounded citations behind a `VectorStore`
 seam with in-memory and durable embedded LanceDB backends. Durable source
 revisions and Parse→Index jobs are coordinated by `openwave-core` and
-`openwave-server`.
+`openwave-server`. The LanceDB backend is the `vec-lance` build feature, off by
+default here and in `openwave-server` because it is the largest dependency tree
+in the workspace; release builds must enable it, and `openwave-server`'s build
+script fails the build when they do not.
 
 **Depends on:** `openwave-core`.
 


### PR DESCRIPTION
`openwave-server` enabled `openwave-retrieval/vec-lance` unconditionally. The
retrieval crate deliberately keeps that feature off by default — it pulls the
arrow/datafusion/parquet/lance tree and needs `protoc` — and the server turned it
back on for everything, tests included. Four tests exercise the durable store;
`openwave-server/src` reaches for the in-memory one 53 times.

The feature is now forwarded under the same name and off by default, with
`openwave-cli` and `openwave-desktop` passing it through. With it off,
`connect_vector_store` returns an `InMemoryVectorStore` and says so on stderr.

## Keeping the durable store in shipped builds

An in-memory index in a packaged app is data loss that looks like a working
build, so the fallback cannot reach one. `crates/openwave-server/build.rs` fails
any build in the release profile that does not enable `vec-lance`:

```
error: failed to run custom build command for `openwave-server`
  openwave-server: a release build must keep the durable vector store, but the
  `vec-lance` feature is off. ...
```

It reads `PROFILE`, not `cfg(debug_assertions)`, so tuning a profile's assertions
cannot quietly disable it. The new CI lane asserts that a release build without
the feature *fails*, so the guard cannot rot; the build script has no
build-dependencies, so that check costs seconds rather than a full release
compile. The release and macOS cache workflows now pass `--features vec-lance`
to `tauri build`, and `cargo tauri build --features vec-lance` is documented in
the desktop README.

## Coverage

A `durable vector store` lane runs `cargo test` for `openwave-retrieval` and
`openwave-server` with `vec-lance` on: the 29 tests in `lance_store.rs` and the
server's `connect_vector_store_opens_a_durable_lance_index_under_data_dir`, which
is now feature-gated. The lean path gets a new test of its own, asserting the
stand-in ingests and searches, writes no index to disk, and starts empty on the
next connect. That lane is the only one that compiles LanceDB, so it is the only
one that installs `protoc`; `clippy`, `desktop test`, and `test` no longer do.

## Numbers

Crates in the dependency graph (`cargo tree -e normal`, unique name+version):

| package | before | after |
|---|---|---|
| `openwave-server` default | 615 | 384 |
| `openwave-server --features vec-lance` | — | 615 |

`cargo tree -p openwave-server -e normal | grep -cE "datafusion|lancedb"` is 0
with default features and 202 with `--features vec-lance`. Same for
`openwave-cli`, `openwave-desktop`, and `cargo tree --workspace`.

Cold `cargo test --workspace --locked` into a scratch `CARGO_TARGET_DIR`
(macOS, warm Cargo registry, empty target directory both times):

| | before | after |
|---|---|---|
| wall clock | 380s | 202s |
| `target/` | 14G | 6.7G |

Both runs pass all 28 test binaries.

`parse-liteparse` was measured and left alone: it accounts for 85 crates
(530 → 615 with the LanceDB tree still in), it needs no build-time system tool,
and turning it off changes what the server accepts rather than only how it
stores things. It is not the same shape of problem.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -D warnings`
(and the same for the three crates with `vec-lance` on), `cargo test --workspace`,
`cargo check --workspace --locked` with no `Cargo.lock` diff.

`openwave serve` was exercised over HTTP in both configurations: ingest through
`POST /documents`, then `POST /search` returning the citation. With the feature
on, the data directory gets its `vectors/` index and the citation is still there
after a restart with no re-ingest; with it off, no `vectors/` directory appears.

Closes #587
