### PR TITLE
feat(connectors): loopback OAuth sign-in for a model-gateway deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6652,6 +6652,18 @@ dependencies = [
 [[package]]
 name = "openwave-connectors"
 version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "openwave-core",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "openwave-core"

--- a/crates/openwave-connectors/Cargo.toml
+++ b/crates/openwave-connectors/Cargo.toml
@@ -11,3 +11,18 @@ authors.workspace = true
 workspace = true
 
 [dependencies]
+axum = { workspace = true }
+base64 = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tokio = { workspace = true, features = ["net", "sync", "time"] }
+uuid = { workspace = true }
+# Only the trait contracts (SecretProvider, AgentError/Result), not the
+# SQLite / keychain / agent-loop machinery — hence default-features = false.
+openwave-core = { path = "../openwave-core", default-features = false }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "net"] }
+async-trait = { workspace = true }

--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -1,0 +1,816 @@
+//! Loopback OAuth client for a model-gateway deployment.
+//!
+//! The gateway is a public-client authorization server: PKCE S256 is
+//! mandatory, there is no client secret, redirects are loopback-only, and
+//! tokens are opaque with rotation and reuse detection on refresh. This
+//! module mirrors the contract its own CLI uses, with one addition: an
+//! explicit installation pin so a swapped-out deployment behind the same URL
+//! is detected instead of silently trusted.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Query, State};
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use openwave_core::{AgentError, Result, SecretProvider};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::net::TcpListener;
+use tokio::sync::{mpsc, Mutex};
+
+/// The audience for profile and entitlement reads (`/api/v1/cli/*`).
+pub const RESOURCE_CONTROL: &str = "control";
+/// The audience for inference calls on the gateway's compatible routes.
+pub const RESOURCE_LLM: &str = "llm";
+
+const SCOPE: &str = "openid profile offline_access models:read inference:invoke";
+const SECRET_KEY: &str = "gateway.credentials_v1";
+/// Refresh an access token this close to expiry instead of using it.
+const EXPIRY_LEEWAY_SECONDS: u64 = 60;
+const SIGN_IN_REQUIRED_PREFIX: &str = "gateway sign-in required";
+
+/// True when an operation failed because there is no usable gateway session —
+/// never signed in, session revoked, or refresh-token reuse detected. Callers
+/// should surface a reconnect affordance instead of treating this as a fault.
+#[must_use]
+pub fn is_sign_in_required(error: &AgentError) -> bool {
+    error.to_string().contains(SIGN_IN_REQUIRED_PREFIX)
+}
+
+fn sign_in_required(detail: &str) -> AgentError {
+    AgentError::config(format!("{SIGN_IN_REQUIRED_PREFIX}: {detail}"))
+}
+
+fn gateway_error(context: &str, detail: impl std::fmt::Display) -> AgentError {
+    AgentError::config(format!("model-gateway {context}: {detail}"))
+}
+
+/// How this client identifies itself to the gateway.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GatewayAuthConfig {
+    base_url: reqwest::Url,
+    client_id: String,
+    /// Attribution declared on refresh. `None` lets the gateway default to
+    /// `generic`; the gateway rejects names outside its known-client set.
+    client_name: Option<String>,
+}
+
+impl GatewayAuthConfig {
+    /// A first-class `openwave` client. Requires the gateway to know that
+    /// client id; use [`Self::modelctl_compat`] against deployments that
+    /// still hardcode `modelctl`.
+    pub fn new(base_url: &str) -> Result<Self> {
+        Self::with_client(base_url, "openwave", None)
+    }
+
+    /// Development-only compatibility identity: authorize as `modelctl`,
+    /// leaving attribution to the gateway's default. Remove once the gateway
+    /// grows a client registry with an `openwave` entry.
+    pub fn modelctl_compat(base_url: &str) -> Result<Self> {
+        Self::with_client(base_url, "modelctl", None)
+    }
+
+    fn with_client(base_url: &str, client_id: &str, client_name: Option<String>) -> Result<Self> {
+        let base_url = reqwest::Url::parse(base_url)
+            .map_err(|_| gateway_error("configuration", "base URL is invalid"))?;
+        if !matches!(base_url.scheme(), "http" | "https") {
+            return Err(gateway_error(
+                "configuration",
+                "base URL must use http or https",
+            ));
+        }
+        if !base_url.username().is_empty() || base_url.password().is_some() {
+            return Err(gateway_error(
+                "configuration",
+                "base URL must not embed credentials",
+            ));
+        }
+        Ok(Self {
+            base_url,
+            client_id: client_id.to_string(),
+            client_name,
+        })
+    }
+
+    /// The configured gateway origin.
+    #[must_use]
+    pub fn base_url(&self) -> &reqwest::Url {
+        &self.base_url
+    }
+}
+
+/// Unauthenticated deployment identity from `/api/v1/meta`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GatewayMeta {
+    pub api_version: String,
+    pub installation_id: String,
+    pub gateway_version: String,
+    pub public_url: String,
+    pub auth_mode: String,
+}
+
+/// The authenticated user, from `/api/v1/cli/me`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct GatewayIdentity {
+    pub user_id: String,
+    pub email: Option<String>,
+    pub display_name: Option<String>,
+    pub session_id: String,
+    pub installation_id: String,
+}
+
+/// One entitled model from `/api/v1/cli/models`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GatewayModel {
+    pub id: String,
+    pub name: String,
+    pub context_window: Option<i64>,
+    pub max_output_tokens: Option<i64>,
+    pub supports_tools: bool,
+    pub supports_vision: bool,
+}
+
+/// One minted access/refresh pair, resource-bound.
+#[derive(Clone, PartialEq, Eq)]
+pub struct TokenSet {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_at_unix: u64,
+    pub scope: String,
+    pub resource: String,
+    pub installation_id: String,
+}
+
+impl std::fmt::Debug for TokenSet {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TokenSet")
+            .field("resource", &self.resource)
+            .field("scope", &self.scope)
+            .field("expires_at_unix", &self.expires_at_unix)
+            .field("installation_id", &self.installation_id)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct CachedAccessToken {
+    token: String,
+    expires_at_unix: u64,
+    scope: String,
+}
+
+impl CachedAccessToken {
+    fn is_fresh(&self) -> bool {
+        self.expires_at_unix > unix_time().saturating_add(EXPIRY_LEEWAY_SECONDS)
+    }
+}
+
+/// The durable signed-in state, serialized as one keychain secret.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GatewayCredentials {
+    pub base_url: String,
+    pub installation_id: String,
+    pub user_id: String,
+    pub account_hint: Option<String>,
+    refresh_token: String,
+    access_tokens: BTreeMap<String, CachedAccessToken>,
+}
+
+impl std::fmt::Debug for GatewayCredentials {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GatewayCredentials")
+            .field("base_url", &self.base_url)
+            .field("installation_id", &self.installation_id)
+            .field("user_id", &self.user_id)
+            .field("account_hint", &self.account_hint)
+            .field(
+                "cached_resources",
+                &self.access_tokens.keys().collect::<Vec<_>>(),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+/// Keychain-backed storage for [`GatewayCredentials`].
+#[derive(Clone)]
+pub struct CredentialVault {
+    secrets: Arc<dyn SecretProvider>,
+}
+
+impl CredentialVault {
+    #[must_use]
+    pub fn new(secrets: Arc<dyn SecretProvider>) -> Self {
+        Self { secrets }
+    }
+
+    pub async fn load(&self) -> Result<Option<GatewayCredentials>> {
+        let Some(raw) = self.secrets.get_secret(SECRET_KEY).await? else {
+            return Ok(None);
+        };
+        serde_json::from_str(&raw)
+            .map(Some)
+            .map_err(|_| gateway_error("credentials", "stored credentials are unreadable"))
+    }
+
+    pub async fn save(&self, credentials: &GatewayCredentials) -> Result<()> {
+        let raw = serde_json::to_string(credentials)?;
+        self.secrets.set_secret(SECRET_KEY, &raw).await
+    }
+
+    pub async fn clear(&self) -> Result<()> {
+        self.secrets.delete_secret(SECRET_KEY).await
+    }
+}
+
+/// Stateless HTTP client for the gateway's OAuth and CLI endpoints.
+#[derive(Clone)]
+pub struct GatewayAuth {
+    config: GatewayAuthConfig,
+    http: reqwest::Client,
+}
+
+impl GatewayAuth {
+    pub fn new(config: GatewayAuthConfig) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| gateway_error("client", error))?;
+        Ok(Self { config, http })
+    }
+
+    /// Fetch the deployment identity used for installation pinning.
+    pub async fn meta(&self) -> Result<GatewayMeta> {
+        let response = self
+            .http
+            .get(self.endpoint("/api/v1/meta")?)
+            .send()
+            .await
+            .map_err(|error| gateway_error("metadata request", error.without_url()))?;
+        decode_json(response, "metadata request").await
+    }
+
+    /// Bind the loopback listener and produce the URL the user's browser
+    /// must visit. The listener stays alive inside the returned
+    /// [`PendingSignIn`] until [`PendingSignIn::finish`] resolves.
+    pub async fn start_sign_in(&self) -> Result<PendingSignIn> {
+        let meta = self.meta().await?;
+        let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .await
+            .map_err(|error| gateway_error("sign-in", error))?;
+        let port = listener
+            .local_addr()
+            .map_err(|error| gateway_error("sign-in", error))?
+            .port();
+        let redirect_uri = format!("http://127.0.0.1:{port}/callback");
+        let verifier = random_token();
+        let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+        let state = random_token();
+
+        let mut authorization_url = self.endpoint("/oauth/authorize")?;
+        authorization_url
+            .query_pairs_mut()
+            .append_pair("response_type", "code")
+            .append_pair("client_id", &self.config.client_id)
+            .append_pair("redirect_uri", &redirect_uri)
+            .append_pair("code_challenge", &challenge)
+            .append_pair("code_challenge_method", "S256")
+            .append_pair("state", &state)
+            .append_pair("scope", SCOPE);
+
+        Ok(PendingSignIn {
+            auth: self.clone(),
+            meta,
+            listener,
+            authorization_url: authorization_url.to_string(),
+            redirect_uri,
+            verifier,
+            state,
+        })
+    }
+
+    /// Exchange the refresh token for a token bound to `resource`, rotating
+    /// the refresh token. `invalid_grant` — an expired, revoked, or reused
+    /// token — maps to a sign-in-required error.
+    pub async fn refresh(
+        &self,
+        refresh_token: &str,
+        resource: &str,
+        expected_installation: &str,
+    ) -> Result<TokenSet> {
+        let mut form: Vec<(&str, &str)> = vec![
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+            ("resource", resource),
+        ];
+        if let Some(client_name) = self.config.client_name.as_deref() {
+            form.push(("client_name", client_name));
+        }
+        let token = self.request_token(&form).await?;
+        if token.resource != resource || token.installation_id != expected_installation {
+            return Err(gateway_error(
+                "token request",
+                "token was minted for an unexpected installation or resource",
+            ));
+        }
+        Ok(token)
+    }
+
+    /// Revoke a refresh token and its session family.
+    pub async fn revoke(&self, refresh_token: &str) -> Result<()> {
+        let response = self
+            .http
+            .post(self.endpoint("/oauth/revoke")?)
+            .form(&[("token", refresh_token)])
+            .send()
+            .await
+            .map_err(|error| gateway_error("revocation request", error.without_url()))?;
+        if !response.status().is_success() {
+            return Err(gateway_error(
+                "revocation request",
+                format!("HTTP status {}", response.status().as_u16()),
+            ));
+        }
+        Ok(())
+    }
+
+    /// The authenticated identity behind a `control` token.
+    pub async fn whoami(&self, access_token: &str) -> Result<GatewayIdentity> {
+        let response = self
+            .http
+            .get(self.endpoint("/api/v1/cli/me")?)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|error| gateway_error("identity request", error.without_url()))?;
+        decode_json(response, "identity request").await
+    }
+
+    /// The models the authenticated user may invoke, optionally filtered to
+    /// one inference protocol (`anthropic` / `openai`).
+    pub async fn models(
+        &self,
+        access_token: &str,
+        protocol: Option<&str>,
+    ) -> Result<Vec<GatewayModel>> {
+        let mut url = self.endpoint("/api/v1/cli/models")?;
+        if let Some(protocol) = protocol {
+            url.query_pairs_mut().append_pair("protocol", protocol);
+        }
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|error| gateway_error("model request", error.without_url()))?;
+        let list: ModelListResponse = decode_json(response, "model request").await?;
+        Ok(list.models)
+    }
+
+    async fn exchange_code(
+        &self,
+        code: &str,
+        redirect_uri: &str,
+        verifier: &str,
+    ) -> Result<TokenSet> {
+        self.request_token(&[
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", redirect_uri),
+            ("client_id", &self.config.client_id),
+            ("code_verifier", verifier),
+        ])
+        .await
+    }
+
+    async fn request_token(&self, form: &[(&str, &str)]) -> Result<TokenSet> {
+        let response = self
+            .http
+            .post(self.endpoint("/oauth/token")?)
+            .form(form)
+            .send()
+            .await
+            .map_err(|error| gateway_error("token request", error.without_url()))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let error: Option<OAuthErrorResponse> = response.json().await.ok();
+            if error
+                .as_ref()
+                .is_some_and(|error| error.error == "invalid_grant")
+            {
+                return Err(sign_in_required("the gateway session is no longer valid"));
+            }
+            let detail = error
+                .and_then(|error| error.error_description.or(Some(error.error)))
+                .unwrap_or_else(|| format!("HTTP status {}", status.as_u16()));
+            return Err(gateway_error("token request", detail));
+        }
+        let token: TokenResponse = response
+            .json()
+            .await
+            .map_err(|_| gateway_error("token request", "invalid token response"))?;
+        Ok(TokenSet {
+            access_token: token.access_token,
+            refresh_token: token.refresh_token,
+            expires_at_unix: unix_time()
+                .saturating_add(u64::try_from(token.expires_in).unwrap_or_default()),
+            scope: token.scope,
+            resource: token.resource,
+            installation_id: token.installation_id,
+        })
+    }
+
+    fn endpoint(&self, path: &str) -> Result<reqwest::Url> {
+        self.config
+            .base_url
+            .join(path)
+            .map_err(|_| gateway_error("configuration", "could not build endpoint URL"))
+    }
+}
+
+/// A sign-in in flight: the loopback listener is bound and the browser URL
+/// is ready. Dropping this cancels the sign-in.
+pub struct PendingSignIn {
+    auth: GatewayAuth,
+    meta: GatewayMeta,
+    listener: TcpListener,
+    authorization_url: String,
+    redirect_uri: String,
+    verifier: String,
+    state: String,
+}
+
+/// A completed sign-in: identity plus the initial `control`-resource tokens.
+#[derive(Debug, Clone)]
+pub struct AuthorizedSession {
+    pub meta: GatewayMeta,
+    pub identity: GatewayIdentity,
+    pub tokens: TokenSet,
+}
+
+impl PendingSignIn {
+    /// The URL to open in the user's browser.
+    #[must_use]
+    pub fn authorization_url(&self) -> &str {
+        &self.authorization_url
+    }
+
+    /// The deployment identity pinned when the sign-in started.
+    #[must_use]
+    pub fn meta(&self) -> &GatewayMeta {
+        &self.meta
+    }
+
+    /// Wait for the browser callback, then exchange and validate the code.
+    pub async fn finish(self, timeout: Duration) -> Result<AuthorizedSession> {
+        let Self {
+            auth,
+            meta,
+            listener,
+            redirect_uri,
+            verifier,
+            state,
+            ..
+        } = self;
+
+        let (sender, mut receiver) = mpsc::channel::<CallbackResult>(1);
+        let callback_app =
+            Router::new()
+                .route("/callback", get(callback))
+                .with_state(CallbackState {
+                    expected_state: state,
+                    sender,
+                });
+        let server = tokio::spawn(async move { axum::serve(listener, callback_app).await });
+        let outcome = tokio::time::timeout(timeout, receiver.recv()).await;
+        server.abort();
+        let _ = server.await;
+
+        let callback = outcome
+            .map_err(|_| gateway_error("sign-in", "browser authorization timed out"))?
+            .ok_or_else(|| gateway_error("sign-in", "the authorization callback closed"))?;
+        if let Some(error) = callback.error {
+            return Err(gateway_error(
+                "sign-in",
+                format!("authorization failed: {error}"),
+            ));
+        }
+        let code = callback
+            .code
+            .ok_or_else(|| gateway_error("sign-in", "no authorization code was returned"))?;
+
+        let tokens = auth.exchange_code(&code, &redirect_uri, &verifier).await?;
+        if tokens.resource != RESOURCE_CONTROL || tokens.installation_id != meta.installation_id {
+            return Err(gateway_error(
+                "sign-in",
+                "token was minted for an unexpected installation or resource",
+            ));
+        }
+        let identity = auth.whoami(&tokens.access_token).await?;
+        if identity.installation_id != meta.installation_id {
+            return Err(gateway_error(
+                "sign-in",
+                "gateway identity changed during authorization",
+            ));
+        }
+        Ok(AuthorizedSession {
+            meta,
+            identity,
+            tokens,
+        })
+    }
+}
+
+/// A signed-in gateway connection: vault-backed, refresh-rotating, and safe
+/// to share. All token motion is serialized so refresh rotation can never
+/// race itself into the gateway's reuse detection.
+pub struct GatewayConnection {
+    auth: GatewayAuth,
+    vault: CredentialVault,
+    token_motion: Mutex<()>,
+}
+
+impl GatewayConnection {
+    #[must_use]
+    pub fn new(auth: GatewayAuth, vault: CredentialVault) -> Self {
+        Self {
+            auth,
+            vault,
+            token_motion: Mutex::new(()),
+        }
+    }
+
+    /// Persist a completed sign-in as the connection's stored credentials.
+    pub async fn store_session(&self, session: &AuthorizedSession) -> Result<()> {
+        let _guard = self.token_motion.lock().await;
+        let mut access_tokens = BTreeMap::new();
+        access_tokens.insert(
+            session.tokens.resource.clone(),
+            CachedAccessToken {
+                token: session.tokens.access_token.clone(),
+                expires_at_unix: session.tokens.expires_at_unix,
+                scope: session.tokens.scope.clone(),
+            },
+        );
+        self.vault
+            .save(&GatewayCredentials {
+                base_url: self.auth.config.base_url.to_string(),
+                installation_id: session.meta.installation_id.clone(),
+                user_id: session.identity.user_id.clone(),
+                account_hint: session
+                    .identity
+                    .email
+                    .clone()
+                    .or_else(|| session.identity.display_name.clone()),
+                refresh_token: session.tokens.refresh_token.clone(),
+                access_tokens,
+            })
+            .await
+    }
+
+    /// The stored (offline) identity, if signed in.
+    pub async fn stored_credentials(&self) -> Result<Option<GatewayCredentials>> {
+        self.vault.load().await
+    }
+
+    /// A fresh access token for `resource`, from cache when possible and via
+    /// rotating refresh otherwise.
+    pub async fn access_token(&self, resource: &str) -> Result<String> {
+        let _guard = self.token_motion.lock().await;
+        let Some(mut credentials) = self.vault.load().await? else {
+            return Err(sign_in_required("no gateway session is stored"));
+        };
+        if let Some(cached) = credentials.access_tokens.get(resource) {
+            if cached.is_fresh() {
+                return Ok(cached.token.clone());
+            }
+        }
+        let token = self
+            .auth
+            .refresh(
+                &credentials.refresh_token,
+                resource,
+                &credentials.installation_id,
+            )
+            .await?;
+        credentials.refresh_token = token.refresh_token.clone();
+        credentials.access_tokens.insert(
+            resource.to_string(),
+            CachedAccessToken {
+                token: token.access_token.clone(),
+                expires_at_unix: token.expires_at_unix,
+                scope: token.scope.clone(),
+            },
+        );
+        self.vault.save(&credentials).await?;
+        Ok(token.access_token)
+    }
+
+    /// Live identity check with a `control` token.
+    pub async fn identity(&self) -> Result<GatewayIdentity> {
+        let token = self.access_token(RESOURCE_CONTROL).await?;
+        self.auth.whoami(&token).await
+    }
+
+    /// Entitled models with a `control` token.
+    pub async fn models(&self, protocol: Option<&str>) -> Result<Vec<GatewayModel>> {
+        let token = self.access_token(RESOURCE_CONTROL).await?;
+        self.auth.models(&token, protocol).await
+    }
+
+    /// Revoke the session at the gateway (best-effort) and always clear the
+    /// local vault. A gateway that is unreachable cannot hold local sign-out
+    /// hostage; its server-side session still dies at refresh-token expiry.
+    pub async fn sign_out(&self) -> Result<()> {
+        let _guard = self.token_motion.lock().await;
+        if let Some(credentials) = self.vault.load().await? {
+            let _ = self.auth.revoke(&credentials.refresh_token).await;
+        }
+        self.vault.clear().await
+    }
+}
+
+async fn callback(
+    State(state): State<CallbackState>,
+    Query(query): Query<CallbackQuery>,
+) -> Response {
+    if query.state.as_deref() != Some(state.expected_state.as_str()) {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Html(callback_page(
+                "Sign-in failed",
+                "The authorization state did not match. Return to OpenWave and try again.",
+            )),
+        )
+            .into_response();
+    }
+    let success = query.code.is_some() && query.error.is_none();
+    let _ = state.sender.try_send(CallbackResult {
+        code: query.code,
+        error: query.error,
+    });
+    let (heading, message) = if success {
+        (
+            "Signed in",
+            "You can close this window and return to OpenWave.",
+        )
+    } else {
+        ("Sign-in denied", "Return to OpenWave for details.")
+    };
+    (
+        axum::http::StatusCode::OK,
+        Html(callback_page(heading, message)),
+    )
+        .into_response()
+}
+
+fn callback_page(heading: &str, message: &str) -> String {
+    format!(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
+         <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\
+         <title>{heading}</title></head><body><main><h1>{heading}</h1>\
+         <p>{message}</p></main></body></html>"
+    )
+}
+
+#[derive(Clone)]
+struct CallbackState {
+    expected_state: String,
+    sender: mpsc::Sender<CallbackResult>,
+}
+
+#[derive(Deserialize)]
+struct CallbackQuery {
+    code: Option<String>,
+    state: Option<String>,
+    error: Option<String>,
+}
+
+struct CallbackResult {
+    code: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: i64,
+    refresh_token: String,
+    scope: String,
+    resource: String,
+    installation_id: String,
+}
+
+#[derive(Deserialize)]
+struct OAuthErrorResponse {
+    error: String,
+    error_description: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ModelListResponse {
+    models: Vec<GatewayModel>,
+}
+
+async fn decode_json<T: for<'de> Deserialize<'de>>(
+    response: reqwest::Response,
+    operation: &str,
+) -> Result<T> {
+    if !response.status().is_success() {
+        return Err(gateway_error(
+            operation,
+            format!("HTTP status {}", response.status().as_u16()),
+        ));
+    }
+    response
+        .json()
+        .await
+        .map_err(|_| gateway_error(operation, "invalid response body"))
+}
+
+/// URL-safe random material from the OS CSPRNG. Two UUIDv4 values give 244
+/// bits of entropy and a 73-byte token, inside PKCE's 43–128 char contract.
+fn random_token() -> String {
+    format!("{}-{}", uuid::Uuid::new_v4(), uuid::Uuid::new_v4())
+}
+
+fn unix_time() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_rejects_invalid_base_urls() {
+        assert!(GatewayAuthConfig::new("http://127.0.0.1:28081").is_ok());
+        assert!(GatewayAuthConfig::new("https://gateway.example").is_ok());
+        for url in ["ftp://x", "not a url", "http://user:pw@host"] {
+            assert!(GatewayAuthConfig::new(url).is_err(), "{url}");
+        }
+    }
+
+    #[test]
+    fn token_types_redact_secret_material() {
+        let tokens = TokenSet {
+            access_token: "mg_at_secret".into(),
+            refresh_token: "mg_rt_secret".into(),
+            expires_at_unix: 0,
+            scope: "profile".into(),
+            resource: RESOURCE_CONTROL.into(),
+            installation_id: "install".into(),
+        };
+        let debug = format!("{tokens:?}");
+        assert!(!debug.contains("mg_at_secret"));
+        assert!(!debug.contains("mg_rt_secret"));
+
+        let credentials = GatewayCredentials {
+            base_url: "http://127.0.0.1/".into(),
+            installation_id: "install".into(),
+            user_id: "user".into(),
+            account_hint: Some("a@example.com".into()),
+            refresh_token: "mg_rt_secret".into(),
+            access_tokens: BTreeMap::from([(
+                RESOURCE_CONTROL.to_string(),
+                CachedAccessToken {
+                    token: "mg_at_secret".into(),
+                    expires_at_unix: 0,
+                    scope: "profile".into(),
+                },
+            )]),
+        };
+        let debug = format!("{credentials:?}");
+        assert!(!debug.contains("mg_at_secret"));
+        assert!(!debug.contains("mg_rt_secret"));
+        assert!(debug.contains("control"));
+    }
+
+    #[test]
+    fn random_tokens_fit_the_pkce_contract() {
+        let token = random_token();
+        assert!((43..=128).contains(&token.len()), "{}", token.len());
+        assert!(token
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-'));
+        assert_ne!(random_token(), random_token());
+    }
+
+    #[test]
+    fn sign_in_required_errors_are_recognizable() {
+        assert!(is_sign_in_required(&sign_in_required("test")));
+        assert!(!is_sign_in_required(&gateway_error("x", "y")));
+    }
+}

--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -39,11 +39,11 @@ const SIGN_IN_REQUIRED_PREFIX: &str = "gateway sign-in required";
 /// should surface a reconnect affordance instead of treating this as a fault.
 #[must_use]
 pub fn is_sign_in_required(error: &AgentError) -> bool {
-    error.to_string().contains(SIGN_IN_REQUIRED_PREFIX)
+    matches!(error, AgentError::Authentication(_))
 }
 
 fn sign_in_required(detail: &str) -> AgentError {
-    AgentError::config(format!("{SIGN_IN_REQUIRED_PREFIX}: {detail}"))
+    AgentError::Authentication(format!("{SIGN_IN_REQUIRED_PREFIX}: {detail}"))
 }
 
 fn gateway_error(context: &str, detail: impl std::fmt::Display) -> AgentError {
@@ -430,9 +430,14 @@ impl GatewayAuth {
     }
 
     fn endpoint(&self, path: &str) -> Result<reqwest::Url> {
-        self.config
-            .base_url
-            .join(path)
+        // Join below the configured base rather than at its origin, so a
+        // gateway deployed under a subpath keeps its prefix.
+        let mut base = self.config.base_url.to_string();
+        if !base.ends_with('/') {
+            base.push('/');
+        }
+        reqwest::Url::parse(&base)
+            .and_then(|base| base.join(path.trim_start_matches('/')))
             .map_err(|_| gateway_error("configuration", "could not build endpoint URL"))
     }
 }
@@ -530,9 +535,14 @@ impl PendingSignIn {
     }
 }
 
