### PR TITLE
feat(server): stream ranged document bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6669,6 +6669,7 @@ dependencies = [
 name = "openwave-core"
 version = "0.0.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "cap-fs-ext",
  "cap-std",

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -32,10 +32,11 @@ keychain = ["dep:keyring", "dep:tokio"]
 # The built-in filesystem tools (read_file / list_dir / write_file).
 tools = ["dep:cap-fs-ext", "dep:cap-std", "dep:tokio"]
 # Durable local byte storage for desktop documents and artifacts.
-blob-fs = ["dep:tokio", "dep:windows-sys"]
+blob-fs = ["dep:async-stream", "dep:tokio", "dep:windows-sys"]
 
 [dependencies]
 async-trait = { workspace = true }
+async-stream = { workspace = true, optional = true }
 cap-std = { workspace = true, optional = true }
 cap-fs-ext = { workspace = true, optional = true }
 futures = { workspace = true }
@@ -50,7 +51,7 @@ chrono = { workspace = true }
 ts-rs = { workspace = true }
 sea-orm = { workspace = true, optional = true }
 sea-orm-migration = { workspace = true, optional = true }
-tokio = { workspace = true, optional = true, features = ["sync"] }
+tokio = { workspace = true, optional = true, features = ["io-util", "sync"] }
 
 # Keychain backends are per-OS: Security framework (macOS), Credential Manager
 # (Windows), and the Secret Service on Linux. The Linux backend uses

--- a/crates/openwave-core/src/blob.rs
+++ b/crates/openwave-core/src/blob.rs
@@ -1,9 +1,7 @@
 //! Durable local [`BlobStore`](crate::BlobStore) implementation.
 
-#[cfg(unix)]
-use std::fs::File;
-use std::fs::{self, OpenOptions};
-use std::io::{ErrorKind, Read, Write};
+use std::fs::{self, File, OpenOptions};
+use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
@@ -13,7 +11,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use uuid::Uuid;
 
-use crate::{AgentError, BlobStore, BlobStream, DocumentSourceBlob, Result};
+use crate::{AgentError, BlobMetadata, BlobStore, BlobStream, DocumentSourceBlob, Result};
 
 /// Filesystem-backed opaque byte storage.
 ///
@@ -155,6 +153,79 @@ impl BlobStore for FsBlobStore {
         })
         .await
         .map_err(|error| AgentError::Store(format!("blob read task failed: {error}")))?
