### PR TITLE
feat(providers): add native Gemini Developer API

### DIFF
--- a/crates/openwave-desktop/ui/src/ModelSelection.test.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.test.ts
@@ -56,6 +56,7 @@ describe("typed model selection", () => {
 
   it("uses product-facing provider labels", () => {
     expect(providerLabel("openai")).toBe("OpenAI");
+    expect(providerLabel("gemini")).toBe("Google Gemini");
     expect(providerLabel("openai_compatible")).toBe("OpenAI-compatible");
   });
 });

--- a/crates/openwave-desktop/ui/src/ModelSelection.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.ts
@@ -38,6 +38,8 @@ export function providerLabel(provider: ProviderKind): string {
       return "Anthropic";
     case "openai":
       return "OpenAI";
+    case "gemini":
+      return "Google Gemini";
     case "openai_compatible":
       return "OpenAI-compatible";
     case "model_gateway":

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -473,7 +473,7 @@ models: Array<CustomModelConfig>, };
  * The known provider kinds. `#[non_exhaustive]` so new kinds can land without
  * breaking wire clients that match on the string form.
  */
-export type ProviderKind = "anthropic" | "openai" | "openai_compatible" | "model_gateway";
+export type ProviderKind = "anthropic" | "openai" | "gemini" | "openai_compatible" | "model_gateway";
 
 /**
  * How hard a reasoning-capable model should think before answering.

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -8,6 +8,7 @@ import type {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
+import { providerLabel } from "../ModelSelection";
 
 export function ProvidersPanel({
   providers,
@@ -98,7 +99,7 @@ function ProviderRow({
   }
 
   return (
-    <SettingsSection title={info.kind.replaceAll("_", " ")}>
+    <SettingsSection title={providerLabel(info.kind)}>
       <div className="flex items-center justify-between gap-3">
         <label className="flex items-center gap-2 text-sm">
           <input

--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -11,11 +11,13 @@ authors.workspace = true
 workspace = true
 
 [features]
-default = ["anthropic", "openai-compat"]
+default = ["anthropic", "openai-compat", "gemini"]
 # The Anthropic (Messages API) provider adapter.
 anthropic = ["dep:reqwest", "dep:async-stream"]
 # OpenAI-compatible Chat Completions adapter (OpenAI, OpenRouter, vLLM, …).
 openai-compat = ["dep:reqwest", "dep:async-stream"]
+# Google Gemini Developer API adapter (native GenerateContent protocol).
+gemini = ["dep:reqwest", "dep:async-stream", "dep:uuid"]
 
 [dependencies]
 openwave-core = { path = "../openwave-core", default-features = false }
@@ -26,7 +28,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true, optional = true }
 async-stream = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
-uuid = { workspace = true }

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -1,0 +1,822 @@
+//! Native Google Gemini Developer API provider.
+//!
+//! Gemini's GenerateContent protocol differs materially from OpenAI-compatible
+//! chat completions: output limits live under `generationConfig`, streamed SSE
+//! frames are complete (but partial) responses, and tool results must preserve
+//! the model's function-call identity. Keeping that conversion here makes the
+//! catalog's Gemini rows honest rather than depending on a compatibility layer
+//! silently accepting or dropping fields it does not understand.
+
+use std::collections::{HashMap, HashSet};
+
+use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use futures::stream::{BoxStream, StreamExt};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use openwave_core::error::{AgentError, Result};
+use openwave_core::provider::{
+    ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, RefusalDetails,
+    StopReason, Usage,
+};
+use openwave_core::{ImageAttachments, ReasoningEffort, Role};
+
+use crate::sse::{classify_provider_error, drain_frames, frame_data_raw, read_bounded_error_body};
+
+const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com";
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+/// Gemini accepts this documented value when an application cannot replay an
+/// opaque thought signature. OpenWave stores provider-neutral tool calls, so
+/// the bypass keeps their history portable across a per-chat model switch.
+const THOUGHT_SIGNATURE_BYPASS: &str = "skip_thought_signature_validator";
+
+fn provider_err(err: impl std::fmt::Display) -> AgentError {
+    AgentError::Provider(err.to_string())
+}
+
+/// A [`ModelProvider`] for the Gemini Developer API's native GenerateContent
+/// streaming endpoint.
+#[derive(Clone)]
+pub struct GeminiProvider {
+    client: reqwest::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl GeminiProvider {
+    /// Build a provider using a Gemini Developer API key.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key: api_key.into(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+        }
+    }
+
+    /// Override the Gemini Developer API base URL. This is primarily useful
+    /// for controlled local test servers; Vertex AI uses a separate auth path.
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    fn endpoint(&self, model: &str) -> String {
+        format!(
+            "{}/v1beta/models/{model}:streamGenerateContent?alt=sse",
+            self.base_url.trim_end_matches('/')
+        )
+    }
+}
+
+#[async_trait]
+impl ModelProvider for GeminiProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("gemini")
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let body = build_request_json(&req)?;
+        let response = self
+            .client
+            .post(self.endpoint(&req.model))
+            .header("x-goog-api-key", &self.api_key)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(provider_err)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = read_bounded_error_body(response.bytes_stream()).await;
+            return Err(classify_gemini_error(status.as_u16(), &body));
+        }
+
+        let stream = async_stream::stream! {
+            let mut bytes = response.bytes_stream();
+            let mut buffer = Vec::new();
+            let mut state = StreamState::default();
+            while let Some(chunk) = bytes.next().await {
+                let chunk = match chunk {
+                    Ok(chunk) => chunk,
+                    Err(error) => {
+                        yield ProviderEvent::Failed {
+                            message: format!("gemini stream ended early: {error}"),
+                        };
+                        return;
+                    }
+                };
+                buffer.extend_from_slice(&chunk);
+                for frame in drain_frames(&mut buffer) {
+                    let Some(data) = frame_data_raw(&frame) else {
+                        continue;
+                    };
+                    let data = match serde_json::from_str::<Value>(&data) {
+                        Ok(data) => data,
+                        Err(_) => {
+                            yield ProviderEvent::Failed {
+                                message: "gemini returned an invalid stream frame".to_string(),
+                            };
+                            return;
+                        }
+                    };
+                    for event in normalize(&data, &mut state) {
+                        yield event;
+                    }
+                    if state.terminal {
+                        return;
+                    }
+                }
+            }
+            if !buffer.is_empty() {
+                let frame = String::from_utf8_lossy(&buffer).into_owned();
+                if let Some(data) = frame_data_raw(&frame) {
+                    let data = match serde_json::from_str::<Value>(&data) {
+                        Ok(data) => data,
+                        Err(_) => {
+                            yield ProviderEvent::Failed {
+                                message: "gemini returned an invalid stream frame".to_string(),
+                            };
+                            return;
+                        }
+                    };
+                    for event in normalize(&data, &mut state) {
+                        yield event;
+                    }
+                }
+            }
+            if !state.terminal {
+                for event in finish_stream(&mut state) {
+                    yield event;
+                }
+            }
+        };
+        Ok(Box::pin(stream))
+    }
+}
+
+/// Build a native GenerateContent request.
+///
+/// Gemini 3 rejects the deprecated sampling controls, so `temperature` is
+/// intentionally not forwarded. The registry only marks Gemini rows as
+/// reasoning-capable when this adapter can turn the selected effort into the
+/// native `thinkingLevel` shape.
+fn build_request_json(req: &ChatRequest) -> Result<Value> {
+    let mut generation_config = json!({
+        "maxOutputTokens": req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+    });
+    if req.reasoning_model {
+        if let Some(effort) = req.reasoning_effort {
+            generation_config["thinkingConfig"] = json!({
+                "thinkingLevel": gemini_thinking_level(effort),
+            });
+        }
+    }
+
+    let mut body = json!({
+        "contents": gemini_contents(&req.messages, &req.images)?,
+        "generationConfig": generation_config,
+    });
+    if let Some(system) = &req.system {
+        body["systemInstruction"] = json!({ "parts": [{ "text": system }] });
+    }
+    if !req.tools.is_empty() {
+        body["tools"] = json!([{
+            "functionDeclarations": req.tools.iter().map(|tool| json!({
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.input_schema,
+            })).collect::<Vec<_>>(),
+        }]);
+        body["toolConfig"] = json!({ "functionCallingConfig": { "mode": "AUTO" } });
+    }
+    Ok(body)
+}
+
+fn gemini_thinking_level(effort: ReasoningEffort) -> &'static str {
+    match effort {
+        ReasoningEffort::None => "minimal",
+        ReasoningEffort::Low => "low",
+        ReasoningEffort::Medium => "medium",
+        ReasoningEffort::High | ReasoningEffort::XHigh | ReasoningEffort::Max => "high",
+    }
+}
+
+/// Translate durable, provider-neutral history to Gemini content messages.
+///
+/// Gemini requires all responses to the parallel calls in one model turn to
+/// form one following user message. The stored transcript keeps tool results as
+/// independent messages, so consecutive pure result messages are coalesced.
+fn gemini_contents(
+    messages: &[openwave_core::provider::ChatMessage],
+    images: &ImageAttachments,
+) -> Result<Vec<Value>> {
+    let tool_names: HashMap<&str, &str> = messages
+        .iter()
+        .flat_map(|message| message.content.iter())
+        .filter_map(|block| match block {
+            ContentBlock::ToolUse { id, name, .. } => Some((id.as_str(), name.as_str())),
+            _ => None,
+        })
+        .collect();
+
+    let mut contents = Vec::with_capacity(messages.len());
+    for message in messages {
+        let role = match message.role {
+            Role::Assistant => "model",
+            Role::System | Role::Tool | Role::User => "user",
+        };
+        let mut parts = Vec::with_capacity(message.content.len());
+        let mut attached_signature = false;
+        for block in &message.content {
+            match block {
+                ContentBlock::Text { text } => parts.push(json!({ "text": text })),
+                ContentBlock::ToolUse { id, name, input } => {
+                    let mut part = json!({
+                        "functionCall": {
+                            "id": id,
+                            "name": name,
+                            "args": input,
+                        },
+                    });
+                    // Gemini validates the first call part of each model turn.
+                    // We deliberately use its portable bypass rather than
+                    // persisting opaque provider state in a cross-model chat.
+                    if !attached_signature {
+                        part["thoughtSignature"] = json!(THOUGHT_SIGNATURE_BYPASS);
+                        attached_signature = true;
+                    }
+                    parts.push(part);
+                }
+                ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    is_error,
+                } => {
+                    let name = tool_names.get(tool_use_id.as_str()).ok_or_else(|| {
+                        AgentError::Provider(
+                            "gemini tool result has no matching function call".to_string(),
+                        )
+                    })?;
+                    let mut response = json!({ "result": content });
+                    if *is_error {
+                        response["is_error"] = json!(true);
+                    }
+                    parts.push(json!({
+                        "functionResponse": {
+                            "id": tool_use_id,
+                            "name": name,
+                            "response": response,
+                        },
+                    }));
+                }
+                ContentBlock::Image { image } => {
+                    let data = images.get(image.blob_id).ok_or_else(|| {
+                        AgentError::Provider(format!(
+                            "image attachment {} has no hydrated bytes",
+                            image.blob_id
+                        ))
+                    })?;
+                    parts.push(json!({
+                        "inlineData": {
+                            "mimeType": data.media_type().as_str(),
+                            "data": BASE64.encode(data.bytes()),
+                        },
+                    }));
+                }
+                // `ContentBlock` is deliberately open for new provider-neutral
+                // variants. Dropping one here would silently change the model
+                // prompt, so make the adapter fail until that new variant gains
+                // an explicit Gemini representation.
+                _ => {
+                    return Err(AgentError::Provider(
+                        "gemini cannot encode an unsupported content block".to_string(),
+                    ));
+                }
+            }
+        }
+        contents.push(json!({ "role": role, "parts": parts }));
+    }
+
+    let function_responses_only = |content: &Value| {
+        content.get("role").and_then(Value::as_str) == Some("user")
+            && content
+                .get("parts")
+                .and_then(Value::as_array)
+                .is_some_and(|parts| {
+                    !parts.is_empty()
+                        && parts
+                            .iter()
+                            .all(|part| part.get("functionResponse").is_some())
+                })
+    };
+    let mut merged = Vec::with_capacity(contents.len());
+    for content in contents {
+        if function_responses_only(&content) && merged.last().is_some_and(function_responses_only) {
+            let previous = merged.last_mut().expect("last was checked");
+            let parts = content
+                .get("parts")
+                .and_then(Value::as_array)
+                .expect("function responses have parts")
+                .clone();
+            previous
+                .get_mut("parts")
+                .and_then(Value::as_array_mut)
+                .expect("function responses have mutable parts")
+                .extend(parts);
+        } else {
+            merged.push(content);
+        }
+    }
+    Ok(merged)
+}
+
+#[derive(Default)]
+struct StreamState {
+    next_tool_index: u32,
+    seen_tool_ids: HashSet<String>,
+    usage: Option<Usage>,
+    saw_tool_call: bool,
+    terminal: bool,
+}
+
+/// Convert one complete Gemini response frame into provider-neutral events.
+fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
+    if state.terminal {
+        return Vec::new();
+    }
+    if let Some(error) = data.get("error") {
+        state.terminal = true;
+        return vec![ProviderEvent::Failed {
+            message: safe_in_band_error(error),
+        }];
+    }
+    if let Some(block_reason) = data
+        .get("promptFeedback")
+        .and_then(|feedback| feedback.get("blockReason"))
+        .and_then(Value::as_str)
+    {
+        state.terminal = true;
+        return vec![ProviderEvent::Refusal {
+            details: refusal_details(block_reason),
+        }];
+    }
+
+    if let Some(metadata) = data.get("usageMetadata") {
+        state.usage = Some(gemini_usage(metadata));
+    }
+
+    let Some(candidate) = data
+        .get("candidates")
+        .and_then(Value::as_array)
+        .and_then(|candidates| candidates.first())
+    else {
+        return Vec::new();
+    };
+
+    let mut events = Vec::new();
+    if let Some(parts) = candidate
+        .get("content")
+        .and_then(|content| content.get("parts"))
+        .and_then(Value::as_array)
+    {
+        for part in parts {
+            if part.get("thought").and_then(Value::as_bool) == Some(true) {
+                if let Some(text) = part
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .filter(|text| !text.is_empty())
+                {
+                    events.push(ProviderEvent::ReasoningDelta {
+                        text: text.to_string(),
+                    });
+                }
+                continue;
+            }
+            if let Some(text) = part
+                .get("text")
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+            {
+                events.push(ProviderEvent::TextDelta {
+                    text: text.to_string(),
+                });
+            }
+            if let Some(call) = part.get("functionCall") {
+                let Some(name) = call
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .filter(|name| !name.is_empty())
+                else {
+                    state.terminal = true;
+                    events.push(ProviderEvent::Failed {
+                        message: "gemini returned a malformed function call".to_string(),
+                    });
+                    return events;
+                };
+                let id = call
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .filter(|id| !id.is_empty())
+                    .map(str::to_owned)
+                    // Current Gemini 3 endpoints supply ids. Synthesizing for
+                    // older or proxy responses still keeps the agent's own
+                    // call/result pairing well-formed.
+                    .unwrap_or_else(|| format!("gemini-{}", Uuid::new_v4()));
+                if !state.seen_tool_ids.insert(id.clone()) {
+                    continue;
+                }
+                let args = call.get("args").cloned().unwrap_or_else(|| json!({}));
+                if !args.is_object() {
+                    state.terminal = true;
+                    events.push(ProviderEvent::Failed {
+                        message: "gemini returned non-object function arguments".to_string(),
+                    });
+                    return events;
+                }
+                let index = state.next_tool_index;
+                state.next_tool_index = state.next_tool_index.saturating_add(1);
+                state.saw_tool_call = true;
+                events.push(ProviderEvent::ToolCallStarted {
+                    index,
+                    id,
+                    name: name.to_string(),
+                });
+                events.push(ProviderEvent::ToolCallArgsDelta {
+                    index,
+                    fragment: serde_json::to_string(&args).expect("JSON values serialize"),
+                });
+            }
+        }
+    }
+
+    if let Some(reason) = candidate.get("finishReason").and_then(Value::as_str) {
+        finish_candidate(reason, state, &mut events);
+    }
+    events
+}
+
+fn finish_stream(state: &mut StreamState) -> Vec<ProviderEvent> {
+    let mut events = Vec::new();
+    emit_usage(state, &mut events);
+    events.push(ProviderEvent::Stop {
+        reason: if state.saw_tool_call {
+            StopReason::ToolUse
+        } else {
+            StopReason::EndTurn
+        },
+    });
+    state.terminal = true;
+    events
+}
+
+fn finish_candidate(reason: &str, state: &mut StreamState, events: &mut Vec<ProviderEvent>) {
+    emit_usage(state, events);
+    state.terminal = true;
+    match reason {
+        "SAFETY" | "RECITATION" | "BLOCKLIST" | "PROHIBITED_CONTENT" | "SPII" => {
+            events.push(ProviderEvent::Refusal {
+                details: refusal_details(reason),
+            });
+        }
+        "MALFORMED_FUNCTION_CALL" | "UNEXPECTED_TOOL_CALL" => {
+            events.push(ProviderEvent::Failed {
+                message: "gemini rejected a function call".to_string(),
+            });
+        }
+        "MAX_TOKENS" => events.push(ProviderEvent::Stop {
+            reason: StopReason::MaxTokens,
+        }),
+        // A Gemini tool call can report `STOP`, so tools must win over the
+        // provider's finish code when the normalized stream contains one.
+        _ => events.push(ProviderEvent::Stop {
+            reason: if state.saw_tool_call {
+                StopReason::ToolUse
+            } else {
+                StopReason::EndTurn
+            },
+        }),
+    }
+}
+
+fn emit_usage(state: &mut StreamState, events: &mut Vec<ProviderEvent>) {
+    if let Some(usage) = state.usage.take() {
+        events.push(ProviderEvent::Usage(usage));
+    }
+}
+
+fn gemini_usage(metadata: &Value) -> Usage {
+    let prompt = u32_at(metadata, "promptTokenCount");
+    let cached = u32_at(metadata, "cachedContentTokenCount");
+    Usage {
+        // Gemini's prompt count includes the cached portion.
+        input_tokens: prompt.saturating_sub(cached),
+        // Thoughts are billed output in addition to candidate tokens.
+        output_tokens: u32_at(metadata, "candidatesTokenCount")
+            .saturating_add(u32_at(metadata, "thoughtsTokenCount")),
+        cache_read_input_tokens: cached,
+        cache_creation_input_tokens: 0,
+    }
+}
+
+fn u32_at(value: &Value, key: &str) -> u32 {
+    value
+        .get(key)
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+        .min(u64::from(u32::MAX)) as u32
+}
+
+fn refusal_details(reason: &str) -> RefusalDetails {
+    let category = reason
+        .bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' => char::from(byte.to_ascii_lowercase()),
+            b'a'..=b'z' | b'0'..=b'9' => char::from(byte),
+            _ => '_',
+        })
+        .collect::<String>();
+    RefusalDetails::from_category(Some(&category))
+}
+
+fn safe_in_band_error(error: &Value) -> String {
+    let status = error
+        .get("code")
+        .and_then(Value::as_u64)
+        .and_then(|code| u16::try_from(code).ok())
+        .filter(|code| (100..=599).contains(code))
+        .unwrap_or(500);
+    format!("gemini returned {status}")
+}
+
+fn classify_gemini_error(status: u16, body: &str) -> AgentError {
+    let prompt_too_long = serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|value| value.get("error").cloned().or(Some(value)))
+        .and_then(|error| {
+            error
+                .get("message")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+        .is_some_and(|message| {
+            let message = message.to_ascii_lowercase();
+            message.contains("too many tokens")
+                || message.contains("input token count")
+                || message.contains("maximum number of tokens")
+        });
+    if prompt_too_long {
+        return AgentError::PromptTooLong(crate::sse::safe_http_error("gemini", status, body));
+    }
+    classify_provider_error("gemini", status, body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::provider::ChatMessage;
+    use openwave_core::tool::ToolSpec;
+
+    fn request(messages: Vec<ChatMessage>) -> ChatRequest {
+        ChatRequest {
+            provider: Some(ProviderId::new("gemini")),
+            model: "gemini-3.6-flash".into(),
+            reasoning_model: true,
+            system: Some("be brief".into()),
+            messages,
+            tools: vec![ToolSpec {
+                name: "read_file".into(),
+                description: "Read a file".into(),
+                input_schema: json!({"type": "object"}),
+            }],
+            max_tokens: Some(65_536),
+            temperature: Some(0.2),
+            reasoning_effort: Some(ReasoningEffort::High),
+            images: ImageAttachments::new(),
+        }
+    }
+
+    #[test]
+    fn request_uses_native_output_cap_and_current_tool_shape() {
+        let body = build_request_json(&request(vec![ChatMessage::text(Role::User, "hi")])).unwrap();
+        assert_eq!(body["generationConfig"]["maxOutputTokens"], 65_536);
+        assert_eq!(
+            body["generationConfig"]["thinkingConfig"]["thinkingLevel"],
+            "high"
+        );
+        assert_eq!(body["systemInstruction"]["parts"][0]["text"], "be brief");
+        assert_eq!(
+            body["tools"][0]["functionDeclarations"][0]["name"],
+            "read_file"
+        );
+        assert_eq!(body["toolConfig"]["functionCallingConfig"]["mode"], "AUTO");
+        assert!(body.get("temperature").is_none());
+        assert!(body["generationConfig"].get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn tool_results_keep_call_identity_and_merge_parallel_results() {
+        let messages = vec![
+            ChatMessage {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::ToolUse {
+                        id: "call_one".into(),
+                        name: "read_file".into(),
+                        input: json!({"path": "one"}),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "call_two".into(),
+                        name: "read_file".into(),
+                        input: json!({"path": "two"}),
+                    },
+                ],
+            },
+            ChatMessage {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "call_one".into(),
+                    content: "one".into(),
+                    is_error: false,
+                }],
+            },
+            ChatMessage {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "call_two".into(),
+                    content: "two".into(),
+                    is_error: false,
+                }],
+            },
+        ];
+        let body = build_request_json(&request(messages)).unwrap();
+        let contents = body["contents"].as_array().unwrap();
+        assert_eq!(contents.len(), 2);
+        assert_eq!(contents[0]["role"], "model");
+        assert_eq!(
+            contents[0]["parts"][0]["thoughtSignature"],
+            THOUGHT_SIGNATURE_BYPASS
+        );
+        assert!(contents[0]["parts"][1].get("thoughtSignature").is_none());
+        let responses = contents[1]["parts"].as_array().unwrap();
+        assert_eq!(responses.len(), 2);
+        assert_eq!(responses[0]["functionResponse"]["id"], "call_one");
+        assert_eq!(responses[0]["functionResponse"]["name"], "read_file");
+        assert_eq!(responses[1]["functionResponse"]["id"], "call_two");
+    }
+
+    // ── Image blocks ───────────────────────────────────────────────
+
+    fn png_ref(blob: u128) -> openwave_core::ImageRef {
+        openwave_core::ImageRef {
+            blob_id: Uuid::from_u128(blob),
+            media_type: openwave_core::ImageMediaType::Png,
+            width: 800,
+            height: 600,
+            byte_len: 3,
+        }
+    }
+
+    #[test]
+    fn image_blocks_become_hydrated_inline_data() {
+        let image = png_ref(1);
+        let mut req = request(vec![ChatMessage {
+            role: Role::User,
+            content: vec![
+                ContentBlock::Text {
+                    text: "what is this?".into(),
+                },
+                ContentBlock::Image { image },
+            ],
+        }]);
+        req.images.insert(
+            image.blob_id,
+            openwave_core::ImageData::new(openwave_core::ImageMediaType::Png, vec![1, 2, 3]),
+        );
+
+        let body = build_request_json(&req).unwrap();
+        let parts = body["contents"][0]["parts"].as_array().unwrap();
+        assert_eq!(parts[0]["text"], "what is this?");
+        assert_eq!(parts[1]["inlineData"]["mimeType"], "image/png");
+        assert_eq!(parts[1]["inlineData"]["data"], BASE64.encode([1, 2, 3]));
+    }
+
+    #[test]
+    fn unhydrated_images_fail_instead_of_being_dropped() {
+        let req = request(vec![ChatMessage {
+            role: Role::User,
+            content: vec![ContentBlock::Image { image: png_ref(9) }],
+        }]);
+        let err = build_request_json(&req).unwrap_err();
+        assert!(err.to_string().contains("no hydrated bytes"), "{err}");
+    }
+
+    fn run(chunks: &[Value]) -> Vec<ProviderEvent> {
+        let mut state = StreamState::default();
+        let mut out = chunks
+            .iter()
+            .flat_map(|chunk| normalize(chunk, &mut state))
+            .collect::<Vec<_>>();
+        if !state.terminal {
+            out.extend(finish_stream(&mut state));
+        }
+        out
+    }
+
+    #[test]
+    fn normalizes_partial_responses_usage_and_parallel_tool_calls() {
+        let out = run(&[
+            json!({"candidates":[{"content":{"parts":[
+                {"thought": true, "text":"considering"},
+                {"text":"I'll inspect it."},
+                {"functionCall":{"id":"call_1", "name":"read_file", "args":{"path":"a"}}},
+                {"functionCall":{"id":"call_2", "name":"read_file", "args":{"path":"b"}}}
+            ]}}]}),
+            json!({"candidates":[{"finishReason":"STOP"}], "usageMetadata": {
+                "promptTokenCount": 10,
+                "cachedContentTokenCount": 4,
+                "candidatesTokenCount": 2,
+                "thoughtsTokenCount": 3
+            }}),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                ProviderEvent::ReasoningDelta {
+                    text: "considering".into()
+                },
+                ProviderEvent::TextDelta {
+                    text: "I'll inspect it.".into()
+                },
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "call_1".into(),
+                    name: "read_file".into()
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: r#"{"path":"a"}"#.into()
+                },
+                ProviderEvent::ToolCallStarted {
+                    index: 1,
+                    id: "call_2".into(),
+                    name: "read_file".into()
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 1,
+                    fragment: r#"{"path":"b"}"#.into()
+                },
+                ProviderEvent::Usage(Usage {
+                    input_tokens: 6,
+                    output_tokens: 5,
+                    cache_read_input_tokens: 4,
+                    cache_creation_input_tokens: 0
+                }),
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn prompt_blocks_and_stream_errors_are_terminal_and_safe() {
+        let blocked = run(&[json!({"promptFeedback":{"blockReason":"SAFETY"}})]);
+        assert_eq!(
+            blocked,
+            vec![ProviderEvent::Refusal {
+                details: RefusalDetails::from_category(Some("safety")),
+            }]
+        );
+        let failed = run(&[json!({"error":{"code":401,"message":"AIza-secret"}})]);
+        assert_eq!(
+            failed,
+            vec![ProviderEvent::Failed {
+                message: "gemini returned 401".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn max_tokens_is_not_reclassified_as_a_retryable_end_turn() {
+        let out = run(&[json!({"candidates":[{"finishReason":"MAX_TOKENS"}]})]);
+        assert_eq!(
+            out,
+            vec![ProviderEvent::Stop {
+                reason: StopReason::MaxTokens
+            }]
+        );
+    }
+
+    #[test]
+    fn endpoint_uses_developer_api_streaming_route() {
+        let provider = GeminiProvider::new("key").with_base_url("http://127.0.0.1:8080/");
+        assert_eq!(
+            provider.endpoint("gemini-3.6-flash"),
+            "http://127.0.0.1:8080/v1beta/models/gemini-3.6-flash:streamGenerateContent?alt=sse"
+        );
+    }
+}

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -17,8 +17,13 @@ pub mod anthropic;
 #[cfg(feature = "openai-compat")]
 pub mod openai_compat;
 
+#[cfg(feature = "gemini")]
+pub mod gemini;
+
 #[cfg(feature = "anthropic")]
 pub use anthropic::AnthropicProvider;
+#[cfg(feature = "gemini")]
+pub use gemini::GeminiProvider;
 #[cfg(feature = "openai-compat")]
 pub use openai_compat::OpenAiCompatProvider;
 pub use router::{BearerTokenSource, Route, RouteKind, Router};

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -19,6 +19,8 @@ use openwave_core::provider::{ChatRequest, ModelProvider, ProviderEvent, Provide
 
 #[cfg(feature = "anthropic")]
 use crate::AnthropicProvider;
+#[cfg(feature = "gemini")]
+use crate::GeminiProvider;
 #[cfg(feature = "openai-compat")]
 use crate::OpenAiCompatProvider;
 
@@ -44,6 +46,8 @@ pub enum RouteKind {
     Openai,
     /// Any OpenAI-compatible Chat Completions gateway.
     OpenaiCompatible,
+    /// Google Gemini Developer API (native GenerateContent protocol).
+    Gemini,
     /// A model-gateway deployment's Anthropic-compatible surface, authenticated
     /// with short-lived resource-scoped tokens instead of a static key.
     ModelGateway,
@@ -56,6 +60,7 @@ impl RouteKind {
             RouteKind::Anthropic => "anthropic",
             RouteKind::Openai => "openai",
             RouteKind::OpenaiCompatible => "openai_compatible",
+            RouteKind::Gemini => "gemini",
             RouteKind::ModelGateway => "model_gateway",
         }
     }
@@ -65,6 +70,7 @@ impl RouteKind {
             "anthropic" => Some(Self::Anthropic),
             "openai" => Some(Self::Openai),
             "openai_compatible" => Some(Self::OpenaiCompatible),
+            "gemini" => Some(Self::Gemini),
             "model_gateway" => Some(Self::ModelGateway),
             _ => None,
         }
@@ -157,6 +163,7 @@ impl Router {
         for kind in [
             RouteKind::Anthropic,
             RouteKind::Openai,
+            RouteKind::Gemini,
             RouteKind::ModelGateway,
             RouteKind::OpenaiCompatible,
         ] {
@@ -176,7 +183,7 @@ impl Router {
 
     /// Select the exact provider requested by the host model registry.
     ///
-    /// Curated Anthropic/OpenAI routes must claim the model. A custom
+    /// Curated Anthropic/OpenAI/Gemini routes must claim the model. A custom
     /// OpenAI-compatible route accepts a legacy free-form model id so existing
     /// pre-registry settings continue to work; new API writes require an
     /// explicit configured custom entry before they can reach this boundary.
@@ -281,6 +288,16 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
                 base.to_string(),
             )))
         }
+        #[cfg(feature = "gemini")]
+        RouteKind::Gemini => {
+            let mut p = GeminiProvider::new(route.api_key.clone());
+            if let Some(base) = &route.base_url {
+                p = p.with_base_url(base.clone());
+            }
+            Some(Arc::new(p))
+        }
+        #[cfg(not(feature = "gemini"))]
+        RouteKind::Gemini => None,
         #[cfg(not(feature = "openai-compat"))]
         RouteKind::Openai | RouteKind::OpenaiCompatible => None,
     }

--- a/crates/openwave-server/src/model_registry.rs
+++ b/crates/openwave-server/src/model_registry.rs
@@ -59,6 +59,14 @@ const EFFORT_NONE_TO_XHIGH: &[ReasoningEffort] = &[
     ReasoningEffort::High,
     ReasoningEffort::XHigh,
 ];
+/// Gemini 3 maps OpenWave's `none` to its `minimal` thinking level and has no
+/// separate levels above `high`.
+const EFFORT_NONE_TO_HIGH: &[ReasoningEffort] = &[
+    ReasoningEffort::None,
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+];
 const EFFORT_LOW_TO_MAX: &[ReasoningEffort] = &[
     ReasoningEffort::Low,
     ReasoningEffort::Medium,
@@ -259,6 +267,50 @@ const MODEL_REGISTRY: &[ModelSpec] = &[
         supports_reasoning: true,
         reasoning_efforts: EFFORT_NONE_TO_XHIGH,
     },
+    // Gemini rows are intentionally limited to ids currently published by
+    // Google. All four accept images, expose thinking levels through `high`,
+    // and have 1,048,576 input / 65,536 output token limits; the native
+    // adapter owns the corresponding GenerateContent wire shape.
+    ModelSpec {
+        id: "gemini-3.6-flash",
+        display_name: "Gemini 3.6 Flash",
+        provider: ProviderKind::Gemini,
+        context_window: 1_048_576,
+        max_output_tokens: 65_536,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        reasoning_efforts: EFFORT_NONE_TO_HIGH,
+    },
+    ModelSpec {
+        id: "gemini-3.5-flash",
+        display_name: "Gemini 3.5 Flash",
+        provider: ProviderKind::Gemini,
+        context_window: 1_048_576,
+        max_output_tokens: 65_536,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        reasoning_efforts: EFFORT_NONE_TO_HIGH,
+    },
+    ModelSpec {
+        id: "gemini-3.5-flash-lite",
+        display_name: "Gemini 3.5 Flash-Lite",
+        provider: ProviderKind::Gemini,
+        context_window: 1_048_576,
+        max_output_tokens: 65_536,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        reasoning_efforts: EFFORT_NONE_TO_HIGH,
+    },
+    ModelSpec {
+        id: "gemini-3.1-pro-preview",
+        display_name: "Gemini 3.1 Pro Preview",
+        provider: ProviderKind::Gemini,
+        context_window: 1_048_576,
+        max_output_tokens: 65_536,
+        input_modalities: TEXT_AND_IMAGE,
+        supports_reasoning: true,
+        reasoning_efforts: EFFORT_NONE_TO_HIGH,
+    },
 ];
 
 /// Curated entries belonging to `provider`, preserving registry display order.
@@ -387,6 +439,7 @@ mod tests {
         match provider {
             ProviderKind::Anthropic => true,
             ProviderKind::Openai => true,
+            ProviderKind::Gemini => true,
             ProviderKind::OpenaiCompatible => false,
             ProviderKind::ModelGateway => true,
         }
@@ -434,6 +487,7 @@ mod tests {
         }
         assert_eq!(models_for(ProviderKind::Anthropic).count(), 7);
         assert_eq!(models_for(ProviderKind::Openai).count(), 6);
+        assert_eq!(models_for(ProviderKind::Gemini).count(), 4);
         assert_eq!(models_for(ProviderKind::OpenaiCompatible).count(), 0);
     }
 
@@ -524,6 +578,18 @@ mod tests {
             find("gpt-5.4-nano").unwrap().reasoning_efforts,
             EFFORT_NONE_TO_XHIGH
         );
+    }
+
+    #[test]
+    fn every_gemini_entry_has_the_native_adapter_contract() {
+        let gemini: Vec<_> = models_for(ProviderKind::Gemini).collect();
+        assert_eq!(gemini.len(), 4);
+        for spec in gemini {
+            assert_eq!(spec.context_window, 1_048_576, "{}", spec.id);
+            assert_eq!(spec.max_output_tokens, 65_536, "{}", spec.id);
+            assert!(spec.supports_reasoning, "{}", spec.id);
+            assert_eq!(spec.reasoning_efforts, EFFORT_NONE_TO_HIGH, "{}", spec.id);
+        }
     }
 
     #[test]

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -36,6 +36,8 @@ pub enum ProviderKind {
     Anthropic,
     /// OpenAI Chat Completions (api.openai.com).
     Openai,
+    /// Google Gemini Developer API (generativelanguage.googleapis.com).
+    Gemini,
     /// Any OpenAI-compatible Chat Completions gateway (OpenRouter, vLLM, …).
     OpenaiCompatible,
     /// A signed-in model-gateway deployment: entitled models synced from the
@@ -49,6 +51,7 @@ impl ProviderKind {
     pub const ALL: &'static [ProviderKind] = &[
         ProviderKind::Anthropic,
         ProviderKind::Openai,
+        ProviderKind::Gemini,
         ProviderKind::OpenaiCompatible,
         ProviderKind::ModelGateway,
     ];
@@ -58,6 +61,7 @@ impl ProviderKind {
         match self {
             ProviderKind::Anthropic => "anthropic",
             ProviderKind::Openai => "openai",
+            ProviderKind::Gemini => "gemini",
             ProviderKind::OpenaiCompatible => "openai_compatible",
             ProviderKind::ModelGateway => "model_gateway",
         }
@@ -68,6 +72,7 @@ impl ProviderKind {
         match s {
             "anthropic" => Some(Self::Anthropic),
             "openai" => Some(Self::Openai),
+            "gemini" => Some(Self::Gemini),
             "openai_compatible" => Some(Self::OpenaiCompatible),
             "model_gateway" => Some(Self::ModelGateway),
             _ => None,
@@ -487,7 +492,7 @@ pub async fn delete_credential(secrets: &dyn SecretProvider, kind: ProviderKind)
     Ok(())
 }
 
-/// Whether `kind` has a usable credential — stored, or (for Anthropic/OpenAI)
+/// Whether `kind` has a usable credential — stored, or (for direct API-key providers)
 /// the matching env fallback the resolver also honors.
 pub async fn has_credential(secrets: &dyn SecretProvider, kind: ProviderKind) -> bool {
     if matches!(
@@ -499,6 +504,7 @@ pub async fn has_credential(secrets: &dyn SecretProvider, kind: ProviderKind) ->
     match kind {
         ProviderKind::Anthropic => std::env::var("ANTHROPIC_API_KEY").is_ok_and(|k| !k.is_empty()),
         ProviderKind::Openai => std::env::var("OPENAI_API_KEY").is_ok_and(|k| !k.is_empty()),
+        ProviderKind::Gemini => std::env::var("GEMINI_API_KEY").is_ok_and(|k| !k.is_empty()),
         ProviderKind::OpenaiCompatible => false,
         // The gateway's credential is its stored OAuth session, not a key.
         ProviderKind::ModelGateway => openwave_connectors::has_stored_credentials(secrets).await,
@@ -685,6 +691,9 @@ pub async fn resolve_api_key(secrets: &dyn SecretProvider, kind: ProviderKind) -
         ProviderKind::Openai => std::env::var("OPENAI_API_KEY")
             .ok()
             .filter(|k| !k.is_empty()),
+        ProviderKind::Gemini => std::env::var("GEMINI_API_KEY")
+            .ok()
+            .filter(|k| !k.is_empty()),
         ProviderKind::OpenaiCompatible => None,
         // Gateway tokens rotate; they are supplied per request by the route's
         // token source, never resolved into a static key.
@@ -703,6 +712,7 @@ pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
     match kind {
         ProviderKind::Anthropic => openwave_router::RouteKind::Anthropic,
         ProviderKind::Openai => openwave_router::RouteKind::Openai,
+        ProviderKind::Gemini => openwave_router::RouteKind::Gemini,
         ProviderKind::OpenaiCompatible => openwave_router::RouteKind::OpenaiCompatible,
         ProviderKind::ModelGateway => openwave_router::RouteKind::ModelGateway,
     }

--- a/crates/openwave-server/src/resolver.rs
+++ b/crates/openwave-server/src/resolver.rs
@@ -2,7 +2,7 @@
 //!
 //! Builds a composite [`openwave_router::Router`] from every enabled,
 //! credentialed provider so the turn's model selects the right adapter
-//! (Anthropic / OpenAI / openai_compatible). The router is rebuilt when the
+//! (Anthropic / OpenAI / Gemini / openai_compatible). The router is rebuilt when the
 //! route set changes (enable/disable, key, base_url); otherwise the cached
 //! instance — and its connection pools — is reused.
 //!

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -10984,56 +10984,66 @@ async fn resolver_builds_a_router_from_enabled_providers() {
 }
 
 #[tokio::test]
-async fn resolver_includes_openai_when_enabled() {
-    let dir = tempfile::tempdir().unwrap();
-    let store: Arc<dyn Store> = Arc::new(
-        DbStore::connect(&format!(
-            "sqlite://{}/test.db?mode=rwc",
-            dir.path().display()
-        ))
+async fn resolver_includes_configured_curated_api_key_providers() {
+    for (kind, model, route_kind) in [
+        (
+            providers::ProviderKind::Openai,
+            "gpt-5.6-sol",
+            openwave_router::RouteKind::Openai,
+        ),
+        (
+            providers::ProviderKind::Gemini,
+            "gemini-3.6-flash",
+            openwave_router::RouteKind::Gemini,
+        ),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}/test.db?mode=rwc",
+                dir.path().display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+        providers::write_credential(
+            &*secrets,
+            kind,
+            &providers::ProviderCredential::api_key("test-api-key"),
+        )
         .await
-        .unwrap(),
-    );
-    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
-    providers::write_credential(
-        &*secrets,
-        providers::ProviderKind::Openai,
-        &providers::ProviderCredential::api_key("sk-openai"),
-    )
-    .await
-    .unwrap();
-    providers::write_config(
-        &*store,
-        providers::ProviderKind::Openai,
-        &providers::ProviderConfig {
-            enabled: true,
-            base_url: None,
-            models: Vec::new(),
-        },
-    )
-    .await
-    .unwrap();
+        .unwrap();
+        providers::write_config(
+            &*store,
+            kind,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: None,
+                models: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
 
-    let routes = providers::collect_routes(&*store, &*secrets, None).await;
-    assert_eq!(routes.len(), 1);
-    assert_eq!(routes[0].kind, openwave_router::RouteKind::Openai);
+        let routes = providers::collect_routes(&*store, &*secrets, None).await;
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].kind, route_kind);
 
-    let resolver = resolver::KeyedResolver::new(
-        store.clone(),
-        secrets.clone(),
-        crate::gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone()),
-    );
-    let provider = resolver.resolve().await;
-    assert_eq!(provider.id().0, "router");
+        let resolver = resolver::KeyedResolver::new(
+            store.clone(),
+            secrets.clone(),
+            crate::gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone()),
+        );
+        let provider = resolver.resolve().await;
+        assert_eq!(provider.id().0, "router");
 
-    // A curated openai model is selectable; an anthropic model is not
-    // (no anthropic route, no openai_compatible fallback).
-    let router = openwave_router::Router::build(routes);
-    assert_eq!(
-        router.select("gpt-5.6-sol"),
-        Some(openwave_router::RouteKind::Openai)
-    );
-    assert_eq!(router.select("claude-opus-4-8"), None);
+        // Curated models stay on their explicitly configured native route;
+        // the absence of a compatibility fallback must not cross providers.
+        let router = openwave_router::Router::build(routes);
+        assert_eq!(router.select(model), Some(route_kind));
+        assert_eq!(router.select("claude-opus-4-8"), None);
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add a native Gemini Developer API adapter with GenerateContent request shaping, SSE normalization, tool-call identity, thinking levels, usage, and safe error handling
- register current Gemini models, credentials, routing, image input, and desktop provider labels
- cover request, image, tool-result, streaming, registry, resolver, wire, and UI label contracts

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo check --workspace --locked`
- `cargo test -p openwave-router`
- `UPDATE_WIRE_TYPES=1 cargo test -p openwave-server --quiet`
- `pnpm test` and `pnpm build` in `crates/openwave-desktop/ui`

## Follow-up
- Vertex service-account authentication and a live Google API turn are not included; this slice supports the Developer API key endpoint only.

Part of #562