### PR TITLE
feat(desktop): mark parked chats needing attention

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -2833,6 +2833,10 @@ impl Store for DbStore {
         ops::user_question::list_pending(self, chat_id).await
     }
 
+    async fn list_pending_chat_prompts(&self) -> Result<Vec<crate::PendingChatPrompt>> {
+        ops::chat_prompt::list_pending_chat_prompts(self).await
+    }
+
     async fn answer_user_questions(
         &self,
         request: &crate::AnswerUserQuestionsRequest,

--- a/crates/openwave-core/src/db/ops/chat_prompt.rs
+++ b/crates/openwave-core/src/db/ops/chat_prompt.rs
@@ -1,0 +1,127 @@
+//! Opaque cross-conversation prompt summaries for shell-level notification.
+
+use std::collections::{BTreeMap, HashMap};
+
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder};
+
+use crate::error::Result;
+use crate::model::{ToolCallExecution, ToolCallStatus, TurnClientWaitStatus, TurnRunStatus};
+use crate::storage::PendingChatPrompt;
+use crate::{
+    validate_request_folder_access_arguments, CallId, ChatId, ASK_USER_QUESTIONS_TOOL,
+    REQUEST_FOLDER_ACCESS_TOOL,
+};
+
+use super::super::{entities, store_err, DbStore};
+
+/// Read the minimal, durable prompt state the desktop needs to find chats that
+/// need attention. This deliberately uses set queries rather than replaying
+/// every chat's prompt endpoint from the shell.
+pub(in crate::db) async fn list_pending_chat_prompts(
+    store: &DbStore,
+) -> Result<Vec<PendingChatPrompt>> {
+    let question_requests = entities::user_question_request::Entity::find()
+        .filter(
+            entities::user_question_request::Column::Status
+                .eq(crate::UserQuestionRequestStatus::Pending.as_str()),
+        )
+        .order_by_asc(entities::user_question_request::Column::ChatId)
+        .order_by_asc(entities::user_question_request::Column::AskedAt)
+        .order_by_asc(entities::user_question_request::Column::CallId)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+
+    // A question request is an auxiliary renderer projection. Keep the same
+    // live-continuation checks as its detailed recovery path so an incomplete
+    // or stale projection cannot leave a chat marked as waiting forever.
+    let question_calls = entities::tool_call::Entity::find()
+        .filter(entities::tool_call::Column::Name.eq(ASK_USER_QUESTIONS_TOOL))
+        .filter(
+            entities::tool_call::Column::Execution.eq(ToolCallExecution::Orchestration.as_str()),
+        )
+        .filter(entities::tool_call::Column::Status.eq(ToolCallStatus::Pending.as_str()))
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(|call| (call.id, call))
+        .collect::<HashMap<_, _>>();
+    let waits = entities::turn_client_wait::Entity::find()
+        .filter(
+            entities::turn_client_wait::Column::Status.eq(TurnClientWaitStatus::Waiting.as_str()),
+        )
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(|wait| (wait.call_id, wait))
+        .collect::<HashMap<_, _>>();
+    let turns = entities::turn_run::Entity::find()
+        .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::WaitingForClient.as_str()))
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(|turn| (turn.id, turn))
+        .collect::<HashMap<_, _>>();
+
+    let mut prompts = BTreeMap::<uuid::Uuid, PendingChatPrompt>::new();
+    for request in question_requests {
+        let Some(call) = question_calls.get(&request.call_id) else {
+            continue;
+        };
+        let Some(wait) = waits.get(&request.call_id) else {
+            continue;
+        };
+        let Some(turn) = turns.get(&request.turn_id) else {
+            continue;
+        };
+        if call.chat_id != request.chat_id
+            || call.turn_id != request.turn_id
+            || call.client_executor_id.is_some()
+            || wait.chat_id != request.chat_id
+            || wait.turn_id != request.turn_id
+            || turn.chat_id != request.chat_id
+            || turn.attempt_count != wait.attempt_count
+            || turn.claim_count != wait.claim_count
+        {
+            continue;
+        }
+        prompts
+            .entry(request.chat_id)
+            .or_insert_with(|| PendingChatPrompt {
+                chat_id: ChatId(request.chat_id),
+                question_call_ids: Vec::new(),
+                folder_access_call_ids: Vec::new(),
+            })
+            .question_call_ids
+            .push(CallId(request.call_id));
+    }
+
+    let folder_calls = entities::tool_call::Entity::find()
+        .filter(entities::tool_call::Column::Name.eq(REQUEST_FOLDER_ACCESS_TOOL))
+        .filter(entities::tool_call::Column::Execution.eq(ToolCallExecution::Client.as_str()))
+        .filter(entities::tool_call::Column::Status.eq(ToolCallStatus::Pending.as_str()))
+        .order_by_asc(entities::tool_call::Column::ChatId)
+        .order_by_asc(entities::tool_call::Column::HistoryOrder)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    for call in folder_calls {
+        if !validate_request_folder_access_arguments(&call.arguments) {
+            continue;
+        }
+        prompts
+            .entry(call.chat_id)
+            .or_insert_with(|| PendingChatPrompt {
+                chat_id: ChatId(call.chat_id),
+                question_call_ids: Vec::new(),
+                folder_access_call_ids: Vec::new(),
+            })
+            .folder_access_call_ids
+            .push(CallId(call.id));
+    }
+
+    Ok(prompts.into_values().collect())
+}

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -8,6 +8,7 @@ use super::{entities, store_err};
 pub(in crate::db) mod agent_run;
 pub(in crate::db) mod approval;
 pub(in crate::db) mod blob;
