### PR TITLE
fix(server): restore model gateway test coverage

### DIFF
--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -388,6 +388,7 @@ mod tests {
             ProviderKind::Anthropic => true,
             ProviderKind::Openai => true,
             ProviderKind::OpenaiCompatible => false,
+            ProviderKind::ModelGateway => true,
         }
     }
 

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -675,6 +675,7 @@ async fn a_curated_openai_model_answers_after_receiving_png_and_jpeg_attachments
         Arc::new(resolver::ConfiguredResolver::new(
             store.clone(),
             secrets.clone(),
+            crate::gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone()),
         )),
         secrets,
         Arc::new(ToolRegistry::new()),


### PR DESCRIPTION
Restores the gateway dependency when constructing the configured resolver in the image-attachment integration test.

Keeps the model-capability invariant exhaustive for the model gateway provider.

Validation:
- cargo fmt --all --check
- cargo test -p openwave-server --lib image_attachment --locked
- cargo clippy -p openwave-server --all-targets --locked -- -D warnings