### PR TITLE
feat(desktop): the Model Gateway settings panel — connect, identity, entitlements

### DIFF
--- a/crates/openwave-desktop/capabilities/default.json
+++ b/crates/openwave-desktop/capabilities/default.json
@@ -13,6 +13,7 @@
   },
   "permissions": [
     "core:default",
-    "core:window:allow-start-dragging"
+    "core:window:allow-start-dragging",
+    "shell:allow-open"
   ]
 }

--- a/crates/openwave-desktop/ui/src/SettingsView.tsx
+++ b/crates/openwave-desktop/ui/src/SettingsView.tsx
@@ -8,6 +8,7 @@ import {
   PlugZap,
   RefreshCw,
   SquareTerminal,
+  Waypoints,
 } from "lucide-react";
 import type { ApiClient, ModelInfo, ProviderInfo } from "./api";
 import type { ThemeMode } from "./theme";
@@ -18,10 +19,12 @@ import { ModelsPanel } from "./settings/ModelsPanel";
 import { AppearancePanel } from "./settings/AppearancePanel";
 import { CodeExecutionPanel } from "./settings/CodeExecutionPanel";
 import { UpdatesPanel } from "./settings/UpdatesPanel";
+import { GatewayPanel } from "./settings/GatewayPanel";
 import { McpPanel } from "./settings/McpPanel";
 
 type SettingsSectionKey =
   | "providers"
+  | "gateway"
   | "models"
   | "web-search"
   | "code-execution"