+pub(in crate::db) mod chat_prompt;
 pub(in crate::db) mod citation;
 pub(in crate::db) mod client_execution;
 pub(in crate::db) mod conversation;

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -157,10 +157,11 @@ pub use storage::{
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
     JournaledToolApprovalOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
     ParkSandboxToolCallOutcome, ParkTurnForAgentRunInboxOutcome, ParkTurnForAgentRunWaitSetOutcome,
-    ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
-    RequestToolApprovalOutcome, RequestTurnCancellationOutcome, ResolveSandboxToolCallOutcome,
-    ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, SecretProvider, Store,
-    SubmitAgentRunResultOutcome, TurnLeaseFence, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+    ParkTurnForClientCallOutcome, PendingChatPrompt, RecordTurnFailureOutcome,
+    RequestAgentRunCancellationOutcome, RequestToolApprovalOutcome, RequestTurnCancellationOutcome,
+    ResolveSandboxToolCallOutcome, ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome,
+    SecretProvider, Store, SubmitAgentRunResultOutcome, TurnLeaseFence,
+    MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{
     input_schema_for, ApprovalClass, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolScratch,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -69,6 +69,18 @@ pub struct ChatRefusalSnapshot {
     pub refusal: RefusalOutcome,
 }
 
+/// Opaque indication that a conversation is parked on a renderer-owned prompt.
+///
+/// This is intentionally a summary rather than a prompt projection: it lets a
+/// shell mark conversations needing attention without exposing question text,
+/// folder-access arguments, executor state, or any other canonical tool data.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PendingChatPrompt {
+    pub chat_id: ChatId,
+    pub question_call_ids: Vec<CallId>,
+    pub folder_access_call_ids: Vec<CallId>,
+}
+
 /// Result of a fail-closed conversation deletion request.
 ///
 /// A conversation is only removable after every turn is terminal and no host
@@ -2626,6 +2638,13 @@ pub trait Store: Send + Sync {
         &self,
         _chat_id: ChatId,
     ) -> Result<Vec<PendingUserQuestions>> {
+        turn_storage_unavailable()
+    }
+
+    /// List every conversation that has a renderer-owned prompt awaiting the
+    /// user. The result carries opaque call ids only; callers fetch detail for
+    /// an individual open conversation through its dedicated recovery route.
+    async fn list_pending_chat_prompts(&self) -> Result<Vec<PendingChatPrompt>> {
         turn_storage_unavailable()
     }
 

--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useChatListStore } from "./ChatListStore";
 import { usePendingPrompts } from "./PendingPrompts";
