### PR TITLE
build: retain lean local test debug artifacts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,16 @@ authors = ["Brightwave, Inc."]
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
 
+# Keep local build artifacts compact while retaining file-and-line panic
+# backtraces. Cargo's test profile inherits this dev setting.
+[profile.dev]
+debug = "line-tables-only"
+
+# Keep tests' correctness checks explicit even as the dev profile evolves.
+[profile.test]
+debug-assertions = true
+overflow-checks = true
+
 # Shared dependency versions. Crates opt in with `dep.workspace = true` so the
 # whole workspace resolves one version of each.
 [workspace.dependencies]


### PR DESCRIPTION
Closes #588

## Summary

- Keep local dev and test artifacts at line-table debug fidelity.
- Explicitly retain test debug assertions and overflow checks.
- Leave release settings and CI environment overrides unchanged.

## Measurements

Measured on the same macOS arm64 host with Cargo 1.96.1, a clean target directory, and `/usr/bin/time -lp cargo test --workspace --locked --quiet`; target size is `du -sk target`.

| Measurement | Baseline | This branch |
| --- | ---: | ---: |
| Cold workspace test | 250.49s | 268.24s |
| Warm workspace test | 49.20s | 62.50s |
| `target/` footprint | 15,291,524 KiB (14.6 GiB) | 10,858,260 KiB (10.4 GiB) |

The candidate timing samples overlapped other full-workspace Rust compilations, so this PR makes no latency-speedup claim. The demonstrated benefit is the 4,433,264 KiB / 29.0% local artifact-footprint reduction. `cargo build --workspace --locked --timings` also generated the local Cargo timing report.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo check --workspace --locked`
- `cargo test --workspace --locked --quiet`
- A temporary, uncommitted expected-panic test verified that debug assertions and checked overflow still panic under the test profile, and that `RUST_BACKTRACE=1` includes the test file and line.