### PR TITLE
feat(desktop): make output exports recoverable

### DIFF
--- a/crates/openwave-desktop/src/client_execution.rs
+++ b/crates/openwave-desktop/src/client_execution.rs
@@ -39,6 +39,9 @@ use receipt_store::{
     FolderOperationPhase, FolderOperationReceipt, ManualFolderConnectReceipt,
     ProductRootAttachmentSync, RegistrationPhase, StoredResolution,
 };
+pub(crate) use receipt_store::{
+    OutputExportFailureReason, OutputExportPhase, OutputExportReceipt, OutputExportTerminal,
+};
 
 const RECOVERY_IDLE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 const RECOVERY_MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(30);

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -11,7 +11,10 @@ use std::{
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 use chrono::{DateTime, Utc};
-use openwave_core::{CallId, ChatId, HostRootId, RootAttachmentChangeId, MAX_ATTACHMENT_REVISION};
+use openwave_core::{
+    validate_deliverable_name, CallId, ChatId, HostRootId, OutputId, OutputRevisionId,
+    RootAttachmentChangeId, MAX_ATTACHMENT_REVISION, MAX_DELIVERABLE_BYTES,
+};
 use openwave_host_broker::GrantSubject;
 use openwave_host_broker::OperationId;
 use serde::{Deserialize, Serialize};
@@ -26,7 +29,9 @@ const MAX_RECEIPTS: usize = 1_024;
 const FOLDER_OPERATION_PREFIX: &str = "folder-operation-";
 const DELEGATED_FILE_READ_PREFIX: &str = "delegated-file-read-";
 const MANUAL_FOLDER_CONNECT_PREFIX: &str = "manual-folder-connect-";
+const OUTPUT_EXPORT_PREFIX: &str = "output-export-";
 const MAX_SAFE_ROOT_DISPLAY_BYTES: usize = 1_024;
+const OUTPUT_EXPORT_RECEIPT_VERSION: u32 = 1;
 
 pub(crate) struct ReceiptStore {
     directory: PathBuf,
@@ -149,6 +154,54 @@ pub(super) struct ManualFolderConnectReceipt {
     pub(super) registration_phase: RegistrationPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) product_sync: Option<ProductRootAttachmentSync>,
+}
+
+/// App-private recovery state for one exact native output export.
+///
+/// The selected destination is required to recover an ambiguous native write,
+/// but it never crosses the native boundary and is redacted from debug output.
+/// The immutable revision identity and digest let recovery verify the effect
+/// without reading arbitrary scratch files or issuing the write again.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) struct OutputExportReceipt {
+    version: u32,
+    pub(crate) operation_id: Uuid,
+    pub(crate) chat_id: ChatId,
+    pub(crate) output_id: OutputId,
+    pub(crate) revision_id: OutputRevisionId,
+    pub(crate) filename: String,
+    pub(crate) byte_len: u64,
+    pub(crate) sha256: [u8; 32],
+    pub(crate) phase: OutputExportPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) destination: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) terminal: Option<OutputExportTerminal>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum OutputExportPhase {
+    Prepared,
+    DestinationSelected,
+    DispatchStarted,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum OutputExportTerminal {
+    Completed,
+    Cancelled,
+    Failed { reason: OutputExportFailureReason },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum OutputExportFailureReason {
+    SourceUnavailable,
+    DestinationUnavailable,
+    AmbiguousNativeFailure,
 }
 
 /// Whether a read-only broker request may have been dispatched already.
@@ -299,6 +352,28 @@ impl std::fmt::Debug for ManualFolderConnectReceipt {
     }
 }
 
+impl std::fmt::Debug for OutputExportReceipt {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OutputExportReceipt")
+            .field("version", &self.version)
+            .field("operation_id", &self.operation_id)
+            .field("chat_id", &self.chat_id)
+            .field("output_id", &self.output_id)
+            .field("revision_id", &self.revision_id)
+            .field("filename", &self.filename)
+            .field("byte_len", &self.byte_len)
+            .field("sha256", &"[redacted]")
+            .field("phase", &self.phase)
+            .field(
+                "destination",
+                &self.destination.as_ref().map(|_| "[redacted]"),
+            )
+            .field("terminal", &self.terminal)
+            .finish()
+    }
+}
+
 impl std::fmt::Debug for FolderAccessIntent {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -431,6 +506,68 @@ impl ManualFolderConnectReceipt {
     }
 }
 
+impl OutputExportReceipt {
+    pub(crate) fn new(
+        operation_id: Uuid,
+        chat_id: ChatId,
+        output_id: OutputId,
+        revision_id: OutputRevisionId,
+        filename: String,
+        byte_len: u64,
+        sha256: [u8; 32],
+    ) -> Self {
+        Self {
+            version: OUTPUT_EXPORT_RECEIPT_VERSION,
+            operation_id,
+            chat_id,
+            output_id,
+            revision_id,
+            filename,
+            byte_len,
+            sha256,
+            phase: OutputExportPhase::Prepared,
+            destination: None,
+            terminal: None,
+        }
+    }
+
+    fn validate(&self) -> io::Result<()> {
+        if self.version != OUTPUT_EXPORT_RECEIPT_VERSION
+            || self.operation_id.is_nil()
+            || self.chat_id.as_uuid().is_nil()
+            || self.output_id.as_uuid().is_nil()
+            || self.revision_id.as_uuid().is_nil()
+            || validate_deliverable_name(&self.filename).is_err()
+            || self.byte_len > MAX_DELIVERABLE_BYTES as u64
+            || self
+                .destination
+                .as_ref()
+                .is_some_and(|destination| !destination.is_absolute())
+            || (matches!(self.phase, OutputExportPhase::Prepared) && self.destination.is_some())
+            || (!matches!(self.phase, OutputExportPhase::Prepared) && self.destination.is_none())
+            || matches!(
+                self.terminal,
+                Some(OutputExportTerminal::Cancelled)
+                    if self.phase != OutputExportPhase::Prepared
+            )
+            || matches!(
+                self.terminal,
+                Some(OutputExportTerminal::Completed)
+                    if self.phase != OutputExportPhase::DispatchStarted
+            )
+            || matches!(
+                self.terminal,
+                Some(OutputExportTerminal::Failed {
+                    reason: OutputExportFailureReason::AmbiguousNativeFailure
+                }) if self.phase != OutputExportPhase::DispatchStarted
+            )
+        {
+            return Err(invalid_data("invalid output-export receipt"));
+        }
+        Ok(())
+    }
+}
+
 impl FolderOperationReceipt {
     pub(super) fn new(
         chat_id: ChatId,
@@ -556,6 +693,7 @@ impl ReceiptStore {
         store.load_operations()?;
         store.load_delegated_file_reads()?;
         store.load_manual_connects()?;
+        store.load_output_exports()?;
         Ok(store)
     }
 
@@ -617,6 +755,26 @@ impl ReceiptStore {
         )
     }
 
+    pub(crate) fn save_output_export(&self, receipt: &OutputExportReceipt) -> io::Result<()> {
+        receipt.validate()?;
+        let bytes = serde_json::to_vec(receipt).map_err(invalid_data)?;
+        if bytes.len() > MAX_RECEIPT_BYTES {
+            return Err(invalid_data("output-export receipt is too large"));
+        }
+        let path = self.output_export_receipt_path(receipt.operation_id);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {}
+            Ok(_) => return Err(invalid_data("output-export receipt is not a regular file")),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                if self.load_output_exports()?.len() >= MAX_RECEIPTS {
+                    return Err(invalid_data("too many durable output-export receipts"));
+                }
+            }
+            Err(error) => return Err(error),
+        }
+        write_atomically(&self.directory, &path, &bytes)
+    }
+
     pub(super) fn remove(&self, call_id: CallId) -> io::Result<()> {
         match fs::remove_file(self.receipt_path(call_id)) {
             Ok(()) => sync_directory(&self.directory),
@@ -670,6 +828,9 @@ impl ReceiptStore {
                 continue;
             }
             if file_name.starts_with(MANUAL_FOLDER_CONNECT_PREFIX) {
+                continue;
+            }
+            if file_name.starts_with(OUTPUT_EXPORT_PREFIX) {
                 continue;
             }
             if file_name.starts_with('.') && file_name.ends_with(".tmp") {
@@ -836,6 +997,65 @@ impl ReceiptStore {
         Ok(receipts)
     }
 
+    pub(crate) fn load_output_export(
+        &self,
+        operation_id: Uuid,
+    ) -> io::Result<Option<OutputExportReceipt>> {
+        if operation_id.is_nil() {
+            return Err(invalid_data("invalid output-export operation identity"));
+        }
+        let path = self.output_export_receipt_path(operation_id);
+        match validate_private_file(&path, MAX_RECEIPT_BYTES) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        }
+        let mut bytes = Vec::new();
+        File::open(path)?
+            .take((MAX_RECEIPT_BYTES + 1) as u64)
+            .read_to_end(&mut bytes)?;
+        if bytes.len() > MAX_RECEIPT_BYTES {
+            return Err(invalid_data("output-export receipt is too large"));
+        }
+        let receipt: OutputExportReceipt = serde_json::from_slice(&bytes).map_err(invalid_data)?;
+        receipt.validate()?;
+        if receipt.operation_id != operation_id {
+            return Err(invalid_data("output-export receipt identity mismatch"));
+        }
+        Ok(Some(receipt))
+    }
+
+    pub(crate) fn load_output_exports(&self) -> io::Result<Vec<OutputExportReceipt>> {
+        let mut receipts = Vec::new();
+        let mut operation_ids = HashSet::new();
+        for entry in fs::read_dir(&self.directory)? {
+            let entry = entry?;
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                return Err(invalid_data("invalid client-execution receipt name"));
+            };
+            let Some(operation_id) = file_name
+                .strip_prefix(OUTPUT_EXPORT_PREFIX)
+                .and_then(|name| name.strip_suffix(".json"))
+            else {
+                continue;
+            };
+            if receipts.len() >= MAX_RECEIPTS {
+                return Err(invalid_data("too many durable output-export receipts"));
+            }
+            let operation_id = Uuid::parse_str(operation_id).map_err(invalid_data)?;
+            let receipt = self
+                .load_output_export(operation_id)?
+                .ok_or_else(|| invalid_data("output-export receipt disappeared"))?;
+            if !operation_ids.insert(operation_id) {
+                return Err(invalid_data("duplicate output-export receipt identity"));
+            }
+            receipts.push(receipt);
+        }
+        receipts.sort_by_key(|receipt| receipt.operation_id);
+        Ok(receipts)
+    }
+
     fn receipt_path(&self, call_id: CallId) -> PathBuf {
         self.directory.join(format!("{call_id}.json"))
     }
@@ -853,6 +1073,11 @@ impl ReceiptStore {
     fn manual_connect_receipt_path(&self, change_id: RootAttachmentChangeId) -> PathBuf {
         self.directory
             .join(format!("{MANUAL_FOLDER_CONNECT_PREFIX}{change_id}.json"))
+    }
+
+    fn output_export_receipt_path(&self, operation_id: Uuid) -> PathBuf {
+        self.directory
+            .join(format!("{OUTPUT_EXPORT_PREFIX}{operation_id}.json"))
     }
 }
 
@@ -1163,6 +1388,44 @@ mod tests {
         assert_eq!(store.load_manual_connects().unwrap(), vec![receipt.clone()]);
         store.remove_manual_connect(receipt.change_id).unwrap();
         assert!(store.load_manual_connects().unwrap().is_empty());
+    }
+
+    #[test]
+    fn output_export_receipts_are_durable_exact_and_redact_native_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let destination_root = tempfile::tempdir().unwrap();
+        let store = ReceiptStore::open(temp.path()).unwrap();
+        let mut receipt = OutputExportReceipt::new(
+            Uuid::new_v4(),
+            ChatId::new(),
+            OutputId::new(),
+            OutputRevisionId::new(),
+            "brief.md".to_owned(),
+            42,
+            [7; 32],
+        );
+        let destination = destination_root.path().join("brief.md");
+        receipt.phase = OutputExportPhase::DispatchStarted;
+        receipt.destination = Some(destination.clone());
+        receipt.terminal = Some(OutputExportTerminal::Failed {
+            reason: OutputExportFailureReason::AmbiguousNativeFailure,
+        });
+        store.save_output_export(&receipt).unwrap();
+        assert_eq!(
+            store.load_output_export(receipt.operation_id).unwrap(),
+            Some(receipt.clone())
+        );
+        assert_eq!(store.load_output_exports().unwrap(), vec![receipt.clone()]);
+        assert!(store.load_all().unwrap().is_empty());
+
+        let debug = format!("{receipt:?}");
+        assert!(!debug.contains(destination.to_str().unwrap()));
+        assert!(!debug.contains(&format!("{:?}", receipt.sha256)));
+
+        let mut conflicting = receipt;
+        conflicting.phase = OutputExportPhase::DestinationSelected;
+        conflicting.terminal = Some(OutputExportTerminal::Completed);
+        assert!(store.save_output_export(&conflicting).is_err());
     }
 
     #[test]

