### PR TITLE
feat(desktop): import dropped sources in a live queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6699,6 +6699,7 @@ dependencies = [
  "cap-fs-ext",
  "cap-std",
  "chrono",
+ "futures",
  "infer",
  "openwave-core",
  "openwave-host-broker",

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -34,6 +34,7 @@ base64.workspace = true
 chrono = { workspace = true }
 cap-fs-ext.workspace = true
 cap-std.workspace = true
+futures.workspace = true
 infer = { version = "=0.19.0", default-features = false }
 openwave-core = { path = "../openwave-core", default-features = false }
 openwave-host-broker = { path = "../openwave-host-broker" }

--- a/crates/openwave-desktop/src/documents.rs
+++ b/crates/openwave-desktop/src/documents.rs
@@ -4,17 +4,20 @@
 //! small catalog/search projection and never sees source locations, indexing
 //! identities, generation metadata, or canonical document payloads.
 
+use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::ambient_authority;
 use cap_std::fs::{Dir, OpenOptions};
+use futures::{stream, StreamExt};
 use openwave_core::{ChatId, DocumentProcessingStatus, DocumentSourceBlob, Store};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use tauri::{AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, DragDropEvent, Emitter, Manager, State, WindowEvent};
 use tauri_plugin_dialog::DialogExt;
 use tokio::sync::oneshot;
 use tokio_util::io::ReaderStream;
@@ -30,7 +33,11 @@ const DOCUMENT_PAGE_SIZE: usize = 200;
 const MAX_LIBRARY_DOCUMENTS: usize = 1_000;
 const CLIENT_EXECUTOR_HEADER: &str = "x-openwave-client-executor";
 const IMPORT_PROGRESS_EVENT: &str = "library-import-progress";
+const IMPORT_DROP_EVENT: &str = "library-import-drop-state";
 const IMPORT_HASH_CHUNK_BYTES: usize = 64 * 1024;
+const MAX_CONCURRENT_IMPORTS: usize = 2;
+const IMPORT_RETRY_DELAYS: [Duration; 2] = [Duration::from_millis(250), Duration::from_secs(1)];
+const DROPPED_PATH_TTL: Duration = Duration::from_secs(15);
 
 #[derive(Debug, Deserialize)]
 struct CatalogPage {
@@ -161,11 +168,76 @@ enum LibraryImportProgressStatus {
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LibraryImportProgress {
+    import_id: String,
     display_name: String,
     status: LibraryImportProgressStatus,
     document_id: Option<String>,
     processing_status: Option<DocumentProcessingStatus>,
     message: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum LibraryImportDropPhase {
+    Enter,
+    Leave,
+    Dropped,
+}
+
+/// A path set by an operating-system drag operation. The renderer never
+/// receives these paths: it can only claim the most recent drop for its own
+/// window, and only once.
+#[derive(Default)]
+pub(crate) struct PendingLibraryDrop {
+    paths: std::sync::Mutex<HashMap<String, PendingDrop>>,
+}
+
+struct PendingDrop {
+    paths: Vec<PathBuf>,
+    received_at: Instant,
+}
+
+impl PendingLibraryDrop {
+    fn record(&self, window_label: &str, paths: Vec<PathBuf>) {
+        let mut pending = self.paths.lock().expect("dropped-path lock poisoned");
+        pending.insert(
+            window_label.to_owned(),
+            PendingDrop {
+                paths,
+                received_at: Instant::now(),
+            },
+        );
+    }
+
+    fn clear(&self, window_label: &str) {
+        self.paths
+            .lock()
+            .expect("dropped-path lock poisoned")
+            .remove(window_label);
+    }
+
+    fn take(&self, window_label: &str) -> Option<Vec<PathBuf>> {
+        let pending = self
+            .paths
+            .lock()
+            .expect("dropped-path lock poisoned")
+            .remove(window_label)?;
+        (pending.received_at.elapsed() <= DROPPED_PATH_TTL).then_some(pending.paths)
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LibraryImportDropState {
+    phase: LibraryImportDropPhase,
+    accepted: bool,
+    file_count: usize,
+}
+
+struct PendingDocumentImport {
+    import_id: Uuid,
+    path: PathBuf,
+    display_name: String,
 }
 
 struct PreparedDocumentImport {
@@ -178,6 +250,19 @@ struct PreparedDocumentImport {
 struct CompletedDocumentImport {
     document: ImportedDocument,
     already_present: bool,
+}
+
+enum ImportFailure {
+    Retryable(String),
+    Permanent(String),
+}
+
+impl ImportFailure {
+    fn message(self) -> String {
+        match self {
+            Self::Retryable(message) | Self::Permanent(message) => message,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -291,7 +376,34 @@ pub(crate) async fn import_library_document(
         return Ok(None);
     };
     let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
-    let completed = import_selected_document(&app, app_state.inner(), chat_id, path).await?;
+    let import_id = Uuid::new_v4();
+    let display_name =
+        import_display_name(&path).unwrap_or_else(|_| "Selected document".to_owned());
+    emit_import_progress(
+        &app,
+        LibraryImportProgress {
+            import_id: import_id.to_string(),
+            display_name,
+            status: LibraryImportProgressStatus::Queued,
+            document_id: None,
+            processing_status: None,
+            message: None,
+        },
+    );
+    let completed =
+        import_selected_document(&app, app_state.inner(), chat_id, path, import_id).await?;
+    emit_import_progress(
+        &app,
+        completed_progress(
+            import_id,
+            &completed.document,
+            if completed.already_present {
+                LibraryImportProgressStatus::AlreadyPresent
+            } else {
+                LibraryImportProgressStatus::Imported
+            },
+        ),
+    );
     Ok(Some(completed.document))
 }
 
@@ -313,20 +425,124 @@ pub(crate) async fn import_library_documents(
     let Some(paths) = pick_documents(&app).await? else {
         return Ok(None);
     };
+    Ok(Some(
+        import_document_paths(
+            &app,
+            app_state.inner(),
+            &host_access,
+            request.chat_id,
+            paths,
+        )
+        .await,
+    ))
+}
 
+/// Claim the most recent operating-system drop for this window and import it.
+/// The renderer submits only its conversation id; the native event loop keeps
+/// the source paths out of the webview and makes the grant single-use.
+#[tauri::command]
+pub(crate) async fn import_dropped_library_documents(
+    app: AppHandle,
+    window: tauri::WebviewWindow,
+    app_state: State<'_, Arc<AppState>>,
+    host_access: State<'_, HostAccess>,
+    request: LibraryRequest,
+) -> Result<Option<LibraryImportBatch>, String> {
+    resolve_conversation_scope(&host_access, request.chat_id).await?;
+    let paths = app
+        .state::<PendingLibraryDrop>()
+        .take(window.label())
+        .ok_or_else(|| "Drop the files into OpenWave again".to_owned())?;
+    Ok(Some(
+        import_document_paths(
+            &app,
+            app_state.inner(),
+            &host_access,
+            request.chat_id,
+            paths,
+        )
+        .await,
+    ))
+}
+
+/// Turn native drag events into a small renderer-safe state signal while
+/// retaining the actual paths in process until the drop is claimed.
+pub(crate) fn handle_window_drag_drop(app: &AppHandle, window_label: &str, event: &WindowEvent) {
+    let WindowEvent::DragDrop(event) = event else {
+        return;
+    };
+    let pending = app.state::<PendingLibraryDrop>();
+    let state = match event {
+        DragDropEvent::Enter { paths, .. } => {
+            pending.clear(window_label);
+            drop_state(LibraryImportDropPhase::Enter, paths)
+        }
+        DragDropEvent::Drop { paths, .. } => {
+            let state = drop_state(LibraryImportDropPhase::Dropped, paths);
+            if state.accepted {
+                pending.record(window_label, paths.clone());
+            } else {
+                pending.clear(window_label);
+            }
+            state
+        }
+        DragDropEvent::Leave => {
+            pending.clear(window_label);
+            LibraryImportDropState {
+                phase: LibraryImportDropPhase::Leave,
+                accepted: false,
+                file_count: 0,
+            }
+        }
+        DragDropEvent::Over { .. } => return,
+        _ => return,
+    };
+    if let Some(window) = app.get_webview_window(window_label) {
+        if let Err(error) = window.emit(IMPORT_DROP_EVENT, state) {
+            eprintln!("openwave-desktop: could not emit import drop state: {error}");
+        }
+    }
+}
+
+fn drop_state(phase: LibraryImportDropPhase, paths: &[PathBuf]) -> LibraryImportDropState {
+    // The host accepts every regular file type. A folder (or a symlink, which
+    // is intentionally rejected later by the capability-safe opener) cannot
+    // be imported as a document and gets an immediate reject state instead.
+    let accepted = !paths.is_empty()
+        && paths.iter().all(|path| {
+            std::fs::symlink_metadata(path)
+                .map(|metadata| metadata.file_type().is_file())
+                .unwrap_or(false)
+        });
+    LibraryImportDropState {
+        phase,
+        accepted,
+        file_count: paths.len(),
+    }
+}
+
+async fn import_document_paths(
+    app: &AppHandle,
+    app_state: &Arc<AppState>,
+    host_access: &HostAccess,
+    chat_id: Uuid,
+    paths: Vec<PathBuf>,
+) -> LibraryImportBatch {
     let pending = paths
         .into_iter()
-        .map(|path| {
-            let display_name =
-                import_display_name(&path).unwrap_or_else(|_| "Selected document".to_owned());
-            (path, display_name)
+        .map(|path| PendingDocumentImport {
+            import_id: Uuid::new_v4(),
+            display_name: import_display_name(&path)
+                .unwrap_or_else(|_| "Selected document".to_owned()),
+            path,
         })
         .collect::<Vec<_>>();
-    for (_, display_name) in &pending {
+    for import in &pending {
         emit_import_progress(
-            &app,
+            app,
             LibraryImportProgress {
-                display_name: display_name.clone(),
+                import_id: import.import_id.to_string(),
+                display_name: import.display_name.clone(),
                 status: LibraryImportProgressStatus::Queued,
                 document_id: None,
                 processing_status: None,
@@ -335,43 +551,67 @@ pub(crate) async fn import_library_documents(
         );
     }
 
-    let mut results = Vec::with_capacity(pending.len());
-    for (path, display_name) in pending {
-        let result = match resolve_conversation_scope(&host_access, request.chat_id).await {
-            Ok(chat_id) => {
-                match import_selected_document(&app, app_state.inner(), chat_id, path).await {
-                    Ok(completed) if completed.already_present => {
-                        emit_import_progress(
-                            &app,
-                            completed_progress(
-                                &completed.document,
-                                LibraryImportProgressStatus::AlreadyPresent,
-                            ),
-                        );
-                        LibraryImportResult::AlreadyPresent {
-                            document: completed.document,
+    let mut results = stream::iter(pending.into_iter().enumerate().map(
+        |(index, import)| async move {
+            let result = match resolve_conversation_scope(host_access, chat_id).await {
+                Ok(chat_id) => {
+                    match import_selected_document(
+                        app,
+                        app_state,
+                        chat_id,
+                        import.path,
+                        import.import_id,
+                    )
+                    .await
+                    {
+                        Ok(completed) if completed.already_present => {
+                            emit_import_progress(
+                                app,
+                                completed_progress(
+                                    import.import_id,
+                                    &completed.document,
+                                    LibraryImportProgressStatus::AlreadyPresent,
+                                ),
+                            );
+                            LibraryImportResult::AlreadyPresent {
+                                document: completed.document,
+                            }
                         }
-                    }
-                    Ok(completed) => {
-                        emit_import_progress(
-                            &app,
-                            completed_progress(
-                                &completed.document,
-                                LibraryImportProgressStatus::Imported,
-                            ),
-                        );
-                        LibraryImportResult::Imported {
-                            document: completed.document,
+                        Ok(completed) => {
+                            emit_import_progress(
+                                app,
+                                completed_progress(
+                                    import.import_id,
+                                    &completed.document,
+                                    LibraryImportProgressStatus::Imported,
+                                ),
+                            );
+                            LibraryImportResult::Imported {
+                                document: completed.document,
+                            }
                         }
+                        Err(message) => failed_import_result(
+                            app,
+                            import.import_id,
+                            import.display_name,
+                            message,
+                        ),
                     }
-                    Err(message) => failed_import_result(&app, display_name, message),
                 }
-            }
-            Err(message) => failed_import_result(&app, display_name, message),
-        };
-        results.push(result);
+                Err(message) => {
+                    failed_import_result(app, import.import_id, import.display_name, message)
+                }
+            };
+            (index, result)
+        },
+    ))
+    .buffer_unordered(MAX_CONCURRENT_IMPORTS)
+    .collect::<Vec<_>>()
+    .await;
+    results.sort_by_key(|(index, _)| *index);
+    LibraryImportBatch {
+        results: results.into_iter().map(|(_, result)| result).collect(),
     }
-    Ok(Some(LibraryImportBatch { results }))
 }
 
 pub(crate) async fn resolve_conversation_scope(
@@ -552,13 +792,43 @@ async fn import_selected_document(
     app_state: &Arc<AppState>,
     chat_id: ChatId,
     path: PathBuf,
+    import_id: Uuid,
 ) -> Result<CompletedDocumentImport, String> {
+    for delay in IMPORT_RETRY_DELAYS
+        .iter()
+        .copied()
+        .map(Some)
+        .chain(std::iter::once(None))
+    {
+        match import_selected_document_once(app, app_state, chat_id, path.clone(), import_id).await
+        {
+            Ok(completed) => return Ok(completed),
+            Err(ImportFailure::Retryable(_)) if delay.is_some() => {
+                // Retrying only a transport or overloaded-server failure is
+                // safe: the server deduplicates by the verified source blob.
+                tokio::time::sleep(delay.expect("retry delay is present")).await;
+            }
+            Err(error) => return Err(error.message()),
+        }
+    }
+    unreachable!("the final import attempt always returns")
+}
+
+async fn import_selected_document_once(
+    app: &AppHandle,
+    app_state: &Arc<AppState>,
+    chat_id: ChatId,
+    path: PathBuf,
+    import_id: Uuid,
+) -> Result<CompletedDocumentImport, ImportFailure> {
     let prepared = tauri::async_runtime::spawn_blocking(move || prepare_selected_document(&path))
         .await
-        .map_err(|_| "Could not read the selected document".to_owned())??;
+        .map_err(|_| ImportFailure::Permanent("Could not read the selected document".to_owned()))?
+        .map_err(ImportFailure::Permanent)?;
     emit_import_progress(
         app,
         LibraryImportProgress {
+            import_id: import_id.to_string(),
             display_name: prepared.display_name.clone(),
             status: LibraryImportProgressStatus::Streaming,
             document_id: None,
@@ -566,7 +836,9 @@ async fn import_selected_document(
             message: None,
         },
     );
-    let info = wait_server_info(app_state).await?;
+    let info = wait_server_info(app_state)
+        .await
+        .map_err(ImportFailure::Permanent)?;
     let sha256 = encode_sha256(prepared.source_blob.sha256);
     let byte_len = prepared.source_blob.byte_len.to_string();
     let body = reqwest::Body::wrap_stream(ReaderStream::with_capacity(
@@ -590,14 +862,23 @@ async fn import_selected_document(
     .body(body)
     .send()
     .await
-    .map_err(|_| "Could not import the selected document".to_owned())?;
+    .map_err(|_| ImportFailure::Retryable("Could not import the selected document".to_owned()))?;
     if !response.status().is_success() {
-        return Err("Could not import the selected document".to_owned());
+        let message = "Could not import the selected document".to_owned();
+        return if response.status().is_server_error()
+            || response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS
+        {
+            Err(ImportFailure::Retryable(message))
+        } else {
+            Err(ImportFailure::Permanent(message))
+        };
     }
     let accepted = response
         .json::<StreamedIngestResponse>()
         .await
-        .map_err(|_| "Document import returned an invalid response".to_owned())?;
+        .map_err(|_| {
+            ImportFailure::Permanent("Document import returned an invalid response".to_owned())
+        })?;
     Ok(CompletedDocumentImport {
         document: ImportedDocument {
             document_id: accepted.document_id.to_string(),
@@ -613,10 +894,12 @@ fn encode_sha256(sha256: [u8; 32]) -> String {
 }
 
 fn completed_progress(
+    import_id: Uuid,
     document: &ImportedDocument,
     status: LibraryImportProgressStatus,
 ) -> LibraryImportProgress {
     LibraryImportProgress {
+        import_id: import_id.to_string(),
         display_name: document.display_name.clone(),
         status,
         document_id: Some(document.document_id.clone()),
@@ -627,12 +910,14 @@ fn completed_progress(
 
 fn failed_import_result(
     app: &AppHandle,
+    import_id: Uuid,
     display_name: String,
     message: String,
 ) -> LibraryImportResult {
     emit_import_progress(
         app,
         LibraryImportProgress {
+            import_id: import_id.to_string(),
             display_name: display_name.clone(),
             status: LibraryImportProgressStatus::Failed,
             document_id: None,
@@ -824,6 +1109,23 @@ mod tests {
         assert_eq!(json["results"][1]["displayName"], "archive.bin");
         assert!(json.to_string().contains("notes.md"));
         assert!(!json.to_string().contains("/Users/"));
+    }
+
+    #[test]
+    fn dropped_paths_are_scoped_to_one_window_and_consumed_once() {
+        let pending = PendingLibraryDrop::default();
+        pending.record("main", vec![PathBuf::from("/Users/private/notes.md")]);
+        pending.record("secondary", vec![PathBuf::from("/Users/private/other.md")]);
+
+        assert_eq!(
+            pending.take("main"),
+            Some(vec![PathBuf::from("/Users/private/notes.md")])
+        );
+        assert_eq!(pending.take("main"), None);
+        assert_eq!(
+            pending.take("secondary"),
+            Some(vec![PathBuf::from("/Users/private/other.md")])
+        );
     }
 
     #[cfg(unix)]

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -158,12 +158,14 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(state)
+        .manage(documents::PendingLibraryDrop::default())
         .manage(updater::UpdateManager::default())
         .invoke_handler(tauri::generate_handler![
             server_info,
             request_user_attention,
             documents::import_library_document,
             documents::import_library_documents,
+            documents::import_dropped_library_documents,
             documents::list_library_documents,
             documents::search_library_documents,
             image_attachments::attach_chat_image,
@@ -198,10 +200,14 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error while building OpenWave");
-    app.run(|app, event| {
-        if matches!(event, tauri::RunEvent::Exit) {
+    app.run(|app, event| match event {
+        tauri::RunEvent::WindowEvent { label, event, .. } => {
+            documents::handle_window_drag_drop(app, &label, &event);
+        }
+        tauri::RunEvent::Exit => {
             tauri::async_runtime::block_on(app.state::<host_access::HostAccess>().shutdown());
         }
+        _ => {}
     });
 }
 

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -26,7 +26,7 @@
         "minHeight": 480,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "dragDropEnabled": false,
+        "dragDropEnabled": true,
         "trafficLightPosition": {
           "x": 16,
           "y": 23

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -30,7 +30,13 @@ import { DeliverablesView } from "./DeliverablesView";
 import { DocumentsView } from "./DocumentsView";
 import { FoldersView } from "./FoldersView";
 import { hasNativeHost } from "./host";
-import { importLibraryDocument, type ImportedDocument } from "./documents";
+import {
+  importLibraryDocuments,
+  type ImportedDocument,
+  type LibraryImportSuccess,
+} from "./documents";
+import { DocumentDropTarget } from "./DocumentDropTarget";
+import { ImportQueue } from "./ImportQueue";
 import {
   readyImageAttachmentIds,
   readyTranscriptImageAttachments,
@@ -298,8 +304,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     setAttachingSource(true);
     setSourceAttachmentError(null);
     try {
-      const source = await importLibraryDocument(chatId);
-      if (source) setRecentSource(source);
+      const batch = await importLibraryDocuments(chatId);
+      const source = batch?.results.find(isImportedDocument);
+      if (source) setRecentSource(source.document);
     } catch (err) {
       setSourceAttachmentError(friendlySourceAttachmentError(err));
     } finally {
@@ -426,6 +433,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         </div>
       </header>
       <PanelLayout layout={layout} renderPanel={renderPanel} />
+      <ImportQueue />
+      <DocumentDropTarget chatId={chatId} />
     </div>
   );
 }
@@ -452,4 +461,10 @@ function textOnlyModelLabel(
 function friendlySourceAttachmentError(error: unknown): string {
   const message = String(error).replace(/^Error:\s*/, "").trim();
   return message && message.length <= 240 ? message : "Could not add that file.";
+}
+
+function isImportedDocument(
+  result: { status: string },
+): result is LibraryImportSuccess {
+  return result.status === "imported" || result.status === "already_present";
 }

--- a/crates/openwave-desktop/ui/src/DocumentDropTarget.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentDropTarget.tsx
@@ -1,0 +1,85 @@
+import { listen } from "@tauri-apps/api/event";
+import { useEffect, useState } from "react";
+import { importDroppedLibraryDocuments } from "./documents";
+import { hasNativeHost } from "./host";
+
+type DropPhase = "enter" | "leave" | "dropped";
+
+type DropState = {
+  phase: DropPhase;
+  accepted: boolean;
+  fileCount: number;
+};
+
+export function DocumentDropTarget({ chatId }: { chatId: string }) {
+  const [state, setState] = useState<DropState | null>(null);
+
+  useEffect(() => {
+    if (!hasNativeHost()) return;
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+    void listen<unknown>("library-import-drop-state", (event) => {
+      const next = parseDropState(event.payload);
+      if (!next || cancelled) return;
+      if (next.phase === "leave") {
+        setState(null);
+        return;
+      }
+      if (next.phase === "dropped") {
+        setState(null);
+        if (next.accepted) void importDroppedLibraryDocuments(chatId).catch(() => {});
+        return;
+      }
+      setState(next);
+    }).then((stop) => {
+      if (cancelled) stop();
+      else unlisten = stop;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [chatId]);
+
+  if (!state) return null;
+  return (
+    <div
+      className={`document-drop-target ${state.accepted ? "accept" : "reject"}`}
+      aria-live="assertive"
+    >
+      <strong>
+        {state.accepted
+          ? `Add ${fileCountCopy(state.fileCount)} to this conversation`
+          : "Only files can be added as sources"}
+      </strong>
+      <span>
+        {state.accepted
+          ? "Release to add them in the background."
+          : "Drop files, not folders or aliases."}
+      </span>
+    </div>
+  );
+}
+
+function parseDropState(value: unknown): DropState | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const state = value as Record<string, unknown>;
+  if (
+    !["enter", "leave", "dropped"].includes(String(state.phase)) ||
+    typeof state.accepted !== "boolean" ||
+    typeof state.fileCount !== "number" ||
+    !Number.isSafeInteger(state.fileCount) ||
+    state.fileCount < 0
+  ) {
+    return null;
+  }
+  return {
+    phase: state.phase as DropPhase,
+    accepted: state.accepted,
+    fileCount: state.fileCount,
+  };
+}
+
+function fileCountCopy(count: number): string {
+  return count === 1 ? "this file" : `${count} files`;
+}

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { FileText } from "lucide-react";
 import {
-  importLibraryDocument,
+  importLibraryDocuments,
   listLibraryDocuments,
   searchLibraryDocuments,
   type ImportedDocument,
   type LibraryDocument,
+  type LibraryImportSuccess,
   type LibrarySearchResult,
 } from "./documents";
 import {
@@ -90,9 +91,10 @@ export function DocumentsView({
     setError(null);
     setImported(null);
     try {
-      const accepted = await importLibraryDocument(chatId);
+      const batch = await importLibraryDocuments(chatId);
+      const accepted = batch?.results.find(isImportedDocument);
       if (!mountedRef.current || !accepted) return;
-      setImported(accepted);
+      setImported(accepted.document);
       await refreshCatalog();
     } catch (err) {
       if (mountedRef.current) {
@@ -149,7 +151,7 @@ export function DocumentsView({
             disabled={importing}
             onClick={() => void onImport()}
           >
-            {importing ? "Adding…" : "Add source…"}
+            {importing ? "Adding…" : "Add sources…"}
           </button>
         </div>
       </header>
@@ -309,6 +311,12 @@ function formatDate(value: string): string {
   return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(
     new Date(value),
   );
+}
+
+function isImportedDocument(
+  result: { status: string },
+): result is LibraryImportSuccess {
+  return result.status === "imported" || result.status === "already_present";
 }
 
 function friendlyError(error: unknown, fallback: string): string {

--- a/crates/openwave-desktop/ui/src/ImportQueue.tsx
+++ b/crates/openwave-desktop/ui/src/ImportQueue.tsx
@@ -1,0 +1,60 @@
+import {
+  importIsActive,
+  sortedImportQueue,
+  useImportQueueStore,
+} from "./ImportQueueStore";
+
+export function ImportQueue() {
+  const entries = useImportQueueStore((state) => state.entries);
+  const dismissCleanRun = useImportQueueStore((state) => state.dismissCleanRun);
+  if (entries.length === 0) return null;
+
+  const sorted = sortedImportQueue(entries);
+  const active = sorted.some((entry) => importIsActive(entry.status));
+  const failed = sorted.some((entry) => entry.status === "failed");
+
+  return (
+    <aside className="import-queue" aria-labelledby="import-queue-title">
+      <header>
+        <div>
+          <h2 id="import-queue-title">
+            {active ? "Adding sources" : failed ? "Some sources need attention" : "Sources added"}
+          </h2>
+          <p>{active ? "OpenWave is preparing your files for this conversation." : null}</p>
+        </div>
+        {!active && !failed && (
+          <button type="button" className="btn" onClick={dismissCleanRun}>
+            Dismiss
+          </button>
+        )}
+      </header>
+      <ul aria-live="polite">
+        {sorted.map((entry) => (
+          <li key={entry.importId} className={`import-queue-${entry.status}`}>
+            <span className="import-queue-name">{entry.displayName}</span>
+            <span className="import-queue-state">
+              {importStateCopy(entry.status, entry.message)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}
+
+function importStateCopy(status: string, message: string | null): string {
+  switch (status) {
+    case "queued":
+      return "Waiting to add";
+    case "streaming":
+      return "Adding";
+    case "imported":
+      return "Added";
+    case "already_present":
+      return "Already added";
+    case "failed":
+      return message ?? "Could not add";
+    default:
+      return "Adding";
+  }
+}

--- a/crates/openwave-desktop/ui/src/ImportQueueStore.test.ts
+++ b/crates/openwave-desktop/ui/src/ImportQueueStore.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  createImportQueueStore,
+  sortedImportQueue,
+  type ImportQueueEntry,
+} from "./ImportQueueStore";
+
+const queued = {
+  importId: "11111111-1111-4111-8111-111111111111",
+  displayName: "notes.md",
+  status: "queued" as const,
+  documentId: null,
+  processingStatus: null,
+  message: null,
+};
+
+describe("ImportQueueStore", () => {
+  it("keeps imports outside a component and advances one item by its native id", () => {
+    const store = createImportQueueStore();
+    store.getState().receive(queued);
+    store.getState().receive({
+      ...queued,
+      status: "imported",
+      documentId: "22222222-2222-4222-8222-222222222222",
+      processingStatus: "queued",
+    });
+
+    expect(store.getState().entries).toEqual([
+      expect.objectContaining({
+        importId: queued.importId,
+        status: "imported",
+        documentId: "22222222-2222-4222-8222-222222222222",
+      }),
+    ]);
+  });
+
+  it("only dismisses a completed run with no failures", () => {
+    const store = createImportQueueStore();
+    store.getState().receive({ ...queued, status: "streaming" });
+    store.getState().dismissCleanRun();
+    expect(store.getState().entries).toHaveLength(1);
+
+    store.getState().receive({
+      ...queued,
+      status: "failed",
+      message: "The file is empty",
+    });
+    store.getState().dismissCleanRun();
+    expect(store.getState().entries).toHaveLength(1);
+
+    const clean = createImportQueueStore();
+    clean.getState().receive({
+      ...queued,
+      status: "imported",
+      documentId: "22222222-2222-4222-8222-222222222222",
+      processingStatus: "queued",
+    });
+    clean.getState().dismissCleanRun();
+    expect(clean.getState().entries).toEqual([]);
+  });
+
+  it("puts failures before active and completed imports", () => {
+    const entries: ImportQueueEntry[] = [
+      { ...queued, status: "imported", updatedAt: 1 },
+      {
+        ...queued,
+        importId: "33333333-3333-4333-8333-333333333333",
+        status: "failed",
+        message: "Unreadable",
+        updatedAt: 3,
+      },
+      {
+        ...queued,
+        importId: "44444444-4444-4444-8444-444444444444",
+        status: "streaming",
+        updatedAt: 2,
+      },
+    ];
+    expect(sortedImportQueue(entries).map((entry) => entry.status)).toEqual([
+      "failed",
+      "imported",
+      "streaming",
+    ]);
+  });
+});

--- a/crates/openwave-desktop/ui/src/ImportQueueStore.ts
+++ b/crates/openwave-desktop/ui/src/ImportQueueStore.ts
@@ -1,0 +1,70 @@
+import { create } from "zustand";
+import {
+  listenForLibraryImportProgress,
+  type LibraryImportProgress,
+  type LibraryImportState,
+} from "./documents";
+import { hasNativeHost } from "./host";
+
+export type ImportQueueEntry = LibraryImportProgress & {
+  updatedAt: number;
+};
+
+export type ImportQueueStore = {
+  entries: ImportQueueEntry[];
+  receive: (progress: LibraryImportProgress) => void;
+  dismissCleanRun: () => void;
+};
+
+export function createImportQueueStore() {
+  return create<ImportQueueStore>()((set) => ({
+    entries: [],
+    receive: (progress) =>
+      set((state) => {
+        const next: ImportQueueEntry = { ...progress, updatedAt: Date.now() };
+        const index = state.entries.findIndex((entry) => entry.importId === progress.importId);
+        if (index === -1) return { entries: [...state.entries, next] };
+        const entries = [...state.entries];
+        entries[index] = next;
+        return { entries };
+      }),
+    // A failed run stays visible until its reader has seen and resolved it.
+    dismissCleanRun: () =>
+      set((state) =>
+        state.entries.some((entry) => entry.status === "failed") ||
+        state.entries.some((entry) => importIsActive(entry.status))
+          ? state
+          : { entries: [] },
+      ),
+  }));
+}
+
+export const useImportQueueStore = createImportQueueStore();
+
+export function importIsActive(status: LibraryImportState): boolean {
+  return status === "queued" || status === "streaming";
+}
+
+export function sortedImportQueue(entries: ImportQueueEntry[]): ImportQueueEntry[] {
+  return [...entries].sort((left, right) => {
+    const leftFailed = left.status === "failed";
+    const rightFailed = right.status === "failed";
+    if (leftFailed !== rightFailed) return leftFailed ? -1 : 1;
+    return left.updatedAt - right.updatedAt;
+  });
+}
+
+let listening = false;
+
+/** Start once at application boot so imports remain visible across navigation. */
+export function startImportQueue(): void {
+  if (listening || !hasNativeHost()) return;
+  listening = true;
+  void listenForLibraryImportProgress((progress) => {
+    useImportQueueStore.getState().receive(progress);
+  }).catch(() => {
+    // The native bridge may not be ready during startup. Import commands still
+    // surface their own errors, and a later app restart installs the listener.
+    listening = false;
+  });
+}

--- a/crates/openwave-desktop/ui/src/documents.test.ts
+++ b/crates/openwave-desktop/ui/src/documents.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   parseImportedDocument,
+  parseLibraryImportBatch,
+  parseLibraryImportProgress,
   parseLibraryCatalog,
   parseLibrarySearchResults,
 } from "./documents";
@@ -8,6 +10,43 @@ import {
 const documentId = "6c3df6af-bc62-4a66-a34e-29f327eaef41";
 
 describe("document library renderer projections", () => {
+  it("parses native batch results and rejects invalid progress", () => {
+    expect(
+      parseLibraryImportBatch({
+        results: [
+          {
+            status: "imported",
+            documentId,
+            displayName: "notes.md",
+            processingStatus: "queued",
+          },
+        ],
+      }),
+    ).toEqual({
+      results: [
+        {
+          status: "imported",
+          document: {
+            documentId,
+            displayName: "notes.md",
+            processingStatus: "queued",
+          },
+        },
+      ],
+    });
+
+    expect(() =>
+      parseLibraryImportProgress({
+        importId: "not-an-id",
+        displayName: "notes.md",
+        status: "streaming",
+        documentId: null,
+        processingStatus: null,
+        message: null,
+      }),
+    ).toThrow("Invalid document import progress");
+  });
+
   it("accepts the closed catalog and import shapes", () => {
     expect(
       parseLibraryCatalog({

--- a/crates/openwave-desktop/ui/src/documents.ts
+++ b/crates/openwave-desktop/ui/src/documents.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 
 export type DocumentProcessingStatus =
   | "queued"
@@ -21,6 +22,35 @@ export type ImportedDocument = {
   displayName: string;
   processingStatus: DocumentProcessingStatus;
 };
+
+export type LibraryImportState =
+  | "queued"
+  | "streaming"
+  | "imported"
+  | "already_present"
+  | "failed";
+
+export type LibraryImportProgress = {
+  importId: string;
+  displayName: string;
+  status: LibraryImportState;
+  documentId: string | null;
+  processingStatus: DocumentProcessingStatus | null;
+  message: string | null;
+};
+
+export type LibraryImportBatch = {
+  results: LibraryImportResult[];
+};
+
+export type LibraryImportSuccess = {
+  status: "imported" | "already_present";
+  document: ImportedDocument;
+};
+
+export type LibraryImportResult =
+  | LibraryImportSuccess
+  | { status: "failed"; displayName: string; message: string };
 
 export type LibrarySearchResult = {
   documentId: string;
@@ -45,6 +75,111 @@ export async function importLibraryDocument(
   return parseImportedDocument(
     await invoke("import_library_document", { request: { chatId } }),
   );
+}
+
+/** Select several sources in one native picker and receive progress by event. */
+export async function importLibraryDocuments(
+  chatId: string,
+): Promise<LibraryImportBatch | null> {
+  return parseLibraryImportBatch(
+    await invoke("import_library_documents", { request: { chatId } }),
+  );
+}
+
+/** Claim one just-dropped native file set without ever serializing its paths. */
+export async function importDroppedLibraryDocuments(
+  chatId: string,
+): Promise<LibraryImportBatch | null> {
+  return parseLibraryImportBatch(
+    await invoke("import_dropped_library_documents", { request: { chatId } }),
+  );
+}
+
+export async function listenForLibraryImportProgress(
+  listener: (progress: LibraryImportProgress) => void,
+): Promise<() => void> {
+  return listen<unknown>("library-import-progress", (event) => {
+    listener(parseLibraryImportProgress(event.payload));
+  });
+}
+
+export function parseLibraryImportProgress(value: unknown): LibraryImportProgress {
+  if (
+    !isExactRecord(value, [
+      "importId",
+      "displayName",
+      "status",
+      "documentId",
+      "processingStatus",
+      "message",
+    ]) ||
+    !isUuid(value.importId) ||
+    typeof value.displayName !== "string" ||
+    value.displayName.length === 0 ||
+    !isSafeRendererText(value.displayName, 255, false) ||
+    !isLibraryImportState(value.status) ||
+    (value.documentId !== null && !isUuid(value.documentId)) ||
+    (value.processingStatus !== null && !isProcessingStatus(value.processingStatus)) ||
+    (value.message !== null &&
+      (typeof value.message !== "string" ||
+        !isSafeRendererText(value.message, 500, false)))
+  ) {
+    throw new Error("Invalid document import progress");
+  }
+  return {
+    importId: value.importId,
+    displayName: value.displayName,
+    status: value.status,
+    documentId: value.documentId,
+    processingStatus: value.processingStatus,
+    message: value.message,
+  };
+}
+
+export function parseLibraryImportBatch(value: unknown): LibraryImportBatch | null {
+  if (value === null) return null;
+  if (!isExactRecord(value, ["results"]) || !Array.isArray(value.results)) {
+    throw new Error("Invalid document import response");
+  }
+  return {
+    results: value.results.map((result) => {
+      if (typeof result !== "object" || result === null || Array.isArray(result)) {
+        throw new Error("Invalid document import response");
+      }
+      const record = result as Record<string, unknown>;
+      if (
+        (record.status === "imported" || record.status === "already_present") &&
+        isExactRecord(record, ["status", "documentId", "displayName", "processingStatus"])
+      ) {
+        const document = parseImportedDocument({
+          documentId: record.documentId,
+          displayName: record.displayName,
+          processingStatus: record.processingStatus,
+        });
+        if (!document) throw new Error("Invalid document import response");
+        return {
+          status: record.status,
+          document,
+        };
+      }
+      if (
+        record.status === "failed" &&
+        isExactRecord(record, ["status", "displayName", "message"]) &&
+        typeof record.displayName === "string" &&
+        record.displayName.length > 0 &&
+        isSafeRendererText(record.displayName, 255, false) &&
+        typeof record.message === "string" &&
+        isSafeRendererText(record.message, 500, false)
+      ) {
+        return {
+          status: "failed",
+          displayName: record.displayName,
+          message: record.message,
+        };
+      }
+      throw new Error("Invalid document import response");
+    }),
+  };
 }
 
 export async function searchLibraryDocuments(
@@ -159,6 +294,12 @@ function parseLibraryDocument(value: unknown): LibraryDocument {
 
 function isProcessingStatus(value: unknown): value is DocumentProcessingStatus {
   return ["queued", "processing", "ready", "failed"].includes(String(value));
+}
+
+function isLibraryImportState(value: unknown): value is LibraryImportState {
+  return ["queued", "streaming", "imported", "already_present", "failed"].includes(
+    String(value),
+  );
 }
 
 function isUuid(value: unknown): value is string {

--- a/crates/openwave-desktop/ui/src/main.tsx
+++ b/crates/openwave-desktop/ui/src/main.tsx
@@ -3,12 +3,14 @@ import ReactDOM from "react-dom/client";
 import { RouterProvider } from "@tanstack/react-router";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { refuseStrayFileDrops } from "./ImageAttachments";
+import { startImportQueue } from "./ImportQueueStore";
 import { router } from "./router";
 import { initTheme } from "./theme";
 import "./styles.css";
 
 initTheme();
 refuseStrayFileDrops(window);
+startImportQueue();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -2855,6 +2855,116 @@ body {
   }
 }
 
+.import-queue {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 30;
+  width: min(24rem, calc(100vw - 2rem));
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 0.7rem;
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-md);
+}
+
+.import-queue > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 0.9rem 0.65rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.import-queue h2,
+.import-queue p {
+  margin: 0;
+}
+
+.import-queue h2 {
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.import-queue p {
+  margin-top: 0.2rem;
+  color: var(--muted-foreground);
+  font-size: 0.78rem;
+}
+
+.import-queue ul {
+  max-height: 14rem;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.import-queue li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.55rem 0.9rem;
+  font-size: 0.8rem;
+}
+
+.import-queue li + li {
+  border-top: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
+}
+
+.import-queue-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.import-queue-state {
+  flex: 0 1 auto;
+  color: var(--muted-foreground);
+  text-align: right;
+}
+
+.import-queue-failed {
+  background: color-mix(in srgb, var(--danger) 7%, var(--bg-elevated));
+}
+
+.import-queue-failed .import-queue-state {
+  color: var(--danger);
+}
+
+.document-drop-target {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  pointer-events: none;
+  border: 3px dashed color-mix(in srgb, var(--color-openwave) 72%, var(--line));
+  background: color-mix(in srgb, var(--color-openwave) 12%, transparent);
+  color: var(--ink);
+  text-align: center;
+}
+
+.document-drop-target strong {
+  font-size: 1.05rem;
+}
+
+.document-drop-target span {
+  color: var(--muted-foreground);
+  font-size: 0.88rem;
+}
+
+.document-drop-target.reject {
+  border-color: color-mix(in srgb, var(--danger) 72%, var(--line));
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+}
+
 } /* @layer components */
 
 /* Scrollbar styling */


### PR DESCRIPTION
Closes #540

## Summary

- accept document drops across an open conversation with a click-through accept/reject overlay; dropped paths remain native-only and can be claimed once
- import files with bounded concurrency and retry only transport or overloaded-server failures with backoff
- show a navigation-resilient import queue that keeps failures visible, sorts them first, and only permits dismissal after a clean run
- let both source entry points select multiple files while preserving each document's durable processing status in the source catalog

## Validation

- `cargo fmt --all --check`
- `cargo check -p openwave-desktop --locked`
- `cargo clippy -p openwave-desktop --all-targets --locked -- -D warnings`
- `cargo test -p openwave-desktop documents::tests --locked`
- `pnpm test`
- `pnpm build`