### PR TITLE
feat(agent): persist durable context checkpoints

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -329,6 +329,27 @@ pub mod message {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod context_checkpoint {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "context_checkpoint")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub chat_id: Uuid,
+        pub source_message_id: Uuid,
+        pub source_message_seq: i64,
+        pub format_version: i32,
+        pub content: String,
+        pub created_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod message_attachment {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -29,6 +29,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddConversationOutputs),
             Box::new(AddMessageAttachments),
             Box::new(AddOutputRevisionCitations),
+            Box::new(AddContextCheckpoints),
         ]
     }
 }
@@ -682,6 +683,91 @@ impl MigrationTrait for AddMessageAttachments {
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
             .drop_table(Table::drop().table(MessageAttachment::Table).to_owned())
+            .await
+    }
+}
+
+/// Stores one bounded, versioned semantic checkpoint per conversation.
+///
+/// It is separate from `message`: checkpoints are agent-maintained provider
+/// context, not user-visible transcript entries. The source sequence is copied
+/// from the validated source message solely to make stale-writer rejection
+/// atomic; source text is never copied into this schema by the migration.
+struct AddContextCheckpoints;
+
+impl MigrationName for AddContextCheckpoints {
+    fn name(&self) -> &str {
+        "m20260727_000016_add_context_checkpoints"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddContextCheckpoints {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(ContextCheckpoint::Table)
+                    .col(
+                        ColumnDef::new(ContextCheckpoint::ChatId)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(ContextCheckpoint::SourceMessageId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ContextCheckpoint::SourceMessageSeq)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ContextCheckpoint::FormatVersion)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ContextCheckpoint::Content)
+                            .string_len(
+                                crate::semantic_checkpoint::MAX_CONTEXT_CHECKPOINT_BYTES as u32,
+                            )
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ContextCheckpoint::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_context_checkpoint_chat")
+                            .from(ContextCheckpoint::Table, ContextCheckpoint::ChatId)
+                            .to(Chat::Table, Chat::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_context_checkpoint_source_message")
+                            .from(ContextCheckpoint::Table, ContextCheckpoint::SourceMessageId)
+                            .to(Message::Table, Message::Id)
+                            .on_delete(ForeignKeyAction::Restrict),
+                    )
+                    .check(Expr::col(ContextCheckpoint::SourceMessageSeq).gt(0))
+                    .check(
+                        Expr::col(ContextCheckpoint::FormatVersion)
+                            .eq(crate::semantic_checkpoint::CONTEXT_CHECKPOINT_FORMAT_V1 as i32),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(ContextCheckpoint::Table).to_owned())
             .await
     }
 }