+import { useRefreshSignals } from "./RefreshSignals";
 import { useUiStore } from "./UiStore";
 
 /**
@@ -25,6 +26,7 @@ const listChats = vi.fn(async () => chats);
 const createChat = vi.fn(async () => chats[0]);
 const listPendingUserQuestions = vi.fn(async () => [] as unknown[]);
 const listPendingFolderAccessRequests = vi.fn(async () => [] as unknown[]);
+const listPendingChatPrompts = vi.fn(async () => [] as unknown[]);
 const requestUserAttention = vi.fn(async () => {});
 const postMessage = vi.fn(async () => {});
 
@@ -40,6 +42,7 @@ vi.mock("./api", () => ({
     createChat = createChat;
     listPendingUserQuestions = listPendingUserQuestions;
     listPendingFolderAccessRequests = listPendingFolderAccessRequests;
+    listPendingChatPrompts = listPendingChatPrompts;
     postMessage = postMessage;
     openEvents = vi.fn(() => ({ close: vi.fn() }));
   },
@@ -119,9 +122,12 @@ beforeEach(() => {
   listChats.mockClear();
   listChats.mockResolvedValue(chats);
   createChat.mockClear();
-  listPendingUserQuestions.mockClear();
+  listPendingUserQuestions.mockReset();
   listPendingUserQuestions.mockResolvedValue([]);
-  listPendingFolderAccessRequests.mockClear();
+  listPendingFolderAccessRequests.mockReset();
+  listPendingFolderAccessRequests.mockResolvedValue([]);
+  listPendingChatPrompts.mockReset();
+  listPendingChatPrompts.mockResolvedValue([]);
   requestUserAttention.mockClear();
   postMessage.mockClear();
   usePendingPrompts.setState({ chatId: null, userQuestions: [], folderAccess: [] });
@@ -148,6 +154,16 @@ describe("app shell", () => {
 
     const recent = await screen.findAllByRole("button", { name: "Roadmap" });
     expect(recent.length).toBeGreaterThan(0);
+  });
+
+  it("marks a parked conversation other than the one that is open", async () => {
+    listPendingChatPrompts.mockResolvedValue([
+      { chatId: "chat-2", questionCallIds: ["call-parked"], folderAccessCallIds: [] },
+    ]);
+    await mountApp({ at: "/c/chat-1" });
+
+    expect(await screen.findByLabelText("New chat needs attention")).toBeInTheDocument();
+    expect(requestUserAttention).toHaveBeenCalledOnce();
   });
 
   it("says so when there is nothing to pick up", async () => {
@@ -259,14 +275,17 @@ describe("app shell", () => {
 
     // What must not stop is being told the agent has parked a turn on a
     // question. The watcher belongs to the shell, so it is still running.
-    const readsBefore = listPendingUserQuestions.mock.calls.length;
+    const readsBefore = listPendingChatPrompts.mock.calls.length;
     listPendingUserQuestions.mockResolvedValue([
       { callId: "call-1", turnId: "turn-1", askedAt: "2026-07-27T00:00:00Z", questions: [] },
     ]);
-    usePendingPrompts.getState().refresh();
+    listPendingChatPrompts.mockResolvedValue([
+      { chatId: "chat-1", questionCallIds: ["call-1"], folderAccessCallIds: [] },
+    ]);
+    useRefreshSignals.getState().signal("userQuestions");
 
     await waitFor(() =>
-      expect(listPendingUserQuestions.mock.calls.length).toBeGreaterThan(readsBefore),
+      expect(listPendingChatPrompts.mock.calls.length).toBeGreaterThan(readsBefore),
     );
     await waitFor(() =>
       expect(usePendingPrompts.getState().userQuestions).toHaveLength(1),

--- a/crates/openwave-desktop/ui/src/ChatAttention.ts
+++ b/crates/openwave-desktop/ui/src/ChatAttention.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+type ChatAttentionStore = {
+  /** Chats with a live user question or folder-access request. */
+  chatIdsWithPendingPrompts: ReadonlySet<string>;
+  setChatIdsWithPendingPrompts: (chatIds: Iterable<string>) => void;
+  clear: () => void;
+};
+
+function sameChatIds(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  return left.size === right.size && [...left].every((chatId) => right.has(chatId));
+}
+
+/**
+ * Shell-level attention state, deliberately separate from the selected chat's
+ * prompt details. Both the recent rail and the all-chats panel subscribe here.
+ */
+export const useChatAttention = create<ChatAttentionStore>()((set) => ({
+  chatIdsWithPendingPrompts: new Set(),
+  setChatIdsWithPendingPrompts: (chatIds) => {
+    const next = new Set(chatIds);
+    set((state) =>
+      sameChatIds(state.chatIdsWithPendingPrompts, next)
+        ? state
+        : { chatIdsWithPendingPrompts: next },
+    );
+  },
+  clear: () =>
+    set((state) =>
+      state.chatIdsWithPendingPrompts.size === 0
+        ? state
+        : { chatIdsWithPendingPrompts: new Set() },
+    ),
+}));

