### PR TITLE
feat(core): retain output revision citations

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1182,6 +1182,55 @@ pub mod output_revision {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod output_revision_citation {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "output_revision_citation")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub output_revision_id: Uuid,
+        pub ordinal: i32,
+        pub chat_id: Uuid,
+        pub turn_id: Uuid,
+        pub evidence_call_id: Uuid,
+        pub evidence_rank: i32,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter)]
+    pub enum Relation {
+        OutputRevision,
+        RetrievalEvidence,
+    }
+
+    impl RelationTrait for Relation {
+        fn def(&self) -> RelationDef {
+            match self {
+                Self::OutputRevision => Entity::belongs_to(super::output_revision::Entity)
+                    .from(Column::OutputRevisionId)
+                    .to(super::output_revision::Column::Id)
+                    .into(),
+                Self::RetrievalEvidence => Entity::belongs_to(super::retrieval_evidence::Entity)
+                    .from((Column::EvidenceCallId, Column::EvidenceRank))
+                    .to((
+                        super::retrieval_evidence::Column::CallId,
+                        super::retrieval_evidence::Column::Rank,
+                    ))
+                    .into(),
+            }
+        }
+    }
+
+    impl Related<super::retrieval_evidence::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::RetrievalEvidence.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod event {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -28,6 +28,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddUserQuestions),
             Box::new(AddConversationOutputs),
             Box::new(AddMessageAttachments),
+            Box::new(AddOutputRevisionCitations),
         ]
     }
 }
