### PR TITLE
feat(providers): a model-gateway provider signed in with rotating OAuth tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6800,6 +6800,7 @@ dependencies = [
  "futures",
  "image",
  "openwave-code-execution",
+ "openwave-connectors",
  "openwave-core",
  "openwave-mcp",
  "openwave-retrieval",

--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -198,6 +198,17 @@ impl std::fmt::Debug for GatewayCredentials {
     }
 }
 
+/// Whether a gateway session is stored, without constructing a vault.
+///
+/// For readiness surfaces (`has_credential`-style projections) that hold only
+/// a borrowed [`SecretProvider`].
+pub async fn has_stored_credentials(secrets: &dyn SecretProvider) -> bool {
+    matches!(
+        secrets.get_secret(SECRET_KEY).await,
+        Ok(Some(raw)) if serde_json::from_str::<GatewayCredentials>(&raw).is_ok()
+    )
+}
+
 /// Keychain-backed storage for [`GatewayCredentials`].
 #[derive(Clone)]
 pub struct CredentialVault {
@@ -557,6 +568,13 @@ impl GatewayConnection {
             vault,
             token_motion: Mutex::new(()),
         }
+    }
+
+    /// The underlying auth client, for flows that operate before a session
+    /// exists (starting a browser sign-in).
+    #[must_use]
+    pub fn auth(&self) -> &GatewayAuth {
+        &self.auth
     }
 
     /// Persist a completed sign-in as the connection's stored credentials.

--- a/crates/openwave-connectors/src/lib.rs
+++ b/crates/openwave-connectors/src/lib.rs
@@ -22,7 +22,7 @@
 mod gateway;
 
 pub use gateway::{
-    is_sign_in_required, AuthorizedSession, CredentialVault, GatewayAuth, GatewayAuthConfig,
-    GatewayConnection, GatewayCredentials, GatewayIdentity, GatewayMeta, GatewayModel,
-    PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
+    has_stored_credentials, is_sign_in_required, AuthorizedSession, CredentialVault, GatewayAuth,
+    GatewayAuthConfig, GatewayConnection, GatewayCredentials, GatewayIdentity, GatewayMeta,
+    GatewayModel, PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
 };

--- a/crates/openwave-desktop/ui/src/ModelSelection.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.ts
@@ -40,5 +40,7 @@ export function providerLabel(provider: ProviderKind): string {
       return "OpenAI";
     case "openai_compatible":
       return "OpenAI-compatible";
+    case "model_gateway":
+      return "Model Gateway";
   }
 }

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -235,6 +235,12 @@ context_window: number,
 max_output_tokens: number, };
 
 /**
+ * Renderer-safe projection of the gateway connection state. Never carries
+ * token material — only what the settings surface displays.
+ */
+export type GatewayStatus = { configured: boolean, enabled: boolean, base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number, sign_in: SignInProgress, };
+
+/**
  * Opaque identifier for a folder registered with a host broker.
  *
  * This is product projection data, not authority: possession of an id never
@@ -461,7 +467,7 @@ models: Array<CustomModelConfig>, };
  * The known provider kinds. `#[non_exhaustive]` so new kinds can land without
  * breaking wire clients that match on the string form.
  */
-export type ProviderKind = "anthropic" | "openai" | "openai_compatible";
+export type ProviderKind = "anthropic" | "openai" | "openai_compatible" | "model_gateway";
 
 /**
  * How hard a reasoning-capable model should think before answering.
@@ -545,6 +551,11 @@ model: string | null,
  * Whether a model API key is configured (never the key itself).
  */
 has_api_key: boolean, };
