### PR TITLE
feat(desktop): show background agents in the transcript

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -768,6 +768,8 @@ fn tool_activity_from_call(call: ToolCallRecord) -> ChatToolActivitySnapshot {
     ChatToolActivitySnapshot {
         tool: crate::RendererToolName::from(call.name.as_str()),
         action: crate::preview::ToolActionPreview::build(&call.name, &call.arguments),
+        background_agent_run_id: (call.name == crate::agent_tools::SPAWN_SANDBOX_AGENT_TOOL)
+            .then(|| crate::AgentRunId::sandbox_for_spawn_call(call.id)),
         status,
         started_at: call.created_at,
         finished_at: call.resolved_at,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -165,6 +165,12 @@ pub struct ChatToolActivitySnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub action: Option<crate::preview::ToolActionPreview>,
+    // Present only for the fixed `spawn_sandbox_agent` renderer tool. It lets
+    // the transcript attach the durable child status without exposing a
+    // canonical tool record, delegated task, or executor identity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub background_agent_run_id: Option<crate::id::AgentRunId>,
     pub status: ChatToolActivityStatus,
     pub started_at: chrono::DateTime<chrono::Utc>,
     pub finished_at: Option<chrono::DateTime<chrono::Utc>>,

--- a/crates/openwave-desktop/ui/src/AgentRunDisplay.test.ts
+++ b/crates/openwave-desktop/ui/src/AgentRunDisplay.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_RUN_STATUS_GROUPS,
+  RUNNING_AGENT_STATUSES,
+  getAgentRunDotClass,
+} from "./AgentRunDisplay";
+
+describe("background-agent display vocabulary", () => {
+  it("keeps live work ahead of settled outcomes", () => {
+    expect(AGENT_RUN_STATUS_GROUPS.map((group) => group.label)).toEqual([
+      "Running",
+      "Stopping",
+      "Completed",
+      "Stopped",
+      "Failed",
+    ]);
+    expect(RUNNING_AGENT_STATUSES).toEqual(
+      new Set(["active", "queued", "running", "waiting", "retry_wait", "cancelling"]),
+    );
+  });
+
+  it("gives every durable status a non-empty dot presentation", () => {
+    for (const status of [
+      "active",
+      "queued",
+      "running",
+      "cancelling",
+      "waiting",
+      "retry_wait",
+      "completed",
+      "failed",
+      "cancelled",
+    ] as const) {
+      expect(getAgentRunDotClass(status)).not.toEqual("");
+    }
+  });
+});

--- a/crates/openwave-desktop/ui/src/AgentRunDisplay.ts
+++ b/crates/openwave-desktop/ui/src/AgentRunDisplay.ts
@@ -1,0 +1,94 @@
+import type { AgentRun } from "./api";
+
+type AgentRunStatus = AgentRun["status"];
+
+export type AgentRunStatusGroup = {
+  id: string;
+  label: string;
+  statuses: readonly AgentRunStatus[];
+};
+
+/**
+ * The vocabulary for durable background work. Groups are deliberately ordered
+ * by what needs attention now, then by the settled outcome a reader is most
+ * likely to look for.
+ */
+export const AGENT_RUN_STATUS_GROUPS: readonly AgentRunStatusGroup[] = [
+  {
+    id: "running",
+    label: "Running",
+    statuses: ["active", "queued", "running", "waiting", "retry_wait"],
+  },
+  { id: "stopping", label: "Stopping", statuses: ["cancelling"] },
+  { id: "completed", label: "Completed", statuses: ["completed"] },
+  { id: "stopped", label: "Stopped", statuses: ["cancelled"] },
+  { id: "failed", label: "Failed", statuses: ["failed"] },
+];
+
+export const RUNNING_AGENT_STATUSES = new Set<AgentRunStatus>([
+  "active",
+  "queued",
+  "running",
+  "waiting",
+  "retry_wait",
+  "cancelling",
+]);
+
+export function getAgentRunDotClass(status: AgentRunStatus): string {
+  switch (status) {
+    case "active":
+    case "queued":
+    case "running":
+    case "waiting":
+    case "retry_wait":
+    case "cancelling":
+      return "animate-pulse bg-muted-foreground";
+    case "completed":
+      return "bg-success";
+    case "failed":
+    case "cancelled":
+      return "bg-destructive";
+  }
+}
+
+export function agentRunStatusDetail(run: AgentRun): string {
+  if (run.activity) {
+    const activity = {
+      web_search: { running: "Searching the web", waiting: "Waiting to search" },
+      read_delegated_file: {
+        running: "Reading a delegated file",
+        waiting: "Waiting to read a delegated file",
+      },
+      list_connected_folders: {
+        running: "Checking connected folders",
+        waiting: "Waiting to check connected folders",
+      },
+      list_folder: { running: "Listing a folder", waiting: "Waiting to list a folder" },
+      read_connected_file: { running: "Reading a file", waiting: "Waiting to read a file" },
+      import_connected_file: { running: "Adding a source", waiting: "Waiting to add a source" },
+    } as const;
+    const presentation = activity[run.activity.kind];
+    if (presentation) return presentation[run.activity.status];
+  }
+
+  switch (run.status) {
+    case "active":
+      return "Ready for this chat";
+    case "queued":
+      return "Queued to start";
+    case "running":
+      return "Working in the background";
+    case "cancelling":
+      return "Stopping";
+    case "waiting":
+      return "Waiting to continue";
+    case "retry_wait":
+      return "Waiting to retry";
+    case "completed":
+      return "Finished";
+    case "failed":
+      return "Could not finish";
+    case "cancelled":
+      return "Stopped";
+  }
+}

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -1,0 +1,80 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { AgentRun } from "./api";
+import { BackgroundAgentList } from "./BackgroundAgentList";
+
+function run(
+  id: string,
+  spawnCallId: string,
+  status: AgentRun["status"],
+): AgentRun {
+  return {
+    id,
+    parent_id: "foreground",
+    spawn_call_id: spawnCallId,
+    execution: "sandbox",
+    status,
+    started_at: null,
+    finished_at: null,
+    last_error_code: null,
+    activity: null,
+    created_at: "2026-07-27T12:00:00Z",
+    updated_at: "2026-07-27T12:00:00Z",
+  };
+}
+
+describe("BackgroundAgentList", () => {
+  it("groups only the durable children of its own spawn step", () => {
+    const markup = renderToStaticMarkup(
+      <BackgroundAgentList
+        spawns={[
+          { callId: "call-running", status: "completed" },
+          { callId: "call-completed", status: "completed" },
+        ]}
+        runs={[
+          run("run-running", "call-running", "running"),
+          run("run-completed", "call-completed", "completed"),
+          run("run-other", "different-call", "failed"),
+        ]}
+        loading={false}
+        error={null}
+        onRetry={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("2 background agents");
+    expect(markup).toContain("Working in the background");
+    expect(markup).toContain("Finished");
+    expect(markup).not.toContain("Could not finish");
+    expect(markup.indexOf("Running")).toBeLessThan(markup.indexOf("Completed"));
+  });
+
+  it("shows a skeleton as soon as a spawn is visible but not durable yet", () => {
+    const markup = renderToStaticMarkup(
+      <BackgroundAgentList
+        spawns={[{ callId: "call-starting", status: "running" }]}
+        runs={[]}
+        loading
+        error={null}
+        onRetry={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Starting background agent");
+  });
+
+  it("keeps a failed spawn out of the agent list when no child was admitted", () => {
+    const markup = renderToStaticMarkup(
+      <BackgroundAgentList
+        spawns={[{ callId: "call-failed", status: "failed" }]}
+        runs={[]}
+        loading={false}
+        error={null}
+        onRetry={() => undefined}
+      />,
+    );
+
+    expect(markup).toEqual("");
+  });
+});

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import { Bot, ChevronRight } from "lucide-react";
+
+import type { AgentRun } from "./api";
+import {
+  AGENT_RUN_STATUS_GROUPS,
+  agentRunStatusDetail,
+  getAgentRunDotClass,
+} from "./AgentRunDisplay";
+import type { ToolCallStatus } from "./ToolCallCard";
+import { cn } from "@/lib/utils";
+
+export type BackgroundAgentSpawn = {
+  callId: string;
+  runId?: string;
+  status: ToolCallStatus;
+};
+
+type BackgroundAgentListProps = {
+  spawns: readonly BackgroundAgentSpawn[];
+  runs: readonly AgentRun[];
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+};
+
+/**
+ * One transcript-local view of the agents requested by a single spawn step.
+ * It observes chat-scoped snapshots only; no scheduler or worker state can be
+ * changed from this card.
+ */
+export function BackgroundAgentList({
+  spawns,
+  runs,
+  loading,
+  error,
+  onRetry,
+}: BackgroundAgentListProps) {
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const sandboxRuns = runs.filter((run) => run.execution === "sandbox");
+  const matchedRuns = sandboxRuns.filter((run) =>
+    spawns.some(
+      (spawn) =>
+        (spawn.runId !== undefined && run.id === spawn.runId) ||
+        run.spawn_call_id === spawn.callId,
+    ),
+  );
+  const matchedRunIds = new Set(matchedRuns.map((run) => run.id));
+  const visibleSpawns = spawns.filter(
+    (spawn) =>
+      matchedRunIds.has(spawn.runId ?? "") ||
+      matchedRuns.some((run) => run.spawn_call_id === spawn.callId) ||
+      (spawn.status !== "failed" && spawn.status !== "cancelled"),
+  );
+  const unresolvedSpawns = visibleSpawns.filter(
+    (spawn) =>
+      !matchedRunIds.has(spawn.runId ?? "") &&
+      !matchedRuns.some((run) => run.spawn_call_id === spawn.callId),
+  );
+
+  if (matchedRuns.length === 0 && unresolvedSpawns.length === 0 && !error) {
+    return null;
+  }
+
+  const toggleGroup = (id: string) => {
+    setCollapsedGroups((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <section
+      className="mt-2 overflow-hidden rounded-lg border border-border bg-background"
+      aria-label="Background agents"
+    >
+      <div className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-muted-foreground">
+        <Bot className="size-4" aria-hidden="true" />
+        <span>
+          {visibleSpawns.length === 1
+            ? "1 background agent"
+            : `${visibleSpawns.length} background agents`}
+        </span>
+      </div>
+      {error ? (
+        <div className="flex items-center justify-between gap-3 border-t border-border px-3 py-2 text-sm" role="status">
+          <span>Background agent status is unavailable.</span>
+          <button
+            type="button"
+            className="shrink-0 font-medium text-primary hover:underline"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
+        </div>
+      ) : (
+        <div aria-live="polite">
+          {AGENT_RUN_STATUS_GROUPS.map((group) => {
+            const groupRuns = matchedRuns.filter((run) => group.statuses.includes(run.status));
+            if (groupRuns.length === 0) return null;
+            const collapsed = collapsedGroups.has(group.id);
+            return (
+              <div key={group.id}>
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-1.5 border-y border-border bg-muted/50 px-3 py-1.5 text-left text-xs font-medium text-foreground hover:bg-muted/60"
+                  onClick={() => toggleGroup(group.id)}
+                  aria-expanded={!collapsed}
+                >
+                  <ChevronRight className={cn("size-3 shrink-0 transition-transform", !collapsed && "rotate-90")} />
+                  <span
+                    className={cn("size-2 shrink-0 rounded-full", getAgentRunDotClass(group.statuses[0]!))}
+                    aria-hidden="true"
+                  />
+                  <span>{group.label}</span>
+                  <span className="text-muted-foreground">{groupRuns.length}</span>
+                </button>
+                {!collapsed && (
+                  <div className="divide-y divide-border/60">
+                    {groupRuns.map((run, index) => (
+                      <div key={run.id} className="flex min-w-0 items-center gap-2 px-3 py-2.5">
+                        <span
+                          className={cn("size-2 shrink-0 rounded-full", getAgentRunDotClass(run.status))}
+                          aria-hidden="true"
+                        />
+                        <span className="min-w-0 flex-1 truncate font-medium text-foreground">
+                          Background agent {index + 1}
+                        </span>
+                        <span className="shrink-0 text-xs text-muted-foreground">
+                          {agentRunStatusDetail(run)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+          {unresolvedSpawns.map((spawn) => (
+            <div key={spawn.callId} className="flex min-w-0 items-center gap-2 border-t border-border px-3 py-2.5">
+              <span className="size-2 shrink-0 animate-pulse rounded-full bg-muted-foreground" aria-hidden="true" />
+              <span className="h-4 w-28 animate-pulse rounded bg-muted" aria-hidden="true" />
+              <span className="text-sm text-muted-foreground">
+                {loading ? "Starting background agent" : "Waiting for background agent"}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -29,6 +29,30 @@ const transcript: ChatTranscript = {
 };
 
 describe("terminal transcript presentation", () => {
+  it("keeps a historical spawn bound to its durable child", () => {
+    const presented = presentChatTranscript({
+      messages: [],
+      tool_activity: [
+        {
+          tool: "spawn_sandbox_agent",
+          status: "completed",
+          started_at: "2026-07-27T12:00:00Z",
+          finished_at: "2026-07-27T12:00:01Z",
+          background_agent_run_id: "child-run",
+        },
+      ],
+      last_event_seq: 4,
+    });
+
+    expect(presented.messages).toEqual([
+      expect.objectContaining({
+        role: "tool",
+        name: "spawn_sandbox_agent",
+        backgroundAgentRunId: "child-run",
+      }),
+    ]);
+  });
+
   it("replaces optimistic text with authoritative content and sources", async () => {
     const listChatMessages = vi.fn(async () => transcript);
     const presented = await loadCurrentTerminalTranscript(

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -38,6 +38,7 @@ export function presentChatTranscript(
             role: "tool",
             callId: entry.id,
             name: entry.name,
+            backgroundAgentRunId: entry.backgroundAgentRunId,
             status: entry.status,
             preview: entry.preview,
           } satisfies ChatMessage,

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -15,6 +16,7 @@ import { useFolderAccessRequests } from "./useFolderAccessRequests";
 import { useToolApprovals } from "./useToolApprovals";
 import { useTurnControls } from "./useTurnControls";
 import { useUserQuestions } from "./useUserQuestions";
+import { useAgentRuns } from "./useAgentRuns";
 import { ArrowDown } from "lucide-react";
 
 export type ChatViewProps = {
@@ -77,6 +79,18 @@ export function ChatView({
   const reasoningActive = useChatSessionStore(
     (session) => session.reasoningActive,
   );
+  const backgroundAgentSpawnKeys = useMemo(
+    () =>
+      messages.flatMap((message) =>
+        message.role === "tool" && message.name === "spawn_sandbox_agent"
+          && message.status !== "failed"
+          && message.status !== "cancelled"
+          ? [message.backgroundAgentRunId ?? message.callId]
+          : [],
+      ),
+    [messages],
+  );
+  const agentRuns = useAgentRuns(client, chat.id, backgroundAgentSpawnKeys);
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const followsLatestRef = useRef(true);
@@ -130,6 +144,10 @@ export function ChatView({
           userQuestionErrors={userQuestions.errors}
           decidingApprovalCalls={approvals.deciding}
           approvalErrors={approvals.errors}
+          backgroundAgentRuns={agentRuns.runs}
+          backgroundAgentRunsLoading={agentRuns.loading}
+          backgroundAgentRunsError={agentRuns.error}
+          onRetryBackgroundAgentRuns={agentRuns.refresh}
           busy={busy}
           reasoningActive={reasoningActive}
           scrollRef={scrollRef}

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -1,8 +1,29 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import type { AgentRun } from "./api";
 import { MessageBubble, MessageList, type ChatMessage } from "./MessageList";
 
 const noop = () => undefined;
+
+function backgroundRun(
+  id: string,
+  spawnCallId: string,
+  status: AgentRun["status"],
+): AgentRun {
+  return {
+    id,
+    parent_id: "foreground",
+    spawn_call_id: spawnCallId,
+    execution: "sandbox",
+    status,
+    started_at: null,
+    finished_at: null,
+    last_error_code: null,
+    activity: null,
+    created_at: "2026-07-27T12:00:00Z",
+    updated_at: "2026-07-27T12:00:00Z",
+  };
+}
 
 describe("MessageBubble", () => {
   it("keeps the user compact while rendering assistant Markdown without a bubble", () => {
@@ -409,6 +430,45 @@ describe("MessageBubble", () => {
     expect(markup).toContain('aria-label="Copy"');
     expect(markup).toContain('dateTime="2026-07-20T10:00:00Z"');
     expect(markup).toContain('dateTime="2026-07-20T10:01:00Z"');
+  });
+});
+
+describe("background-agent transcript activity", () => {
+  it("hangs the durable status card below its exact delegation phase", () => {
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={[
+          {
+            id: "spawn-row",
+            role: "tool",
+            callId: "spawn-call",
+            name: "spawn_sandbox_agent",
+            status: "completed",
+          },
+          { id: "assistant", role: "assistant", text: "I will wait.", sources: [] },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        backgroundAgentRuns={[backgroundRun("run-1", "spawn-call", "running")]}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup).toContain("1 background agent");
+    expect(markup).toContain("Working in the background");
+    expect(markup.indexOf("1 background agent")).toBeLessThan(
+      markup.indexOf("I will wait."),
+    );
   });
 });
 

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -3,6 +3,7 @@ import type { ReactNode, RefObject, UIEvent } from "react";
 import type {
   ApprovalGrantRung,
   ApiClient,
+  AgentRun,
   PendingFolderAccessRequest,
   PendingUserQuestions,
   ToolActionPreview,
@@ -24,6 +25,7 @@ import { WelcomeState } from "./WelcomeState";
 import { UserQuestionsCard } from "./UserQuestionsCard";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
 import { TranscriptImageAttachments } from "./TranscriptImageAttachments";
+import { BackgroundAgentList } from "./BackgroundAgentList";
 
 export type ChatMessage =
   | {
@@ -56,6 +58,8 @@ export type ChatMessage =
       callId: string;
       name: string;
       status: ToolCallStatus;
+      /** Durable child identity retained by a hydrated spawn activity. */
+      backgroundAgentRunId?: string;
       /** The tool's own closed view of what it is doing, when it has one. */
       preview?: ToolActionPreview | null;
       /** What the call produced, once it has produced anything. */
@@ -87,6 +91,10 @@ type MessageListProps = {
   userQuestionErrors?: Record<string, string>;
   decidingApprovalCalls: Set<string>;
   approvalErrors: Record<string, string>;
+  backgroundAgentRuns?: AgentRun[];
+  backgroundAgentRunsLoading?: boolean;
+  backgroundAgentRunsError?: string | null;
+  onRetryBackgroundAgentRuns?: () => void;
   busy: boolean;
   reasoningActive?: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
@@ -124,6 +132,10 @@ export function MessageList({
   userQuestionErrors = {},
   decidingApprovalCalls,
   approvalErrors,
+  backgroundAgentRuns = [],
+  backgroundAgentRunsLoading = false,
+  backgroundAgentRunsError = null,
+  onRetryBackgroundAgentRuns = () => undefined,
   busy,
   reasoningActive = false,
   scrollRef,
@@ -150,6 +162,12 @@ export function MessageList({
     approvalState,
     imageClient,
     chatId,
+    {
+      runs: backgroundAgentRuns,
+      loading: backgroundAgentRunsLoading,
+      error: backgroundAgentRunsError,
+      retry: onRetryBackgroundAgentRuns,
+    },
   );
   // Only greet a genuinely empty, fully-hydrated conversation. While an
   // existing chat's transcript is still loading it is transiently empty; showing
@@ -231,6 +249,12 @@ export function groupMessageItems(
   },
   imageClient?: Pick<ApiClient, "getChatImageAttachment">,
   chatId?: string,
+  backgroundAgents: {
+    runs: AgentRun[];
+    loading: boolean;
+    error: string | null;
+    retry: () => void;
+  } = { runs: [], loading: false, error: null, retry: () => undefined },
 ) {
   const items: ReactNode[] = [];
   let index = 0;
@@ -290,6 +314,30 @@ export function groupMessageItems(
         entry.role === "tool" && !parked.has(entry.callId),
     );
     const cards = surfacedCards(phase, parked, onApproval, approvalState, chatId);
+    const spawns = activities.flatMap((entry) =>
+      entry.name === "spawn_sandbox_agent"
+        ? [
+            {
+              callId: entry.callId,
+              runId: entry.backgroundAgentRunId,
+              status: entry.status,
+            },
+          ]
+        : [],
+    );
+    const children: ReactNode[] = [...cards];
+    if (spawns.length > 0) {
+      children.push(
+        <BackgroundAgentList
+          key="background-agents"
+          spawns={spawns}
+          runs={backgroundAgents.runs}
+          loading={backgroundAgents.loading}
+          error={backgroundAgents.error}
+          onRetry={backgroundAgents.retry}
+        />,
+      );
+    }
 
     // A tool row renders model-influenced data through several defensive
     // parsers. If one of them is ever wrong, the throw should cost this phase
@@ -304,7 +352,7 @@ export function groupMessageItems(
         }
       >
         <ToolActivityGroup activities={activities} groupIndex={groupIndex}>
-          {cards.length > 0 ? cards : undefined}
+          {children.length > 0 ? children : undefined}
         </ToolActivityGroup>
       </ErrorBoundary>,
     );

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -24,6 +24,8 @@ export type HydratedTranscriptEntry =
       id: string;
       kind: "tool";
       name: string;
+      /** Opaque child correlation for a historical sandbox spawn. */
+      backgroundAgentRunId?: string;
       preview: ToolActionPreview | null;
       status: ToolCallStatus;
       createdAt: string;
@@ -79,6 +81,7 @@ export function hydrateTranscriptHistory(
       // Already an allowlisted renderer tool name, folded server-side, so the
       // same presentation the live stream uses applies directly.
       name: activity.tool,
+      backgroundAgentRunId: activity.background_agent_run_id,
       status: activity.status,
       // History carries what the call did but not what it produced: results
       // are not persisted, so a reloaded command card shows its command alone.

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -64,7 +64,7 @@ last_error_code: string | null,
  * arguments, results, provider call identities, executor leases, or raw
  * executor diagnostics.
  */
-activity: AgentActivitySnapshot | null, created_at: string, updated_at: string, };
+activity: AgentActivitySnapshot | null, created_at: string, updated_at: string, spawn_call_id: CallId | null, };
 
 /**
  * Durable lifecycle of an [`AgentRun`].
@@ -189,7 +189,7 @@ tool: RendererToolName,
  * from the arguments it ran with, so history describes the same action
  * the live stream did.
  */
-action?: ToolActionPreview, status: ChatToolActivityStatus, started_at: string, finished_at: string | null, };
+action?: ToolActionPreview, background_agent_run_id?: AgentRunId, status: ChatToolActivityStatus, started_at: string, finished_at: string | null, };
 
 /**
  * Fixed lifecycle vocabulary exposed for a historical tool card.

--- a/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentRun, ApiClient } from "./api";
+import { useAgentRuns } from "./useAgentRuns";
+
+function run(status: AgentRun["status"] = "running"): AgentRun {
+  return {
+    id: "run-1",
+    parent_id: "foreground",
+    spawn_call_id: "spawn-1",
+    execution: "sandbox",
+    status,
+    started_at: null,
+    finished_at: null,
+    last_error_code: null,
+    activity: null,
+    created_at: "2026-07-27T12:00:00Z",
+    updated_at: "2026-07-27T12:00:00Z",
+  };
+}
+
+function client(listAgentRuns: () => Promise<AgentRun[]>): ApiClient {
+  return { listAgentRuns: vi.fn(listAgentRuns) } as unknown as ApiClient;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useAgentRuns", () => {
+  it("reads the exact chat once a spawn row is present", async () => {
+    const api = client(async () => [run()]);
+    const { result } = renderHook(() => useAgentRuns(api, "chat-1", ["spawn-1"]));
+
+    await waitFor(() => expect(result.current.runs).toEqual([run()]));
+    expect(api.listAgentRuns).toHaveBeenCalledWith("chat-1");
+  });
+
+  it("does not issue a read before the transcript contains a spawn", () => {
+    const api = client(async () => [run()]);
+    renderHook(() => useAgentRuns(api, "chat-1", []));
+
+    expect(api.listAgentRuns).not.toHaveBeenCalled();
+  });
+
+  it("polls while the exact visible child is live", async () => {
+    vi.useFakeTimers();
+    const api = client(async () => [run("running")]);
+    renderHook(() => useAgentRuns(api, "chat-1", ["spawn-1"]));
+
+    await act(async () => {});
+    expect(api.listAgentRuns).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(api.listAgentRuns).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops polling when only an unrelated child is live", async () => {
+    vi.useFakeTimers();
+    const api = client(async () => [
+      run("completed"),
+      { ...run("running"), id: "run-other", spawn_call_id: "spawn-other" },
+    ]);
+    renderHook(() => useAgentRuns(api, "chat-1", ["spawn-1"]));
+
+    await act(async () => {});
+    expect(api.listAgentRuns).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(api.listAgentRuns).toHaveBeenCalledTimes(1);
+  });
+});

--- a/crates/openwave-desktop/ui/src/useAgentRuns.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { AgentRun, ApiClient } from "./api";
+import { RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
+
+const LIVE_POLL_INTERVAL_MS = 5_000;
+
+export type AgentRuns = {
+  runs: AgentRun[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+};
+
+/**
+ * Observe the durable children attached to visible spawn steps.
+ *
+ * Agent state advances outside the foreground event stream, so a live or not
+ * yet resolved spawn is re-read until the durable snapshot catches up. Every
+ * read is scoped to the selected chat and stale responses are discarded on a
+ * chat switch.
+ */
+export function useAgentRuns(
+  client: ApiClient | null,
+  chatId: string | null,
+  spawnKeys: readonly string[],
+): AgentRuns {
+  const [runs, setRuns] = useState<AgentRun[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const refreshRef = useRef<(() => void) | null>(null);
+  const spawnKey = [...new Set(spawnKeys)].sort().join(",");
+  const observing = client !== null && chatId !== null && spawnKey.length > 0;
+
+  useEffect(() => {
+    if (!client || !chatId || !spawnKey) {
+      setRuns([]);
+      setLoading(false);
+      setError(null);
+      refreshRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+    let requestSeq = 0;
+    const refresh = async () => {
+      const seq = ++requestSeq;
+      try {
+        const listed = await client.listAgentRuns(chatId);
+        if (cancelled || seq !== requestSeq) return;
+        setRuns(listed);
+        setError(null);
+      } catch (cause) {
+        if (!cancelled && seq === requestSeq) setError(String(cause));
+      } finally {
+        if (!cancelled && seq === requestSeq) setLoading(false);
+      }
+    };
+
+    setRuns([]);
+    setLoading(true);
+    setError(null);
+    refreshRef.current = () => void refresh();
+    void refresh();
+    return () => {
+      cancelled = true;
+      requestSeq += 1;
+      refreshRef.current = null;
+    };
+  }, [client, chatId, spawnKey]);
+
+  const matchesVisibleSpawn = (run: AgentRun) =>
+    run.execution === "sandbox" &&
+    spawnKeys.some((key) => run.id === key || run.spawn_call_id === key);
+  const hasLiveSandbox = runs.some(
+    (run) => matchesVisibleSpawn(run) && RUNNING_AGENT_STATUSES.has(run.status),
+  );
+  const hasUnresolvedSpawn =
+    observing &&
+    spawnKeys.some(
+      (key) =>
+        !runs.some(
+          (run) => matchesVisibleSpawn(run) && (run.id === key || run.spawn_call_id === key),
+        ),
+    );
+  useEffect(() => {
+    if (!hasLiveSandbox && !hasUnresolvedSpawn) return;
+    const interval = window.setInterval(
+      () => refreshRef.current?.(),
+      LIVE_POLL_INTERVAL_MS,
+    );
+    return () => window.clearInterval(interval);
+  }, [hasLiveSandbox, hasUnresolvedSpawn]);
+
+  return {
+    runs,
+    loading,
+    error,
+    refresh: () => refreshRef.current?.(),
+  };
+}

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1200,6 +1200,10 @@ pub struct AgentRunSnapshot {
     pub activity: Option<AgentActivitySnapshot>,
     pub created_at: chrono::DateTime<Utc>,
     pub updated_at: chrono::DateTime<Utc>,
+    // This is an OpenWave call id, not a provider call identity. It lets a
+    // transcript observer attach this durable status to its exact spawning
+    // step without exposing delegated input or executor data.
+    pub spawn_call_id: Option<openwave_core::CallId>,
 }
 
 impl AgentRunSnapshot {
@@ -1207,6 +1211,7 @@ impl AgentRunSnapshot {
         Self {
             id: run.id,
             parent_id: run.parent_id,
+            spawn_call_id: run.spawn_call_id,
             execution: run.execution,
             status: run.status,
             started_at: run.started_at,

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -7878,6 +7878,10 @@ async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
         snapshot.get("activity"),
         Some(&serde_json::json!({"kind": "web_search", "status": "waiting"}))
     );
+    assert_eq!(
+        snapshot.get("spawn_call_id"),
+        Some(&serde_json::json!(run.spawn_call_id))
+    );
 
     // The projection is intentionally independent of the durable checkpoint's
     // sensitive executor data.
@@ -9561,6 +9565,44 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
         openwave_core::ResolveToolCallOutcome::Resolved
     );
 
+    // Spawn history carries only the derived child id. The task and canonical
+    // call record stay server-side, while the transcript can reattach the
+    // durable child snapshot to this exact historical step after a reload.
+    let spawn_call_id = CallId::new();
+    store
+        .accept_tool_call(&ToolCallRecord {
+            id: spawn_call_id,
+            chat_id: chat.id,
+            turn_id: turn.id,
+            provider_id: "provider-spawn".into(),
+            name: openwave_core::SPAWN_SANDBOX_AGENT_TOOL.into(),
+            arguments: serde_json::json!({"task": "private delegated task"}),
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: started_at + chrono::Duration::milliseconds(3),
+            resolved_at: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .resolve_server_tool_call(
+                spawn_call_id,
+                &ToolCallResolution::Completed {
+                    result: "private child id".into(),
+                },
+                started_at + chrono::Duration::seconds(1),
+            )
+            .await
+            .unwrap(),
+        openwave_core::ResolveToolCallOutcome::Resolved
+    );
+
     // An approval-in-flight call must stay on the event journal. Including it
     // in this durable snapshot could race its corresponding live event.
     store
@@ -9665,7 +9707,7 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
     }
     let transcript: serde_json::Value = serde_json::from_str(&body).unwrap();
     let activity = transcript["tool_activity"].as_array().unwrap();
-    assert_eq!(activity.len(), 2);
+    assert_eq!(activity.len(), 3);
     assert!(activity.iter().any(|card| {
         card["tool"] == "other"
             && card["status"] == "failed"
@@ -9675,6 +9717,13 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
     assert!(activity
         .iter()
         .any(|card| { card["tool"] == "request_folder_access" && card["status"] == "cancelled" }));
+    assert!(activity.iter().any(|card| {
+        card["tool"] == "spawn_sandbox_agent"
+            && card["background_agent_run_id"]
+                == serde_json::json!(openwave_core::AgentRunId::sandbox_for_spawn_call(
+                    spawn_call_id
+                ))
+    }));
 }
 
 #[tokio::test]

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -260,7 +260,9 @@ The response is deliberately renderer-safe: worker lease tokens, delegated
 input, raw failure details, and scheduler bookkeeping never cross this API
 boundary. A bounded failure code may be included for display and recovery
 guidance; detailed provider, transport, or executor diagnostics remain
-server-side.
+server-side. A sandbox snapshot also carries its opaque OpenWave spawn-call id
+so the transcript can attach it to the exact visible delegation row; this is a
+renderer correlation key, not a provider call identity or scheduler control.
 
 When an agent has a live, supported tool checkpoint, the snapshot may also
 contain a small `activity` object. Its values are a deliberately admitted,


### PR DESCRIPTION
## Summary
- show sandboxed background agents below their exact transcript delegation step, with ordered lifecycle groups and immediate skeleton rows
- retain opaque spawn-to-run correlation across live and hydrated transcripts without exposing delegated input or executor details
- poll read-only chat snapshots only while a visible delegation is unresolved or active

## Verification
- cargo fmt --all --check
- cargo test -p openwave-server wire_types --lib --quiet
- cargo test -p openwave-server agent_run_snapshots_expose_only_safe_live_sandbox_activity --lib --quiet
- cargo test -p openwave-server transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data --lib --quiet
- cargo check --workspace --locked --quiet
- pnpm exec tsc --noEmit
- pnpm exec vitest run src/AgentRunDisplay.test.ts src/BackgroundAgentList.test.tsx src/useAgentRuns.test.ts src/MessageList.test.tsx src/ChatTranscriptPresentation.test.ts
- pnpm build

Closes #499