### PR TITLE
fix(release): reject untagged publications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,16 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       actions: write
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+      - name: Reject an invalid published release tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: node scripts/check-release-tag.mjs "$RELEASE_TAG"
       - name: Dispatch the build from the shared main cache scope
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -119,10 +119,13 @@ automatic.
    For the first release only, set `v0.1.0`, click **Generate release notes**,
    and curate the full-history result as described above.
 3. Complete the release-readiness review, then click **Publish release**.
-4. GitHub creates the tag and emits the `release.published` event. A short-lived
-   dispatcher starts the production build from the current `main` workflow and
-   passes only the tag. Running the build from `main` gives every release the
-   same trusted compiler-cache scope; the build still queries GitHub for the
+4. GitHub creates the tag and emits the `release.published` event. Confirm the
+   draft still has its proposed `vMAJOR.MINOR.PATCH` tag before publishing:
+   GitHub can otherwise publish an untagged release. A short-lived dispatcher
+   rejects an invalid tag before it queues a production build; for a valid tag,
+   it starts the production build from the current `main` workflow and passes
+   only that tag. Running the build from `main` gives every release the same
+   trusted compiler-cache scope; the build still queries GitHub for the
    published release, checks out that exact tag, rejects malformed tags,
    prereleases, drafts, or commits outside `main`, and pins all later jobs to
    the resolved commit SHA.

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -130,9 +130,20 @@ test("production secrets remain isolated to the release workflow", () => {
 
 test("release builds use the trusted shared main cache scope", () => {
   const release = workflows["release.yml"];
+  const dispatchJob = workflowJob(release, "dispatch");
   assert.match(release, /gh workflow run release\.yml/);
   assert.match(release, /--ref main/);
   assert.match(release, /actions: write/);
+  assert.match(dispatchJob, /contents: read/);
+  assert.match(
+    dispatchJob,
+    /node scripts\/check-release-tag\.mjs "\$RELEASE_TAG"/,
+  );
+  assert.ok(
+    dispatchJob.indexOf("Reject an invalid published release tag") <
+      dispatchJob.indexOf("gh workflow run release.yml"),
+    "published release tags must be validated before dispatching a production build",
+  );
   assert.match(
     release,
     /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main'/,


### PR DESCRIPTION
## Summary
- Validate a published release tag before dispatching the production workflow.
- Prevent invalid or untagged releases from creating a second failed workflow run.
- Document the tag check and lock its ordering down with a workflow test.

## Validation
- node --test scripts/*.test.mjs
- bw dev lint --check