### PR TITLE
feat!: ship macOS releases for Apple Silicon only

### DIFF
--- a/.github/workflows/cache-macos.yml
+++ b/.github/workflows/cache-macos.yml
@@ -39,9 +39,7 @@ jobs:
           cache-targets: false
 
       - name: Fetch Cargo dependency downloads
-        run: |
-          cargo fetch --locked --target aarch64-apple-darwin
-          cargo fetch --locked --target x86_64-apple-darwin
+        run: cargo fetch --locked --target aarch64-apple-darwin
 
   warm:
     name: macOS cache · ${{ matrix.arch }}
@@ -51,11 +49,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Apple Silicon only while the product is in active development; see
+        # docs/releases.md. Restoring Intel means adding its row back here, to
+        # the two release matrices, and to MACOS_ARCHITECTURES.
         include:
           - arch: aarch64
             target: aarch64-apple-darwin
-          - arch: x86_64
-            target: x86_64-apple-darwin
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,11 +252,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Apple Silicon only while the product is in active development; see
+        # docs/releases.md.
         include:
           - arch: aarch64
             target: aarch64-apple-darwin
-          - arch: x86_64
-            target: x86_64-apple-darwin
     env:
       CARGO_INCREMENTAL: 0
       RUSTC_WRAPPER: sccache
@@ -385,11 +385,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Apple Silicon only while the product is in active development; see
+        # docs/releases.md.
         include:
           - arch: aarch64
             target: aarch64-apple-darwin
-          - arch: x86_64
-            target: x86_64-apple-darwin
     env:
       # Reuse compiler outputs across trusted release runs without caching the
       # signed bundles or any signing material.
@@ -786,13 +786,6 @@ jobs:
           name: openwave-macos-aarch64-${{ needs.validate.outputs.version }}
           path: dist/macos/aarch64
 
-      - name: Download Intel artifacts
-        if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: openwave-macos-x86_64-${{ needs.validate.outputs.version }}
-          path: dist/macos/x86_64
-
       - name: Create release manifests and checksums
         if: ${{ needs.inspect_hosted.outputs.exists != 'true' }}
         run: >-
@@ -956,7 +949,6 @@ jobs:
           while IFS=$'\t' read -r arch url digest; do
             case "$arch" in
               aarch64) name="OpenWave-macos-apple-silicon.dmg" ;;
-              x86_64) name="OpenWave-macos-intel.dmg" ;;
               *) echo "Unsupported release architecture: $arch" >&2; exit 1 ;;
             esac
             curl --fail --silent --show-error --location "$url" \
@@ -970,8 +962,8 @@ jobs:
             "$manifest")
 
           dmg_count="$(find downloads -name '*.dmg' -type f | wc -l)"