@@ -6137,6 +6223,17 @@ enum Message {
     Role,
     Content,
     TurnLeaseToken,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum ContextCheckpoint {
+    Table,
+    ChatId,
+    SourceMessageId,
+    SourceMessageSeq,
+    FormatVersion,
+    Content,
     CreatedAt,
 }
 

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -44,6 +44,7 @@ use crate::model::{
     TurnSteerStatus, MAX_ROOT_ATTACHMENTS,
 };
 use crate::provider::{StopReason, Usage};
+use crate::semantic_checkpoint::{ContextCheckpoint, SaveContextCheckpointOutcome};
 use crate::storage::{
     AcceptAgentRunOutcome, AcceptClaimedToolCallOutcome, AcceptSandboxAgentRunAndParkTurnOutcome,
     AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AdmitSandboxAgentRunOutcome,
@@ -1853,6 +1854,17 @@ impl Store for DbStore {
 
     async fn delete_output(&self, id: OutputId, deleted_at: chrono::DateTime<Utc>) -> Result<bool> {
         ops::output::delete_output(self, id, deleted_at).await
+    }
+
+    async fn save_context_checkpoint(
+        &self,
+        checkpoint: &ContextCheckpoint,
+    ) -> Result<SaveContextCheckpointOutcome> {
+        ops::context_checkpoint::save_context_checkpoint(self, checkpoint).await
+    }
+
+    async fn get_context_checkpoint(&self, chat_id: ChatId) -> Result<Option<ContextCheckpoint>> {
+        ops::context_checkpoint::get_context_checkpoint(self, chat_id).await
     }
 
     async fn begin_root_attachment_change(

--- a/crates/openwave-core/src/db/ops/context_checkpoint.rs
+++ b/crates/openwave-core/src/db/ops/context_checkpoint.rs
@@ -1,0 +1,145 @@
+//! Durable, monotonic semantic checkpoints for one conversation.
+//!
+//! Checkpoints are a bounded cache of meaning, not transcript messages. The
+//! chat write lock makes their source-boundary comparison serializable across
+//! workers, so a resumed older worker cannot replace a newer checkpoint.
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, Set, TransactionTrait,
+};
+
+use crate::error::{AgentError, Result};
+use crate::id::{ChatId, MessageId};
+use crate::semantic_checkpoint::{ContextCheckpoint, SaveContextCheckpointOutcome};
+
+use super::super::{entities, store_err, DbStore};
+use super::{acquire_chat_write_lock, turn::canonical_db_timestamp};
+
+pub(in crate::db) async fn save_context_checkpoint(
+    store: &DbStore,
+    checkpoint: &ContextCheckpoint,
+) -> Result<SaveContextCheckpointOutcome> {
+    checkpoint.validate()?;
+    let created_at = canonical_db_timestamp(checkpoint.created_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if !acquire_chat_write_lock(&transaction, checkpoint.chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "chat {} does not exist",
+            checkpoint.chat_id
+        )));
+    }
+    let Some(source) = entities::message::Entity::find_by_id(checkpoint.source_message_id.0)
+        .filter(entities::message::Column::ChatId.eq(checkpoint.chat_id.0))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "context checkpoint source message {} does not belong to chat {}",
+            checkpoint.source_message_id, checkpoint.chat_id
+        )));
+    };
+
+    if let Some(existing) =
+        find_context_checkpoint_model_on(&transaction, checkpoint.chat_id).await?
+    {
+        let current = context_checkpoint_from_model(existing.clone())?;
+        if existing.source_message_seq > source.seq {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(SaveContextCheckpointOutcome::Stale(current));
+        }
+        if existing.source_message_seq == source.seq {
+            transaction.rollback().await.map_err(store_err)?;
+            return if existing.source_message_id == checkpoint.source_message_id.0
+                && existing.format_version == i32::from(checkpoint.format_version)
+                && existing.content == checkpoint.content
+            {
+                Ok(SaveContextCheckpointOutcome::Existing(current))
+            } else {
+                Ok(SaveContextCheckpointOutcome::Conflict(current))
+            };
+        }
+    }
+
+    let stored = entities::context_checkpoint::ActiveModel {
+        chat_id: Set(checkpoint.chat_id.0),
+        source_message_id: Set(checkpoint.source_message_id.0),
+        source_message_seq: Set(source.seq),
+        format_version: Set(i32::from(checkpoint.format_version)),
+        content: Set(checkpoint.content.clone()),
+        created_at: Set(created_at),
+    };
+    if find_context_checkpoint_model_on(&transaction, checkpoint.chat_id)
+        .await?
+        .is_some()
+    {
+        stored.update(&transaction).await.map_err(store_err)?;
+    } else {
+        stored.insert(&transaction).await.map_err(store_err)?;
+    }
+    let saved = require_context_checkpoint_on(&transaction, checkpoint.chat_id).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(SaveContextCheckpointOutcome::Saved(saved))
+}
+
+pub(in crate::db) async fn get_context_checkpoint(
+    store: &DbStore,
+    chat_id: ChatId,
+) -> Result<Option<ContextCheckpoint>> {
+    find_context_checkpoint_on(&store.conn, chat_id).await
+}
+
+async fn find_context_checkpoint_model_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+) -> Result<Option<entities::context_checkpoint::Model>>
+where
+    C: ConnectionTrait,
+{
+    entities::context_checkpoint::Entity::find_by_id(chat_id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)
+}
+
+async fn find_context_checkpoint_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+) -> Result<Option<ContextCheckpoint>>
+where
+    C: ConnectionTrait,
+{
+    find_context_checkpoint_model_on(conn, chat_id)
+        .await?
+        .map(context_checkpoint_from_model)
+        .transpose()
+}
+
+async fn require_context_checkpoint_on<C>(conn: &C, chat_id: ChatId) -> Result<ContextCheckpoint>
+where
+    C: ConnectionTrait,
+{
+    find_context_checkpoint_on(conn, chat_id)
+        .await?
+        .ok_or_else(|| {
+            AgentError::Store(format!("context checkpoint for chat {chat_id} is missing"))
+        })
+}
+
+fn context_checkpoint_from_model(
+    model: entities::context_checkpoint::Model,
+) -> Result<ContextCheckpoint> {
+    let checkpoint = ContextCheckpoint {
+        chat_id: ChatId(model.chat_id),
+        source_message_id: MessageId(model.source_message_id),
+        format_version: u16::try_from(model.format_version).map_err(|_| {
+            AgentError::Store("stored context checkpoint format version is outside u16".into())
+        })?,
+        content: model.content,
+        created_at: model.created_at,
+    };
+    checkpoint.validate()?;
+    Ok(checkpoint)
+}

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -591,6 +591,14 @@ pub(in crate::db) async fn delete_chat(
         .exec(&transaction)
         .await
         .map_err(store_err)?;
+    // A context checkpoint references its inclusive source message. It is
+    // provider-only state, so delete it before the source message rather than
+    // leaving a checkpoint that could outlive this conversation's history.
+    entities::context_checkpoint::Entity::delete_many()
+        .filter(entities::context_checkpoint::Column::ChatId.eq(chat_id.0))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
     entities::message::Entity::delete_many()
         .filter(entities::message::Column::ChatId.eq(chat_id.0))
         .exec(&transaction)

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -11,6 +11,7 @@ pub(in crate::db) mod blob;
 pub(in crate::db) mod chat_prompt;
 pub(in crate::db) mod citation;
 pub(in crate::db) mod client_execution;
+pub(in crate::db) mod context_checkpoint;
 pub(in crate::db) mod conversation;
 pub(in crate::db) mod document;
 pub(in crate::db) mod message_attachment;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -11,6 +11,7 @@ use crate::{ApprovalClass, ChunkId, ToolApprovalStatus};
 use chrono::{DateTime, Utc};
 
 mod agent_run;
+mod context_checkpoint;
 mod delegated_file_read;
 mod message_attachment;
 mod multi_agent_wait;

--- a/crates/openwave-core/src/db/tests/context_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/context_checkpoint.rs
@@ -1,0 +1,158 @@
+use super::*;
+use crate::semantic_checkpoint::{
+    ContextCheckpoint, SaveContextCheckpointOutcome, CONTEXT_CHECKPOINT_FORMAT_V1,
+    MAX_CONTEXT_CHECKPOINT_BYTES,
+};
+
+fn at(second: i64) -> DateTime<Utc> {
+    DateTime::<Utc>::from_timestamp(1_710_000_000 + second, 0).unwrap()
+}
+
+async fn store_with_messages() -> (tempfile::TempDir, DbStore, Chat, Message, Message) {
+    let (dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let first = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        role: Role::User,
+        content: "Choose SQLite for local development.".into(),
+        created_at: at(0),
+    };
+    let second = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        role: Role::Assistant,
+        content: "The local database choice is SQLite.".into(),
+        created_at: at(1),
+    };
+    store.append_message(&first).await.unwrap();
+    store.append_message(&second).await.unwrap();
+    (dir, store, chat, first, second)
+}
+
+fn checkpoint(
+    chat_id: ChatId,
+    source_message_id: MessageId,
+    content: &str,
+    second: i64,
+) -> ContextCheckpoint {
+    ContextCheckpoint {
+        chat_id,
+        source_message_id,
+        format_version: CONTEXT_CHECKPOINT_FORMAT_V1,
+        content: content.into(),
+        created_at: at(second),
+    }
+}
+
+#[tokio::test]
+async fn checkpoint_is_durable_bounded_and_invisible_to_the_transcript() {
+    let (_dir, store, chat, first, second) = store_with_messages().await;
+    let initial = checkpoint(chat.id, first.id, "User selected SQLite.", 2);
+
+    assert_eq!(
+        store.save_context_checkpoint(&initial).await.unwrap(),
+        SaveContextCheckpointOutcome::Saved(initial.clone())
+    );
+    assert_eq!(
+        store.get_context_checkpoint(chat.id).await.unwrap(),
+        Some(initial.clone())
+    );
+    assert_eq!(
+        store.list_messages(chat.id).await.unwrap(),
+        [first.clone(), second.clone()],
+        "a checkpoint is provider context, not a visible message"
+    );
+
+    let advanced = checkpoint(
+        chat.id,
+        second.id,
+        "User selected SQLite; the assistant confirmed it.",
+        3,
+    );
+    assert_eq!(
+        store.save_context_checkpoint(&advanced).await.unwrap(),
+        SaveContextCheckpointOutcome::Saved(advanced.clone())
+    );
+    assert_eq!(
+        store.save_context_checkpoint(&advanced).await.unwrap(),
+        SaveContextCheckpointOutcome::Existing(advanced.clone()),
+        "an ambiguous response can be retried without a second checkpoint"
+    );
+    assert_eq!(
+        store
+            .save_context_checkpoint(&checkpoint(chat.id, first.id, "old", 4))
+            .await
+            .unwrap(),
+        SaveContextCheckpointOutcome::Stale(advanced.clone()),
+        "a recovered older worker cannot replace newer context"
+    );
+    assert_eq!(
+        store
+            .save_context_checkpoint(&checkpoint(chat.id, second.id, "different", 4))
+            .await
+            .unwrap(),
+        SaveContextCheckpointOutcome::Conflict(advanced),
+        "the same boundary has one immutable payload"
+    );
+}
+
+#[tokio::test]
+async fn checkpoint_rejects_cross_chat_boundaries_and_malformed_payloads() {
+    let (_dir, store, chat, first, _second) = store_with_messages().await;
+    let other = sample_chat();
+    store.create_chat(&other).await.unwrap();
+
+    let cross_chat = checkpoint(other.id, first.id, "not allowed", 2);
+    assert!(store.save_context_checkpoint(&cross_chat).await.is_err());
+    assert!(store
+        .get_context_checkpoint(other.id)
+        .await
+        .unwrap()
+        .is_none());
+
+    let empty = checkpoint(chat.id, first.id, "   ", 2);
+    assert!(store.save_context_checkpoint(&empty).await.is_err());
+    let oversized = checkpoint(
+        chat.id,
+        first.id,
+        &"x".repeat(MAX_CONTEXT_CHECKPOINT_BYTES + 1),
+        2,
+    );
+    assert!(store.save_context_checkpoint(&oversized).await.is_err());
+    let unknown_format = ContextCheckpoint {
+        format_version: CONTEXT_CHECKPOINT_FORMAT_V1 + 1,
+        ..checkpoint(chat.id, first.id, "valid text", 2)
+    };
+    assert!(store
+        .save_context_checkpoint(&unknown_format)
+        .await
+        .is_err());
+    assert!(store
+        .get_context_checkpoint(chat.id)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn deleting_a_chat_removes_its_checkpoint_before_its_source_message() {
+    let (_dir, store, chat, first, _second) = store_with_messages().await;
+    store
+        .save_context_checkpoint(&checkpoint(chat.id, first.id, "durable context", 2))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.delete_chat(chat.id).await.unwrap(),
+        DeleteChatOutcome::Deleted
+    );
+    assert!(store
+        .get_context_checkpoint(chat.id)
+        .await
+        .unwrap()
+        .is_none());
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod model;
 pub mod preview;
 pub mod provider;
 mod renderer_tool;
+pub mod semantic_checkpoint;
 pub mod steer;
 pub mod storage;
 pub mod tool;
@@ -142,6 +143,10 @@ pub use provider::{
     RefusalDetails, RefusalOutcome, StopReason, Usage,
 };
 pub use renderer_tool::RendererToolName;
+pub use semantic_checkpoint::{
+    ContextCheckpoint, SaveContextCheckpointOutcome, CONTEXT_CHECKPOINT_FORMAT_V1,
+    MAX_CONTEXT_CHECKPOINT_BYTES,
+};
 pub use steer::{SteerInbox, SteerMessage};
 pub use storage::{
     AcceptAgentRunOutcome, AcceptClaimedToolCallOutcome, AcceptSandboxAgentRunAndParkTurnOutcome,

--- a/crates/openwave-core/src/semantic_checkpoint.rs
+++ b/crates/openwave-core/src/semantic_checkpoint.rs
@@ -1,0 +1,90 @@
+//! Durable, bounded summaries of a conversation prefix.
+//!
+//! A semantic checkpoint is deliberately not a [`crate::Message`]: it is
+//! agent-maintained context, not user-visible conversation history. The
+//! checkpoint producer and provider projection arrive in follow-up slices; this
+//! module owns the persisted contract they share.
+
+use chrono::{DateTime, Utc};
+
+use crate::error::{AgentError, Result};
+use crate::id::{ChatId, MessageId};
+
+/// The only checkpoint payload format this build can read and write.
+///
+/// Future formats must use a new value and add an explicit reader before they
+/// are accepted. Treating an unknown payload as current context could turn a
+/// failed migration into a misleading model prompt.
+pub const CONTEXT_CHECKPOINT_FORMAT_V1: u16 = 1;
+
+/// Largest UTF-8 payload accepted for one checkpoint.
+///
+/// There is one current checkpoint per conversation. Bounding it keeps a
+/// checkpoint from becoming another unbounded transcript and leaves room for
+/// recent messages in a provider context window.
+pub const MAX_CONTEXT_CHECKPOINT_BYTES: usize = 12 * 1024;
+
+/// A versioned summary of durable conversation history through one message.
+///
+/// `source_message_id` is an inclusive boundary in this conversation's
+/// durable message order. Stores must reject a boundary owned by another chat,
+/// and only permit it to advance, so an old worker cannot overwrite newer
+/// context after recovering from a crash.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextCheckpoint {
+    /// Conversation exclusively owning this checkpoint.
+    pub chat_id: ChatId,
+    /// Inclusive durable-message boundary covered by `content`.
+    pub source_message_id: MessageId,
+    /// Version of the structured checkpoint payload.
+    pub format_version: u16,
+    /// Opaque, bounded checkpoint payload.
+    pub content: String,
+    /// Host-stamped time this current checkpoint was committed.
+    pub created_at: DateTime<Utc>,
+}
+
+impl ContextCheckpoint {
+    /// Reject payloads this version cannot safely retain or later project.
+    pub fn validate(&self) -> Result<()> {
+        if self.format_version != CONTEXT_CHECKPOINT_FORMAT_V1 {
+            return Err(AgentError::Store(format!(
+                "unsupported context checkpoint format {}",
+                self.format_version
+            )));
+        }
+        if self.content.is_empty() || self.content.trim().is_empty() {
+            return Err(AgentError::Store(
+                "context checkpoint content must not be empty".into(),
+            ));
+        }
+        if self.content.len() > MAX_CONTEXT_CHECKPOINT_BYTES {
+            return Err(AgentError::Store(format!(
+                "context checkpoint content exceeds {MAX_CONTEXT_CHECKPOINT_BYTES} bytes"
+            )));
+        }
+        if self.content.contains('\0') {
+            return Err(AgentError::Store(
+                "context checkpoint content must not contain null bytes".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Result of storing one chat's next semantic checkpoint.
+///
+/// Exact retries recover the existing record. A retry that targets the same
+/// source boundary but changes its content is a conflict rather than an
+/// arbitrary rewrite; a boundary behind the current one is stale.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SaveContextCheckpointOutcome {
+    /// The supplied checkpoint became the conversation's current checkpoint.
+    Saved(ContextCheckpoint),
+    /// An identical checkpoint had already committed.
+    Existing(ContextCheckpoint),
+    /// A later source boundary is already durable for this conversation.
+    Stale(ContextCheckpoint),
+    /// The source boundary matches, but the durable payload differs.
+    Conflict(ContextCheckpoint),
+}

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -42,6 +42,7 @@ use crate::model::{
     TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
 };
 use crate::provider::{RefusalOutcome, StopReason, Usage};
+use crate::semantic_checkpoint::{ContextCheckpoint, SaveContextCheckpointOutcome};
 use crate::{AnswerUserQuestionsRequest, PendingUserQuestions};
 
 /// Largest pending attachment-reconciliation page accepted by [`Store`].
@@ -911,6 +912,12 @@ fn output_storage_unavailable<T>() -> Result<T> {
     ))
 }
 
+fn context_checkpoint_storage_unavailable<T>() -> Result<T> {
+    Err(AgentError::Store(
+        "durable context-checkpoint storage is not implemented by this Store".into(),
+    ))
+}
+
 fn turn_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "durable turn storage is not implemented by this Store".into(),
@@ -1480,6 +1487,28 @@ pub trait Store: Send + Sync {
         _deleted_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool> {
         output_storage_unavailable()
+    }
+
+    /// Persist the next versioned context checkpoint for one conversation.
+    ///
+    /// Implementations verify that the inclusive source-message boundary
+    /// belongs to `checkpoint.chat_id`, and serialize writes per chat. An exact
+    /// retry recovers the durable record; stale and conflicting rewrites are
+    /// returned as typed outcomes instead of replacing newer context.
+    async fn save_context_checkpoint(
+        &self,
+        _checkpoint: &ContextCheckpoint,
+    ) -> Result<SaveContextCheckpointOutcome> {
+        context_checkpoint_storage_unavailable()
+    }
+
+    /// Fetch the one current semantic checkpoint for a conversation.
+    ///
+    /// This record is intentionally distinct from visible messages. Consumers
+    /// that later project it into a provider request must treat it as bounded,
+    /// untrusted historical data rather than as a capability grant.
+    async fn get_context_checkpoint(&self, _chat_id: ChatId) -> Result<Option<ContextCheckpoint>> {
+        context_checkpoint_storage_unavailable()
     }
 
     /// Atomically begin one exact broker-backed attachment change.


### PR DESCRIPTION
## Summary

- add a bounded, versioned checkpoint record scoped to one chat and anchored to an inclusive message boundary
- make checkpoint writes idempotent and reject stale or conflicting rewrites under the chat write lock
- remove checkpoint state before its source message when a chat is deleted

The record is intentionally separate from visible messages. Checkpoint generation, provider projection, usage accounting, and UI remain follow-up slices for #418.

Closes #610
Part of #418

## Validation

- cargo fmt --all --check
- cargo check --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace