### PR TITLE
feat(desktop): render chat image attachments in transcripts

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -642,6 +642,8 @@ pub(in crate::db) async fn get_chat_transcript(
         return Ok(None);
     }
     let messages = list_messages_on(&transaction, chat_id).await?;
+    let message_attachments =
+        super::message_attachment::list_for_chat_on(&transaction, chat_id).await?;
     let refusals = list_terminal_refusals_on(&transaction, chat_id).await?;
     let citations = super::citation::list_snapshots_on(&transaction, chat_id).await?;
     let tool_activity = list_terminal_tool_activity_on(&transaction, chat_id).await?;
@@ -649,6 +651,7 @@ pub(in crate::db) async fn get_chat_transcript(
     transaction.commit().await.map_err(store_err)?;
     Ok(Some(ChatTranscriptSnapshot {
         messages,
+        message_attachments,
         refusals,
         citations,
         tool_activity,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -59,6 +59,9 @@ pub type BlobStream = BoxStream<'static, Result<Vec<u8>>>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatTranscriptSnapshot {
     pub messages: Vec<Message>,
+    /// Durable image identities grouped into the renderer transcript under the
+    /// same per-chat fence as `messages`.
+    pub message_attachments: Vec<MessageAttachment>,
     /// Refusal outcomes keyed to their durably completed assistant message.
     pub refusals: Vec<ChatRefusalSnapshot>,
     /// Ordered renderer-safe sources keyed to their assistant message.

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -1374,6 +1374,7 @@ impl Store for MemStore {
             .unwrap_or(0);
         Ok(Some(ChatTranscriptSnapshot {
             messages: Vec::new(),
+            message_attachments: Vec::new(),
             refusals: Vec::new(),
             citations: Vec::new(),
             tool_activity: Vec::new(),

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -31,7 +31,10 @@ import { DocumentsView } from "./DocumentsView";
 import { FoldersView } from "./FoldersView";
 import { hasNativeHost } from "./host";
 import { importLibraryDocument, type ImportedDocument } from "./documents";
-import { readyImageAttachmentIds } from "./ImageAttachments";
+import {
+  readyImageAttachmentIds,
+  readyTranscriptImageAttachments,
+} from "./ImageAttachments";
 import { useImageAttachments } from "./useImageAttachments";
 import { modelForSelection } from "./ModelSelection";
 import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
@@ -248,6 +251,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   async function sendMessage(content: string) {
     if (!chat || !content || busy || deletingChatId !== null) return;
     const attachments = readyImageAttachmentIds(images.attachments);
+    const transcriptImages = readyTranscriptImageAttachments(images.attachments);
     const turnId = crypto.randomUUID();
     terminalHydrationGenerationRef.current += 1;
     setComposerDraft("");
@@ -257,7 +261,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       activeTurnId: turnId,
       messages: [
         ...session.messages,
-        { id: nextId(), role: "user", text: content, createdAt: new Date().toISOString() },
+        {
+          id: nextId(),
+          role: "user",
+          text: content,
+          images: transcriptImages,
+          createdAt: new Date().toISOString(),
+        },
       ],
     }));
     signalTurnLifecycle("submitted");

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -173,6 +173,47 @@ describe("terminal transcript presentation", () => {
     ]);
   });
 
+  it("carries durable user-image identity and geometry into the message list", () => {
+    const presented = presentChatTranscript({
+      messages: [
+        {
+          id: "user-image",
+          role: "user",
+          content: "Describe this screenshot",
+          created_at: "2026-07-19T10:00:00Z",
+          citations: [],
+          image_attachments: [
+            {
+              attachment_id: "image-opaque-id",
+              media_type: "image/png",
+              width: 320,
+              height: 240,
+            },
+          ],
+        },
+      ],
+      tool_activity: [],
+      last_event_seq: 15,
+    });
+
+    expect(presented.messages).toEqual([
+      {
+        id: "user-image",
+        role: "user",
+        text: "Describe this screenshot",
+        images: [
+          {
+            attachmentId: "image-opaque-id",
+            mediaType: "image/png",
+            width: 320,
+            height: 240,
+          },
+        ],
+        createdAt: "2026-07-19T10:00:00Z",
+      },
+    ]);
+  });
+
   it("hydrates empty and partial refusals beside their durable assistant output", () => {
     const presented = presentChatTranscript({
       messages: [

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -68,6 +68,7 @@ export function presentChatTranscript(
           id: entry.id,
           role: "user",
           text: entry.text,
+          images: entry.images,
           createdAt: entry.createdAt,
         } satisfies ChatMessage,
       ];

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -145,6 +145,7 @@ export function ChatView({
           onUserQuestionsCancel={userQuestions.cancel}
           onSelectPrompt={onSelectPrompt}
           hydrated={hydrated}
+          imageClient={client}
         />
         {hasUnreadActivity && (
           <button

--- a/crates/openwave-desktop/ui/src/ImageAttachments.test.ts
+++ b/crates/openwave-desktop/ui/src/ImageAttachments.test.ts
@@ -15,6 +15,7 @@ import {
   queuedImageAttachment,
   readyImageAttachment,
   readyImageAttachmentIds,
+  readyTranscriptImageAttachments,
   withRetryQueued,
   withUploadFailed,
   withUploadProgress,
@@ -139,6 +140,20 @@ describe("image attachment state machine", () => {
     expect(readyImageAttachmentIds(list)).toEqual([
       ATTACHMENT_ID,
       OTHER_ATTACHMENT_ID,
+    ]);
+    expect(readyTranscriptImageAttachments(list)).toEqual([
+      {
+        attachmentId: ATTACHMENT_ID,
+        mediaType: "image/png",
+        width: 800,
+        height: 600,
+      },
+      {
+        attachmentId: OTHER_ATTACHMENT_ID,
+        mediaType: "image/png",
+        width: 800,
+        height: 600,
+      },
     ]);
   });
 

--- a/crates/openwave-desktop/ui/src/ImageAttachments.ts
+++ b/crates/openwave-desktop/ui/src/ImageAttachments.ts
@@ -42,6 +42,14 @@ export type PublishedImage = {
   byteLen: number;
 };
 
+/** The durable image detail a message needs after the composer has cleared. */
+export type TranscriptImageAttachment = {
+  attachmentId: string;
+  mediaType: string;
+  width: number;
+  height: number;
+};
+
 /** A published image plus the name the host picker read it under. */
 export type PickedImage = PublishedImage & { fileName: string };
 
@@ -246,6 +254,38 @@ export function readyImageAttachmentIds(
     .map((attachment) => attachment.attachmentId)
     .filter((id): id is string => id !== null);
   return [...new Set(ids)];
+}
+
+/**
+ * Convert ready composer chips into the stable identity and geometry that the
+ * optimistic user message can retain after the composer clears. Duplicate
+ * content-addressed ids are folded just as they are in the turn request.
+ */
+export function readyTranscriptImageAttachments(
+  attachments: readonly ImageAttachment[],
+): TranscriptImageAttachment[] {
+  const seen = new Set<string>();
+  return attachments.flatMap((attachment) => {
+    if (
+      attachment.status !== "ready" ||
+      attachment.attachmentId === null ||
+      attachment.mediaType === null ||
+      attachment.width === null ||
+      attachment.height === null ||
+      seen.has(attachment.attachmentId)
+    ) {
+      return [];
+    }
+    seen.add(attachment.attachmentId);
+    return [
+      {
+        attachmentId: attachment.attachmentId,
+        mediaType: attachment.mediaType,
+        width: attachment.width,
+        height: attachment.height,
+      },
+    ];
+  });
 }
 
 /** Whole-percent upload progress for the chip's bar. */

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApprovalCard } from "./ApprovalCard";
@@ -408,6 +408,58 @@ describe("row memoization", () => {
     expect((MessageBubble as unknown as { $$typeof: symbol }).$$typeof).toBe(
       Symbol.for("react.memo"),
     );
+  });
+});
+
+describe("historical image attachments", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("fetches image pixels with the chat client and releases the object URL", async () => {
+    const createObjectUrl = vi.fn(() => "blob:transcript-image");
+    const revokeObjectUrl = vi.fn();
+    vi.stubGlobal("URL", {
+      createObjectURL: createObjectUrl,
+      revokeObjectURL: revokeObjectUrl,
+    });
+    const getChatImageAttachment = vi.fn(async () =>
+      new Blob(["pixels"], { type: "image/png" }),
+    );
+    const { unmount } = render(
+      <MessageBubble
+        message={{
+          id: "user-image",
+          role: "user",
+          text: "Describe this",
+          images: [
+            {
+              attachmentId: "image-opaque-id",
+              mediaType: "image/png",
+              width: 320,
+              height: 240,
+            },
+          ],
+        }}
+        busy={false}
+        imageClient={{ getChatImageAttachment }}
+        chatId="chat-1"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(getChatImageAttachment).toHaveBeenCalledWith(
+        "chat-1",
+        "image-opaque-id",
+        expect.any(AbortSignal),
+      ),
+    );
+    const image = await screen.findByRole("img", {
+      name: "Attached image 1: 320 by 240 pixels",
+    });
+    expect(image).toHaveAttribute("src", "blob:transcript-image");
+    expect(createObjectUrl).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:transcript-image");
   });
 });
 

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from "react";
 import type { ReactNode, RefObject, UIEvent } from "react";
 import type {
   ApprovalGrantRung,
+  ApiClient,
   PendingFolderAccessRequest,
   PendingUserQuestions,
   ToolActionPreview,
@@ -21,9 +22,17 @@ import { ErrorBoundary } from "./ErrorBoundary";
 import { ToolActivityGroup } from "./ToolActivityGroup";
 import { WelcomeState } from "./WelcomeState";
 import { UserQuestionsCard } from "./UserQuestionsCard";
+import type { TranscriptImageAttachment } from "./ImageAttachments";
+import { TranscriptImageAttachments } from "./TranscriptImageAttachments";
 
 export type ChatMessage =
-  | { id: string; role: "user"; text: string; createdAt?: string }
+  | {
+      id: string;
+      role: "user";
+      text: string;
+      images?: TranscriptImageAttachment[];
+      createdAt?: string;
+    }
   | {
       id: string;
       role: "assistant";
@@ -99,6 +108,7 @@ type MessageListProps = {
   onUserQuestionsCancel?: (turnId: string) => void;
   onSelectPrompt?: (prompt: string) => void;
   hydrated?: boolean;
+  imageClient?: Pick<ApiClient, "getChatImageAttachment">;
 };
 
 export function MessageList({
@@ -125,6 +135,7 @@ export function MessageList({
   onUserQuestionsCancel = () => undefined,
   onSelectPrompt,
   hydrated = true,
+  imageClient,
 }: MessageListProps) {
   // Stable identity between renders so memoized rows only re-render when the
   // approval state itself changes, not on every streamed token.
@@ -137,6 +148,7 @@ export function MessageList({
     busy,
     onApproval,
     approvalState,
+    imageClient,
     chatId,
   );
   // Only greet a genuinely empty, fully-hydrated conversation. While an
@@ -217,6 +229,7 @@ export function groupMessageItems(
     decidingApprovalCalls: Set<string>;
     approvalErrors: Record<string, string>;
   },
+  imageClient?: Pick<ApiClient, "getChatImageAttachment">,
   chatId?: string,
 ) {
   const items: ReactNode[] = [];
@@ -249,6 +262,8 @@ export function groupMessageItems(
           key={message.id}
           message={message}
           busy={message.id === streamingAssistantId}
+          imageClient={imageClient}
+          chatId={chatId}
         />,
       );
       index += 1;
@@ -393,9 +408,13 @@ export const MessageBubble = memo(MessageBubbleImpl);
 function MessageBubbleImpl({
   message,
   busy,
+  imageClient,
+  chatId,
 }: {
   message: ChatMessage;
   busy: boolean;
+  imageClient?: Pick<ApiClient, "getChatImageAttachment">;
+  chatId?: string;
 }) {
   if (message.role === "assistant") {
     if (!message.text && message.sources.length === 0) return null;
@@ -429,6 +448,13 @@ function MessageBubbleImpl({
     return (
       <div className="message-user-frame">
         <article className="message message-user" aria-label="You">
+          {message.images && message.images.length > 0 && imageClient && chatId && (
+            <TranscriptImageAttachments
+              client={imageClient}
+              chatId={chatId}
+              images={message.images}
+            />
+          )}
           <MessageMarkdown>{message.text}</MessageMarkdown>
         </article>
         <MessageFooter

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -6,6 +6,7 @@ import type {
   ToolActionPreview,
 } from "./api";
 import type { AssistantSource } from "./AssistantSources";
+import type { TranscriptImageAttachment } from "./ImageAttachments";
 import type { ToolCallStatus } from "./ToolCallCard";
 
 export type HydratedTranscriptEntry =
@@ -14,6 +15,7 @@ export type HydratedTranscriptEntry =
       kind: "message";
       role: ChatMessage["role"];
       text: string;
+      images: TranscriptImageAttachment[];
       sources: AssistantSource[];
       createdAt: string;
       refusal?: RendererRefusal;
@@ -38,6 +40,17 @@ export function hydrateTranscriptHistory(
       kind: "message" as const,
       role: message.role,
       text: message.content,
+      images:
+        message.role === "user"
+          ? (message.image_attachments ?? []).map(
+              ({ attachment_id, media_type, width, height }) => ({
+                attachmentId: attachment_id,
+                mediaType: media_type,
+                width,
+                height,
+              }),
+            )
+          : [],
       // Ownership is already established by the server, which groups citations
       // by message before nesting them in each snapshot — which is why the
       // wire shape carries no `message_id`. Re-filtering on one here compared

--- a/crates/openwave-desktop/ui/src/TranscriptImageAttachments.tsx
+++ b/crates/openwave-desktop/ui/src/TranscriptImageAttachments.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import type { ApiClient } from "./api";
+import type { TranscriptImageAttachment } from "./ImageAttachments";
+
+type TranscriptImageAttachmentsProps = {
+  client: Pick<ApiClient, "getChatImageAttachment">;
+  chatId: string;
+  images: readonly TranscriptImageAttachment[];
+};
+
+/** Fetch transcript pixels with the renderer bearer, never through an image URL. */
+export function TranscriptImageAttachments({
+  client,
+  chatId,
+  images,
+}: TranscriptImageAttachmentsProps) {
+  return (
+    <div className="message-image-grid" aria-label="Attached images">
+      {images.map((image, index) => (
+        <TranscriptImage
+          key={image.attachmentId}
+          client={client}
+          chatId={chatId}
+          image={image}
+          index={index}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TranscriptImage({
+  client,
+  chatId,
+  image,
+  index,
+}: {
+  client: Pick<ApiClient, "getChatImageAttachment">;
+  chatId: string;
+  image: TranscriptImageAttachment;
+  index: number;
+}) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+  const label = `Attached image ${index + 1}: ${image.width} by ${image.height} pixels`;
+
+  useEffect(() => {
+    const abort = new AbortController();
+    let objectUrl: string | null = null;
+    setUrl(null);
+    setUnavailable(false);
+
+    void client
+      .getChatImageAttachment(chatId, image.attachmentId, abort.signal)
+      .then((blob) => {
+        if (abort.signal.aborted) return;
+        if (blob.type !== image.mediaType) {
+          setUnavailable(true);
+          return;
+        }
+        objectUrl = URL.createObjectURL(blob);
+        setUrl(objectUrl);
+      })
+      .catch(() => {
+        if (!abort.signal.aborted) setUnavailable(true);
+      });
+
+    return () => {
+      abort.abort();
+      if (objectUrl !== null) URL.revokeObjectURL(objectUrl);
+    };
+  }, [client, chatId, image.attachmentId, image.mediaType]);
+
+  if (url !== null) {
+    return (
+      <img
+        className="message-image"
+        src={url}
+        alt={label}
+        width={image.width}
+        height={image.height}
+      />
+    );
+  }
+
+  return (
+    <div className="message-image-pending" role="status" aria-label={label}>
+      {unavailable ? "Attached image unavailable" : "Loading attached image…"}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -486,6 +486,29 @@ describe("active turn steering", () => {
   });
 });
 
+describe("historical image API", () => {
+  it("uses the chat bearer to fetch pixels rather than putting a token in the URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("pixels", {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    const blob = await client.getChatImageAttachment("chat/1", "image/1");
+
+    expect(blob.type).toBe("image/png");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1/chats/chat%2F1/attachments/images/image%2F1",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer token" },
+      }),
+    );
+  });
+});
+
 describe("project-scoped conversation API", () => {
   it("creates a named project and a chat in that exact scope", async () => {
     const fetchMock = vi

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -39,6 +39,7 @@ import {
   type RendererSequencedEvent,
   type RendererToolName,
   type ToolActionPreview,
+  type TranscriptImageAttachment as WireTranscriptImageAttachment,
   type TranscriptRole,
   type ToolApprovalKind,
   type ToolResultPreview as WireToolResultPreview,
@@ -138,8 +139,13 @@ export type Chat = WireChat;
  * that reads it. Narrowing it to match the wire would delete that guard rather
  * than earn it, so the override is spelled out instead of hidden.
  */
-export type ChatMessage = Omit<ChatMessageSnapshot, "citations"> & {
+export type ChatMessage = Omit<
+  ChatMessageSnapshot,
+  "citations" | "image_attachments"
+> & {
   citations?: ChatMessageCitation[];
+  /** Omitted by the server when this message has no images. */
+  image_attachments?: ChatMessageImageAttachment[];
 };
 
 /**
@@ -149,6 +155,9 @@ export type ChatMessage = Omit<ChatMessageSnapshot, "citations"> & {
  * deliberately skips `message_id` on the wire. Do not reintroduce it.
  */
 export type ChatMessageCitation = AssistantCitationSnapshot;
+
+/** One durable image identity in a historical user message. */
+export type ChatMessageImageAttachment = WireTranscriptImageAttachment;
 
 /**
  * A fixed, terminal tool-card projection with no canonical tool data.
@@ -616,6 +625,28 @@ export class ApiClient {
     return this.json(`/chats/${chatId}/messages`, {
       headers: this.headers(),
     });
+  }
+
+  async getChatImageAttachment(
+    chatId: string,
+    attachmentId: string,
+    signal?: AbortSignal,
+  ): Promise<Blob> {
+    const response = await fetch(
+      `${this.baseUrl}/chats/${encodeURIComponent(chatId)}/attachments/images/${encodeURIComponent(attachmentId)}`,
+      { headers: this.headers(), signal },
+    );
+    if (!response.ok) {
+      let detail = response.statusText;
+      try {
+        const body = (await response.json()) as { message?: string };
+        if (body.message) detail = body.message;
+      } catch {
+        /* ignore */
+      }
+      throw new Error(`${response.status}: ${detail}`);
+    }
+    return response.blob();
   }
 
   patchChatTitle(chatId: string, title: string | null): Promise<Chat> {

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -144,7 +144,13 @@ export type ChatId = string;
  * A renderer-safe durable transcript entry. Internal routing and tool state
  * deliberately remain behind the server boundary.
  */
-export type ChatMessageSnapshot = { id: MessageId, role: TranscriptRole, content: string, created_at: string, citations: Array<AssistantCitationSnapshot>, refusal?: RendererRefusal, };
+export type ChatMessageSnapshot = { id: MessageId, role: TranscriptRole, content: string, created_at: string, citations: Array<AssistantCitationSnapshot>, 
+/**
+ * Images submitted with this user message. These are durable identity and
+ * geometry only; image bytes remain behind a chat-scoped authenticated
+ * endpoint and never enter the transcript payload.
+ */
+image_attachments?: Array<TranscriptImageAttachment>, refusal?: RendererRefusal, };
 
 /**
  * One pathless root in a conversation's exact ordered projection.
@@ -630,6 +636,23 @@ server: string,
  * The validated `ui://` document reference.
  */
 resource_uri: string, };
+
+/**
+ * One renderer-safe image identity attached to a historical user message.
+ */
+export type TranscriptImageAttachment = { 
+/**
+ * Content-addressed opaque attachment identity, not a host path.
+ */
+attachment_id: string, 
+/**
+ * Sniffed IANA media type from the trusted image ingest boundary.
+ */
+media_type: string, 
+/**
+ * Header-derived dimensions, bounded at image publication.
+ */
+width: number, height: number, };
 
 /**
  * The roles a visible transcript entry can have.

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -793,6 +793,30 @@ body {
   color: var(--ink);
 }
 
+.message-image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 0.55rem;
+}
+
+.message-image,
+.message-image-pending {
+  display: block;
+  width: 100%;
+  max-width: 18rem;
+  max-height: 16rem;
+  border-radius: 8px;
+  object-fit: contain;
+}
+
+.message-image-pending {
+  min-height: 6rem;
+  padding: 0.75rem;
+  color: var(--muted-foreground);
+  background: color-mix(in oklch, var(--muted) 60%, transparent);
+}
+
 .message-assistant {
   align-self: flex-start;
   padding: 0.1rem 0;

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -308,6 +308,13 @@ pub fn app(state: AppState) -> Router {
             axum::routing::delete(routes::delete_provider_credential),
         )
         .merge(public_document_api)
+        // The transcript must fetch pixels with its bearer rather than putting
+        // a token in an image URL. Unlike image publication, this is renderer
+        // presentation of an image already durably attached to the chat.
+        .route(
+            "/chats/{chat_id}/attachments/images/{attachment_id}",
+            get(routes::get_chat_image_attachment),
+        )
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
         .route(
             "/chats/pending-prompts",

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -915,9 +915,38 @@ pub struct ChatMessageSnapshot {
     pub content: String,
     pub created_at: chrono::DateTime<Utc>,
     pub citations: Vec<openwave_core::AssistantCitationSnapshot>,
+    /// Images submitted with this user message. These are durable identity and
+    /// geometry only; image bytes remain behind a chat-scoped authenticated
+    /// endpoint and never enter the transcript payload.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub image_attachments: Option<Vec<TranscriptImageAttachment>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub refusal: Option<crate::event_projection::RendererRefusal>,
+}
+
+/// One renderer-safe image identity attached to a historical user message.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct TranscriptImageAttachment {
+    /// Content-addressed opaque attachment identity, not a host path.
+    pub attachment_id: uuid::Uuid,
+    /// Sniffed IANA media type from the trusted image ingest boundary.
+    pub media_type: String,
+    /// Header-derived dimensions, bounded at image publication.
+    pub width: u32,
+    pub height: u32,
+}
+
+impl From<openwave_core::MessageAttachment> for TranscriptImageAttachment {
+    fn from(attachment: openwave_core::MessageAttachment) -> Self {
+        Self {
+            attachment_id: attachment.image.blob_id,
+            media_type: attachment.image.media_type.as_str().to_owned(),
+            width: attachment.image.width,
+            height: attachment.image.height,
+        }
+    }
 }
 
 /// One visible transcript plus the durable journal watermark that produced it.
@@ -975,6 +1004,7 @@ impl ChatMessageSnapshot {
             content: message.content,
             created_at: message.created_at,
             citations: Vec::new(),
+            image_attachments: None,
             refusal: None,
         })
     }
@@ -999,6 +1029,13 @@ pub async fn list_chat_messages(
             .or_insert_with(Vec::new)
             .push(citation);
     }
+    let mut image_attachments_by_message = std::collections::HashMap::new();
+    for attachment in transcript.message_attachments {
+        image_attachments_by_message
+            .entry(attachment.message_id)
+            .or_insert_with(Vec::new)
+            .push(TranscriptImageAttachment::from(attachment));
+    }
     let mut refusals_by_message = transcript
         .refusals
         .into_iter()
@@ -1017,6 +1054,13 @@ pub async fn list_chat_messages(
             snapshot.citations = citations_by_message
                 .remove(&snapshot.id)
                 .unwrap_or_default();
+            if snapshot.role == TranscriptRole::User {
+                let image_attachments = image_attachments_by_message
+                    .remove(&snapshot.id)
+                    .unwrap_or_default();
+                snapshot.image_attachments =
+                    (!image_attachments.is_empty()).then_some(image_attachments);
+            }
             snapshot.refusal = refusals_by_message.remove(&snapshot.id);
             Some(snapshot)
         })

--- a/crates/openwave-server/src/routes/image_attachment.rs
+++ b/crates/openwave-server/src/routes/image_attachment.rs
@@ -20,9 +20,10 @@
 
 use std::io::Cursor;
 
+use axum::body::Body;
 use axum::extract::State;
 use axum::http::{header, HeaderMap, StatusCode};
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use image::{ImageFormat, ImageReader};
 use serde::Serialize;
 use uuid::Uuid;
@@ -99,6 +100,63 @@ pub async fn publish_chat_image_attachment(
         StatusCode::CREATED,
         crate::extract::Json(PublishedImageAttachment::from(image)),
     ))
+}
+
+/// `GET /chats/{chat_id}/attachments/images/{attachment_id}` — return pixels
+/// only for an image durably attached to this conversation.
+///
+/// This is deliberately separate from the renderer transcript. The transcript
+/// contains identity and geometry only; a renderer must present its bearer
+/// token and the image must still be referenced by a message in the requested
+/// chat before bytes can cross this endpoint.
+pub async fn get_chat_image_attachment(
+    State(state): State<AppState>,
+    Path((chat_id, attachment_id)): Path<(ChatId, Uuid)>,
+) -> Result<Response, ServerError> {
+    if state.store.get_chat(chat_id).await?.is_none() {
+        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
+    }
+    let attachment = state
+        .store
+        .list_message_attachments(chat_id)
+        .await?
+        .into_iter()
+        .find(|attachment| attachment.image.blob_id == attachment_id)
+        .ok_or_else(|| {
+            ServerError::not_found(format!(
+                "image attachment {attachment_id} not found in chat {chat_id}"
+            ))
+        })?;
+    let bytes = state
+        .blobs
+        .get(attachment.image.blob_id)
+        .await?
+        .ok_or_else(|| {
+            ServerError::internal(format!(
+                "image attachment {attachment_id} is missing from blob storage"
+            ))
+        })?;
+    let actual_len = u64::try_from(bytes.len())
+        .map_err(|_| ServerError::internal("image attachment byte length exceeds u64"))?;
+    if actual_len != attachment.image.byte_len {
+        return Err(ServerError::internal(format!(
+            "image attachment {attachment_id} does not match its descriptor"
+        )));
+    }
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, attachment.image.media_type.as_str())
+        .header(header::CONTENT_LENGTH, actual_len.to_string())
+        // The bearer is never put in a URL. Do not let the resulting pixels
+        // persist in an HTTP cache either; the renderer owns the object URL's
+        // short lifetime instead.
+        .header(header::CACHE_CONTROL, "no-store")
+        .body(Body::from(bytes))
+        .map_err(|error| {
+            ServerError::internal(format!(
+                "failed to build image attachment response: {error}"
+            ))
+        })
 }
 
 /// Derive durable identity from candidate image bytes.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -52,6 +52,7 @@ fn transcript_citation_json_is_closed_and_renderer_bounded() {
             heading: Some("h".repeat(openwave_core::MAX_CITATION_HEADING_CHARS)),
             pages: (1..=u32::try_from(openwave_core::MAX_CITATION_PAGES).unwrap()).collect(),
         }],
+        image_attachments: None,
         refusal: None,
     };
     let json = serde_json::to_value(snapshot).unwrap();

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -8,6 +8,10 @@ fn image_attachments_uri(chat: ChatId) -> String {
     format!("/chats/{chat}/attachments/images")
 }
 
+fn transcript_image_uri(chat: ChatId, attachment_id: uuid::Uuid) -> String {
+    format!("/chats/{chat}/attachments/images/{attachment_id}")
+}
+
 /// Publish `bytes` for `chat` under a declared `Content-Type`.
 async fn publish_image(
     router: &Router,
@@ -328,6 +332,102 @@ async fn a_turn_records_its_attachments_and_an_unpublished_id_is_refused() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     let error: AgentErrorInfo = json_body(response).await;
     assert_eq!(error.kind, "image_attachment_not_found");
+}
+
+#[tokio::test]
+async fn transcript_projects_image_identity_and_fetches_pixels_with_the_chat_bearer() {
+    let (router, token, _state, _store, _dir) = test_app_with_state().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let bytes = png_header(320, 240);
+    let attachment_id = publish_png(&router, &bearer, chat.id, bytes.clone()).await;
+
+    assert_eq!(
+        send_message_with_attachments(
+            &router,
+            &bearer,
+            chat.id,
+            TurnId::new(),
+            "what is in this?",
+            &[attachment_id],
+        )
+        .await
+        .status(),
+        StatusCode::ACCEPTED
+    );
+
+    let transcript = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/messages", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(transcript.status(), StatusCode::OK);
+    let transcript: serde_json::Value = json_body(transcript).await;
+    let images = &transcript["messages"][0]["image_attachments"];
+    assert_eq!(
+        images,
+        &serde_json::json!([{
+            "attachment_id": attachment_id,
+            "media_type": "image/png",
+            "width": 320,
+            "height": 240,
+        }])
+    );
+    let encoded = images.to_string();
+    for forbidden in ["byte_len", "bytes", "path", "blob", "data:"] {
+        assert!(
+            !encoded.contains(forbidden),
+            "transcript attachment leaked {forbidden}: {encoded}"
+        );
+    }
+
+    let pixels = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(transcript_image_uri(chat.id, attachment_id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(pixels.status(), StatusCode::OK);
+    assert_eq!(pixels.headers()[header::CONTENT_TYPE], "image/png");
+    assert_eq!(pixels.headers()[header::CACHE_CONTROL], "no-store");
+    assert_eq!(
+        pixels.headers()[header::CONTENT_LENGTH],
+        bytes.len().to_string()
+    );
+    assert_eq!(
+        to_bytes(pixels.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .as_ref(),
+        bytes.as_slice()
+    );
+
+    // Publishing the same content in another chat does not grant that chat a
+    // reference to this message attachment.
+    let other_chat = make_chat(&router, &bearer).await;
+    let absent = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(transcript_image_uri(other_chat.id, attachment_id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(absent.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #567

## Summary
- project durable image attachment identity and dimensions with each historical user message
- fetch attachment pixels through a bearer-authenticated, chat-scoped endpoint and render them as short-lived object URLs
- preserve image previews on optimistic messages and add server and UI coverage

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked -- --quiet
- cargo check --workspace --locked
- pnpm test
- pnpm exec tsc --noEmit
- pnpm run build