-          (( dmg_count == 2 )) || {
-            echo "Expected both macOS disk images, found $dmg_count." >&2
+          (( dmg_count == 1 )) || {
+            echo "Expected one macOS disk image, found $dmg_count." >&2
             exit 1
           }
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 
 <p align="center">
   <a href="https://github.com/brightwave-inc/openwave/releases/latest/download/OpenWave-macos-apple-silicon.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-Apple%20Silicon-000000.svg?logo=apple&logoColor=white" alt="Download for macOS, Apple Silicon"></a>
-  <a href="https://github.com/brightwave-inc/openwave/releases/latest/download/OpenWave-macos-intel.dmg"><img src="https://img.shields.io/badge/Download%20for%20macOS-Intel-555555.svg?logo=apple&logoColor=white" alt="Download for macOS, Intel"></a>
 </p>
 
 ---

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -131,23 +131,22 @@ automatic.
    the resolved commit SHA.
 5. The dispatched workflow first checks whether that exact tag, commit, and
    publication date already have a complete immutable release on S3. A
-   credential-free Apple Silicon and Intel prerequisite otherwise compiles the
-   tag with its product version and saves unsigned Cargo outputs before any
-   signing or notarization can fail.
-6. The production jobs restore those exact prepared outputs, sign the apps with
-   the Developer ID identity, notarize and staple the app and DMG, verify them
-   with Apple tooling, and create signed Tauri updater archives.
-7. Only after both architectures pass does the publisher upload immutable
-   versioned files, advance the public manifests, invalidate their CDN paths,
-   and smoke-test the hosted release. If a prior attempt already uploaded the
+   credential-free prerequisite otherwise compiles the tag with its product
+   version and saves unsigned Cargo outputs before any signing or notarization
+   can fail.
+6. The production job restores those exact prepared outputs, signs the app with
+   the Developer ID identity, notarizes and staples the app and DMG, verifies
+   them with Apple tooling, and creates a signed Tauri updater archive.
+7. Only after the build passes does the publisher upload immutable versioned
+   files, advance the public manifests, invalidate their CDN paths, and
+   smoke-test the hosted release. If a prior attempt already uploaded the
    complete immutable prefix, a new dispatch validates and reuses those bytes,
-   skips both desktop builds, and resumes only mutable metadata publication,
+   skips the desktop build, and resumes only mutable metadata publication,
    CDN invalidation, and smoke testing.
-8. A final job downloads both notarized disk images back from the CDN, checks
-   them against the immutable manifest digests, and attaches them to the GitHub
-   Release as `OpenWave-macos-apple-silicon.dmg` and `OpenWave-macos-intel.dmg`
-   with `.sha256` sidecars. It holds no signing or AWS credentials. The names
-   omit the version so that
+8. A final job downloads the notarized disk image back from the CDN, checks it
+   against the immutable manifest digests, and attaches it to the GitHub
+   Release as `OpenWave-macos-apple-silicon.dmg` with a `.sha256` sidecar. It
+   holds no signing or AWS credentials. The name omits the version so that
    `https://github.com/brightwave-inc/openwave/releases/latest/download/<name>`
    stays a permanent download link for the README; the release page and the
    app's own version string identify which build it is.
@@ -159,6 +158,28 @@ release** build completes successfully; the initial dispatch run is not the
 shipping signal.
 
 ## Public macOS delivery
+
+### Apple Silicon only, for now
+
+A release ships one `aarch64` build. Intel is paused while the product is in
+active development. Cross-compiling `x86_64` on GitHub's arm64 macOS runners
+takes roughly two and a half times as long as the native build for the
+identical crate set — about 18 minutes against 7 on a recent release — so the
+Intel job, not the one anybody installs, set the length of every release and
+cache-warm run. No one on the team or in early testing uses an Intel Mac.
+
+`MACOS_ARCHITECTURES` in `scripts/create-release-manifests.mjs` is the single
+source of truth for what a release contains: it drives the manifest, the
+`latest.json` platform keys, and the immutable prefix below. Restoring Intel
+means adding `x86_64` there and adding its row back to the two `release.yml`
+build matrices and the `cache-macos.yml` warm matrix.
+
+Two consequences worth knowing. `latest.json` advertises only
+`darwin-aarch64`, so an Intel install finds no update rather than a broken one.
+And the preflight that resumes an already-hosted release validates it against
+the current architecture set, so a release published before this change cannot
+be re-dispatched; it fails on the artifact count instead of silently
+republishing.
 
 The public download contract is rooted at:
 
@@ -172,8 +193,7 @@ Each release has an immutable prefix:
 openwave/releases/vMAJOR.MINOR.PATCH/
 ├── manifest.json
 └── macos/
-    ├── aarch64/
-    └── x86_64/
+    └── aarch64/
 ```
 
 Each architecture directory contains a notarized DMG, a zip of the notarized
@@ -196,8 +216,8 @@ releases can advance automatically.
 
 **Warm macOS release cache** runs independently after relevant changes land on
 `main`. A short prerequisite job saves Cargo dependency downloads before the
-two architecture jobs compile the desktop app with `--no-bundle`. This keeps a
-later UI setup or compilation failure from also losing newly downloaded Cargo
+build job compiles the desktop app with `--no-bundle`. This keeps a later UI
+setup or compilation failure from also losing newly downloaded Cargo
 dependencies. Each architecture then saves one unsigned archive containing
 Cargo fingerprints, build-script outputs, compiled dependency files, and the
 credential-free Rust products produced by `--no-bundle`: the desktop

--- a/scripts/create-release-manifests.mjs
+++ b/scripts/create-release-manifests.mjs
@@ -12,7 +12,9 @@ import { pathToFileURL } from "node:url";
 
 import { parseReleaseTag } from "./check-release-tag.mjs";
 
-export const MACOS_ARCHITECTURES = ["aarch64", "x86_64"];
+// The architectures a release ships. Apple Silicon only while the product is
+// in active development; see docs/releases.md.
+export const MACOS_ARCHITECTURES = ["aarch64"];
 
 const ARTIFACT_FORMATS = [
   { extension: ".dmg", format: "dmg" },

--- a/scripts/create-release-manifests.test.mjs
+++ b/scripts/create-release-manifests.test.mjs
@@ -42,18 +42,15 @@ test("creates a complete manifest and Tauri updater document", () => {
   const dist = releaseFixture();
   const { manifest, latest } = createReleaseManifests({ dist, ...RELEASE });
 
-  assert.equal(manifest.artifacts.length, 6);
-  assert.deepEqual(Object.keys(latest.platforms), [
-    "darwin-aarch64",
-    "darwin-x86_64",
-  ]);
+  assert.equal(manifest.artifacts.length, MACOS_ARCHITECTURES.length * 3);
+  assert.deepEqual(Object.keys(latest.platforms), ["darwin-aarch64"]);
   assert.match(
     latest.platforms["darwin-aarch64"].url,
     /releases\/v0\.4\.2\/macos\/aarch64\/OpenWave_0\.4\.2_aarch64\.app\.tar\.gz$/,
   );
   assert.equal(
-    latest.platforms["darwin-x86_64"].signature,
-    "signature-x86_64",
+    latest.platforms["darwin-aarch64"].signature,
+    "signature-aarch64",
   );
 
   const diskManifest = JSON.parse(
@@ -75,8 +72,8 @@ test("fails closed when an architecture is incomplete", () => {
   const missing = path.join(
     dist,
     "macos",
-    "x86_64",
-    "OpenWave_0.4.2_x86_64.app.tar.gz.sig",
+    "aarch64",
+    "OpenWave_0.4.2_aarch64.app.tar.gz.sig",
   );
   writeFileSync(missing, "");
 

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -184,7 +184,6 @@ test("cache warming cannot access production credentials or publish", () => {
   assert.match(cache, /^  cargo-downloads:$/m);
   assert.match(cache, /^    needs: cargo-downloads$/m);
   assert.match(cache, /cargo fetch --locked --target aarch64-apple-darwin/);
-  assert.match(cache, /cargo fetch --locked --target x86_64-apple-darwin/);
   assert.match(cache, /cancel-in-progress: false/);
   assert.match(cache, /--no-bundle --ci/);
   assert.match(cache, /continue-on-error: true/);
@@ -372,7 +371,6 @@ test("GitHub release downloads are copied from the hosted release", () => {
   assert.match(attachJob, /releases\/v\$OPENWAVE_VERSION\/manifest\.json/);
   assert.match(attachJob, /sha256sum --check --strict/);
   assert.match(attachJob, /OpenWave-macos-apple-silicon\.dmg/);
-  assert.match(attachJob, /OpenWave-macos-intel\.dmg/);
   assert.match(attachJob, /gh release upload "\$RELEASE_TAG"/);
 
   assert.match(


### PR DESCRIPTION
The `x86_64` matrix leg set the length of every macOS release and cache-warm
run. On the v0.9.0 release, `prepare unsigned macOS · x86_64` took 17m37s
against 6m45s for `aarch64` — 12m16s of compile against 4m53s, for an identical
crate set. Cross-compiling for Intel on GitHub's arm64 runners is just slower,
and it ran on every push to `main` touching `crates/**` plus every release.

Nobody on the team runs an Intel Mac and there are no Intel installs to keep
updated, so pause that build until there's a reason to ship it.

- `x86_64` comes out of the two `release.yml` matrices and the
  `cache-macos.yml` warm matrix, and `cargo fetch` no longer pre-downloads for
  that target.
- `MACOS_ARCHITECTURES` in `scripts/create-release-manifests.mjs` drops to
  `["aarch64"]`. That constant is the single source of truth: it drives the
  manifest, the `latest.json` platform keys, and the immutable release prefix,
  so the publish and resume paths follow from it. The publisher's Intel
  artifact download and the Intel branch of the GitHub-asset name map go with
  it, and the disk-image count drops to one.
- The README loses the Intel download badge.
- `docs/releases.md` gets a short section explaining the decision and what
  restoring Intel takes: one array entry and three matrix rows.

Two consequences, both documented:

- `latest.json` advertises only `darwin-aarch64`, so an Intel install finds no
  update rather than a broken one.
- The preflight that resumes an already-hosted release validates it against the
  current architecture set, so v0.9.0 and earlier can't be re-dispatched — they
  fail loudly on artifact count instead of silently republishing.

Tests: `create-release-manifests.test.mjs` now derives the artifact count from
`MACOS_ARCHITECTURES` rather than hardcoding 6, and the "fails closed when an
architecture is incomplete" case moves to the arch that still exists.
`workflow-security.test.mjs` drops the two assertions that pinned the Intel
target and the Intel asset name. No tests were deleted.

Verified with `node --test scripts/*.test.mjs` (72 pass) and by parsing both
workflows to confirm each matrix resolves to a single `aarch64` leg. No Rust
changed.

Closes #652
