### PR TITLE
feat(release): group notes by scope

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -52,11 +52,6 @@ category-template: "### $TITLE"
 change-template: "- $TITLE ([#$NUMBER]($URL)) by @$AUTHOR"
 change-title-escapes: '\<*_&'
 no-changes-template: "- No user-facing changes."
-replacers:
-  # Category headings already communicate the change type, so remove the
-  # Conventional Commit prefix from each rendered PR title.
-  - search: '/- (?:feat|fix|perf|deps|revert)(?:\([^)]+\))?!?: /g'
-    replace: "- "
 template: |
   ## What's Changed
 

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -66,7 +66,23 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - id: release_drafter
+        uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7
+      - name: Group release notes by Conventional Commit scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BODY: ${{ steps.release_drafter.outputs.body }}
+          RELEASE_ID: ${{ steps.release_drafter.outputs.id }}
+        run: |
+          original="$RUNNER_TEMP/release-body.md"
+          formatted="$RUNNER_TEMP/formatted-release-body.md"
+          printf '%s' "$RELEASE_BODY" > "$original"
+          node scripts/format-release-notes.mjs < "$original" > "$formatted"
+          cmp --silent "$original" "$formatted" && exit 0
+          jq -n --rawfile body "$formatted" '{body: $body}' | gh api \
+            --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+            --input - >/dev/null
 
   backfill:
     name: backfill release labels

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -67,8 +67,11 @@ without asking authors to classify a PR twice:
 | Any `!`    | Breaking Changes            |
 
 Documentation and other maintenance-only types remain excluded. In the rendered
-notes, the section heading supplies the type, so Release Drafter removes the
-redundant Conventional Commit prefix from each PR title.
+notes, the section heading supplies the type, so the draft formatter removes the
+redundant Conventional Commit prefix from each PR title. A user-facing change
+with a scope is placed beneath a matching third-level heading: for example,
+`feat(desktop): add document search` is rendered under **New Features**, then
+under **Desktop**. Unscoped changes remain directly under their section.
 
 For historical or imported pull requests, the **Release draft** workflow has a
 manual `workflow_dispatch` backfill. Its default dry run reports the exact
@@ -88,7 +91,9 @@ The release-draft workflow keeps exactly one draft GitHub Release up to date:
    before merge.
 2. After the PR is squash-merged to `main`, Release Drafter adds it to the
    native draft, groups the release notes into the sections above, and suggests
-   the next tag. Breaking changes are always shown first.
+   the next tag. The draft formatter then groups scoped Conventional Commit
+   titles beneath scope subheadings within those sections. Breaking changes are
+   always shown first.
 3. Maintenance-only PRs are omitted. The largest release effect among included
    PRs chooses the proposed version; the category labels do not independently
    change the version.
@@ -97,9 +102,11 @@ The first release has no previous published release to use as a comparison
 baseline, so Release Drafter intentionally leaves that draft as a manual
 starting point. For `v0.1.0`, set the tag deliberately and click **Generate
 release notes** in GitHub; `.github/release.yml` applies the same sections to
