### PR TITLE
feat(gateway): list the entitled connected apps in settings

### DIFF
--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -130,6 +130,18 @@ pub struct GatewayModel {
     pub supports_vision: bool,
 }
 
+/// One entitled connected app from `/api/v1/cli/apps`: the apps the user
+/// reaches through team grants, and the slugs of the MCP endpoints that
+/// aggregate each one (the `mcp:<slug>` resources a client may request).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GatewayApp {
+    pub id: String,
+    pub name: String,
+    pub app_kind: String,
+    pub enabled: bool,
+    pub mcp_endpoint_slugs: Vec<String>,
+}
+
 /// One minted access/refresh pair, resource-bound.
 #[derive(Clone, PartialEq, Eq)]
 pub struct TokenSet {
@@ -380,6 +392,23 @@ impl GatewayAuth {
             .map_err(|error| gateway_error("model request", error.without_url()))?;
         let list: ModelListResponse = decode_json(response, "model request").await?;
         Ok(list.models)
+    }
+
+    /// The connected apps the authenticated user is entitled to, or `None`
+    /// against a gateway that predates the JSON apps surface.
+    pub async fn apps(&self, access_token: &str) -> Result<Option<Vec<GatewayApp>>> {
+        let response = self
+            .http
+            .get(self.endpoint("/api/v1/cli/apps")?)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|error| gateway_error("app request", error.without_url()))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let list: AppListResponse = decode_json(response, "app request").await?;
+        Ok(Some(list.apps))
     }
 
     async fn exchange_code(
@@ -650,6 +679,13 @@ impl GatewayConnection {
         self.auth.models(&token, protocol).await
     }
 
+    /// Entitled connected apps with a `control` token; `None` when the
+    /// gateway predates the apps surface.
+    pub async fn apps(&self) -> Result<Option<Vec<GatewayApp>>> {
+        let token = self.access_token(RESOURCE_CONTROL).await?;
+        self.auth.apps(&token).await
+    }
+
     /// Revoke the session at the gateway (best-effort) and always clear the
     /// local vault. A gateway that is unreachable cannot hold local sign-out
     /// hostage; its server-side session still dies at refresh-token expiry.
@@ -742,6 +778,11 @@ struct OAuthErrorResponse {
 #[derive(Deserialize)]
 struct ModelListResponse {
     models: Vec<GatewayModel>,
+}
+
+#[derive(Deserialize)]
+struct AppListResponse {
+    apps: Vec<GatewayApp>,
 }
 
 async fn decode_json<T: for<'de> Deserialize<'de>>(

--- a/crates/openwave-connectors/src/lib.rs
+++ b/crates/openwave-connectors/src/lib.rs
@@ -22,7 +22,7 @@
 mod gateway;
 
 pub use gateway::{
-    has_stored_credentials, is_sign_in_required, AuthorizedSession, CredentialVault, GatewayAuth,
-    GatewayAuthConfig, GatewayConnection, GatewayCredentials, GatewayIdentity, GatewayMeta,
-    GatewayModel, PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
+    has_stored_credentials, is_sign_in_required, AuthorizedSession, CredentialVault, GatewayApp,
+    GatewayAuth, GatewayAuthConfig, GatewayConnection, GatewayCredentials, GatewayIdentity,
+    GatewayMeta, GatewayModel, PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
 };

--- a/crates/openwave-connectors/tests/gateway_flow.rs
+++ b/crates/openwave-connectors/tests/gateway_flow.rs
@@ -63,6 +63,8 @@ struct FakeGateway {
     revoked: Mutex<Vec<String>>,
     token_requests: AtomicUsize,
     corrupt_state: AtomicBool,
+    /// Serve 404 for `/api/v1/cli/apps`, like a gateway that predates it.
+    apps_unsupported: AtomicBool,
 }
 
 impl FakeGateway {
@@ -250,6 +252,25 @@ async fn models(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> 
     .into_response()
 }
 
+async fn apps(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> Response {
+    if gateway.apps_unsupported.load(Ordering::SeqCst) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    if bearer_resource(&gateway, &headers).as_deref() != Some("control") {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    Json(json!({
+        "apps": [{
+            "id": "app-incident",
+            "name": "Incident API",
+            "app_kind": "rest_api",
+            "enabled": true,
+            "mcp_endpoint_slugs": ["example-security-tools"],
+        }]
+    }))
+    .into_response()
+}
+
 async fn serve_fake_gateway(gateway: Arc<FakeGateway>) -> SocketAddr {
     let app = Router::new()
         .route("/api/v1/meta", get(meta))
@@ -258,6 +279,7 @@ async fn serve_fake_gateway(gateway: Arc<FakeGateway>) -> SocketAddr {
         .route("/oauth/revoke", post(revoke))
         .route("/api/v1/cli/me", get(me))
         .route("/api/v1/cli/models", get(models))
+        .route("/api/v1/cli/apps", get(apps))
         .with_state(gateway);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
@@ -398,4 +420,21 @@ async fn sign_out_revokes_remotely_and_clears_the_vault() {
         .await
         .expect_err("signed-out connection must fail");
     assert!(is_sign_in_required(&error), "{error}");
+}
+
+#[tokio::test]
+async fn apps_lists_entitlements_and_degrades_when_the_surface_is_missing() {
+    let (gateway, connection) = signed_in_connection().await;
+
+    let apps = connection.apps().await.unwrap().unwrap();
+    assert_eq!(apps.len(), 1);
+    assert_eq!(apps[0].name, "Incident API");
+    assert_eq!(apps[0].app_kind, "rest_api");
+    assert!(apps[0].enabled);
+    assert_eq!(apps[0].mcp_endpoint_slugs, ["example-security-tools"]);
+
+    // An older gateway without the JSON apps surface is "unsupported", not an
+    // error and not an empty entitlement list.
+    gateway.apps_unsupported.store(true, Ordering::SeqCst);
+    assert_eq!(connection.apps().await.unwrap(), None);
 }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -15,6 +15,8 @@ import {
   type McpHealth as WireMcpHealth,
   type McpServerDefinition as WireMcpServerDefinition,
   type McpViewSession,
+  type GatewayApps as WireGatewayApps,
+  type GatewayAppInfo as WireGatewayAppInfo,
   type GatewayStatus as WireGatewayStatus,
   type SignInProgress,
   type McpServerInfo as WireMcpServerInfo,
@@ -234,6 +236,12 @@ export type GatewaySignInProgress = SignInProgress;
 
 /** Renderer-safe model-gateway connection state; never token material. */
 export type GatewayStatus = WireGatewayStatus;
+
+/** The signed-in user's entitled connected apps, fetched live per request. */
+export type GatewayApps = WireGatewayApps;
+
+/** One entitled connected app and the MCP endpoint slugs that carry it. */
+export type GatewayAppInfo = WireGatewayAppInfo;
 
 /**
  * Opaque envelope for a sandboxed MCP App view; never rendered directly.
@@ -538,6 +546,10 @@ export class ApiClient {
       method: "POST",
       headers: this.headers(),
     });
+  }
+
+  getGatewayApps(): Promise<GatewayApps> {
+    return this.json("/gateway/apps", { headers: this.headers() });
   }
 
   syncGatewayModels(): Promise<GatewayStatus> {

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -241,6 +241,24 @@ context_window: number,
 max_output_tokens: number, };
 
 /**
+ * One entitled connected app, with the slugs of the MCP endpoints that
+ * aggregate it — the `mcp:<slug>` resources a mount would request.
+ */
+export type GatewayAppInfo = { id: string, name: string, app_kind: string, enabled: boolean, mcp_endpoint_slugs: Array<string>, };
+
+/**
+ * Renderer-safe list of the connected apps the signed-in user is entitled
+ * to, fetched live from the gateway (never cached: a revoked grant is gone
+ * on the next request).
+ */
+export type GatewayApps = { 
+/**
+ * False when the connected gateway predates the JSON apps surface; the
+ * renderer hides the section instead of showing an empty list as "none".
+ */
+supported: boolean, apps: Array<GatewayAppInfo>, };
+
+/**
  * Renderer-safe projection of the gateway connection state. Never carries
  * token material — only what the settings surface displays.
  */

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -30,6 +30,7 @@ function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
       .mockResolvedValue({ authorization_url: "http://gw/oauth/authorize?x=1" }),
     gatewaySignOut: vi.fn().mockResolvedValue(signedOut),
     syncGatewayModels: vi.fn().mockResolvedValue(signedIn),
+    getGatewayApps: vi.fn().mockResolvedValue({ supported: true, apps: [] }),
     putProvider: vi.fn().mockResolvedValue({}),
     ...overrides,
   } as unknown as ApiClient;
@@ -135,6 +136,40 @@ describe("GatewayPanel", () => {
     });
     expect(screen.getByText("Signed in")).toBeInTheDocument();
     expect(onChanged).toHaveBeenCalled();
+  });
+
+  it("lists entitled connected apps, and hides the section on an older gateway", async () => {
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+      getGatewayApps: vi.fn().mockResolvedValue({
+        supported: true,
+        apps: [
+          {
+            id: "app-1",
+            name: "Incident API",
+            app_kind: "rest_api",
+            enabled: true,
+            mcp_endpoint_slugs: ["example-security-tools"],
+          },
+        ],
+      }),
+    });
+    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+
+    expect(await screen.findByText("Incident API")).toBeInTheDocument();
+    expect(screen.getByText(/example-security-tools/)).toBeInTheDocument();
+
+    cleanup();
+    // A gateway that predates the JSON apps surface: no section, no error.
+    const older = api({
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+      getGatewayApps: vi
+        .fn()
+        .mockResolvedValue({ supported: false, apps: [] }),
+    });
+    render(<GatewayPanel client={older} onChanged={() => undefined} />);
+    expect(await screen.findByText("Signed in")).toBeInTheDocument();
+    expect(screen.queryByText("Connected apps")).not.toBeInTheDocument();
   });
 
   it("surfaces a failed sign-in with its bounded message", async () => {

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ExternalLink, LogOut, RefreshCw } from "lucide-react";
-import type { ApiClient, GatewayStatus } from "../api";
+import type { ApiClient, GatewayApps, GatewayStatus } from "../api";
 import { openExternal } from "../host";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -37,6 +37,7 @@ export function GatewayPanel({
   onChanged: () => void;
 }) {
   const [status, setStatus] = useState<GatewayStatus | null>(null);
+  const [apps, setApps] = useState<GatewayApps | null>(null);
   const [baseUrl, setBaseUrl] = useState("");
   const [dirty, setDirty] = useState(false);
   const [working, setWorking] = useState(false);
@@ -62,6 +63,28 @@ export function GatewayPanel({
   useEffect(() => {
     reload().catch((err) => setError(String(err)));
   }, [reload]);
+
+  // Entitled apps are never cached server-side (a revoked grant disappears on
+  // the next request), so fetch them fresh whenever the signed-in state turns
+  // on. A fetch failure only hides the section; models keep working.
+  useEffect(() => {
+    if (!status?.signed_in) {
+      setApps(null);
+      return;
+    }
+    let cancelled = false;
+    client
+      .getGatewayApps()
+      .then((next) => {
+        if (!cancelled) setApps(next);
+      })
+      .catch(() => {
+        if (!cancelled) setApps(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, status?.signed_in]);
 
   // While the browser flow is pending, watch for its outcome.
   useEffect(() => {
@@ -250,6 +273,39 @@ export function GatewayPanel({
           </>
         )}
       </SettingsSection>
+
+      {status.signed_in && apps?.supported && (
+        <SettingsSection title="Connected apps">
+          {apps.apps.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              No connected apps are granted to your teams yet.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {apps.apps.map((app) => (
+                <li key={app.id} className="rounded-md border px-3 py-2 text-sm">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{app.name}</span>
+                    <span className="text-muted-foreground text-xs">
+                      {app.app_kind}
+                    </span>
+                    {!app.enabled && (
+                      <span className="text-muted-foreground text-xs">
+                        disabled
+                      </span>
+                    )}
+                  </div>
+                  {app.mcp_endpoint_slugs.length > 0 && (
+                    <p className="text-muted-foreground text-xs">
+                      via {app.mcp_endpoint_slugs.join(", ")}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </SettingsSection>
+      )}
 
       <p className="text-sm leading-relaxed text-muted-foreground">
         Sign-in happens in your browser against the gateway itself; OpenWave

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -70,6 +70,28 @@ pub(crate) struct GatewayStatus {
     pub(crate) sign_in: SignInProgress,
 }
 
+/// Renderer-safe list of the connected apps the signed-in user is entitled
+/// to, fetched live from the gateway (never cached: a revoked grant is gone
+/// on the next request).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub(crate) struct GatewayApps {
+    /// False when the connected gateway predates the JSON apps surface; the
+    /// renderer hides the section instead of showing an empty list as "none".
+    pub(crate) supported: bool,
+    pub(crate) apps: Vec<GatewayAppInfo>,
+}
+
+/// One entitled connected app, with the slugs of the MCP endpoints that
+/// aggregate it — the `mcp:<slug>` resources a mount would request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub(crate) struct GatewayAppInfo {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) app_kind: String,
+    pub(crate) enabled: bool,
+    pub(crate) mcp_endpoint_slugs: Vec<String>,
+}
+
 impl GatewayRuntime {
     pub(crate) fn new(store: Arc<dyn Store>, secrets: Arc<dyn SecretProvider>) -> Arc<Self> {
         Arc::new(Self {
@@ -101,6 +123,35 @@ impl GatewayRuntime {
                 .map(|credentials| credentials.installation_id.clone()),
             model_count: config.models.len(),
             sign_in: self.sign_in.lock().await.clone(),
+        })
+    }
+
+    /// The entitled connected apps, fetched live from the gateway with the
+    /// stored session. Requires a configured gateway and a signed-in session;
+    /// a gateway without the JSON apps surface reports `supported: false`.
+    pub(crate) async fn apps(&self) -> Result<GatewayApps> {
+        let connection = self
+            .connection()
+            .await?
+            .ok_or_else(|| AgentError::config("no model gateway is configured"))?;
+        Ok(match connection.apps().await? {
+            Some(apps) => GatewayApps {
+                supported: true,
+                apps: apps
+                    .into_iter()
+                    .map(|app| GatewayAppInfo {
+                        id: app.id,
+                        name: app.name,
+                        app_kind: app.app_kind,
+                        enabled: app.enabled,
+                        mcp_endpoint_slugs: app.mcp_endpoint_slugs,
+                    })
+                    .collect(),
+            },
+            None => GatewayApps {
+                supported: false,
+                apps: Vec::new(),
+            },
         })
     }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -282,6 +282,7 @@ pub fn app(state: AppState) -> Router {
             get(routes::get_mcp_app_payload),
         )
         .route("/gateway/status", get(routes::get_gateway_status))
+        .route("/gateway/apps", get(routes::get_gateway_apps))
         .route("/gateway/sign-in", post(routes::post_gateway_sign_in))
         .route("/gateway/sign-out", post(routes::post_gateway_sign_out))
         .route(

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -171,6 +171,15 @@ pub async fn post_gateway_sign_out(
     Ok(Json(state.gateway.status().await?))
 }
 
+/// `GET /gateway/apps` — the signed-in user's entitled connected apps,
+/// fetched live from the gateway. Fails when no gateway is configured or no
+/// session is stored; the renderer only asks while signed in.
+pub async fn get_gateway_apps(
+    State(state): State<AppState>,
+) -> Result<Json<crate::gateway_runtime::GatewayApps>, ServerError> {
+    Ok(Json(state.gateway.apps().await?))
+}
+
 /// `POST /gateway/models/sync` — refetch the entitled models into the
 /// provider's model set.
 pub async fn post_gateway_models_sync(

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -339,6 +339,7 @@ mod tests {
         generate::collect_from::<crate::mcp_config::McpServerDefinition>(&cfg, &mut out);
         generate::collect_from::<crate::routes::McpViewSession>(&cfg, &mut out);
         generate::collect_from::<crate::gateway_runtime::GatewayStatus>(&cfg, &mut out);
+        generate::collect_from::<crate::gateway_runtime::GatewayApps>(&cfg, &mut out);
         generate::collect_from::<openwave_core::Project>(&cfg, &mut out);
         generate::collect_from::<openwave_core::Chat>(&cfg, &mut out);
         generate::collect_from::<crate::routes::AgentRunSnapshot>(&cfg, &mut out);


### PR DESCRIPTION
Closes #641. Stacked on #644 — review only the top commit; GitHub retargets to `main` when the base merges.

model-gateway#112 added `GET /api/v1/cli/apps`: the connected apps the signed-in user actually reaches through team grants — name, kind, enabled state, and the slugs of the MCP endpoints that aggregate each app — behind the same control-resource bearer auth as the models route.

## What this adds

- **Connector**: `GatewayAuth::apps` / `GatewayConnection::apps`, returning `None` when the gateway 404s the route (predates the surface) — distinct from an entitled-but-empty list.
- **Server**: `GatewayRuntime::apps` and `GET /gateway/apps`, with `GatewayApps` / `GatewayAppInfo` wire types generated into `wire.ts` per the #575 standard. Entitlements are never cached (the gateway drops a revoked grant on the next request, and so do we).
- **Panel**: a **Connected apps** section in Settings → Model Gateway while signed in — app name, kind, enabled state, and its endpoint slugs. Hidden entirely against an older gateway; a fetch failure only hides the section, models keep working.

The endpoint slugs are the bridge to #625: mounting `mcp:<slug>` endpoints straight from the session (killing the manual URL + env-var token ritual) is the follow-up slice.

## Tests

- One connector flow test against the in-process fake: entitlements decode end-to-end with a control token, and flipping the fake to 404 yields the "unsupported" result rather than an error or `[]`.
- One panel test: the section renders name + slugs when supported, and is absent (with no error) against an older gateway.

Gates: full Rust workspace (fmt, clippy `-D warnings`, tests, `--locked`), `tsc`, vitest (511), production build. Not yet exercised against a live gateway — the local dev gateway process predates the route (it 404s, i.e. the degradation path); worth one live smoke after restarting `make dev` on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