-/// A signed-in gateway connection: vault-backed, refresh-rotating, and safe
-/// to share. All token motion is serialized so refresh rotation can never
-/// race itself into the gateway's reuse detection.
+/// A signed-in gateway connection: vault-backed and refresh-rotating.
+///
+/// Share the *instance*: token motion is serialized per connection, so one
+/// shared `GatewayConnection` can never race itself into the gateway's
+/// reuse detection — but two instances (or two processes) over the same
+/// keychain entry can. A crash between a successful refresh and the vault
+/// write loses the rotated token, which reads as signed-out on the next
+/// call; that window is inherent to rotation and recovers via reconnect.
 pub struct GatewayConnection {
     auth: GatewayAuth,
     vault: CredentialVault,

--- a/crates/openwave-connectors/src/lib.rs
+++ b/crates/openwave-connectors/src/lib.rs
@@ -1,4 +1,28 @@
-//! OpenWave connectors — loopback OAuth (RFC 8252 + PKCE), token refresh, and
-//! the source connector tools that ingest from Drive, Box, and friends.
+//! OpenWave connectors — loopback OAuth (RFC 8252 + PKCE) for model-gateway,
+//! plus the future source connector tools that ingest from Drive, Box, and
+//! friends.
 //!
-//! Scaffolding only. Implementation lands in Phase 2.
+//! [`GatewayAuth`] speaks to a model-gateway deployment's own OAuth 2.0
+//! authorization server. The gateway's endpoints are fixed relative to its
+//! base URL, so the client pins the deployment through `/api/v1/meta`'s
+//! `installation_id` and refuses tokens minted by any other installation.
+//!
+//! The flow is authorization code + PKCE S256 on a loopback redirect: the
+//! desktop opens the returned authorization URL in the system browser, the
+//! browser lands on a short-lived local listener, and the code is exchanged
+//! for a `control`-resource token. Narrower audiences (`llm`,
+//! `mcp:<endpoint>`) are minted on demand through resource-scoped refresh.
+//!
+//! Tokens are stored through the host's [`SecretProvider`] — the OS keychain
+//! in the desktop app — never in ordinary settings, and none of the types in
+//! this crate include token material in their `Debug` output.
+//!
+//! [`SecretProvider`]: openwave_core::SecretProvider
+
+mod gateway;
+
+pub use gateway::{
+    is_sign_in_required, AuthorizedSession, CredentialVault, GatewayAuth, GatewayAuthConfig,
+    GatewayConnection, GatewayCredentials, GatewayIdentity, GatewayMeta, GatewayModel,
+    PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
+};

--- a/crates/openwave-connectors/tests/gateway_flow.rs
+++ b/crates/openwave-connectors/tests/gateway_flow.rs
@@ -398,16 +398,3 @@ async fn sign_out_revokes_remotely_and_clears_the_vault() {
         .expect_err("signed-out connection must fail");
     assert!(is_sign_in_required(&error), "{error}");
 }
-
-#[tokio::test]
-async fn the_default_identity_is_a_first_class_openwave_client() {
-    let auth = GatewayAuth::new(GatewayAuthConfig::new("http://127.0.0.1:1").unwrap()).unwrap();
-    // start_sign_in requires a reachable gateway; the identity choice is
-    // visible without one via the config used to build authorization URLs.
-    drop(auth);
-    let config = GatewayAuthConfig::new("http://127.0.0.1:1").unwrap();
-    assert_ne!(
-        config,
-        GatewayAuthConfig::modelctl_compat("http://127.0.0.1:1").unwrap()
-    );
-}

--- a/crates/openwave-connectors/tests/gateway_flow.rs
+++ b/crates/openwave-connectors/tests/gateway_flow.rs
@@ -1,0 +1,413 @@
+//! End-to-end exercises of the gateway OAuth client against an in-process
+//! fake that implements the deployment's real contract: PKCE S256 checked at
+//! exchange, one-time codes, rotating refresh tokens with reuse detection,
+//! resource-scoped audiences, and bearer-authenticated CLI endpoints.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use axum::extract::{Form, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Json, Redirect, Response};
+use axum::routing::{get, post};
+use axum::Router;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use openwave_connectors::{
+    is_sign_in_required, CredentialVault, GatewayAuth, GatewayAuthConfig, GatewayConnection,
+    RESOURCE_CONTROL, RESOURCE_LLM,
+};
+use openwave_core::{Result as CoreResult, SecretProvider};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+const INSTALLATION: &str = "11111111-2222-3333-4444-555555555555";
+const USER: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const SESSION: &str = "99999999-8888-7777-6666-555555555555";
+
+#[derive(Default)]
+struct MockSecrets(Mutex<HashMap<String, String>>);
+
+#[async_trait::async_trait]
+impl SecretProvider for MockSecrets {
+    async fn get_secret(&self, key: &str) -> CoreResult<Option<String>> {
+        Ok(self.0.lock().unwrap().get(key).cloned())
+    }
+
+    async fn set_secret(&self, key: &str, value: &str) -> CoreResult<()> {
+        self.0.lock().unwrap().insert(key.into(), value.into());
+        Ok(())
+    }
+
+    async fn delete_secret(&self, key: &str) -> CoreResult<()> {
+        self.0.lock().unwrap().remove(key);
+        Ok(())
+    }
+}
+
+struct PendingCode {
+    challenge: String,
+    redirect_uri: String,
+}
+
+#[derive(Default)]
+struct FakeGateway {
+    codes: Mutex<HashMap<String, PendingCode>>,
+    /// refresh token -> still valid
+    refresh_tokens: Mutex<HashMap<String, bool>>,
+    /// access token -> resource
+    access_tokens: Mutex<HashMap<String, String>>,
+    revoked: Mutex<Vec<String>>,
+    token_requests: AtomicUsize,
+    corrupt_state: AtomicBool,
+}
+
+impl FakeGateway {
+    fn mint(self: &Arc<Self>, resource: &str) -> Value {
+        let access = format!("mg_at_{}", uuid_like());
+        let refresh = format!("mg_rt_{}", uuid_like());
+        self.access_tokens
+            .lock()
+            .unwrap()
+            .insert(access.clone(), resource.to_string());
+        self.refresh_tokens
+            .lock()
+            .unwrap()
+            .insert(refresh.clone(), true);
+        json!({
+            "access_token": access,
+            "token_type": "Bearer",
+            "expires_in": 600,
+            "refresh_token": refresh,
+            "scope": scope_for(resource),
+            "resource": resource,
+            "installation_id": INSTALLATION,
+        })
+    }
+}
+
+fn scope_for(resource: &str) -> &'static str {
+    match resource {
+        "control" => "profile models:read",
+        "llm" => "models:read inference:invoke",
+        _ => "mcp:invoke",
+    }
+}
+
+fn uuid_like() -> String {
+    use std::sync::atomic::AtomicU64;
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    format!("token{}", NEXT.fetch_add(1, Ordering::SeqCst))
+}
+
+async fn meta() -> Json<Value> {
+    Json(json!({
+        "api_version": "v1",
+        "installation_id": INSTALLATION,
+        "gateway_version": "0.1.0-test",
+        "public_url": "http://fake.test/",
+        "auth_mode": "development",
+    }))
+}
+
+async fn authorize(
+    State(gateway): State<Arc<FakeGateway>>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Response {
+    if query.get("client_id").map(String::as_str) != Some("modelctl")
+        || query.get("code_challenge_method").map(String::as_str) != Some("S256")
+        || query.get("response_type").map(String::as_str) != Some("code")
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+    let code = format!("code_{}", uuid_like());
+    let redirect_uri = query.get("redirect_uri").cloned().unwrap_or_default();
+    gateway.codes.lock().unwrap().insert(
+        code.clone(),
+        PendingCode {
+            challenge: query.get("code_challenge").cloned().unwrap_or_default(),
+            redirect_uri: redirect_uri.clone(),
+        },
+    );
+    let state = if gateway.corrupt_state.load(Ordering::SeqCst) {
+        "wrong-state".to_string()
+    } else {
+        query.get("state").cloned().unwrap_or_default()
+    };
+    Redirect::to(&format!("{redirect_uri}?code={code}&state={state}")).into_response()
+}
+
+async fn token(
+    State(gateway): State<Arc<FakeGateway>>,
+    Form(form): Form<HashMap<String, String>>,
+) -> Response {
+    gateway.token_requests.fetch_add(1, Ordering::SeqCst);
+    match form.get("grant_type").map(String::as_str) {
+        Some("authorization_code") => {
+            let Some(code) = form.get("code") else {
+                return StatusCode::BAD_REQUEST.into_response();
+            };
+            let Some(pending) = gateway.codes.lock().unwrap().remove(code) else {
+                return invalid_grant();
+            };
+            let verifier = form.get("code_verifier").cloned().unwrap_or_default();
+            let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
+            if challenge != pending.challenge
+                || form.get("redirect_uri") != Some(&pending.redirect_uri)
+                || form.get("client_id").map(String::as_str) != Some("modelctl")
+            {
+                return invalid_grant();
+            }
+            Json(gateway.mint("control")).into_response()
+        }
+        Some("refresh_token") => {
+            let Some(refresh) = form.get("refresh_token") else {
+                return StatusCode::BAD_REQUEST.into_response();
+            };
+            let mut refresh_tokens = gateway.refresh_tokens.lock().unwrap();
+            if refresh_tokens.get(refresh) != Some(&true) {
+                drop(refresh_tokens);
+                return invalid_grant();
+            }
+            refresh_tokens.insert(refresh.clone(), false);
+            drop(refresh_tokens);
+            let resource = form.get("resource").cloned().unwrap_or_default();
+            Json(gateway.mint(&resource)).into_response()
+        }
+        _ => StatusCode::BAD_REQUEST.into_response(),
+    }
+}
+
+fn invalid_grant() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({"error": "invalid_grant"})),
+    )
+        .into_response()
+}
+
+async fn revoke(
+    State(gateway): State<Arc<FakeGateway>>,
+    Form(form): Form<HashMap<String, String>>,
+) -> StatusCode {
+    if let Some(token) = form.get("token") {
+        gateway
+            .refresh_tokens
+            .lock()
+            .unwrap()
+            .insert(token.clone(), false);
+        gateway.revoked.lock().unwrap().push(token.clone());
+    }
+    StatusCode::OK
+}
+
+fn bearer_resource(gateway: &FakeGateway, headers: &HeaderMap) -> Option<String> {
+    let token = headers
+        .get("authorization")?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")?;
+    gateway.access_tokens.lock().unwrap().get(token).cloned()
+}
+
+async fn me(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> Response {
+    if bearer_resource(&gateway, &headers).as_deref() != Some("control") {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    Json(json!({
+        "user_id": USER,
+        "email": "abaas@example.test",
+        "display_name": "Abaas",
+        "client_name": "modelctl",
+        "session_id": SESSION,
+        "installation_id": INSTALLATION,
+    }))
+    .into_response()
+}
+
+async fn models(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> Response {
+    if bearer_resource(&gateway, &headers).as_deref() != Some("control") {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    Json(json!({
+        "models": [{
+            "id": "anthropic/claude-fable-5",
+            "name": "Claude Fable 5",
+            "context_window": 500000,
+            "max_output_tokens": 64000,
+            "supports_tools": true,
+            "supports_vision": true,
+        }]
+    }))
+    .into_response()
+}
+
+async fn serve_fake_gateway(gateway: Arc<FakeGateway>) -> SocketAddr {
+    let app = Router::new()
+        .route("/api/v1/meta", get(meta))
+        .route("/oauth/authorize", get(authorize))
+        .route("/oauth/token", post(token))
+        .route("/oauth/revoke", post(revoke))
+        .route("/api/v1/cli/me", get(me))
+        .route("/api/v1/cli/models", get(models))
+        .with_state(gateway);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    address
+}
+
+fn browser() -> reqwest::Client {
+    // Unlike the auth client, the "browser" follows the authorize redirect
+    // out to the loopback listener.
+    reqwest::Client::builder().build().unwrap()
+}
+
+async fn signed_in_connection() -> (Arc<FakeGateway>, GatewayConnection) {
+    let gateway = Arc::new(FakeGateway::default());
+    let address = serve_fake_gateway(gateway.clone()).await;
+    let auth =
+        GatewayAuth::new(GatewayAuthConfig::modelctl_compat(&format!("http://{address}")).unwrap())
+            .unwrap();
+
+    let pending = auth.start_sign_in().await.unwrap();
+    let url = pending.authorization_url().to_string();
+    let finish = tokio::spawn(pending.finish(Duration::from_secs(5)));
+    browser().get(&url).send().await.unwrap();
+    let session = finish.await.unwrap().unwrap();
+
+    let connection =
+        GatewayConnection::new(auth, CredentialVault::new(Arc::new(MockSecrets::default())));
+    connection.store_session(&session).await.unwrap();
+    (gateway, connection)
+}
+
+#[tokio::test]
+async fn full_sign_in_flow_verifies_pkce_installation_and_identity() {
+    let gateway = Arc::new(FakeGateway::default());
+    let address = serve_fake_gateway(gateway.clone()).await;
+    let auth =
+        GatewayAuth::new(GatewayAuthConfig::modelctl_compat(&format!("http://{address}")).unwrap())
+            .unwrap();
+
+    let pending = auth.start_sign_in().await.unwrap();
+    assert_eq!(pending.meta().installation_id, INSTALLATION);
+    let url = pending.authorization_url().to_string();
+    assert!(url.contains("client_id=modelctl"));
+    assert!(url.contains("code_challenge_method=S256"));
+    assert!(url.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A"));
+
+    let finish = tokio::spawn(pending.finish(Duration::from_secs(5)));
+    let page = browser().get(&url).send().await.unwrap();
+    assert!(page.status().is_success());
+    let session = finish.await.unwrap().unwrap();
+
+    assert_eq!(session.tokens.resource, RESOURCE_CONTROL);
+    assert_eq!(session.tokens.installation_id, INSTALLATION);
+    assert_eq!(session.identity.user_id, USER);
+    assert_eq!(
+        session.identity.email.as_deref(),
+        Some("abaas@example.test")
+    );
+    // Exactly one token request: the code exchange.
+    assert_eq!(gateway.token_requests.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn access_tokens_cache_per_resource_and_rotate_on_refresh() {
+    let (gateway, connection) = signed_in_connection().await;
+    let exchanges = gateway.token_requests.load(Ordering::SeqCst);
+
+    // The control token stored at sign-in is still fresh: no new request.
+    let control = connection.access_token(RESOURCE_CONTROL).await.unwrap();
+    assert_eq!(gateway.token_requests.load(Ordering::SeqCst), exchanges);
+
+    // A new resource forces one rotating refresh; the result is then cached.
+    let llm = connection.access_token(RESOURCE_LLM).await.unwrap();
+    assert_ne!(control, llm);
+    assert_eq!(gateway.token_requests.load(Ordering::SeqCst), exchanges + 1);
+    assert_eq!(connection.access_token(RESOURCE_LLM).await.unwrap(), llm);
+    assert_eq!(gateway.token_requests.load(Ordering::SeqCst), exchanges + 1);
+
+    let models = connection.models(None).await.unwrap();
+    assert_eq!(models[0].id, "anthropic/claude-fable-5");
+    assert!(models[0].supports_tools);
+    let identity = connection.identity().await.unwrap();
+    assert_eq!(identity.user_id, USER);
+}
+
+#[tokio::test]
+async fn a_stale_refresh_token_reads_as_signed_out() {
+    let (_gateway, connection) = signed_in_connection().await;
+    let stale = connection.stored_credentials().await.unwrap().unwrap();
+
+    // Rotate once so the stored refresh token in `stale` is superseded…
+    connection.access_token(RESOURCE_LLM).await.unwrap();
+    // …then simulate a vault that missed the rotation.
+    let vault = CredentialVault::new(Arc::new(MockSecrets::default()));
+    vault.save(&stale).await.unwrap();
+    let auth =
+        GatewayAuth::new(GatewayAuthConfig::modelctl_compat(&stale.base_url).unwrap()).unwrap();
+    let stale_connection = GatewayConnection::new(auth, vault);
+
+    let error = stale_connection
+        .access_token(RESOURCE_LLM)
+        .await
+        .expect_err("superseded refresh token must fail");
+    assert!(is_sign_in_required(&error), "{error}");
+}
+
+#[tokio::test]
+async fn a_state_mismatch_never_reaches_the_token_endpoint() {
+    let gateway = Arc::new(FakeGateway::default());
+    gateway.corrupt_state.store(true, Ordering::SeqCst);
+    let address = serve_fake_gateway(gateway.clone()).await;
+    let auth =
+        GatewayAuth::new(GatewayAuthConfig::modelctl_compat(&format!("http://{address}")).unwrap())
+            .unwrap();
+
+    let pending = auth.start_sign_in().await.unwrap();
+    let url = pending.authorization_url().to_string();
+    let finish = tokio::spawn(pending.finish(Duration::from_secs(2)));
+    let page = browser().get(&url).send().await.unwrap();
+    assert_eq!(page.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let error = finish
+        .await
+        .unwrap()
+        .expect_err("state mismatch must fail the sign-in");
+    assert!(error.to_string().contains("timed out"), "{error}");
+    assert_eq!(gateway.token_requests.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn sign_out_revokes_remotely_and_clears_the_vault() {
+    let (gateway, connection) = signed_in_connection().await;
+    connection.sign_out().await.unwrap();
+
+    assert_eq!(gateway.revoked.lock().unwrap().len(), 1);
+    assert!(connection.stored_credentials().await.unwrap().is_none());
+    let error = connection
+        .access_token(RESOURCE_CONTROL)
+        .await
+        .expect_err("signed-out connection must fail");
+    assert!(is_sign_in_required(&error), "{error}");
+}
+
+#[tokio::test]
+async fn the_default_identity_is_a_first_class_openwave_client() {
+    let auth = GatewayAuth::new(GatewayAuthConfig::new("http://127.0.0.1:1").unwrap()).unwrap();
+    // start_sign_in requires a reachable gateway; the identity choice is
+    // visible without one via the config used to build authorization URLs.
+    drop(auth);
+    let config = GatewayAuthConfig::new("http://127.0.0.1:1").unwrap();
+    assert_ne!(
+        config,
+        GatewayAuthConfig::modelctl_compat("http://127.0.0.1:1").unwrap()
+    );
+}


### PR DESCRIPTION
The reserved connectors scaffold becomes the gateway auth client:
authorization code + PKCE S256 on a loopback listener, exchanged for the
gateway's opaque resource-bound tokens. The deployment is pinned by
/api/v1/meta's installation id at sign-in start, and every minted token
must match that installation and its requested resource, so a swapped
deployment behind a familiar URL is detected instead of trusted.

GatewayConnection layers rotation-safe token custody on top: credentials
live as one keychain secret behind the host's SecretProvider, access
tokens cache per resource with an expiry leeway, refresh rotates under a
single lock so concurrent callers can never trip the gateway's
reuse detection against themselves, and invalid_grant maps to a
recognizable sign-in-required error so the UI can offer reconnect
instead of a fault. Sign-out revokes best-effort and always clears
local state. No token, verifier, or code appears in Debug output,
errors, or logs.

The gateway currently accepts only its own CLI's client id;
GatewayAuthConfig::modelctl_compat carries that compatibility identity
for development until the gateway grows a client registry
(brightwave-inc/model-gateway#99), while ::new declares the first-class
openwave client for when it does.

Verified against both an in-process fake implementing the gateway's
contract and a live development gateway (code exchange, identity,
models, resource-scoped refresh, reuse-detection revocation).

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)