### PR TITLE
feat(outputs): publish text deliverables as durable revisions

### DIFF
--- a/crates/openwave-core/src/deliverable.rs
+++ b/crates/openwave-core/src/deliverable.rs
@@ -12,21 +12,22 @@ use chrono::{DateTime, Utc};
 use crate::citation::AssistantCitationReference;
 use crate::id::{ChatId, OutputCitationId, OutputId, OutputRevisionId, TurnId};
 
-/// Private-scratch directory holding the output files in use today.
+/// Private-scratch directory holding legacy filename-addressed output files.
 ///
-/// This is what `create_deliverable` writes and what the desktop Outputs view
-/// reads, so it is the only catalog the shipped product has. Identity here is
-/// the filename, and rewriting a file destroys the bytes it replaced.
+/// The desktop catalog still reads this compatibility surface.
+/// `create_deliverable` writes it first, validates those bytes at the
+/// publication boundary, then snapshots them under [`OUTPUTS_DIRECTORY`].
+/// Identity here is the filename, and rewriting a file destroys the bytes it
+/// replaced.
 ///
-/// The durable record layer below is the intended replacement and nothing
-/// writes it yet; see [`OUTPUTS_DIRECTORY`].
+/// The durable record layer below is the intended replacement; see
+/// [`OUTPUTS_DIRECTORY`].
 pub const DELIVERABLES_DIRECTORY: &str = "artifacts";
 /// Private-scratch directory holding immutable revision bytes.
 ///
 /// Paired with the `output` and `output_revision` tables. The store layer is
-/// complete and has no callers outside this crate: the cutover from
-/// [`DELIVERABLES_DIRECTORY`] is a separate slice. Anything reasoning about
-/// what a user can actually see today should look there, not here.
+/// complete and owns every new text-deliverable publication. Projecting these
+/// records through the desktop catalog is a separate slice.
 pub const OUTPUTS_DIRECTORY: &str = "outputs";
 /// Largest text artifact the foreground agent may create.
 pub const MAX_DELIVERABLE_BYTES: usize = 512 * 1024;

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -384,10 +384,31 @@ id_type!(
     /// encodes a filename or a host path.
     OutputId
 );
+
+impl OutputId {
+    const NAMESPACE: Uuid = Uuid::from_u128(0x5500_62d4_2528_4cc6_90f8_a788_e119_bf36);
+
+    /// Derive the retry-stable output identity for one canonical tool call.
+    #[must_use]
+    pub fn for_call(call_id: CallId) -> Self {
+        Self(Uuid::new_v5(&Self::NAMESPACE, call_id.as_uuid().as_bytes()))
+    }
+}
+
 id_type!(
     /// Identifies one immutable revision of an output.
     OutputRevisionId
 );
+
+impl OutputRevisionId {
+    const NAMESPACE: Uuid = Uuid::from_u128(0x72cb_0277_5a3c_45ee_bda8_4353_4f74_feb2);
+
+    /// Derive the retry-stable revision identity for one canonical tool call.
+    #[must_use]
+    pub fn for_call(call_id: CallId) -> Self {
+        Self(Uuid::new_v5(&Self::NAMESPACE, call_id.as_uuid().as_bytes()))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/openwave-core/src/tools/create_deliverable.rs
+++ b/crates/openwave-core/src/tools/create_deliverable.rs
@@ -1,23 +1,37 @@
 use std::path::Path;
+use std::str::FromStr;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 
 use crate::deliverable::{
-    validate_deliverable_name, DELIVERABLES_DIRECTORY, MAX_DELIVERABLE_BYTES,
-    MAX_DELIVERABLE_NAME_CHARS,
+    output_revision_relative_path, validate_deliverable_name, CreateOutput, NewOutputRevision,
+    DELIVERABLES_DIRECTORY, MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_NAME_CHARS,
 };
 use crate::error::Result;
+use crate::id::{OutputId, OutputRevisionId};
+use crate::storage::Store;
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 
 use super::arguments;
 use super::definitions;
-use super::private_scratch::write_utf8_file;
+use super::private_scratch::{publish_immutable_file, read_regular_file_bytes, write_utf8_file};
 
 /// `create_deliverable` — create or update a user-visible text artifact.
-pub struct CreateDeliverable;
+pub struct CreateDeliverable {
+    store: Arc<dyn Store>,
+}
+
+impl CreateDeliverable {
+    #[must_use]
+    pub fn new(store: Arc<dyn Store>) -> Self {
+        Self { store }
+    }
+}
 
 #[derive(Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -32,6 +46,10 @@ pub(super) struct Arguments {
         description = "Complete UTF-8 text contents of the output file (maximum 512 KiB)."
     )]
     content: String,
