### PR TITLE
feat(desktop): type live tool activity copy

### DIFF
--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.dom.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ToolActivityGroup } from "./ToolActivityGroup";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("ToolActivityGroup live copy", () => {
+  it("types a changed row title while another tool keeps the phase live", async () => {
+    vi.useFakeTimers();
+    const { rerender } = render(
+      <ToolActivityGroup
+        groupIndex={0}
+        activities={[
+          { id: "search", name: "web_search", status: "running" },
+          { id: "read", name: "read_file", status: "running" },
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByLabelText("Searching the web").textContent).toBe(
+      "Searching the web",
+    );
+
+    rerender(
+      <ToolActivityGroup
+        groupIndex={0}
+        activities={[
+          { id: "search", name: "web_search", status: "completed" },
+          { id: "read", name: "read_file", status: "running" },
+        ]}
+      />,
+    );
+
+    const completedSearch = screen.getByLabelText("Searched the web");
+    expect(completedSearch.textContent).not.toBe("Searched the web");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(completedSearch.textContent).toBe("Searched the web");
+  });
+});

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from "lucide-react";
 import { toolCallPresentation, type ToolCallStatus } from "./ToolCallCard";
 import { ToolIcon } from "./ToolIcon";
 import { ToolStatusIcon } from "./ToolStatusIcon";
+import { useStreamingTypewriter } from "./useStreamingTypewriter";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -48,6 +49,10 @@ export function ToolActivityGroup({
   const contentId = `tool-activity-group-${groupIndex}`;
   const safeActivities = normalizeActivities(activities);
   const summary = toolActivityGroupPresentation(safeActivities);
+  const displayedSummary = useStreamingTypewriter(
+    summary.label,
+    summary.inProgress,
+  );
 
   // A phase can be all cards and no rail — every call in it parked on an
   // approval, say. The cards are the part that must never go missing, so they
@@ -84,9 +89,10 @@ export function ToolActivityGroup({
           role="status"
           aria-live="polite"
           aria-atomic="true"
+          aria-label={summary.label}
           className={cn(summary.inProgress && "animate-pulse")}
         >
-          {summary.label}
+          <span aria-hidden="true">{displayedSummary}</span>
         </span>
         <ChevronDown
           className={cn(
@@ -101,43 +107,53 @@ export function ToolActivityGroup({
           className="relative ml-1.5 flex flex-col gap-4 border-l-2 py-1 pl-4 text-sm"
           role="list"
         >
-          {safeActivities.map((activity, index) => {
-            const presentation = toolCallPresentation(
-              activity.name,
-              activity.status,
-            );
-            return (
-              <div
-                className="grid gap-1"
-                role="listitem"
-                key={activity.id ?? `position:${index}`}
-              >
-                <div className="flex items-center gap-1.5 font-medium">
-                  {/* Pinned onto the rail, knocking out the border behind it,
-                      so the row reads as a stop on the timeline rather than a
-                      bullet sitting beside one. */}
-                  <div
-                    className="text-muted-foreground bg-background absolute -left-px -translate-x-1/2 [&_svg]:size-4"
-                    aria-hidden="true"
-                  >
-                    <ToolIcon name={activity.name} />
-                  </div>
-                  <ToolStatusIcon tone={presentation.tone} />
-                  <p
-                    className={cn(
-                      "whitespace-nowrap",
-                      presentation.tone === "running" && "animate-pulse",
-                    )}
-                  >
-                    {presentation.title}
-                  </p>
-                </div>
-              </div>
-            );
-          })}
+          {safeActivities.map((activity, index) => (
+            <ToolActivityRow
+              key={activity.id ?? `position:${index}`}
+              activity={activity}
+              live={summary.inProgress}
+            />
+          ))}
         </div>
       )}
       <div className="mt-2 flex flex-col gap-2 empty:hidden">{children}</div>
+    </div>
+  );
+}
+
+function ToolActivityRow({
+  activity,
+  live,
+}: {
+  activity: ToolActivity;
+  live: boolean;
+}) {
+  const presentation = toolCallPresentation(activity.name, activity.status);
+  const displayedTitle = useStreamingTypewriter(presentation.title, live);
+
+  return (
+    <div className="grid gap-1" role="listitem">
+      <div className="flex items-center gap-1.5 font-medium">
+        {/* Pinned onto the rail, knocking out the border behind it, so the row
+            reads as a stop on the timeline rather than a bullet sitting beside
+            one. */}
+        <div
+          className="text-muted-foreground bg-background absolute -left-px -translate-x-1/2 [&_svg]:size-4"
+          aria-hidden="true"
+        >
+          <ToolIcon name={activity.name} />
+        </div>
+        <ToolStatusIcon tone={presentation.tone} />
+        <p
+          aria-label={presentation.title}
+          className={cn(
+            "whitespace-nowrap",
+            presentation.tone === "running" && "animate-pulse",
+          )}
+        >
+          <span aria-hidden="true">{displayedTitle}</span>
+        </p>
+      </div>
     </div>
   );
 }

--- a/crates/openwave-desktop/ui/src/useStreamingTypewriter.test.ts
+++ b/crates/openwave-desktop/ui/src/useStreamingTypewriter.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useStreamingTypewriter } from "./useStreamingTypewriter";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useStreamingTypewriter", () => {
+  it("shows historical transcript content immediately", () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useStreamingTypewriter(text, false),
+      { initialProps: { text: "Searched the web" } },
+    );
+
+    expect(result.current).toBe("Searched the web");
+    rerender({ text: "Read a file" });
+    expect(result.current).toBe("Read a file");
+  });
+
+  it("types a later live update", async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ text, live }) => useStreamingTypewriter(text, live),
+      { initialProps: { text: "Searching the web", live: true } },
+    );
+
+    rerender({ text: "Searching the web and 1 other task", live: true });
+    expect(result.current).not.toBe("Searching the web and 1 other task");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(result.current).toBe("Searching the web and 1 other task");
+  });
+
+  it("finishes immediately when a live step settles", async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ text, live }) => useStreamingTypewriter(text, live),
+      { initialProps: { text: "Searching the web", live: true } },
+    );
+
+    rerender({ text: "Searching the web and 1 other task", live: true });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20);
+    });
+    rerender({ text: "Searched the web and 1 other task", live: false });
+
+    expect(result.current).toBe("Searched the web and 1 other task");
+  });
+});

