### PR TITLE
fix(build): sign dev binaries with a stable identifier so one keychain approval covers all

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,25 @@ re-trigger the access prompt on every rebuild. To prevent that, `cargo run`
 and `cargo test` launch through
 [`scripts/macos-dev-sign-runner.sh`](scripts/macos-dev-sign-runner.sh), which
 signs the binary with your `openwave-dev` or `Apple Development` certificate
-(whichever exists) before running it. Click **Always Allow** once per binary
-and the prompt won't return. With no certificate in the keychain the wrapper
-is a no-op; you can also set `OPENWAVE_DEV_SIGNING_IDENTITY` to pick an
-identity explicitly, or set it empty to opt out.
+(whichever exists) before running it. Every binary is signed with the same
+fixed identifier, so clicking **Always Allow** once covers all dev binaries —
+including test executables, whose hashed file names change between builds.
+With no certificate in the keychain the wrapper is a no-op; you can also set
+`OPENWAVE_DEV_SIGNING_IDENTITY` to pick an identity explicitly, or set it
+empty to opt out.
+
+If the prompt asks for your **login keychain password** (instead of a plain
+Allow/Deny), the keychain item was created by an older ad-hoc-signed build
+and its partition list doesn't include your signing certificate's team.
+Repair it once per secret, then Always Allow sticks:
+
+```sh
+security set-generic-password-partition-list \
+  -S "apple-tool:,apple:,teamid:<YOUR_TEAM_ID>" -s openwave -a <account>
+```
+
+(`security find-identity -v -p codesigning` shows the team id in parentheses;
+`security find-generic-password -s openwave` lists the accounts.)
 
 ### Desktop UI
 

--- a/scripts/macos-dev-sign-runner.sh
+++ b/scripts/macos-dev-sign-runner.sh
@@ -11,6 +11,13 @@
 # stable identity gives the binary a stable designated requirement, so one
 # approval per binary persists across rebuilds.
 #
+# Every binary is signed with the same fixed identifier (`openwave-dev`)
+# rather than codesign's default (the file name). The keychain ACL matches on
+# the designated requirement — identifier + certificate — so with a shared
+# identifier one "Always Allow" covers every dev binary, including test
+# executables, whose hashed file names would otherwise produce a fresh
+# designated requirement (and a fresh prompt) on every rebuild.
+#
 # Identity, in order of preference:
 #   1. $OPENWAVE_DEV_SIGNING_IDENTITY (set to opt out with an empty value)
 #   2. an "openwave-dev" self-signed certificate, if one exists
@@ -38,12 +45,14 @@ find_identity() {
 
 identity="${OPENWAVE_DEV_SIGNING_IDENTITY-$(find_identity)}"
 
+identifier="openwave-dev"
+
 if [[ -n "$identity" ]]; then
   # Unchanged binaries keep their signature from the previous run; re-signing
-  # only when the identity differs leaves them untouched.
+  # only when the identity or identifier differs leaves them untouched.
   current="$(codesign --display --verbose=2 "$bin" 2>&1 || true)"
-  if [[ "$current" != *"Authority=$identity"* ]]; then
-    codesign --force --sign "$identity" "$bin" 2>/dev/null ||
+  if [[ "$current" != *"Authority=$identity"* || "$current" != *"Identifier=$identifier"* ]]; then
+    codesign --force --sign "$identity" --identifier "$identifier" "$bin" 2>/dev/null ||
       echo "warning: codesign with '$identity' failed; running unsigned" >&2
   fi
 fi


### PR DESCRIPTION
## What

The macOS dev-sign runner now passes `--identifier openwave-dev` to codesign, and only skips re-signing when both the authority and the identifier already match. CONTRIBUTING's keychain section is updated to match, and now documents the login-keychain-password variant of the prompt and its one-time repair.

## Why

codesign defaults the identifier to the binary's file name, and the keychain ACL matches on the designated requirement (identifier + certificate). So even with a stable signing identity, each binary needed its own Always Allow — and test executables, whose file names embed a hash that changes between builds, could never keep an approval at all. With a shared fixed identifier, every dev binary has the same designated requirement and a single Always Allow covers all of them, permanently.

Separately, keychain items created by older ad-hoc-signed builds carry a partition list that doesn't include the signing team, which is why the prompt sometimes demands the login keychain password instead of offering a plain Allow. That needs a one-time `security set-generic-password-partition-list` repair, now documented in CONTRIBUTING.

## Testing

Ran the runner against a freshly compiled scratch binary with a hash-suffixed name: it signs with `Identifier=openwave-dev` and the designated requirement comes out as `identifier "openwave-dev" and … certificate leaf[subject.CN] = "Apple Development: …"` — identical for any file name. A second run leaves the CDHash untouched (skip path works). `bash -n` passes. Docs-only + script change; no Rust code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)