-GitHub's native output. Curate that one-time full-history result before
-publishing. From then on, the last published tag and the managed PR labels make
-the maintained draft and its proposed version automatic.
+GitHub's native output. GitHub's native generator cannot create dynamic scope
+subheadings, so add those manually if desired for that one-time full-history
+release. Curate that result before publishing. From then on, the last published
+tag and the managed PR labels make the maintained draft and its proposed version
+automatic.
 
 ## Publishing a release
 

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+import { parsePrTitle } from "./check-pr-title.mjs";
+
+const SCOPED_CATEGORY_TITLES = new Set([
+  "Breaking Changes",
+  "New Features",
+  "Bug Fixes",
+  "Performance Improvements",
+  "Dependency Updates",
+  "Reverted Changes",
+]);
+
+const CHANGE_LINE_PATTERN = /^- (.*?) \(\[#\d+\]\([^)]*\)\) by @\S+$/;
+
+const SCOPE_ACRONYMS = new Map([
+  ["api", "API"],
+  ["cli", "CLI"],
+  ["db", "DB"],
+  ["mcp", "MCP"],
+  ["ui", "UI"],
+  ["ux", "UX"],
+]);
+
+function scopeHeading(scope) {
+  return scope
+    .split(/([._/-])/)
+    .map((part) => {
+      if (/^[._/-]$/.test(part)) return part;
+      if (SCOPE_ACRONYMS.has(part)) return SCOPE_ACRONYMS.get(part);
+      return `${part[0].toUpperCase()}${part.slice(1)}`;
+    })
+    .join("");
+}
+
+function parseChangeLine(line) {
+  const match = CHANGE_LINE_PATTERN.exec(line);
+  if (!match) return null;
+
+  const title = parsePrTitle(match[1]);
+  if (!title) return null;
+
+  return {
+    scope: title.scope,
+    line: line.replace(match[1], title.description),
+  };
+}
+
+function formatCategory(lines) {
+  let contentLength = lines.length;
+  while (contentLength > 0 && lines[contentLength - 1] === "") {
+    contentLength -= 1;
+  }
+  const contentLines = lines.slice(0, contentLength);
+  const trailingLines = lines.slice(contentLength);
+  const changes = contentLines.map(parseChangeLine);
+  if (changes.every((change) => change === null)) return lines;
+
+  const scopedChanges = new Map();
+  const unscopedLines = [];
+  for (let index = 0; index < contentLines.length; index += 1) {
+    const change = changes[index];
+    if (!change?.scope) {
+      unscopedLines.push(change ? change.line : contentLines[index]);
+      continue;
+    }
+
+    const group = scopedChanges.get(change.scope) ?? [];
+    group.push(change.line);
+    scopedChanges.set(change.scope, group);
+  }
+
+  if (scopedChanges.size === 0) return [...unscopedLines, ...trailingLines];
+
+  const formatted = unscopedLines.filter((line) => line !== "");
+  for (const scope of [...scopedChanges.keys()].sort()) {
+    if (formatted.length > 0) formatted.push("");
+    formatted.push(`#### ${scopeHeading(scope)}`, ...scopedChanges.get(scope));
+  }
+  return [...formatted, ...trailingLines];
+}
+
+export function formatReleaseNotes(body) {
+  if (typeof body !== "string") {
+    throw new Error("release notes must be a string");
+  }
+
+  const lines = body.split("\n");
+  const formatted = [];
+  for (let index = 0; index < lines.length; ) {
+    const heading = /^### (.+)$/.exec(lines[index]);
+    if (!heading || !SCOPED_CATEGORY_TITLES.has(heading[1])) {
+      formatted.push(lines[index]);
+      index += 1;
+      continue;
+    }
+
+    formatted.push(lines[index]);
+    const categoryStart = index + 1;
+    index = categoryStart;
+    while (index < lines.length && !/^### /.test(lines[index])) index += 1;
+    formatted.push(...formatCategory(lines.slice(categoryStart, index)));
+  }
+
+  return formatted.join("\n");
+}
+
+async function main() {
+  let body = "";
+  for await (const chunk of process.stdin) body += chunk;
+  process.stdout.write(formatReleaseNotes(body));
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/scripts/format-release-notes.test.mjs
+++ b/scripts/format-release-notes.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatReleaseNotes } from "./format-release-notes.mjs";
+
+test("renders Conventional Commit scopes as subheadings within their category", () => {
+  const notes = `## What's Changed
+
+### New Features
+- feat(desktop): add document search ([#12](https://example.com/12)) by @octo
+- feat: add a default workspace ([#13](https://example.com/13)) by @octo
+- feat(core): add saved searches ([#14](https://example.com/14)) by @octo
+
+### Bug Fixes
+- fix(desktop): prevent a startup crash ([#15](https://example.com/15)) by @octo
+### Other Changes
+- docs: update the setup guide ([#16](https://example.com/16)) by @octo
+`;
+
+  assert.equal(
+    formatReleaseNotes(notes),
+    `## What's Changed
+
+### New Features
+- add a default workspace ([#13](https://example.com/13)) by @octo
+
+#### Core
+- add saved searches ([#14](https://example.com/14)) by @octo
+
+#### Desktop
+- add document search ([#12](https://example.com/12)) by @octo
+
+### Bug Fixes
+#### Desktop
+- prevent a startup crash ([#15](https://example.com/15)) by @octo
+### Other Changes
+- docs: update the setup guide ([#16](https://example.com/16)) by @octo
+`,
+  );
+});
+
+test("keeps unscoped release entries in their category without a subheading", () => {
+  const notes = `### Dependency Updates
+- deps: update sqlite ([#17](https://example.com/17)) by @octo
+`;
+
+  assert.equal(
+    formatReleaseNotes(notes),
+    `### Dependency Updates
+- update sqlite ([#17](https://example.com/17)) by @octo
+`,
+  );
+});
+
+test("uses readable acronyms in scoped headings and leaves unrelated entries alone", () => {
+  const notes = `### Breaking Changes
+- feat(mcp)!: replace the protocol ([#18](https://example.com/18)) by @octo
+### Other Changes
+- Plain historical change ([#19](https://example.com/19)) by @octo
+`;
+
+  assert.equal(
+    formatReleaseNotes(notes),
+    `### Breaking Changes
+#### MCP
+- replace the protocol ([#18](https://example.com/18)) by @octo
+### Other Changes
+- Plain historical change ([#19](https://example.com/19)) by @octo
+`,
+  );
+});


### PR DESCRIPTION
## Summary
- Group scoped Conventional Commit entries beneath nested release-note headings.
- Preserve the existing release categories, semantic version labels, and unscoped entries.
- Document the maintained-draft behavior and cover it with formatter tests.

## Validation
- node --test scripts/*.test.mjs
- bw dev lint --check