@@ -410,6 +411,133 @@ impl MigrationTrait for AddConversationOutputs {
             .await?;
         manager
             .drop_table(Table::drop().table(Output::Table).to_owned())
+            .await
+    }
+}
+
+/// Persists the bounded evidence lineage of each immutable output revision.
+///
+/// The cited evidence is scoped to the producing chat and turn, rather than
+/// relying on a source token alone. This preserves the exact source sequence
+/// without allowing a revision to reference another conversation's evidence.
+struct AddOutputRevisionCitations;
+
+impl MigrationName for AddOutputRevisionCitations {
+    fn name(&self) -> &str {
+        "m20260727_000015_add_output_revision_citations"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddOutputRevisionCitations {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(OutputRevisionCitation::Table)
+                    .col(
+                        ColumnDef::new(OutputRevisionCitation::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(OutputRevisionCitation::OutputRevisionId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutputRevisionCitation::Ordinal)
+                            .integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutputRevisionCitation::ChatId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutputRevisionCitation::TurnId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutputRevisionCitation::EvidenceCallId)
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OutputRevisionCitation::EvidenceRank)
+                            .integer()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_output_revision_citation_revision")
+                            .from_tbl(OutputRevisionCitation::Table)
+                            .from_col(OutputRevisionCitation::OutputRevisionId)
+                            .to_tbl(OutputRevision::Table)
+                            .to_col(OutputRevision::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_output_revision_citation_evidence")
+                            .from_tbl(OutputRevisionCitation::Table)
+                            .from_col(OutputRevisionCitation::EvidenceCallId)
+                            .from_col(OutputRevisionCitation::EvidenceRank)
+                            .from_col(OutputRevisionCitation::ChatId)
+                            .from_col(OutputRevisionCitation::TurnId)
+                            .to_tbl(RetrievalEvidence::Table)
+                            .to_col(RetrievalEvidence::CallId)
+                            .to_col(RetrievalEvidence::Rank)
+                            .to_col(RetrievalEvidence::ChatId)
+                            .to_col(RetrievalEvidence::TurnId)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .check(
+                        Expr::col(OutputRevisionCitation::Ordinal)
+                            .between(1, crate::deliverable::MAX_OUTPUT_CITATIONS as i32),
+                    )
+                    .check(
+                        Expr::col(OutputRevisionCitation::EvidenceRank)
+                            .between(1, crate::RetrievalEvidenceInput::MAX_RESULTS as i32),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_output_revision_citation_ordinal")
+                    .table(OutputRevisionCitation::Table)
+                    .col(OutputRevisionCitation::OutputRevisionId)
+                    .col(OutputRevisionCitation::Ordinal)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_output_revision_citation_evidence")
+                    .table(OutputRevisionCitation::Table)
+                    .col(OutputRevisionCitation::OutputRevisionId)
+                    .col(OutputRevisionCitation::EvidenceCallId)
+                    .col(OutputRevisionCitation::EvidenceRank)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(OutputRevisionCitation::Table)
+                    .to_owned(),
+            )
             .await
     }
 }
@@ -5662,6 +5790,18 @@ enum OutputRevision {
     Sha256,
     TurnId,
     CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum OutputRevisionCitation {
+    Table,
+    Id,
+    OutputRevisionId,
+    Ordinal,
+    ChatId,
+    TurnId,
+    EvidenceCallId,
+    EvidenceRank,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -17,7 +17,9 @@ use sea_orm_migration::MigratorTrait;
 use serde_json::Value;
 
 use crate::approval::{ApprovalDecision, ApprovalRequest, ToolApproval};
-use crate::deliverable::{CreateOutput, NewOutputRevision, OutputRecord, OutputRevision};
+use crate::deliverable::{
+    CreateOutput, NewOutputRevision, OutputCitationSnapshot, OutputRecord, OutputRevision,
+};
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 #[cfg(test)]
@@ -1840,6 +1842,13 @@ impl Store for DbStore {
 
     async fn get_output_revision(&self, id: OutputRevisionId) -> Result<Option<OutputRevision>> {
         ops::output::get_output_revision(self, id).await
+    }
+
+    async fn list_output_revision_citations(
+        &self,
+        revision_id: OutputRevisionId,
+    ) -> Result<Vec<OutputCitationSnapshot>> {
+        ops::output::list_output_revision_citations(self, revision_id).await
     }
 
     async fn delete_output(&self, id: OutputId, deleted_at: chrono::DateTime<Utc>) -> Result<bool> {

--- a/crates/openwave-core/src/db/ops/output.rs
+++ b/crates/openwave-core/src/db/ops/output.rs
@@ -5,17 +5,25 @@
 //! revision. Revisions are insert-only: an update appends, and the previous
 //! bytes stay addressable by their own revision id.
 
+use std::collections::HashSet;
+
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
     QuerySelect, Set, TransactionTrait,
 };
 
+use crate::citation::{
+    AssistantCitationReference, MAX_CITATION_EXCERPT_CHARS, MAX_CITATION_HEADING_CHARS,
+    MAX_CITATION_PAGES,
+};
 use crate::deliverable::{
     deliverable_media_type, validate_deliverable_name, CreateOutput, NewOutputRevision,
-    OutputRecord, OutputRevision, MAX_DELIVERABLE_BYTES, MAX_OUTPUT_REVISIONS,
+    OutputCitationSnapshot, OutputRecord, OutputRevision, MAX_DELIVERABLE_BYTES,
+    MAX_OUTPUT_CITATIONS, MAX_OUTPUT_REVISIONS,
 };
 use crate::error::{AgentError, Result};
-use crate::id::{ChatId, OutputId, OutputRevisionId};
+use crate::id::{ChatId, OutputCitationId, OutputId, OutputRevisionId};
+use crate::model::SourceLocation;
 
 use super::super::{entities, store_err, DbStore};
 use super::acquire_chat_write_lock;
@@ -38,12 +46,10 @@ pub(in crate::db) async fn create_output(
     if let Some(existing) = find_output_on(&transaction, request.id).await? {
         // An exact retry must return the original record rather than fail. A
         // reused id that describes different content is a caller bug.
+        let exact =
+            exact_output_on(&transaction, &existing, request, media_type, created_at).await?;
         transaction.rollback().await.map_err(store_err)?;
-        return if existing.chat_id == request.chat_id
-            && existing.filename == request.filename
-            && existing.current_revision == request.revision.id
-            && existing.revision_count == 1
-        {
+        return if exact {
             Ok(existing)
         } else {
             Err(AgentError::Store(format!(
@@ -52,6 +58,8 @@ pub(in crate::db) async fn create_output(
             )))
         };
     }
+    let evidence =
+        resolve_revision_citations_on(&transaction, request.chat_id, &request.revision).await?;
     entities::output::ActiveModel {
         id: Set(request.id.0),
         chat_id: Set(request.chat_id.0),
@@ -67,6 +75,8 @@ pub(in crate::db) async fn create_output(
     .await
     .map_err(store_err)?;
     insert_revision_on(&transaction, request.id, 1, &request.revision, created_at).await?;
+    insert_revision_citations_on(&transaction, request.chat_id, &request.revision, &evidence)
+        .await?;
     let record = require_output_on(&transaction, request.id).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(record)
@@ -98,11 +108,11 @@ pub(in crate::db) async fn append_output_revision(
         return Err(AgentError::Store(format!("output {output_id} is deleted")));
     }
     if let Some(recorded) = find_revision_on(&transaction, revision.id).await? {
+        let exact = recorded.output_id == output_id
+            && revision_matches(&recorded, revision, created_at)
+            && exact_revision_citations_on(&transaction, existing.chat_id, revision).await?;
         transaction.rollback().await.map_err(store_err)?;
-        return if recorded.output_id == output_id
-            && recorded.byte_len == revision.byte_len
-            && recorded.sha256 == revision.sha256
-        {
+        return if exact {
             require_output(store, output_id).await
         } else {
             Err(AgentError::Store(format!(
@@ -119,7 +129,9 @@ pub(in crate::db) async fn append_output_revision(
             "output {output_id} has reached its {MAX_OUTPUT_REVISIONS}-revision limit"
         )));
     }
+    let evidence = resolve_revision_citations_on(&transaction, existing.chat_id, revision).await?;
     insert_revision_on(&transaction, output_id, ordinal, revision, created_at).await?;
+    insert_revision_citations_on(&transaction, existing.chat_id, revision, &evidence).await?;
     entities::output::ActiveModel {
         id: Set(output_id.0),
         current_revision_id: Set(revision.id.0),
@@ -185,6 +197,81 @@ pub(in crate::db) async fn get_output_revision(
     find_revision_on(&store.conn, id).await
 }
 
+pub(in crate::db) async fn list_output_revision_citations(
+    store: &DbStore,
+    revision_id: OutputRevisionId,
+) -> Result<Vec<OutputCitationSnapshot>> {
+    let rows = entities::output_revision_citation::Entity::find()
+        .find_also_related(entities::retrieval_evidence::Entity)
+        .filter(entities::output_revision_citation::Column::OutputRevisionId.eq(revision_id.0))
+        .order_by_asc(entities::output_revision_citation::Column::Ordinal)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    let mut snapshots = Vec::with_capacity(rows.len());
+    for (index, (row, evidence)) in rows.into_iter().enumerate() {
+        let ordinal = u16::try_from(row.ordinal)
+            .map_err(|_| AgentError::Store("invalid output citation ordinal".into()))?;
+        if row.ordinal != i32::try_from(index + 1).expect("citation limit fits i32")
+            || !(1..=MAX_OUTPUT_CITATIONS as i32).contains(&row.ordinal)
+            || row.id != OutputCitationId::derive(revision_id, ordinal).0
+        {
+            return Err(AgentError::Store(
+                "output citation ordering or identity is corrupt".into(),
+            ));
+        }
+        let evidence = evidence
+            .ok_or_else(|| AgentError::Store("output citation evidence disappeared".into()))?;
+        if evidence.chat_id != row.chat_id || evidence.turn_id != row.turn_id {
+            return Err(AgentError::Store(
+                "output citation evidence owner is corrupt".into(),
+            ));
+        }
+        let evidence = super::client_execution::evidence_from_model(evidence)?;
+        if evidence.turn_id.0 != row.turn_id
+            || evidence.call_id.0 != row.evidence_call_id
+            || i32::from(evidence.evidence.rank) != row.evidence_rank
+        {
+            return Err(AgentError::Store(
+                "output citation projection owner is corrupt".into(),
+            ));
+        }
+        let mut pages = Vec::new();
+        for region in evidence.evidence.source_regions {
+            let SourceLocation::Page { number } = region.location;
+            let page = number.get();
+            if !pages.contains(&page) {
+                pages.push(page);
+                if pages.len() == MAX_CITATION_PAGES {
+                    break;
+                }
+            }
+        }
+        let headings = evidence.evidence.heading_path;
+        let heading = (!headings.is_empty()).then(|| {
+            headings
+                .join(" > ")
+                .chars()
+                .take(MAX_CITATION_HEADING_CHARS)
+                .collect()
+        });
+        snapshots.push(OutputCitationSnapshot {
+            id: OutputCitationId(row.id),
+            output_revision_id: revision_id,
+            ordinal,
+            excerpt: evidence
+                .evidence
+                .snippet
+                .chars()
+                .take(MAX_CITATION_EXCERPT_CHARS)
+                .collect(),
+            heading,
+            pages,
+        });
+    }
+    Ok(snapshots)
+}
+
 pub(in crate::db) async fn delete_output(
     store: &DbStore,
     id: OutputId,
@@ -228,6 +315,20 @@ fn validate_revision(revision: &NewOutputRevision) -> Result<()> {
             "output revision is too large (maximum {MAX_DELIVERABLE_BYTES} bytes)"
         )));
     }
+    if revision.citations.len() > MAX_OUTPUT_CITATIONS
+        || revision
+            .citations
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>()
+            .len()
+            != revision.citations.len()
+        || (!revision.citations.is_empty() && revision.turn_id.is_none())
+    {
+        return Err(AgentError::Store(
+            "output revision citation references are invalid".into(),
+        ));
+    }
     Ok(())
 }
 
@@ -258,6 +359,152 @@ where
     .await
     .map_err(store_err)?;
     Ok(())
+}
+
+async fn insert_revision_citations_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+    revision: &NewOutputRevision,
+    evidence: &[entities::retrieval_evidence::Model],
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    if evidence.is_empty() {
+        return Ok(());
+    }
+    let turn_id = revision.turn_id.ok_or_else(|| {
+        AgentError::Store("output revision citations require a producing turn".into())
+    })?;
+    let rows = evidence
+        .iter()
+        .enumerate()
+        .map(
+            |(index, row)| entities::output_revision_citation::ActiveModel {
+                id: Set(OutputCitationId::derive(
+                    revision.id,
+                    u16::try_from(index + 1).expect("citation limit fits u16"),
+                )
+                .0),
+                output_revision_id: Set(revision.id.0),
+                ordinal: Set(i32::try_from(index + 1).expect("citation limit fits i32")),
+                chat_id: Set(chat_id.0),
+                turn_id: Set(turn_id.0),
+                evidence_call_id: Set(row.call_id),
+                evidence_rank: Set(row.rank),
+            },
+        )
+        .collect::<Vec<_>>();
+    entities::output_revision_citation::Entity::insert_many(rows)
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+async fn resolve_revision_citations_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+    revision: &NewOutputRevision,
+) -> Result<Vec<entities::retrieval_evidence::Model>>
+where
+    C: ConnectionTrait,
+{
+    let Some(turn_id) = revision.turn_id else {
+        return Ok(Vec::new());
+    };
+    super::citation::resolve_references_on(conn, chat_id, turn_id, &revision.citations).await
+}
+
+async fn exact_revision_citations_on<C>(
+    conn: &C,
+    chat_id: ChatId,
+    revision: &NewOutputRevision,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let expected = resolve_revision_citations_on(conn, chat_id, revision)
+        .await?
+        .into_iter()
+        .map(|evidence| AssistantCitationReference {
+            source_token: evidence.source_token,
+        })
+        .collect::<Vec<_>>();
+    Ok(exact_references_for_revision_on(conn, revision.id).await? == expected)
+}
+
+async fn exact_references_for_revision_on<C>(
+    conn: &C,
+    revision_id: OutputRevisionId,
+) -> Result<Vec<AssistantCitationReference>>
+where
+    C: ConnectionTrait,
+{
+    let rows = entities::output_revision_citation::Entity::find()
+        .find_also_related(entities::retrieval_evidence::Entity)
+        .filter(entities::output_revision_citation::Column::OutputRevisionId.eq(revision_id.0))
+        .order_by_asc(entities::output_revision_citation::Column::Ordinal)
+        .all(conn)
+        .await
+        .map_err(store_err)?;
+    let mut references = Vec::with_capacity(rows.len());
+    for (row, evidence) in rows {
+        let evidence = evidence
+            .ok_or_else(|| AgentError::Store("output citation evidence disappeared".into()))?;
+        if evidence.chat_id != row.chat_id || evidence.turn_id != row.turn_id {
+            return Err(AgentError::Store(
+                "output citation evidence owner is corrupt".into(),
+            ));
+        }
+        references.push(AssistantCitationReference {
+            source_token: evidence.source_token,
+        });
+    }
+    Ok(references)
+}
+
+async fn exact_output_on<C>(
+    conn: &C,
+    stored: &OutputRecord,
+    request: &CreateOutput,
+    media_type: &str,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    if stored.chat_id != request.chat_id
+        || stored.filename != request.filename
+        || stored.media_type != media_type
+        || stored.current_revision != request.revision.id
+        || stored.revision_count != 1
+        || stored.created_at != created_at
+        || stored.updated_at != created_at
+        || stored.deleted_at.is_some()
+    {
+        return Ok(false);
+    }
+    let Some(revision) = find_revision_on(conn, request.revision.id).await? else {
+        return Err(AgentError::Store(
+            "output record has no current revision".into(),
+        ));
+    };
+    Ok(revision.output_id == request.id
+        && revision_matches(&revision, &request.revision, created_at)
+        && exact_revision_citations_on(conn, request.chat_id, &request.revision).await?)
+}
+
+fn revision_matches(
+    stored: &OutputRevision,
+    request: &NewOutputRevision,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    stored.id == request.id
+        && stored.byte_len == request.byte_len
+        && stored.sha256 == request.sha256
+        && stored.turn_id == request.turn_id
+        && stored.created_at == created_at
 }
 
 async fn find_output_on<C>(conn: &C, id: OutputId) -> Result<Option<OutputRecord>>

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5309,11 +5309,52 @@ async fn m0013_adds_outputs_to_an_existing_conversation_store() {
             byte_len: 7,
             sha256: [3; 32],
             turn_id: None,
+            citations: Vec::new(),
             created_at: DateTime::<Utc>::from_timestamp(1_710_000_000, 0).unwrap(),
         },
     };
     let created = store.create_output(&request).await.unwrap();
     assert_eq!(store.list_outputs(chat.id, 10).await.unwrap(), [created]);
+}
+
+#[tokio::test]
+async fn m0015_adds_output_citations_without_changing_existing_outputs() {
+    let dir = tempfile::tempdir().unwrap();
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        dir.path().join("output-citation-upgrade.db").display()
+    );
+    let conn = Database::connect(&url).await.unwrap();
+    conn.execute_unprepared("PRAGMA foreign_keys=ON;")
+        .await
+        .unwrap();
+    migration::Migrator::up(&conn, Some(14)).await.unwrap();
+    let store = DbStore { conn: conn.clone() };
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let request = crate::deliverable::CreateOutput {
+        id: crate::id::OutputId::new(),
+        chat_id: chat.id,
+        filename: "brief.md".into(),
+        revision: crate::deliverable::NewOutputRevision {
+            id: crate::id::OutputRevisionId::new(),
+            byte_len: 7,
+            sha256: [3; 32],
+            turn_id: None,
+            citations: Vec::new(),
+            created_at: DateTime::<Utc>::from_timestamp(1_710_000_000, 0).unwrap(),
+        },
+    };
+    let created = store.create_output(&request).await.unwrap();
+
+    migration::Migrator::up(&conn, None).await.unwrap();
+
+    assert_eq!(store.get_output(created.id).await.unwrap(), Some(created));
+    assert!(store
+        .list_output_revision_citations(request.revision.id)
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -1,8 +1,13 @@
 use super::*;
+use crate::citation::AssistantCitationReference;
 use crate::deliverable::{
     CreateOutput, NewOutputRevision, OutputRecord, MAX_DELIVERABLE_BYTES, MAX_OUTPUT_REVISIONS,
 };
-use crate::id::{OutputId, OutputRevisionId};
+use crate::id::{CallId, DocumentId, OutputId, OutputRevisionId};
+use crate::model::{
+    ByteSpan, DocumentGeneration, RetrievalEvidenceInput, RetrievalEvidenceSource,
+    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus,
+};
 
 fn at(second: i64) -> DateTime<Utc> {
     DateTime::<Utc>::from_timestamp(1_710_000_000 + second, 0).unwrap()
@@ -18,6 +23,7 @@ fn revision(seed: u8, second: i64) -> NewOutputRevision {
         byte_len: u64::from(seed) + 1,
         sha256: digest(seed),
         turn_id: None,
+        citations: Vec::new(),
         created_at: at(second),
     }
 }
@@ -36,6 +42,65 @@ async fn store_with_chat() -> (tempfile::TempDir, DbStore, Chat) {
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
     (dir, store, chat)
+}
+
+async fn persist_evidence(
+    store: &DbStore,
+    chat_id: ChatId,
+    turn_id: TurnId,
+    source_token: uuid::Uuid,
+    rank: u16,
+    snippet: &str,
+) {
+    let call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id,
+        turn_id,
+        provider_id: format!("search_{rank}"),
+        name: "search".into(),
+        arguments: serde_json::json!({"query": "citation"}),
+        execution: ToolCallExecution::Server,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: at(i64::from(rank)),
+        resolved_at: None,
+    };
+    store.accept_tool_call(&call).await.unwrap();
+    let span = ByteSpan::new(0, snippet.len());
+    let document_id = DocumentId::new();
+    let evidence = RetrievalEvidenceInput {
+        rank,
+        source_token,
+        document_id,
+        generation: DocumentGeneration {
+            content_revision: 1,
+            revision_token: uuid::Uuid::new_v4(),
+        },
+        chunk_id: crate::ChunkId::derive(document_id, span.start, span.end),
+        span,
+        snippet: snippet.into(),
+        heading_path: vec![format!("Section {rank}")],
+        source_regions: Vec::new(),
+        source: RetrievalEvidenceSource::Inline,
+    };
+    assert_eq!(
+        store
+            .resolve_server_tool_call_with_evidence(
+                call.id,
+                &ToolCallResolution::Completed {
+                    result: "found source".into(),
+                },
+                at(i64::from(rank) + 10),
+                &[evidence],
+            )
+            .await
+            .unwrap(),
+        ResolveToolCallOutcome::Resolved
+    );
 }
 
 #[tokio::test]
@@ -304,4 +369,125 @@ async fn a_revision_records_the_turn_that_produced_it() {
         .unwrap()
         .unwrap();
     assert_eq!(stored.turn_id, Some(turn_id));
+}
+
+#[tokio::test]
+async fn output_revisions_retain_ordered_scoped_citations_and_retry_them_exactly() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let turn_id = TurnId::new();
+    let first = uuid::Uuid::new_v4();
+    let second = uuid::Uuid::new_v4();
+    persist_evidence(&store, chat.id, turn_id, first, 1, "first source").await;
+    persist_evidence(&store, chat.id, turn_id, second, 1, "second source").await;
+    let mut request = create_request(chat.id, "brief.md", 1);
+    request.revision.turn_id = Some(turn_id);
+    request.revision.citations = vec![
+        AssistantCitationReference {
+            source_token: uuid::Uuid::new_v4(),
+        },
+        AssistantCitationReference {
+            source_token: second,
+        },
+        AssistantCitationReference {
+            source_token: first,
+        },
+    ];
+
+    let created = store.create_output(&request).await.unwrap();
+    assert_eq!(store.create_output(&request).await.unwrap(), created);
+    let citations = store
+        .list_output_revision_citations(created.current_revision)
+        .await
+        .unwrap();
+    assert_eq!(citations.len(), 2, "unknown source tokens are not retained");
+    assert_eq!(citations[0].ordinal, 1);
+    assert_eq!(citations[0].excerpt, "second source");
+    assert_eq!(citations[0].heading.as_deref(), Some("Section 1"));
+    assert_eq!(citations[1].ordinal, 2);
+    assert_eq!(citations[1].excerpt, "first source");
+
+    let mut conflicting_retry = request.clone();
+    conflicting_retry.revision.citations.reverse();
+    assert!(store.create_output(&conflicting_retry).await.is_err());
+
+    let mut appended = revision(2, 30);
+    appended.turn_id = Some(turn_id);
+    appended.citations = vec![AssistantCitationReference {
+        source_token: first,
+    }];
+    store
+        .append_output_revision(created.id, &appended)
+        .await
+        .unwrap();
+    assert!(store
+        .append_output_revision(
+            created.id,
+            &NewOutputRevision {
+                citations: vec![AssistantCitationReference {
+                    source_token: second,
+                }],
+                ..appended
+            },
+        )
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn output_citations_cannot_cross_turn_or_conversation_boundaries() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let other_chat = sample_chat();
+    store.create_chat(&other_chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let same_turn = uuid::Uuid::new_v4();
+    let other_turn = uuid::Uuid::new_v4();
+    let other_chat_token = uuid::Uuid::new_v4();
+    persist_evidence(&store, chat.id, turn_id, same_turn, 1, "same turn").await;
+    persist_evidence(&store, chat.id, TurnId::new(), other_turn, 1, "other turn").await;
+    persist_evidence(
+        &store,
+        other_chat.id,
+        TurnId::new(),
+        other_chat_token,
+        1,
+        "other chat",
+    )
+    .await;
+    let mut request = create_request(chat.id, "brief.md", 1);
+    request.revision.turn_id = Some(turn_id);
+    request.revision.citations = vec![
+        AssistantCitationReference {
+            source_token: other_turn,
+        },
+        AssistantCitationReference {
+            source_token: other_chat_token,
+        },
+        AssistantCitationReference {
+            source_token: same_turn,
+        },
+    ];
+
+    let created = store.create_output(&request).await.unwrap();
+    let citations = store
+        .list_output_revision_citations(created.current_revision)
+        .await
+        .unwrap();
+    assert_eq!(citations.len(), 1);
+    assert_eq!(citations[0].excerpt, "same turn");
+
+    let mut invalid = revision(2, 30);
+    invalid.citations = vec![AssistantCitationReference {
+        source_token: same_turn,
+    }];
+    assert!(store
+        .append_output_revision(created.id, &invalid)
+        .await
+        .is_err());
+
+    store.delete_chat(chat.id).await.unwrap();
+    assert!(store
+        .list_output_revision_citations(created.current_revision)
+        .await
+        .unwrap()
+        .is_empty());
 }

--- a/crates/openwave-core/src/deliverable.rs
+++ b/crates/openwave-core/src/deliverable.rs
@@ -9,7 +9,8 @@ use std::path::PathBuf;
 
 use chrono::{DateTime, Utc};
 
-use crate::id::{ChatId, OutputId, OutputRevisionId, TurnId};
+use crate::citation::AssistantCitationReference;
+use crate::id::{ChatId, OutputCitationId, OutputId, OutputRevisionId, TurnId};
 
 /// Private-scratch directory holding the output files in use today.
 ///
@@ -36,6 +37,11 @@ pub const MAX_DELIVERABLE_NAME_CHARS: usize = 120;
 /// Reaching the bound is a product decision rather than a storage failure: the
 /// store refuses a further revision so no caller can silently lose history.
 pub const MAX_OUTPUT_REVISIONS: u32 = 100;
+/// Most distinct source-evidence rows one output revision may cite.
+///
+/// An output can only cite evidence shown to the turn that produced it, so the
+/// same retrieval-result bound used for assistant messages is sufficient.
+pub const MAX_OUTPUT_CITATIONS: usize = crate::citation::MAX_ASSISTANT_CITATIONS;
 
 /// Private-scratch location of one immutable revision's bytes.
 ///
@@ -95,6 +101,18 @@ pub struct OutputRevision {
     pub created_at: DateTime<Utc>,
 }
 
+/// Renderer-safe historical citation projected from immutable output evidence.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, ts_rs::TS)]
+pub struct OutputCitationSnapshot {
+    pub id: OutputCitationId,
+    #[serde(skip)]
+    pub output_revision_id: OutputRevisionId,
+    pub ordinal: u16,
+    pub excerpt: String,
+    pub heading: Option<String>,
+    pub pages: Vec<u32>,
+}
+
 /// Content-identifying fields of a revision the caller has already written.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewOutputRevision {
@@ -107,6 +125,11 @@ pub struct NewOutputRevision {
     pub sha256: [u8; 32],
     /// Turn that produced the revision, when it came from an agent turn.
     pub turn_id: Option<TurnId>,
+    /// Ordered evidence references selected while producing this revision.
+    ///
+    /// References only resolve against the revision's chat and producing turn;
+    /// a cited revision therefore always has a producing turn.
+    pub citations: Vec<AssistantCitationReference>,
     /// Host-stamped creation time.
     pub created_at: DateTime<Utc>,
 }

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -75,6 +75,11 @@ id_type!(
     AssistantCitationId
 );
 
+id_type!(
+    /// Opaque renderer identity for one output-revision citation.
+    OutputCitationId
+);
+
 impl AssistantCitationId {
     const NAMESPACE: Uuid = Uuid::from_u128(0x2b74_9531_8d6e_4e11_a80b_8f50_413e_927c);
 
@@ -84,6 +89,20 @@ impl AssistantCitationId {
         let message_namespace = Uuid::new_v5(&Self::NAMESPACE, message_id.as_uuid().as_bytes());
         Self(Uuid::new_v5(
             &message_namespace,
+            ordinal.to_string().as_bytes(),
+        ))
+    }
+}
+
+impl OutputCitationId {
+    const NAMESPACE: Uuid = Uuid::from_u128(0x9c4e_74f0_3198_40bd_8acd_3e09_83b5_c6d7);
+
+    /// Derive one stable citation identity from its revision and one-based ordinal.
+    #[must_use]
+    pub fn derive(revision_id: OutputRevisionId, ordinal: u16) -> Self {
+        let revision_namespace = Uuid::new_v5(&Self::NAMESPACE, revision_id.as_uuid().as_bytes());
+        Self(Uuid::new_v5(
+            &revision_namespace,
             ordinal.to_string().as_bytes(),
         ))
     }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -99,15 +99,16 @@ pub use config::{Config, Profile};
 pub use db::DbStore;
 pub use deliverable::{
     deliverable_media_type, output_revision_relative_path, validate_deliverable_name, CreateOutput,
-    NewOutputRevision, OutputRecord, OutputRevision, DELIVERABLES_DIRECTORY, MAX_DELIVERABLE_BYTES,
-    MAX_DELIVERABLE_NAME_CHARS, MAX_OUTPUT_REVISIONS, OUTPUTS_DIRECTORY,
+    NewOutputRevision, OutputCitationSnapshot, OutputRecord, OutputRevision,
+    DELIVERABLES_DIRECTORY, MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_NAME_CHARS,
+    MAX_OUTPUT_CITATIONS, MAX_OUTPUT_REVISIONS, OUTPUTS_DIRECTORY,
 };
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{
     AgentRunId, AssistantCitationId, CallId, ChatId, ChunkId, DocumentId, DocumentJobId,
-    HostRootId, HostRootIdError, MessageId, OutputId, OutputRevisionId, ProjectId,
-    RootAttachmentChangeId, RootAttachmentChangeIdError, StepId, TurnId, TurnSteerId,
+    HostRootId, HostRootIdError, MessageId, OutputCitationId, OutputId, OutputRevisionId,
+    ProjectId, RootAttachmentChangeId, RootAttachmentChangeIdError, StepId, TurnId, TurnSteerId,
 };
 pub use image::{
     ImageAttachments, ImageData, ImageMediaType, ImageRef, MAX_IMAGE_BYTES, MAX_IMAGE_DIMENSION,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -20,7 +20,9 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::approval::{ApprovalDecision, ApprovalRequest, ToolApproval};
-use crate::deliverable::{CreateOutput, NewOutputRevision, OutputRecord, OutputRevision};
+use crate::deliverable::{
+    CreateOutput, NewOutputRevision, OutputCitationSnapshot, OutputRecord, OutputRevision,
+};
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{
@@ -1441,6 +1443,14 @@ pub trait Store: Send + Sync {
 
     /// Fetch one revision by opaque id.
     async fn get_output_revision(&self, _id: OutputRevisionId) -> Result<Option<OutputRevision>> {
+        output_storage_unavailable()
+    }
+
+    /// List renderer-safe source citations for one immutable output revision.
+    async fn list_output_revision_citations(
+        &self,
+        _revision_id: OutputRevisionId,
+    ) -> Result<Vec<OutputCitationSnapshot>> {
         output_storage_unavailable()
     }
 


### PR DESCRIPTION
## Summary

- persist bounded, ordered retrieval-evidence references for immutable output revisions
- expose renderer-safe citation snapshots and fence references to the producing chat and turn
- make output creation and revision retries compare their complete immutable provenance

## Tests

- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked
- cargo check --workspace --locked

Closes #614
Part of #417