### PR TITLE
fix(release): keep grouped notes compact

### DIFF
--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -96,8 +96,14 @@ function formatCategory(lines) {
     if (formatted.length > 0) formatted.push("");
     formatted.push(`#### ${scopeHeading(scope)}`, ...scopeChanges);
   }
-  if (flatLines.length > 0 && formatted.length > 0) formatted.push("");
-  formatted.push(...flatLines);
+  if (flatLines.length > 0 && formatted.length > 0) {
+    // A bare blank line between two bullet runs makes GitHub render both as
+    // one loose list. A heading closes the grouped list before the compact
+    // inline scope changes begin.
+    formatted.push("", "#### Other", ...flatLines);
+  } else {
+    formatted.push(...flatLines);
+  }
   return [...formatted, ...trailingLines];
 }
 

--- a/scripts/format-release-notes.test.mjs
+++ b/scripts/format-release-notes.test.mjs
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { formatReleaseNotes } from "./format-release-notes.mjs";
 
-test("groups repeated scopes and keeps singleton scopes compact at the end", () => {
+test("separates grouped and singleton scopes into tight Markdown lists", () => {
   const notes = `## What's Changed
 
 ### New Features
@@ -27,6 +27,7 @@ test("groups repeated scopes and keeps singleton scopes compact at the end", () 
 - add document search ([#12](https://example.com/12)) by @octo
 - add keyboard shortcuts ([#15](https://example.com/15)) by @octo
 
+#### Other
 - add a default workspace ([#13](https://example.com/13)) by @octo
 - **Core:** add saved searches ([#14](https://example.com/14)) by @octo
 


### PR DESCRIPTION
Closes #649

Separates grouped scope lists from inline scope entries with an `Other` heading. This keeps GitHub from interpreting the category as one loose Markdown list with paragraph spacing between every item.

Validation:
- `node --test scripts/format-release-notes.test.mjs`
- `node --test scripts/workflow-security.test.mjs`