### PR TITLE
fix(desktop): run dev builds under a distinct app identifier

### DIFF
--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -50,6 +50,12 @@ Rust host boots the in-process API; the webview calls `server_info` to learn the
 base URL and token. The Tauri pre-dev command builds and stages the broker
 sidecar for the current target automatically.
 
+Debug builds run under the identifier `io.brightwave.openwave.dev` (instead of
+`io.brightwave.openwave`), so `cargo tauri dev` keeps its own single-instance
+lock and app-data directory and can run alongside an installed release build.
+This means dev and release profiles do not share state: the first dev run after
+this change starts from an empty data directory.
+
 A dev build leaves out `vec-lance`, so document search runs on an in-memory
 index that is discarded when the app exits — the LanceDB tree it replaces is
 about 330 crates of build time. Add `--features vec-lance` when you are working

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -140,6 +140,16 @@ fn home_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg_attr(not(debug_assertions), allow(unused_mut))]
+    let mut context = tauri::generate_context!();
+    // Debug builds run under a distinct identifier so `cargo tauri dev` holds its
+    // own single-instance lock and app-data dir instead of colliding with an
+    // installed release build.
+    #[cfg(debug_assertions)]
+    {
+        context.config_mut().identifier = "io.brightwave.openwave.dev".into();
+    }
+
     let (info_tx, info_rx) = watch::channel(None);
     let state = Arc::new(AppState { info_rx });
 
@@ -198,7 +208,7 @@ pub fn run() {
             });
             Ok(())
         })
-        .build(tauri::generate_context!())
+        .build(context)
         .expect("error while building OpenWave");
     app.run(|app, event| match event {
         tauri::RunEvent::WindowEvent { label, event, .. } => {


### PR DESCRIPTION
## What

Debug builds now override the Tauri app identifier to `io.brightwave.openwave.dev` at startup (release builds are untouched). This gives `cargo tauri dev` its own single-instance lock and its own app-data directory, so a dev build and an installed release build can run side by side.

## Why

`tauri-plugin-single-instance` keys its macOS lock on a socket path derived purely from the config identifier (`/tmp/<identifier>_si.sock` in v2.4.3 — the `semver` feature that would add the version to the path is not enabled). Dev and release builds both presented `io.brightwave.openwave`, so launching one while the other was running just focused the existing window and exited. Both profiles also resolved the same `app_data_dir`, so even without the lock they would have shared one profile's state concurrently.

The override lives in code rather than a `--config` merge file so it applies to every `cargo tauri dev` invocation without anyone remembering a flag.

## Notes

- Dev profiles no longer share state with release installs: the first dev run after this lands starts from an empty data directory. Documented in the desktop README.
- No tests added: the change is a two-line startup override of third-party plugin behavior; a test would only re-assert the constant.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p openwave-desktop --all-targets --locked -- -D warnings`
- `cargo test -p openwave-desktop --locked` — 70 passed

Closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)