--- a/crates/openwave-desktop/ui/src/ChatsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatsPanel.dom.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Chat } from "./api";
+import { useChatAttention } from "./ChatAttention";
+import { useChatListStore } from "./ChatListStore";
+import { ChatsPanel } from "./ChatsPanel";
+import { renderWithRouter } from "./test/router";
+
+const chats: Chat[] = [
+  { id: "chat-1", title: "Roadmap", project_id: null } as unknown as Chat,
+  { id: "chat-2", title: "Release notes", project_id: null } as unknown as Chat,
+];
+
+beforeEach(() => {
+  useChatListStore.setState({
+    chats,
+    creatingChat: false,
+    deletingChatId: null,
+  });
+  useChatAttention.getState().clear();
+});
+afterEach(cleanup);
+
+describe("ChatsPanel", () => {
+  it("marks waiting chats throughout the searchable list", async () => {
+    useChatAttention.getState().setChatIdsWithPendingPrompts(["chat-2"]);
+    await renderWithRouter(<ChatsPanel activeChatId={null} onNewChat={vi.fn()} />);
+
+    expect(screen.getByLabelText("Release notes needs attention")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Roadmap needs attention")).not.toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ChatsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/ChatsPanel.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { MessageCircleMore, Search } from "lucide-react";
+import { CircleAlert, MessageCircleMore, Search } from "lucide-react";
 
 import type { Chat } from "./api";
+import { useChatAttention } from "./ChatAttention";
 import { useChatListStore } from "./ChatListStore";
 import { PanelSecondaryHeader } from "./components/PanelHeader";
 import { Button } from "./components/ui/button";
@@ -36,6 +37,9 @@ export function ChatsPanel({
 }) {
   const navigate = useNavigate();
   const chats = useChatListStore((state) => state.chats);
+  const chatIdsWithPendingPrompts = useChatAttention(
+    (state) => state.chatIdsWithPendingPrompts,
+  );
   const creatingChat = useChatListStore((state) => state.creatingChat);
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const [query, setQuery] = useState("");
@@ -102,6 +106,15 @@ export function ChatsPanel({
                   >
                     <MessageCircleMore className="size-4 shrink-0 text-muted-foreground" />
                     <span className="min-w-0 truncate">{title}</span>
+                    {chatIdsWithPendingPrompts.has(chat.id) && (
+                      <span
+                        className="ml-auto shrink-0 text-amber-600 dark:text-amber-400"
+                        aria-label={`${title} needs attention`}
+                        title="Needs attention"
+                      >
+                        <CircleAlert aria-hidden="true" className="size-4" />
+                      </span>
+                    )}
                   </button>
                 </li>
               );

--- a/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.dom.test.tsx
@@ -3,6 +3,7 @@ import { act, cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Chat } from "./api";
+import { useChatAttention } from "./ChatAttention";
 import { useChatListStore, type ChatListStore } from "./ChatListStore";
 import { Sidebar, type SidebarProps } from "./Sidebar";
 import { renderWithRouter } from "./test/router";
@@ -44,7 +45,10 @@ async function renderSidebar(overrides: Partial<SidebarProps> = {}) {
   return { props, router };
 }
 
-beforeEach(() => seedStores());
+beforeEach(() => {
+  seedStores();
+  useChatAttention.getState().clear();
+});
 afterEach(cleanup);
 
 describe("Sidebar", () => {
@@ -101,6 +105,14 @@ describe("Sidebar", () => {
         } as unknown as Chat);
     });
     expect(screen.getByText("Retro notes")).toBeInTheDocument();
+  });
+
+  it("marks recent chats that are waiting for a response", async () => {
+    useChatAttention.getState().setChatIdsWithPendingPrompts(["chat-2"]);
+    await renderSidebar();
+
+    expect(screen.getByLabelText("New chat needs attention")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Roadmap needs attention")).not.toBeInTheDocument();
   });
 
   it("opens a workspace panel by writing it into the URL", async () => {

--- a/crates/openwave-desktop/ui/src/Sidebar.tsx
+++ b/crates/openwave-desktop/ui/src/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import {
+  CircleAlert,
   Ellipsis,
   FolderOpen,
   Library,
@@ -18,6 +19,7 @@ import {
 } from "lucide-react";
 
 import type { Chat } from "./api";
+import { useChatAttention } from "./ChatAttention";
 import { useChatListStore } from "./ChatListStore";
 import {
   DropdownMenu,
@@ -81,6 +83,9 @@ export function Sidebar({
 }: SidebarProps) {
   const navigate = useNavigate();
   const chats = useChatListStore((state) => state.chats);
+  const chatIdsWithPendingPrompts = useChatAttention(
+    (state) => state.chatIdsWithPendingPrompts,
+  );
   const activeChatId = useChatListStore((state) => state.selected?.id ?? null);
   const chatsError = useChatListStore((state) => state.chatsError);
   const creatingChat = useChatListStore((state) => state.creatingChat);
@@ -197,6 +202,7 @@ export function Sidebar({
               key={chat.id}
               chat={chat}
               active={onChatRoute && chat.id === activeChatId}
+              needsAttention={chatIdsWithPendingPrompts.has(chat.id)}
               renaming={renamingChatId === chat.id}
               renameDraft={renameChatDraft}
               savingTitle={savingTitle}
@@ -280,6 +286,7 @@ function WorkspacePanelButton({
 function RecentChatRow({
   chat,
   active,
+  needsAttention,
   renaming,
   renameDraft,
   savingTitle,
@@ -293,6 +300,7 @@ function RecentChatRow({
 }: {
   chat: Chat;
   active: boolean;
+  needsAttention: boolean;
   renaming: boolean;
   renameDraft: string;
   savingTitle: boolean;
@@ -345,6 +353,15 @@ function RecentChatRow({
       >
         {title}
       </button>
+      {needsAttention && (
+        <span
+          className="shrink-0 text-amber-600 dark:text-amber-400"
+          aria-label={`${title} needs attention`}
+          title="Needs attention"
+        >
+          <CircleAlert aria-hidden="true" size={15} />
+        </span>
+      )}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ApiClient,
   parseFolderAccessRequest,
+  parsePendingChatPrompt,
   parsePendingUserQuestions,
   parsePendingToolApproval,
   parseSandboxAgentCancellation,
@@ -97,6 +98,52 @@ describe("parseFolderAccessRequest", () => {
         claimed: "yes",
       }),
     ).toBeNull();
+  });
+});
+
+describe("pending chat prompt summaries", () => {
+  const safe = {
+    chat_id: "chat-1",
+    question_call_ids: ["question-1"],
+    folder_access_call_ids: ["folder-1"],
+  };
+
+  it("accepts only opaque prompt identities", () => {
+    expect(parsePendingChatPrompt(safe)).toEqual({
+      chatId: "chat-1",
+      questionCallIds: ["question-1"],
+      folderAccessCallIds: ["folder-1"],
+    });
+  });
+
+  it("rejects detail, duplicate identities, and empty summaries", () => {
+    expect(parsePendingChatPrompt({ ...safe, questions: [{ question: "private" }] })).toBeNull();
+    expect(
+      parsePendingChatPrompt({ ...safe, folder_access_call_ids: ["question-1"] }),
+    ).toBeNull();
+    expect(
+      parsePendingChatPrompt({
+        ...safe,
+        question_call_ids: [],
+        folder_access_call_ids: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("fetches and validates the complete page", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([safe]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await expect(client.listPendingChatPrompts()).resolves.toEqual([
+      { chatId: "chat-1", questionCallIds: ["question-1"], folderAccessCallIds: ["folder-1"] },
+    ]);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://127.0.0.1/chats/pending-prompts");
   });
 });
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -255,6 +255,13 @@ export type PendingFolderAccessRequest = {
   claimedByDesktop: boolean;
 };
 
+/** Opaque prompt state used to mark another chat as needing attention. */
+export type PendingChatPrompt = {
+  chatId: string;
+  questionCallIds: string[];
+  folderAccessCallIds: string[];
+};
+
 export type UserQuestionOption = {
   id: string;
   label: string;
@@ -501,6 +508,24 @@ export class ApiClient {
 
   listChats(): Promise<Chat[]> {
     return this.json("/chats", { headers: this.headers() });
+  }
+
+  async listPendingChatPrompts(): Promise<PendingChatPrompt[]> {
+    const body = await this.json<unknown>("/chats/pending-prompts", {
+      headers: this.headers(),
+    });
+    if (!Array.isArray(body)) {
+      throw new Error("pending chat prompt response is not an array");
+    }
+    const prompts = new Map<string, PendingChatPrompt>();
+    for (const item of body) {
+      const prompt = parsePendingChatPrompt(item);
+      if (!prompt || prompts.has(prompt.chatId)) {
+        throw new Error("pending chat prompt response contains invalid data");
+      }
+      prompts.set(prompt.chatId, prompt);
+    }
+    return [...prompts.values()];
   }
 
   deleteChat(chatId: string): Promise<void> {
@@ -766,6 +791,46 @@ export function parseFolderAccessRequest(
     folderHint,
     claimedByDesktop: value.claimed,
   };
+}
+
+/**
+ * Validate the intentionally small parked-chat summary before it reaches
+ * shared shell state. Details belong to the selected chat's recovery route,
+ * never to the list indicator.
+ */
+export function parsePendingChatPrompt(value: unknown): PendingChatPrompt | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<{
+      chat_id: string;
+      question_call_ids: string[];
+      folder_access_call_ids: string[];
+    }>(value, ["chat_id", "question_call_ids", "folder_access_call_ids"]) ||
+    !nonEmptyBounded(value.chat_id, 128)
+  ) {
+    return null;
+  }
+  const questionCallIds = parseOpaqueCallIds(value.question_call_ids);
+  const folderAccessCallIds = parseOpaqueCallIds(value.folder_access_call_ids);
+  if (
+    !questionCallIds ||
+    !folderAccessCallIds ||
+    questionCallIds.length + folderAccessCallIds.length === 0 ||
+    questionCallIds.some((callId) => folderAccessCallIds.includes(callId))
+  ) {
+    return null;
+  }
+  return { chatId: value.chat_id, questionCallIds, folderAccessCallIds };
+}
+
+function parseOpaqueCallIds(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.length > 64) return null;
+  const callIds = new Set<string>();
+  for (const callId of value) {
+    if (!nonEmptyBounded(callId, 128) || callIds.has(callId)) return null;
+    callIds.add(callId);
+  }
+  return [...callIds];
 }
 
 export function parsePendingUserQuestions(

--- a/crates/openwave-desktop/ui/src/useChatPromptWatcher.test.ts
+++ b/crates/openwave-desktop/ui/src/useChatPromptWatcher.test.ts
@@ -3,6 +3,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ApiClient } from "./api";
+import { useChatAttention } from "./ChatAttention";
 import { usePendingPrompts } from "./PendingPrompts";
 import { useRefreshSignals } from "./RefreshSignals";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
@@ -20,8 +21,16 @@ function folderRequest(callId: string) {
   return { callId, turnId: "turn-1", displayPath: "~/Notes" };
 }
 
+function prompt(
+  chatId: string,
+  { questions = [], folderAccess = [] }: { questions?: string[]; folderAccess?: string[] } = {},
+) {
+  return { chatId, questionCallIds: questions, folderAccessCallIds: folderAccess };
+}
+
 function stubClient(overrides: Record<string, unknown> = {}) {
   return {
+    listPendingChatPrompts: vi.fn().mockResolvedValue([]),
     listPendingUserQuestions: vi.fn().mockResolvedValue([]),
     listPendingFolderAccessRequests: vi.fn().mockResolvedValue([]),
     ...overrides,
@@ -31,6 +40,7 @@ function stubClient(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.mocked(host.requestUserAttention).mockClear();
   usePendingPrompts.setState({ chatId: null, userQuestions: [], folderAccess: [] });
+  useChatAttention.getState().clear();
 });
 afterEach(cleanup);
 
@@ -55,17 +65,18 @@ describe("useChatPromptWatcher", () => {
     act(() => useRefreshSignals.getState().signal("userQuestions"));
 
     await waitFor(() => expect(client.listPendingUserQuestions).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(client.listPendingChatPrompts).toHaveBeenCalledTimes(2));
   });
 
   it("asks for attention once per question, not once per read", async () => {
     const client = stubClient({
-      listPendingUserQuestions: vi.fn().mockResolvedValue([question("call-1")]),
+      listPendingChatPrompts: vi.fn().mockResolvedValue([prompt("chat-2", { questions: ["call-1"] })]),
     });
     renderHook(() => useChatPromptWatcher(client, "chat-1"));
     await waitFor(() => expect(host.requestUserAttention).toHaveBeenCalledTimes(1));
 
     act(() => useRefreshSignals.getState().signal("userQuestions"));
-    await waitFor(() => expect(client.listPendingUserQuestions).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(client.listPendingChatPrompts).toHaveBeenCalledTimes(2));
 
     expect(host.requestUserAttention).toHaveBeenCalledTimes(1);
   });
@@ -73,18 +84,18 @@ describe("useChatPromptWatcher", () => {
   it("forgets a question once it stops being pending", async () => {
     // The announce-set spans the life of the shell, so it has to be pruned or a
     // long session accumulates the id of every question ever asked.
-    const listPendingUserQuestions = vi
+    const listPendingChatPrompts = vi
       .fn()
-      .mockResolvedValueOnce([question("call-1")])
+      .mockResolvedValueOnce([prompt("chat-1", { questions: ["call-1"] })])
       .mockResolvedValue([]);
-    const client = stubClient({ listPendingUserQuestions });
+    const client = stubClient({ listPendingChatPrompts });
     renderHook(() => useChatPromptWatcher(client, "chat-1"));
     await waitFor(() => expect(host.requestUserAttention).toHaveBeenCalledTimes(1));
 
     act(() => useRefreshSignals.getState().signal("userQuestions"));
     await waitFor(() => expect(usePendingPrompts.getState().userQuestions).toHaveLength(0));
 
-    listPendingUserQuestions.mockResolvedValue([question("call-2")]);
+    listPendingChatPrompts.mockResolvedValue([prompt("chat-1", { questions: ["call-2"] })]);
     act(() => useRefreshSignals.getState().signal("userQuestions"));
 
     await waitFor(() => expect(host.requestUserAttention).toHaveBeenCalledTimes(2));
@@ -129,10 +140,21 @@ describe("useChatPromptWatcher", () => {
     expect(usePendingPrompts.getState().userQuestions).toHaveLength(0);
   });
 
-  it("stops watching when there is no conversation open", async () => {
-    const client = stubClient();
+  it("marks parked chats even when no conversation is open", async () => {
+    const client = stubClient({
+      listPendingChatPrompts: vi.fn().mockResolvedValue([
+        prompt("chat-2", { questions: ["call-question"] }),
+        prompt("chat-3", { folderAccess: ["call-folder"] }),
+      ]),
+    });
     renderHook(() => useChatPromptWatcher(client, null));
 
+    await waitFor(() =>
+      expect(useChatAttention.getState().chatIdsWithPendingPrompts).toEqual(
+        new Set(["chat-2", "chat-3"]),
+      ),
+    );
+    expect(host.requestUserAttention).toHaveBeenCalledTimes(1);
     expect(client.listPendingUserQuestions).not.toHaveBeenCalled();
     expect(usePendingPrompts.getState().userQuestions).toEqual([]);
   });

--- a/crates/openwave-desktop/ui/src/useChatPromptWatcher.ts
+++ b/crates/openwave-desktop/ui/src/useChatPromptWatcher.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 
 import type { ApiClient } from "./api";
+import { useChatAttention } from "./ChatAttention";
 import { requestUserAttention } from "./host";
 import { usePendingPrompts } from "./PendingPrompts";
 import { useRefreshSignals } from "./RefreshSignals";
@@ -8,35 +9,97 @@ import { useRefreshSignals } from "./RefreshSignals";
 const POLL_INTERVAL_MS = 10_000;
 
 const promptActions = usePendingPrompts.getState();
+const attentionActions = useChatAttention.getState();
 
 /**
- * Watches the open conversation for anything the agent is parked waiting on.
+ * Watches every conversation for a parked prompt and keeps detailed prompt
+ * cards current for the open one.
  *
- * Mounted by the shell rather than by a view, because the answer to "has the
- * agent asked me something?" cannot depend on which screen is rendered. Reading
- * the settings screen does not mean the agent stopped asking.
- *
- * Polling is the durable truth and the event stream only says when to look
- * again, so this stays correct with no socket at all — which is what makes it
- * safe for the conversation itself to unmount.
+ * The summary poll is deliberately one server-side read, rather than a browser
+ * loop over chats. Detail still comes from the selected chat's established
+ * recovery routes, which keeps prompt content scoped to the conversation that
+ * can render it.
  */
 export function useChatPromptWatcher(client: ApiClient | null, chatId: string | null): void {
-  // Which questions the reader has already been alerted to. This lives for as
-  // long as the shell does, so it spans chat switches and screen changes: a
-  // question announced once is not announced again when the reader comes back
-  // to it. Pruned to what is still pending on every read, so a long session
-  // does not accumulate the id of every question ever asked.
+  // Which questions the shell has already announced. It spans chat switches
+  // and screens, then is pruned to the current server summary after each read.
   const announcedCallIdsRef = useRef<Set<string>>(new Set());
   const refreshRef = useRef<(() => void) | null>(null);
+  const detailsRefreshRef = useRef<(() => void) | null>(null);
   const questionsSignal = useRefreshSignals((state) => state.userQuestions);
   const folderSignal = useRefreshSignals((state) => state.folderAccess);
+
+  useEffect(() => {
+    if (!client) {
+      attentionActions.clear();
+      announcedCallIdsRef.current = new Set();
+      refreshRef.current = null;
+      return;
+    }
+
+    // A new client can point at a different local profile. Do not leave its
+    // sidebar carrying the previous server's attention state until the first
+    // summary response arrives.
+    attentionActions.clear();
+    announcedCallIdsRef.current = new Set();
+    let cancelled = false;
+    let summarySeq = 0;
+
+    const readSummary = async () => {
+      const seq = ++summarySeq;
+      try {
+        const pending = await client.listPendingChatPrompts();
+        if (cancelled || seq !== summarySeq) return;
+
+        attentionActions.setChatIdsWithPendingPrompts(
+          pending.map((prompt) => prompt.chatId),
+        );
+        const pendingQuestionIds = new Set(
+          pending.flatMap((prompt) => prompt.questionCallIds),
+        );
+        const unannounced = [...pendingQuestionIds].filter(
+          (callId) => !announcedCallIdsRef.current.has(callId),
+        );
+        announcedCallIdsRef.current = pendingQuestionIds;
+        if (unannounced.length > 0) {
+          void requestUserAttention().catch(() => {
+            // Attention is a best-effort hint. Durable polling is truth.
+          });
+        }
+      } catch (err) {
+        if (!cancelled && seq === summarySeq) {
+          // Keep the last successful state visible. Clearing it on a transient
+          // failure would make a waiting chat look resolved.
+          console.error("failed to refresh pending chat prompts", err);
+        }
+      }
+    };
+
+    const readAll = () => {
+      void readSummary();
+      detailsRefreshRef.current?.();
+    };
+
+    refreshRef.current = readAll;
+    readAll();
+    const interval = window.setInterval(readAll, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      summarySeq += 1;
+      window.clearInterval(interval);
+      refreshRef.current = null;
+    };
+  }, [client]);
 
   useEffect(() => {
     promptActions.reset(chatId);
     if (!client || !chatId) {
       promptActions.setRefresh(() => {});
+      detailsRefreshRef.current = null;
       return;
     }
+
     let cancelled = false;
     let questionsSeq = 0;
     let folderSeq = 0;
@@ -45,16 +108,8 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
       const seq = ++questionsSeq;
       try {
         const pending = await client.listPendingUserQuestions(chatId);
-        if (cancelled || seq !== questionsSeq) return;
-        const unannounced = pending.filter(
-          (request) => !announcedCallIdsRef.current.has(request.callId),
-        );
-        announcedCallIdsRef.current = new Set(pending.map((request) => request.callId));
-        promptActions.setUserQuestions(chatId, pending);
-        if (unannounced.length > 0) {
-          void requestUserAttention().catch(() => {
-            // Attention is a best-effort hint. Durable polling is truth.
-          });
+        if (!cancelled && seq === questionsSeq) {
+          promptActions.setUserQuestions(chatId, pending);
         }
       } catch (err) {
         if (!cancelled && seq === questionsSeq) {
@@ -76,22 +131,20 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
       }
     };
 
-    const readAll = () => {
+    const readDetails = () => {
       void readQuestions();
       void readFolderAccess();
     };
 
-    refreshRef.current = readAll;
-    promptActions.setRefresh(readAll);
-    readAll();
-    const interval = window.setInterval(readAll, POLL_INTERVAL_MS);
+    detailsRefreshRef.current = readDetails;
+    promptActions.setRefresh(readDetails);
+    readDetails();
 
     return () => {
       cancelled = true;
       questionsSeq += 1;
       folderSeq += 1;
-      window.clearInterval(interval);
-      refreshRef.current = null;
+      detailsRefreshRef.current = null;
       promptActions.setRefresh(() => {});
     };
   }, [client, chatId]);

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -290,6 +290,10 @@ pub fn app(state: AppState) -> Router {
         .merge(public_document_api)
         .route("/chats", post(routes::create_chat).get(routes::list_chats))
         .route(
+            "/chats/pending-prompts",
+            get(routes::list_pending_chat_prompts),
+        )
+        .route(
             "/chats/{id}",
             get(routes::get_chat)
                 .patch(routes::patch_chat)

--- a/crates/openwave-server/src/routes/user_questions.rs
+++ b/crates/openwave-server/src/routes/user_questions.rs
@@ -4,7 +4,7 @@ use axum::extract::State;
 use chrono::Utc;
 use openwave_core::{
     AnswerUserQuestions, AnswerUserQuestionsOutcome, AnswerUserQuestionsRequest, CallId, ChatId,
-    PendingUserQuestions, TurnRunStatus,
+    PendingChatPrompt, PendingUserQuestions, TurnRunStatus,
 };
 use serde::Serialize;
 
@@ -23,6 +23,17 @@ pub async fn list_pending_user_questions(
     Ok(Json(
         state.store.list_pending_user_questions(chat_id).await?,
     ))
+}
+
+/// `GET /chats/pending-prompts` — opaque cross-conversation attention state.
+///
+/// The shell uses this single summary read to find parked chats. Detail stays
+/// behind each chat's dedicated prompt-recovery route, so this endpoint never
+/// carries question content, folder-access arguments, or executor metadata.
+pub async fn list_pending_chat_prompts(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<PendingChatPrompt>>, ServerError> {
+    Ok(Json(state.store.list_pending_chat_prompts().await?))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -3974,6 +3974,86 @@ async fn renderer_pending_client_executions_are_a_closed_folder_consent_projecti
 }
 
 #[tokio::test]
+async fn pending_chat_prompts_are_cross_chat_opaque_summaries() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let question_chat = make_chat(&router, &bearer).await;
+    let (_question_turn_id, question_call) =
+        park_user_questions_for_route_test(&*store, question_chat.id).await;
+    let folder_chat = make_chat(&router, &bearer).await;
+    let folder_call = ToolCallRecord {
+        id: CallId::new(),
+        chat_id: folder_chat.id,
+        turn_id: TurnId::new(),
+        provider_id: "folder-provider-secret".into(),
+        name: openwave_core::REQUEST_FOLDER_ACCESS_TOOL.into(),
+        arguments: serde_json::json!({
+            "reason": "Read the project notes",
+            "requested_capabilities": ["read_files"],
+            "folder_hint": "documents",
+        }),
+        execution: ToolCallExecution::Client,
+        status: ToolCallStatus::Pending,
+        result: None,
+        error_code: None,
+        error_detail: None,
+        client_executor_id: None,
+        client_lease_expires_at: None,
+        created_at: chrono::Utc::now(),
+        resolved_at: None,
+    };
+    let folder_call = match store.accept_tool_call(&folder_call).await.unwrap() {
+        openwave_core::AcceptToolCallOutcome::Accepted(call)
+        | openwave_core::AcceptToolCallOutcome::Existing(call) => call,
+        openwave_core::AcceptToolCallOutcome::IdentityConflict => {
+            panic!("fresh folder call identity conflicted")
+        }
+    };
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/chats/pending-prompts")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let summaries: serde_json::Value = json_body(response).await;
+    let summaries = summaries.as_array().expect("summary response is an array");
+    assert_eq!(summaries.len(), 2);
+    assert!(summaries.iter().any(|summary| {
+        summary["chat_id"] == question_chat.id.to_string()
+            && summary["question_call_ids"] == serde_json::json!([question_call.id.to_string()])
+            && summary["folder_access_call_ids"] == serde_json::json!([])
+    }));
+    assert!(summaries.iter().any(|summary| {
+        summary["chat_id"] == folder_chat.id.to_string()
+            && summary["question_call_ids"] == serde_json::json!([])
+            && summary["folder_access_call_ids"] == serde_json::json!([folder_call.id.to_string()])
+    }));
+
+    let serialized = serde_json::to_string(summaries).unwrap();
+    for private in [
+        "provider-question",
+        "folder-provider-secret",
+        "Where should I deploy?",
+        "Read the project notes",
+        "arguments",
+        "turn_id",
+        "client_executor_id",
+        "folder_hint",
+    ] {
+        assert!(
+            !serialized.contains(private),
+            "pending-chat summary exposed {private}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn client_resolution_publishes_cancellation_and_wakes_resumable_turns() {
     let dir = tempfile::tempdir().unwrap();
     let store: Arc<dyn Store> = Arc::new(


### PR DESCRIPTION
Closes #559

Adds one opaque server-side prompt-summary endpoint so the desktop can discover parked prompts without polling every chat. The shell retains detailed recovery for the selected chat, marks every waiting chat in Recent and All chats, and requests attention once per pending user question.

Tests cover the cross-chat summary boundary, watcher deduplication, list indicators, and the app shell noticing a parked non-open chat.

Validated with cargo fmt --all --check, cargo clippy --workspace --all-targets --locked -- -D warnings, cargo test --workspace --locked, cargo check --workspace --locked, pnpm test, and pnpm run build in crates/openwave-desktop/ui.