+    #[schemars(
+        description = "Opaque output id returned by an earlier call. Omit this to create a new output."
+    )]
+    output_id: Option<String>,
 }
 
 #[async_trait]
@@ -70,22 +88,130 @@ impl Tool for CreateDeliverable {
             Ok(workspace) => workspace,
             Err(message) => return Ok(ToolOutput::error(message)),
         };
+        let Some(call_id) = ctx.call_id else {
+            return Ok(ToolOutput::error(
+                "durable output publication requires a canonical tool-call identity",
+            ));
+        };
+        let calls = match self.store.list_tool_calls(ctx.chat_id).await {
+            Ok(calls) => calls,
+            Err(error) => {
+                return Ok(ToolOutput::error(format!(
+                    "could not verify durable tool-call identity: {error}"
+                )));
+            }
+        };
+        let call = match calls.into_iter().find(|call| call.id == call_id) {
+            Some(call) if call.name == definitions::CREATE_DELIVERABLE => call,
+            Some(_) => {
+                return Ok(ToolOutput::error(
+                    "canonical tool-call identity is not a create_deliverable call",
+                ));
+            }
+            None => {
+                return Ok(ToolOutput::error(
+                    "canonical tool-call identity is not owned by this conversation",
+                ));
+            }
+        };
+        let requested_output_id = match arguments.output_id {
+            Some(raw) => match OutputId::from_str(&raw) {
+                Ok(id) => Some(id),
+                Err(_) => return Ok(ToolOutput::error("output_id must be an opaque UUID")),
+            },
+            None => None,
+        };
+        let output_id = requested_output_id.unwrap_or_else(|| OutputId::for_call(call_id));
+        if let Some(existing) = requested_output_id {
+            match self.store.get_output(existing).await? {
+                Some(record) if record.chat_id != ctx.chat_id => {
+                    return Ok(ToolOutput::error(
+                        "output_id belongs to another conversation",
+                    ));
+                }
+                Some(record) if record.filename != arguments.filename => {
+                    return Ok(ToolOutput::error(
+                        "output_id has a different filename; preserve the existing output filename when revising it",
+                    ));
+                }
+                Some(_) => {}
+                None => {
+                    return Ok(ToolOutput::error(
+                        "output_id does not exist in this conversation",
+                    ))
+                }
+            }
+        }
         let filename = arguments.filename;
-        let relative_path = Path::new(DELIVERABLES_DIRECTORY).join(&filename);
-        let content_len = content.len();
-        let result = tokio::task::spawn_blocking(move || {
-            write_utf8_file(&workspace, &relative_path, &content)
-        })
-        .await;
-        match result {
-            Ok(Ok(())) => Ok(ToolOutput::text(format!(
-                "Created `{filename}` ({content_len} bytes). The file is available to the user in Outputs."
-            ))),
-            Ok(Err(error)) => Ok(ToolOutput::error(format!(
-                "could not create deliverable: {error}"
-            ))),
+        let source_path = Path::new(DELIVERABLES_DIRECTORY).join(&filename);
+        let revision_id = OutputRevisionId::for_call(call_id);
+        let relative_path = output_revision_relative_path(output_id, revision_id);
+        let result =
+            tokio::task::spawn_blocking(move || -> std::result::Result<Vec<u8>, String> {
+                write_utf8_file(&workspace, &source_path, &content)
+                    .map_err(|error| error.to_string())?;
+                let published =
+                    read_regular_file_bytes(&workspace, &source_path, MAX_DELIVERABLE_BYTES)?;
+                if published.is_empty()
+                    || published.contains(&0)
+                    || std::str::from_utf8(&published).is_err()
+                {
+                    return Err("validated deliverable scratch file is not usable text".into());
+                }
+                if published != content {
+                    return Err("deliverable scratch file changed during publication".into());
+                }
+                publish_immutable_file(&workspace, &relative_path, &published)?;
+                Ok(published)
+            })
+            .await;
+        let published = match result {
+            Ok(Ok(published)) => published,
+            Ok(Err(error)) => {
+                return Ok(ToolOutput::error(format!(
+                    "could not publish deliverable revision: {error}"
+                )));
+            }
+            Err(error) => {
+                return Ok(ToolOutput::error(format!(
+                    "could not publish deliverable revision: filesystem task failed: {error}"
+                )));
+            }
+        };
+        let content_len = published.len();
+        let revision = NewOutputRevision {
+            id: revision_id,
+            byte_len: content_len as u64,
+            sha256: Sha256::digest(&published).into(),
+            turn_id: Some(call.turn_id),
+            citations: Vec::new(),
+            created_at: call.created_at,
+        };
+        let record = match requested_output_id {
+            Some(existing) => self.store.append_output_revision(existing, &revision).await,
+            None => {
+                self.store
+                    .create_output(&CreateOutput {
+                        id: output_id,
+                        chat_id: ctx.chat_id,
+                        filename,
+                        revision,
+                    })
+                    .await
+            }
+        };
+        match record {
+            Ok(record) => Ok(ToolOutput::text(format!(
+                "Published output {} revision {} ({} bytes).",
+                record.id, record.current_revision, content_len
+            ))
+            .with_data(json!({
+                "output_id": record.id,
+                "revision_id": record.current_revision,
+                "revision_count": record.revision_count,
+            }))),
             Err(error) => Ok(ToolOutput::error(format!(
-                "could not create deliverable: filesystem task failed: {error}"
+                "could not publish deliverable: {error}"
             ))),
         }
     }