--- a/crates/openwave-desktop/ui/src/useStreamingTypewriter.ts
+++ b/crates/openwave-desktop/ui/src/useStreamingTypewriter.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const TICK_INTERVAL_MS = 20;
+const SMOOTHING_FACTOR = 18;
+
+/**
+ * Types subsequent live changes without reanimating content that was already
+ * present when the component mounted. Transcript history therefore appears
+ * immediately, while an active step gains motion only as it receives new
+ * presentation text.
+ */
+export function useStreamingTypewriter(text: string, live: boolean): string {
+  const [displayed, setDisplayed] = useState(text);
+  const displayedRef = useRef(text);
+  const targetRef = useRef(text);
+  const liveRef = useRef(live);
+  const mountedRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+
+  const showImmediately = useCallback((value: string) => {
+    displayedRef.current = value;
+    setDisplayed(value);
+  }, []);
+
+  const stop = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const tick = useCallback(() => {
+    const target = targetRef.current;
+    if (!liveRef.current || document.visibilityState !== "visible") {
+      timerRef.current = null;
+      showImmediately(target);
+      return;
+    }
+
+    let current = displayedRef.current;
+    // A summary can switch from one tool's wording to another rather than
+    // merely append. Restarting avoids showing a hybrid of the two titles.
+    if (!target.startsWith(current)) {
+      current = "";
+      showImmediately(current);
+    }
+    const remaining = target.length - current.length;
+    if (remaining <= 0) {
+      timerRef.current = null;
+      return;
+    }
+
+    const nextLength = Math.min(
+      target.length,
+      current.length + Math.max(1, Math.ceil(remaining / SMOOTHING_FACTOR)),
+    );
+    showImmediately(target.slice(0, nextLength));
+    timerRef.current = window.setTimeout(tick, TICK_INTERVAL_MS);
+  }, [showImmediately]);
+
+  useEffect(() => {
+    const previousTarget = targetRef.current;
+    targetRef.current = text;
+    liveRef.current = live;
+
+    // The first value may be a rehydrated transcript. Never make someone
+    // wait for history to render, even if React mounts this row mid-turn.
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      showImmediately(text);
+      return;
+    }
+    if (!live) {
+      stop();
+      showImmediately(text);
+      return;
+    }
+    if (text === previousTarget) return;
+
+    if (timerRef.current === null) tick();
+  }, [live, showImmediately, stop, text, tick]);
+
+  useEffect(() => stop, [stop]);
+
+  return displayed;
+}


### PR DESCRIPTION
## Summary
- type later live changes to activity-phase labels and expanded tool-row titles
- render mounted or settled transcript content immediately, with adaptive catch-up and cleanup for interrupted updates
- keep accessibility labels complete while visual copy animates, so assistive technology receives one coherent update

The renderer already receives the first tool-call event at the first provider observation, so this does not add an artificial placeholder protocol.

## Verification
- pnpm exec tsc --noEmit
- pnpm test (468 tests)
- pnpm build

Closes #502