### PR TITLE
fix(desktop): make the model menu scrollable so the tail groups are reachable

### DIFF
--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -144,7 +144,7 @@ export function ModelMenu({
       <DropdownMenuContent
         align="start"
         side="top"
-        className="model-menu-content"
+        className="model-menu-content overflow-y-auto"
       >
         <DropdownMenuItem
           onSelect={() => {
@@ -276,7 +276,7 @@ export function ReasoningEffortMenu({
       <DropdownMenuContent
         align="start"
         side="top"
-        className="model-menu-content"
+        className="model-menu-content overflow-y-auto"
       >
         <DropdownMenuItem
           onSelect={() => {

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1836,7 +1836,14 @@ body {
 
 .model-menu-content {
   min-width: 15rem;
-  max-height: 60vh;
+  /* Bounded by the space Radix measured between the trigger and the viewport
+     edge, so the tail of the list is always reachable by scrolling. The
+     overflow override lives on the element as a utility class: this rule is in
+     `@layer components`, which loses to the base `overflow-hidden` utility. */
+  max-height: min(
+    60vh,
+    calc(var(--radix-dropdown-menu-content-available-height) - 0.5rem)
+  );
   overflow-y: auto;
 }
 

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1842,7 +1842,7 @@ body {
      `@layer components`, which loses to the base `overflow-hidden` utility. */
   max-height: min(
     60vh,
-    calc(var(--radix-dropdown-menu-content-available-height) - 0.5rem)
+    calc(var(--radix-dropdown-menu-content-available-height, 100vh) - 0.5rem)
   );
   overflow-y: auto;
 }


### PR DESCRIPTION
## Problem

Two smoke reports, one bug: gateway-provided models were "missing" from the composer's model picker, and the picker's scrolling felt janky/laggy.

The menu's scroll was never functional. `DropdownMenuContent`'s base `overflow-hidden` utility outranks `.model-menu-content { overflow-y: auto }`, which lives in `@layer components` — ordered below the utilities layer in Tailwind v4. While the catalog fit inside the 60vh cap nobody could tell; the widened catalog (#552) pushed the list past it, clipping the tail of the menu — including the entire Model Gateway group — with no way to reach it. Wheel input over the menu did nothing while Radix's keyboard/hover focus still force-jumped content, which is the "lag".

## Fix

- Pass `overflow-y-auto` through `className` on both menu contents so the override participates in the utilities layer and wins the y-axis.
- Bound `.model-menu-content`'s max-height by `--radix-dropdown-menu-content-available-height` (min'd with the existing 60vh) so the cap also holds on short windows where 60vh wouldn't fit above the trigger.

## Verification

Reproduced and verified live in a browser against `openwave serve` running on a copy of the real desktop store (19 models, 2 from the gateway):

- Before: computed `overflow-y: hidden`, `scrollHeight` 974px vs `clientHeight` 560px — 414px of menu (Gemini tail + Model Gateway group) unreachable.
- After: computed `overflow-y: auto`, menu scrolls to the end, **Model Gateway → Sample Claude / Sample Coder** visible and selectable; picking one updates the composer to "Model: Sample Claude".
- `tsc`, vitest (510 passing), and a production `vite build` are green. No regression test added: the defect is CSS cascade-layer ordering, which jsdom doesn't compute — a class-name assertion would be tautological.

🤖 Generated with [Claude Code](https://claude.com/claude-code)