--- a/crates/openwave-core/src/tools/private_scratch.rs
+++ b/crates/openwave-core/src/tools/private_scratch.rs
@@ -31,6 +31,16 @@ pub(super) fn relative_path(rel: &str) -> std::result::Result<PathBuf, String> {
 }
 
 pub(super) fn read_utf8_file(workspace: &Dir, path: &Path) -> std::result::Result<String, String> {
+    let bytes = read_regular_file_bytes(workspace, path, MAX_READ_FILE_BYTES)?;
+    String::from_utf8(bytes).map_err(|_| "file is not valid UTF-8".into())
+}
+
+/// Read a bounded regular file without following a caller-controlled path.
+pub(super) fn read_regular_file_bytes(
+    workspace: &Dir,
+    path: &Path,
+    max_bytes: usize,
+) -> std::result::Result<Vec<u8>, String> {
     let mut options = OpenOptions::new();
     options.read(true).nonblock(true);
     let file = workspace
@@ -40,22 +50,18 @@ pub(super) fn read_utf8_file(workspace: &Dir, path: &Path) -> std::result::Resul
     if !metadata.is_file() {
         return Err("path is not a regular file".into());
     }
-    if metadata.len() > MAX_READ_FILE_BYTES as u64 {
-        return Err(format!(
-            "file is too large (maximum {MAX_READ_FILE_BYTES} bytes)"
-        ));
+    if metadata.len() > max_bytes as u64 {
+        return Err(format!("file is too large (maximum {max_bytes} bytes)"));
     }
 
     let mut bytes = Vec::with_capacity(metadata.len() as usize);
-    file.take((MAX_READ_FILE_BYTES + 1) as u64)
+    file.take((max_bytes + 1) as u64)
         .read_to_end(&mut bytes)
         .map_err(|error| error.to_string())?;
-    if bytes.len() > MAX_READ_FILE_BYTES {
-        return Err(format!(
-            "file is too large (maximum {MAX_READ_FILE_BYTES} bytes)"
-        ));
+    if bytes.len() > max_bytes {
+        return Err(format!("file is too large (maximum {max_bytes} bytes)"));
     }
-    String::from_utf8(bytes).map_err(|_| "file is not valid UTF-8".into())
+    Ok(bytes)
 }
 
 pub(super) fn list_directory(workspace: &Dir, path: &Path) -> std::result::Result<String, String> {
@@ -142,4 +148,90 @@ pub(super) fn write_utf8_file(workspace: &Dir, path: &Path, content: &[u8]) -> s
         let _ = parent.remove_file(&temp_name);
     }
     result
+}
+
+/// Publish bytes at a write-once path without replacing an earlier revision.
+///
+/// A hard link gives the temporary file an atomic, no-replace final name. If a
+/// previous attempt already published that name, accepting it only when its
+/// exact bytes match makes an interrupted store response safe to retry.
+pub(super) fn publish_immutable_file(
+    workspace: &Dir,
+    path: &Path,
+    content: &[u8],
+) -> std::result::Result<(), String> {
+    let parent_path = path.parent().unwrap_or_else(|| Path::new(""));
+    workspace
+        .create_dir_all(parent_path)
+        .map_err(|error| error.to_string())?;
+    let parent = if parent_path.as_os_str().is_empty() {
+        workspace.try_clone()
+    } else {
+        workspace.open_dir(parent_path)
+    }
+    .map_err(|error| error.to_string())?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| "path must name a file".to_string())?;
+    let temp_name = format!(".openwave-{}.tmp", uuid::Uuid::new_v4());
+
+    let write_temp = || -> std::io::Result<()> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true).nonblock(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = parent.open_with(&temp_name, &options)?;
+        if !file.metadata()?.is_file() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "temporary path is not a regular file",
+            ));
+        }
+        file.write_all(content)?;
+        file.sync_all()?;
+        Ok(())
+    };
+
+    if let Err(error) = write_temp() {
+        let _ = parent.remove_file(&temp_name);
+        return Err(error.to_string());
+    }
+
+    match parent.hard_link(&temp_name, &parent, file_name) {
+        Ok(()) => {
+            let _ = parent.remove_file(&temp_name);
+            #[cfg(unix)]
+            parent
+                .open(".")
+                .and_then(|directory| directory.sync_all())
+                .map_err(|error| format!("could not sync immutable revision directory: {error}"))?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            let _ = parent.remove_file(&temp_name);
+            let metadata = parent
+                .symlink_metadata(file_name)
+                .map_err(|read_error| read_error.to_string())?;
+            if !metadata.file_type().is_file() || metadata.len() != content.len() as u64 {
+                return Err("immutable revision path already exists with different content".into());
+            }
+            let mut options = OpenOptions::new();
+            options.read(true).nonblock(true);
+            let mut file = parent
+                .open_with(file_name, &options)
+                .map_err(|read_error| read_error.to_string())?;
+            let mut existing = Vec::with_capacity(content.len());
+            file.read_to_end(&mut existing)
+                .map_err(|read_error| read_error.to_string())?;
+            if existing == content {
+                Ok(())
+            } else {
+                Err("immutable revision path already exists with different content".into())
+            }
+        }
+        Err(error) => {
+            let _ = parent.remove_file(&temp_name);
+            Err(error.to_string())
+        }
+    }
 }

