### PR TITLE
fix(desktop): give the chat pane its slot's height

### DIFF
--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -525,9 +525,13 @@ body {
   padding: 1.1rem 1.25rem 3rem;
 }
 
+/* The panel slot the pane sits in is a plain block, so nothing stretches the
+   pane to the slot's height: without this the transcript — `flex: 1 1 0` —
+   resolves to nothing and the composer rides up over the messages. */
 .chat-pane {
   display: flex;
   flex-direction: column;
+  height: 100%;
   min-height: 0;
   min-width: 0;
   overflow: clip;


### PR DESCRIPTION
The chat pane rendered upside down: the composer sat at the top of the panel, the user's message overlapped it, and the rest of the panel was dead space.

The pane is placed straight into a resizable panel slot, which is a plain block element — nothing stretches its child to the slot's height. `.chat-pane` never asked for one, so its height came from its content, and the transcript's `flex: 1 1 0` contributes nothing to that. The transcript resolved to zero height, the composer was laid out at the top of the slot, and the transcript's own padding box spilled the messages over it.

`height: 100%` on the pane. Other panels get this from `PanelFrame`; the chat pane is rendered without that frame, so it has to ask for it itself.

Verified by rendering the pane's markup inside the real `PanelLayout` in a browser: reproduced the overlap, then confirmed the transcript fills the panel and the composer sits at the bottom. `tsc`, vitest (506 tests), and a production build all pass. No test added — this is a layout height jsdom does not compute, so a unit test could not have caught it and would not catch the next one.