+
+/**
+ * Renderer-safe progress of the current sign-in attempt.
+ */
+export type SignInProgress = { "state": "idle" } | { "state": "pending", authorization_url: string, } | { "state": "failed", message: string, };
 
 /**
  * The action a call will take, in a form a human can inspect.

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -23,9 +23,14 @@ export function ProvidersPanel({
       title="Providers"
       description="Keys stay on this machine. Enable a provider, then save a credential."
     >
-      {providers.map((p) => (
-        <ProviderRow key={p.kind} info={p} client={client} onChanged={onChanged} />
-      ))}
+      {providers
+        // The gateway signs in with OAuth, not a pasted key; its whole
+        // surface (connect, identity, entitled models) lives in the
+        // dedicated Model Gateway settings panel.
+        .filter((p) => p.kind !== "model_gateway")
+        .map((p) => (
+          <ProviderRow key={p.kind} info={p} client={client} onChanged={onChanged} />
+        ))}
     </SettingsPanel>
   );
 }

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -35,6 +35,9 @@ pub struct AnthropicProvider {
     client: reqwest::Client,
     api_key: String,
     base_url: String,
+    /// Per-request credential supplier for gateways that mint short-lived
+    /// tokens. Takes precedence over `api_key` when present.
+    token_source: Option<std::sync::Arc<dyn crate::BearerTokenSource>>,
 }
 
 impl AnthropicProvider {
@@ -44,6 +47,7 @@ impl AnthropicProvider {
             client: reqwest::Client::new(),
             api_key: api_key.into(),
             base_url: DEFAULT_BASE_URL.to_string(),
+            token_source: None,
         }
     }
 
@@ -52,6 +56,17 @@ impl AnthropicProvider {
     #[must_use]
     pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into();
+        self
+    }
+
+    /// Fetch the credential from `source` at each request instead of using a
+    /// static key. For gateways whose tokens rotate under the adapter.
+    #[must_use]
+    pub fn with_token_source(
+        mut self,
+        source: std::sync::Arc<dyn crate::BearerTokenSource>,
+    ) -> Self {
+        self.token_source = Some(source);
         self
     }
 }
@@ -65,6 +80,10 @@ impl ModelProvider for AnthropicProvider {
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         let body = build_request_json(&req)?;
         let url = format!("{}/v1/messages", self.base_url);
+        let api_key = match &self.token_source {
+            Some(source) => source.bearer_token().await?,
+            None => self.api_key.clone(),
+        };
 
         // Setup failures (connection, auth, 4xx/5xx) surface here as `Err` so the
         // router can classify and fail over; the returned stream only yields
@@ -72,7 +91,7 @@ impl ModelProvider for AnthropicProvider {
         let response = self
             .client
             .post(url)
-            .header("x-api-key", &self.api_key)
+            .header("x-api-key", &api_key)
             .header("anthropic-version", ANTHROPIC_VERSION)
             .header("content-type", "application/json")
             .json(&body)

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -21,4 +21,4 @@ pub mod openai_compat;
 pub use anthropic::AnthropicProvider;
 #[cfg(feature = "openai-compat")]
 pub use openai_compat::OpenAiCompatProvider;
-pub use router::{Route, RouteKind, Router};
+pub use router::{BearerTokenSource, Route, RouteKind, Router};

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -22,6 +22,18 @@ use crate::AnthropicProvider;
 #[cfg(feature = "openai-compat")]
 use crate::OpenAiCompatProvider;
 
+/// A per-request credential supplier for routes whose token is short-lived.
+///
+/// A static key is snapshotted into the adapter for the lifetime of a cached
+/// router; a governed endpoint minting ten-minute tokens needs the opposite —
+/// the adapter asks this source at each request and the source refreshes
+/// behind its own lock. Implementations must never log or echo the token.
+#[async_trait]
+pub trait BearerTokenSource: Send + Sync {
+    /// A currently valid token, refreshing if the cached one is near expiry.
+    async fn bearer_token(&self) -> Result<String>;
+}
+
 /// Which concrete adapter a [`Route`] builds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
@@ -32,6 +44,9 @@ pub enum RouteKind {
     Openai,
     /// Any OpenAI-compatible Chat Completions gateway.
     OpenaiCompatible,
+    /// A model-gateway deployment's Anthropic-compatible surface, authenticated
+    /// with short-lived resource-scoped tokens instead of a static key.
+    ModelGateway,
 }
 
 impl RouteKind {
@@ -41,6 +56,7 @@ impl RouteKind {
             RouteKind::Anthropic => "anthropic",
             RouteKind::Openai => "openai",
             RouteKind::OpenaiCompatible => "openai_compatible",
+            RouteKind::ModelGateway => "model_gateway",
         }
     }
 
@@ -49,6 +65,7 @@ impl RouteKind {
             "anthropic" => Some(Self::Anthropic),
             "openai" => Some(Self::Openai),
             "openai_compatible" => Some(Self::OpenaiCompatible),
+            "model_gateway" => Some(Self::ModelGateway),
             _ => None,
         }
     }
@@ -59,13 +76,16 @@ impl RouteKind {
 pub struct Route {
     /// Which adapter to build.
     pub kind: RouteKind,
-    /// API key / bearer token.
+    /// API key / bearer token. Empty when `token_source` supplies credentials.
     pub api_key: String,
     /// Optional base URL override (required in practice for `OpenaiCompatible`).
     pub base_url: Option<String>,
     /// Curated model ids this route claims. Used for preferential selection;
     /// `OpenaiCompatible` typically passes an empty list (free-form fallback).
     pub curated_models: Vec<String>,
+    /// Per-request credential supplier for short-lived tokens. Takes
+    /// precedence over `api_key` when present.
+    pub token_source: Option<Arc<dyn BearerTokenSource>>,
 }
 
 impl std::fmt::Debug for Route {
@@ -75,6 +95,7 @@ impl std::fmt::Debug for Route {
             .field("api_key", &"***")
             .field("base_url", &self.base_url)
             .field("curated_models", &self.curated_models)
+            .field("token_source", &self.token_source.is_some())
             .finish()
     }
 }
@@ -136,6 +157,7 @@ impl Router {
         for kind in [
             RouteKind::Anthropic,
             RouteKind::Openai,
+            RouteKind::ModelGateway,
             RouteKind::OpenaiCompatible,
         ] {
             if self
@@ -204,7 +226,7 @@ impl ModelProvider for Router {
 }
 
 fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
-    if route.api_key.is_empty() {
+    if route.api_key.is_empty() && route.token_source.is_none() {
         return None;
     }
     match route.kind {
@@ -218,6 +240,25 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         }
         #[cfg(not(feature = "anthropic"))]
         RouteKind::Anthropic => None,
+
+        #[cfg(feature = "anthropic")]
+        RouteKind::ModelGateway => {
+            // A gateway route is only usable with its base URL and a live
+            // token source; a static key cannot follow the gateway's
+            // ten-minute rotation.
+            let base = route.base_url.as_deref()?;
+            if !(base.starts_with("https://") || base.starts_with("http://")) {
+                return None;
+            }
+            let source = route.token_source.clone()?;
+            Some(Arc::new(
+                AnthropicProvider::new(String::new())
+                    .with_base_url(base.to_string())
+                    .with_token_source(source),
+            ))
+        }
+        #[cfg(not(feature = "anthropic"))]
+        RouteKind::ModelGateway => None,
 
         #[cfg(feature = "openai-compat")]
         RouteKind::Openai => {
@@ -252,9 +293,16 @@ fn fingerprint_routes(routes: &[Route]) -> String {
         .iter()
         .map(|r| {
             format!(
-                "{}|{:x}|{}|{}",
+                "{}|{}|{}|{}",
                 r.kind.as_str(),
-                fnv1a64(&r.api_key),
+                // A rotating token must not thrash the cached router; the
+                // fingerprint tracks *whether* a live source exists, and the
+                // source itself refreshes per request.
+                if r.token_source.is_some() {
+                    "oauth".to_string()
+                } else {
+                    format!("{:x}", fnv1a64(&r.api_key))
+                },
                 r.base_url.as_deref().unwrap_or(""),
                 {
                     let mut models = r.curated_models.clone();
@@ -290,6 +338,7 @@ mod tests {
             api_key: key.into(),
             base_url: base.map(str::to_owned),
             curated_models: models.iter().map(|m| (*m).to_string()).collect(),
+            token_source: None,
         }
     }
 
@@ -355,6 +404,69 @@ mod tests {
             Some("file:///etc/passwd"),
         )]);
         assert_eq!(router.select("anything"), None);
+    }
+
+    struct StaticSource(&'static str);
+
+    #[async_trait]
+    impl BearerTokenSource for StaticSource {
+        async fn bearer_token(&self) -> Result<String> {
+            Ok(self.0.to_string())
+        }
+    }
+
+    #[test]
+    fn a_model_gateway_route_requires_a_live_token_source() {
+        // No source ⇒ no adapter, even with a base URL: a static key cannot
+        // follow the gateway's rotation, so there is nothing to build.
+        let without = Router::build(vec![route(
+            RouteKind::ModelGateway,
+            "",
+            &["claude-fable-5"],
+            Some("http://127.0.0.1:28081/compat/anthropic"),
+        )]);
+        assert_eq!(without.select("claude-fable-5"), None);
+
+        let mut gateway = route(
+            RouteKind::ModelGateway,
+            "",
+            &["claude-fable-5"],
+            Some("http://127.0.0.1:28081/compat/anthropic"),
+        );
+        gateway.token_source = Some(Arc::new(StaticSource("mg_at_x")));
+        let with = Router::build(vec![gateway]);
+        assert_eq!(with.select("claude-fable-5"), Some(RouteKind::ModelGateway));
+        // Only claimed (synced) models route to the gateway; it is not a
+        // free-form fallback.
+        assert_eq!(with.select("unknown"), None);
+        assert_eq!(
+            with.select_for(Some(&ProviderId::new("model_gateway")), "claude-fable-5"),
+            Some(RouteKind::ModelGateway)
+        );
+        assert_eq!(
+            with.select_for(Some(&ProviderId::new("model_gateway")), "unknown"),
+            None
+        );
+    }
+
+    #[test]
+    fn fingerprint_is_stable_across_token_rotation() {
+        let build = |token: &'static str| {
+            let mut r = route(
+                RouteKind::ModelGateway,
+                "",
+                &["m"],
+                Some("http://127.0.0.1:1/compat/anthropic"),
+            );
+            r.token_source = Some(Arc::new(StaticSource(token)));
+            Router::build(vec![r])
+        };
+        // The token value must not enter the fingerprint: a rotation would
+        // otherwise rebuild the cached router every ten minutes.
+        assert_eq!(
+            build("mg_at_one").fingerprint(),
+            build("mg_at_two").fingerprint()
+        );
     }
 
     #[test]

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -40,6 +40,7 @@ vec-lance = ["openwave-retrieval/vec-lance"]
 [dependencies]
 openwave-code-execution = { path = "../openwave-code-execution" }
 openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools", "keychain", "blob-fs"] }
+openwave-connectors = { path = "../openwave-connectors" }
 openwave-mcp = { path = "../openwave-mcp" }
 openwave-router = { path = "../openwave-router" }
 openwave-retrieval = { path = "../openwave-retrieval" }

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -1,0 +1,574 @@
+//! The server's handle on a signed-in model-gateway session.
+//!
+//! Owns the [`GatewayConnection`] built from the persisted provider
+//! configuration, hands the router a per-request token source for the
+//! gateway's short-lived `llm` tokens, and syncs the entitled model list into
+//! the provider's stored custom-model set so the picker and model policy work
+//! from durable local state while the gateway stays the live authority at
+//! inference time.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use openwave_connectors::{
+    CredentialVault, GatewayAuth, GatewayAuthConfig, GatewayConnection, RESOURCE_LLM,
+};
+use openwave_core::{AgentError, Result, SecretProvider, Store};
+use openwave_router::BearerTokenSource;
+use serde::Serialize;
+use tokio::sync::Mutex;
+
+use crate::providers::{self, CustomModelConfig, ProviderKind};
+
+/// How long a browser sign-in may stay pending before it fails.
+const SIGN_IN_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Development-only escape hatch: the gateway hardcodes its own CLI's client
+/// id until it grows a client registry, so that identity is the default. Set
+/// this variable to exactly `openwave` to use the first-class client id once
+/// the deployed gateway registers it; any other value is ignored.
+const CLIENT_ID_ENV: &str = "OPENWAVE_GATEWAY_CLIENT_ID";
+
+pub(crate) struct GatewayRuntime {
+    store: Arc<dyn Store>,
+    secrets: Arc<dyn SecretProvider>,
+    /// One connection per configured base URL; rebuilt when the URL changes.
+    cached: Mutex<Option<(String, Arc<GatewayConnection>)>>,
+    /// The one in-flight browser sign-in, if any.
+    sign_in: Mutex<SignInProgress>,
+    /// Bumped by every `begin_sign_in` and `sign_out`; a background exchange
+    /// task may only store its session and stamp its outcome while its own
+    /// generation is still current, so a stale attempt can neither clobber a
+    /// newer one's status nor resurrect a signed-out session.
+    sign_in_generation: std::sync::atomic::AtomicU64,
+}
+
+/// Renderer-safe progress of the current sign-in attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub(crate) enum SignInProgress {
+    /// No sign-in is running.
+    Idle,
+    /// The browser flow is open; the renderer should offer this URL.
+    Pending { authorization_url: String },
+    /// The last attempt failed with a bounded, secret-free message.
+    Failed { message: String },
+}
+
+/// Renderer-safe projection of the gateway connection state. Never carries
+/// token material — only what the settings surface displays.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub(crate) struct GatewayStatus {
+    pub(crate) configured: bool,
+    pub(crate) enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub(crate) base_url: Option<String>,
+    pub(crate) signed_in: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub(crate) account_hint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub(crate) installation_id: Option<String>,
+    pub(crate) model_count: usize,
+    pub(crate) sign_in: SignInProgress,
+}
+
+impl GatewayRuntime {
+    pub(crate) fn new(store: Arc<dyn Store>, secrets: Arc<dyn SecretProvider>) -> Arc<Self> {
+        Arc::new(Self {
+            store,
+            secrets,
+            cached: Mutex::new(None),
+            sign_in: Mutex::new(SignInProgress::Idle),
+            sign_in_generation: std::sync::atomic::AtomicU64::new(0),
+        })
+    }
+
+    /// The renderer-facing connection status.
+    pub(crate) async fn status(&self) -> Result<GatewayStatus> {
+        let config = providers::read_config(&*self.store, ProviderKind::ModelGateway).await?;
+        let credentials = match self.connection().await? {
+            Some(connection) => connection.stored_credentials().await?,
+            None => None,
+        };
+        Ok(GatewayStatus {
+            configured: config.base_url.is_some(),
+            enabled: config.enabled,
+            base_url: config.base_url,
+            signed_in: credentials.is_some(),
+            account_hint: credentials
+                .as_ref()
+                .and_then(|credentials| credentials.account_hint.clone()),
+            installation_id: credentials
+                .as_ref()
+                .map(|credentials| credentials.installation_id.clone()),
+            model_count: config.models.len(),
+            sign_in: self.sign_in.lock().await.clone(),
+        })
+    }
+
+    /// Start a browser sign-in and return the URL to open.
+    ///
+    /// The exchange completes in a background task: on success the session is
+    /// stored and the entitled models synced; on failure the status surface
+    /// carries the bounded error until the next attempt.
+    pub(crate) async fn begin_sign_in(self: &Arc<Self>) -> Result<String> {
+        let connection = self
+            .connection()
+            .await?
+            .ok_or_else(|| AgentError::config("no model gateway is configured"))?;
+        let pending = connection.auth().start_sign_in().await?;
+        let authorization_url = pending.authorization_url().to_string();
+        let generation = {
+            let mut sign_in = self.sign_in.lock().await;
+            let generation = self
+                .sign_in_generation
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                + 1;
+            *sign_in = SignInProgress::Pending {
+                authorization_url: authorization_url.clone(),
+            };
+            generation
+        };
+
+        let runtime = self.clone();
+        tokio::spawn(async move {
+            let finished = pending.finish(SIGN_IN_TIMEOUT).await;
+            // Hold the state lock across the generation check and every
+            // effect: `sign_out` bumps the generation and revokes under this
+            // same lock, so a completion racing a sign-out either observes
+            // the bump here and abandons, or finishes entirely before the
+            // sign-out proceeds — a signed-out session can never be
+            // resurrected between check and store.
+            let mut sign_in = runtime.sign_in.lock().await;
+            if runtime
+                .sign_in_generation
+                .load(std::sync::atomic::Ordering::SeqCst)
+                != generation
+            {
+                return;
+            }
+            *sign_in = match finished {
+                Ok(session) => match connection.store_session(&session).await {
+                    Ok(()) => {
+                        // Best-effort: a failed first sync leaves an explicit
+                        // refresh affordance, not a failed sign-in.
+                        let _ = runtime.sync_models().await;
+                        SignInProgress::Idle
+                    }
+                    Err(error) => SignInProgress::Failed {
+                        message: error.to_string(),
+                    },
+                },
+                Err(error) => SignInProgress::Failed {
+                    message: error.to_string(),
+                },
+            };
+        });
+        Ok(authorization_url)
+    }
+
+    /// Revoke the session (best-effort at the gateway), clear local state, and
+    /// drop the synced model snapshot.
+    pub(crate) async fn sign_out(&self) -> Result<()> {
+        // Take the state lock for the whole operation and invalidate any
+        // pending browser flow before revoking anything: an exchange that
+        // completes during the revoke round-trip serializes behind this lock
+        // and then observes the bump, so it abandons instead of re-saving
+        // the session it just minted.
+        let mut sign_in = self.sign_in.lock().await;
+        self.sign_in_generation
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if let Some(connection) = self.connection().await? {
+            connection.sign_out().await?;
+        }
+        let mut config = providers::read_config(&*self.store, ProviderKind::ModelGateway).await?;
+        if !config.models.is_empty() {
+            config.models = Vec::new();
+            providers::write_config(&*self.store, ProviderKind::ModelGateway, &config).await?;
+        }
+        *sign_in = SignInProgress::Idle;
+        Ok(())
+    }
+
+    /// The connection for the configured gateway, or `None` when no base URL
+    /// is configured.
+    pub(crate) async fn connection(&self) -> Result<Option<Arc<GatewayConnection>>> {
+        let config = providers::read_config(&*self.store, ProviderKind::ModelGateway).await?;
+        let Some(base_url) = config.base_url else {
+            return Ok(None);
+        };
+        let mut cached = self.cached.lock().await;
+        if let Some((url, connection)) = cached.as_ref() {
+            if *url == base_url {
+                return Ok(Some(connection.clone()));
+            }
+        }
+        let auth_config = match std::env::var(CLIENT_ID_ENV)
+            .ok()
+            .filter(|id| id == "openwave")
+        {
+            Some(_) => GatewayAuthConfig::new(&base_url)?,
+            None => GatewayAuthConfig::modelctl_compat(&base_url)?,
+        };
+        let connection = Arc::new(GatewayConnection::new(
+            GatewayAuth::new(auth_config)?,
+            CredentialVault::new(self.secrets.clone()),
+        ));
+        *cached = Some((base_url, connection.clone()));
+        Ok(Some(connection))
+    }
+
+    /// A router token source, when the provider is configured and a session is
+    /// stored. `None` keeps the gateway route out of the router entirely.
+    pub(crate) async fn route_token_source(&self) -> Option<Arc<dyn BearerTokenSource>> {
+        if !openwave_connectors::has_stored_credentials(&*self.secrets).await {
+            return None;
+        }
+        let connection = self.connection().await.ok().flatten()?;
+        Some(Arc::new(GatewayTokenSource(connection)))
+    }
+
+    /// Fetch the entitled models and persist them as the provider's model set.
+    ///
+    /// Returns how many models are entitled. The persisted snapshot drives the
+    /// picker and model policy; entitlement itself stays live at the gateway,
+    /// which refuses a revoked model at inference time regardless of what is
+    /// cached here.
+    pub(crate) async fn sync_models(&self) -> Result<usize> {
+        let connection = self
+            .connection()
+            .await?
+            .ok_or_else(|| AgentError::config("no model gateway is configured"))?;
+        // The gateway routes these models over its Anthropic-compatible
+        // surface, so sync exactly the set that protocol can serve.
+        let models = connection.models(Some("anthropic_messages")).await?;
+        let mut config = providers::read_config(&*self.store, ProviderKind::ModelGateway).await?;
+        config.models = models
+            .into_iter()
+            .map(|model| CustomModelConfig {
+                id: model.id,
+                display_name: Some(model.name),
+                context_window: clamp_u32(model.context_window, 32_768),
+                max_output_tokens: clamp_u32(model.max_output_tokens, 4_096),
+            })
+            .collect();
+        // The gateway is trusted for entitlements, not for shapes: the synced
+        // set is held to the same bounds as user-entered custom models.
+        providers::validate_custom_models(&config.models).map_err(|error| {
+            AgentError::config(format!("gateway model sync rejected: {error:?}"))
+        })?;
+        let count = config.models.len();
+        providers::write_config(&*self.store, ProviderKind::ModelGateway, &config).await?;
+        Ok(count)
+    }
+}
+
+fn clamp_u32(value: Option<i64>, default: u32) -> u32 {
+    value
+        .and_then(|value| u32::try_from(value).ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+/// Router-facing supplier of the gateway's `llm`-resource token. Refresh and
+/// rotation live inside [`GatewayConnection`]; this is just the seam.
+struct GatewayTokenSource(Arc<GatewayConnection>);
+
+#[async_trait]
+impl BearerTokenSource for GatewayTokenSource {
+    async fn bearer_token(&self) -> Result<String> {
+        self.0.access_token(RESOURCE_LLM).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::extract::{Form, State};
+    use axum::http::HeaderMap;
+    use axum::response::{IntoResponse, Json, Response};
+    use axum::routing::{get, post};
+    use axum::Router as AxumRouter;
+    use openwave_core::DbStore;
+    use serde_json::{json, Value};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MockSecrets(std::sync::Mutex<HashMap<String, String>>);
+
+    #[async_trait]
+    impl SecretProvider for MockSecrets {
+        async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+            Ok(self.0.lock().unwrap().get(key).cloned())
+        }
+        async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
+            self.0.lock().unwrap().insert(key.into(), value.into());
+            Ok(())
+        }
+        async fn delete_secret(&self, key: &str) -> Result<()> {
+            self.0.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeGateway {
+        refreshes: AtomicUsize,
+    }
+
+    async fn token(
+        State(gateway): State<Arc<FakeGateway>>,
+        Form(form): Form<HashMap<String, String>>,
+    ) -> Json<Value> {
+        assert_eq!(
+            form.get("grant_type").map(String::as_str),
+            Some("refresh_token")
+        );
+        let sequence = gateway.refreshes.fetch_add(1, Ordering::SeqCst);
+        let resource = form.get("resource").cloned().unwrap_or_default();
+        Json(json!({
+            "access_token": format!("mg_at_{resource}_{sequence}"),
+            "token_type": "Bearer",
+            "expires_in": 600,
+            "refresh_token": format!("mg_rt_{sequence}"),
+            "scope": "models:read inference:invoke",
+            "resource": resource,
+            "installation_id": "install-1",
+        }))
+    }
+
+    async fn models(
+        axum::extract::Query(query): axum::extract::Query<HashMap<String, String>>,
+        headers: HeaderMap,
+    ) -> Response {
+        assert_eq!(
+            query.get("protocol").map(String::as_str),
+            Some("anthropic_messages")
+        );
+        let bearer = headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        assert!(bearer.starts_with("Bearer mg_at_control_"), "{bearer}");
+        Json(json!({
+            "models": [
+                {
+                    "id": "sample-claude",
+                    "name": "Sample Claude",
+                    "context_window": 200000,
+                    "max_output_tokens": 8192,
+                    "supports_tools": true,
+                    "supports_vision": true
+                },
+                {
+                    "id": "sample-coder",
+                    "name": "Sample Coder",
+                    "context_window": null,
+                    "max_output_tokens": null,
+                    "supports_tools": true,
+                    "supports_vision": false
+                }
+            ]
+        }))
+        .into_response()
+    }
+
+    async fn serve(gateway: Arc<FakeGateway>) -> std::net::SocketAddr {
+        let app = AxumRouter::new()
+            .route("/oauth/token", post(token))
+            .route("/api/v1/cli/models", get(models))
+            .with_state(gateway);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        address
+    }
+
+    async fn signed_in_runtime(
+        base_url: &str,
+    ) -> (Arc<GatewayRuntime>, Arc<dyn Store>, tempfile::TempDir) {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
+        // Stored credentials are private to the connectors crate by design;
+        // seed the vault through its serialized form, exactly as a completed
+        // sign-in would have persisted it.
+        let credentials: openwave_connectors::GatewayCredentials = serde_json::from_value(json!({
+            "base_url": base_url,
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "account_hint": "abaas@example.test",
+            "refresh_token": "mg_rt_seed",
+            "access_tokens": {}
+        }))
+        .unwrap();
+        CredentialVault::new(secrets.clone())
+            .save(&credentials)
+            .await
+            .unwrap();
+        providers::write_config(
+            &*store,
+            ProviderKind::ModelGateway,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: Some(base_url.to_string()),
+                models: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+        (
+            GatewayRuntime::new(store.clone(), secrets),
+            store,
+            directory,
+        )
+    }
+
+    #[tokio::test]
+    async fn syncs_entitled_models_into_the_provider_config() {
+        let address = serve(Arc::new(FakeGateway::default())).await;
+        let base = format!("http://{address}");
+        let (runtime, store, _directory) = signed_in_runtime(&base).await;
+
+        assert_eq!(runtime.sync_models().await.unwrap(), 2);
+
+        let config = providers::read_config(&*store, ProviderKind::ModelGateway)
+            .await
+            .unwrap();
+        assert_eq!(config.models.len(), 2);
+        assert_eq!(config.models[0].id, "sample-claude");
+        assert_eq!(
+            config.models[0].display_name.as_deref(),
+            Some("Sample Claude")
+        );
+        assert_eq!(config.models[0].context_window, 200_000);
+        // Absent limits fall back to the conservative custom-model defaults.
+        assert_eq!(config.models[1].context_window, 32_768);
+        assert_eq!(config.models[1].max_output_tokens, 4_096);
+
+        // The synced snapshot resolves as a model policy under the gateway key.
+        let policy =
+            providers::resolve_model_policy(&*store, "model_gateway::sample-claude", false)
+                .await
+                .unwrap()
+                .expect("synced model resolves");
+        assert_eq!(policy.provider, ProviderKind::ModelGateway);
+        assert_eq!(policy.display_name, "Sample Claude");
+    }
+
+    #[tokio::test]
+    async fn the_route_token_source_mints_llm_tokens_per_rotation() {
+        let gateway = Arc::new(FakeGateway::default());
+        let address = serve(gateway.clone()).await;
+        let base = format!("http://{address}");
+        let (runtime, store, _directory) = signed_in_runtime(&base).await;
+
+        let source = runtime
+            .route_token_source()
+            .await
+            .expect("signed-in runtime offers a token source");
+        let token = source.bearer_token().await.unwrap();
+        assert!(token.starts_with("mg_at_llm_"), "{token}");
+        // A fresh token is cached: no second refresh inside the expiry leeway.
+        assert_eq!(source.bearer_token().await.unwrap(), token);
+        assert_eq!(gateway.refreshes.load(Ordering::SeqCst), 1);
+
+        // The route set includes the gateway with its synced models claimed.
+        runtime.sync_models().await.unwrap();
+        let routes = providers::collect_routes(
+            &*store,
+            &*runtime.secrets,
+            runtime.route_token_source().await,
+        )
+        .await;
+        let gateway_route = routes
+            .iter()
+            .find(|route| route.kind == openwave_router::RouteKind::ModelGateway)
+            .expect("gateway route present");
+        assert_eq!(
+            gateway_route.base_url.as_deref(),
+            Some(format!("{base}/compat/anthropic").as_str())
+        );
+        assert!(gateway_route.api_key.is_empty());
+        assert!(gateway_route
+            .curated_models
+            .contains(&"sample-claude".to_string()));
+    }
+
+    #[tokio::test]
+    async fn status_reflects_the_session_and_sign_out_clears_the_snapshot() {
+        let address = serve(Arc::new(FakeGateway::default())).await;
+        let base = format!("http://{address}");
+        let (runtime, store, _directory) = signed_in_runtime(&base).await;
+        runtime.sync_models().await.unwrap();
+
+        let status = runtime.status().await.unwrap();
+        assert!(status.configured && status.enabled && status.signed_in);
+        assert_eq!(status.account_hint.as_deref(), Some("abaas@example.test"));
+        assert_eq!(status.installation_id.as_deref(), Some("install-1"));
+        assert_eq!(status.model_count, 2);
+        assert_eq!(status.sign_in, SignInProgress::Idle);
+        // The projection carries no token-shaped material.
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(!json.contains("mg_at_"));
+        assert!(!json.contains("mg_rt_"));
+
+        runtime.sign_out().await.unwrap();
+        let status = runtime.status().await.unwrap();
+        assert!(!status.signed_in);
+        assert_eq!(status.model_count, 0);
+        assert!(status.account_hint.is_none());
+        let config = providers::read_config(&*store, ProviderKind::ModelGateway)
+            .await
+            .unwrap();
+        assert!(config.models.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_signed_out_runtime_offers_no_route() {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
+        providers::write_config(
+            &*store,
+            ProviderKind::ModelGateway,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: Some("http://127.0.0.1:1".to_string()),
+                models: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+        let runtime = GatewayRuntime::new(store.clone(), secrets);
+
+        assert!(runtime.route_token_source().await.is_none());
+        let routes = providers::collect_routes(&*store, &*runtime.secrets, None).await;
+        assert!(routes
+            .iter()
+            .all(|route| route.kind != openwave_router::RouteKind::ModelGateway));
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -27,6 +27,7 @@ mod error;
 mod event_projection;
 mod extract;
 mod foreground_prompt;
+mod gateway_runtime;
 mod mcp_config;
 mod model_registry;
 mod provider;
@@ -271,6 +272,13 @@ pub fn app(state: AppState) -> Router {
         .route(
             "/mcp/servers/{name}/view-session",
             post(routes::post_mcp_view_session),
+        )
+        .route("/gateway/status", get(routes::get_gateway_status))
+        .route("/gateway/sign-in", post(routes::post_gateway_sign_in))
+        .route("/gateway/sign-out", post(routes::post_gateway_sign_out))
+        .route(
+            "/gateway/models/sync",
+            post(routes::post_gateway_models_sync),
         )
         .route(
             "/web-search/credentials",
@@ -543,7 +551,12 @@ async fn bind_inner(
     // Pre-providers installs may only have an env/legacy key — enable Anthropic
     // so `KeyedResolver`'s enabled check doesn't fail-closed on upgrade.
     providers::migrate_legacy_anthropic(&*store, &*secrets).await?;
-    let resolver = Arc::new(KeyedResolver::new(store.clone(), secrets.clone()));
+    let gateway = gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone());
+    let resolver = Arc::new(KeyedResolver::new(
+        store.clone(),
+        secrets.clone(),
+        gateway.clone(),
+    ));
     let embedder = resolve_embedder(&*store, &*secrets).await;
     let vector_store = connect_vector_store(&config, embedder.dimensions()).await?;
     let code_execution = Arc::new(code_execution::ConfiguredCodeExecutionProvider::new(
@@ -560,7 +573,7 @@ async fn bind_inner(
         store.clone(),
     );
     let tools = Arc::new(tools);
-    let state = match client_executor_id {
+    let mut state = match client_executor_id {
         Some(client_executor_id) => AppState::new_with_client_executor_id(
             config,
             store,
@@ -581,6 +594,11 @@ async fn bind_inner(
             agent_config,
         ),
     };
+    // The resolver and the /gateway routes must share ONE runtime: refresh
+    // rotation is serialized per GatewayConnection instance, and two
+    // instances over the same keychain entry can race a stale refresh token
+    // into the gateway's reuse detection (a spurious full sign-out).
+    state.gateway = gateway;
     state.mcp.initialize(mcp_servers).await?;
     let token = state.token.clone();
     let client_executor_token = state.client_executor_token.clone();

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -38,6 +38,10 @@ pub enum ProviderKind {
     Openai,
     /// Any OpenAI-compatible Chat Completions gateway (OpenRouter, vLLM, …).
     OpenaiCompatible,
+    /// A signed-in model-gateway deployment: entitled models synced from the
+    /// gateway, inference through its Anthropic-compatible surface with
+    /// short-lived OAuth tokens.
+    ModelGateway,
 }
 
 impl ProviderKind {
@@ -46,6 +50,7 @@ impl ProviderKind {
         ProviderKind::Anthropic,
         ProviderKind::Openai,
         ProviderKind::OpenaiCompatible,
+        ProviderKind::ModelGateway,
     ];
 
     /// Wire/path form (`anthropic`, `openai`, `openai_compatible`).
@@ -54,6 +59,7 @@ impl ProviderKind {
             ProviderKind::Anthropic => "anthropic",
             ProviderKind::Openai => "openai",
             ProviderKind::OpenaiCompatible => "openai_compatible",
+            ProviderKind::ModelGateway => "model_gateway",
         }
     }
 
@@ -63,6 +69,7 @@ impl ProviderKind {
             "anthropic" => Some(Self::Anthropic),
             "openai" => Some(Self::Openai),
             "openai_compatible" => Some(Self::OpenaiCompatible),
+            "model_gateway" => Some(Self::ModelGateway),
             _ => None,
         }
     }
@@ -98,6 +105,10 @@ pub enum ProviderCredential {
         /// The secret key material.
         key: String,
     },
+    /// An OAuth-backed provider. A marker, not the tokens: the token set lives
+    /// in its own keychain entry managed by `openwave-connectors`, so the
+    /// rotating material never rides the provider settings surface.
+    Oauth {},
 }
 
 impl ProviderCredential {
@@ -110,6 +121,7 @@ impl ProviderCredential {
     pub fn as_api_key(&self) -> Option<&str> {
         match self {
             Self::ApiKey { key } => Some(key.as_str()),
+            Self::Oauth {} => None,
         }
     }
 }
@@ -119,6 +131,7 @@ impl std::fmt::Debug for ProviderCredential {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ApiKey { .. } => f.debug_struct("ApiKey").field("key", &"***").finish(),
+            Self::Oauth {} => f.debug_struct("Oauth").finish(),
         }
     }
 }
@@ -216,15 +229,15 @@ impl ResolvedModelPolicy {
         }
     }
 
-    fn custom(model: &CustomModelConfig) -> Self {
+    fn custom_for(provider: ProviderKind, model: &CustomModelConfig) -> Self {
         Self {
-            key: model_registry::selection_key(ProviderKind::OpenaiCompatible, &model.id),
+            key: model_registry::selection_key(provider, &model.id),
             id: model.id.clone(),
             display_name: model
                 .display_name
                 .clone()
                 .unwrap_or_else(|| model_registry::display_name_for(&model.id)),
-            provider: ProviderKind::OpenaiCompatible,
+            provider,
             context_window: model.context_window,
             max_output_tokens: model.max_output_tokens,
             input_modalities: vec![InputModality::Text],
@@ -236,12 +249,15 @@ impl ResolvedModelPolicy {
     }
 
     fn legacy_custom(id: &str) -> Self {
-        Self::custom(&CustomModelConfig {
-            id: id.to_owned(),
-            display_name: None,
-            context_window: default_custom_context_window(),
-            max_output_tokens: default_custom_max_output_tokens(),
-        })
+        Self::custom_for(
+            ProviderKind::OpenaiCompatible,
+            &CustomModelConfig {
+                id: id.to_owned(),
+                display_name: None,
+                context_window: default_custom_context_window(),
+                max_output_tokens: default_custom_max_output_tokens(),
+            },
+        )
     }
 }
 
@@ -403,6 +419,8 @@ pub async fn has_credential(secrets: &dyn SecretProvider, kind: ProviderKind) ->
         ProviderKind::Anthropic => std::env::var("ANTHROPIC_API_KEY").is_ok_and(|k| !k.is_empty()),
         ProviderKind::Openai => std::env::var("OPENAI_API_KEY").is_ok_and(|k| !k.is_empty()),
         ProviderKind::OpenaiCompatible => false,
+        // The gateway's credential is its stored OAuth session, not a key.
+        ProviderKind::ModelGateway => openwave_connectors::has_stored_credentials(secrets).await,
     }
 }
 
@@ -465,6 +483,16 @@ pub async fn update_provider(
     }
 
     if let Some(credential) = update.credential {
+        // The gateway's only credential is its OAuth session, managed by the
+        // sign-in flow; accepting a pasted key here would light up
+        // has_credential with nothing the router can use.
+        if kind == ProviderKind::ModelGateway
+            && matches!(credential, ProviderCredential::ApiKey { .. })
+        {
+            return Err(ServerError::bad_request(
+                "model_gateway signs in with OAuth; api keys are not accepted",
+            ));
+        }
         match &credential {
             ProviderCredential::ApiKey { key } if key.is_empty() => {
                 return Err(ServerError::bad_request("credential key must not be empty"));
@@ -485,7 +513,9 @@ pub async fn update_provider(
     })
 }
 
-fn validate_custom_models(models: &[CustomModelConfig]) -> std::result::Result<(), ServerError> {
+pub(crate) fn validate_custom_models(
+    models: &[CustomModelConfig],
+) -> std::result::Result<(), ServerError> {
     validate_custom_models_against(models, |id| {
         model_registry::find_for(ProviderKind::OpenaiCompatible, id).is_some()
     })
@@ -574,6 +604,9 @@ pub async fn resolve_api_key(secrets: &dyn SecretProvider, kind: ProviderKind) -
             .ok()
             .filter(|k| !k.is_empty()),
         ProviderKind::OpenaiCompatible => None,
+        // Gateway tokens rotate; they are supplied per request by the route's
+        // token source, never resolved into a static key.
+        ProviderKind::ModelGateway => None,
     }
 }
 
@@ -589,6 +622,7 @@ pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
         ProviderKind::Anthropic => openwave_router::RouteKind::Anthropic,
         ProviderKind::Openai => openwave_router::RouteKind::Openai,
         ProviderKind::OpenaiCompatible => openwave_router::RouteKind::OpenaiCompatible,
+        ProviderKind::ModelGateway => openwave_router::RouteKind::ModelGateway,
     }
 }
 
@@ -600,6 +634,7 @@ pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
 pub async fn collect_routes(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
+    gateway_tokens: Option<std::sync::Arc<dyn openwave_router::BearerTokenSource>>,
 ) -> Vec<openwave_router::Route> {
     let mut routes = Vec::new();
     for &kind in ProviderKind::ALL {
@@ -608,6 +643,27 @@ pub async fn collect_routes(
             Err(_) => continue,
         };
         if !config.enabled {
+            continue;
+        }
+        if kind == ProviderKind::ModelGateway {
+            // The gateway route rides its live token source; without a signed-in
+            // session there is nothing to route to.
+            let Some(source) = gateway_tokens.clone() else {
+                continue;
+            };
+            let Some(base) = config.base_url.as_deref() else {
+                continue;
+            };
+            if !(base.starts_with("https://") || base.starts_with("http://")) {
+                continue;
+            }
+            routes.push(openwave_router::Route {
+                kind: route_kind(kind),
+                api_key: String::new(),
+                base_url: Some(format!("{}/compat/anthropic", base.trim_end_matches('/'))),
+                curated_models: config.models.into_iter().map(|model| model.id).collect(),
+                token_source: Some(source),
+            });
             continue;
         }
         let Some(api_key) = resolve_api_key(secrets, kind).await else {
@@ -630,6 +686,7 @@ pub async fn collect_routes(
                 .map(|spec| spec.id.to_string())
                 .chain(config.models.into_iter().map(|model| model.id))
                 .collect(),
+            token_source: None,
         });
     }
     routes
@@ -682,7 +739,10 @@ pub async fn resolve_model_policy(
         if let Some(spec) = model_registry::find_for(provider, id) {
             return Ok(Some(ResolvedModelPolicy::curated(spec)));
         }
-        if provider != ProviderKind::OpenaiCompatible {
+        if !matches!(
+            provider,
+            ProviderKind::OpenaiCompatible | ProviderKind::ModelGateway
+        ) {
             return Ok(None);
         }
         let config = read_config(store, provider).await?;
@@ -690,7 +750,7 @@ pub async fn resolve_model_policy(
             .models
             .iter()
             .find(|model| model.id == id)
-            .map(ResolvedModelPolicy::custom));
+            .map(|model| ResolvedModelPolicy::custom_for(provider, model)));
     }
 
     let config = read_config(store, ProviderKind::OpenaiCompatible).await?;
@@ -702,7 +762,7 @@ pub async fn resolve_model_policy(
             .models
             .iter()
             .filter(|model| model.id == value)
-            .map(ResolvedModelPolicy::custom),
+            .map(|model| ResolvedModelPolicy::custom_for(ProviderKind::OpenaiCompatible, model)),
     );
     match owners.len() {
         1 => return Ok(owners.pop()),
@@ -722,7 +782,10 @@ pub async fn provider_is_usable(
     if !config.enabled || !has_credential(secrets, kind).await {
         return Ok(false);
     }
-    if kind == ProviderKind::OpenaiCompatible {
+    if matches!(
+        kind,
+        ProviderKind::OpenaiCompatible | ProviderKind::ModelGateway
+    ) {
         let Some(base) = config.base_url.as_deref() else {
             return Ok(false);
         };
@@ -747,9 +810,12 @@ pub async fn catalog_models(
             policy: ResolvedModelPolicy::curated(spec),
             available,
         }));
-        if kind == ProviderKind::OpenaiCompatible {
+        if matches!(
+            kind,
+            ProviderKind::OpenaiCompatible | ProviderKind::ModelGateway
+        ) {
             models.extend(config.models.iter().map(|model| CatalogModel {
-                policy: ResolvedModelPolicy::custom(model),
+                policy: ResolvedModelPolicy::custom_for(kind, model),
                 available,
             }));
         }
@@ -770,6 +836,16 @@ mod tests {
         let back: ProviderCredential = serde_json::from_str(&json).unwrap();
         assert_eq!(back.as_api_key(), Some("sk-secret"));
         assert!(!format!("{cred:?}").contains("sk-secret"));
+
+        // The OAuth marker is additive on the same tagged wire and carries no
+        // key material of its own.
+        let oauth: ProviderCredential = serde_json::from_str(r#"{"type":"oauth"}"#).unwrap();
+        assert_eq!(oauth, ProviderCredential::Oauth {});
+        assert_eq!(oauth.as_api_key(), None);
+        assert_eq!(
+            serde_json::to_string(&oauth).unwrap(),
+            r#"{"type":"oauth"}"#
+        );
     }
 
     #[test]
@@ -894,12 +970,15 @@ mod tests {
         // requested effort is dropped rather than sent to something that would
         // reject it.
         let mut config = AgentConfig::default();
-        let custom = ResolvedModelPolicy::custom(&CustomModelConfig {
-            id: "local-model".into(),
-            display_name: None,
-            context_window: 32_768,
-            max_output_tokens: 4_096,
-        });
+        let custom = ResolvedModelPolicy::custom_for(
+            ProviderKind::OpenaiCompatible,
+            &CustomModelConfig {
+                id: "local-model".into(),
+                display_name: None,
+                context_window: 32_768,
+                max_output_tokens: 4_096,
+            },
+        );
         apply_model_policy(&mut config, &custom, Some(ReasoningEffort::High)).unwrap();
         assert_eq!(config.provider, Some(ProviderId::new("openai_compatible")));
         assert_eq!(config.context_window, 32_768);

--- a/crates/openwave-server/src/resolver.rs
+++ b/crates/openwave-server/src/resolver.rs
@@ -49,16 +49,22 @@ pub trait ProviderResolver: Send + Sync {
 pub struct ConfiguredResolver {
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
+    gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
     cached: Mutex<CachedProvider>,
 }
 
 impl ConfiguredResolver {
     /// A resolver that reads provider config from `store` and credentials from
-    /// `secrets`.
-    pub fn new(store: Arc<dyn Store>, secrets: Arc<dyn SecretProvider>) -> Self {
+    /// `secrets`, with `gateway` supplying the model-gateway token source.
+    pub fn new(
+        store: Arc<dyn Store>,
+        secrets: Arc<dyn SecretProvider>,
+        gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
+    ) -> Self {
         Self {
             store,
             secrets,
+            gateway,
             cached: Mutex::new(None),
         }
     }
@@ -70,7 +76,8 @@ pub type KeyedResolver = ConfiguredResolver;
 #[async_trait]
 impl ProviderResolver for ConfiguredResolver {
     async fn resolve(&self) -> Arc<dyn ModelProvider> {
-        let routes = providers::collect_routes(&*self.store, &*self.secrets).await;
+        let gateway_tokens = self.gateway.route_token_source().await;
+        let routes = providers::collect_routes(&*self.store, &*self.secrets, gateway_tokens).await;
         let router = Router::build(routes);
         let fingerprint = router.fingerprint().to_string();
 

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -75,6 +75,46 @@ pub async fn put_mcp_servers(
     ))
 }
 
+/// `GET /gateway/status` — renderer-safe model-gateway connection state.
+pub async fn get_gateway_status(
+    State(state): State<AppState>,
+) -> Result<Json<crate::gateway_runtime::GatewayStatus>, ServerError> {
+    Ok(Json(state.gateway.status().await?))
+}
+
+/// `POST /gateway/sign-in` — start the browser sign-in and return the URL the
+/// renderer should open. The exchange completes in the background; poll
+/// `GET /gateway/status` for the outcome.
+pub async fn post_gateway_sign_in(
+    State(state): State<AppState>,
+) -> Result<Json<GatewaySignInStarted>, ServerError> {
+    let authorization_url = state.gateway.begin_sign_in().await?;
+    Ok(Json(GatewaySignInStarted { authorization_url }))
+}
+
+#[derive(Serialize)]
+pub struct GatewaySignInStarted {
+    authorization_url: String,
+}
+
+/// `POST /gateway/sign-out` — revoke at the gateway (best-effort) and clear
+/// local session state and the synced model snapshot.
+pub async fn post_gateway_sign_out(
+    State(state): State<AppState>,
+) -> Result<Json<crate::gateway_runtime::GatewayStatus>, ServerError> {
+    state.gateway.sign_out().await?;
+    Ok(Json(state.gateway.status().await?))
+}
+
+/// `POST /gateway/models/sync` — refetch the entitled models into the
+/// provider's model set.
+pub async fn post_gateway_models_sync(
+    State(state): State<AppState>,
+) -> Result<Json<crate::gateway_runtime::GatewayStatus>, ServerError> {
+    state.gateway.sync_models().await?;
+    Ok(Json(state.gateway.status().await?))
+}
+
 /// `POST /mcp/servers/{name}/view-session` — trade the API bearer for a
 /// single-use frame token addressing one prefetched MCP Apps view.
 ///

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -41,6 +41,11 @@ pub struct AppState {
     pub tools: Arc<ToolRegistry>,
     /// Runtime-managed MCP connections and immutable per-turn tool snapshots.
     pub(crate) mcp: Arc<McpRuntime>,
+    /// The signed-in model-gateway session handle (sign-in, model sync,
+    /// per-request tokens). The production assembly in `bind_inner` replaces
+    /// this with the resolver's instance — refresh rotation is serialized
+    /// per instance, so routes and resolver must share one.
+    pub(crate) gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
     /// The retrieval pipeline used by the durable document worker and the
     /// agent's shared `search` tool.
     pub retrieval: Arc<Retriever>,
@@ -129,6 +134,7 @@ impl AppState {
         let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
         let blob_writes = Arc::new(BlobWriteGuard::new(config.data_dir.join("blob-locks")));
         let mcp = Arc::new(McpRuntime::new(tools.clone(), store.clone()));
+        let gateway = crate::gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone());
         Ok(Self {
             config: Arc::new(config),
             store: store.clone(),
@@ -137,6 +143,7 @@ impl AppState {
             secrets,
             tools,
             mcp,
+            gateway,
             retrieval,
             document_job_wake: Arc::new(Notify::new()),
             turn_job_wake: Arc::new(Notify::new()),

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -10309,6 +10309,7 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
         Arc::new(resolver::ConfiguredResolver::new(
             store.clone(),
             secrets.clone(),
+            crate::gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone()),
         )),
         secrets,
         Arc::new(ToolRegistry::new()),
@@ -10514,7 +10515,11 @@ async fn resolver_builds_a_router_from_enabled_providers() {
     .await
     .unwrap();
 
-    let resolver = resolver::KeyedResolver::new(store.clone(), secrets.clone());
+    let resolver = resolver::KeyedResolver::new(
+        store.clone(),
+        secrets.clone(),
+        crate::gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone()),
+    );
     let resolved = resolver.resolve().await;
     // Composite router — selection happens on stream from req.model.
     assert_eq!(resolved.id().0, "router");
@@ -10581,11 +10586,15 @@ async fn resolver_includes_openai_when_enabled() {
     .await
     .unwrap();
 
-    let routes = providers::collect_routes(&*store, &*secrets).await;
+    let routes = providers::collect_routes(&*store, &*secrets, None).await;
     assert_eq!(routes.len(), 1);
     assert_eq!(routes[0].kind, openwave_router::RouteKind::Openai);
 
-    let resolver = resolver::KeyedResolver::new(store, secrets);
+    let resolver = resolver::KeyedResolver::new(
+        store.clone(),
+        secrets.clone(),
+        crate::gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone()),
+    );
     let provider = resolver.resolve().await;
     assert_eq!(provider.id().0, "router");
 
@@ -10630,7 +10639,7 @@ async fn openai_compatible_route_is_free_form_fallback() {
     .await
     .unwrap();
 
-    let routes = providers::collect_routes(&*store, &*secrets).await;
+    let routes = providers::collect_routes(&*store, &*secrets, None).await;
     let router = openwave_router::Router::build(routes);
     assert_eq!(
         router.select("llama-3-local"),

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -411,6 +411,7 @@ async fn a_turn_carrying_images_against_a_text_only_model_is_refused() {
         Arc::new(resolver::ConfiguredResolver::new(
             store.clone(),
             secrets.clone(),
+            crate::gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone()),
         )),
         secrets,
         Arc::new(ToolRegistry::new()),

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -338,6 +338,7 @@ mod tests {
         // it — and the renderer uses it on its own as the PUT body shape.
         generate::collect_from::<crate::mcp_config::McpServerDefinition>(&cfg, &mut out);
         generate::collect_from::<crate::routes::McpViewSession>(&cfg, &mut out);
+        generate::collect_from::<crate::gateway_runtime::GatewayStatus>(&cfg, &mut out);
         generate::collect_from::<openwave_core::Project>(&cfg, &mut out);
         generate::collect_from::<openwave_core::Chat>(&cfg, &mut out);
         generate::collect_from::<crate::routes::AgentRunSnapshot>(&cfg, &mut out);


### PR DESCRIPTION
ProviderKind gains model_gateway, and ProviderCredential gains the
promised additive oauth marker — a tag, not tokens: the session lives in
the connectors crate's own keychain entry, so rotating material never
rides the provider settings surface.

The router learns per-request credentials. A Route may carry a
BearerTokenSource; the gateway adapter asks it before every request
instead of snapshotting a key, and the route fingerprint tracks only
that a live source exists, so the gateway's ten-minute rotation cannot
thrash the cached router. Gateway inference rides the existing Anthropic
adapter against {base}/compat/anthropic — the gateway accepts its opaque
tokens on the same header.

Entitled models sync into the provider's persisted model set (names,
context windows, output caps; conservative defaults where the gateway
reports none), so the picker and model policy work from durable local
state under model_gateway::{id} keys while entitlement stays live at the
gateway, which refuses a revoked model at inference time regardless of
the snapshot.

The server also grows the session surface the settings UI will drive:
GET /gateway/status (renderer-safe projection, never token material),
POST /gateway/sign-in (returns the browser URL; the exchange completes
in the background and syncs models on success), /gateway/sign-out
(best-effort revoke, clears local state and the snapshot), and
/gateway/models/sync. The provider list panel hides the gateway row —
its surface is the dedicated panel in the next slice.

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)