### PR TITLE
refactor(gateway): sign in as the registered openwave client

### DIFF
--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -63,8 +63,11 @@ pub struct GatewayAuthConfig {
 impl GatewayAuthConfig {
     /// The registered `openwave` public client: the gateway's client registry
     /// names it on the consent page and attributes its sessions to OpenWave.
+    /// The name is also declared on every refresh, because usage attribution
+    /// reads the access token's client name — omitting it there would leave
+    /// inference calls attributed `generic` despite the registered client id.
     pub fn new(base_url: &str) -> Result<Self> {
-        Self::with_client(base_url, "openwave", None)
+        Self::with_client(base_url, "openwave", Some("openwave".to_string()))
     }
 
     fn with_client(base_url: &str, client_id: &str, client_name: Option<String>) -> Result<Self> {

--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -61,18 +61,10 @@ pub struct GatewayAuthConfig {
 }
 
 impl GatewayAuthConfig {
-    /// A first-class `openwave` client. Requires the gateway to know that
-    /// client id; use [`Self::modelctl_compat`] against deployments that
-    /// still hardcode `modelctl`.
+    /// The registered `openwave` public client: the gateway's client registry
+    /// names it on the consent page and attributes its sessions to OpenWave.
     pub fn new(base_url: &str) -> Result<Self> {
         Self::with_client(base_url, "openwave", None)
-    }
-
-    /// Development-only compatibility identity: authorize as `modelctl`,
-    /// leaving attribution to the gateway's default. Remove once the gateway
-    /// grows a client registry with an `openwave` entry.
-    pub fn modelctl_compat(base_url: &str) -> Result<Self> {
-        Self::with_client(base_url, "modelctl", None)
     }
 
     fn with_client(base_url: &str, client_id: &str, client_name: Option<String>) -> Result<Self> {

--- a/crates/openwave-connectors/tests/gateway_flow.rs
+++ b/crates/openwave-connectors/tests/gateway_flow.rs
@@ -117,7 +117,7 @@ async fn authorize(
     State(gateway): State<Arc<FakeGateway>>,
     Query(query): Query<HashMap<String, String>>,
 ) -> Response {
-    if query.get("client_id").map(String::as_str) != Some("modelctl")
+    if query.get("client_id").map(String::as_str) != Some("openwave")
         || query.get("code_challenge_method").map(String::as_str) != Some("S256")
         || query.get("response_type").map(String::as_str) != Some("code")
     {
@@ -157,7 +157,7 @@ async fn token(
             let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
             if challenge != pending.challenge
                 || form.get("redirect_uri") != Some(&pending.redirect_uri)
-                || form.get("client_id").map(String::as_str) != Some("modelctl")
+                || form.get("client_id").map(String::as_str) != Some("openwave")
             {
                 return invalid_grant();
             }
@@ -221,7 +221,7 @@ async fn me(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> Resp
         "user_id": USER,
         "email": "abaas@example.test",
         "display_name": "Abaas",
-        "client_name": "modelctl",
+        "client_name": "openwave",
         "session_id": SESSION,
         "installation_id": INSTALLATION,
     }))
@@ -272,8 +272,7 @@ async fn signed_in_connection() -> (Arc<FakeGateway>, GatewayConnection) {
     let gateway = Arc::new(FakeGateway::default());
     let address = serve_fake_gateway(gateway.clone()).await;
     let auth =
-        GatewayAuth::new(GatewayAuthConfig::modelctl_compat(&format!("http://{address}")).unwrap())
-            .unwrap();
+        GatewayAuth::new(GatewayAuthConfig::new(&format!("http://{address}")).unwrap()).unwrap();
 
     let pending = auth.start_sign_in().await.unwrap();
     let url = pending.authorization_url().to_string();
@@ -292,13 +291,12 @@ async fn full_sign_in_flow_verifies_pkce_installation_and_identity() {
     let gateway = Arc::new(FakeGateway::default());
     let address = serve_fake_gateway(gateway.clone()).await;
     let auth =
-        GatewayAuth::new(GatewayAuthConfig::modelctl_compat(&format!("http://{address}")).unwrap())
-            .unwrap();
+        GatewayAuth::new(GatewayAuthConfig::new(&format!("http://{address}")).unwrap()).unwrap();
 
     let pending = auth.start_sign_in().await.unwrap();
     assert_eq!(pending.meta().installation_id, INSTALLATION);
     let url = pending.authorization_url().to_string();
-    assert!(url.contains("client_id=modelctl"));
+    assert!(url.contains("client_id=openwave"));
     assert!(url.contains("code_challenge_method=S256"));
     assert!(url.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A"));
 
@@ -351,8 +349,7 @@ async fn a_stale_refresh_token_reads_as_signed_out() {
     // …then simulate a vault that missed the rotation.
     let vault = CredentialVault::new(Arc::new(MockSecrets::default()));
     vault.save(&stale).await.unwrap();
-    let auth =
-        GatewayAuth::new(GatewayAuthConfig::modelctl_compat(&stale.base_url).unwrap()).unwrap();
+    let auth = GatewayAuth::new(GatewayAuthConfig::new(&stale.base_url).unwrap()).unwrap();
     let stale_connection = GatewayConnection::new(auth, vault);
 
     let error = stale_connection
@@ -368,8 +365,7 @@ async fn a_state_mismatch_never_reaches_the_token_endpoint() {
     gateway.corrupt_state.store(true, Ordering::SeqCst);
     let address = serve_fake_gateway(gateway.clone()).await;
     let auth =
-        GatewayAuth::new(GatewayAuthConfig::modelctl_compat(&format!("http://{address}")).unwrap())
-            .unwrap();
+        GatewayAuth::new(GatewayAuthConfig::new(&format!("http://{address}")).unwrap()).unwrap();
 
     let pending = auth.start_sign_in().await.unwrap();
     let url = pending.authorization_url().to_string();

--- a/crates/openwave-connectors/tests/gateway_flow.rs
+++ b/crates/openwave-connectors/tests/gateway_flow.rs
@@ -164,6 +164,11 @@ async fn token(
             Json(gateway.mint("control")).into_response()
         }
         Some("refresh_token") => {
+            // Attribution rides the refresh grant: every minted access token
+            // must carry the client name, or usage reads as `generic`.
+            if form.get("client_name").map(String::as_str) != Some("openwave") {
+                return invalid_grant();
+            }
             let Some(refresh) = form.get("refresh_token") else {
                 return StatusCode::BAD_REQUEST.into_response();
             };

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -24,12 +24,6 @@ use crate::providers::{self, CustomModelConfig, ProviderKind};
 /// How long a browser sign-in may stay pending before it fails.
 const SIGN_IN_TIMEOUT: Duration = Duration::from_secs(300);
 
-/// Development-only escape hatch: the gateway hardcodes its own CLI's client
-/// id until it grows a client registry, so that identity is the default. Set
-/// this variable to exactly `openwave` to use the first-class client id once
-/// the deployed gateway registers it; any other value is ignored.
-const CLIENT_ID_ENV: &str = "OPENWAVE_GATEWAY_CLIENT_ID";
-
 pub(crate) struct GatewayRuntime {
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
@@ -207,13 +201,7 @@ impl GatewayRuntime {
                 return Ok(Some(connection.clone()));
             }
         }
-        let auth_config = match std::env::var(CLIENT_ID_ENV)
-            .ok()
-            .filter(|id| id == "openwave")
-        {
-            Some(_) => GatewayAuthConfig::new(&base_url)?,
-            None => GatewayAuthConfig::modelctl_compat(&base_url)?,
-        };
+        let auth_config = GatewayAuthConfig::new(&base_url)?;
         let connection = Arc::new(GatewayConnection::new(
             GatewayAuth::new(auth_config)?,
             CredentialVault::new(self.secrets.clone()),


### PR DESCRIPTION
The gateway grew a client registry (brightwave-inc/model-gateway#111) and registers `openwave` as a first-class public client, with attribution (brightwave-inc/model-gateway#110). This removes the two stubs that existed only because those were missing:

- `GatewayAuthConfig::modelctl_compat` — the impersonation default — is gone; `new()` is the only constructor and sends `client_id=openwave`.
- The `OPENWAVE_GATEWAY_CLIENT_ID` env escape hatch in `GatewayRuntime` is gone with it.

The connector's fake gateway now models the post-registry contract: it accepts exactly `client_id=openwave` at both `/oauth/authorize` and the token exchange, so the full sign-in flow test proves the identity actually sent.

User-visible effect: the gateway's consent page now says **OpenWave** instead of "modelctl CLI", and sessions — including per-call inference usage — are attributed to OpenWave (review catch: attribution reads the client name declared on the refresh grant, so `new()` now sends it; without it calls attribute as `generic`).

Note: this requires a gateway at or past model-gateway#111 (`v0.1.0-alpha.18` line). Older deployments reject the unknown client at `/oauth/authorize` with an HTML "authorization request is invalid" page before consent, so no code is issued and the pending sign-in times out after 300s — recoverable and visible in the browser, and no breakage of existing sessions (refresh binds to the refresh token, not `client_id`).

Gates: `cargo fmt`, `clippy --workspace -D warnings`, full workspace test suite, `--locked` check all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