--- a/crates/openwave-core/src/tools/tests.rs
+++ b/crates/openwave-core/src/tools/tests.rs
@@ -1,19 +1,88 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use serde_json::json;
+use sha2::{Digest, Sha256};
 
 use super::private_scratch::{read_utf8_file, write_utf8_file, MAX_READ_FILE_BYTES};
 use super::{CreateDeliverable, ListDir, ReadFile, WriteFile};
-use crate::id::ChatId;
+use crate::id::{CallId, ChatId, OutputId, OutputRevisionId, TurnId};
+use crate::model::{Chat, ToolCallExecution, ToolCallRecord, ToolCallStatus};
+use crate::storage::Store;
 use crate::tool::{Tool, ToolCtx};
+use crate::DbStore;
 
 fn ctx(dir: &Path) -> ToolCtx {
     ToolCtx::try_new_legacy_workspace(ChatId::new(), None, dir.to_path_buf()).unwrap()
 }
 
+async fn output_fixture() -> (tempfile::TempDir, Arc<DbStore>, ChatId) {
+    let directory = tempfile::tempdir().unwrap();
+    let store = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            directory.path().join("outputs.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let chat = Chat {
+        id: ChatId::new(),
+        project_id: None,
+        title: None,
+        model: None,
+        reasoning_effort: None,
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
+        created_at: chrono::Utc::now(),
+    };
+    store.create_chat(&chat).await.unwrap();
+    (directory, store, chat.id)
+}
+
+async fn accept_deliverable_call(store: &DbStore, chat_id: ChatId, call_id: CallId) -> TurnId {
+    let turn_id = TurnId::new();
+    store
+        .accept_tool_call(&ToolCallRecord {
+            id: call_id,
+            chat_id,
+            turn_id,
+            provider_id: format!("provider-{call_id}"),
+            name: "create_deliverable".into(),
+            arguments: json!({}),
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: chrono::Utc::now(),
+            resolved_at: None,
+        })
+        .await
+        .unwrap();
+    turn_id
+}
+
+fn durable_ctx(directory: &Path, chat_id: ChatId, call_id: CallId) -> ToolCtx {
+    ToolCtx::try_new_legacy_workspace(chat_id, None, directory.to_path_buf())
+        .unwrap()
+        .with_call_id(call_id)
+}
+
+fn published_ids(output: &crate::ToolOutput) -> (OutputId, OutputRevisionId) {
+    let data = output.data.as_ref().expect("published output data");
+    (
+        serde_json::from_value(data["output_id"].clone()).unwrap(),
+        serde_json::from_value(data["revision_id"].clone()).unwrap(),
+    )
+}
+
 #[tokio::test]
 async fn every_file_tool_fails_closed_without_private_scratch() {
-    let ctx = ToolCtx::without_private_scratch(ChatId::new(), None);
+    let (_directory, store, chat_id) = output_fixture().await;
+    let ctx = ToolCtx::without_private_scratch(chat_id, None);
 
     let read = ReadFile
         .execute(&ctx, json!({"path": "note.txt"}))
@@ -24,7 +93,7 @@ async fn every_file_tool_fails_closed_without_private_scratch() {
         .execute(&ctx, json!({"path": "note.txt", "content": "nope"}))
         .await
         .unwrap();
-    let deliverable = CreateDeliverable
+    let deliverable = CreateDeliverable::new(store)
         .execute(&ctx, json!({"filename": "brief.md", "content": "nope"}))
         .await
         .unwrap();
@@ -35,8 +104,9 @@ async fn every_file_tool_fails_closed_without_private_scratch() {
     assert!(deliverable.is_error);
 }
 
-#[test]
-fn built_in_tool_schemas_preserve_their_provider_contracts() {
+#[tokio::test]
+async fn built_in_tool_schemas_preserve_their_provider_contracts() {
+    let (_directory, store, _chat_id) = output_fixture().await;
     assert_eq!(
         ReadFile.spec().input_schema,
         json!({
@@ -80,7 +150,7 @@ fn built_in_tool_schemas_preserve_their_provider_contracts() {
         })
     );
     assert_eq!(
-        CreateDeliverable.spec().input_schema,
+        CreateDeliverable::new(store).spec().input_schema,
         json!({
             "type": "object",
             "properties": {
@@ -95,6 +165,10 @@ fn built_in_tool_schemas_preserve_their_provider_contracts() {
                     "description": "Complete UTF-8 text contents of the output file (maximum 512 KiB).",
                     "minLength": 1,
                     "maxLength": crate::MAX_DELIVERABLE_BYTES
+                },
+                "output_id": {
+                    "type": ["string", "null"],
+                    "description": "Opaque output id returned by an earlier call. Omit this to create a new output."
                 }
             },
             "required": ["filename", "content"],
@@ -124,9 +198,12 @@ async fn malformed_arguments_include_the_typed_schema() {
 
 #[tokio::test]
 async fn deliverables_are_isolated_in_their_closed_directory() {
-    let dir = tempfile::tempdir().unwrap();
-    let ctx = ctx(dir.path());
-    let spec = CreateDeliverable.spec();
+    let (dir, store, chat_id) = output_fixture().await;
+    let first_call = CallId::new();
+    let first_turn = accept_deliverable_call(&store, chat_id, first_call).await;
+    let ctx = durable_ctx(dir.path(), chat_id, first_call);
+    let tool = CreateDeliverable::new(store.clone());
+    let spec = tool.spec();
     assert_eq!(
         spec.input_schema["properties"]["filename"]["maxLength"],
         crate::MAX_DELIVERABLE_NAME_CHARS
@@ -137,7 +214,7 @@ async fn deliverables_are_isolated_in_their_closed_directory() {
     );
     assert_eq!(spec.input_schema["additionalProperties"], false);
 
-    let output = CreateDeliverable
+    let output = tool
         .execute(
             &ctx,
             json!({"filename": "Research brief.md", "content": "# Findings\n\nGrounded."}),
@@ -145,34 +222,143 @@ async fn deliverables_are_isolated_in_their_closed_directory() {
         .await
         .unwrap();
     assert!(!output.is_error, "{output:?}");
+    let (output_id, first_revision_id) = published_ids(&output);
+    assert_eq!(
+        std::fs::read_to_string(
+            dir.path()
+                .join(crate::OUTPUTS_DIRECTORY)
+                .join(output_id.to_string())
+                .join(first_revision_id.to_string()),
+        )
+        .unwrap(),
+        "# Findings\n\nGrounded."
+    );
     assert_eq!(
         std::fs::read_to_string(dir.path().join("artifacts/Research brief.md")).unwrap(),
         "# Findings\n\nGrounded."
     );
-    assert!(output.content.contains("Outputs"));
+    let first = store.get_output(output_id).await.unwrap().unwrap();
+    let first_revision = store
+        .get_output_revision(first_revision_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.chat_id, chat_id);
+    assert_eq!(first.current_revision, first_revision_id);
+    assert_eq!(first_revision.turn_id, Some(first_turn));
+    assert_eq!(
+        first_revision.byte_len,
+        "# Findings\n\nGrounded.".len() as u64
+    );
+    let first_digest: [u8; 32] = Sha256::digest(b"# Findings\n\nGrounded.").into();
+    assert_eq!(first_revision.sha256, first_digest);
+    assert!(output.content.contains(&output_id.to_string()));
+    assert!(output.content.contains(&first_revision_id.to_string()));
+    assert!(!output.content.contains(dir.path().to_str().unwrap()));
+    assert!(!output.content.contains("outputs/"));
+
+    // The same canonical call is an exact retry, not a second publication.
+    let retried = tool
+        .execute(
+            &ctx,
+            json!({"filename": "Research brief.md", "content": "# Findings\n\nGrounded."}),
+        )
+        .await
+        .unwrap();
+    assert_eq!(published_ids(&retried), (output_id, first_revision_id));
+    assert_eq!(
+        store.list_output_revisions(output_id).await.unwrap().len(),
+        1
+    );
+
+    let second_call = CallId::new();
+    let second_turn = accept_deliverable_call(&store, chat_id, second_call).await;
+    let update = tool
+        .execute(
+            &durable_ctx(dir.path(), chat_id, second_call),
+            json!({
+                "output_id": output_id,
+                "filename": "Research brief.md",
+                "content": "# Findings\n\nRevised."
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(!update.is_error, "{update:?}");
+    let (updated_output_id, second_revision_id) = published_ids(&update);
+    assert_eq!(updated_output_id, output_id);
+    let updated = store.get_output(output_id).await.unwrap().unwrap();
+    assert_eq!(updated.current_revision, second_revision_id);
+    assert_eq!(updated.revision_count, 2);
+    let revisions = store.list_output_revisions(output_id).await.unwrap();
+    assert_eq!(revisions.len(), 2);
+    assert_eq!(revisions[0].id, second_revision_id);
+    assert_eq!(revisions[0].ordinal, 2);
+    assert_eq!(revisions[0].turn_id, Some(second_turn));
+    assert_eq!(revisions[1].id, first_revision_id);
+    assert_eq!(
+        std::fs::read_to_string(
+            dir.path()
+                .join(crate::OUTPUTS_DIRECTORY)
+                .join(output_id.to_string())
+                .join(first_revision_id.to_string()),
+        )
+        .unwrap(),
+        "# Findings\n\nGrounded."
+    );
+    assert_eq!(
+        std::fs::read_to_string(
+            dir.path()
+                .join(crate::OUTPUTS_DIRECTORY)
+                .join(output_id.to_string())
+                .join(second_revision_id.to_string()),
+        )
+        .unwrap(),
+        "# Findings\n\nRevised."
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("artifacts/Research brief.md")).unwrap(),
+        "# Findings\n\nRevised."
+    );
+    let retried_update = tool
+        .execute(
+            &durable_ctx(dir.path(), chat_id, second_call),
+            json!({
+                "output_id": output_id,
+                "filename": "Research brief.md",
+                "content": "# Findings\n\nRevised."
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        published_ids(&retried_update),
+        (output_id, second_revision_id)
+    );
+    assert_eq!(
+        store.list_output_revisions(output_id).await.unwrap().len(),
+        2
+    );
 
     for arguments in [
         json!({"filename": "../escape.md", "content": "nope"}),
         json!({"filename": "opaque.pdf", "content": "nope"}),
         json!({"filename": "empty.txt", "content": ""}),
+        json!({"filename": "bad-id.txt", "content": "x", "output_id": "not-an-id"}),
         json!({"filename": "extra.txt", "content": "x", "path": "outside"}),
     ] {
-        assert!(
-            CreateDeliverable
-                .execute(&ctx, arguments)
-                .await
-                .unwrap()
-                .is_error
-        );
+        assert!(tool.execute(&ctx, arguments).await.unwrap().is_error);
     }
 }
 
 #[tokio::test]
 async fn deliverable_size_is_bounded_before_writing() {
-    let dir = tempfile::tempdir().unwrap();
-    let output = CreateDeliverable
+    let (dir, store, chat_id) = output_fixture().await;
+    let call_id = CallId::new();
+    accept_deliverable_call(&store, chat_id, call_id).await;
+    let output = CreateDeliverable::new(store)
         .execute(
-            &ctx(dir.path()),
+            &durable_ctx(dir.path(), chat_id, call_id),
             json!({
                 "filename": "oversized.txt",
                 "content": "x".repeat(crate::MAX_DELIVERABLE_BYTES + 1)
@@ -181,7 +367,85 @@ async fn deliverable_size_is_bounded_before_writing() {
         .await
         .unwrap();
     assert!(output.is_error);
-    assert!(!dir.path().join("artifacts/oversized.txt").exists());
+    assert!(!dir.path().join(crate::OUTPUTS_DIRECTORY).exists());
+}
+
+#[tokio::test]
+async fn deliverable_updates_fail_closed_across_conversations() {
+    let (first_directory, store, first_chat) = output_fixture().await;
+    let first_call = CallId::new();
+    accept_deliverable_call(&store, first_chat, first_call).await;
+    let tool = CreateDeliverable::new(store.clone());
+    let created = tool
+        .execute(
+            &durable_ctx(first_directory.path(), first_chat, first_call),
+            json!({"filename": "brief.md", "content": "private"}),
+        )
+        .await
+        .unwrap();
+    let (output_id, _) = published_ids(&created);
+
+    let second_directory = tempfile::tempdir().unwrap();
+    let second_chat = Chat {
+        id: ChatId::new(),
+        project_id: None,
+        title: None,
+        model: None,
+        reasoning_effort: None,
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
+        created_at: chrono::Utc::now(),
+    };
+    store.create_chat(&second_chat).await.unwrap();
+    let second_call = CallId::new();
+    accept_deliverable_call(&store, second_chat.id, second_call).await;
+    let intruder = tool
+        .execute(
+            &durable_ctx(second_directory.path(), second_chat.id, second_call),
+            json!({
+                "output_id": output_id,
+                "filename": "brief.md",
+                "content": "stolen"
+            }),
+        )
+        .await
+        .unwrap();
+    assert!(intruder.is_error, "{intruder:?}");
+    assert!(intruder.content.contains("another conversation"));
+    assert!(!second_directory
+        .path()
+        .join(crate::OUTPUTS_DIRECTORY)
+        .exists());
+    assert_eq!(
+        store.list_output_revisions(output_id).await.unwrap().len(),
+        1
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn deliverable_publication_rejects_a_symlinked_revision_directory() {
+    let (directory, store, chat_id) = output_fixture().await;
+    let outside = tempfile::tempdir().unwrap();
+    std::os::unix::fs::symlink(
+        outside.path(),
+        directory.path().join(crate::OUTPUTS_DIRECTORY),
+    )
+    .unwrap();
+    let call_id = CallId::new();
+    accept_deliverable_call(&store, chat_id, call_id).await;
+
+    let output = CreateDeliverable::new(store.clone())
+        .execute(
+            &durable_ctx(directory.path(), chat_id, call_id),
+            json!({"filename": "brief.md", "content": "must stay private"}),
+        )
+        .await
+        .unwrap();
+
+    assert!(output.is_error, "{output:?}");
+    assert!(std::fs::read_dir(outside.path()).unwrap().next().is_none());
+    assert!(store.list_outputs(chat_id, 10).await.unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -743,7 +743,7 @@ fn agent_deps(
         .with(Box::new(ReadFile))
         .with(Box::new(ListDir))
         .with(Box::new(WriteFile))
-        .with(Box::new(CreateDeliverable))
+        .with(Box::new(CreateDeliverable::new(source_store.clone())))
         .with(Box::new(ExecTool::new(code_execution)))
         .with(search)
         .with(Box::new(source_tools::ListSourcesTool::new(


### PR DESCRIPTION
## Summary

- snapshot each validated scratch deliverable into a chat-owned immutable output revision
- return retry-stable opaque output and revision identities, while preserving the legacy scratch artifact for the current catalog
- reject cross-chat output updates and unsafe scratch paths without writing durable records

## Verification

- `cargo fmt --all --check`
- `cargo test -p openwave-core 'tools::tests::' --no-fail-fast`\n- `cargo clippy -p openwave-core --lib --locked -- -D warnings`\n- `cargo check -p openwave-server --locked` passed before the final core-local scratch-copy adjustment; its repeat was deferred to CI after the shared build volume filled.\n\nCloses #632