@@ -35,6 +38,7 @@ const SECTIONS: {
   icon: ComponentType<{ size?: number }>;
 }[] = [
   { key: "providers", label: "Providers", icon: KeyRound },
+  { key: "gateway", label: "Model Gateway", icon: Waypoints },
   { key: "models", label: "Models", icon: Cpu },
   { key: "web-search", label: "Web search", icon: Globe },
   { key: "code-execution", label: "Code execution", icon: SquareTerminal },
@@ -105,6 +109,9 @@ export function SettingsView({
             client={client}
             onChanged={onProvidersChanged}
           />
+        )}
+        {section === "gateway" && (
+          <GatewayPanel client={client} onChanged={onProvidersChanged} />
         )}
         {section === "models" && (
           <ModelsPanel client={client} models={models} />

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -15,6 +15,8 @@ import {
   type McpHealth as WireMcpHealth,
   type McpServerDefinition as WireMcpServerDefinition,
   type McpViewSession,
+  type GatewayStatus as WireGatewayStatus,
+  type SignInProgress,
   type McpServerInfo as WireMcpServerInfo,
   type McpServersInfo as WireMcpServersInfo,
   type ModelInfo as WireModelInfo,
@@ -217,6 +219,12 @@ export type ExecResultPreview = Extract<ToolResultPreview, { tool: "exec" }>;
 
 /** A single-use frame address for one MCP Apps view. */
 export type McpViewSessionInfo = McpViewSession;
+
+/** Progress of the one in-flight gateway browser sign-in. */
+export type GatewaySignInProgress = SignInProgress;
+
+/** Renderer-safe model-gateway connection state; never token material. */
+export type GatewayStatus = WireGatewayStatus;
 
 /**
  * Opaque envelope for a sandboxed MCP App view; never rendered directly.
@@ -495,6 +503,31 @@ export class ApiClient {
       method: "POST",
       headers: this.headers(true),
       body: JSON.stringify({ uri }),
+    });
+  }
+
+  getGatewayStatus(): Promise<GatewayStatus> {
+    return this.json("/gateway/status", { headers: this.headers() });
+  }
+
+  gatewaySignIn(): Promise<{ authorization_url: string }> {
+    return this.json("/gateway/sign-in", {
+      method: "POST",
+      headers: this.headers(),
+    });
+  }
+
+  gatewaySignOut(): Promise<GatewayStatus> {
+    return this.json("/gateway/sign-out", {
+      method: "POST",
+      headers: this.headers(),
+    });
+  }
+
+  syncGatewayModels(): Promise<GatewayStatus> {
+    return this.json("/gateway/models/sync", {
+      method: "POST",
+      headers: this.headers(),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -65,3 +65,18 @@ export function resolveFolderAccessRequest(
 export function hasMacOverlayTitlebar(): boolean {
   return hasNativeHost() && navigator.userAgent.includes("Mac OS");
 }
+
+/**
+ * Open a URL in the user's default browser.
+ *
+ * The webview swallows `window.open` and `target="_blank"` (no new-window
+ * handler by design), so anything that must leave the app — the gateway
+ * sign-in page — goes through the shell plugin, whose `open` permission
+ * validates the URL scheme. Returns false outside the native host so callers
+ * can fall back to `window.open` in a plain browser.
+ */
+export async function openExternal(url: string): Promise<boolean> {
+  if (!isTauri()) return false;
+  await invoke("plugin:shell|open", { path: url });
+  return true;
+}

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient, GatewayStatus } from "../api";
+import { GatewayPanel } from "./GatewayPanel";
+
+const signedOut: GatewayStatus = {
+  configured: true,
+  enabled: true,
+  base_url: "http://127.0.0.1:28081",
+  signed_in: false,
+  model_count: 0,
+  sign_in: { state: "idle" },
+};
+
+const signedIn: GatewayStatus = {
+  ...signedOut,
+  signed_in: true,
+  account_hint: "abaas@example.test",
+  installation_id: "install-1",
+  model_count: 2,
+};
+
+function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
+  return {
+    getGatewayStatus: vi.fn().mockResolvedValue(signedOut),
+    gatewaySignIn: vi
+      .fn()
+      .mockResolvedValue({ authorization_url: "http://gw/oauth/authorize?x=1" }),
+    gatewaySignOut: vi.fn().mockResolvedValue(signedOut),
+    syncGatewayModels: vi.fn().mockResolvedValue(signedIn),
+    putProvider: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("GatewayPanel", () => {
+  it("connects through the browser and never asks for a credential", async () => {
+    const client = api();
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    const user = userEvent.setup();
+    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+
+    expect(await screen.findByText("Not signed in")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/API key/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Connect/ }));
+    await waitFor(() => expect(client.gatewaySignIn).toHaveBeenCalled());
+    expect(open).toHaveBeenCalledWith(
+      "http://gw/oauth/authorize?x=1",
+      "_blank",
+      "noreferrer,noopener",
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it("shows identity and entitlements when signed in, and disconnects", async () => {
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+    });
+    const onChanged = vi.fn();
+    const user = userEvent.setup();
+    render(<GatewayPanel client={client} onChanged={onChanged} />);
+
+    expect(await screen.findByText("Signed in")).toBeInTheDocument();
+    expect(screen.getByText(/abaas@example\.test/)).toBeInTheDocument();
+    expect(screen.getByText(/2 models entitled/)).toBeInTheDocument();
+    expect(screen.getByText(/Installation install-1/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Refresh models/ }));
+    await waitFor(() => expect(client.syncGatewayModels).toHaveBeenCalled());
+    expect(onChanged).toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /Disconnect/ }));
+    await waitFor(() => expect(client.gatewaySignOut).toHaveBeenCalled());
+  });
+
+  it("saves the gateway URL as provider configuration", async () => {
+    const client = api({
+      getGatewayStatus: vi
+        .fn()
+        .mockResolvedValue({ ...signedOut, configured: false, base_url: undefined }),
+    });
+    const user = userEvent.setup();
+    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+
+    await screen.findByText("Not signed in");
+    // Unconfigured, the connect affordance stays off.
+    expect(screen.getByRole("button", { name: /Connect/ })).toBeDisabled();
+
+    await user.type(
+      screen.getByPlaceholderText("https://gateway.example"),
+      "http://127.0.0.1:28081",
+    );
+    await user.click(screen.getByRole("button", { name: "Save gateway URL" }));
+    await waitFor(() =>
+      expect(client.putProvider).toHaveBeenCalledWith("model_gateway", {
+        enabled: true,
+        base_url: "http://127.0.0.1:28081",
+      }),
+    );
+  });
+
+  it("watches a pending browser sign-in and refreshes the catalog on completion", async () => {
+    const getGatewayStatus = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ...signedOut,
+        sign_in: { state: "pending", authorization_url: "http://gw/authorize" },
+      })
+      .mockResolvedValue(signedIn);
+    const client = api({ getGatewayStatus });
+    const onChanged = vi.fn();
+    vi.useFakeTimers();
+    render(<GatewayPanel client={client} onChanged={onChanged} />);
+    // Flush the initial status load.
+    await act(async () => {});
+
+    const reopen = screen.getByRole("link", {
+      name: /Open the sign-in page again/,
+    });
+    expect(reopen).toHaveAttribute("href", "http://gw/authorize");
+
+    // The poll notices the background exchange completing.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+    });
+    expect(screen.getByText("Signed in")).toBeInTheDocument();
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it("surfaces a failed sign-in with its bounded message", async () => {
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue({
+        ...signedOut,
+        sign_in: { state: "failed", message: "browser authorization timed out" },
+      }),
+    });
+    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+
+    expect(
+      await screen.findByText(/browser authorization timed out/),
+    ).toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -1,0 +1,262 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ExternalLink, LogOut, RefreshCw } from "lucide-react";
+import type { ApiClient, GatewayStatus } from "../api";
+import { openExternal } from "../host";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  SettingsError,
+  SettingsField,
+  SettingsPanel,
+  SettingsSection,
+} from "./primitives";
+
+const SIGN_IN_POLL_MS = 2_000;
+
+/** Native opener first; `window.open` only works in a plain browser tab. */
+async function openSignInPage(url: string) {
+  if (!(await openExternal(url).catch(() => false))) {
+    window.open(url, "_blank", "noreferrer,noopener");
+  }
+}
+
+/**
+ * The Model Gateway connection: one toggle, one URL, one sign-in.
+ *
+ * Authentication is the gateway's own OAuth flow in the system browser —
+ * OpenWave never sees a password or IdP credential, only the gateway's
+ * rotating tokens, which live in the keychain. Signed in, the entitled
+ * models sync into the picker; signed out, the app is exactly the local
+ * bring-your-own-key product it was before.
+ */
+export function GatewayPanel({
+  client,
+  onChanged,
+}: {
+  client: ApiClient;
+  onChanged: () => void;
+}) {
+  const [status, setStatus] = useState<GatewayStatus | null>(null);
+  const [baseUrl, setBaseUrl] = useState("");
+  const [dirty, setDirty] = useState(false);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Refs, not state reads, inside `reload`: transition detection must not
+  // live in a state updater (updaters are pure and StrictMode double-invokes
+  // them), and the poll must not refill a field the user is editing.
+  const signedInRef = useRef(false);
+  const dirtyRef = useRef(false);
+
+  const reload = useCallback(async () => {
+    const next = await client.getGatewayStatus();
+    // Entitlements changed while we watched: refresh the model picker.
+    if (!signedInRef.current && next.signed_in) onChanged();
+    signedInRef.current = next.signed_in;
+    setStatus(next);
+    setBaseUrl((current) =>
+      current === "" && !dirtyRef.current ? (next.base_url ?? "") : current,
+    );
+    return next;
+  }, [client, onChanged]);
+
+  useEffect(() => {
+    reload().catch((err) => setError(String(err)));
+  }, [reload]);
+
+  // While the browser flow is pending, watch for its outcome.
+  useEffect(() => {
+    if (status?.sign_in.state !== "pending") return;
+    const timer = window.setInterval(() => {
+      void reload().catch(() => undefined);
+    }, SIGN_IN_POLL_MS);
+    return () => window.clearInterval(timer);
+  }, [status?.sign_in.state, reload]);
+
+  async function run(action: () => Promise<unknown>) {
+    setWorking(true);
+    setError(null);
+    try {
+      await action();
+      await reload();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  async function save(enabled: boolean) {
+    await run(async () => {
+      await client.putProvider("model_gateway", {
+        enabled,
+        base_url: baseUrl.trim() === "" ? null : baseUrl.trim(),
+      });
+      setDirty(false);
+      dirtyRef.current = false;
+      onChanged();
+    });
+  }
+
+  if (!status) {
+    return (
+      <SettingsPanel title="Model Gateway" description="Loading…" busy>
+        {error && <SettingsError>{error}</SettingsError>}
+      </SettingsPanel>
+    );
+  }
+
+  const pendingUrl =
+    status.sign_in.state === "pending" ? status.sign_in.authorization_url : null;
+
+  return (
+    <SettingsPanel
+      title="Model Gateway"
+      description="Sign in to a model-gateway deployment to use the models and governed tools you are entitled to. Off, OpenWave stays fully local."
+      busy={working}
+    >
+      <SettingsSection>
+        <label className="flex items-center gap-2 text-sm font-medium">
+          <input
+            type="checkbox"
+            checked={status.enabled}
+            disabled={working}
+            onChange={(event) => void save(event.target.checked)}
+          />
+          Use Model Gateway
+        </label>
+
+        <SettingsField
+          label="Gateway URL"
+          hint="The deployment's base URL, e.g. http://127.0.0.1:28081 for a local dev gateway."
+        >
+          <Input
+            value={baseUrl}
+            disabled={working}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="https://gateway.example"
+            onChange={(event) => {
+              setBaseUrl(event.target.value);
+              setDirty(true);
+              dirtyRef.current = true;
+            }}
+          />
+        </SettingsField>
+        {dirty && (
+          <Button
+            type="button"
+            disabled={working}
+            onClick={() => void save(status.enabled)}
+          >
+            Save gateway URL
+          </Button>
+        )}
+      </SettingsSection>
+
+      <SettingsSection title="Connection">
+        {status.signed_in ? (
+          <>
+            <div className="web-search-state is-ready" role="status">
+              <strong>Signed in</strong>
+              <span>
+                {status.account_hint ?? "Connected"} ·{" "}
+                {status.model_count === 1
+                  ? "1 model entitled"
+                  : `${status.model_count} models entitled`}
+              </span>
+            </div>
+            {status.installation_id && (
+              <p className="text-muted-foreground text-xs">
+                Installation {status.installation_id}
+              </p>
+            )}
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={working}
+                onClick={() =>
+                  void run(async () => {
+                    await client.syncGatewayModels();
+                    onChanged();
+                  })
+                }
+              >
+                <RefreshCw size={14} />
+                Refresh models
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                disabled={working}
+                onClick={() =>
+                  void run(async () => {
+                    await client.gatewaySignOut();
+                    onChanged();
+                  })
+                }
+              >
+                <LogOut size={14} />
+                Disconnect
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="web-search-state is-not-configured" role="status">
+              <strong>Not signed in</strong>
+              <span>
+                {status.configured
+                  ? "Connect to sign in with your browser."
+                  : "Save the gateway URL, then connect."}
+              </span>
+            </div>
+            {status.sign_in.state === "failed" && (
+              <SettingsError>{status.sign_in.message}</SettingsError>
+            )}
+            {pendingUrl ? (
+              <p className="text-sm">
+                Waiting for the browser…{" "}
+                <a
+                  className="underline"
+                  href={pendingUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  onClick={(event) => {
+                    // The webview swallows target="_blank"; route through the
+                    // native opener and keep the href for hover/copy.
+                    event.preventDefault();
+                    void openSignInPage(pendingUrl);
+                  }}
+                >
+                  Open the sign-in page again
+                </a>
+              </p>
+            ) : (
+              <Button
+                type="button"
+                disabled={working || !status.configured || dirty}
+                onClick={() =>
+                  void run(async () => {
+                    const started = await client.gatewaySignIn();
+                    await openSignInPage(started.authorization_url);
+                  })
+                }
+              >
+                <ExternalLink size={14} />
+                Connect
+              </Button>
+            )}
+          </>
+        )}
+      </SettingsSection>
+
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        Sign-in happens in your browser against the gateway itself; OpenWave
+        never sees your identity provider credentials. Tokens are stored in the
+        system keychain and revoked at the gateway when you disconnect.
+      </p>
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsPanel>
+  );
+}


### PR DESCRIPTION
The turnkey surface: a toggle, the deployment URL, and a Connect button
that opens the gateway's own browser sign-in. The panel never asks for
a credential — there is no key field to fill — and while the exchange
completes in the background it watches the connection status, then
shows who is signed in, which installation, and how many models are
entitled, refreshing the model picker as entitlements land. Refresh
models resyncs on demand; Disconnect revokes at the gateway and returns
the app to exactly its local bring-your-own-key behavior.

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)