### PR TITLE
feat(mcp): connect to Streamable HTTP servers with a selected bearer token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6728,8 +6728,11 @@ name = "openwave-mcp"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "axum",
  "chrono",
+ "futures",
  "openwave-core",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -257,9 +257,12 @@ export type InputModality = "text" | "image";
 export type McpHealth = "initializing" | "healthy" | "degraded" | "reconnecting" | "disabled";
 
 /**
- * One local stdio MCP process definition.
+ * One external MCP server definition: a local stdio process (`command`) or a
+ * remote Streamable HTTP endpoint (`url`). Exactly one of the two is set;
+ * [`validate_servers`] enforces that process fields stay with `command` and
+ * `bearer_token_env` stays with `url`.
  */
-export type McpServerDefinition = { name: string, command: string, args: Array<string>, 
+export type McpServerDefinition = { name: string, command: string | null, args: Array<string>, 
 /**
  * Explicit literal values. The UI labels these as non-secret.
  */
@@ -267,13 +270,22 @@ env: { [key in string]: string },
 /**
  * Parent environment names to forward. Their values never enter this type.
  */
-env_from: Array<string>, cwd: string | null, request_timeout_ms: number, enabled: boolean, };
+env_from: Array<string>, cwd: string | null, 
+/**
+ * Streamable HTTP endpoint for a remote server.
+ */
+url: string | null, 
+/**
+ * Parent environment name holding the HTTP bearer token. The value is
+ * resolved at connect time and never enters this type.
+ */
+bearer_token_env: string | null, request_timeout_ms: number, enabled: boolean, };
 
 /**
  * One renderer-safe server projection. Resolved `env_from` values and child
  * process details are intentionally absent.
  */
-export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null, name: string, command: string, args: Array<string>, 
+export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null, name: string, command: string | null, args: Array<string>, 
 /**
  * Explicit literal values. The UI labels these as non-secret.
  */
@@ -281,7 +293,16 @@ env: { [key in string]: string },
 /**
  * Parent environment names to forward. Their values never enter this type.
  */