--- a/crates/openwave-desktop/src/deliverables.rs
+++ b/crates/openwave-desktop/src/deliverables.rs
@@ -1,8 +1,10 @@
-//! Native bridge for conversation-private generated outputs.
+//! Native bridge for durable conversation outputs.
 //!
-//! The model writes only to a closed directory inside private scratch. The
-//! renderer receives bounded text and safe metadata, while a user-selected save
-//! destination stays entirely inside this native boundary.
+//! The renderer names an output only by opaque identity. Authoritative output
+//! ownership and immutable revision metadata come from the product store;
+//! private scratch paths and selected export destinations terminate inside this
+//! module. Native exports are keyed by a renderer-minted operation identity so
+//! an ambiguous response can recover one exact terminal receipt.
 
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -10,22 +12,25 @@ use std::path::{Path, PathBuf};
 use cap_fs_ext::{DirExt as _, FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::ambient_authority;
 use cap_std::fs::{Dir, OpenOptions};
-use chrono::{DateTime, Utc};
 use openwave_core::{
-    deliverable_media_type, validate_deliverable_name, ChatId, DELIVERABLES_DIRECTORY,
-    MAX_DELIVERABLE_BYTES,
+    deliverable_media_type, ChatId, OutputId, OutputRecord, OutputRevision, OutputRevisionId,
+    Store, MAX_DELIVERABLE_BYTES, OUTPUTS_DIRECTORY,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use tauri::{AppHandle, Manager, State};
 use tauri_plugin_dialog::DialogExt;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
+use crate::client_execution::{
+    OutputExportFailureReason, OutputExportPhase, OutputExportReceipt, OutputExportTerminal,
+    ReceiptStore,
+};
 use crate::documents::resolve_conversation_scope;
 use crate::host_access::HostAccess;
 
 const MAX_DELIVERABLES: usize = 100;
-const MAX_DELIVERABLE_DIRECTORY_ENTRIES: usize = 1_000;
 const MAX_PREVIEW_CHARACTERS: usize = 100_000;
 
 #[derive(Debug, Deserialize)]
@@ -38,15 +43,25 @@ pub(crate) struct DeliverablesRequest {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(crate) struct DeliverableRequest {
     chat_id: Uuid,
-    filename: String,
+    output_id: OutputId,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ExportDeliverableRequest {
+    operation_id: Uuid,
+    chat_id: Uuid,
+    output_id: OutputId,
 }
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DeliverableSummary {
+    output_id: OutputId,
     filename: String,
     media_type: String,
     size_bytes: u64,
+    revision_count: u32,
     updated_at: String,
 }
 
@@ -60,23 +75,51 @@ pub(crate) struct DeliverablesCatalog {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DeliverablePreview {
+    output_id: OutputId,
     filename: String,
     media_type: String,
     content: String,
     truncated: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OutputExportResult {
+    operation_id: Uuid,
+    output_id: OutputId,
+    revision_id: OutputRevisionId,
+    #[serde(flatten)]
+    terminal: OutputExportTerminal,
+}
+
 #[tauri::command]
 pub(crate) async fn list_deliverables(
-    app: AppHandle,
     host_access: State<'_, HostAccess>,
     request: DeliverablesRequest,
 ) -> Result<DeliverablesCatalog, String> {
     let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
-    let scratch_root = crate::data_dir(&app)?.join("scratch");
-    tauri::async_runtime::spawn_blocking(move || list_deliverables_in_root(&scratch_root, chat_id))
+    let store = host_access
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let mut outputs = store
+        .list_outputs(chat_id, (MAX_DELIVERABLES + 1) as u64)
         .await
-        .map_err(|_| "Could not load this conversation's outputs".to_owned())?
+        .map_err(|_| "Could not load this conversation's outputs".to_owned())?;
+    let truncated = outputs.len() > MAX_DELIVERABLES;
+    outputs.truncate(MAX_DELIVERABLES);
+    let mut deliverables = Vec::with_capacity(outputs.len());
+    for output in outputs {
+        let revision = store
+            .get_output_revision(output.current_revision)
+            .await
+            .map_err(|_| "Could not load this conversation's outputs".to_owned())?
+            .ok_or_else(|| "Could not load this conversation's outputs".to_owned())?;
+        deliverables.push(summary_from_record(&output, &revision)?);
+    }
+    Ok(DeliverablesCatalog {
+        deliverables,
+        truncated,
+    })
 }
 
 #[tauri::command]
@@ -86,144 +129,410 @@ pub(crate) async fn read_deliverable(
     request: DeliverableRequest,
 ) -> Result<DeliverablePreview, String> {
     let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
-    validate_deliverable_name(&request.filename)
-        .map_err(|_| "Invalid output filename".to_owned())?;
+    let (output, revision) =
+        require_live_output(host_access.store(), chat_id, request.output_id).await?;
     let scratch_root = crate::data_dir(&app)?.join("scratch");
-    let filename = request.filename;
-    tauri::async_runtime::spawn_blocking(move || {
-        let content = read_deliverable_bytes(&scratch_root, chat_id, &filename)?;
-        preview_from_bytes(filename, content)
+    let read_output = output.clone();
+    let bytes = tauri::async_runtime::spawn_blocking(move || {
+        read_output_revision_bytes(&scratch_root, chat_id, &read_output, &revision)
     })
     .await
-    .map_err(|_| "Could not preview that output".to_owned())?
+    .map_err(|_| "Could not preview that output".to_owned())??;
+    preview_from_bytes(&output, bytes)
 }
 
 #[tauri::command]
 pub(crate) async fn export_deliverable(
     app: AppHandle,
     host_access: State<'_, HostAccess>,
-    request: DeliverableRequest,
-) -> Result<bool, String> {
-    let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
-    validate_deliverable_name(&request.filename)
-        .map_err(|_| "Invalid output filename".to_owned())?;
-    let _picker = host_access
-        .picker
-        .try_lock()
-        .map_err(|_| "A file or folder picker is already open".to_owned())?;
-    let scratch_root = crate::data_dir(&app)?.join("scratch");
-    let filename = request.filename;
-    let read_filename = filename.clone();
-    let content = tauri::async_runtime::spawn_blocking(move || {
-        read_deliverable_bytes(&scratch_root, chat_id, &read_filename)
-    })
-    .await
-    .map_err(|_| "Could not read that output".to_owned())??;
+    request: ExportDeliverableRequest,
+) -> Result<OutputExportResult, String> {
+    if request.operation_id.is_nil() || request.output_id.as_uuid().is_nil() {
+        return Err("Invalid output export request".to_owned());
+    }
+    let _export = host_access.output_exports.lock().await;
+    if let Some(mut receipt) = host_access
+        .receipts
+        .load_output_export(request.operation_id)
+        .map_err(private_receipt_error)?
+    {
+        if receipt.chat_id.as_uuid() != &request.chat_id || receipt.output_id != request.output_id {
+            return Err("That export operation belongs to a different output".to_owned());
+        }
+        return recover_output_export_receipt(&host_access.receipts, &mut receipt);
+    }
 
-    let Some(destination) = pick_export_path(&app, &filename).await? else {
-        return Ok(false);
-    };
-    // A picker may remain open while the selected conversation is deleted.
-    // Revalidate before the one user-authorized host write.
-    resolve_conversation_scope(&host_access, request.chat_id).await?;
-    tauri::async_runtime::spawn_blocking(move || {
-        write_exported_deliverable(&destination, &content)
+    let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
+    let (output, revision) =
+        require_live_output(host_access.store(), chat_id, request.output_id).await?;
+    let mut receipt = OutputExportReceipt::new(
+        request.operation_id,
+        chat_id,
+        output.id,
+        revision.id,
+        output.filename.clone(),
+        revision.byte_len,
+        revision.sha256,
+    );
+    host_access
+        .receipts
+        .save_output_export(&receipt)
+        .map_err(private_receipt_error)?;
+
+    let scratch_root = crate::data_dir(&app)?.join("scratch");
+    let read_output = output.clone();
+    let read_revision = revision.clone();
+    let content = match tauri::async_runtime::spawn_blocking(move || {
+        read_output_revision_bytes(&scratch_root, chat_id, &read_output, &read_revision)
     })
     .await
-    .map_err(|_| "Could not save that output".to_owned())??;
-    Ok(true)
+    {
+        Ok(Ok(content)) => content,
+        Ok(Err(_)) | Err(_) => {
+            return terminalize_output_export(
+                &host_access.receipts,
+                &mut receipt,
+                OutputExportTerminal::Failed {
+                    reason: OutputExportFailureReason::SourceUnavailable,
+                },
+            );
+        }
+    };
+
+    let picker = match host_access.picker.try_lock() {
+        Ok(picker) => picker,
+        Err(_) => {
+            return terminalize_output_export(
+                &host_access.receipts,
+                &mut receipt,
+                OutputExportTerminal::Failed {
+                    reason: OutputExportFailureReason::DestinationUnavailable,
+                },
+            );
+        }
+    };
+    let destination = match pick_export_path(&app, &output.filename).await {
+        Ok(Some(destination)) if destination.is_absolute() => destination,
+        Ok(None) => {
+            return terminalize_output_export(
+                &host_access.receipts,
+                &mut receipt,
+                OutputExportTerminal::Cancelled,
+            );
+        }
+        Ok(Some(_)) | Err(_) => {
+            return terminalize_output_export(
+                &host_access.receipts,
+                &mut receipt,
+                OutputExportTerminal::Failed {
+                    reason: OutputExportFailureReason::DestinationUnavailable,
+                },
+            );
+        }
+    };
+    drop(picker);
+
+    receipt.phase = OutputExportPhase::DestinationSelected;
+    receipt.destination = Some(destination.clone());
+    host_access
+        .receipts
+        .save_output_export(&receipt)
+        .map_err(private_receipt_error)?;
+
+    // A picker can remain open while the output or conversation is deleted.
+    // Revalidate the exact durable identities before the one authorized write.
+    if require_exact_revision(
+        host_access.store(),
+        chat_id,
+        output.id,
+        revision.id,
+        revision.byte_len,
+        revision.sha256,
+    )
+    .await
+    .is_err()
+    {
+        return terminalize_output_export(
+            &host_access.receipts,
+            &mut receipt,
+            OutputExportTerminal::Failed {
+                reason: OutputExportFailureReason::SourceUnavailable,
+            },
+        );
+    }
+
+    receipt.phase = OutputExportPhase::DispatchStarted;
+    host_access
+        .receipts
+        .save_output_export(&receipt)
+        .map_err(private_receipt_error)?;
+    let write_destination = destination.clone();
+    let write = tauri::async_runtime::spawn_blocking(move || {
+        write_exported_deliverable(&write_destination, &content)
+    })
+    .await;
+    let terminal = match write {
+        Ok(Ok(())) => OutputExportTerminal::Completed,
+        Ok(Err(_)) | Err(_) if destination_matches_revision(&destination, &revision) => {
+            OutputExportTerminal::Completed
+        }
+        Ok(Err(_)) | Err(_) => OutputExportTerminal::Failed {
+            reason: OutputExportFailureReason::AmbiguousNativeFailure,
+        },
+    };
+    terminalize_output_export(&host_access.receipts, &mut receipt, terminal)
 }
 
-fn list_deliverables_in_root(
+async fn require_live_output(
+    store: Option<&std::sync::Arc<dyn Store>>,
+    chat_id: ChatId,
+    output_id: OutputId,
+) -> Result<(OutputRecord, OutputRevision), String> {
+    let store = store.ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let output = store
+        .get_output(output_id)
+        .await
+        .map_err(|_| "Could not load that output".to_owned())?
+        .filter(|output| output.chat_id == chat_id && output.deleted_at.is_none())
+        .ok_or_else(|| "Output not found in this conversation".to_owned())?;
+    let revision = store
+        .get_output_revision(output.current_revision)
+        .await
+        .map_err(|_| "Could not load that output".to_owned())?
+        .filter(|revision| revision.output_id == output.id)
+        .ok_or_else(|| "Output not found in this conversation".to_owned())?;
+    Ok((output, revision))
+}
+
+async fn require_exact_revision(
+    store: Option<&std::sync::Arc<dyn Store>>,
+    chat_id: ChatId,
+    output_id: OutputId,
+    revision_id: OutputRevisionId,
+    byte_len: u64,
+    sha256: [u8; 32],
+) -> Result<(), String> {
+    let store = store.ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let output = store
+        .get_output(output_id)
+        .await
+        .map_err(|_| "Could not load that output".to_owned())?
+        .filter(|output| output.chat_id == chat_id && output.deleted_at.is_none())
+        .ok_or_else(|| "Output not found in this conversation".to_owned())?;
+    let revision = store
+        .get_output_revision(revision_id)
+        .await
+        .map_err(|_| "Could not load that output".to_owned())?
+        .filter(|revision| {
+            revision.output_id == output.id
+                && revision.byte_len == byte_len
+                && revision.sha256 == sha256
+        })
+        .ok_or_else(|| "Output not found in this conversation".to_owned())?;
+    if revision.id != revision_id {
+        return Err("Output not found in this conversation".to_owned());
+    }
+    Ok(())
+}
+
+fn summary_from_record(
+    output: &OutputRecord,
+    revision: &OutputRevision,
+) -> Result<DeliverableSummary, String> {
+    if output.deleted_at.is_some()
+        || output.current_revision != revision.id
+        || output.id != revision.output_id
+        || output.revision_count == 0
+        || revision.byte_len > MAX_DELIVERABLE_BYTES as u64
+        || deliverable_media_type(&output.filename) != Some(output.media_type.as_str())
+    {
+        return Err("Could not load this conversation's outputs".to_owned());
+    }
+    Ok(DeliverableSummary {
+        output_id: output.id,
+        filename: output.filename.clone(),
+        media_type: output.media_type.clone(),
+        size_bytes: revision.byte_len,
+        revision_count: output.revision_count,
+        updated_at: output.updated_at.to_rfc3339(),
+    })
+}
+
+fn read_output_revision_bytes(
     scratch_root: &Path,
     chat_id: ChatId,
-) -> Result<DeliverablesCatalog, String> {
-    let Some(directory) = open_deliverables_directory(scratch_root, chat_id)? else {
-        return Ok(DeliverablesCatalog {
-            deliverables: Vec::new(),
-            truncated: false,
-        });
-    };
-    let entries = directory
-        .read_dir(".")
-        .map_err(|_| "Could not load this conversation's outputs".to_owned())?;
-    let mut deliverables = Vec::new();
-    let mut inspected = 0usize;
-    for entry in entries {
-        inspected += 1;
-        if inspected > MAX_DELIVERABLE_DIRECTORY_ENTRIES {
-            return Err("This conversation has too many output files".to_owned());
-        }
-        let Ok(entry) = entry else {
-            continue;
-        };
-        let Some(filename) = entry.file_name().to_str().map(str::to_owned) else {
-            continue;
-        };
-        if validate_deliverable_name(&filename).is_err() {
-            continue;
-        }
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
-        if !file_type.is_file() || file_type.is_symlink() {
-            continue;
-        }
-        let Ok(metadata) = entry.metadata() else {
-            continue;
-        };
-        if metadata.len() > MAX_DELIVERABLE_BYTES as u64 {
-            continue;
-        }
-        let Some(media_type) = deliverable_media_type(&filename) else {
-            continue;
-        };
-        let updated_at = metadata
-            .modified()
-            .map(|time| DateTime::<Utc>::from(time.into_std()))
-            .unwrap_or_else(|_| DateTime::<Utc>::UNIX_EPOCH)
-            .to_rfc3339();
-        deliverables.push(DeliverableSummary {
-            filename,
-            media_type: media_type.to_owned(),
-            size_bytes: metadata.len(),
-            updated_at,
-        });
+    output: &OutputRecord,
+    revision: &OutputRevision,
+) -> Result<Vec<u8>, String> {
+    if output.chat_id != chat_id
+        || output.deleted_at.is_some()
+        || revision.output_id != output.id
+        || revision.byte_len > MAX_DELIVERABLE_BYTES as u64
+    {
+        return Err("Output not found in this conversation".to_owned());
     }
-    deliverables.sort_by(|left, right| {
-        right
-            .updated_at
-            .cmp(&left.updated_at)
-            .then_with(|| left.filename.cmp(&right.filename))
-    });
-    let truncated = deliverables.len() > MAX_DELIVERABLES;
-    deliverables.truncate(MAX_DELIVERABLES);
-    Ok(DeliverablesCatalog {
-        deliverables,
+    let Some(root) = open_regular_directory(scratch_root)? else {
+        return Err("Output content is unavailable".to_owned());
+    };
+    let chat_name = chat_id.to_string();
+    let output_name = output.id.to_string();
+    if !is_regular_child_directory(&root, &chat_name)? {
+        return Err("Output content is unavailable".to_owned());
+    }
+    let chat = root
+        .open_dir_nofollow(&chat_name)
+        .map_err(|_| "Output content is unavailable".to_owned())?;
+    if !is_regular_child_directory(&chat, OUTPUTS_DIRECTORY)? {
+        return Err("Output content is unavailable".to_owned());
+    }
+    let outputs = chat
+        .open_dir_nofollow(OUTPUTS_DIRECTORY)
+        .map_err(|_| "Output content is unavailable".to_owned())?;
+    if !is_regular_child_directory(&outputs, &output_name)? {
+        return Err("Output content is unavailable".to_owned());
+    }
+    let revisions = outputs
+        .open_dir_nofollow(&output_name)
+        .map_err(|_| "Output content is unavailable".to_owned())?;
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = revisions
+        .open_with(revision.id.to_string(), &options)
+        .map_err(|_| "Output content is unavailable".to_owned())?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| "Output content is unavailable".to_owned())?;
+    if !metadata.is_file() || metadata.len() != revision.byte_len {
+        return Err("Output content is unavailable".to_owned());
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take((MAX_DELIVERABLE_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| "Output content is unavailable".to_owned())?;
+    if bytes.len() as u64 != revision.byte_len
+        || bytes.len() > MAX_DELIVERABLE_BYTES
+        || <[u8; 32]>::from(Sha256::digest(&bytes)) != revision.sha256
+    {
+        return Err("Output content is unavailable".to_owned());
+    }
+    Ok(bytes)
+}
+
+fn preview_from_bytes(output: &OutputRecord, bytes: Vec<u8>) -> Result<DeliverablePreview, String> {
+    let text =
+        String::from_utf8(bytes).map_err(|_| "Output is not a supported text file".to_owned())?;
+    if text.contains('\0')
+        || deliverable_media_type(&output.filename) != Some(output.media_type.as_str())
+    {
+        return Err("Output is not a supported text file".to_owned());
+    }
+    let mut characters = text.chars();
+    let content: String = characters.by_ref().take(MAX_PREVIEW_CHARACTERS).collect();
+    let truncated = characters.next().is_some();
+    Ok(DeliverablePreview {
+        output_id: output.id,
+        filename: output.filename.clone(),
+        media_type: output.media_type.clone(),
+        content,
         truncated,
     })
 }
 
-fn open_deliverables_directory(
-    scratch_root: &Path,
-    chat_id: ChatId,
-) -> Result<Option<Dir>, String> {
-    let Some(root) = open_regular_directory(scratch_root)? else {
-        return Ok(None);
+fn recover_output_export_receipt(
+    store: &ReceiptStore,
+    receipt: &mut OutputExportReceipt,
+) -> Result<OutputExportResult, String> {
+    if receipt.terminal.is_none() {
+        let terminal = match receipt.phase {
+            // No selected destination means no host write could have happened.
+            OutputExportPhase::Prepared => OutputExportTerminal::Cancelled,
+            // A destination was durably selected, but dispatch was not. Recovery
+            // refuses to issue a delayed write after native state may have moved.
+            OutputExportPhase::DestinationSelected => OutputExportTerminal::Failed {
+                reason: OutputExportFailureReason::DestinationUnavailable,
+            },
+            // Once dispatch may have begun, recovery only verifies the exact
+            // digest. It never repeats the write.
+            OutputExportPhase::DispatchStarted => {
+                if receipt.destination.as_ref().is_some_and(|destination| {
+                    destination_matches(destination, receipt.byte_len, receipt.sha256)
+                }) {
+                    OutputExportTerminal::Completed
+                } else {
+                    OutputExportTerminal::Failed {
+                        reason: OutputExportFailureReason::AmbiguousNativeFailure,
+                    }
+                }
+            }
+        };
+        receipt.terminal = Some(terminal);
+        store
+            .save_output_export(receipt)
+            .map_err(private_receipt_error)?;
+    }
+    output_export_result(receipt)
+}
+
+fn terminalize_output_export(
+    store: &ReceiptStore,
+    receipt: &mut OutputExportReceipt,
+    terminal: OutputExportTerminal,
+) -> Result<OutputExportResult, String> {
+    receipt.terminal = Some(terminal);
+    store
+        .save_output_export(receipt)
+        .map_err(private_receipt_error)?;
+    output_export_result(receipt)
+}
+
+fn output_export_result(receipt: &OutputExportReceipt) -> Result<OutputExportResult, String> {
+    Ok(OutputExportResult {
+        operation_id: receipt.operation_id,
+        output_id: receipt.output_id,
+        revision_id: receipt.revision_id,
+        terminal: receipt
+            .terminal
+            .ok_or_else(|| "Output export has no terminal receipt".to_owned())?,
+    })
+}
+
+fn destination_matches_revision(destination: &Path, revision: &OutputRevision) -> bool {
+    destination_matches(destination, revision.byte_len, revision.sha256)
+}
+
+fn destination_matches(destination: &Path, byte_len: u64, sha256: [u8; 32]) -> bool {
+    if !destination.is_absolute() || byte_len > MAX_DELIVERABLE_BYTES as u64 {
+        return false;
+    }
+    let Some(parent) = destination.parent() else {
+        return false;
     };
-    let chat_name = chat_id.to_string();
-    if !is_regular_child_directory(&root, &chat_name)? {
-        return Ok(None);
+    let Some(filename) = destination.file_name() else {
+        return false;
+    };
+    let Ok(directory) = Dir::open_ambient_dir(parent, ambient_authority()) else {
+        return false;
+    };
+    let Ok(metadata) = directory.symlink_metadata(filename) else {
+        return false;
+    };
+    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() != byte_len {
+        return false;
     }
-    let chat = root
-        .open_dir_nofollow(&chat_name)
-        .map_err(|_| "Could not open this conversation's private outputs".to_owned())?;
-    if !is_regular_child_directory(&chat, DELIVERABLES_DIRECTORY)? {
-        return Ok(None);
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let Ok(file) = directory.open_with(filename, &options) else {
+        return false;
+    };
+    let mut bytes = Vec::with_capacity(byte_len as usize);
+    if file
+        .take((MAX_DELIVERABLE_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .is_err()
+    {
+        return false;
     }
-    chat.open_dir_nofollow(DELIVERABLES_DIRECTORY)
-        .map(Some)
-        .map_err(|_| "Could not open this conversation's private outputs".to_owned())
+    bytes.len() as u64 == byte_len && <[u8; 32]>::from(Sha256::digest(&bytes)) == sha256
 }
 
 fn open_regular_directory(path: &Path) -> Result<Option<Dir>, String> {
@@ -259,57 +568,6 @@ fn is_regular_child_directory(parent: &Dir, name: &str) -> Result<bool, String> 
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(_) => Err("Could not inspect private outputs".to_owned()),
     }
-}
-
-fn read_deliverable_bytes(
-    scratch_root: &Path,
-    chat_id: ChatId,
-    filename: &str,
-) -> Result<Vec<u8>, String> {
-    validate_deliverable_name(filename).map_err(|_| "Invalid output filename".to_owned())?;
-    let directory = open_deliverables_directory(scratch_root, chat_id)?
-        .ok_or_else(|| "Output not found".to_owned())?;
-    let mut options = OpenOptions::new();
-    options.read(true).follow(FollowSymlinks::No);
-    let file = directory
-        .open_with(filename, &options)
-        .map_err(|_| "Output not found".to_owned())?;
-    let metadata = file
-        .metadata()
-        .map_err(|_| "Could not read that output".to_owned())?;
-    if !metadata.is_file() || metadata.len() > MAX_DELIVERABLE_BYTES as u64 {
-        return Err("Output is not a supported text file".to_owned());
-    }
-    let mut bytes = Vec::with_capacity(metadata.len() as usize);
-    file.take((MAX_DELIVERABLE_BYTES + 1) as u64)
-        .read_to_end(&mut bytes)
-        .map_err(|_| "Could not read that output".to_owned())?;
-    if bytes.len() > MAX_DELIVERABLE_BYTES
-        || bytes.contains(&0)
-        || std::str::from_utf8(&bytes).is_err()
-    {
-        return Err("Output is not a supported text file".to_owned());
-    }
-    Ok(bytes)
-}
-
-fn preview_from_bytes(filename: String, bytes: Vec<u8>) -> Result<DeliverablePreview, String> {
-    let text =
-        String::from_utf8(bytes).map_err(|_| "Output is not a supported text file".to_owned())?;
-    if text.contains('\0') {
-        return Err("Output is not a supported text file".to_owned());
-    }
-    let mut characters = text.chars();
-    let content: String = characters.by_ref().take(MAX_PREVIEW_CHARACTERS).collect();
-    let truncated = characters.next().is_some();
-    let media_type = deliverable_media_type(&filename)
-        .ok_or_else(|| "Output is not a supported text file".to_owned())?;
-    Ok(DeliverablePreview {
-        filename,
-        media_type: media_type.to_owned(),
-        content,
-        truncated,
-    })
 }
 
 async fn pick_export_path(app: &AppHandle, filename: &str) -> Result<Option<PathBuf>, String> {
@@ -382,65 +640,238 @@ fn write_exported_deliverable(destination: &Path, content: &[u8]) -> Result<(), 
     result.map_err(|_| "Could not save that output".to_owned())
 }
 
+fn private_receipt_error(_error: std::io::Error) -> String {
+    "Could not recover that output export".to_owned()
+}
+
 #[cfg(test)]
 mod tests {
+    use chrono::{TimeZone as _, Utc};
+
     use super::*;
 
-    fn artifact_path(root: &Path, chat_id: ChatId, filename: &str) -> PathBuf {
-        root.join(chat_id.to_string())
-            .join(DELIVERABLES_DIRECTORY)
-            .join(filename)
+    fn output_record(
+        chat_id: ChatId,
+        filename: &str,
+        content: &[u8],
+    ) -> (OutputRecord, OutputRevision) {
+        let output_id = OutputId::new();
+        let revision_id = OutputRevisionId::new();
+        let created_at = Utc.timestamp_opt(1_800_000_000, 0).unwrap();
+        (
+            OutputRecord {
+                id: output_id,
+                chat_id,
+                filename: filename.to_owned(),
+                media_type: deliverable_media_type(filename).unwrap().to_owned(),
+                current_revision: revision_id,
+                revision_count: 1,
+                created_at,
+                updated_at: created_at,
+                deleted_at: None,
+            },
+            OutputRevision {
+                id: revision_id,
+                output_id,
+                ordinal: 1,
+                byte_len: content.len() as u64,
+                sha256: Sha256::digest(content).into(),
+                turn_id: None,
+                created_at,
+            },
+        )
+    }
+
+    fn revision_path(root: &Path, output: &OutputRecord, revision: &OutputRevision) -> PathBuf {
+        root.join(output.chat_id.to_string())
+            .join(OUTPUTS_DIRECTORY)
+            .join(output.id.to_string())
+            .join(revision.id.to_string())
     }
 
     #[test]
-    fn catalog_and_preview_are_exactly_conversation_scoped() {
-        let scratch = tempfile::tempdir().unwrap();
-        let first = ChatId::new();
-        let second = ChatId::new();
-        let first_path = artifact_path(scratch.path(), first, "brief.md");
-        let second_path = artifact_path(scratch.path(), second, "other.txt");
-        std::fs::create_dir_all(first_path.parent().unwrap()).unwrap();
-        std::fs::create_dir_all(second_path.parent().unwrap()).unwrap();
-        std::fs::write(&first_path, "# Brief").unwrap();
-        std::fs::write(&second_path, "private").unwrap();
+    fn catalog_and_preview_project_durable_opaque_identity() {
+        let content = b"# Brief";
+        let (output, revision) = output_record(ChatId::new(), "brief.md", content);
+        let summary = summary_from_record(&output, &revision).unwrap();
+        assert_eq!(summary.output_id, output.id);
+        assert_eq!(summary.size_bytes, content.len() as u64);
+        assert_eq!(summary.revision_count, 1);
 
-        let catalog = list_deliverables_in_root(scratch.path(), first).unwrap();
-        assert_eq!(catalog.deliverables.len(), 1);
-        assert_eq!(catalog.deliverables[0].filename, "brief.md");
-        assert!(!catalog.truncated);
-        let preview = preview_from_bytes(
-            "brief.md".to_owned(),
-            read_deliverable_bytes(scratch.path(), first, "brief.md").unwrap(),
-        )
-        .unwrap();
+        let preview = preview_from_bytes(&output, content.to_vec()).unwrap();
+        assert_eq!(preview.output_id, output.id);
         assert_eq!(preview.content, "# Brief");
-        assert!(read_deliverable_bytes(scratch.path(), first, "other.txt").is_err());
+        let serialized = serde_json::to_value(preview).unwrap();
+        assert_eq!(
+            serialized
+                .as_object()
+                .unwrap()
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>(),
+            ["content", "filename", "mediaType", "outputId", "truncated"]
+        );
+        for forbidden in ["path", "scratch", "chatId", "token", "sha256"] {
+            assert!(!serialized.to_string().contains(forbidden));
+        }
+    }
+
+    #[test]
+    fn immutable_revision_reads_are_exactly_scoped_and_content_addressed() {
+        let scratch = tempfile::tempdir().unwrap();
+        let content = b"private";
+        let (output, revision) = output_record(ChatId::new(), "brief.txt", content);
+        let path = revision_path(scratch.path(), &output, &revision);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, content).unwrap();
+
+        assert_eq!(
+            read_output_revision_bytes(scratch.path(), output.chat_id, &output, &revision).unwrap(),
+            content
+        );
+        assert!(
+            read_output_revision_bytes(scratch.path(), ChatId::new(), &output, &revision).is_err()
+        );
+        std::fs::write(path, b"tampered").unwrap();
+        assert!(
+            read_output_revision_bytes(scratch.path(), output.chat_id, &output, &revision).is_err()
+        );
     }
 
     #[cfg(unix)]
     #[test]
-    fn private_catalog_and_export_reject_symlinks() {
+    fn private_revision_and_export_destinations_reject_symlinks() {
         use std::os::unix::fs::symlink;
 
         let scratch = tempfile::tempdir().unwrap();
-        let chat_id = ChatId::new();
         let outside = tempfile::tempdir().unwrap();
-        std::fs::write(outside.path().join("secret.md"), "secret").unwrap();
-        let directory = artifact_path(scratch.path(), chat_id, "link.md");
-        std::fs::create_dir_all(directory.parent().unwrap()).unwrap();
-        symlink(outside.path().join("secret.md"), &directory).unwrap();
-        assert!(read_deliverable_bytes(scratch.path(), chat_id, "link.md").is_err());
+        let content = b"private";
+        let (output, revision) = output_record(ChatId::new(), "brief.txt", content);
+        let path = revision_path(scratch.path(), &output, &revision);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let outside_source = outside.path().join("source.txt");
+        std::fs::write(&outside_source, content).unwrap();
+        symlink(&outside_source, &path).unwrap();
+        assert!(
+            read_output_revision_bytes(scratch.path(), output.chat_id, &output, &revision).is_err()
+        );
 
-        let linked_chat = ChatId::new();
-        symlink(outside.path(), scratch.path().join(linked_chat.to_string())).unwrap();
-        assert!(list_deliverables_in_root(scratch.path(), linked_chat).is_err());
-
-        let destination = outside.path().join("destination.md");
-        let target = outside.path().join("target.md");
+        let destination = outside.path().join("destination.txt");
+        let target = outside.path().join("target.txt");
         std::fs::write(&target, "keep").unwrap();
         symlink(&target, &destination).unwrap();
         assert!(write_exported_deliverable(&destination, b"replace").is_err());
+        assert!(!destination_matches_revision(&destination, &revision));
         assert_eq!(std::fs::read_to_string(target).unwrap(), "keep");
+    }
+
+    #[test]
+    fn exact_export_retries_recover_completed_cancelled_and_ambiguous_receipts() {
+        let private = tempfile::tempdir().unwrap();
+        let receipts = ReceiptStore::open(private.path()).unwrap();
+        let destination_root = tempfile::tempdir().unwrap();
+        let content = b"exact";
+        let (output, revision) = output_record(ChatId::new(), "brief.txt", content);
+
+        let mut cancelled = OutputExportReceipt::new(
+            Uuid::new_v4(),
+            output.chat_id,
+            output.id,
+            revision.id,
+            output.filename.clone(),
+            revision.byte_len,
+            revision.sha256,
+        );
+        receipts.save_output_export(&cancelled).unwrap();
+        let first_cancel = recover_output_export_receipt(&receipts, &mut cancelled).unwrap();
+        let mut cancelled_retry = receipts
+            .load_output_export(cancelled.operation_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            recover_output_export_receipt(&receipts, &mut cancelled_retry).unwrap(),
+            first_cancel
+        );
+        assert!(matches!(
+            first_cancel.terminal,
+            OutputExportTerminal::Cancelled
+        ));
+
+        let interrupted_destination = destination_root.path().join("interrupted.txt");
+        let mut interrupted = OutputExportReceipt::new(
+            Uuid::new_v4(),
+            output.chat_id,
+            output.id,
+            revision.id,
+            output.filename.clone(),
+            revision.byte_len,
+            revision.sha256,
+        );
+        interrupted.phase = OutputExportPhase::DestinationSelected;
+        interrupted.destination = Some(interrupted_destination.clone());
+        receipts.save_output_export(&interrupted).unwrap();
+        let interrupted_result =
+            recover_output_export_receipt(&receipts, &mut interrupted).unwrap();
+        assert!(matches!(
+            interrupted_result.terminal,
+            OutputExportTerminal::Failed {
+                reason: OutputExportFailureReason::DestinationUnavailable
+            }
+        ));
+        assert!(
+            !interrupted_destination.exists(),
+            "recovery must not replay a write that was never dispatched"
+        );
+
+        let destination = destination_root.path().join("brief.txt");
+        std::fs::write(&destination, content).unwrap();
+        let mut completed = OutputExportReceipt::new(
+            Uuid::new_v4(),
+            output.chat_id,
+            output.id,
+            revision.id,
+            output.filename.clone(),
+            revision.byte_len,
+            revision.sha256,
+        );
+        completed.phase = OutputExportPhase::DispatchStarted;
+        completed.destination = Some(destination);
+        receipts.save_output_export(&completed).unwrap();
+        let completed_result = recover_output_export_receipt(&receipts, &mut completed).unwrap();
+        assert!(matches!(
+            completed_result.terminal,
+            OutputExportTerminal::Completed
+        ));
+
+        let ambiguous_destination = destination_root.path().join("ambiguous.txt");
+        std::fs::write(&ambiguous_destination, b"different").unwrap();
+        let mut ambiguous = OutputExportReceipt::new(
+            Uuid::new_v4(),
+            output.chat_id,
+            output.id,
+            revision.id,
+            output.filename,
+            revision.byte_len,
+            revision.sha256,
+        );
+        ambiguous.phase = OutputExportPhase::DispatchStarted;
+        ambiguous.destination = Some(ambiguous_destination);
+        receipts.save_output_export(&ambiguous).unwrap();
+        let first_ambiguous = recover_output_export_receipt(&receipts, &mut ambiguous).unwrap();
+        let mut ambiguous_retry = receipts
+            .load_output_export(ambiguous.operation_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            recover_output_export_receipt(&receipts, &mut ambiguous_retry).unwrap(),
+            first_ambiguous
+        );
+        assert!(matches!(
+            first_ambiguous.terminal,
+            OutputExportTerminal::Failed {
+                reason: OutputExportFailureReason::AmbiguousNativeFailure
+            }
+        ));
     }
 
     #[test]
@@ -466,15 +897,25 @@ mod tests {
     }
 
     #[test]
-    fn renderer_projection_is_bounded_and_pathless() {
-        let preview = preview_from_bytes(
-            "brief.md".to_owned(),
-            "x".repeat(MAX_PREVIEW_CHARACTERS + 5).into_bytes(),
-        )
-        .unwrap();
-        assert_eq!(preview.content.chars().count(), MAX_PREVIEW_CHARACTERS);
-        assert!(preview.truncated);
-        let serialized = serde_json::to_value(preview).unwrap();
+    fn requests_and_export_results_are_renderer_safe() {
+        assert!(
+            serde_json::from_value::<ExportDeliverableRequest>(serde_json::json!({
+                "operationId": Uuid::new_v4(),
+                "chatId": Uuid::new_v4(),
+                "outputId": OutputId::new(),
+                "path": "/tmp/private"
+            }))
+            .is_err()
+        );
+        let result = OutputExportResult {
+            operation_id: Uuid::new_v4(),
+            output_id: OutputId::new(),
+            revision_id: OutputRevisionId::new(),
+            terminal: OutputExportTerminal::Failed {
+                reason: OutputExportFailureReason::AmbiguousNativeFailure,
+            },
+        };
+        let serialized = serde_json::to_value(result).unwrap();
         assert_eq!(
             serialized
                 .as_object()
@@ -482,35 +923,10 @@ mod tests {
                 .keys()
                 .cloned()
                 .collect::<Vec<_>>(),
-            ["content", "filename", "mediaType", "truncated"]
+            ["operationId", "outputId", "reason", "revisionId", "status"]
         );
-        for forbidden in ["path", "scratch", "chatId", "token"] {
+        for forbidden in ["path", "destination", "content", "sha256", "chatId"] {
             assert!(!serialized.to_string().contains(forbidden));
         }
-    }
-
-    #[test]
-    fn output_reads_reject_non_text_content() {
-        let scratch = tempfile::tempdir().unwrap();
-        let chat_id = ChatId::new();
-        let nul_path = artifact_path(scratch.path(), chat_id, "nul.txt");
-        std::fs::create_dir_all(nul_path.parent().unwrap()).unwrap();
-        std::fs::write(&nul_path, b"not\0text").unwrap();
-        std::fs::write(artifact_path(scratch.path(), chat_id, "binary.txt"), [0xff]).unwrap();
-
-        assert!(read_deliverable_bytes(scratch.path(), chat_id, "nul.txt").is_err());
-        assert!(read_deliverable_bytes(scratch.path(), chat_id, "binary.txt").is_err());
-    }
-
-    #[test]
-    fn requests_reject_scope_and_path_injection() {
-        assert!(
-            serde_json::from_value::<DeliverableRequest>(serde_json::json!({
-                "chatId": Uuid::new_v4(),
-                "filename": "brief.md",
-                "path": "/tmp/private"
-            }))
-            .is_err()
-        );
     }
 }

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -20,6 +20,7 @@ use crate::client_execution::{ControlPlaneClient, ReceiptStore};
 pub(crate) struct HostAccess {
     pub(super) broker: BrokerClient,
     pub(super) picker: Mutex<()>,
+    pub(super) output_exports: Mutex<()>,
     pub(super) root_changes: Mutex<()>,
     store: OnceCell<std::sync::Arc<dyn Store>>,
     pub(super) control_plane: OnceCell<ControlPlaneClient>,
@@ -37,6 +38,7 @@ impl HostAccess {
         Ok(Self {
             broker: BrokerClient::new(app, data_dir, home_dir),
             picker: Mutex::const_new(()),
+            output_exports: Mutex::const_new(()),
             root_changes: Mutex::const_new(()),
             store: OnceCell::new(),
             control_plane: OnceCell::new(),

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -392,7 +392,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       case "outputs":
         return (
           <PanelFrame position={side} spaceBetween>
-            <DeliverablesView chatId={chatId} initialFilename={panel.filename} />
+            <DeliverablesView chatId={chatId} initialOutputId={panel.outputId} />
           </PanelFrame>
         );
       case "folders":

--- a/crates/openwave-desktop/ui/src/DeliverablesView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.dom.test.tsx
@@ -7,22 +7,34 @@ import { DeliverablesView } from "./DeliverablesView";
 
 afterEach(cleanup);
 
+const firstOutputId = "550062d4-2528-5cc6-90f8-a788e119bf36";
+const secondOutputId = "ce116263-15b5-5df2-b472-269378e9da58";
+const revisionId = "72cb0277-5a3c-45ee-bda8-43534f74feb2";
+
 describe("DeliverablesView", () => {
   it("previews and explicitly exports a conversation output", async () => {
-    const exportOutput = vi.fn().mockResolvedValue(true);
+    const exportOutput = vi.fn().mockResolvedValue({
+      operationId: "0e44560b-5d3b-4f80-b24c-647560f7ef19",
+      outputId: firstOutputId,
+      revisionId,
+      status: "completed" as const,
+    });
     const apis = {
       list: vi.fn().mockResolvedValue({
         deliverables: [
           {
+            outputId: firstOutputId,
             filename: "Research brief.md",
             mediaType: "text/markdown" as const,
             sizeBytes: 42,
+            revisionCount: 1,
             updatedAt: "2026-07-24T00:00:00Z",
           },
         ],
         truncated: false,
       }),
       read: vi.fn().mockResolvedValue({
+        outputId: firstOutputId,
         filename: "Research brief.md",
         mediaType: "text/markdown" as const,
         content: "# Findings\n\nGrounded.",
@@ -37,7 +49,7 @@ describe("DeliverablesView", () => {
     expect(await screen.findByRole("heading", { name: "Findings" })).toBeVisible();
     await userEvent.click(screen.getByRole("button", { name: /Save As/ }));
     await waitFor(() =>
-      expect(exportOutput).toHaveBeenCalledWith("chat-1", "Research brief.md"),
+      expect(exportOutput).toHaveBeenCalledWith("chat-1", firstOutputId),
     );
     expect(await screen.findByText("Research brief.md was saved.")).toBeVisible();
   });
@@ -48,15 +60,15 @@ describe("DeliverablesView", () => {
     render(
       <DeliverablesView
         chatId="chat-1"
-        initialFilename="Second.md"
+        initialOutputId={secondOutputId}
         apis={apis}
       />,
     );
 
     await waitFor(() =>
-      expect(apis.read).toHaveBeenCalledWith("chat-1", "Second.md"),
+      expect(apis.read).toHaveBeenCalledWith("chat-1", secondOutputId),
     );
-    expect(apis.read).not.toHaveBeenCalledWith("chat-1", "First.md");
+    expect(apis.read).not.toHaveBeenCalledWith("chat-1", firstOutputId);
   });
 
   it("falls back to the list when it is pointed at an output this chat lacks", async () => {
@@ -65,15 +77,18 @@ describe("DeliverablesView", () => {
     render(
       <DeliverablesView
         chatId="chat-1"
-        initialFilename="Missing.md"
+        initialOutputId="550062d4-2528-5cc6-90f8-a788e119bf37"
         apis={apis}
       />,
     );
 
     await waitFor(() =>
-      expect(apis.read).toHaveBeenCalledWith("chat-1", "First.md"),
+      expect(apis.read).toHaveBeenCalledWith("chat-1", firstOutputId),
     );
-    expect(apis.read).not.toHaveBeenCalledWith("chat-1", "Missing.md");
+    expect(apis.read).not.toHaveBeenCalledWith(
+      "chat-1",
+      "550062d4-2528-5cc6-90f8-a788e119bf37",
+    );
   });
 
   it("stops steering once the reader chooses another output", async () => {
@@ -82,22 +97,22 @@ describe("DeliverablesView", () => {
     render(
       <DeliverablesView
         chatId="chat-1"
-        initialFilename="Second.md"
+        initialOutputId={secondOutputId}
         apis={apis}
       />,
     );
     await waitFor(() =>
-      expect(apis.read).toHaveBeenCalledWith("chat-1", "Second.md"),
+      expect(apis.read).toHaveBeenCalledWith("chat-1", secondOutputId),
     );
 
     await userEvent.click(screen.getByRole("button", { name: /First\.md/ }));
     await waitFor(() =>
-      expect(apis.read).toHaveBeenCalledWith("chat-1", "First.md"),
+      expect(apis.read).toHaveBeenCalledWith("chat-1", firstOutputId),
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Refresh" }));
     await waitFor(() => expect(apis.list).toHaveBeenCalledTimes(2));
-    expect(apis.read).toHaveBeenLastCalledWith("chat-1", "First.md");
+    expect(apis.read).toHaveBeenLastCalledWith("chat-1", firstOutputId);
   });
 
   it("explains how to create the first output", async () => {
@@ -125,21 +140,30 @@ describe("DeliverablesView", () => {
       list: vi.fn().mockResolvedValue({
         deliverables: [
           {
+            outputId: firstOutputId,
             filename: "brief.txt",
             mediaType: "text/plain" as const,
             sizeBytes: 5,
+            revisionCount: 1,
             updatedAt: "2026-07-24T00:00:00Z",
           },
         ],
         truncated: false,
       }),
       read: vi.fn().mockResolvedValue({
+        outputId: firstOutputId,
         filename: "brief.txt",
         mediaType: "text/plain" as const,
         content: "brief",
         truncated: false,
       }),
-      export: vi.fn().mockRejectedValue(new Error("Selected folder is unavailable")),
+      export: vi.fn().mockResolvedValue({
+        operationId: "0e44560b-5d3b-4f80-b24c-647560f7ef19",
+        outputId: firstOutputId,
+        revisionId,
+        status: "failed" as const,
+        reason: "ambiguous_native_failure" as const,
+      }),
     };
 
     render(
@@ -148,13 +172,14 @@ describe("DeliverablesView", () => {
     await screen.findByText("brief");
     await userEvent.click(screen.getByRole("button", { name: /Save As/ }));
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Selected folder is unavailable",
+      "could not confirm whether the output was saved",
     );
   });
 
   it("keeps the refreshed preview when an older read completes later", async () => {
     let resolveStalePreview:
       | ((preview: {
+          outputId: string;
           filename: string;
           mediaType: "text/plain";
           content: string;
@@ -162,6 +187,7 @@ describe("DeliverablesView", () => {
         }) => void)
       | undefined;
     const stalePreview = new Promise<{
+      outputId: string;
       filename: string;
       mediaType: "text/plain";
       content: string;
@@ -173,9 +199,11 @@ describe("DeliverablesView", () => {
       list: vi.fn().mockResolvedValue({
         deliverables: [
           {
+            outputId: firstOutputId,
             filename: "status.txt",
             mediaType: "text/plain" as const,
             sizeBytes: 7,
+            revisionCount: 1,
             updatedAt: "2026-07-24T00:00:00Z",
           },
         ],
@@ -186,6 +214,7 @@ describe("DeliverablesView", () => {
         .mockReturnValueOnce(stalePreview)
         .mockResolvedValueOnce({
           filename: "status.txt",
+          outputId: firstOutputId,
           mediaType: "text/plain" as const,
           content: "refreshed",
           truncated: false,
@@ -202,6 +231,7 @@ describe("DeliverablesView", () => {
 
     await act(async () => {
       resolveStalePreview?.({
+        outputId: firstOutputId,
         filename: "status.txt",
         mediaType: "text/plain",
         content: "stale",
@@ -214,25 +244,38 @@ describe("DeliverablesView", () => {
 });
 
 function twoOutputApis() {
-  const outputs = ["First.md", "Second.md"];
+  const outputs = [
+    { outputId: firstOutputId, filename: "First.md" },
+    { outputId: secondOutputId, filename: "Second.md" },
+  ];
   return {
     list: vi.fn().mockResolvedValue({
-      deliverables: outputs.map((filename) => ({
+      deliverables: outputs.map(({ outputId, filename }) => ({
+        outputId,
         filename,
         mediaType: "text/markdown" as const,
         sizeBytes: 12,
+        revisionCount: 1,
         updatedAt: "2026-07-24T00:00:00Z",
       })),
       truncated: false,
     }),
-    read: vi.fn().mockImplementation((_chatId: string, filename: string) =>
-      Promise.resolve({
+    read: vi.fn().mockImplementation((_chatId: string, outputId: string) => {
+      const filename =
+        outputs.find((output) => output.outputId === outputId)?.filename ?? "Missing";
+      return Promise.resolve({
+        outputId,
         filename,
         mediaType: "text/markdown" as const,
         content: `# ${filename}`,
         truncated: false,
-      }),
-    ),
-    export: vi.fn().mockResolvedValue(true),
+      });
+    }),
+    export: vi.fn().mockResolvedValue({
+      operationId: "0e44560b-5d3b-4f80-b24c-647560f7ef19",
+      outputId: firstOutputId,
+      revisionId,
+      status: "completed" as const,
+    }),
   };
 }

--- a/crates/openwave-desktop/ui/src/DeliverablesView.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.tsx
@@ -6,6 +6,7 @@ import {
   readDeliverable,
   type DeliverablePreview,
   type DeliverablesCatalog,
+  type OutputExportResult,
 } from "./deliverables";
 import { MessageMarkdown } from "./MessageMarkdown";
 import {
@@ -16,8 +17,8 @@ import {
 
 type DeliverableApis = {
   list: (chatId: string) => Promise<DeliverablesCatalog>;
-  read: (chatId: string, filename: string) => Promise<DeliverablePreview>;
-  export: (chatId: string, filename: string) => Promise<boolean>;
+  read: (chatId: string, outputId: string) => Promise<DeliverablePreview>;
+  export: (chatId: string, outputId: string) => Promise<OutputExportResult>;
 };
 
 const defaultApis: DeliverableApis = {
@@ -28,12 +29,12 @@ const defaultApis: DeliverableApis = {
 
 export function DeliverablesView({
   chatId,
-  initialFilename,
+  initialOutputId,
   apis = defaultApis,
 }: {
   chatId: string;
-  /** Output to preview on arrival; ignored when this chat has no such file. */
-  initialFilename?: string;
+  /** Opaque output to preview on arrival; ignored when this chat does not own it. */
+  initialOutputId?: string;
   apis?: DeliverableApis;
 }) {
   const [catalog, setCatalog] = useState<DeliverablesCatalog>({
@@ -54,7 +55,7 @@ export function DeliverablesView({
   const [previewVersion, setPreviewVersion] = useState(0);
   const catalogGenerationRef = useRef(0);
   const previewGenerationRef = useRef(0);
-  const pendingFilenameRef = useRef<string | null>(initialFilename ?? null);
+  const pendingOutputIdRef = useRef<string | null>(initialOutputId ?? null);
 
   async function refresh(showLoading = false) {
     const generation = ++catalogGenerationRef.current;
@@ -67,17 +68,17 @@ export function DeliverablesView({
       // or a choice from the list must not snap back to where the caller
       // pointed. Resolving here rather than after the fact means an output the
       // chat does not own never gets read.
-      const target = pendingFilenameRef.current;
-      pendingFilenameRef.current = null;
-      const owns = (filename: string | null | undefined) =>
-        !!filename && next.deliverables.some((item) => item.filename === filename);
+      const target = pendingOutputIdRef.current;
+      pendingOutputIdRef.current = null;
+      const owns = (outputId: string | null | undefined) =>
+        !!outputId && next.deliverables.some((item) => item.outputId === outputId);
       setCatalog(next);
       setSelected((current) =>
         owns(target)
           ? target
           : owns(current)
             ? current
-            : (next.deliverables[0]?.filename ?? null),
+            : (next.deliverables[0]?.outputId ?? null),
       );
       setPreviewVersion((current) => current + 1);
     } catch (caught) {
@@ -95,11 +96,11 @@ export function DeliverablesView({
     setError(null);
     setPreviewError(null);
     setExportStatus(null);
-    // The requested filename belongs to the conversation that asked for it. Its
+    // The requested opaque identity belongs to the conversation that asked for it. Its
     // only other clear sits after the stale-generation bail, which a chat switch
     // always takes — so without resetting here the next conversation opens on
     // the file the previous one wanted.
-    pendingFilenameRef.current = initialFilename ?? null;
+    pendingOutputIdRef.current = initialOutputId ?? null;
     void refresh(true);
     return () => {
       catalogGenerationRef.current += 1;
@@ -110,17 +111,17 @@ export function DeliverablesView({
   // Being pointed somewhere new while the surface is already open resolves
   // against the catalog in hand, and otherwise waits for the next one.
   useEffect(() => {
-    if (!initialFilename) return;
-    if (catalog.deliverables.some((item) => item.filename === initialFilename)) {
-      pendingFilenameRef.current = null;
-      setSelected(initialFilename);
+    if (!initialOutputId) return;
+    if (catalog.deliverables.some((item) => item.outputId === initialOutputId)) {
+      pendingOutputIdRef.current = null;
+      setSelected(initialOutputId);
     } else {
-      pendingFilenameRef.current = initialFilename;
+      pendingOutputIdRef.current = initialOutputId;
     }
     // `catalog` is read here, so it belongs in the dependencies: a target set
     // before the list arrived has to re-resolve when it does, by any path and
     // not only through an explicit refresh.
-  }, [initialFilename, catalog]);
+  }, [initialOutputId, catalog]);
 
   useEffect(() => {
     if (!selected) {
@@ -157,9 +158,17 @@ export function DeliverablesView({
     setExporting(true);
     setExportStatus(null);
     try {
-      const saved = await apis.export(chatId, selected);
-      if (saved) {
-        setExportStatus({ message: `${selected} was saved.`, error: false });
+      const result = await apis.export(chatId, selected);
+      const filename =
+        catalog.deliverables.find((item) => item.outputId === selected)?.filename ??
+        "Output";
+      if (result.status === "completed") {
+        setExportStatus({ message: `${filename} was saved.`, error: false });
+      } else if (result.status === "failed") {
+        setExportStatus({
+          message: exportFailureMessage(result.reason),
+          error: true,
+        });
       }
     } catch (caught) {
       setExportStatus({
@@ -234,10 +243,10 @@ export function DeliverablesView({
                 {catalog.deliverables.map((item) => (
                   <button
                     type="button"
-                    className={`deliverable-row${selected === item.filename ? " is-selected" : ""}`}
-                    aria-current={selected === item.filename ? "true" : undefined}
-                    key={item.filename}
-                    onClick={() => setSelected(item.filename)}
+                    className={`deliverable-row${selected === item.outputId ? " is-selected" : ""}`}
+                    aria-current={selected === item.outputId ? "true" : undefined}
+                    key={item.outputId}
+                    onClick={() => setSelected(item.outputId)}
                   >
                     <span className="deliverable-icon" aria-hidden="true">
                       <FileOutput size={16} />
@@ -245,7 +254,11 @@ export function DeliverablesView({
                     <span className="deliverable-copy">
                       <strong>{item.filename}</strong>
                       <small>
-                        {formatBytes(item.sizeBytes)} · {formatDate(item.updatedAt)}
+                        {formatBytes(item.sizeBytes)} ·{" "}
+                        {item.revisionCount === 1
+                          ? "1 revision"
+                          : `${item.revisionCount} revisions`}{" "}
+                        · {formatDate(item.updatedAt)}
                       </small>
                     </span>
                   </button>
@@ -256,7 +269,7 @@ export function DeliverablesView({
             <section className="deliverable-preview-panel" aria-label="Output preview">
               <div className="deliverable-preview-heading">
                 <div>
-                  <h2>{selected ?? "Preview"}</h2>
+                  <h2>{preview?.filename ?? "Preview"}</h2>
                   {preview && <p>{mediaTypeLabel(preview.mediaType)}</p>}
                 </div>
                 <button
@@ -333,6 +346,19 @@ function mediaTypeLabel(mediaType: DeliverablePreview["mediaType"]): string {
       return "HTML";
     default:
       return "Plain text";
+  }
+}
+
+function exportFailureMessage(
+  reason: Extract<OutputExportResult, { status: "failed" }>["reason"],
+): string {
+  switch (reason) {
+    case "source_unavailable":
+      return "That output revision is no longer available.";
+    case "destination_unavailable":
+      return "The selected save destination is no longer available.";
+    case "ambiguous_native_failure":
+      return "OpenWave could not confirm whether the output was saved. Check the selected destination before trying again.";
   }
 }
 

--- a/crates/openwave-desktop/ui/src/deliverables.test.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.test.ts
@@ -1,18 +1,31 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+
 import {
+  exportDeliverable,
   parseDeliverablePreview,
   parseDeliverablesCatalog,
+  parseOutputExportResult,
 } from "./deliverables";
 
+const outputId = "550062d4-2528-5cc6-90f8-a788e119bf36";
+const revisionId = "72cb0277-5a3c-45ee-bda8-43534f74feb2";
+
+beforeEach(() => invokeMock.mockReset());
+
 describe("deliverable renderer projections", () => {
-  it("accepts only the bounded closed catalog", () => {
+  it("accepts only the bounded opaque catalog", () => {
     expect(
       parseDeliverablesCatalog({
         deliverables: [
           {
+            outputId,
             filename: "Research brief.md",
             mediaType: "text/markdown",
             sizeBytes: 42,
+            revisionCount: 2,
             updatedAt: "2026-07-24T00:00:00Z",
           },
         ],
@@ -21,9 +34,11 @@ describe("deliverable renderer projections", () => {
     ).toEqual({
       deliverables: [
         {
+          outputId,
           filename: "Research brief.md",
           mediaType: "text/markdown",
           sizeBytes: 42,
+          revisionCount: 2,
           updatedAt: "2026-07-24T00:00:00Z",
         },
       ],
@@ -42,9 +57,11 @@ describe("deliverable renderer projections", () => {
       parseDeliverablesCatalog({
         deliverables: [
           {
+            outputId,
             filename,
             mediaType: "text/markdown",
             sizeBytes: 1,
+            revisionCount: 1,
             updatedAt: "2026-07-24T00:00:00Z",
           },
         ],
@@ -53,9 +70,10 @@ describe("deliverable renderer projections", () => {
     ).toThrow("Invalid output response");
   });
 
-  it("rejects canonical paths and oversized previews", () => {
+  it("rejects canonical paths, missing opaque ids, and oversized previews", () => {
     expect(() =>
       parseDeliverablePreview({
+        outputId,
         filename: "brief.md",
         mediaType: "text/markdown",
         content: "safe",
@@ -67,9 +85,77 @@ describe("deliverable renderer projections", () => {
       parseDeliverablePreview({
         filename: "brief.md",
         mediaType: "text/markdown",
+        content: "safe",
+        truncated: false,
+      }),
+    ).toThrow("Invalid output preview response");
+    expect(() =>
+      parseDeliverablePreview({
+        outputId,
+        filename: "brief.md",
+        mediaType: "text/markdown",
         content: "x".repeat(100_001),
         truncated: true,
       }),
     ).toThrow("Invalid output preview response");
+  });
+
+  it("accepts only exact pathless export receipts", () => {
+    expect(
+      parseOutputExportResult({
+        operationId: "0e44560b-5d3b-4f80-b24c-647560f7ef19",
+        outputId,
+        revisionId,
+        status: "failed",
+        reason: "ambiguous_native_failure",
+      }),
+    ).toEqual({
+      operationId: "0e44560b-5d3b-4f80-b24c-647560f7ef19",
+      outputId,
+      revisionId,
+      status: "failed",
+      reason: "ambiguous_native_failure",
+    });
+    expect(() =>
+      parseOutputExportResult({
+        operationId: "0e44560b-5d3b-4f80-b24c-647560f7ef19",
+        outputId,
+        revisionId,
+        status: "completed",
+        destination: "/private/export.md",
+      }),
+    ).toThrow("Invalid output export response");
+  });
+
+  it("retries an ambiguous bridge response with the exact operation identity", async () => {
+    invokeMock
+      .mockRejectedValueOnce(new Error("bridge response lost"))
+      .mockImplementationOnce(
+        (
+          _command: string,
+          {
+            request,
+          }: {
+            request: {
+              operationId: string;
+              outputId: string;
+            };
+          },
+        ) =>
+          Promise.resolve({
+            operationId: request.operationId,
+            outputId: request.outputId,
+            revisionId,
+            status: "completed",
+          }),
+      );
+
+    await expect(exportDeliverable("chat-1", outputId)).resolves.toMatchObject({
+      outputId,
+      revisionId,
+      status: "completed",
+    });
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+    expect(invokeMock.mock.calls[1]?.[1]).toEqual(invokeMock.mock.calls[0]?.[1]);
   });
 });

--- a/crates/openwave-desktop/ui/src/deliverables.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.ts
@@ -1,9 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 
 export type DeliverableSummary = {
+  outputId: string;
   filename: string;
   mediaType: DeliverableMediaType;
   sizeBytes: number;
+  revisionCount: number;
   updatedAt: string;
 };
 
@@ -13,11 +15,30 @@ export type DeliverablesCatalog = {
 };
 
 export type DeliverablePreview = {
+  outputId: string;
   filename: string;
   mediaType: DeliverableMediaType;
   content: string;
   truncated: boolean;
 };
+
+export type OutputExportResult =
+  | {
+      operationId: string;
+      outputId: string;
+      revisionId: string;
+      status: "completed" | "cancelled";
+    }
+  | {
+      operationId: string;
+      outputId: string;
+      revisionId: string;
+      status: "failed";
+      reason:
+        | "source_unavailable"
+        | "destination_unavailable"
+        | "ambiguous_native_failure";
+    };
 
 export type DeliverableMediaType =
   | "text/markdown"
@@ -30,6 +51,7 @@ const MAX_DELIVERABLES = 100;
 const MAX_FILENAME_CHARACTERS = 120;
 const MAX_PREVIEW_CHARACTERS = 100_000;
 const MAX_DELIVERABLE_BYTES = 512 * 1024;
+const MAX_OUTPUT_REVISIONS = 100;
 
 export async function listDeliverables(
   chatId: string,
@@ -41,24 +63,29 @@ export async function listDeliverables(
 
 export async function readDeliverable(
   chatId: string,
-  filename: string,
+  outputId: string,
 ): Promise<DeliverablePreview> {
   return parseDeliverablePreview(
-    await invoke("read_deliverable", { request: { chatId, filename } }),
+    await invoke("read_deliverable", { request: { chatId, outputId } }),
   );
 }
 
 export async function exportDeliverable(
   chatId: string,
-  filename: string,
-): Promise<boolean> {
-  const exported = await invoke("export_deliverable", {
-    request: { chatId, filename },
-  });
-  if (typeof exported !== "boolean") {
-    throw new Error("Invalid output export response");
+  outputId: string,
+): Promise<OutputExportResult> {
+  const operationId = crypto.randomUUID();
+  const request = { operationId, chatId, outputId };
+  let value: unknown;
+  try {
+    value = await invoke("export_deliverable", { request });
+  } catch {
+    // The native side persists the operation before opening the picker and
+    // never repeats a possibly dispatched write. One exact retry therefore
+    // recovers the same terminal receipt after an ambiguous bridge response.
+    value = await invoke("export_deliverable", { request });
   }
-  return exported;
+  return parseOutputExportResult(value, operationId, outputId);
 }
 
 export function parseDeliverablesCatalog(value: unknown): DeliverablesCatalog {
@@ -80,7 +107,14 @@ export function parseDeliverablesCatalog(value: unknown): DeliverablesCatalog {
 
 export function parseDeliverablePreview(value: unknown): DeliverablePreview {
   if (
-    !isExactRecord(value, ["filename", "mediaType", "content", "truncated"]) ||
+    !isExactRecord(value, [
+      "outputId",
+      "filename",
+      "mediaType",
+      "content",
+      "truncated",
+    ]) ||
+    !isOpaqueId(value.outputId) ||
     !isDeliverableFilename(value.filename) ||
     !isDeliverableMediaType(value.mediaType) ||
     typeof value.content !== "string" ||
@@ -91,6 +125,7 @@ export function parseDeliverablePreview(value: unknown): DeliverablePreview {
     throw new Error("Invalid output preview response");
   }
   return {
+    outputId: value.outputId,
     filename: value.filename,
     mediaType: value.mediaType,
     content: value.content,
@@ -98,29 +133,94 @@ export function parseDeliverablePreview(value: unknown): DeliverablePreview {
   };
 }
 
+export function parseOutputExportResult(
+  value: unknown,
+  expectedOperationId?: string,
+  expectedOutputId?: string,
+): OutputExportResult {
+  if (
+    !isRecord(value) ||
+    !isOpaqueId(value.operationId) ||
+    !isOpaqueId(value.outputId) ||
+    !isOpaqueId(value.revisionId) ||
+    (expectedOperationId !== undefined &&
+      value.operationId !== expectedOperationId) ||
+    (expectedOutputId !== undefined && value.outputId !== expectedOutputId)
+  ) {
+    throw new Error("Invalid output export response");
+  }
+  if (
+    (value.status === "completed" || value.status === "cancelled") &&
+    isExactRecord(value, ["operationId", "outputId", "revisionId", "status"])
+  ) {
+    return {
+      operationId: value.operationId,
+      outputId: value.outputId,
+      revisionId: value.revisionId,
+      status: value.status,
+    };
+  }
+  if (
+    value.status === "failed" &&
+    isExactRecord(value, [
+      "operationId",
+      "outputId",
+      "revisionId",
+      "status",
+      "reason",
+    ]) &&
+    [
+      "source_unavailable",
+      "destination_unavailable",
+      "ambiguous_native_failure",
+    ].includes(String(value.reason))
+  ) {
+    return {
+      operationId: value.operationId,
+      outputId: value.outputId,
+      revisionId: value.revisionId,
+      status: "failed",
+      reason: value.reason as Extract<
+        OutputExportResult,
+        { status: "failed" }
+      >["reason"],
+    };
+  }
+  throw new Error("Invalid output export response");
+}
+
 function parseDeliverableSummary(value: unknown): DeliverableSummary {
   if (
     !isExactRecord(value, [
+      "outputId",
       "filename",
       "mediaType",
       "sizeBytes",
+      "revisionCount",
       "updatedAt",
     ]) ||
+    !isOpaqueId(value.outputId) ||
     !isDeliverableFilename(value.filename) ||
     !isDeliverableMediaType(value.mediaType) ||
     typeof value.sizeBytes !== "number" ||
     !Number.isSafeInteger(value.sizeBytes) ||
     value.sizeBytes < 0 ||
     value.sizeBytes > MAX_DELIVERABLE_BYTES ||
+    typeof value.revisionCount !== "number" ||
+    !Number.isSafeInteger(value.revisionCount) ||
+    value.revisionCount < 1 ||
+    value.revisionCount > MAX_OUTPUT_REVISIONS ||
     typeof value.updatedAt !== "string" ||
     !Number.isFinite(Date.parse(value.updatedAt))
   ) {
     throw new Error("Invalid output response");
   }
   return {
+    outputId: value.outputId,
     filename: value.filename,
     mediaType: value.mediaType,
     sizeBytes: value.sizeBytes,
+    revisionCount: value.revisionCount,
     updatedAt: value.updatedAt,
   };
 }
@@ -149,11 +249,25 @@ function isDeliverableMediaType(value: unknown): value is DeliverableMediaType {
   ].includes(String(value));
 }
 
+function isOpaqueId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value !== "00000000-0000-0000-0000-000000000000" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function isExactRecord(
   value: unknown,
   keys: readonly string[],
 ): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+  if (!isRecord(value)) {
     return false;
   }
   const actual = Object.keys(value);

--- a/crates/openwave-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelTypes.ts
@@ -7,7 +7,7 @@
 export type PanelContent =
   | { type: "chat" }
   | { type: "sources"; documentId?: string }
-  | { type: "outputs"; filename?: string }
+  | { type: "outputs"; outputId?: string }
   | { type: "folders" };
 
 export type PanelType = PanelContent["type"];

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
@@ -23,12 +23,12 @@ describe("parsePanelSegment", () => {
     });
   });
 
-  it("keeps the dots inside an output filename", () => {
-    // Splitting on every separator would read this as an output named
-    // "report" with a stray "md" hanging off it.
-    expect(parsePanelSegment("outputs.quarterly report.md")).toEqual({
+  it("carries an opaque output identity", () => {
+    expect(
+      parsePanelSegment("outputs.550062d4-2528-5cc6-90f8-a788e119bf36"),
+    ).toEqual({
       type: "outputs",
-      filename: "quarterly report.md",
+      outputId: "550062d4-2528-5cc6-90f8-a788e119bf36",
     });
   });
 
@@ -48,7 +48,10 @@ describe("parsePanelSegment", () => {
       { type: "sources" },
       { type: "sources", documentId: "doc-1" },
       { type: "outputs" },
-      { type: "outputs", filename: "notes.md" },
+      {
+        type: "outputs",
+        outputId: "550062d4-2528-5cc6-90f8-a788e119bf36",
+      },
       { type: "folders" },
     ] as const) {
       expect(parsePanelSegment(encodePanelSegment(panel))).toEqual(panel);

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.ts
@@ -16,12 +16,11 @@ import {
  *   sources
  *   sources.{documentId}
  *   outputs
- *   outputs.{filename}
+ *   outputs.{outputId}
  *   folders
  *
- * Only the first separator is significant. Output filenames carry their own
- * dots — `outputs.report.md` is one output named `report.md`, not a malformed
- * segment — so the identifier is the whole remainder of the string.
+ * Only the first separator is significant. Output navigation carries the
+ * durable opaque output identity rather than display filename.
  */
 export function parsePanelSegment(segment: string): PanelContent | null {
   const separator = segment.indexOf(".");
@@ -36,7 +35,7 @@ export function parsePanelSegment(segment: string): PanelContent | null {
     case "sources":
       return id ? { type: "sources", documentId: id } : { type: "sources" };
     case "outputs":
-      return id ? { type: "outputs", filename: id } : { type: "outputs" };
+      return id ? { type: "outputs", outputId: id } : { type: "outputs" };
     default:
       return null;
   }
@@ -51,7 +50,7 @@ export function encodePanelSegment(panel: PanelContent): string {
     case "sources":
       return panel.documentId ? `sources.${panel.documentId}` : "sources";
     case "outputs":
-      return panel.filename ? `outputs.${panel.filename}` : "outputs";
+      return panel.outputId ? `outputs.${panel.outputId}` : "outputs";
   }
 }
 


### PR DESCRIPTION
Refs #417

Cuts output catalog, preview, navigation, and export over to opaque output/revision identities. Adds native-only durable export receipts with exact completed, cancelled, and ambiguous retry recovery while keeping renderer responses pathless.

Validation: desktop fmt/clippy/tests, workspace check, UI tests, TypeScript check, and production build.