### PR TITLE
feat(models): advertise curated image input

### DIFF
--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -38,7 +38,7 @@ impl InputModality {
     }
 }
 
-const TEXT_ONLY: &[InputModality] = &[InputModality::Text];
+const TEXT_AND_IMAGE: &[InputModality] = &[InputModality::Text, InputModality::Image];
 
 /// The reasoning-effort scales the curated rows draw from, ascending.
 ///
@@ -123,10 +123,10 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 1_000_000,
         max_output_tokens: 128_000,
-        // The upstream model accepts images, but OpenWave's normalized content
-        // contract is text/tool-only today. Do not advertise a capability that
-        // cannot make it through the complete request path.
-        input_modalities: TEXT_ONLY,
+        // Image input is advertised only where the provider documents vision
+        // and this provider's adapter shapes hydrated image bytes into the
+        // request format. The capability guard below keeps that promise honest.
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         // Claude 4.6 and later reason on an adaptive thinking block, and the
         // Anthropic adapter sends one along with the chat's chosen effort. That
@@ -140,7 +140,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 1_000_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
@@ -150,7 +150,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 200_000,
         max_output_tokens: 64_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         // Haiku 4.5 predates the adaptive switch: it rejects the effort
         // control, so the adapter leaves both off and the picker hides it.
@@ -162,7 +162,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 1_000_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
@@ -172,7 +172,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 1_000_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
@@ -182,7 +182,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 1_000_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
@@ -192,7 +192,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Anthropic,
         context_window: 1_000_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         reasoning_efforts: EFFORT_LOW_TO_MAX,
     },
@@ -202,7 +202,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Openai,
         context_window: 1_050_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         // The whole GPT-5 line reasons on a caller-selected effort, which the
         // OpenAI-compatible adapter already sends alongside
@@ -215,7 +215,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Openai,
         context_window: 1_050_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         reasoning_efforts: EFFORT_NONE_TO_MAX,
     },
@@ -225,7 +225,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Openai,
         context_window: 1_050_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         reasoning_efforts: EFFORT_NONE_TO_MAX,
     },
@@ -235,7 +235,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Openai,
         context_window: 1_050_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
@@ -245,7 +245,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Openai,
         context_window: 400_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
@@ -255,7 +255,7 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         provider: ProviderKind::Openai,
         context_window: 400_000,
         max_output_tokens: 128_000,
-        input_modalities: TEXT_ONLY,
+        input_modalities: TEXT_AND_IMAGE,
         supports_reasoning: true,
         reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