-env_from: Array<string>, cwd: string | null, request_timeout_ms: number, enabled: boolean, };
+env_from: Array<string>, cwd: string | null, 
+/**
+ * Streamable HTTP endpoint for a remote server.
+ */
+url: string | null, 
+/**
+ * Parent environment name holding the HTTP bearer token. The value is
+ * resolved at connect time and never enters this type.
+ */
+bearer_token_env: string | null, request_timeout_ms: number, enabled: boolean, };
 
 export type McpServersInfo = { servers: Array<McpServerInfo>, };
 

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -14,6 +14,8 @@ const healthy: McpServersInfo = {
       env: { LOG_LEVEL: "info" },
       env_from: ["PRIVATE_DOCS_TOKEN"],
       cwd: "/tmp/docs",
+      url: null,
+      bearer_token_env: null,
       request_timeout_ms: 60_000,
       enabled: true,
       health: "healthy",
@@ -108,6 +110,116 @@ describe("McpPanel", () => {
     expect(
       screen.getByText(/Save and verify changes before reconnecting/),
     ).toBeInTheDocument();
+  });
+
+  it("switches a server to HTTP and sends a url definition without process fields", async () => {
+    const client = api({ servers: [] });
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await screen.findByText(/No MCP servers configured/);
+    await user.click(screen.getByRole("button", { name: "Add server" }));
+    await user.click(
+      screen.getByRole("radio", { name: "Remote endpoint (HTTP)" }),
+    );
+
+    // Process-only editors leave the form with the transport.
+    expect(
+      screen.queryByPlaceholderText("/absolute/path/to/server"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add variable name" }),
+    ).not.toBeInTheDocument();
+
+    await user.type(
+      screen.getByPlaceholderText("https://gateway.example/mcp/tools"),
+      "http://127.0.0.1:28081/mcp/tools",
+    );
+    await user.type(
+      screen.getByPlaceholderText("GATEWAY_TOKEN"),
+      "MY_GATEWAY_TOKEN",
+    );
+    await user.click(screen.getByRole("button", { name: "Save and verify" }));
+
+    await waitFor(() =>
+      expect(client.putMcpServers).toHaveBeenCalledWith([
+        expect.objectContaining({
+          command: null,
+          args: [],
+          env: {},
+          env_from: [],
+          cwd: null,
+          url: "http://127.0.0.1:28081/mcp/tools",
+          bearer_token_env: "MY_GATEWAY_TOKEN",
+        }),
+      ]),
+    );
+  });
+
+  it("returning to stdio clears the http fields", async () => {
+    const client = api({ servers: [] });
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await screen.findByText(/No MCP servers configured/);
+    await user.click(screen.getByRole("button", { name: "Add server" }));
+    await user.click(
+      screen.getByRole("radio", { name: "Remote endpoint (HTTP)" }),
+    );
+    await user.type(
+      screen.getByPlaceholderText("https://gateway.example/mcp/tools"),
+      "http://127.0.0.1/mcp",
+    );
+    await user.click(
+      screen.getByRole("radio", { name: "Local process (stdio)" }),
+    );
+    await user.type(
+      screen.getByPlaceholderText("/absolute/path/to/server"),
+      "/opt/mcp/docs",
+    );
+    await user.click(screen.getByRole("button", { name: "Save and verify" }));
+
+    await waitFor(() =>
+      expect(client.putMcpServers).toHaveBeenCalledWith([
+        expect.objectContaining({
+          command: "/opt/mcp/docs",
+          url: null,
+          bearer_token_env: null,
+        }),
+      ]),
+    );
+  });
+
+  it("shows health for an http server without asking for a token value", async () => {
+    render(
+      <McpPanel
+        client={api({
+          servers: [
+            {
+              ...healthy.servers[0],
+              name: "gateway",
+              command: null,
+              args: [],
+              env: {},
+              env_from: [],
+              cwd: null,
+              url: "http://127.0.0.1:28081/mcp/tools",
+              bearer_token_env: "GATEWAY_TOKEN",
+              tool_count: 1,
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(await screen.findByText("Healthy")).toBeInTheDocument();
+    expect(screen.getByText("1 tool available to new turns.")).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("http://127.0.0.1:28081/mcp/tools"),
+    ).toBeInTheDocument();
+    // Only the variable name is ever displayed.
+    expect(screen.getByDisplayValue("GATEWAY_TOKEN")).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Remote endpoint (HTTP)" })).toBeChecked();
   });
 
   it("surfaces secret-free degraded diagnostics", async () => {

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -25,12 +25,40 @@ function emptyServer(index: number): McpServerInfo {
     env: {},
     env_from: [],
     cwd: null,
+    url: null,
+    bearer_token_env: null,
     request_timeout_ms: DEFAULT_TIMEOUT_MS,
     enabled: true,
     health: "initializing",
     tool_count: 0,
     diagnostic: null,
   };
+}
+
+type Transport = "stdio" | "http";
+
+function transportOf(server: McpServerInfo): Transport {
+  return server.url !== null ? "http" : "stdio";
+}
+
+/** Switching transports clears the other transport's fields so a saved
+ * definition can never carry both. */
+function transportFields(transport: Transport): Partial<McpServerInfo> {
+  return transport === "http"
+    ? {
+        command: null,
+        args: [],
+        env: {},
+        env_from: [],
+        cwd: null,
+        url: "",
+        bearer_token_env: null,
+      }
+    : {
+        command: "",
+        url: null,
+        bearer_token_env: null,
+      };
 }
 
 function definition(server: McpServerInfo): McpServerDefinition {
@@ -123,7 +151,7 @@ export function McpPanel({ client }: { client: ApiClient }) {
   return (
     <SettingsPanel
       title="MCP servers"
-      description="Connect local stdio tool servers without a shell or a desktop restart."
+      description="Connect local stdio tool servers or remote HTTP endpoints without a shell or a desktop restart."
       busy={loading || working}
     >
       {loading ? (
@@ -186,45 +214,111 @@ export function McpPanel({ client }: { client: ApiClient }) {
                 />
               </SettingsField>
 
-              <SettingsField
-                label="Executable"
-                hint="An executable path or command name. OpenWave never invokes a shell."
-              >
-                <Input
-                  value={server.command}
-                  disabled={working}
-                  autoComplete="off"
-                  spellCheck={false}
-                  placeholder="/absolute/path/to/server"
-                  onChange={(event) =>
-                    update(index, { command: event.target.value })
-                  }
-                />
-              </SettingsField>
+              <FieldGroup label="Transport">
+                <div className="flex gap-4" role="radiogroup" aria-label="Transport">
+                  {(["stdio", "http"] as const).map((transport) => (
+                    <label
+                      key={transport}
+                      className="flex items-center gap-2 text-sm"
+                    >
+                      <input
+                        type="radio"
+                        name={`transport-${index}`}
+                        checked={transportOf(server) === transport}
+                        disabled={working}
+                        onChange={() =>
+                          update(index, transportFields(transport))
+                        }
+                      />
+                      {transport === "stdio"
+                        ? "Local process (stdio)"
+                        : "Remote endpoint (HTTP)"}
+                    </label>
+                  ))}
+                </div>
+              </FieldGroup>
 
-              <StringListEditor
-                label="Arguments"
-                values={server.args}
-                disabled={working}
-                addLabel="Add argument"
-                onChange={(args) => update(index, { args })}
-              />
+              {transportOf(server) === "stdio" && (
+                <>
+                  <SettingsField
+                    label="Executable"
+                    hint="An executable path or command name. OpenWave never invokes a shell."
+                  >
+                    <Input
+                      value={server.command ?? ""}
+                      disabled={working}
+                      autoComplete="off"
+                      spellCheck={false}
+                      placeholder="/absolute/path/to/server"
+                      onChange={(event) =>
+                        update(index, { command: event.target.value })
+                      }
+                    />
+                  </SettingsField>
 
-              <SettingsField
-                label="Working directory"
-                hint="Optional. It does not grant the server any OpenWave folder capability."
-              >
-                <Input
-                  value={server.cwd ?? ""}
-                  disabled={working}
-                  autoComplete="off"
-                  spellCheck={false}
-                  placeholder="Optional"
-                  onChange={(event) =>
-                    update(index, { cwd: event.target.value || null })
-                  }
-                />
-              </SettingsField>
+                  <StringListEditor
+                    label="Arguments"
+                    values={server.args}
+                    disabled={working}
+                    addLabel="Add argument"
+                    onChange={(args) => update(index, { args })}
+                  />
+
+                  <SettingsField
+                    label="Working directory"
+                    hint="Optional. It does not grant the server any OpenWave folder capability."
+                  >
+                    <Input
+                      value={server.cwd ?? ""}
+                      disabled={working}
+                      autoComplete="off"
+                      spellCheck={false}
+                      placeholder="Optional"
+                      onChange={(event) =>
+                        update(index, { cwd: event.target.value || null })
+                      }
+                    />
+                  </SettingsField>
+                </>
+              )}
+
+              {transportOf(server) === "http" && (
+                <>
+                  <SettingsField
+                    label="Server URL"
+                    hint="An http or https MCP endpoint. Credentials never go in the URL."
+                  >
+                    <Input
+                      value={server.url ?? ""}
+                      disabled={working}
+                      autoComplete="off"
+                      spellCheck={false}
+                      placeholder="https://gateway.example/mcp/tools"
+                      onChange={(event) =>
+                        update(index, { url: event.target.value })
+                      }
+                    />
+                  </SettingsField>
+
+                  <SettingsField
+                    label="Bearer token variable"
+                    hint="Optional. Only the name is saved; the token is read from the host environment when connecting and never displayed."
+                  >
+                    <Input
+                      value={server.bearer_token_env ?? ""}
+                      disabled={working}
+                      autoComplete="off"
+                      spellCheck={false}
+                      placeholder="GATEWAY_TOKEN"
+                      onChange={(event) =>
+                        update(index, {
+                          bearer_token_env: event.target.value || null,
+                        })
+                      }
+                    />
+                  </SettingsField>
+                </>
+              )}
 
               <SettingsField
                 label="Request timeout (ms)"
@@ -245,20 +339,24 @@ export function McpPanel({ client }: { client: ApiClient }) {
                 />
               </SettingsField>
 
-              <EnvironmentEditor
-                values={server.env}
-                disabled={working}
-                onChange={(env) => update(index, { env })}
-              />
+              {transportOf(server) === "stdio" && (
+                <>
+                  <EnvironmentEditor
+                    values={server.env}
+                    disabled={working}
+                    onChange={(env) => update(index, { env })}
+                  />
 
-              <StringListEditor
-                label="Forward environment names"
-                hint="Only names are saved or displayed. Their values are resolved in the host process and never returned to the app."
-                values={server.env_from}
-                disabled={working}
-                addLabel="Add variable name"
-                onChange={(env_from) => update(index, { env_from })}
-              />
+                  <StringListEditor
+                    label="Forward environment names"
+                    hint="Only names are saved or displayed. Their values are resolved in the host process and never returned to the app."
+                    values={server.env_from}
+                    disabled={working}
+                    addLabel="Add variable name"
+                    onChange={(env_from) => update(index, { env_from })}
+                  />
+                </>
+              )}
 
               <div className="flex flex-wrap gap-2">
                 {server.enabled &&
@@ -326,8 +424,8 @@ export function McpPanel({ client }: { client: ApiClient }) {
             MCP tools are always sensitive and keep OpenWave’s existing approval
             boundary. Child environments start empty. Put credentials in the
             host environment and select only their variable names above; do not
-            enter secrets in the executable, arguments, working directory, or
-            literal values.
+            enter secrets in the executable, arguments, working directory,
+            literal values, or a server URL.
           </p>
         </>
       )}

--- a/crates/openwave-mcp/Cargo.toml
+++ b/crates/openwave-mcp/Cargo.toml
@@ -12,6 +12,8 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+futures = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["io-std", "io-util", "process", "sync", "time"] }
@@ -20,5 +22,6 @@ tokio = { workspace = true, features = ["io-std", "io-util", "process", "sync", 
 openwave-core = { path = "../openwave-core", default-features = false }
 
 [dev-dependencies]
+axum = { workspace = true }
 chrono = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt", "net"] }

--- a/crates/openwave-mcp/src/client.rs
+++ b/crates/openwave-mcp/src/client.rs
@@ -1,4 +1,5 @@
-//! MCP client support for mounting an external stdio tool server.
+//! MCP client support for mounting an external tool server over stdio or
+//! Streamable HTTP.
 
 use std::collections::HashSet;
 use std::process::Stdio;
@@ -16,6 +17,7 @@ use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tokio::time::timeout;
 
+use crate::http::HttpWire;
 use crate::protocol::{Response, RpcError, PROTOCOL_VERSION};
 
 const CLIENT_NAME: &str = "openwave";
@@ -30,7 +32,7 @@ const MAX_TOOL_SCHEMA_BYTES: usize = 64 * 1024;
 const MAX_TOOL_METADATA_BYTES: usize = 512 * 1024;
 const MAX_TOOL_LIST_PAGES: usize = 64;
 const MAX_CURSOR_BYTES: usize = 4 * 1024;
-const MAX_JSON_RPC_FRAME_BYTES: usize = 2 * 1024 * 1024;
+pub(crate) const MAX_JSON_RPC_FRAME_BYTES: usize = 2 * 1024 * 1024;
 
 /// Default maximum time to wait for one external MCP request.
 pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
@@ -87,7 +89,7 @@ impl McpClient {
     {
         Self::connect_session(
             server_name.into(),
-            Session::new(
+            Session::stream(
                 Box::new(BufReader::new(reader)),
                 Box::new(writer),
                 None,
@@ -146,7 +148,7 @@ impl McpClient {
 
         let client = Self::connect_session(
             server_name,
-            Session::new(
+            Session::stream(
                 Box::new(BufReader::new(stdout)),
                 Box::new(stdin),
                 Some(child),
@@ -154,6 +156,43 @@ impl McpClient {
             ),
         )
         .await?;
+        client.session.lock().await.request_timeout = request_timeout;
+        Ok(client)
+    }
+
+    /// Connect to an external Streamable HTTP MCP server.
+    ///
+    /// `bearer_token` is attached as an `Authorization: Bearer` header on every
+    /// request and never appears in errors, logs, or the mounted tool surface.
+    pub async fn connect_http(
+        server_name: impl Into<String>,
+        url: &str,
+        bearer_token: Option<&str>,
+    ) -> Result<Self> {
+        Self::connect_http_with_timeouts(
+            server_name,
+            url,
+            bearer_token,
+            DEFAULT_REQUEST_TIMEOUT,
+            DEFAULT_REQUEST_TIMEOUT,
+        )
+        .await
+    }
+
+    /// Connect over HTTP with a separately bounded initialization timeout, in
+    /// the same shape as [`Self::spawn_with_timeouts`].
+    pub async fn connect_http_with_timeouts(
+        server_name: impl Into<String>,
+        url: &str,
+        bearer_token: Option<&str>,
+        initialization_timeout: Duration,
+        request_timeout: Duration,
+    ) -> Result<Self> {
+        let server_name = server_name.into();
+        validate_server_name(&server_name)?;
+        let wire = HttpWire::new(url, bearer_token)?;
+        let client =
+            Self::connect_session(server_name, Session::http(wire, initialization_timeout)).await?;
         client.session.lock().await.request_timeout = request_timeout;
         Ok(client)
     }
@@ -259,30 +298,42 @@ impl McpClient {
 }
 
 struct Session {
-    reader: BoxReader,
-    writer: BoxWriter,
+    wire: Wire,
     next_id: u64,
     request_timeout: Duration,
     tools_list_changed: bool,
-    // Keeping the child owns its lifecycle; `kill_on_drop(true)` handles both a
-    // normal registry teardown and a failed initialization.
-    _child: Option<Child>,
+}
+
+enum Wire {
+    Stream(StreamWire),
+    Http(HttpWire),
 }
 
 impl Session {
-    fn new(
+    fn stream(
         reader: BoxReader,
         writer: BoxWriter,
         child: Option<Child>,
         request_timeout: Duration,
     ) -> Self {
         Self {
-            reader,
-            writer,
+            wire: Wire::Stream(StreamWire {
+                reader,
+                writer,
+                _child: child,
+            }),
             next_id: 1,
             request_timeout,
             tools_list_changed: false,
-            _child: child,
+        }
+    }
+
+    fn http(wire: HttpWire, request_timeout: Duration) -> Self {
+        Self {
+            wire: Wire::Http(wire),
+            next_id: 1,
+            request_timeout,
+            tools_list_changed: false,
         }
     }
 
@@ -302,18 +353,47 @@ impl Session {
             "method": method,
             "params": params
         });
-        timeout(self.request_timeout, self.write_value(&request))
-            .await
-            .map_err(|_| mcp_message(format!("timed out writing {method} request")))??;
-        match timeout(self.request_timeout, self.read_response(id)).await {
+        let request_timeout = self.request_timeout;
+        let Self {
+            wire,
+            tools_list_changed,
+            ..
+        } = self;
+        let outcome = match wire {
+            Wire::Stream(stream) => {
+                timeout(request_timeout, stream.write_value(&request))
+                    .await
+                    .map_err(|_| mcp_message(format!("timed out writing {method} request")))??;
+                timeout(
+                    request_timeout,
+                    stream.read_response(id, tools_list_changed),
+                )
+                .await
+            }
+            Wire::Http(http) => {
+                timeout(
+                    request_timeout,
+                    http.request(id, &request, tools_list_changed),
+                )
+                .await
+            }
+        };
+        match outcome {
             Ok(result) => result,
             Err(_) => {
-                let _ = self
-                    .notify(
-                        "notifications/cancelled",
-                        json!({"requestId": id, "reason": "OpenWave MCP request timed out"}),
-                    )
-                    .await;
+                // Best-effort courtesy: tell the server the request is dead so
+                // it can stop working on it. Failure to deliver changes nothing.
+                let cancelled = json!({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/cancelled",
+                    "params": {"requestId": id, "reason": "OpenWave MCP request timed out"}
+                });
+                let _ = match &mut self.wire {
+                    Wire::Stream(stream) => {
+                        timeout(request_timeout, stream.write_value(&cancelled)).await
+                    }
+                    Wire::Http(http) => timeout(request_timeout, http.notify(&cancelled)).await,
+                };
                 Err(mcp_message(format!(
                     "external server timed out handling {method}"
                 )))
@@ -327,11 +407,28 @@ impl Session {
             "method": method,
             "params": params
         });
-        timeout(self.request_timeout, self.write_value(&notification))
-            .await
-            .map_err(|_| mcp_message(format!("timed out writing {method} notification")))?
+        match &mut self.wire {
+            Wire::Stream(stream) => {
+                timeout(self.request_timeout, stream.write_value(&notification))
+                    .await
+                    .map_err(|_| mcp_message(format!("timed out writing {method} notification")))?
+            }
+            Wire::Http(http) => timeout(self.request_timeout, http.notify(&notification))
+                .await
+                .map_err(|_| mcp_message(format!("timed out writing {method} notification")))?,
+        }
     }
+}
 
+struct StreamWire {
+    reader: BoxReader,
+    writer: BoxWriter,
+    // Keeping the child owns its lifecycle; `kill_on_drop(true)` handles both a
+    // normal registry teardown and a failed initialization.
+    _child: Option<Child>,
+}
+
+impl StreamWire {
     async fn write_value(&mut self, value: &Value) -> Result<()> {
         let mut encoded = serde_json::to_vec(value)?;
         encoded.push(b'\n');
@@ -345,7 +442,11 @@ impl Session {
             .map_err(|error| mcp_error("could not flush external server request", error))
     }
 
-    async fn read_response(&mut self, expected_id: u64) -> Result<Value> {
+    async fn read_response(
+        &mut self,
+        expected_id: u64,
+        tools_list_changed: &mut bool,
+    ) -> Result<Value> {
         loop {
             let Some(line) = read_bounded_line(&mut self.reader).await? else {
                 return Err(mcp_message("external server closed stdout before replying"));
@@ -355,67 +456,96 @@ impl Session {
             }
             let value: Value = serde_json::from_slice(&line)
                 .map_err(|error| mcp_error("external server returned malformed JSON-RPC", error))?;
-
-            // Server notifications are asynchronous and need no response. Ping
-            // is part of the MCP base protocol in either direction. The client
-            // advertises no other request-producing capabilities, so fail closed
-            // for any other server request.
-            if let Some(method) = value.get("method").and_then(Value::as_str) {
-                if method == "notifications/tools/list_changed" && value.get("id").is_none() {
-                    self.tools_list_changed = true;
+            match classify_incoming(value, expected_id, tools_list_changed)? {
+                Incoming::FinalResult(result) => return Ok(result),
+                Incoming::ServerRequest { id, method } => {
+                    let response = server_request_response(id, &method)?;
+                    self.write_value(&response).await?;
                 }
-                if let Some(id) = value.get("id") {
-                    self.write_server_request_response(id.clone(), method)
-                        .await?;
-                }
-                continue;
+                Incoming::Ignored => {}
             }
-
-            let response: IncomingResponse = serde_json::from_value(value).map_err(|error| {
-                mcp_error(
-                    "external server returned an invalid JSON-RPC response",
-                    error,
-                )
-            })?;
-            if response.jsonrpc != "2.0" {
-                return Err(mcp_message(
-                    "external server response did not use JSON-RPC 2.0",
-                ));
-            }
-            if response.id.as_u64().is_some_and(|id| id < expected_id) {
-                // A server may complete an already-cancelled timed-out request
-                // after the client has moved on. Calls are serialized, so only
-                // an older numeric id can safely be recognized as stale.
-                continue;
-            }
-            if response.id != json!(expected_id) {
-                return Err(mcp_message(format!(
-                    "external server replied with id {} while waiting for {expected_id}",
-                    response.id
-                )));
-            }
-            return match (response.result, response.error) {
-                (Some(result), None) => Ok(result),
-                (None, Some(error)) => Err(mcp_message(format!(
-                    "external server returned JSON-RPC error {}: {}",
-                    error.code, error.message
-                ))),
-                _ => Err(mcp_message(
-                    "external server response must contain exactly one of result or error",
-                )),
-            };
         }
     }
+}
 
-    async fn write_server_request_response(&mut self, id: Value, method: &str) -> Result<()> {
-        let response = if method == "ping" {
-            Response::result(id, json!({}))
-        } else {
-            Response::error(id, RpcError::method_not_found(method))
-        };
-        let value = serde_json::to_value(response)?;
-        self.write_value(&value).await
+/// One classified incoming JSON-RPC message, transport-independent.
+pub(crate) enum Incoming {
+    /// The response matching the in-flight request id.
+    FinalResult(Value),
+    /// A server-initiated request that needs an answer on the write path.
+    ServerRequest { id: Value, method: String },
+    /// A notification or a stale response to an already-abandoned request.
+    Ignored,
+}
+
+/// Classify one message the way the stdio loop always has: notifications latch
+/// `tools/list_changed`, server requests are surfaced for a fail-closed answer,
+/// stale numeric ids are skipped, and anything else must be the response.
+pub(crate) fn classify_incoming(
+    value: Value,
+    expected_id: u64,
+    tools_list_changed: &mut bool,
+) -> Result<Incoming> {
+    // Server notifications are asynchronous and need no response. Ping is part
+    // of the MCP base protocol in either direction. The client advertises no
+    // other request-producing capabilities, so fail closed for any other
+    // server request.
+    if let Some(method) = value.get("method").and_then(Value::as_str) {
+        if method == "notifications/tools/list_changed" && value.get("id").is_none() {
+            *tools_list_changed = true;
+        }
+        if let Some(id) = value.get("id") {
+            return Ok(Incoming::ServerRequest {
+                id: id.clone(),
+                method: method.to_string(),
+            });
+        }
+        return Ok(Incoming::Ignored);
     }
+
+    let response: IncomingResponse = serde_json::from_value(value).map_err(|error| {
+        mcp_error(
+            "external server returned an invalid JSON-RPC response",
+            error,
+        )
+    })?;
+    if response.jsonrpc != "2.0" {
+        return Err(mcp_message(
+            "external server response did not use JSON-RPC 2.0",
+        ));
+    }
+    if response.id.as_u64().is_some_and(|id| id < expected_id) {
+        // A server may complete an already-cancelled timed-out request after
+        // the client has moved on. Calls are serialized, so only an older
+        // numeric id can safely be recognized as stale.
+        return Ok(Incoming::Ignored);
+    }
+    if response.id != json!(expected_id) {
+        return Err(mcp_message(format!(
+            "external server replied with id {} while waiting for {expected_id}",
+            response.id
+        )));
+    }
+    match (response.result, response.error) {
+        (Some(result), None) => Ok(Incoming::FinalResult(result)),
+        (None, Some(error)) => Err(mcp_message(format!(
+            "external server returned JSON-RPC error {}: {}",
+            error.code, error.message
+        ))),
+        _ => Err(mcp_message(
+            "external server response must contain exactly one of result or error",
+        )),
+    }
+}
+
+/// The fail-closed answer to a server-initiated request.
+pub(crate) fn server_request_response(id: Value, method: &str) -> Result<Value> {
+    let response = if method == "ping" {
+        Response::result(id, json!({}))
+    } else {
+        Response::error(id, RpcError::method_not_found(method))
+    };
+    Ok(serde_json::to_value(response)?)
 }
 
 async fn read_bounded_line(reader: &mut BoxReader) -> Result<Option<Vec<u8>>> {
@@ -715,11 +845,11 @@ fn decode_result<T: for<'de> Deserialize<'de>>(method: &str, value: Value) -> Re
     })
 }
 
-fn mcp_message(message: impl Into<String>) -> AgentError {
+pub(crate) fn mcp_message(message: impl Into<String>) -> AgentError {
     AgentError::msg(format!("MCP client error: {}", message.into()))
 }
 
-fn mcp_error(context: impl AsRef<str>, error: impl std::fmt::Display) -> AgentError {
+pub(crate) fn mcp_error(context: impl AsRef<str>, error: impl std::fmt::Display) -> AgentError {
     mcp_message(format!("{}: {error}", context.as_ref()))
 }
 
@@ -1119,5 +1249,229 @@ mod tests {
     fn non_text_content_is_preserved_for_the_model() {
         let block = json!({"type": "resource_link", "uri": "file:///report.pdf"});
         assert_eq!(content_for_model(&block), block.to_string());
+    }
+
+    mod http_transport {
+        use std::net::SocketAddr;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use axum::extract::State;
+        use axum::http::{HeaderMap, StatusCode};
+        use axum::response::{IntoResponse, Response as AxumResponse};
+        use axum::routing::post;
+        use axum::Router;
+
+        use super::*;
+
+        const TEST_TOKEN: &str = "test-token-abc123";
+        const TEST_SESSION_ID: &str = "session-xyz";
+
+        #[derive(Default)]
+        struct ServerState {
+            requests: AtomicUsize,
+            sse: bool,
+        }
+
+        async fn handler(
+            State(state): State<Arc<ServerState>>,
+            headers: HeaderMap,
+            body: String,
+        ) -> AxumResponse {
+            let authorization = headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default();
+            if authorization != format!("Bearer {TEST_TOKEN}") {
+                return StatusCode::UNAUTHORIZED.into_response();
+            }
+            assert!(headers
+                .get("accept")
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|accept| accept.contains("application/json")));
+            assert_eq!(
+                headers
+                    .get("mcp-protocol-version")
+                    .and_then(|value| value.to_str().ok()),
+                Some(PROTOCOL_VERSION)
+            );
+            let request: Value = serde_json::from_str(&body).unwrap();
+            let sequence = state.requests.fetch_add(1, Ordering::SeqCst);
+            if sequence > 0 {
+                // Every request after initialize must echo the issued session.
+                assert_eq!(
+                    headers
+                        .get("mcp-session-id")
+                        .and_then(|value| value.to_str().ok()),
+                    Some(TEST_SESSION_ID)
+                );
+            }
+            let Some(id) = request.get("id").cloned() else {
+                return StatusCode::ACCEPTED.into_response();
+            };
+            let result = match request["method"].as_str().unwrap() {
+                "initialize" => json!({
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "http-fixture", "version": "9"}
+                }),
+                "tools/list" => json!({
+                    "tools": [{
+                        "name": "lookup",
+                        "description": "Look something up",
+                        "inputSchema": {"type": "object"}
+                    }]
+                }),
+                "tools/call" => json!({
+                    "content": [{"type": "text", "text": "http result"}],
+                    "structuredContent": {"via": "http"},
+                    "isError": false
+                }),
+                "ping" => json!({}),
+                method => panic!("unexpected method: {method}"),
+            };
+            let response = json!({"jsonrpc": "2.0", "id": id, "result": result});
+            if state.sse {
+                let notification =
+                    json!({"jsonrpc": "2.0", "method": "notifications/tools/list_changed"});
+                let stream_body =
+                    format!("event: message\ndata: {notification}\n\ndata: {response}\n\n");
+                (
+                    [
+                        ("content-type", "text/event-stream"),
+                        ("mcp-session-id", TEST_SESSION_ID),
+                    ],
+                    stream_body,
+                )
+                    .into_response()
+            } else {
+                (
+                    [
+                        ("content-type", "application/json"),
+                        ("mcp-session-id", TEST_SESSION_ID),
+                    ],
+                    response.to_string(),
+                )
+                    .into_response()
+            }
+        }
+
+        async fn serve(state: Arc<ServerState>) -> SocketAddr {
+            let app = Router::new().route("/mcp", post(handler)).with_state(state);
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+            address
+        }
+
+        #[tokio::test]
+        async fn connects_and_calls_tools_over_json_responses() {
+            let address = serve(Arc::new(ServerState::default())).await;
+            let client = McpClient::connect_http(
+                "gateway",
+                &format!("http://{address}/mcp"),
+                Some(TEST_TOKEN),
+            )
+            .await
+            .unwrap();
+            assert_eq!(client.server_info().name, "http-fixture");
+
+            let mut registry = ToolRegistry::new();
+            client.mount(&mut registry);
+            let output = registry
+                .get("mcp__gateway__lookup")
+                .unwrap()
+                .execute(
+                    &ToolCtx::new_legacy_workspace(
+                        ChatId::new(),
+                        None,
+                        PathBuf::from("unused-by-mcp"),
+                    ),
+                    json!({}),
+                )
+                .await
+                .unwrap();
+            assert_eq!(output.content, "http result");
+            assert_eq!(output.data, Some(json!({"via": "http"})));
+            assert_eq!(
+                client.probe().await.unwrap(),
+                McpProbe::Ready {
+                    tools_list_changed: false
+                }
+            );
+        }
+
+        #[tokio::test]
+        async fn reads_event_stream_responses_and_latches_notifications() {
+            let address = serve(Arc::new(ServerState {
+                requests: AtomicUsize::new(0),
+                sse: true,
+            }))
+            .await;
+            let client = McpClient::connect_http(
+                "gateway",
+                &format!("http://{address}/mcp"),
+                Some(TEST_TOKEN),
+            )
+            .await
+            .unwrap();
+            // Every SSE response carried a tools/list_changed notification
+            // ahead of the result; the probe must surface the latch.
+            assert_eq!(
+                client.probe().await.unwrap(),
+                McpProbe::Ready {
+                    tools_list_changed: true
+                }
+            );
+        }
+
+        #[tokio::test]
+        async fn rejected_credentials_fail_without_echoing_the_token() {
+            let address = serve(Arc::new(ServerState::default())).await;
+            let error = McpClient::connect_http(
+                "gateway",
+                &format!("http://{address}/mcp"),
+                Some("wrong-token"),
+            )
+            .await
+            .err()
+            .expect("wrong token must fail");
+            let message = error.to_string();
+            assert!(message.contains("rejected the configured credentials"));
+            assert!(!message.contains("wrong-token"));
+        }
+
+        #[tokio::test]
+        async fn an_unreachable_server_fails_with_a_bounded_error() {
+            let error = McpClient::connect_http_with_timeouts(
+                "gateway",
+                "http://127.0.0.1:1/mcp",
+                None,
+                Duration::from_secs(2),
+                Duration::from_secs(2),
+            )
+            .await
+            .err()
+            .expect("unreachable server must fail");
+            assert!(error
+                .to_string()
+                .contains("could not reach external server"));
+        }
+
+        #[tokio::test]
+        async fn http_connect_validates_the_namespace_and_url_first() {
+            let error = McpClient::connect_http("bad server", "http://127.0.0.1/mcp", None)
+                .await
+                .err()
+                .expect("invalid name must fail");
+            assert!(error.to_string().contains("ASCII letters"));
+
+            let error = McpClient::connect_http("gateway", "ftp://host/mcp", None)
+                .await
+                .err()
+                .expect("invalid scheme must fail");
+            assert!(error.to_string().contains("http or https"));
+        }
     }
 }

--- a/crates/openwave-mcp/src/client.rs
+++ b/crates/openwave-mcp/src/client.rs
@@ -1443,6 +1443,37 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn redirects_are_not_followed_with_a_credential_in_hand() {
+            // A redirecting endpoint must surface as an error, not as a
+            // silently relocated (and re-credentialed) request.
+            let app = Router::new().route(
+                "/mcp",
+                post(|| async {
+                    (
+                        StatusCode::FOUND,
+                        [("location", "http://127.0.0.1:1/elsewhere")],
+                    )
+                        .into_response()
+                }),
+            );
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let address = listener.local_addr().unwrap();
+            tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+
+            let error = McpClient::connect_http(
+                "gateway",
+                &format!("http://{address}/mcp"),
+                Some(TEST_TOKEN),
+            )
+            .await
+            .err()
+            .expect("redirect must fail");
+            assert!(error.to_string().contains("HTTP status 302"), "{error}");
+        }
+
+        #[tokio::test]
         async fn an_unreachable_server_fails_with_a_bounded_error() {
             let error = McpClient::connect_http_with_timeouts(
                 "gateway",

--- a/crates/openwave-mcp/src/http.rs
+++ b/crates/openwave-mcp/src/http.rs
@@ -1,0 +1,371 @@
+//! Streamable HTTP client transport for external MCP servers.
+//!
+//! Each JSON-RPC request is one authenticated `POST`. A server may answer with
+//! a single `application/json` message or with a `text/event-stream` carrying
+//! interim notifications before the final response. Responses to
+//! client notifications are expected to be empty (HTTP 202).
+//!
+//! The bearer token lives only inside the prebuilt `Authorization` header value
+//! and is never echoed into errors or logs.
+
+use openwave_core::Result;
+use serde_json::Value;
+
+use crate::client::{mcp_error, mcp_message, MAX_JSON_RPC_FRAME_BYTES};
+use crate::protocol::PROTOCOL_VERSION;
+
+const SESSION_ID_HEADER: &str = "mcp-session-id";
+const PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+const MAX_SESSION_ID_BYTES: usize = 4 * 1024;
+
+/// One Streamable HTTP connection to an external MCP server.
+pub(crate) struct HttpWire {
+    client: reqwest::Client,
+    url: reqwest::Url,
+    /// Prebuilt `Bearer …` header value; kept whole so the raw token never
+    /// travels through formatting code that could end up in an error.
+    authorization: Option<String>,
+    /// Server-assigned session, echoed on every request once issued.
+    session_id: Option<String>,
+}
+
+/// Validate a candidate MCP server URL without connecting.
+///
+/// Exposed so configuration layers can reject an invalid URL before accepting
+/// a definition, with the same rules the transport applies.
+pub fn validate_http_url(url: &str) -> Result<()> {
+    let parsed =
+        reqwest::Url::parse(url).map_err(|_| mcp_message("external server URL is invalid"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(mcp_message("external server URL must use http or https"));
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(mcp_message(
+            "external server URL must not embed credentials",
+        ));
+    }
+    if parsed.host_str().is_none() {
+        return Err(mcp_message("external server URL must name a host"));
+    }
+    Ok(())
+}
+
+impl HttpWire {
+    pub(crate) fn new(url: &str, bearer_token: Option<&str>) -> Result<Self> {
+        validate_http_url(url)?;
+        let url =
+            reqwest::Url::parse(url).map_err(|_| mcp_message("external server URL is invalid"))?;
+        if bearer_token.is_some_and(|token| {
+            token.is_empty() || token.bytes().any(|byte| byte.is_ascii_control())
+        }) {
+            return Err(mcp_message(
+                "external server bearer token must be a non-empty header-safe value",
+            ));
+        }
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .build()
+                .map_err(|error| mcp_error("could not build HTTP client", error))?,
+            url,
+            authorization: bearer_token.map(|token| format!("Bearer {token}")),
+            session_id: None,
+        })
+    }
+
+    /// Send one request and read messages until the matching response arrives.
+    ///
+    /// Interim server notifications set `tools_list_changed` exactly like the
+    /// stdio transport. A server request embedded in the stream is answered
+    /// with a follow-up POST because the response channel is one-way.
+    pub(crate) async fn request(
+        &mut self,
+        expected_id: u64,
+        message: &Value,
+        tools_list_changed: &mut bool,
+    ) -> Result<Value> {
+        let response = self.post(message).await?;
+        self.absorb_session_id(&response)?;
+        let status = response.status();
+        if status == reqwest::StatusCode::ACCEPTED {
+            return Err(mcp_message(
+                "external server accepted a request without replying",
+            ));
+        }
+        check_status(status)?;
+
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        if content_type.starts_with("text/event-stream") {
+            self.read_event_stream(expected_id, response, tools_list_changed)
+                .await
+        } else if content_type.starts_with("application/json") {
+            let body = read_bounded_body(response).await?;
+            let value: Value = serde_json::from_slice(&body)
+                .map_err(|error| mcp_error("external server returned malformed JSON-RPC", error))?;
+            match crate::client::classify_incoming(value, expected_id, tools_list_changed)? {
+                crate::client::Incoming::FinalResult(result) => Ok(result),
+                crate::client::Incoming::ServerRequest { .. }
+                | crate::client::Incoming::Ignored => Err(mcp_message(
+                    "external server JSON response did not answer the request",
+                )),
+            }
+        } else {
+            Err(mcp_message(
+                "external server replied with an unsupported content type",
+            ))
+        }
+    }
+
+    /// Send one notification. Streamable HTTP servers acknowledge with an
+    /// empty 202; any success status is accepted and the body is ignored.
+    pub(crate) async fn notify(&mut self, message: &Value) -> Result<()> {
+        let response = self.post(message).await?;
+        self.absorb_session_id(&response)?;
+        check_status(response.status())
+    }
+
+    async fn post(&self, message: &Value) -> Result<reqwest::Response> {
+        let mut request = self
+            .client
+            .post(self.url.clone())
+            .header(
+                reqwest::header::ACCEPT,
+                "application/json, text/event-stream",
+            )
+            .header(PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION)
+            .json(message);
+        if let Some(authorization) = &self.authorization {
+            request = request.header(reqwest::header::AUTHORIZATION, authorization);
+        }
+        if let Some(session_id) = &self.session_id {
+            request = request.header(SESSION_ID_HEADER, session_id);
+        }
+        request
+            .send()
+            .await
+            .map_err(|error| mcp_error("could not reach external server", without_url(error)))
+    }
+
+    async fn read_event_stream(
+        &mut self,
+        expected_id: u64,
+        response: reqwest::Response,
+        tools_list_changed: &mut bool,
+    ) -> Result<Value> {
+        use futures::StreamExt;
+
+        let mut stream = response.bytes_stream();
+        let mut parser = SseParser::default();
+        let mut server_requests: Vec<(Value, String)> = Vec::new();
+        let mut outcome = None;
+        'read: while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| {
+                mcp_error("could not read external server stream", without_url(error))
+            })?;
+            for data in parser.push(&chunk)? {
+                let value: Value = serde_json::from_slice(data.as_bytes()).map_err(|error| {
+                    mcp_error("external server returned malformed JSON-RPC", error)
+                })?;
+                match crate::client::classify_incoming(value, expected_id, tools_list_changed)? {
+                    crate::client::Incoming::FinalResult(result) => {
+                        outcome = Some(result);
+                        break 'read;
+                    }
+                    crate::client::Incoming::ServerRequest { id, method } => {
+                        server_requests.push((id, method));
+                    }
+                    crate::client::Incoming::Ignored => {}
+                }
+            }
+        }
+        drop(stream);
+        // Answer embedded server requests after releasing the stream so the
+        // reply POSTs cannot deadlock against an unread response body.
+        for (id, method) in server_requests {
+            let response = crate::client::server_request_response(id, &method)?;
+            let _ = self.notify(&response).await;
+        }
+        outcome.ok_or_else(|| mcp_message("external server closed the stream before replying"))
+    }
+
+    fn absorb_session_id(&mut self, response: &reqwest::Response) -> Result<()> {
+        let Some(session_id) = response.headers().get(SESSION_ID_HEADER) else {
+            return Ok(());
+        };
+        let session_id = session_id
+            .to_str()
+            .map_err(|_| mcp_message("external server session id is not visible ASCII"))?;
+        if session_id.is_empty() || session_id.len() > MAX_SESSION_ID_BYTES {
+            return Err(mcp_message("external server session id exceeds the limit"));
+        }
+        self.session_id = Some(session_id.to_string());
+        Ok(())
+    }
+}
+
+fn check_status(status: reqwest::StatusCode) -> Result<()> {
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(mcp_message(
+            "external server rejected the configured credentials",
+        ));
+    }
+    if !status.is_success() {
+        return Err(mcp_message(format!(
+            "external server replied with HTTP status {}",
+            status.as_u16()
+        )));
+    }
+    Ok(())
+}
+
+/// Strip the request URL from a reqwest error display chain. The URL is
+/// non-secret configuration, but diagnostics stay stable and minimal.
+fn without_url(error: reqwest::Error) -> impl std::fmt::Display {
+    error.without_url()
+}
+
+async fn read_bounded_body(response: reqwest::Response) -> Result<Vec<u8>> {
+    use futures::StreamExt;
+
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_JSON_RPC_FRAME_BYTES as u64)
+    {
+        return Err(mcp_message(
+            "external server JSON-RPC frame exceeds the limit",
+        ));
+    }
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| {
+            mcp_error(
+                "could not read external server response",
+                without_url(error),
+            )
+        })?;
+        if body.len().saturating_add(chunk.len()) > MAX_JSON_RPC_FRAME_BYTES {
+            return Err(mcp_message(
+                "external server JSON-RPC frame exceeds the limit",
+            ));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+/// Incremental `text/event-stream` parser that yields complete event payloads.
+///
+/// Only `data:` fields matter for MCP; other fields and comments are ignored.
+/// The unconsumed buffer and any accumulating event share one frame bound.
+#[derive(Default)]
+struct SseParser {
+    buffer: Vec<u8>,
+    event_data: Vec<String>,
+    event_bytes: usize,
+}
+
+impl SseParser {
+    fn push(&mut self, chunk: &[u8]) -> Result<Vec<String>> {
+        if self
+            .buffer
+            .len()
+            .saturating_add(chunk.len())
+            .saturating_add(self.event_bytes)
+            > MAX_JSON_RPC_FRAME_BYTES
+        {
+            return Err(mcp_message(
+                "external server JSON-RPC frame exceeds the limit",
+            ));
+        }
+        self.buffer.extend_from_slice(chunk);
+        let mut events = Vec::new();
+        while let Some(newline) = self.buffer.iter().position(|byte| *byte == b'\n') {
+            let mut line: Vec<u8> = self.buffer.drain(..=newline).collect();
+            line.pop();
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+            if line.is_empty() {
+                if !self.event_data.is_empty() {
+                    events.push(self.event_data.join("\n"));
+                    self.event_data.clear();
+                    self.event_bytes = 0;
+                }
+                continue;
+            }
+            let Some(value) = line.strip_prefix(b"data:") else {
+                // event/id/retry fields and ":" comments are irrelevant here.
+                continue;
+            };
+            let value = value.strip_prefix(b" ").unwrap_or(value);
+            let value = std::str::from_utf8(value)
+                .map_err(|_| mcp_message("external server stream is not valid UTF-8"))?;
+            self.event_bytes = self.event_bytes.saturating_add(value.len());
+            self.event_data.push(value.to_string());
+        }
+        Ok(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sse_parser_joins_multi_line_data_and_ignores_other_fields() {
+        let mut parser = SseParser::default();
+        let events = parser
+            .push(b": comment\nevent: message\ndata: {\"a\":\ndata: 1}\nid: 7\n\n")
+            .unwrap();
+        assert_eq!(events, vec!["{\"a\":\n1}".to_string()]);
+    }
+
+    #[test]
+    fn sse_parser_handles_crlf_and_split_chunks() {
+        let mut parser = SseParser::default();
+        assert!(parser.push(b"data: {\"x\"").unwrap().is_empty());
+        assert!(parser.push(b": 2}\r\n").unwrap().is_empty());
+        let events = parser.push(b"\r\n").unwrap();
+        assert_eq!(events, vec!["{\"x\": 2}".to_string()]);
+    }
+
+    #[test]
+    fn sse_parser_enforces_the_frame_bound() {
+        let mut parser = SseParser::default();
+        let error = parser
+            .push(&vec![b'x'; MAX_JSON_RPC_FRAME_BYTES + 1])
+            .expect_err("oversized stream must fail");
+        assert!(error.to_string().contains("frame exceeds"));
+    }
+
+    #[test]
+    fn url_validation_rejects_unsupported_shapes() {
+        assert!(validate_http_url("http://127.0.0.1:9000/mcp").is_ok());
+        assert!(validate_http_url("https://gateway.example/mcp/tools").is_ok());
+        for url in [
+            "ftp://host/mcp",
+            "http://user:secret@host/mcp",
+            "not a url",
+            "unix:/tmp/socket",
+        ] {
+            assert!(validate_http_url(url).is_err(), "{url} must be rejected");
+        }
+    }
+
+    #[test]
+    fn bearer_tokens_must_be_header_safe() {
+        assert!(HttpWire::new("http://127.0.0.1/mcp", Some("token-1")).is_ok());
+        assert!(HttpWire::new("http://127.0.0.1/mcp", None).is_ok());
+        for token in ["", "line\nbreak", "tab\there"] {
+            assert!(
+                HttpWire::new("http://127.0.0.1/mcp", Some(token)).is_err(),
+                "{token:?} must be rejected"
+            );
+        }
+    }
+}

--- a/crates/openwave-mcp/src/http.rs
+++ b/crates/openwave-mcp/src/http.rs
@@ -64,6 +64,10 @@ impl HttpWire {
         }
         Ok(Self {
             client: reqwest::Client::builder()
+                // A credentialed client must not follow redirects: reqwest
+                // strips Authorization cross-host, but a same-host https→http
+                // downgrade would resend the bearer in cleartext.
+                .redirect(reqwest::redirect::Policy::none())
                 .build()
                 .map_err(|error| mcp_error("could not build HTTP client", error))?,
             url,
@@ -84,7 +88,6 @@ impl HttpWire {
         tools_list_changed: &mut bool,
     ) -> Result<Value> {
         let response = self.post(message).await?;
-        self.absorb_session_id(&response)?;
         let status = response.status();
         if status == reqwest::StatusCode::ACCEPTED {
             return Err(mcp_message(
@@ -92,6 +95,8 @@ impl HttpWire {
             ));
         }
         check_status(status)?;
+        // Only a successful exchange may (re)bind the session.
+        self.absorb_session_id(&response)?;
 
         let content_type = response
             .headers()
@@ -124,8 +129,8 @@ impl HttpWire {
     /// empty 202; any success status is accepted and the body is ignored.
     pub(crate) async fn notify(&mut self, message: &Value) -> Result<()> {
         let response = self.post(message).await?;
-        self.absorb_session_id(&response)?;
-        check_status(response.status())
+        check_status(response.status())?;
+        self.absorb_session_id(&response)
     }
 
     async fn post(&self, message: &Value) -> Result<reqwest::Response> {

--- a/crates/openwave-mcp/src/lib.rs
+++ b/crates/openwave-mcp/src/lib.rs
@@ -14,8 +14,9 @@
 //! transport-agnostic; [`serve_stdio`] runs it over the standard newline-delimited
 //! JSON-RPC stdio transport that MCP clients launch servers with.
 //! [`McpClient`] connects in the other direction: it initializes an external
-//! stdio MCP server, discovers its tools, and mounts namespaced proxies into an
-//! OpenWave [`ToolRegistry`](openwave_core::ToolRegistry).
+//! MCP server — a spawned stdio child or a remote Streamable HTTP endpoint —
+//! discovers its tools, and mounts namespaced proxies into an OpenWave
+//! [`ToolRegistry`](openwave_core::ToolRegistry).
 //!
 //! The protocol layer is hand-rolled ([`protocol`]) rather than pulling a full MCP
 //! SDK — the surface a tool server needs is small, and this keeps the crate light
@@ -43,6 +44,7 @@
 //! MCP tool can reach outside OpenWave's workspace and process boundary.
 
 mod client;
+mod http;
 pub mod protocol;
 mod server;
 mod stdio;
@@ -50,6 +52,7 @@ mod stdio;
 pub use client::{
     McpClient, McpProbe, McpServerInfo, DEFAULT_REQUEST_TIMEOUT, MAX_SERVER_NAME_BYTES,
 };
+pub use http::validate_http_url;
 pub use protocol::PROTOCOL_VERSION;
 pub use server::McpServer;
 pub use stdio::{serve, serve_stdio};

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -1,10 +1,12 @@
-//! Runtime configuration and supervision for external MCP stdio servers.
+//! Runtime configuration and supervision for external MCP servers.
 //!
-//! Definitions are typed data, never shell fragments. Every child starts with a
-//! cleared environment and receives only literal values explicitly marked
-//! non-secret plus values selected by *name* from the parent environment. The
-//! latter values are resolved only at the process boundary and are never stored
-//! or projected through the API.
+//! A definition is either a local stdio child process or a remote Streamable
+//! HTTP endpoint. Definitions are typed data, never shell fragments. Every
+//! child starts with a cleared environment and receives only literal values
+//! explicitly marked non-secret plus values selected by *name* from the parent
+//! environment; an HTTP server's bearer token is likewise selected by name.
+//! Selected values are resolved only at the connection boundary and are never
+//! stored or projected through the API.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
@@ -87,12 +89,16 @@ pub(crate) struct McpServersConfig {
     pub(crate) servers: Vec<McpServerDefinition>,
 }
 
-/// One local stdio MCP process definition.
+/// One external MCP server definition: a local stdio process (`command`) or a
+/// remote Streamable HTTP endpoint (`url`). Exactly one of the two is set;
+/// [`validate_servers`] enforces that process fields stay with `command` and
+/// `bearer_token_env` stays with `url`.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct McpServerDefinition {
     pub(crate) name: String,
-    pub(crate) command: String,
+    #[serde(default)]
+    pub(crate) command: Option<String>,
     #[serde(default)]
     pub(crate) args: Vec<String>,
     /// Explicit literal values. The UI labels these as non-secret.
@@ -103,6 +109,13 @@ pub(crate) struct McpServerDefinition {
     pub(crate) env_from: Vec<String>,
     #[serde(default)]
     pub(crate) cwd: Option<PathBuf>,
+    /// Streamable HTTP endpoint for a remote server.
+    #[serde(default)]
+    pub(crate) url: Option<String>,
+    /// Parent environment name holding the HTTP bearer token. The value is
+    /// resolved at connect time and never enters this type.
+    #[serde(default)]
+    pub(crate) bearer_token_env: Option<String>,
     #[serde(default = "default_request_timeout_ms")]
     pub(crate) request_timeout_ms: u64,
     #[serde(default = "enabled_by_default")]
@@ -119,6 +132,8 @@ impl std::fmt::Debug for McpServerDefinition {
             .field("env_names", &self.env.keys().collect::<Vec<_>>())
             .field("env_from", &self.env_from)
             .field("cwd", &self.cwd)
+            .field("url", &self.url)
+            .field("bearer_token_env", &self.bearer_token_env)
             .field("request_timeout_ms", &self.request_timeout_ms)
             .field("enabled", &self.enabled)
             .finish()
@@ -127,7 +142,12 @@ impl std::fmt::Debug for McpServerDefinition {
 
 impl McpServerDefinition {
     fn build_command(&self) -> Result<Command> {
-        let mut command = Command::new(&self.command);
+        let Some(program) = &self.command else {
+            return Err(AgentError::config(
+                "MCP server definition has no command to spawn",
+            ));
+        };
+        let mut command = Command::new(program);
         command.args(&self.args);
         // Deliberately unconditional: a renderer cannot widen a child to the
         // desktop's provider credentials or other ambient environment.
@@ -148,6 +168,17 @@ impl McpServerDefinition {
     }
 
     async fn connect(&self) -> Result<McpClient> {
+        if let Some(url) = &self.url {
+            let bearer_token = self.resolve_bearer_token()?;
+            return McpClient::connect_http_with_timeouts(
+                self.name.clone(),
+                url,
+                bearer_token.as_deref(),
+                INITIALIZATION_TIMEOUT,
+                Duration::from_millis(self.request_timeout_ms),
+            )
+            .await;
+        }
         McpClient::spawn_with_timeouts(
             self.name.clone(),
             self.build_command()?,
@@ -155,6 +186,18 @@ impl McpServerDefinition {
             Duration::from_millis(self.request_timeout_ms),
         )
         .await
+    }
+
+    /// Resolve the selected bearer token by name at the connection boundary.
+    fn resolve_bearer_token(&self) -> Result<Option<String>> {
+        let Some(name) = &self.bearer_token_env else {
+            return Ok(None);
+        };
+        std::env::var(name).map(Some).map_err(|_| {
+            AgentError::config(format!(
+                "required parent environment variable {name:?} is not set"
+            ))
+        })
     }
 }
 
@@ -679,9 +722,57 @@ fn validate_servers(servers: &[McpServerDefinition]) -> Result<()> {
     let mut names = HashSet::new();
     for server in servers {
         validate_name(&server.name)?;
-        validate_process_string(&server.name, "command", &server.command)?;
-        if server.command.is_empty() {
-            return Err(server_error(&server.name, "command must not be empty"));
+        match (&server.command, &server.url) {
+            (Some(_), Some(_)) => {
+                return Err(server_error(
+                    &server.name,
+                    "must configure either command or url, not both",
+                ));
+            }
+            (None, None) => {
+                return Err(server_error(
+                    &server.name,
+                    "must configure a command or a url",
+                ));
+            }
+            (Some(command), None) => {
+                validate_process_string(&server.name, "command", command)?;
+                if command.is_empty() {
+                    return Err(server_error(&server.name, "command must not be empty"));
+                }
+                if server.bearer_token_env.is_some() {
+                    return Err(server_error(
+                        &server.name,
+                        "bearer_token_env applies only to url servers",
+                    ));
+                }
+            }
+            (None, Some(url)) => {
+                validate_process_string(&server.name, "url", url)?;
+                openwave_mcp::validate_http_url(url)
+                    .map_err(|error| server_error(&server.name, error))?;
+                if !server.args.is_empty() {
+                    return Err(server_error(
+                        &server.name,
+                        "args apply only to command servers",
+                    ));
+                }
+                if !server.env.is_empty() || !server.env_from.is_empty() {
+                    return Err(server_error(
+                        &server.name,
+                        "process environment applies only to command servers",
+                    ));
+                }
+                if server.cwd.is_some() {
+                    return Err(server_error(
+                        &server.name,
+                        "cwd applies only to command servers",
+                    ));
+                }
+                if let Some(bearer_name) = &server.bearer_token_env {
+                    validate_environment_name(&server.name, bearer_name)?;
+                }
+            }
         }
         if server.args.len() > MAX_ARGS {
             return Err(server_error(
@@ -777,9 +868,13 @@ fn connection_diagnostic(definition: &McpServerDefinition) -> String {
     if let Some(name) = definition
         .env_from
         .iter()
+        .chain(&definition.bearer_token_env)
         .find(|name| std::env::var_os(name).is_none())
     {
         return format!("Required parent environment variable {name:?} is not set.");
+    }
+    if definition.url.is_some() {
+        return "Could not connect to this server. Check its URL and credentials.".to_string();
     }
     "Could not initialize this server. Check its executable, arguments, and working directory."
         .to_string()
@@ -803,13 +898,30 @@ mod tests {
     fn disabled_definition(name: &str, command: &str) -> McpServerDefinition {
         McpServerDefinition {
             name: name.to_string(),
-            command: command.to_string(),
+            command: Some(command.to_string()),
             args: Vec::new(),
             env: BTreeMap::new(),
             env_from: Vec::new(),
             cwd: None,
+            url: None,
+            bearer_token_env: None,
             request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
             enabled: false,
+        }
+    }
+
+    fn http_definition(name: &str, url: &str) -> McpServerDefinition {
+        McpServerDefinition {
+            name: name.to_string(),
+            command: None,
+            args: Vec::new(),
+            env: BTreeMap::new(),
+            env_from: Vec::new(),
+            cwd: None,
+            url: Some(url.to_string()),
+            bearer_token_env: None,
+            request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
+            enabled: true,
         }
     }
 
@@ -851,7 +963,7 @@ mod tests {
         .unwrap();
         let server = &config.0[0];
         assert_eq!(server.name, "private_docs");
-        assert_eq!(server.command, "/usr/local/bin/docs-mcp");
+        assert_eq!(server.command.as_deref(), Some("/usr/local/bin/docs-mcp"));
         assert_eq!(server.args, ["--stdio"]);
         assert_eq!(server.env.get("LOG_LEVEL").unwrap(), "info");
         assert_eq!(server.env_from, ["DOCS_TOKEN"]);
@@ -1068,7 +1180,10 @@ mod tests {
             .mark_degraded("docs", old_epoch, INITIAL_RECONNECT_BACKOFF)
             .await;
         let info = runtime.info().await;
-        assert_eq!(info.servers[0].definition.command, "/bin/new");
+        assert_eq!(
+            info.servers[0].definition.command.as_deref(),
+            Some("/bin/new")
+        );
         assert_eq!(info.servers[0].health, McpHealth::Disabled);
         assert!(info.servers[0].diagnostic.is_none());
     }
@@ -1114,6 +1229,171 @@ mod tests {
             "exactly one caller should perform the failed connection attempt"
         );
         assert_eq!(runtime.info().await.servers[0].health, McpHealth::Degraded);
+    }
+
+    #[test]
+    fn parses_a_streamable_http_server_configuration() {
+        let config = parse(
+            r#"{
+                "servers": [{
+                    "name": "gateway",
+                    "url": "http://127.0.0.1:28081/mcp/tools",
+                    "bearer_token_env": "GATEWAY_TOKEN",
+                    "request_timeout_ms": 2500
+                }]
+            }"#,
+        )
+        .unwrap();
+        let server = &config.0[0];
+        assert_eq!(
+            server.url.as_deref(),
+            Some("http://127.0.0.1:28081/mcp/tools")
+        );
+        assert_eq!(server.bearer_token_env.as_deref(), Some("GATEWAY_TOKEN"));
+        assert!(server.command.is_none());
+    }
+
+    #[test]
+    fn each_server_is_exactly_one_transport() {
+        let both = parse(
+            r#"{"servers":[{"name":"docs","command":"/bin/docs","url":"http://127.0.0.1/mcp"}]}"#,
+        )
+        .err()
+        .unwrap();
+        assert!(both.to_string().contains("not both"));
+
+        let neither = parse(r#"{"servers":[{"name":"docs"}]}"#).err().unwrap();
+        assert!(neither.to_string().contains("command or a url"));
+    }
+
+    #[test]
+    fn transport_specific_fields_stay_with_their_transport() {
+        let bearer_on_stdio = parse(
+            r#"{"servers":[{"name":"docs","command":"/bin/docs","bearer_token_env":"TOKEN"}]}"#,
+        )
+        .err()
+        .unwrap();
+        assert!(bearer_on_stdio.to_string().contains("only to url servers"));
+
+        for (field, fragment) in [
+            (r#""args":["--stdio"]"#, "args apply only"),
+            (r#""env":{"A":"b"}"#, "environment applies only"),
+            (r#""env_from":["TOKEN"]"#, "environment applies only"),
+            (r#""cwd":"/srv""#, "cwd applies only"),
+        ] {
+            let error = parse(&format!(
+                r#"{{"servers":[{{"name":"docs","url":"http://127.0.0.1/mcp",{field}}}]}}"#
+            ))
+            .err()
+            .unwrap();
+            assert!(error.to_string().contains(fragment), "{field}: {error}");
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_http_urls() {
+        for url in ["ftp://host/mcp", "http://user:secret@host/mcp", "not a url"] {
+            let error = parse(&format!(
+                r#"{{"servers":[{{"name":"docs","url":"{url}"}}]}}"#
+            ))
+            .err()
+            .unwrap();
+            assert!(!error.to_string().contains("secret"), "{url}: {error}");
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_selected_bearer_token_fails_by_name_without_a_value() {
+        const MISSING: &str = "OPENWAVE_TEST_MCP_BEARER_MUST_NOT_EXIST_8A31";
+        assert!(std::env::var_os(MISSING).is_none());
+        let mut definition = http_definition("gateway", "http://127.0.0.1:1/mcp");
+        definition.bearer_token_env = Some(MISSING.to_string());
+        let error = definition.connect().await.err().unwrap();
+        assert!(error.to_string().contains(MISSING));
+        assert!(error.to_string().contains("is not set"));
+
+        let diagnostic = connection_diagnostic(&definition);
+        assert!(diagnostic.contains(MISSING));
+        assert!(!diagnostic.contains('\n'));
+    }
+
+    #[test]
+    fn http_diagnostics_are_fixed_strings_without_the_url() {
+        let definition = http_definition("gateway", "http://127.0.0.1:9/mcp");
+        let diagnostic = connection_diagnostic(&definition);
+        assert_eq!(
+            diagnostic,
+            "Could not connect to this server. Check its URL and credentials."
+        );
+    }
+
+    async fn serve_fake_http_mcp() -> std::net::SocketAddr {
+        use axum::http::HeaderMap;
+        use axum::routing::post;
+
+        async fn handler(
+            headers: HeaderMap,
+            body: String,
+        ) -> ([(&'static str, &'static str); 1], String) {
+            // The config layer resolved the selected variable into the header.
+            let expected = format!("Bearer {}", std::env::var("PATH").unwrap());
+            assert_eq!(
+                headers
+                    .get("authorization")
+                    .and_then(|value| value.to_str().ok()),
+                Some(expected.as_str())
+            );
+            let request: serde_json::Value = serde_json::from_str(&body).unwrap();
+            let id = request.get("id").cloned().unwrap_or_default();
+            let result = match request["method"].as_str().unwrap_or_default() {
+                "initialize" => serde_json::json!({
+                    "protocolVersion": openwave_mcp::PROTOCOL_VERSION,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "config-fixture", "version": "1"}
+                }),
+                "tools/list" => serde_json::json!({
+                    "tools": [{
+                        "name": "lookup",
+                        "description": "Look something up",
+                        "inputSchema": {"type": "object"}
+                    }]
+                }),
+                _ => serde_json::json!({}),
+            };
+            (
+                [("content-type", "application/json")],
+                serde_json::json!({"jsonrpc": "2.0", "id": id, "result": result}).to_string(),
+            )
+        }
+
+        let app = axum::Router::new().route("/mcp", post(handler));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        address
+    }
+
+    #[tokio::test]
+    async fn replaces_with_a_streamable_http_server_and_mounts_its_tools() {
+        let address = serve_fake_http_mcp().await;
+        let (runtime, _store, _directory) = test_runtime().await;
+        let mut definition = http_definition("gateway", &format!("http://{address}/mcp"));
+        // PATH always exists, so the selected-name path is exercised for real
+        // without mutating the test process environment.
+        definition.bearer_token_env = Some("PATH".to_string());
+        runtime
+            .replace(McpServersConfig {
+                servers: vec![definition],
+            })
+            .await
+            .unwrap();
+
+        let info = runtime.info().await;
+        assert_eq!(info.servers[0].health, McpHealth::Healthy);
+        assert_eq!(info.servers[0].tool_count, 1);
+        assert!(runtime.snapshot().get("mcp__gateway__lookup").is_some());
     }
 
     #[test]

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -1,29 +1,38 @@
-# Local MCP servers
+# External MCP servers
 
-OpenWave connects to local MCP servers over stdio. In the desktop app, open
-**Settings → MCP servers**, add a definition, and choose **Save and verify**.
-OpenWave starts the executable directly with the argument array shown in the
-form; it never joins the fields into a shell command.
+OpenWave connects to MCP servers over two transports: a local stdio child
+process or a remote Streamable HTTP endpoint. In the desktop app, open
+**Settings → MCP servers**, add a definition, pick its transport, and choose
+**Save and verify**. For a stdio server, OpenWave starts the executable
+directly with the argument array shown in the form; it never joins the fields
+into a shell command. For an HTTP server, OpenWave sends each JSON-RPC request
+as an authenticated `POST` and accepts both plain JSON and `text/event-stream`
+responses.
 
 Each server has:
 
 - a stable namespace containing ASCII letters, numbers, `_`, or `-`;
-- an executable and zero or more individual arguments;
-- an optional working directory;
-- a request timeout from 1 to 3,600,000 milliseconds;
-- optional literal **non-secret** environment values;
-- optional `env_from` names selected from the OpenWave host environment; and
+- exactly one transport:
+  - **stdio** — an executable, zero or more individual arguments, an optional
+    working directory, optional literal **non-secret** environment values, and
+    optional `env_from` names selected from the OpenWave host environment; or
+  - **HTTP** — an `http`/`https` URL and an optional bearer-token variable
+    name selected from the OpenWave host environment;
+- a request timeout from 1 to 3,600,000 milliseconds; and
 - an enabled switch.
 
 The child environment starts empty. Literal values are ordinary settings and
-are visible in the Settings form. Executables, arguments, and working
-directories are also ordinary displayed settings, so do not put credentials in
+are visible in the Settings form. Executables, arguments, working directories,
+and URLs are also ordinary displayed settings, so do not put credentials in
 any of those fields. For a credential, set it in the environment that launches
-OpenWave and enter only its variable name under **Forward environment names**.
-OpenWave resolves that value at process launch; it does not store it in SQLite
+OpenWave and enter only its variable name — under **Forward environment names**
+for a stdio server, or **Bearer token variable** for an HTTP server. OpenWave
+resolves that value at the connection boundary; it does not store it in SQLite
 or return it to the renderer. A missing selected name produces a server-specific
 error containing the name, not a value. Child stderr is discarded so a server
-cannot copy a forwarded credential into OpenWave's host logs.
+cannot copy a forwarded credential into OpenWave's host logs, and HTTP
+diagnostics are fixed strings that never echo the URL, a token, or a response
+body.
 
 All mounted names use `mcp__{namespace}__{remote_tool}`. MCP tools are sensitive:
 the existing OpenWave approval gate must approve each call before it crosses
@@ -72,6 +81,13 @@ named by `OPENWAVE_MCP_CONFIG`:
         "LOG_LEVEL": "info"
       },
       "env_from": ["DOCUMENTS_TOKEN"],
+      "request_timeout_ms": 60000,
+      "enabled": true
+    },
+    {
+      "name": "gateway",
+      "url": "https://gateway.example/mcp/tools",
+      "bearer_token_env": "GATEWAY_TOKEN",
       "request_timeout_ms": 60000,
       "enabled": true
     }

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -137,8 +137,9 @@ replayed. Unsupported hosts fail closed with no unconfined fallback. See
 [Code execution](code-execution.md).
 
 External MCP servers follow the same rule through `openwave-mcp`. A connected
-stdio server completes MCP initialization and paginated `tools/list` discovery
-before its proxies are registered. Each remote name is locally namespaced as
+server — a local stdio child or a remote Streamable HTTP endpoint — completes
+MCP initialization and paginated `tools/list` discovery before its proxies are
+registered. Each remote name is locally namespaced as
 `mcp__{server}__{tool}` and keeps the remote input schema unchanged. Calls are
 serialized per external server and their text, structured content, and error
 flag are translated back into `ToolOutput`. Because MCP tools can cross both the
@@ -146,14 +147,16 @@ workspace and process boundary, every mounted proxy is classified `Sensitive`.
 Each call needs one explicit approval; MCP approval is never remembered by tool
 name because Settings can replace the process behind a stable namespace.
 
-The desktop Settings page manages external stdio servers at runtime. Each entry
-declares a unique namespace, executable, argument array, optional working
-directory, explicit non-secret environment, selected `env_from` names, and a
-bounded request timeout. No shell interprets any field. Child environments are
-always cleared before the selected names and literal values are added, so an MCP
-process cannot inherit provider credentials or other desktop secrets by
-accident. Resolved `env_from` values never enter the database or renderer, and
-child stderr is discarded instead of being copied into host logs.
+The desktop Settings page manages external servers at runtime. Each entry
+declares a unique namespace, one transport — an executable with argument array,
+optional working directory, explicit non-secret environment, and selected
+`env_from` names, or an `http`/`https` URL with a selected bearer-token
+variable name — and a bounded request timeout. No shell interprets any field.
+Child environments are always cleared before the selected names and literal
+values are added, so an MCP process cannot inherit provider credentials or
+other desktop secrets by accident. Resolved `env_from` and bearer-token values
+never enter the database or renderer, and child stderr is discarded instead of
+being copied into host logs.
 
 Saving first validates and connects the complete candidate set, then atomically
 publishes it for later turns. A failure leaves the prior connection set active.
@@ -168,7 +171,7 @@ requests.
 The legacy `OPENWAVE_MCP_CONFIG` JSON file remains available for headless boot;
 when no saved configuration exists it uses the same closed schema and fails
 startup if an enabled server cannot initialize.
-See [Local MCP servers](mcp-servers.md) for the field contract and setup flow.
+See [External MCP servers](mcp-servers.md) for the field contract and setup flow.
 
 ## Foreground and sandbox surfaces
 


### PR DESCRIPTION
The MCP client so far only spawned local stdio children, so a remote
endpoint — such as a governed gateway's /mcp/{slug} routes — was
unreachable. The session now carries a transport enum: the existing
newline-delimited stream wire, or an HTTP wire that POSTs each JSON-RPC
request and reads either a plain JSON reply or a text/event-stream,
classifying interim notifications and stale ids with the same rules the
stdio loop always applied. Server-assigned session ids are echoed, the
negotiated protocol version travels as a header, and response bodies
share the existing 2 MiB frame bound.

A server definition is now exactly one transport: the process fields, or
an http/https URL plus an optional bearer-token variable name. Only the
name is stored or displayed; the value is resolved from the host
environment at connect time, prebuilt into the Authorization header, and
never echoed into errors, diagnostics, logs, or renderer data. Health
supervision, capped-backoff reconnect, atomic publish, and per-turn
registry snapshots treat both transports identically.

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)