### PR TITLE
feat(desktop): run the MCP Apps host bridge so views light up with real data

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -119,6 +119,7 @@ export function ChatView({
       <div className="message-view">
         <MessageList
           messages={messages}
+          chatId={chat.id}
           folderAccessRequests={folderAccess.requests}
           userQuestionRequests={userQuestions.requests}
           nativeHost={nativeHost}

--- a/crates/openwave-desktop/ui/src/McpAppBridge.test.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createMcpAppBridge,
+  MCP_APPS_PROTOCOL_VERSION,
+  type McpAppPayload,
+} from "./McpAppBridge";
+
+const PAYLOAD: McpAppPayload = {
+  arguments: { operation: "list" },
+  content: '{"status":200}',
+  structured_content: { status: 200 },
+  is_error: false,
+};
+
+function harness(theme: "light" | "dark" = "dark") {
+  const postMessage = vi.fn();
+  const frame = { postMessage } as unknown as Window;
+  const onHeight = vi.fn();
+  let currentTheme = theme;
+  const bridge = createMcpAppBridge({
+    frame: () => frame,
+    theme: () => currentTheme,
+    onHeight,
+  });
+  const fromView = (data: unknown, source: unknown = frame) =>
+    bridge.handleMessage({ data, source } as MessageEvent);
+  const sent = () => postMessage.mock.calls.map(([message]) => message);
+  const targets = () => postMessage.mock.calls.map(([, target]) => target);
+  return {
+    bridge,
+    fromView,
+    sent,
+    targets,
+    onHeight,
+    frame,
+    setTheme: (next: "light" | "dark") => {
+      currentTheme = next;
+    },
+  };
+}
+
+describe("createMcpAppBridge", () => {
+  it("answers ui/initialize with every required result field", () => {
+    const { fromView, sent, targets } = harness("dark");
+    fromView({ jsonrpc: "2.0", id: 0, method: "ui/initialize", params: {} });
+
+    expect(sent()).toEqual([
+      {
+        jsonrpc: "2.0",
+        id: 0,
+        result: {
+          protocolVersion: MCP_APPS_PROTOCOL_VERSION,
+          hostInfo: { name: "OpenWave", version: "1.0.0" },
+          hostCapabilities: {},
+          hostContext: { theme: "dark", displayMode: "inline", platform: "desktop" },
+        },
+      },
+    ]);
+    // A sandboxed frame's origin is opaque; only "*" delivers.
+    expect(targets()).toEqual(["*"]);
+  });
+
+  it("reads the theme at initialize time, not at construction", () => {
+    // One bridge must survive a theme change without losing handshake state;
+    // the reply reflects whatever the app's theme is when the view asks.
+    const { fromView, sent, setTheme } = harness("light");
+    setTheme("dark");
+    fromView({ jsonrpc: "2.0", id: 0, method: "ui/initialize", params: {} });
+    const [reply] = sent() as Array<{ result: { hostContext: { theme: string } } }>;
+    expect(reply.result.hostContext.theme).toBe("dark");
+  });
+
+  it("buffers the payload until the view reports initialized, then sends input before result", () => {
+    const { bridge, fromView, sent } = harness();
+    bridge.deliverPayload(PAYLOAD);
+    expect(sent()).toEqual([]);
+
+    fromView({ jsonrpc: "2.0", method: "ui/notifications/initialized" });
+    expect(sent().map((message) => (message as { method?: string }).method)).toEqual([
+      "ui/notifications/tool-input",
+      "ui/notifications/tool-result",
+    ]);
+    const [input, result] = sent() as Array<{ params: Record<string, unknown> }>;
+    expect(input.params).toEqual({ arguments: { operation: "list" } });
+    expect(result.params).toEqual({
+      content: [{ type: "text", text: '{"status":200}' }],
+      structuredContent: { status: 200 },
+      isError: false,
+    });
+
+    // The pair is sent exactly once, whichever side repeats itself.
+    fromView({ jsonrpc: "2.0", method: "ui/notifications/initialized" });
+    bridge.deliverPayload(PAYLOAD);
+    expect(sent()).toHaveLength(2);
+  });
+
+  it("delivers a payload that arrives after initialization", () => {
+    const { bridge, fromView, sent } = harness();
+    fromView({ jsonrpc: "2.0", method: "ui/notifications/initialized" });
+    expect(sent()).toEqual([]);
+    bridge.deliverPayload({ content: "text only", is_error: true });
+    const [input, result] = sent() as Array<{ params: Record<string, unknown> }>;
+    expect(input.params).toEqual({ arguments: {} });
+    // No structuredContent key at all when the tool produced none.
+    expect(result.params).toEqual({
+      content: [{ type: "text", text: "text only" }],
+      isError: true,
+    });
+  });
+
+  it("rejects unknown requests with method-not-found and ignores unknown notifications", () => {
+    const { fromView, sent } = harness();
+    fromView({ jsonrpc: "2.0", id: 7, method: "ui/open-link", params: { url: "https://x" } });
+    expect(sent()).toEqual([
+      { jsonrpc: "2.0", id: 7, error: { code: -32601, message: "Method not found" } },
+    ]);
+    fromView({ jsonrpc: "2.0", method: "notifications/message", params: { level: "info" } });
+    fromView({ jsonrpc: "2.0", method: "ui/notifications/request-teardown" });
+    expect(sent()).toHaveLength(1);
+  });
+
+  it("answers ping and clamps size-changed heights", () => {
+    const { fromView, sent, onHeight } = harness();
+    fromView({ jsonrpc: "2.0", id: 1, method: "ping", params: {} });
+    expect(sent()).toEqual([{ jsonrpc: "2.0", id: 1, result: {} }]);
+
+    fromView({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { height: 512.4 } });
+    expect(onHeight).toHaveBeenLastCalledWith(513);
+    fromView({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { height: 20 } });
+    expect(onHeight).toHaveBeenLastCalledWith(160);
+    fromView({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { height: 99999 } });
+    expect(onHeight).toHaveBeenLastCalledWith(800);
+    fromView({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: {} });
+    expect(onHeight).toHaveBeenCalledTimes(3);
+  });
+
+  it("ignores messages from other sources and non-JSON-RPC traffic", () => {
+    const { fromView, sent } = harness();
+    fromView({ jsonrpc: "2.0", id: 0, method: "ui/initialize" }, { not: "the frame" });
+    fromView("just a string");
+    fromView({ some: "other postMessage traffic" });
+    fromView(null);
+    expect(sent()).toEqual([]);
+  });
+
+  it("posts nothing after dispose", () => {
+    const { bridge, fromView, sent } = harness();
+    bridge.dispose();
+    fromView({ jsonrpc: "2.0", id: 0, method: "ui/initialize" });
+    bridge.deliverPayload(PAYLOAD);
+    expect(sent()).toEqual([]);
+  });
+});

--- a/crates/openwave-desktop/ui/src/McpAppBridge.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.ts
@@ -1,0 +1,159 @@
+/**
+ * The host side of the MCP Apps postMessage protocol.
+ *
+ * The embedded view (built on `@modelcontextprotocol/ext-apps`) speaks plain
+ * JSON-RPC 2.0 over `window.postMessage`: it sends `ui/initialize` first,
+ * follows with a `ui/notifications/initialized` notification, and then
+ * expects the tool's input and result as notifications. The JSON-RPC
+ * envelope is strict on the view side, so replies carry exactly the standard
+ * fields and nothing else.
+ *
+ * The frame is sandboxed without `allow-same-origin`, so its origin is
+ * opaque; identity is established by `event.source` alone, and outbound
+ * messages use the `"*"` target origin (a `"null"` target would not
+ * deliver). Anything that is not JSON-RPC from our frame is ignored;
+ * requests we do not implement get a standard method-not-found error so the
+ * view degrades without hanging.
+ */
+
+export const MCP_APPS_PROTOCOL_VERSION = "2026-01-26";
+
+import type { McpAppPayload } from "./api";
+
+export type { McpAppPayload };
+
+const MIN_FRAME_HEIGHT = 160;
+const MAX_FRAME_HEIGHT = 800;
+
+export type McpAppBridge = {
+  /** Window `message` handler. Filters to the bridged frame's source. */
+  handleMessage: (event: MessageEvent) => void;
+  /** Provide the tool payload; delivered once the view has initialized. */
+  deliverPayload: (payload: McpAppPayload) => void;
+  /** Stop posting anything further (frame unmounting). */
+  dispose: () => void;
+};
+
+export function createMcpAppBridge(options: {
+  /** The bridged frame's window, when mounted. */
+  frame: () => Window | null;
+  /** Read lazily when the view initializes, so one bridge — and its
+   * buffered handshake state — survives a theme change. */
+  theme: () => "light" | "dark";
+  onHeight?: (height: number) => void;
+}): McpAppBridge {
+  let viewInitialized = false;
+  let payload: McpAppPayload | null = null;
+  let delivered = false;
+  let disposed = false;
+
+  function post(message: unknown) {
+    if (disposed) return;
+    options.frame()?.postMessage(message, "*");
+  }
+
+  function flush() {
+    if (!viewInitialized || delivered || payload === null) return;
+    delivered = true;
+    // Ordering contract: input exactly once, before the result.
+    post({
+      jsonrpc: "2.0",
+      method: "ui/notifications/tool-input",
+      params: { arguments: isRecord(payload.arguments) ? payload.arguments : {} },
+    });
+    post({
+      jsonrpc: "2.0",
+      method: "ui/notifications/tool-result",
+      params: {
+        content: [{ type: "text", text: payload.content }],
+        ...(payload.structured_content === undefined ||
+        payload.structured_content === null
+          ? {}
+          : { structuredContent: payload.structured_content }),
+        isError: payload.is_error,
+      },
+    });
+  }
+
+  function handleMessage(event: MessageEvent) {
+    const frame = options.frame();
+    if (disposed || frame === null || event.source !== frame) return;
+    const message: unknown = event.data;
+    if (!isRecord(message) || message.jsonrpc !== "2.0") return;
+    const method = typeof message.method === "string" ? message.method : null;
+    const id = message.id;
+    const isRequest = method !== null && id !== undefined;
+
+    if (isRequest) {
+      switch (method) {
+        case "ui/initialize":
+          post({
+            jsonrpc: "2.0",
+            id,
+            result: {
+              protocolVersion: MCP_APPS_PROTOCOL_VERSION,
+              hostInfo: { name: "OpenWave", version: "1.0.0" },
+              hostCapabilities: {},
+              // All four result fields are required by the view's schema —
+              // an omitted hostContext fails its connect outright.
+              hostContext: {
+                theme: options.theme(),
+                displayMode: "inline",
+                platform: "desktop",
+              },
+            },
+          });
+          break;
+        case "ping":
+          post({ jsonrpc: "2.0", id, result: {} });
+          break;
+        default:
+          // Fail closed but politely: the view sees a rejected promise, not
+          // a hung request or a torn-down connection.
+          post({
+            jsonrpc: "2.0",
+            id,
+            error: { code: -32601, message: "Method not found" },
+          });
+      }
+      return;
+    }
+
+    switch (method) {
+      case "ui/notifications/initialized":
+        viewInitialized = true;
+        flush();
+        break;
+      case "ui/notifications/size-changed": {
+        const height = isRecord(message.params)
+          ? message.params.height
+          : undefined;
+        if (typeof height === "number" && Number.isFinite(height)) {
+          options.onHeight?.(
+            Math.min(MAX_FRAME_HEIGHT, Math.max(MIN_FRAME_HEIGHT, Math.ceil(height))),
+          );
+        }
+        break;
+      }
+      default:
+        // Logging, teardown requests, and future notifications are safe to
+        // drop; nothing in the protocol requires an answer to them.
+        break;
+    }
+  }
+
+  return {
+    handleMessage,
+    deliverPayload(next) {
+      payload = next;
+      flush();
+    },
+    dispose() {
+      disposed = true;
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/crates/openwave-desktop/ui/src/McpAppCard.tsx
+++ b/crates/openwave-desktop/ui/src/McpAppCard.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AppWindow, ShieldCheck } from "lucide-react";
 import { useApp } from "./AppContext";
+import { createMcpAppBridge, type McpAppBridge } from "./McpAppBridge";
 
 /**
  * The sandboxed surface for an MCP Apps view.
@@ -11,21 +12,84 @@ import { useApp } from "./AppContext";
  * with the app: `sandbox="allow-scripts"` deliberately omits
  * `allow-same-origin`, so the view runs with an opaque origin — no cookies,
  * no storage, no reach into OpenWave's DOM or its bearer token.
+ *
+ * The card also runs the MCP Apps host bridge: it answers the view's
+ * `ui/initialize`, and once the view reports ready it forwards the call's
+ * input and result — fetched as an opaque envelope the transcript itself
+ * never reads — so an interactive view lights up with real data.
  */
 type ViewState =
   | { kind: "loading" }
   | { kind: "unavailable" }
   | { kind: "ready"; url: string };
 
+const DEFAULT_FRAME_HEIGHT = 384;
+
 export function McpAppCard({
   server,
   resourceUri,
+  chatId,
+  callId,
 }: {
   server: string;
   resourceUri: string;
+  /** When both ids are present the bridge delivers the call's result. */
+  chatId?: string;
+  callId?: string;
 }) {
-  const { client } = useApp();
+  const { client, themeMode } = useApp();
   const [state, setState] = useState<ViewState>({ kind: "loading" });
+  const [frameHeight, setFrameHeight] = useState(DEFAULT_FRAME_HEIGHT);
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const bridgeRef = useRef<McpAppBridge | null>(null);
+
+  const resolveTheme = useCallback(
+    (): "light" | "dark" =>
+      themeMode === "system"
+        ? window.matchMedia?.("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"
+        : themeMode,
+    [themeMode],
+  );
+  const themeRef = useRef(resolveTheme);
+  themeRef.current = resolveTheme;
+
+  // The bridge listener must exist before the frame's document runs, or the
+  // view's ui/initialize request is lost and it hangs until its timeout.
+  // One bridge per mount: recreating it (e.g. on a theme change) would
+  // destroy the buffered handshake state mid-flight and strand the view
+  // without its data, so the theme is read through a ref instead.
+  useEffect(() => {
+    const bridge = createMcpAppBridge({
+      frame: () => frameRef.current?.contentWindow ?? null,
+      theme: () => themeRef.current(),
+      onHeight: setFrameHeight,
+    });
+    bridgeRef.current = bridge;
+    window.addEventListener("message", bridge.handleMessage);
+    return () => {
+      window.removeEventListener("message", bridge.handleMessage);
+      bridge.dispose();
+      bridgeRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!chatId || !callId) return;
+    let cancelled = false;
+    void client
+      .getMcpAppPayload(chatId, callId)
+      .then((payload) => {
+        if (!cancelled) bridgeRef.current?.deliverPayload(payload);
+      })
+      .catch(() => {
+        // Without a payload the view still renders; it just waits for data.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, chatId, callId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -75,11 +139,13 @@ export function McpAppCard({
         )}
         {state.kind === "ready" && (
           <iframe
+            ref={frameRef}
             title={`MCP App view from ${server}`}
             src={state.url}
             sandbox="allow-scripts"
             referrerPolicy="no-referrer"
-            className="h-96 w-full border-0"
+            className="w-full border-0"
+            style={{ height: frameHeight }}
           />
         )}
       </div>

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -66,6 +66,8 @@ export type ChatMessage =
 
 type MessageListProps = {
   messages: ChatMessage[];
+  /** Enables MCP App cards to fetch their call's result envelope. */
+  chatId?: string;
   folderAccessRequests: PendingFolderAccessRequest[];
   userQuestionRequests?: PendingUserQuestions[];
   nativeHost: boolean;
@@ -101,6 +103,7 @@ type MessageListProps = {
 
 export function MessageList({
   messages,
+  chatId,
   folderAccessRequests,
   userQuestionRequests = [],
   nativeHost,
@@ -134,6 +137,7 @@ export function MessageList({
     busy,
     onApproval,
     approvalState,
+    chatId,
   );
   // Only greet a genuinely empty, fully-hydrated conversation. While an
   // existing chat's transcript is still loading it is transiently empty; showing
@@ -213,6 +217,7 @@ export function groupMessageItems(
     decidingApprovalCalls: Set<string>;
     approvalErrors: Record<string, string>;
   },
+  chatId?: string,
 ) {
   const items: ReactNode[] = [];
   let index = 0;
@@ -269,7 +274,7 @@ export function groupMessageItems(
       (entry): entry is ToolMessage =>
         entry.role === "tool" && !parked.has(entry.callId),
     );
-    const cards = surfacedCards(phase, parked, onApproval, approvalState);
+    const cards = surfacedCards(phase, parked, onApproval, approvalState, chatId);
 
     // A tool row renders model-influenced data through several defensive
     // parsers. If one of them is ever wrong, the throw should cost this phase
@@ -313,6 +318,7 @@ function surfacedCards(
     decidingApprovalCalls: Set<string>;
     approvalErrors: Record<string, string>;
   },
+  chatId?: string,
 ): ReactNode[] {
   const cards: ReactNode[] = [];
   // In the order the calls happened, so the cards read as a sequence rather
@@ -347,6 +353,8 @@ function surfacedCards(
           key={entry.id}
           server={entry.result.server}
           resourceUri={entry.result.resourceUri}
+          chatId={chatId}
+          callId={entry.callId}
         />,
       );
       continue;

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -218,6 +218,19 @@ export type ExecResultPreview = Extract<ToolResultPreview, { tool: "exec" }>;
 /** A single-use frame address for one MCP Apps view. */
 export type McpViewSessionInfo = McpViewSession;
 
+/**
+ * Opaque envelope for a sandboxed MCP App view; never rendered directly.
+ *
+ * Hand-written on purpose: the payload's JSON fields are untyped passthrough
+ * for the view, which the wire-type generator's precision guard refuses.
+ */
+export type McpAppPayload = {
+  arguments?: unknown;
+  content: string;
+  structured_content?: unknown;
+  is_error: boolean;
+};
+
 
 /** Approval kinds a human may approve from the renderer. */
 export function isApprovableKind(kind: RendererApprovalKind): boolean {
@@ -483,6 +496,13 @@ export class ApiClient {
       headers: this.headers(true),
       body: JSON.stringify({ uri }),
     });
+  }
+
+  getMcpAppPayload(chatId: string, callId: string): Promise<McpAppPayload> {
+    return this.json(
+      `/chats/${encodeURIComponent(chatId)}/calls/${encodeURIComponent(callId)}/mcp-app-payload`,
+      { headers: this.headers() },
+    );
   }
 
   createProject(title: string): Promise<Project> {

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -273,6 +273,10 @@ pub fn app(state: AppState) -> Router {
             "/mcp/servers/{name}/view-session",
             post(routes::post_mcp_view_session),
         )
+        .route(
+            "/chats/{chat_id}/calls/{call_id}/mcp-app-payload",
+            get(routes::get_mcp_app_payload),
+        )
         .route("/gateway/status", get(routes::get_gateway_status))
         .route("/gateway/sign-in", post(routes::post_gateway_sign_in))
         .route("/gateway/sign-out", post(routes::post_gateway_sign_out))

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -75,6 +75,71 @@ pub async fn put_mcp_servers(
     ))
 }
 
+/// `GET /chats/{chat_id}/calls/{call_id}/mcp-app-payload` — the completed
+/// call's result, packaged for its declared MCP Apps view.
+///
+/// Only calls whose output carried a validated view declaration answer here,
+/// and the payload is handed to the renderer as an opaque envelope for the
+/// sandboxed frame — the transcript presentation itself never reads it.
+pub async fn get_mcp_app_payload(
+    State(state): State<AppState>,
+    Path((chat_id, call_id)): Path<(ChatId, CallId)>,
+) -> Result<Json<McpAppPayload>, ServerError> {
+    let events = state.store.list_events(chat_id, 0).await?;
+    mcp_app_payload_from_events(&events, call_id)
+        .map(Json)
+        .ok_or_else(|| ServerError::not_found("no MCP App payload for this call"))
+}
+
+/// The MCP `CallToolResult` fields the view consumes, plus the call's
+/// model-authored arguments for the `tool-input` notification.
+///
+/// Deliberately not a generated wire type: `arguments` and
+/// `structured_content` are opaque passthrough JSON for the sandboxed view,
+/// and the generator's precision guard rightly refuses `any`-shaped fields.
+/// The renderer never reads them; the hand-written TS twin documents the
+/// same opacity.
+#[derive(Debug, PartialEq, Serialize)]
+pub struct McpAppPayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    arguments: Option<serde_json::Value>,
+    content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    structured_content: Option<serde_json::Value>,
+    is_error: bool,
+}
+
+fn mcp_app_payload_from_events(
+    events: &[SequencedEvent],
+    call_id: CallId,
+) -> Option<McpAppPayload> {
+    let mut fragments = String::new();
+    let mut completed = None;
+    for event in events {
+        match &event.event {
+            openwave_core::AgentEvent::ToolCallArgsDelta {
+                call_id: id,
+                fragment,
+            } if *id == call_id => fragments.push_str(fragment),
+            openwave_core::AgentEvent::ToolCallCompleted {
+                call_id: id,
+                output,
+                ..
+            } if *id == call_id => completed = Some(output),
+            _ => {}
+        }
+    }
+    // Mirror the preview filter: an error output never renders a card, so
+    // it serves no payload either.
+    let output = completed.filter(|output| output.ui_view.is_some() && !output.is_error)?;
+    Some(McpAppPayload {
+        arguments: serde_json::from_str(&fragments).ok(),
+        content: output.content.clone(),
+        structured_content: output.data.clone(),
+        is_error: output.is_error,
+    })
+}
+
 /// `GET /gateway/status` — renderer-safe model-gateway connection state.
 pub async fn get_gateway_status(
     State(state): State<AppState>,
@@ -2152,4 +2217,86 @@ async fn send_event(socket: &mut WebSocket, event: &SequencedEvent) -> Result<()
         return Ok(());
     };
     socket.send(Message::Text(json.into())).await
+}
+
+#[cfg(test)]
+mod mcp_app_payload_tests {
+    use openwave_core::{AgentEvent, ToolOutput, ToolUiView};
+
+    use super::*;
+
+    fn sequenced(seq: i64, event: AgentEvent) -> SequencedEvent {
+        SequencedEvent { seq, event }
+    }
+
+    #[test]
+    fn assembles_arguments_and_result_for_a_view_declaring_call() {
+        let call = CallId::new();
+        let other = CallId::new();
+        let events = vec![
+            sequenced(
+                1,
+                AgentEvent::ToolCallArgsDelta {
+                    call_id: call,
+                    fragment: "{\"operation\":".into(),
+                },
+            ),
+            sequenced(
+                2,
+                AgentEvent::ToolCallArgsDelta {
+                    call_id: other,
+                    fragment: "{\"unrelated\":true}".into(),
+                },
+            ),
+            sequenced(
+                3,
+                AgentEvent::ToolCallArgsDelta {
+                    call_id: call,
+                    fragment: "\"list\"}".into(),
+                },
+            ),
+            sequenced(
+                4,
+                AgentEvent::ToolCallCompleted {
+                    call_id: call,
+                    output: ToolOutput::text("{\"status\":200}")
+                        .with_data(serde_json::json!({"status": 200}))
+                        .with_ui_view(ToolUiView {
+                            server: "gateway".into(),
+                            resource_uri: "ui://gateway/app.html".into(),
+                        }),
+                    action: None,
+                    result: None,
+                },
+            ),
+        ];
+
+        let payload = mcp_app_payload_from_events(&events, call).expect("payload exists");
+        assert_eq!(
+            payload.arguments,
+            Some(serde_json::json!({"operation": "list"}))
+        );
+        assert_eq!(payload.content, "{\"status\":200}");
+        assert_eq!(
+            payload.structured_content,
+            Some(serde_json::json!({"status": 200}))
+        );
+        assert!(!payload.is_error);
+    }
+
+    #[test]
+    fn calls_without_a_view_declaration_expose_no_payload() {
+        let call = CallId::new();
+        let events = vec![sequenced(
+            1,
+            AgentEvent::ToolCallCompleted {
+                call_id: call,
+                output: ToolOutput::text("plain result"),
+                action: None,
+                result: None,
+            },
+        )];
+        assert!(mcp_app_payload_from_events(&events, call).is_none());
+        assert!(mcp_app_payload_from_events(&events, CallId::new()).is_none());
+    }
 }


### PR DESCRIPTION
The sandboxed frame from the previous slice rendered a static document;
an MCP App is not static — it expects the ext-apps handshake and its
tool result. The card now runs the host side of that protocol over
postMessage: plain JSON-RPC 2.0, identity by event.source (a sandboxed
frame's origin is opaque, so "*" is the only deliverable target), the
listener installed before the frame's document runs so the view's
ui/initialize is never lost.

The bridge answers ui/initialize with the full required result
(protocol version, host identity, empty capabilities, and a host
context carrying the app's resolved theme), replies to ping, rejects
everything else with method-not-found so an ambitious view degrades
instead of hanging, honors size-changed within clamped bounds, and —
once the view reports initialized — forwards tool-input then
tool-result exactly once, buffering whichever side arrives first.

The result travels as an opaque envelope from a new authenticated
route: the completed call's model-authored arguments (reassembled from
its journaled argument deltas), result text, structured content, and
error flag — answered only for calls whose output declared a view. The
transcript presentation itself still never reads any of it.

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)