@@ -378,6 +378,19 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
+    /// Whether OpenWave can actually put an image on the wire for `provider`.
+    ///
+    /// Provider documentation alone does not earn a model `InputModality::Image`.
+    /// Each provider has its own request adapter, and a custom compatible
+    /// endpoint is not known to support the image branch at all.
+    const fn provider_carries_image_input(provider: ProviderKind) -> bool {
+        match provider {
+            ProviderKind::Anthropic => true,
+            ProviderKind::Openai => true,
+            ProviderKind::OpenaiCompatible => false,
+        }
+    }
+
     #[test]
     fn registry_provider_model_keys_are_unique_and_capabilities_are_well_formed() {
         let mut keys = HashSet::new();
@@ -393,9 +406,10 @@ mod tests {
             assert!(spec.context_window >= spec.max_output_tokens);
             assert!(spec.accepts(InputModality::Text));
             assert!(
-                !spec.accepts(InputModality::Image),
-                "{} advertises image input before the provider contract supports it",
-                spec.id
+                !spec.accepts(InputModality::Image) || provider_carries_image_input(spec.provider),
+                "{} advertises image input under `{}`, which cannot carry an image block through the complete request path",
+                spec.id,
+                spec.provider
             );
             assert!(
                 !spec.supports_reasoning_effort() || spec.supports_reasoning,

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1455,17 +1455,13 @@ mod image_capability_tests {
         reasoning_efforts: &[],
     };
 
-    const MULTIMODAL: ModelSpec = ModelSpec {
-        input_modalities: &[InputModality::Text, InputModality::Image],
-        ..TEXT_ONLY
-    };
-
     #[test]
     fn advertised_image_input_is_the_only_thing_that_admits_a_turn_with_images() {
-        // Every curated model is pinned text-only today, so the accepting case
-        // is constructed here rather than read from the registry: the rule has
-        // to hold from the moment a model does advertise image input.
-        assert!(require_image_input(&providers::ResolvedModelPolicy::curated(&MULTIMODAL)).is_ok());
+        let native_model = crate::model_registry::find("claude-opus-5")
+            .expect("the default curated Anthropic model is registered");
+        assert!(
+            require_image_input(&providers::ResolvedModelPolicy::curated(native_model)).is_ok()
+        );
 
         let refused = require_image_input(&providers::ResolvedModelPolicy::curated(&TEXT_ONLY))
             .expect_err("a text-only model must refuse a turn carrying images");

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -8768,9 +8768,12 @@ async fn models_catalog_is_served() {
     assert_eq!(opus["key"], "anthropic::claude-opus-4-8");
     assert_eq!(opus["context_window"], 1_000_000);
     assert_eq!(opus["max_output_tokens"], 128_000);
-    assert_eq!(opus["input_modalities"], serde_json::json!(["text"]));
+    assert_eq!(
+        opus["input_modalities"],
+        serde_json::json!(["text", "image"])
+    );
     assert!(opus["supports_reasoning"].as_bool().unwrap());
-    assert!(!opus["multimodal"].as_bool().unwrap());
+    assert!(opus["multimodal"].as_bool().unwrap());
     assert!(!opus["available"].as_bool().unwrap());
     // The catalog carries the effort levels the model itself accepts, so a
     // client can offer exactly those and no more.

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -87,6 +87,56 @@ fn stored_blob_count(data_dir: &std::path::Path) -> usize {
         .count()
 }
 
+type OpenAiRequestCapture =
+    Arc<std::sync::Mutex<Option<tokio::sync::oneshot::Sender<serde_json::Value>>>>;
+
+/// Records the actual payload the configured OpenAI adapter sends, then emits a
+/// minimal successful streaming response. This keeps the capability test local
+/// while exercising the same resolver and adapter path as a desktop turn.
+async fn capture_openai_image_request(
+    axum::extract::State(capture): axum::extract::State<OpenAiRequestCapture>,
+    axum::Json(request): axum::Json<serde_json::Value>,
+) -> impl axum::response::IntoResponse {
+    if let Some(sender) = capture.lock().unwrap().take() {
+        let _ = sender.send(request);
+    }
+    (
+        [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+        concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"The images arrived.\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        ),
+    )
+}
+
+fn one_pixel_jpeg() -> Vec<u8> {
+    let image = image::RgbImage::from_pixel(1, 1, image::Rgb([0, 0, 0]));
+    let mut bytes = Vec::new();
+    image::codecs::jpeg::JpegEncoder::new(&mut bytes)
+        .encode_image(&image)
+        .unwrap();
+    bytes
+}
+
+fn spawn_turn_worker_with_image_blobs(state: &AppState) {
+    let worker = crate::turn_worker::TurnWorker::new(
+        state.store.clone(),
+        state.resolver.clone(),
+        state.tools.clone(),
+        state.approvals.clone(),
+        state.events.clone(),
+        state.active_turns.clone(),
+        state.turn_job_wake.clone(),
+        state.agent_run_wake.clone(),
+        state.agent_config.clone(),
+        None,
+        crate::turn_worker::TurnWorkerConfig::default(),
+    )
+    .with_blobs(state.blobs.clone());
+    tokio::spawn(worker.run());
+}
+
 #[tokio::test]
 async fn publishing_returns_opaque_identity_and_bounded_metadata_only() {
     let (router, token, _store, _dir) = test_app().await;
@@ -383,21 +433,28 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
         .unwrap(),
     );
     let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    // A user-registered OpenAI-compatible model: OpenWave cannot know whether
+    // an arbitrary endpoint accepts images, so it remains text-only.
     providers::write_config(
         &*store,
-        providers::ProviderKind::Anthropic,
+        providers::ProviderKind::OpenaiCompatible,
         &providers::ProviderConfig {
             enabled: true,
-            base_url: None,
-            models: Vec::new(),
+            base_url: Some("http://127.0.0.1:1234/v1".into()),
+            models: vec![providers::CustomModelConfig {
+                id: "vendor/model".into(),
+                display_name: Some("Vendor Model".into()),
+                context_window: 65_536,
+                max_output_tokens: 8_192,
+            }],
         },
     )
     .await
     .unwrap();
     providers::write_credential(
         &*secrets,
-        providers::ProviderKind::Anthropic,
-        &providers::ProviderCredential::api_key("sk-anthropic"),
+        providers::ProviderKind::OpenaiCompatible,
+        &providers::ProviderCredential::api_key("sk-local"),
     )
     .await
     .unwrap();
@@ -416,7 +473,7 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
         Arc::new(ToolRegistry::new()),
         retrieval,
         AgentConfig {
-            model: "anthropic::claude-opus-4-8".into(),
+            model: "openai_compatible::vendor/model".into(),
             ..AgentConfig::default()
         },
     );
@@ -424,12 +481,10 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
     let router = app(state);
     let chat = make_chat(&router, &bearer).await;
 
-    // The selected model is a real, available, curated one — it simply does not
-    // advertise image input.
-    let policy = providers::resolve_model_policy(&*store, "anthropic::claude-opus-4-8", false)
+    let policy = providers::resolve_model_policy(&*store, "openai_compatible::vendor/model", false)
         .await
         .unwrap()
-        .expect("a curated model resolves");
+        .expect("a registered custom model resolves");
     assert!(!policy
         .input_modalities
         .contains(&crate::model_registry::InputModality::Image));
@@ -461,4 +516,130 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
         send_message(&router, &bearer, chat.id, "what is in this screenshot?").await,
         StatusCode::ACCEPTED
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_curated_openai_model_answers_after_receiving_png_and_jpeg_attachments() {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let capture: OpenAiRequestCapture = Arc::new(std::sync::Mutex::new(Some(sender)));
+    let provider = axum::Router::new()
+        .route(
+            "/v1/chat/completions",
+            axum::routing::post(capture_openai_image_request),
+        )
+        .with_state(capture);
+    let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, provider).await;
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("image-capability.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Openai,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: Some(format!("http://{address}/v1")),
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+    providers::write_credential(
+        &*secrets,
+        providers::ProviderKind::Openai,
+        &providers::ProviderCredential::api_key("sk-test"),
+    )
+    .await
+    .unwrap();
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(resolver::ConfiguredResolver::new(
+            store.clone(),
+            secrets.clone(),
+        )),
+        secrets,
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "openai::gpt-5.6-sol".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let bearer = format!("Bearer {}", state.token);
+    spawn_turn_worker_with_image_blobs(&state);
+    let router = app(state);
+    let chat = make_chat(&router, &bearer).await;
+
+    let png = publish_png(&router, &bearer, chat.id, png_header(1, 1)).await;
+    let jpeg = publish_image(&router, &bearer, chat.id, "image/jpeg", one_pixel_jpeg()).await;
+    assert_eq!(jpeg.status(), StatusCode::CREATED);
+    let jpeg: serde_json::Value = json_body(jpeg).await;
+    let jpeg: uuid::Uuid = jpeg["attachment_id"].as_str().unwrap().parse().unwrap();
+
+    assert_eq!(
+        send_message_with_attachments(
+            &router,
+            &bearer,
+            chat.id,
+            TurnId::new(),
+            "Describe these attachments.",
+            &[png, jpeg],
+        )
+        .await
+        .status(),
+        StatusCode::ACCEPTED
+    );
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert!(events.iter().any(
+        |event| matches!(&event.event, AgentEvent::TextDelta { text } if text == "The images arrived.")
+    ));
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCompleted { .. })
+    ));
+
+    let request = tokio::time::timeout(std::time::Duration::from_secs(1), receiver)
+        .await
+        .expect("configured provider did not receive the image request")
+        .expect("configured provider request capture was dropped");
+    assert_eq!(request["model"], "gpt-5.6-sol");
+    let content = request["messages"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|message| message["role"] == "user" && message["content"].is_array())
+        .and_then(|message| message["content"].as_array())
+        .expect("the provider request has the user message parts");
+    assert_eq!(content[0]["type"], "text");
+    assert_eq!(content[0]["text"], "Describe these attachments.");
+    for (part, media_type) in content[1..].iter().zip(["image/png", "image/jpeg"]) {
+        assert_eq!(part["type"], "image_url");
+        assert!(
+            part["image_url"]["url"]
+                .as_str()
+                .unwrap()
+                .starts_with(&format!("data:{media_type};base64,")),
+            "expected {media_type} data URL, got {part}"
+        );
+    }
+    assert_eq!(content.len(), 3);
 }


### PR DESCRIPTION
## Summary
- Mark the curated Anthropic and OpenAI models as accepting image input, while leaving user-configured compatible endpoints conservative.
- Guard the registry so an image capability can only be advertised by a provider with a supported request path.
- Exercise a configured curated OpenAI turn through the real adapter with attached PNG and JPEG bytes, and confirm the local streaming provider answers.

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo check --workspace --locked
- cargo test --workspace
- pnpm --dir crates/openwave-desktop/ui exec vitest run src/ModelMenu.test.tsx src/Composer.test.tsx
- pnpm --dir crates/openwave-desktop/ui run build
- git diff --check

Live-provider note: no Anthropic or OpenAI credentials were available locally. The end-to-end coverage uses the configured OpenAI adapter against a loopback streaming server; it verifies the exact model request includes both image data URLs and returns an answer.

Closes #462