+    }
+
+    async fn metadata(&self, id: Uuid) -> Result<Option<BlobMetadata>> {
+        let path = self.blob_path(id);
+        let access = Arc::clone(&self.access);
+        tokio::task::spawn_blocking(move || {
+            let _guard = access
+                .read()
+                .map_err(|_| AgentError::Store("blob store lock poisoned".into()))?;
+            match fs::metadata(path) {
+                Ok(metadata) => Ok(Some(BlobMetadata {
+                    byte_len: metadata.len(),
+                })),
+                Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+                Err(error) => Err(blob_error("read metadata", error)),
+            }
+        })
+        .await
+        .map_err(|error| AgentError::Store(format!("blob metadata task failed: {error}")))?
+    }
+
+    async fn read_range(
+        &self,
+        id: Uuid,
+        range: std::ops::Range<u64>,
+    ) -> Result<Option<BlobStream>> {
+        if range.start > range.end {
+            return Err(AgentError::Store("blob range start exceeds its end".into()));
+        }
+        let path = self.blob_path(id);
+        let access = Arc::clone(&self.access);
+        let start = range.start;
+        let file = tokio::task::spawn_blocking(move || {
+            let _guard = access
+                .read()
+                .map_err(|_| AgentError::Store("blob store lock poisoned".into()))?;
+            let mut file = match File::open(path) {
+                Ok(file) => file,
+                Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+                Err(error) => return Err(blob_error("open range reader", error)),
+            };
+            file.seek(SeekFrom::Start(start))
+                .map_err(|error| blob_error("seek range reader", error))?;
+            Ok(Some(file))
+        })
+        .await
+        .map_err(|error| AgentError::Store(format!("blob range task failed: {error}")))??;
+        let Some(file) = file else {
+            return Ok(None);
+        };
+
+        let remaining = range.end - range.start;
+        let stream = async_stream::try_stream! {
+            use tokio::io::AsyncReadExt;
+
+            let mut file = tokio::fs::File::from_std(file);
+            let mut remaining = remaining;
+            let mut buffer = vec![0; 64 * 1024];
+            while remaining > 0 {
+                let limit = usize::try_from(remaining.min(buffer.len() as u64))
+                    .expect("bounded buffer length fits in usize");
+                let read = file
+                    .read(&mut buffer[..limit])
+                    .await
+                    .map_err(|error| blob_error("read range", error))?;
+                if read == 0 {
+                    Err(AgentError::Store("blob ended before the requested range".into()))?;
+                }
+                remaining -= u64::try_from(read).expect("usize always fits in u64");
+                yield buffer[..read].to_vec();
+            }
+        };
+        Ok(Some(Box::pin(stream)))
     }
 
     fn delete(&self, id: Uuid) -> Result<()> {
@@ -324,6 +395,7 @@ fn blob_error(action: &str, error: std::io::Error) -> AgentError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::TryStreamExt;
 
     #[tokio::test]
     async fn roundtrips_reopens_and_deletes_idempotently() {
@@ -353,6 +425,38 @@ mod tests {
         reopened.delete(id).unwrap();
         reopened.delete(id).unwrap();
         assert_eq!(reopened.get(id).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn reads_metadata_and_a_bounded_range_stream() {
+        let directory = tempfile::tempdir().unwrap();
+        let id = Uuid::new_v4();
+        let store = FsBlobStore::new(directory.path());
+        let bytes: Vec<u8> = (0..(2 * 64 * 1024))
+            .map(|index| u8::try_from(index % 251).expect("remainder fits in u8"))
+            .collect();
+        store.put(id, bytes.clone()).await.unwrap();
+
+        assert_eq!(
+            store.metadata(id).await.unwrap(),
+            Some(BlobMetadata {
+                byte_len: u64::try_from(bytes.len()).expect("usize always fits in u64"),
+            })
+        );
+        let range = 123..(123 + 64 * 1024 + 17);
+        let chunks = store
+            .read_range(id, range.clone())
+            .await
+            .unwrap()
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert!(chunks.iter().all(|chunk| chunk.len() <= 64 * 1024));
+        assert_eq!(
+            chunks.concat(),
+            bytes[usize::try_from(range.start).unwrap()..usize::try_from(range.end).unwrap()]
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -147,7 +147,7 @@ pub use storage::{
     AcceptAgentRunOutcome, AcceptClaimedToolCallOutcome, AcceptSandboxAgentRunAndParkTurnOutcome,
     AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AdmitSandboxAgentRunOutcome,
     AnswerUserQuestionsOutcome, AppendClaimedMessageOutcome, ApplyTurnSteerOutcome,
-    BeginRootAttachmentChangeOutcome, BlobStore, BlobStream, ChatRefusalSnapshot,
+    BeginRootAttachmentChangeOutcome, BlobMetadata, BlobStore, BlobStream, ChatRefusalSnapshot,
     ChatToolActivitySnapshot, ChatToolActivityStatus, ChatTranscriptSnapshot,
     CheckpointSandboxSpawnOutcome, ClaimAgentRunInboxOutcome, ClaimClientToolCallOutcome,
     ClaimDelegatedFileReadOutcome, ClaimSandboxToolCallOutcome, ClaimScanTerminalEvent,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -16,9 +16,13 @@
 //! introduce those record types.
 
 use async_trait::async_trait;
-use futures::{stream::BoxStream, StreamExt};
+use futures::{
+    stream::{self, BoxStream},
+    StreamExt,
+};
 use serde::Serialize;
 use serde_json::Value;
+use std::ops::Range;
 
 use crate::approval::{ApprovalDecision, ApprovalRequest, ToolApproval};
 use crate::deliverable::{
@@ -47,8 +51,11 @@ use crate::{AnswerUserQuestionsRequest, PendingUserQuestions};
 /// Largest pending attachment-reconciliation page accepted by [`Store`].
 pub const MAX_PENDING_ROOT_ATTACHMENT_CHANGES: u64 = 256;
 
-/// Chunks supplied to a [`BlobStore`] without requiring the caller to buffer a
-/// whole source in memory.
+/// Chunks supplied to or read from a [`BlobStore`] without requiring either
+/// side to buffer a whole source in memory.
+///
+/// Dropping a storage-backed bounded-read stream must cancel any in-flight
+/// storage read.
 pub type BlobStream = BoxStream<'static, Result<Vec<u8>>>;
 
 /// A mutually consistent conversation transcript and event-journal cursor.
@@ -2767,6 +2774,13 @@ pub trait SecretProvider: Send + Sync {
     async fn delete_secret(&self, key: &str) -> Result<()>;
 }
 
+/// Metadata that can be read without materializing a blob's bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlobMetadata {
+    /// Number of bytes in the immutable blob.
+    pub byte_len: u64,
+}
+
 /// Opaque byte storage for documents, images, and exports.
 #[async_trait]
 pub trait BlobStore: Send + Sync {
@@ -2809,6 +2823,38 @@ pub trait BlobStore: Send + Sync {
 
     /// Fetch bytes by `id`, or `None` if absent.
     async fn get(&self, id: uuid::Uuid) -> Result<Option<Vec<u8>>>;
+
+    /// Fetch a blob's length without reading its bytes.
+    ///
+    /// Backends should override this when their storage can obtain metadata
+    /// independently. The compatibility implementation keeps existing custom
+    /// stores correct while they adopt the bounded-read API.
+    async fn metadata(&self, id: uuid::Uuid) -> Result<Option<BlobMetadata>> {
+        self.get(id).await.map(|bytes| {
+            bytes.map(|bytes| BlobMetadata {
+                byte_len: u64::try_from(bytes.len()).expect("usize always fits in u64"),
+            })
+        })
+    }
+
+    /// Read the half-open byte `range` without materializing bytes outside it.
+    ///
+    /// A backend that cannot yet stream uses the compatibility implementation;
+    /// production stores should override it so response ranges remain bounded.
+    async fn read_range(&self, id: uuid::Uuid, range: Range<u64>) -> Result<Option<BlobStream>> {
+        let Some(bytes) = self.get(id).await? else {
+            return Ok(None);
+        };
+        let start = usize::try_from(range.start)
+            .map_err(|_| AgentError::Store("blob range start exceeds usize".into()))?;
+        let end = usize::try_from(range.end)
+            .map_err(|_| AgentError::Store("blob range end exceeds usize".into()))?;
+        let bytes = bytes
+            .get(start..end)
+            .ok_or_else(|| AgentError::Store("requested byte range is outside the blob".into()))?
+            .to_vec();
+        Ok(Some(stream::once(async move { Ok(bytes) }).boxed()))
+    }
 
     /// Delete a blob synchronously; a no-op if it doesn't exist.
     ///

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -2,7 +2,7 @@
 
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::http::{header, HeaderMap, HeaderValue, Method, StatusCode};
 use axum::response::{IntoResponse, Response};
 use chrono::Utc;
 use futures::StreamExt;
@@ -812,9 +812,10 @@ pub async fn get_chat_document(
 pub async fn get_document_file_content(
     State(state): State<AppState>,
     Path(id): Path<DocumentId>,
+    method: Method,
     headers: HeaderMap,
 ) -> Result<Response, ServerError> {
-    serve_document_file_content(&state, id, None, None, &headers).await
+    serve_document_file_content(&state, id, None, None, method, &headers).await
 }
 
 /// `GET /projects/{project_id}/documents/{document_id}/file-content` — serve
@@ -822,10 +823,19 @@ pub async fn get_document_file_content(
 pub async fn get_project_document_file_content(
     State(state): State<AppState>,
     Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
+    method: Method,
     headers: HeaderMap,
 ) -> Result<Response, ServerError> {
     require_project(&state, project_id).await?;
-    serve_document_file_content(&state, document_id, None, Some(project_id), &headers).await
+    serve_document_file_content(
+        &state,
+        document_id,
+        None,
+        Some(project_id),
+        method,
+        &headers,
+    )
+    .await
 }
 
 /// `GET /chats/{chat_id}/documents/{document_id}/file-content` — serve original
@@ -833,10 +843,11 @@ pub async fn get_project_document_file_content(
 pub async fn get_chat_document_file_content(
     State(state): State<AppState>,
     Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
+    method: Method,
     headers: HeaderMap,
 ) -> Result<Response, ServerError> {
     require_chat(&state, chat_id).await?;
-    serve_document_file_content(&state, document_id, Some(chat_id), None, &headers).await
+    serve_document_file_content(&state, document_id, Some(chat_id), None, method, &headers).await
 }
 
 async fn serve_document_file_content(
@@ -844,6 +855,7 @@ async fn serve_document_file_content(
     document_id: DocumentId,
     chat_id: Option<ChatId>,
     project_id: Option<ProjectId>,
+    method: Method,
     headers: &HeaderMap,
 ) -> Result<Response, ServerError> {
     let Some(document) = state
@@ -861,13 +873,12 @@ async fn serve_document_file_content(
             "original bytes for document {document_id} not found"
         )));
     };
-    let bytes = state.blobs.get(source_blob.id).await?.ok_or_else(|| {
+    let metadata = state.blobs.metadata(source_blob.id).await?.ok_or_else(|| {
         ServerError::internal(format!(
             "original bytes for document {document_id} are missing from blob storage"
         ))
     })?;
-    let actual_len = u64::try_from(bytes.len())
-        .map_err(|_| ServerError::internal("document byte length exceeds u64"))?;
+    let actual_len = metadata.byte_len;
     if actual_len != source_blob.byte_len {
         return Err(ServerError::internal(format!(
             "original byte length for document {document_id} does not match its descriptor"
@@ -883,33 +894,45 @@ async fn serve_document_file_content(
         Ok(range) => range,
         Err(()) => return Ok(range_not_satisfiable_response(actual_len)),
     };
-    let (status, content_range, body) = match requested_range {
+    let (status, content_range, range, body_len) = match requested_range {
         Some(range) => {
-            let start = usize::try_from(range.start)
-                .map_err(|_| ServerError::internal("document range start exceeds usize"))?;
-            let end_exclusive = usize::try_from(range.end_inclusive + 1)
-                .map_err(|_| ServerError::internal("document range end exceeds usize"))?;
+            let end_exclusive = range.end_inclusive + 1;
             (
                 StatusCode::PARTIAL_CONTENT,
                 Some(format!(
                     "bytes {}-{}/{}",
                     range.start, range.end_inclusive, actual_len
                 )),
-                bytes[start..end_exclusive].to_vec(),
+                range.start..end_exclusive,
+                end_exclusive - range.start,
             )
         }
-        None => (StatusCode::OK, None, bytes),
+        None => (StatusCode::OK, None, 0..actual_len, actual_len),
+    };
+    let body = if method == Method::HEAD {
+        Body::empty()
+    } else {
+        let stream = state
+            .blobs
+            .read_range(source_blob.id, range)
+            .await?
+            .ok_or_else(|| {
+                ServerError::internal(format!(
+                    "original bytes for document {document_id} are missing from blob storage"
+                ))
+            })?;
+        Body::from_stream(stream)
     };
 
     let mut response = Response::builder()
         .status(status)
         .header(header::CONTENT_TYPE, content_type)
         .header(header::ACCEPT_RANGES, "bytes")
-        .header(header::CONTENT_LENGTH, body.len().to_string());
+        .header(header::CONTENT_LENGTH, body_len.to_string());
     if let Some(content_range) = content_range {
         response = response.header(header::CONTENT_RANGE, content_range);
     }
-    response.body(Body::from(body)).map_err(|error| {
+    response.body(body).map_err(|error| {
         ServerError::internal(format!("failed to build document response: {error}"))
     })
 }

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1,6 +1,10 @@
 use super::*;
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::ops::Range;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -10,9 +14,9 @@ use futures::stream::{self, BoxStream, StreamExt};
 // Tests use the in-memory store; production wires LanceDB in `bind`.
 use openwave_core::{
     Agent, AgentConfig, AgentErrorInfo, AgentEvent, AgentRunInboxStatus, AgentRunStatus,
-    ApprovalClass, BeginRootAttachmentChange, BlobStore, CallId, Chat, ChatId, ChatRequest,
-    ChatRootAttachment, ClaimedAgentEvent, ClientToolCallRequest, ContentBlock,
-    DeleteProjectOutcome, HostRootId, Message, MessageId, ModelProvider,
+    ApprovalClass, BeginRootAttachmentChange, BlobMetadata, BlobStore, BlobStream, CallId, Chat,
+    ChatId, ChatRequest, ChatRootAttachment, ClaimedAgentEvent, ClientToolCallRequest,
+    ContentBlock, DeleteProjectOutcome, HostRootId, Message, MessageId, ModelProvider,
     ParkSandboxToolCallOutcome, ParkTurnForClientCallOutcome, Project, ProjectId, ProviderEvent,
     ProviderId, Role, RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentOrigin,
     SandboxToolCallRequest, SecretProvider, SequencedEvent, StopReason, Tool, ToolCallExecution,
@@ -617,6 +621,109 @@ struct FirstPutGatedBlobStore {
     calls: AtomicUsize,
     entered: Notify,
     release: Notify,
+}
+
+/// An instrumented store used to prove a response range never falls back to
+/// [`BlobStore::get`], which would materialize the complete source.
+struct RangeOnlyBlobStore {
+    bytes: Arc<Vec<u8>>,
+    full_reads: AtomicUsize,
+    requested_ranges: Mutex<Vec<Range<u64>>>,
+}
+
+#[async_trait]
+impl BlobStore for RangeOnlyBlobStore {
+    async fn put(&self, _id: uuid::Uuid, _bytes: Vec<u8>) -> Result<()> {
+        Err(AgentError::Store(
+            "range-only test store cannot publish".into(),
+        ))
+    }
+
+    async fn get(&self, _id: uuid::Uuid) -> Result<Option<Vec<u8>>> {
+        self.full_reads.fetch_add(1, Ordering::SeqCst);
+        Err(AgentError::Store(
+            "document route must not materialize the blob".into(),
+        ))
+    }
+
+    async fn metadata(&self, _id: uuid::Uuid) -> Result<Option<BlobMetadata>> {
+        Ok(Some(BlobMetadata {
+            byte_len: u64::try_from(self.bytes.len()).expect("usize always fits in u64"),
+        }))
+    }
+
+    async fn read_range(&self, _id: uuid::Uuid, range: Range<u64>) -> Result<Option<BlobStream>> {
+        self.requested_ranges.lock().unwrap().push(range.clone());
+        let start = usize::try_from(range.start)
+            .map_err(|_| AgentError::Store("test range start exceeds usize".into()))?;
+        let end = usize::try_from(range.end)
+            .map_err(|_| AgentError::Store("test range end exceeds usize".into()))?;
+        let bytes = self
+            .bytes
+            .get(start..end)
+            .ok_or_else(|| AgentError::Store("test range is outside source bytes".into()))?
+            .to_vec();
+        Ok(Some(stream::once(async move { Ok(bytes) }).boxed()))
+    }
+
+    fn delete(&self, _id: uuid::Uuid) -> Result<()> {
+        Ok(())
+    }
+}
+
+struct PendingBlobStream {
+    dropped: Arc<AtomicBool>,
+}
+
+impl futures::Stream for PendingBlobStream {
+    type Item = Result<Vec<u8>>;
+
+    fn poll_next(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Pending
+    }
+}
+
+impl Drop for PendingBlobStream {
+    fn drop(&mut self) {
+        self.dropped.store(true, Ordering::SeqCst);
+    }
+}
+
+/// A stream that stays pending until the HTTP body is cancelled.
+struct CancellationAwareBlobStore {
+    byte_len: u64,
+    stream_dropped: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl BlobStore for CancellationAwareBlobStore {
+    async fn put(&self, _id: uuid::Uuid, _bytes: Vec<u8>) -> Result<()> {
+        Err(AgentError::Store(
+            "cancellation test store cannot publish".into(),
+        ))
+    }
+
+    async fn get(&self, _id: uuid::Uuid) -> Result<Option<Vec<u8>>> {
+        Err(AgentError::Store(
+            "document route must not materialize the blob".into(),
+        ))
+    }
+
+    async fn metadata(&self, _id: uuid::Uuid) -> Result<Option<BlobMetadata>> {
+        Ok(Some(BlobMetadata {
+            byte_len: self.byte_len,
+        }))
+    }
+
+    async fn read_range(&self, _id: uuid::Uuid, _range: Range<u64>) -> Result<Option<BlobStream>> {
+        Ok(Some(Box::pin(PendingBlobStream {
+            dropped: Arc::clone(&self.stream_dropped),
+        })))
+    }
+
+    fn delete(&self, _id: uuid::Uuid) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -4963,6 +5070,119 @@ async fn document_file_content_supports_full_head_and_single_range_responses() {
             .unwrap()
             .is_empty());
     }
+}
+
+#[tokio::test]
+async fn document_file_content_streams_only_the_requested_range() {
+    let (upload_router, token, mut state, _store, _dir) = test_app_with_state().await;
+    let bearer = format!("Bearer {token}");
+    let raw: Vec<u8> = (0..(2 * 1024 * 1024))
+        .map(|index| u8::try_from(index % 251).expect("remainder fits in u8"))
+        .collect();
+    let accepted: serde_json::Value = json_body(
+        post_raw(
+            &upload_router,
+            &bearer,
+            "/documents/raw?title=large.pdf",
+            Some("application/pdf"),
+            raw.clone(),
+        )
+        .await,
+    )
+    .await;
+    let tracker = Arc::new(RangeOnlyBlobStore {
+        bytes: Arc::new(raw.clone()),
+        full_reads: AtomicUsize::new(0),
+        requested_ranges: Mutex::new(Vec::new()),
+    });
+    state.blobs = tracker.clone();
+    let router = app(state);
+    let selected_range = 1_048_576_u64..1_048_608;
+    let uri = format!(
+        "/documents/{}/file-content",
+        accepted["document_id"].as_str().unwrap()
+    );
+
+    let response = request_document_file_content(
+        &router,
+        axum::http::Method::GET,
+        &uri,
+        Some(&bearer),
+        Some("bytes=1048576-1048607"),
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+    assert_eq!(
+        to_bytes(response.into_body(), usize::MAX).await.unwrap(),
+        raw[1_048_576..1_048_608]
+    );
+    assert_eq!(tracker.full_reads.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        tracker.requested_ranges.lock().unwrap().as_slice(),
+        std::slice::from_ref(&selected_range)
+    );
+
+    let head = request_document_file_content(
+        &router,
+        axum::http::Method::HEAD,
+        &uri,
+        Some(&bearer),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(head.status(), StatusCode::OK);
+    assert!(to_bytes(head.into_body(), usize::MAX)
+        .await
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        tracker.requested_ranges.lock().unwrap().as_slice(),
+        std::slice::from_ref(&selected_range)
+    );
+}
+
+#[tokio::test]
+async fn document_file_content_cancels_its_blob_stream_when_response_is_dropped() {
+    let (upload_router, token, mut state, _store, _dir) = test_app_with_state().await;
+    let bearer = format!("Bearer {token}");
+    let raw = b"cancellation source".to_vec();
+    let accepted: serde_json::Value = json_body(
+        post_raw(
+            &upload_router,
+            &bearer,
+            "/documents/raw?title=cancel.txt",
+            Some("text/plain"),
+            raw.clone(),
+        )
+        .await,
+    )
+    .await;
+    let stream_dropped = Arc::new(AtomicBool::new(false));
+    state.blobs = Arc::new(CancellationAwareBlobStore {
+        byte_len: u64::try_from(raw.len()).expect("usize always fits in u64"),
+        stream_dropped: Arc::clone(&stream_dropped),
+    });
+    let router = app(state);
+    let uri = format!(
+        "/documents/{}/file-content",
+        accepted["document_id"].as_str().unwrap()
+    );
+
+    let response = request_document_file_content(
+        &router,
+        axum::http::Method::GET,
+        &uri,
+        Some(&bearer),
+        None,
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(!stream_dropped.load(Ordering::SeqCst));
+    drop(response);
+    assert!(stream_dropped.load(Ordering::SeqCst));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add metadata and bounded read streams to the blob-storage contract
- stream full and single-range document responses from the filesystem store while preserving range headers and scope checks
- verify bounded range reads and response-drop cancellation

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked -- --quiet
- cargo check --workspace --locked

Closes #579