### PR TITLE
fix(release): preserve draft identity

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -74,13 +74,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_BODY: ${{ steps.release_drafter.outputs.body }}
           RELEASE_ID: ${{ steps.release_drafter.outputs.id }}
+          RELEASE_TAG: v${{ steps.release_drafter.outputs.resolved_version }}
         run: |
           original="$RUNNER_TEMP/release-body.md"
           formatted="$RUNNER_TEMP/formatted-release-body.md"
           printf '%s' "$RELEASE_BODY" > "$original"
           node scripts/format-release-notes.mjs < "$original" > "$formatted"
           cmp --silent "$original" "$formatted" && exit 0
-          jq -n --rawfile body "$formatted" '{body: $body}' | gh api \
+          jq -n --arg tag "$RELEASE_TAG" --rawfile body "$formatted" \
+            '{tag_name: $tag, body: $body}' | gh api \
             --method PATCH "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
             --input - >/dev/null
 

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -8,6 +8,10 @@ const workflows = Object.fromEntries(
     .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
     .map((name) => [name, readFileSync(new URL(name, workflowDirectory), "utf8")]),
 );
+const releaseDrafterConfig = readFileSync(
+  new URL("../.github/release-drafter.yml", import.meta.url),
+  "utf8",
+);
 const tauriConfig = JSON.parse(
   readFileSync(
     new URL("../crates/openwave-desktop/tauri.conf.json", import.meta.url),
@@ -56,6 +60,22 @@ test("third-party workflow actions use immutable commit SHAs", () => {
       );
     }
   }
+});
+
+test("release-drafter retains a stable draft tag after formatting", () => {
+  assert.match(releaseDrafterConfig, /tag-template: "v\$RESOLVED_VERSION"/);
+  assert.match(releaseDrafterConfig, /^tag-prefix: "v"$/m);
+
+  const draftJob = workflowJob(workflows["release-draft.yml"], "draft");
+  assert.match(draftJob, /id: release_drafter/);
+  assert.match(
+    draftJob,
+    /RELEASE_TAG: v\$\{\{ steps\.release_drafter\.outputs\.resolved_version \}\}/,
+  );
+  assert.match(
+    draftJob,
+    /\{tag_name: \$tag, body: \$body\}/,
+  );
 });
 
 test("workflow container images are pinned by digest", () => {


### PR DESCRIPTION
Closes #646

Preserves release-drafter's tag while formatting the draft body. GitHub otherwise replaces the tag with an `untagged-*` placeholder, preventing the next run from finding and updating its draft.

Validation: `node --test scripts/workflow-security.test.mjs`.