### PR TITLE
test(server): split public listener contracts

### DIFF
--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -12890,16 +12890,6 @@ async fn approval_endpoint_rejects_unpresentable_sensitive_tool_approval() {
 }
 
 #[tokio::test]
-async fn bind_yields_a_loopback_addr_and_token() {
-    openwave_core::KeychainSecretProvider::use_mock();
-    let dir = tempfile::tempdir().unwrap();
-    let server = bind(Config::desktop(dir.path())).await.unwrap();
-    assert!(server.local_addr().ip().is_loopback());
-    assert!(!server.token().is_empty());
-    assert!(server.store().list_chats().await.unwrap().is_empty());
-}
-
-#[tokio::test]
 async fn malformed_requests_get_json_errors_not_plaintext() {
     let (router, token, _store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
@@ -12938,16 +12928,6 @@ async fn malformed_requests_get_json_errors_not_plaintext() {
     assert_eq!(info.kind, "bad_request");
 }
 
-#[tokio::test]
-async fn self_host_profile_is_not_yet_supported() {
-    let dir = tempfile::tempdir().unwrap();
-    let config = Config {
-        profile: Profile::SelfHost,
-        data_dir: dir.path().to_path_buf(),
-    };
-    assert!(bind(config).await.is_err());
-}
-
 #[test]
 fn one_server_process_owns_a_desktop_data_directory() {
     let dir = tempfile::tempdir().unwrap();
@@ -12957,87 +12937,6 @@ fn one_server_process_owns_a_desktop_data_directory() {
 
     drop(first);
     InstanceLock::acquire(&config).expect("dropping the server releases its directory lock");
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn serve_answers_over_a_real_socket() {
-    openwave_core::KeychainSecretProvider::use_mock();
-    let dir = tempfile::tempdir().unwrap();
-    let server = bind(Config::desktop(dir.path())).await.unwrap();
-    let addr = server.local_addr();
-    let token = server.token().to_string();
-    // The listener is already bound, so connections queue immediately; drive
-    // the accept loop in the background for the duration of the test.
-    tokio::spawn(async move {
-        let _ = server.serve().await;
-    });
-
-    let client = reqwest::Client::new();
-    let health = client
-        .get(format!("http://{addr}/healthz"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(health.status(), reqwest::StatusCode::OK);
-
-    let unauthed = client
-        .get(format!("http://{addr}/chats"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(unauthed.status(), reqwest::StatusCode::UNAUTHORIZED);
-
-    let authed = client
-        .get(format!("http://{addr}/chats"))
-        .bearer_auth(&token)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(authed.status(), reqwest::StatusCode::OK);
-    assert_eq!(authed.json::<Vec<Chat>>().await.unwrap(), vec![]);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn cors_preflight_allows_localhost_origin() {
-    openwave_core::KeychainSecretProvider::use_mock();
-    let dir = tempfile::tempdir().unwrap();
-    let server = bind(Config::desktop(dir.path())).await.unwrap();
-    let addr = server.local_addr();
-    tokio::spawn(async move {
-        let _ = server.serve().await;
-    });
-
-    let client = reqwest::Client::new();
-    let preflight = client
-        .request(reqwest::Method::OPTIONS, format!("http://{addr}/chats"))
-        .header(reqwest::header::ORIGIN, "http://localhost:1420")
-        .header(reqwest::header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
-        .header(
-            reqwest::header::ACCESS_CONTROL_REQUEST_HEADERS,
-            "authorization,range,if-range",
-        )
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(preflight.status(), reqwest::StatusCode::OK);
-    let allow_origin = preflight
-        .headers()
-        .get(reqwest::header::ACCESS_CONTROL_ALLOW_ORIGIN)
-        .and_then(|v| v.to_str().ok());
-    assert_eq!(allow_origin, Some("http://localhost:1420"));
-    let allow_headers = preflight
-        .headers()
-        .get(reqwest::header::ACCESS_CONTROL_ALLOW_HEADERS)
-        .and_then(|value| value.to_str().ok())
-        .unwrap();
-    for expected in ["authorization", "range", "if-range"] {
-        assert!(
-            allow_headers
-                .split(',')
-                .any(|header| header.trim().eq_ignore_ascii_case(expected)),
-            "missing {expected} in {allow_headers}"
-        );
-    }
 }
 
 // --- WebSocket event stream ---

--- a/crates/openwave-server/tests/listener.rs
+++ b/crates/openwave-server/tests/listener.rs
@@ -1,0 +1,94 @@
+use openwave_core::{Chat, Config, KeychainSecretProvider};
+use openwave_server::bind;
+
+#[tokio::test]
+async fn bind_yields_a_loopback_addr_and_token() {
+    KeychainSecretProvider::use_mock();
+    let dir = tempfile::tempdir().unwrap();
+    let server = bind(Config::desktop(dir.path())).await.unwrap();
+
+    assert!(server.local_addr().ip().is_loopback());
+    assert!(!server.token().is_empty());
+    assert!(server.store().list_chats().await.unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn serve_answers_over_a_real_socket() {
+    KeychainSecretProvider::use_mock();
+    let dir = tempfile::tempdir().unwrap();
+    let server = bind(Config::desktop(dir.path())).await.unwrap();
+    let addr = server.local_addr();
+    let token = server.token().to_string();
+    // The listener is already bound, so connections queue immediately; drive
+    // the accept loop in the background for the duration of the test.
+    tokio::spawn(async move {
+        let _ = server.serve().await;
+    });
+
+    let client = reqwest::Client::new();
+    let health = client
+        .get(format!("http://{addr}/healthz"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(health.status(), reqwest::StatusCode::OK);
+
+    let unauthed = client
+        .get(format!("http://{addr}/chats"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unauthed.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let authed = client
+        .get(format!("http://{addr}/chats"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(authed.status(), reqwest::StatusCode::OK);
+    assert_eq!(authed.json::<Vec<Chat>>().await.unwrap(), vec![]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cors_preflight_allows_localhost_origin() {
+    KeychainSecretProvider::use_mock();
+    let dir = tempfile::tempdir().unwrap();
+    let server = bind(Config::desktop(dir.path())).await.unwrap();
+    let addr = server.local_addr();
+    tokio::spawn(async move {
+        let _ = server.serve().await;
+    });
+
+    let client = reqwest::Client::new();
+    let preflight = client
+        .request(reqwest::Method::OPTIONS, format!("http://{addr}/chats"))
+        .header(reqwest::header::ORIGIN, "http://localhost:1420")
+        .header(reqwest::header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .header(
+            reqwest::header::ACCESS_CONTROL_REQUEST_HEADERS,
+            "authorization,range,if-range",
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(preflight.status(), reqwest::StatusCode::OK);
+    let allow_origin = preflight
+        .headers()
+        .get(reqwest::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .and_then(|value| value.to_str().ok());
+    assert_eq!(allow_origin, Some("http://localhost:1420"));
+    let allow_headers = preflight
+        .headers()
+        .get(reqwest::header::ACCESS_CONTROL_ALLOW_HEADERS)
+        .and_then(|value| value.to_str().ok())
+        .unwrap();
+    for expected in ["authorization", "range", "if-range"] {
+        assert!(
+            allow_headers
+                .split(',')
+                .any(|header| header.trim().eq_ignore_ascii_case(expected)),
+            "missing {expected} in {allow_headers}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- move the public bind, real-socket, and CORS contracts into one `listener` integration binary
- remove `self_host_profile_is_not_yet_supported`: it only asserts that an unimplemented profile still fails, so a future failure would tell us to delete the test rather than reveal a regression
- compare the named tests before and after: the three moved contracts retain their names; the self-host placeholder is the only removal

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo check --workspace --locked`

## Follow-up

This is the first, low-conflict slice of #590. The remaining private worker and WebSocket suites need a separate, measured extraction plan; this PR intentionally does not close the umbrella issue.

Part of #590