### PR TITLE
fix(release): compact scope grouping

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -68,10 +68,12 @@ without asking authors to classify a PR twice:
 
 Documentation and other maintenance-only types remain excluded. In the rendered
 notes, the section heading supplies the type, so the draft formatter removes the
-redundant Conventional Commit prefix from each PR title. A user-facing change
-with a scope is placed beneath a matching third-level heading: for example,
-`feat(desktop): add document search` is rendered under **New Features**, then
-under **Desktop**. Unscoped changes remain directly under their section.
+redundant Conventional Commit prefix from each PR title. When a category has
+multiple user-facing changes with the same scope, the formatter groups them
+under a third-level heading: for example, multiple `feat(desktop)` changes are
+rendered under **New Features**, then **Desktop**. A singleton scope is kept
+compact as an inline prefix, and unscoped changes appear in the flat tail of the
+section.
 
 For historical or imported pull requests, the **Release draft** workflow has a
 manual `workflow_dispatch` backfill. Its default dry run reports the exact
@@ -91,9 +93,9 @@ The release-draft workflow keeps exactly one draft GitHub Release up to date:
    before merge.
 2. After the PR is squash-merged to `main`, Release Drafter adds it to the
    native draft, groups the release notes into the sections above, and suggests
-   the next tag. The draft formatter then groups scoped Conventional Commit
-   titles beneath scope subheadings within those sections. Breaking changes are
-   always shown first.
+   the next tag. The draft formatter then groups repeated scoped Conventional
+   Commit titles beneath scope subheadings and keeps other entries compact at
+   the end of their section. Breaking changes are always shown first.
 3. Maintenance-only PRs are omitted. The largest release effect among included
    PRs chooses the proposed version; the category labels do not independently
    change the version.

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -48,6 +48,10 @@ function parseChangeLine(line) {
   };
 }
 
+function inlineScope(scope, line) {
+  return `- **${scopeHeading(scope)}:** ${line.slice(2)}`;
+}
+
 function formatCategory(lines) {
   let contentLength = lines.length;
   while (contentLength > 0 && lines[contentLength - 1] === "") {
@@ -72,13 +76,28 @@ function formatCategory(lines) {
     scopedChanges.set(change.scope, group);
   }
 
-  if (scopedChanges.size === 0) return [...unscopedLines, ...trailingLines];
-
-  const formatted = unscopedLines.filter((line) => line !== "");
+  const groupedScopes = [];
+  const singletonLines = [];
   for (const scope of [...scopedChanges.keys()].sort()) {
-    if (formatted.length > 0) formatted.push("");
-    formatted.push(`#### ${scopeHeading(scope)}`, ...scopedChanges.get(scope));
+    const scopeChanges = scopedChanges.get(scope);
+    if (scopeChanges.length === 1) {
+      singletonLines.push(inlineScope(scope, scopeChanges[0]));
+      continue;
+    }
+    groupedScopes.push([scope, scopeChanges]);
   }
+
+  const flatLines = [
+    ...unscopedLines.filter((line) => line !== ""),
+    ...singletonLines,
+  ];
+  const formatted = [];
+  for (const [scope, scopeChanges] of groupedScopes) {
+    if (formatted.length > 0) formatted.push("");
+    formatted.push(`#### ${scopeHeading(scope)}`, ...scopeChanges);
+  }
+  if (flatLines.length > 0 && formatted.length > 0) formatted.push("");
+  formatted.push(...flatLines);
   return [...formatted, ...trailingLines];
 }
 

--- a/scripts/format-release-notes.test.mjs
+++ b/scripts/format-release-notes.test.mjs
@@ -3,18 +3,19 @@ import test from "node:test";
 
 import { formatReleaseNotes } from "./format-release-notes.mjs";
 
-test("renders Conventional Commit scopes as subheadings within their category", () => {
+test("groups repeated scopes and keeps singleton scopes compact at the end", () => {
   const notes = `## What's Changed
 
 ### New Features
 - feat(desktop): add document search ([#12](https://example.com/12)) by @octo
 - feat: add a default workspace ([#13](https://example.com/13)) by @octo
 - feat(core): add saved searches ([#14](https://example.com/14)) by @octo
+- feat(desktop): add keyboard shortcuts ([#15](https://example.com/15)) by @octo
 
 ### Bug Fixes
-- fix(desktop): prevent a startup crash ([#15](https://example.com/15)) by @octo
+- fix(desktop): prevent a startup crash ([#16](https://example.com/16)) by @octo
 ### Other Changes
-- docs: update the setup guide ([#16](https://example.com/16)) by @octo
+- docs: update the setup guide ([#17](https://example.com/17)) by @octo
 `;
 
   assert.equal(
@@ -22,19 +23,17 @@ test("renders Conventional Commit scopes as subheadings within their category", 
     `## What's Changed
 
 ### New Features
-- add a default workspace ([#13](https://example.com/13)) by @octo
-
-#### Core
-- add saved searches ([#14](https://example.com/14)) by @octo
-
 #### Desktop
 - add document search ([#12](https://example.com/12)) by @octo
+- add keyboard shortcuts ([#15](https://example.com/15)) by @octo
+
+- add a default workspace ([#13](https://example.com/13)) by @octo
+- **Core:** add saved searches ([#14](https://example.com/14)) by @octo
 
 ### Bug Fixes
-#### Desktop
-- prevent a startup crash ([#15](https://example.com/15)) by @octo
+- **Desktop:** prevent a startup crash ([#16](https://example.com/16)) by @octo
 ### Other Changes
-- docs: update the setup guide ([#16](https://example.com/16)) by @octo
+- docs: update the setup guide ([#17](https://example.com/17)) by @octo
 `,
   );
 });
@@ -52,7 +51,7 @@ test("keeps unscoped release entries in their category without a subheading", ()
   );
 });
 
-test("uses readable acronyms in scoped headings and leaves unrelated entries alone", () => {
+test("uses readable acronyms in singleton scope prefixes", () => {
   const notes = `### Breaking Changes
 - feat(mcp)!: replace the protocol ([#18](https://example.com/18)) by @octo
 ### Other Changes
@@ -62,8 +61,7 @@ test("uses readable acronyms in scoped headings and leaves unrelated entries alo
   assert.equal(
     formatReleaseNotes(notes),
     `### Breaking Changes
-#### MCP
-- replace the protocol ([#18](https://example.com/18)) by @octo
+- **MCP:** replace the protocol ([#18](https://example.com/18)) by @octo
 ### Other Changes
 - Plain historical change ([#19](https://example.com/19)) by @octo
 `,


### PR DESCRIPTION
## Summary
- Use scope subheadings only when a category has multiple entries for that scope.
- Render singleton scopes inline and put all flat entries after grouped scopes.
- Document the compact layout and add regression coverage.

## Validation
- node --test scripts/*.test.mjs
- bw dev lint --check